### PR TITLE
Add anchor to scene path, and display stream anchor

### DIFF
--- a/ui/v2/src/components/scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -23,7 +23,16 @@ export const SceneFileInfoPanel: FunctionComponent<ISceneFileInfoPanelProps> = (
     return (
       <tr>
         <td>Path</td>
-        <td>{props.scene.path}</td>
+        <td><a href={"file://"+props.scene.path}>{"file://"+props.scene.path}</a> </td>
+      </tr>
+    );
+  }
+  
+  function renderStream() {
+    return (
+      <tr>
+        <td>Stream</td>
+        <td><a href={props.scene.paths.stream}>{props.scene.paths.stream}</a> </td>
       </tr>
     );
   }
@@ -114,6 +123,7 @@ export const SceneFileInfoPanel: FunctionComponent<ISceneFileInfoPanelProps> = (
         <tbody>
           {renderChecksum()}
           {renderPath()}
+          {renderStream()}
           {renderFileSize()}
           {renderDuration()}
           {renderDimensions()}


### PR DESCRIPTION
This allows to play videos which are not supported by JWplayer. Stash will display links to the local file and the stream in the "File Info" panel. This allows to open the stream or local file directly in the browser (if supported) or the app that is registered for the respective file type (e.g. VLC).

This addresses issues #52 and #62 (which are basically duplicates)