### PR TITLE
Fix Makefile for Windows. Add UI target #78

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,12 @@ gqlgen:
 # Runs gofmt -w on the project's source code, modifying any files that do not match its style.
 .PHONY: fmt
 fmt:
-	go list ./... | grep -v vendor | xargs go fmt
+	go fmt ./...
 
 # Runs go vet on the project's source code.
-# https://stackoverflow.com/questions/40531874/how-to-make-go-linters-ignore-vendor
 .PHONY: vet
 vet:
-	go list ./... | grep -v vendor | xargs go vet
+	go vet ./...
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 .PHONY: gqlgen
 gqlgen:
 	go run scripts/gqlgen.go
+	cd ui/v2 && yarn run gqlgen
 
 # Runs gofmt -w on the project's source code, modifying any files that do not match its style.
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+ifeq ($(OS),Windows_NT)
+  SEPARATOR := &&
+  SET := set
+endif
+
 build:
-	CGO_ENABLED=1 packr2 build -mod=vendor -v
+	$(SET) CGO_ENABLED=1 $(SEPARATOR) packr2 build -mod=vendor -v
 
 install:
 	packr2 install
@@ -26,3 +31,7 @@ vet:
 .PHONY: lint
 lint:
 	revive -config revive.toml -exclude ./vendor/...  ./...
+
+.PHONY: ui
+ui:
+	cd ui/v2 && yarn build


### PR DESCRIPTION
Addresses #78.

Makes the Makefile compatible with Windows running mingw32-make. The fmt and vet targets no longer need the grep/xargs stuff since go now excludes the vendor directory when matching ./... (as of 1.9 maybe?).

Added ui target for convenience.