### PR TITLE
Add basic live transcoding for non-streamable files

### DIFF
--- a/pkg/ffmpeg/encoder.go
+++ b/pkg/ffmpeg/encoder.go
@@ -1,10 +1,13 @@
 package ffmpeg
 
 import (
-	"github.com/stashapp/stash/pkg/logger"
+	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/stashapp/stash/pkg/logger"
 )
 
 type Encoder struct {
@@ -59,4 +62,19 @@ func (e *Encoder) run(probeResult VideoFile, args []string) (string, error) {
 	}
 
 	return stdoutString, nil
+}
+
+func (e *Encoder) stream(probeResult VideoFile, args []string) (io.ReadCloser, *os.Process, error) {
+	cmd := exec.Command(e.Path, args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if nil != err {
+		logger.Error("FFMPEG stdout not available: " + err.Error())
+	}
+
+	if err = cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	return stdout, cmd.Process, nil
 }

--- a/pkg/ffmpeg/encoder_transcode.go
+++ b/pkg/ffmpeg/encoder_transcode.go
@@ -1,5 +1,10 @@
 package ffmpeg
 
+import (
+	"io"
+	"os"
+)
+
 type TranscodeOptions struct {
 	OutputPath string
 }
@@ -19,4 +24,19 @@ func (e *Encoder) Transcode(probeResult VideoFile, options TranscodeOptions) {
 		options.OutputPath,
 	}
 	_, _ = e.run(probeResult, args)
+}
+
+func (e *Encoder) StreamTranscode(probeResult VideoFile) (io.ReadCloser, *os.Process, error) {
+	args := []string{
+		"-i", probeResult.Path,
+		"-c:v", "libvpx-vp9",
+		"-vf", "scale=iw:-2",
+		"-deadline", "realtime",
+		"-cpu-used", "5",
+		"-crf", "30",
+		"-b:v", "0",
+		"-f", "webm",
+		"pipe:",
+	}
+	return e.stream(probeResult, args)
 }


### PR DESCRIPTION
Adds very basic live transcoding to allow playing of files that are not directly streamable.

Kills the ffmpeg process when it detects that the connection is closed.

Does not currently support seeking or even resuming a running stream (it restarts from the start of the video) because of the lack of byte range support. 

Currently encodes to webm with a fixed crf. 

It's a very basic start, but it's better than nothing. Assuming no one else looks into this in the short term, I'll look into seeking next, but based on my previous experience, it's a non-trivial problem. It would probably also be worth caching transcoded files so that we can retrieve and play them, rather than re-transcode them each time.