### PR TITLE
Add delete tag button #96

### DIFF
--- a/pkg/models/querybuilder_tag.go
+++ b/pkg/models/querybuilder_tag.go
@@ -52,6 +52,19 @@ func (qb *TagQueryBuilder) Update(updatedTag Tag, tx *sqlx.Tx) (*Tag, error) {
 }
 
 func (qb *TagQueryBuilder) Destroy(id string, tx *sqlx.Tx) error {
+	// delete tag from scenes and markers first
+	_, err := tx.Exec("DELETE FROM scenes_tags WHERE tag_id = ?", id)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec("DELETE FROM scene_markers_tags WHERE tag_id = ?", id)
+	if err != nil {
+		return err
+	}
+
+	// does not unset primary_tag_id in scene_markers because it is not nullable
+
 	return executeDeleteQuery("tags", id, tx)
 }
 

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -151,6 +151,9 @@ export class StashService {
   public static useTagUpdate(input: GQL.TagUpdateInput) {
     return GQL.useTagUpdate({ variables: input, refetchQueries: ["AllTags"] });
   }
+  public static useTagDestroy(input: GQL.TagDestroyInput) {
+    return GQL.useTagDestroy({ variables: input, refetchQueries: ["AllTags"] });
+  }
 
   public static useConfigureGeneral(input: GQL.ConfigGeneralInput) {
     return GQL.useConfigureGeneral({ variables: { input }, refetchQueries: ["Configuration"] });


### PR DESCRIPTION
Resolves #96 

Adds a delete tag button to each tag row (with trash icon).

Changed the `TagQueryBuilder.Destroy` function to also delete references to the tag from the scenes and markers tables, since otherwise you would need to remove all of the tag references manually before deleting the tag. Can't do anything with the `primary_tag_id `on scene markers, since it cannot be unset. Scene markers referencing the tag would need to be modified manually prior to deleting the tag.