### PR TITLE
Bulk update scenes

### DIFF
--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -35,8 +35,8 @@ mutation BulkSceneUpdate(
   $rating: Int,
   $studio_id: ID,
   $gallery_id: ID,
-  $performer_ids: [ID],
-  $tag_ids: [ID]) {
+  $performer_ids: [ID!],
+  $tag_ids: [ID!]) {
 
   bulkSceneUpdate(input: {
                         ids: $ids,

--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -26,6 +26,34 @@ mutation SceneUpdate(
   }
 }
 
+mutation BulkSceneUpdate(
+  $ids: [ID!] = [],
+  $title: String,
+  $details: String,
+  $url: String,
+  $date: String,
+  $rating: Int,
+  $studio_id: ID,
+  $gallery_id: ID,
+  $performer_ids: [ID!] = [],
+  $tag_ids: [ID!] = []) {
+
+  bulkSceneUpdate(input: {
+                        ids: $ids,
+                        title: $title,
+                        details: $details,
+                        url: $url,
+                        date: $date,
+                        rating: $rating,
+                        studio_id: $studio_id,
+                        gallery_id: $gallery_id,
+                        performer_ids: $performer_ids,
+                        tag_ids: $tag_ids
+                      }) {
+      ...SceneData
+  }
+}
+
 mutation SceneDestroy($id: ID!, $delete_file: Boolean, $delete_generated : Boolean) {
   sceneDestroy(input: {id: $id, delete_file: $delete_file, delete_generated: $delete_generated})
 }

--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -35,8 +35,8 @@ mutation BulkSceneUpdate(
   $rating: Int,
   $studio_id: ID,
   $gallery_id: ID,
-  $performer_ids: [ID!] = [],
-  $tag_ids: [ID!] = []) {
+  $performer_ids: [ID],
+  $tag_ids: [ID]) {
 
   bulkSceneUpdate(input: {
                         ids: $ids,

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -77,6 +77,7 @@ type Query {
 
 type Mutation {
   sceneUpdate(input: SceneUpdateInput!): Scene
+  bulkSceneUpdate(input: BulkSceneUpdateInput!): [Scene!]
   sceneDestroy(input: SceneDestroyInput!): Boolean!
 
   sceneMarkerCreate(input: SceneMarkerCreateInput!): SceneMarker

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -63,8 +63,8 @@ input BulkSceneUpdateInput {
   rating: Int
   studio_id: ID
   gallery_id: ID
-  performer_ids: [ID!]
-  tag_ids: [ID!]
+  performer_ids: [ID]
+  tag_ids: [ID]
 }
 
 input SceneDestroyInput {

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -63,8 +63,8 @@ input BulkSceneUpdateInput {
   rating: Int
   studio_id: ID
   gallery_id: ID
-  performer_ids: [ID]
-  tag_ids: [ID]
+  performer_ids: [ID!]
+  tag_ids: [ID!]
 }
 
 input SceneDestroyInput {

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -53,6 +53,20 @@ input SceneUpdateInput {
   tag_ids: [ID!]
 }
 
+input BulkSceneUpdateInput {
+  clientMutationId: String
+  ids: [ID!]
+  title: String
+  details: String
+  url: String
+  date: String
+  rating: Int
+  studio_id: ID
+  gallery_id: ID
+  performer_ids: [ID!]
+  tag_ids: [ID!]
+}
+
 input SceneDestroyInput {
   id: ID!
   delete_file: Boolean

--- a/pkg/api/resolver.go
+++ b/pkg/api/resolver.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/99designs/gqlgen/graphql"
+
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scraper"
 )
@@ -164,4 +166,14 @@ func (r *queryResolver) ScrapeFreeones(ctx context.Context, performer_name strin
 
 func (r *queryResolver) ScrapeFreeonesPerformerList(ctx context.Context, query string) ([]string, error) {
 	return scraper.GetPerformerNames(query)
+}
+
+// wasFieldIncluded returns true if the given field was included in the request.
+// Slices are unmarshalled to empty slices even if the field was omitted. This
+// method determines if it was omitted altogether.
+func wasFieldIncluded(ctx context.Context, field string) bool {
+	rctx := graphql.GetRequestContext(ctx)
+	
+	_, ret := rctx.Variables[field]
+	return ret
 }

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -192,22 +192,15 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input models.Bul
 		}
 
 		// Save the performers
-		// There's no way to distinguish between a slice that wasn't sent through
-		// and an empty slice. Workaround is to interpret input as follows:
-		// - empty slice means ignore
-		// - slice with a single nil element means unset
-		if len(input.PerformerIds) > 0 {
+		if wasFieldIncluded(ctx, "performer_ids") {
 			var performerJoins []models.PerformersScenes
 			for _, pid := range input.PerformerIds {
-				// ignore nil ids
-				if pid != nil {
-					performerID, _ := strconv.Atoi(*pid)
-					performerJoin := models.PerformersScenes{
-						PerformerID: performerID,
-						SceneID:     sceneID,
-					}
-					performerJoins = append(performerJoins, performerJoin)
+				performerID, _ := strconv.Atoi(pid)
+				performerJoin := models.PerformersScenes{
+					PerformerID: performerID,
+					SceneID:     sceneID,
 				}
+				performerJoins = append(performerJoins, performerJoin)
 			}
 			if err := jqb.UpdatePerformersScenes(sceneID, performerJoins, tx); err != nil {
 				_ = tx.Rollback()
@@ -216,17 +209,15 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input models.Bul
 		}
 
 		// Save the tags
-		if len(input.PerformerIds) > 0 {
+		if wasFieldIncluded(ctx, "tag_ids") {
 			var tagJoins []models.ScenesTags
 			for _, tid := range input.TagIds {
-				if tid != nil {
-					tagID, _ := strconv.Atoi(*tid)
-					tagJoin := models.ScenesTags{
-						SceneID: sceneID,
-						TagID:   tagID,
-					}
-					tagJoins = append(tagJoins, tagJoin)
+				tagID, _ := strconv.Atoi(tid)
+				tagJoin := models.ScenesTags{
+					SceneID: sceneID,
+					TagID:   tagID,
 				}
+				tagJoins = append(tagJoins, tagJoin)
 			}
 			if err := jqb.UpdateScenesTags(sceneID, tagJoins, tx); err != nil {
 				_ = tx.Rollback()

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -25,6 +25,8 @@ interface IListFilterProps {
   onChangeDisplayMode: (displayMode: DisplayMode) => void;
   onAddCriterion: (criterion: Criterion, oldId?: string) => void;
   onRemoveCriterion: (criterion: Criterion) => void;
+  onSelectAll?: () => void;
+  onSelectNone?: () => void;
   filter: ListFilterModel;
 }
 
@@ -134,6 +136,39 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
     ));
   }
 
+  function onSelectAll() {
+    if (props.onSelectAll) {
+      props.onSelectAll();
+    }
+  }
+
+  function onSelectNone() {
+    if (props.onSelectNone) {
+      props.onSelectNone();
+    }
+  }
+
+  function renderSelectAll() {
+    if (props.onSelectAll) {
+      return <Button onClick={() => onSelectAll()} text="Select All"/>;
+    }
+  }
+
+  function renderSelectNone() {
+    if (props.onSelectNone) {
+      return <Button onClick={() => onSelectNone()} text="Select None"/>;
+    }
+  }
+
+  function renderSelectAllNone() {
+    return (
+      <>
+      {renderSelectAll()}
+      {renderSelectNone()}
+      </>
+    );
+  }
+
   function render() {
     return (
       <>
@@ -175,6 +210,10 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
 
           <ButtonGroup className="filter-item">
             {renderDisplayModeOptions()}
+          </ButtonGroup>
+
+          <ButtonGroup className="filter-item">
+            {renderSelectAllNone()}
           </ButtonGroup>
         </div>
         <div style={{display: "flex", justifyContent: "center", margin: "10px auto"}}>

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ButtonGroup,
   Card,
+  Checkbox,
   Divider,
   Elevation,
   H4,
@@ -19,11 +20,14 @@ import { SceneHelpers } from "./helpers";
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
+  selected: boolean | undefined;
+  onSelectedChanged: (selected : boolean, shiftKey : boolean) => void;
 }
 
 export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardProps) => {
   const [previewPath, setPreviewPath] = useState<string | undefined>(undefined);
   const videoHoverHook = VideoHoverHook.useVideoHover({resetOnMouseLeave: false});
+  
 
   function maybeRenderRatingBanner() {
     if (!props.scene.rating) { return; }
@@ -115,6 +119,8 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     setPreviewPath("");
   }
 
+  var shiftKey = false;
+
   return (
     <Card
       className="grid-item"
@@ -122,6 +128,12 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
+      <Checkbox
+        className="card-select"
+        checked={props.selected}
+        onChange={() => props.onSelectedChanged(!props.selected, shiftKey)}
+        onClick={(event: React.MouseEvent<HTMLInputElement, MouseEvent>) => { shiftKey = event.shiftKey; event.stopPropagation(); } }
+      />
       <Link to={`/scenes/${props.scene.id}`} className="image previewable">
         {maybeRenderRatingBanner()}
         <video className="preview" loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>

--- a/ui/v2/src/components/scenes/SceneList.tsx
+++ b/ui/v2/src/components/scenes/SceneList.tsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import React, { FunctionComponent } from "react";
 import { QueryHookResult } from "react-apollo-hooks";
-import { FindScenesQuery, FindScenesVariables } from "../../core/generated-graphql";
+import { FindScenesQuery, FindScenesVariables, SlimSceneDataFragment } from "../../core/generated-graphql";
 import { ListHook } from "../../hooks/ListHook";
 import { IBaseProps } from "../../models/base-props";
 import { ListFilterModel } from "../../models/list-filter/filter";
@@ -9,6 +9,7 @@ import { DisplayMode, FilterMode } from "../../models/list-filter/types";
 import { WallPanel } from "../Wall/WallPanel";
 import { SceneCard } from "./SceneCard";
 import { SceneListTable } from "./SceneListTable";
+import { SceneSelectedOptions } from "./SceneSelectedOptions";
 
 interface ISceneListProps extends IBaseProps {}
 
@@ -17,14 +18,50 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
     filterMode: FilterMode.Scenes,
     props,
     renderContent,
+    renderSelectedOptions
   });
 
-  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel) {
+  function renderSelectedOptions(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, selectedIds: Set<string>) {
+    // find the selected items from the ids
+    if (!result.data || !result.data.findScenes) { return undefined; }
+
+    var scenes = result.data.findScenes.scenes;
+    
+    var selectedScenes : SlimSceneDataFragment[] = [];
+    selectedIds.forEach((id) => {
+      var scene = scenes.find((scene) => {
+        return scene.id === id;
+      });
+
+      if (scene) {
+        selectedScenes.push(scene);
+      }
+    });
+
+    return (
+      <>
+      <SceneSelectedOptions selected={selectedScenes} onScenesUpdated={() => { return; }}/>
+      </>
+    );
+  }
+
+  function renderSceneCard(scene : SlimSceneDataFragment, selectedIds: Set<string>) {
+    return (
+      <SceneCard 
+        key={scene.id} 
+        scene={scene} 
+        selected={selectedIds.has(scene.id)}
+        onSelectedChanged={(selected: boolean, shiftKey: boolean) => listData.onSelectChange(scene.id, selected, shiftKey)}
+      />
+    )
+  }
+
+  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel, selectedIds: Set<string>) {
     if (!result.data || !result.data.findScenes) { return; }
     if (filter.displayMode === DisplayMode.Grid) {
       return (
         <div className="grid">
-          {result.data.findScenes.scenes.map((scene) => (<SceneCard key={scene.id} scene={scene} />))}
+          {result.data.findScenes.scenes.map((scene) => renderSceneCard(scene, selectedIds))}
         </div>
       );
     } else if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
+++ b/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
@@ -100,19 +100,6 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
       sceneInput.tag_ids = tagIds;
     }
 
-    // The Go implementation of graphql doesn't seem to be
-    // able to distinguish between an empty passed array and
-    // an undefined array (both umarshal to empty slice)
-
-    // we'll send an array containing undefined to signify
-    // unsetting of the applicable fields
-    if (sceneInput.performer_ids && sceneInput.performer_ids.length == 0) {
-      sceneInput.performer_ids = [undefined];
-    }
-    if (sceneInput.tag_ids && sceneInput.tag_ids.length == 0) {
-      sceneInput.tag_ids = [undefined];
-    }
-
     return sceneInput;
   }
 

--- a/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
+++ b/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
@@ -1,0 +1,307 @@
+import _ from "lodash";
+import {
+  AnchorButton,
+  Button,
+  ButtonGroup,
+  ControlGroup,
+  FormGroup,
+  HTMLSelect,
+  InputGroup,
+  Menu,
+  MenuItem,
+  Popover,
+  Spinner,
+  Tag,
+} from "@blueprintjs/core";
+import React, { FunctionComponent, SyntheticEvent, useEffect, useRef, useState } from "react";
+import { FilterSelect } from "../select/FilterSelect";
+import { FilterMultiSelect } from "../select/FilterMultiSelect";
+import { StashService } from "../../core/StashService";
+import * as GQL from "../../core/generated-graphql";
+import { ErrorUtils } from "../../utils/errors";
+import { ToastUtils } from "../../utils/toasts";
+
+interface IListOperationProps {
+  selected: GQL.SlimSceneDataFragment[],
+  onScenesUpdated: () => void;
+}
+
+export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (props: IListOperationProps) => {
+  const [rating, setRating] = useState<string>("");
+  const [studioId, setStudioId] = useState<string | undefined>(undefined);
+  const [performerIds, setPerformerIds] = useState<string[] | undefined>(undefined);
+  const [tagIds, setTagIds] = useState<string[] | undefined>(undefined);
+
+  const updateScenes = StashService.useBulkSceneUpdate(getSceneInput());
+
+  // Network state
+  const [isLoading, setIsLoading] = useState(false);
+
+  function getSceneInput() : GQL.BulkSceneUpdateInput {
+    // need to determine what we are actually setting on each scene
+    var aggregateRating = getRating(props.selected);
+    var aggregateStudioId = getStudioId(props.selected);
+    var aggregatePerformerIds = getPerformerIds(props.selected);
+    var aggregateTagIds = getTagIds(props.selected);
+
+    var sceneInput : GQL.BulkSceneUpdateInput = {
+      ids: props.selected.map((scene) => {
+        return scene.id;
+      })
+    };
+
+    // if rating is undefined 
+    if (rating === "") {
+      // and all scenes have the same rating, then we are unsetting the rating.
+      if(aggregateRating) {
+        // an undefined rating is ignored in the server, so set it to 0 instead
+        sceneInput.rating = 0;
+      }
+      // otherwise not setting the rating
+    } else {
+      // if rating is set, then we are setting the rating for all
+      sceneInput.rating = Number.parseInt(rating);
+    }
+    
+    // if studioId is undefined 
+    if (studioId === undefined) {
+      // and all scenes have the same studioId,
+      // then unset the studioId, otherwise ignoring studioId
+      if (aggregateStudioId) {
+        // an undefined studio_id is ignored in the server, so set it to empty string instead
+        sceneInput.studio_id = "";
+      }
+    } else {
+      // if studioId is set, then we are setting it
+      sceneInput.studio_id = studioId;
+    }
+    
+    // if performerIds are empty
+    if (!performerIds || performerIds.length === 0) {
+      // and all scenes have the same ids,
+      if (aggregatePerformerIds.length > 0) {
+        // then unset the performerIds, otherwise ignore
+        sceneInput.performer_ids = performerIds;
+      }
+    } else {
+      // if performerIds non-empty, then we are setting them
+      sceneInput.performer_ids = performerIds;
+    }
+    
+    // if tagIds non-empty, then we are setting them
+    if (!tagIds || tagIds.length === 0) {
+      // and all scenes have the same ids,
+      if (aggregateTagIds.length > 0) {
+        // then unset the tagIds, otherwise ignore
+        sceneInput.tag_ids = tagIds;
+      }
+    } else {
+      // if tagIds non-empty, then we are setting them
+      sceneInput.tag_ids = tagIds;
+    }
+
+    return sceneInput;
+  }
+
+  async function onSave() {
+    setIsLoading(true);
+    try {
+      const result = await updateScenes();
+      ToastUtils.success("Updated scenes");
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+    setIsLoading(false);
+    props.onScenesUpdated();
+  }
+
+  function getRating(state: GQL.SlimSceneDataFragment[]) {
+    var ret : number | undefined;
+    var first = true;
+
+    state.forEach((scene : GQL.SlimSceneDataFragment) => {
+      if (first) {
+        ret = scene.rating;
+        first = false;
+      } else {
+        if (ret !== scene.rating) {
+          ret = undefined;
+        }
+      }
+    });
+
+    return ret;
+  }
+
+  function getStudioId(state: GQL.SlimSceneDataFragment[]) {
+    var ret : string | undefined;
+    var first = true;
+
+    state.forEach((scene : GQL.SlimSceneDataFragment) => {
+      if (first) {
+        ret = scene.studio ? scene.studio.id : undefined;
+        first = false;
+      } else {
+        if (scene.studio && ret != scene.studio.id) {
+          ret = undefined;
+        }
+      }
+    });
+
+    return ret;
+  }
+
+  function toId(object : any) {
+    return object.id;
+  }
+
+  function getPerformerIds(state: GQL.SlimSceneDataFragment[]) {
+    var ret : string[] = [];
+    var first = true;
+
+    state.forEach((scene : GQL.SlimSceneDataFragment) => {
+      if (first) {
+        ret = !!scene.performers ? scene.performers.map(toId).sort() : [];
+        first = false;
+      } else {
+        const perfIds = !!scene.performers ? scene.performers.map(toId).sort() : [];
+        
+        if (!_.isEqual(performerIds, perfIds)) {
+          ret = [];
+        }
+      }
+    });
+
+    return ret;
+  }
+
+  function getTagIds(state: GQL.SlimSceneDataFragment[]) {
+    var ret : string[] = [];
+    var first = true;
+
+    state.forEach((scene : GQL.SlimSceneDataFragment) => {
+      if (first) {
+        ret = !!scene.tags ? scene.tags.map(toId).sort() : [];
+        first = false;
+      } else {
+        const tIds = !!scene.tags ? scene.tags.map(toId).sort() : [];
+        
+        if (!_.isEqual(ret, tIds)) {
+          ret = [];
+        }
+      }
+    });
+
+    return ret;
+  }
+
+  function updateScenesEditState(state: GQL.SlimSceneDataFragment[]) {
+    function toId(object : any) {
+      return object.id;
+    }
+
+    var rating : string = "";
+    var studioId : string | undefined;
+    var performerIds : string[] = [];
+    var tagIds : string[] = [];
+    var first = true;
+
+    state.forEach((scene : GQL.SlimSceneDataFragment) => {
+      var thisRating = scene.rating ? scene.rating.toString() : "";
+      var thisStudio = scene.studio ? scene.studio.id : undefined;
+
+      if (first) {
+        rating = thisRating;
+        studioId = thisStudio;
+        performerIds = !!scene.performers ? scene.performers.map(toId).sort() : [];
+        tagIds = !!scene.tags ? scene.tags.map(toId).sort() : [];
+        first = false;
+      } else {
+        if (rating !== thisRating) {
+          rating = "";
+        }
+        if (studioId != thisStudio) {
+          studioId = undefined;
+        }
+        const perfIds = !!scene.performers ? scene.performers.map(toId).sort() : [];
+        const tIds = !!scene.tags ? scene.tags.map(toId).sort() : [];
+        
+        if (!_.isEqual(performerIds, perfIds)) {
+          performerIds = [];
+        }
+
+        if (!_.isEqual(tagIds, tIds)) {
+          tagIds = [];
+        }
+      }
+    });
+    
+    setRating(rating);
+    setStudioId(studioId);
+    setPerformerIds(performerIds);
+    setTagIds(tagIds);
+  }
+
+  useEffect(() => {
+    updateScenesEditState(props.selected);
+  }, [props.selected]);
+
+  function renderMultiSelect(type: "performers" | "tags", initialIds: string[] | undefined) {
+    return (
+      <FilterMultiSelect
+        type={type}
+        onUpdate={(items) => {
+          const ids = items.map((i) => i.id);
+          switch (type) {
+            case "performers": setPerformerIds(ids); break;
+            case "tags": setTagIds(ids); break;
+          }
+        }}
+        initialIds={initialIds}
+      />
+    );
+  }
+  
+  function render() {
+    return (
+      <>
+        {isLoading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
+        <div className="operation-container">
+          <FormGroup className="operation-item" label="Rating">
+            <HTMLSelect
+              options={["", 1, 2, 3, 4, 5]}
+              onChange={(event) => setRating(event.target.value)}
+              value={rating}
+            />
+          </FormGroup>
+          
+          <FormGroup className="operation-item" label="Studio">
+            <FilterSelect
+              type="studios"
+              onSelectItem={(item : any) => setStudioId(item ? item.id : undefined)}
+              initialId={studioId}
+            />
+          </FormGroup>
+
+          <FormGroup className="operation-item" label="Performers">
+            {renderMultiSelect("performers", performerIds)}
+          </FormGroup>
+
+          <FormGroup className="operation-item" label="Tags">
+            {renderMultiSelect("tags", tagIds)}
+          </FormGroup>
+          
+          <ButtonGroup className="operation-item">
+            <Button 
+              intent="primary"
+              onClick={() => onSave()}>
+                Apply
+            </Button>
+          </ButtonGroup>
+        </div>
+      </>
+    );
+  }
+
+  return render();
+};

--- a/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
+++ b/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
@@ -100,6 +100,19 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
       sceneInput.tag_ids = tagIds;
     }
 
+    // The Go implementation of graphql doesn't seem to be
+    // able to distinguish between an empty passed array and
+    // an undefined array (both umarshal to empty slice)
+
+    // we'll send an array containing undefined to signify
+    // unsetting of the applicable fields
+    if (sceneInput.performer_ids && sceneInput.performer_ids.length == 0) {
+      sceneInput.performer_ids = [undefined];
+    }
+    if (sceneInput.tag_ids && sceneInput.tag_ids.length == 0) {
+      sceneInput.tag_ids = [undefined];
+    }
+
     return sceneInput;
   }
 
@@ -142,7 +155,8 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
         ret = scene.studio ? scene.studio.id : undefined;
         first = false;
       } else {
-        if (scene.studio && ret != scene.studio.id) {
+        var studioId = scene.studio ? scene.studio.id : undefined;
+        if (ret != studioId) {
           ret = undefined;
         }
       }
@@ -166,7 +180,7 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
       } else {
         const perfIds = !!scene.performers ? scene.performers.map(toId).sort() : [];
         
-        if (!_.isEqual(performerIds, perfIds)) {
+        if (!_.isEqual(ret, perfIds)) {
           ret = [];
         }
       }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -176,6 +176,10 @@ export class StashService {
     return GQL.useSceneUpdate({ variables: input });
   }
 
+  public static useBulkSceneUpdate(input: GQL.BulkSceneUpdateInput) {
+    return GQL.useBulkSceneUpdate({ variables: input, refetchQueries: ["FindScenes"] });
+  }
+  
   public static useSceneDestroy(input: GQL.SceneDestroyInput) {
     return GQL.useSceneDestroy({ variables: input });
   }

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -87,6 +87,14 @@ code {
   position: relative;
 }
 
+.grid-item label.card-select {
+  position: absolute;
+  padding-left: 15px;
+  margin-top: -12px;
+  z-index: 10;
+  opacity: 0.5;
+}
+
 video.preview {
   // height: 225px; // slows down the page
   width: 100%;
@@ -95,7 +103,7 @@ video.preview {
   object-fit: cover;
 }
 
-.filter-item {
+.filter-item, .operation-item {
   margin: 0 10px;
 }
 
@@ -116,7 +124,7 @@ video.preview {
   }
 }
 
-.filter-container {
+.filter-container, .operation-container {
   display: flex;
   justify-content: center;
   margin: 10px auto;


### PR DESCRIPTION
Adds checkboxes to the scene grid view. Clicking one or more checkboxes shows a bulk-update row which allows setting Rating, Studio, Performers and Tags. Server-side API is added.

Need to iron out a few bugs (mostly due to my inexperience with React):
- ~bulk update row sometimes doesn't hide when everything is de-selected~ [fixed]
- ~fields are supposed to update based on what is selected - ie if all selected scenes have the same tags, then those tags should be populated in the bulk update field. It works for the first selected scene, but not the subsequent ones~ [fixed]

Would also like ~select all/none buttons~ [added], and ~add shift-click shortcut to select multiple scenes~ [added].