### PR TITLE
Add delete for performers and studios

### DIFF
--- a/graphql/documents/mutations/performer.graphql
+++ b/graphql/documents/mutations/performer.graphql
@@ -83,3 +83,7 @@ mutation PerformerUpdate(
     ...PerformerData
   }
 }
+
+mutation PerformerDestroy($id: ID!) {
+  performerDestroy(input: { id: $id })
+}

--- a/graphql/documents/mutations/studio.graphql
+++ b/graphql/documents/mutations/studio.graphql
@@ -18,3 +18,7 @@ mutation StudioUpdate(
     ...StudioData
   }
 }
+
+mutation StudioDestroy($id: ID!) {
+  studioDestroy(input: { id: $id })
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -79,9 +79,11 @@ type Mutation {
 
   performerCreate(input: PerformerCreateInput!): Performer
   performerUpdate(input: PerformerUpdateInput!): Performer
+  performerDestroy(input: PerformerDestroyInput!): Boolean!
 
   studioCreate(input: StudioCreateInput!): Studio
   studioUpdate(input: StudioUpdateInput!): Studio
+  studioDestroy(input: StudioDestroyInput!): Boolean!
 
   tagCreate(input: TagCreateInput!): Tag
   tagUpdate(input: TagUpdateInput!): Tag

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -66,6 +66,10 @@ input PerformerUpdateInput {
   image: String
 }
 
+input PerformerDestroyInput {
+  id: ID!
+}
+
 type FindPerformersResultType {
   count: Int!
   performers: [Performer!]!

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -23,6 +23,10 @@ input StudioUpdateInput {
   image: String
 }
 
+input StudioDestroyInput {
+  id: ID!
+}
+
 type FindStudiosResultType {
   count: Int!
   studios: [Studio!]!

--- a/pkg/api/resolver_mutation_performer.go
+++ b/pkg/api/resolver_mutation_performer.go
@@ -175,3 +175,17 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 
 	return performer, nil
 }
+
+func (r *mutationResolver) PerformerDestroy(ctx context.Context, input models.PerformerDestroyInput) (bool, error) {
+	qb := models.NewPerformerQueryBuilder()
+	tx := database.DB.MustBeginTx(ctx, nil)
+	if err := qb.Destroy(input.ID, tx); err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+

--- a/pkg/api/resolver_mutation_studio.go
+++ b/pkg/api/resolver_mutation_studio.go
@@ -3,11 +3,12 @@ package api
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"time"
+
 	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"strconv"
-	"time"
 )
 
 func (r *mutationResolver) StudioCreate(ctx context.Context, input models.StudioCreateInput) (*models.Studio, error) {
@@ -84,4 +85,17 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 	}
 
 	return studio, nil
+}
+
+func (r *mutationResolver) StudioDestroy(ctx context.Context, input models.StudioDestroyInput) (bool, error) {
+	qb := models.NewStudioQueryBuilder()
+	tx := database.DB.MustBeginTx(ctx, nil)
+	if err := qb.Destroy(input.ID, tx); err != nil {
+		_ = tx.Rollback()
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -108,12 +108,14 @@ type ComplexityRoot struct {
 	Mutation struct {
 		ConfigureGeneral   func(childComplexity int, input ConfigGeneralInput) int
 		PerformerCreate    func(childComplexity int, input PerformerCreateInput) int
+		PerformerDestroy   func(childComplexity int, input PerformerDestroyInput) int
 		PerformerUpdate    func(childComplexity int, input PerformerUpdateInput) int
 		SceneMarkerCreate  func(childComplexity int, input SceneMarkerCreateInput) int
 		SceneMarkerDestroy func(childComplexity int, id string) int
 		SceneMarkerUpdate  func(childComplexity int, input SceneMarkerUpdateInput) int
 		SceneUpdate        func(childComplexity int, input SceneUpdateInput) int
 		StudioCreate       func(childComplexity int, input StudioCreateInput) int
+		StudioDestroy      func(childComplexity int, input StudioDestroyInput) int
 		StudioUpdate       func(childComplexity int, input StudioUpdateInput) int
 		TagCreate          func(childComplexity int, input TagCreateInput) int
 		TagDestroy         func(childComplexity int, input TagDestroyInput) int
@@ -288,8 +290,10 @@ type MutationResolver interface {
 	SceneMarkerDestroy(ctx context.Context, id string) (bool, error)
 	PerformerCreate(ctx context.Context, input PerformerCreateInput) (*Performer, error)
 	PerformerUpdate(ctx context.Context, input PerformerUpdateInput) (*Performer, error)
+	PerformerDestroy(ctx context.Context, input PerformerDestroyInput) (bool, error)
 	StudioCreate(ctx context.Context, input StudioCreateInput) (*Studio, error)
 	StudioUpdate(ctx context.Context, input StudioUpdateInput) (*Studio, error)
+	StudioDestroy(ctx context.Context, input StudioDestroyInput) (bool, error)
 	TagCreate(ctx context.Context, input TagCreateInput) (*Tag, error)
 	TagUpdate(ctx context.Context, input TagUpdateInput) (*Tag, error)
 	TagDestroy(ctx context.Context, input TagDestroyInput) (bool, error)
@@ -598,6 +602,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.PerformerCreate(childComplexity, args["input"].(PerformerCreateInput)), true
 
+	case "Mutation.performerDestroy":
+		if e.complexity.Mutation.PerformerDestroy == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_performerDestroy_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.PerformerDestroy(childComplexity, args["input"].(PerformerDestroyInput)), true
+
 	case "Mutation.performerUpdate":
 		if e.complexity.Mutation.PerformerUpdate == nil {
 			break
@@ -669,6 +685,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.StudioCreate(childComplexity, args["input"].(StudioCreateInput)), true
+
+	case "Mutation.studioDestroy":
+		if e.complexity.Mutation.StudioDestroy == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_studioDestroy_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.StudioDestroy(childComplexity, args["input"].(StudioDestroyInput)), true
 
 	case "Mutation.studioUpdate":
 		if e.complexity.Mutation.StudioUpdate == nil {
@@ -1840,9 +1868,11 @@ type Mutation {
 
   performerCreate(input: PerformerCreateInput!): Performer
   performerUpdate(input: PerformerUpdateInput!): Performer
+  performerDestroy(input: PerformerDestroyInput!): Boolean!
 
   studioCreate(input: StudioCreateInput!): Studio
   studioUpdate(input: StudioUpdateInput!): Studio
+  studioDestroy(input: StudioDestroyInput!): Boolean!
 
   tagCreate(input: TagCreateInput!): Tag
   tagUpdate(input: TagUpdateInput!): Tag
@@ -2054,6 +2084,10 @@ input PerformerUpdateInput {
   image: String
 }
 
+input PerformerDestroyInput {
+  id: ID!
+}
+
 type FindPerformersResultType {
   count: Int!
   performers: [Performer!]!
@@ -2212,6 +2246,10 @@ input StudioUpdateInput {
   image: String
 }
 
+input StudioDestroyInput {
+  id: ID!
+}
+
 type FindStudiosResultType {
   count: Int!
   studios: [Studio!]!
@@ -2262,6 +2300,20 @@ func (ec *executionContext) field_Mutation_performerCreate_args(ctx context.Cont
 	var arg0 PerformerCreateInput
 	if tmp, ok := rawArgs["input"]; ok {
 		arg0, err = ec.unmarshalNPerformerCreateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformerCreateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_performerDestroy_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 PerformerDestroyInput
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNPerformerDestroyInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformerDestroyInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2346,6 +2398,20 @@ func (ec *executionContext) field_Mutation_studioCreate_args(ctx context.Context
 	var arg0 StudioCreateInput
 	if tmp, ok := rawArgs["input"]; ok {
 		arg0, err = ec.unmarshalNStudioCreateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudioCreateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_studioDestroy_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 StudioDestroyInput
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNStudioDestroyInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudioDestroyInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -3625,6 +3691,40 @@ func (ec *executionContext) _Mutation_performerUpdate(ctx context.Context, field
 	return ec.marshalOPerformer2ᚖgithubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformer(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_performerDestroy(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_performerDestroy_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().PerformerDestroy(rctx, args["input"].(PerformerDestroyInput))
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Mutation_studioCreate(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
@@ -3685,6 +3785,40 @@ func (ec *executionContext) _Mutation_studioUpdate(ctx context.Context, field gr
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalOStudio2ᚖgithubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudio(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_studioDestroy(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_studioDestroy_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().StudioDestroy(rctx, args["input"].(StudioDestroyInput))
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_tagCreate(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -8131,6 +8265,24 @@ func (ec *executionContext) unmarshalInputPerformerCreateInput(ctx context.Conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputPerformerDestroyInput(ctx context.Context, v interface{}) (PerformerDestroyInput, error) {
+	var it PerformerDestroyInput
+	var asMap = v.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputPerformerFilterType(ctx context.Context, v interface{}) (PerformerFilterType, error) {
 	var it PerformerFilterType
 	var asMap = v.(map[string]interface{})
@@ -8548,6 +8700,24 @@ func (ec *executionContext) unmarshalInputStudioCreateInput(ctx context.Context,
 		case "image":
 			var err error
 			it.Image, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputStudioDestroyInput(ctx context.Context, v interface{}) (StudioDestroyInput, error) {
+	var it StudioDestroyInput
+	var asMap = v.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalNID2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9045,10 +9215,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_performerCreate(ctx, field)
 		case "performerUpdate":
 			out.Values[i] = ec._Mutation_performerUpdate(ctx, field)
+		case "performerDestroy":
+			out.Values[i] = ec._Mutation_performerDestroy(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "studioCreate":
 			out.Values[i] = ec._Mutation_studioCreate(ctx, field)
 		case "studioUpdate":
 			out.Values[i] = ec._Mutation_studioUpdate(ctx, field)
+		case "studioDestroy":
+			out.Values[i] = ec._Mutation_studioDestroy(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "tagCreate":
 			out.Values[i] = ec._Mutation_tagCreate(ctx, field)
 		case "tagUpdate":
@@ -11010,6 +11190,10 @@ func (ec *executionContext) unmarshalNPerformerCreateInput2githubᚗcomᚋstasha
 	return ec.unmarshalInputPerformerCreateInput(ctx, v)
 }
 
+func (ec *executionContext) unmarshalNPerformerDestroyInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformerDestroyInput(ctx context.Context, v interface{}) (PerformerDestroyInput, error) {
+	return ec.unmarshalInputPerformerDestroyInput(ctx, v)
+}
+
 func (ec *executionContext) unmarshalNPerformerUpdateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformerUpdateInput(ctx context.Context, v interface{}) (PerformerUpdateInput, error) {
 	return ec.unmarshalInputPerformerUpdateInput(ctx, v)
 }
@@ -11317,6 +11501,10 @@ func (ec *executionContext) marshalNStudio2ᚖgithubᚗcomᚋstashappᚋstashᚋ
 
 func (ec *executionContext) unmarshalNStudioCreateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudioCreateInput(ctx context.Context, v interface{}) (StudioCreateInput, error) {
 	return ec.unmarshalInputStudioCreateInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNStudioDestroyInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudioDestroyInput(ctx context.Context, v interface{}) (StudioDestroyInput, error) {
+	return ec.unmarshalInputStudioDestroyInput(ctx, v)
 }
 
 func (ec *executionContext) unmarshalNStudioUpdateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐStudioUpdateInput(ctx context.Context, v interface{}) (StudioUpdateInput, error) {

--- a/pkg/models/generated_models.go
+++ b/pkg/models/generated_models.go
@@ -109,6 +109,10 @@ type PerformerCreateInput struct {
 	Image string `json:"image"`
 }
 
+type PerformerDestroyInput struct {
+	ID string `json:"id"`
+}
+
 type PerformerFilterType struct {
 	// Filter by favorite
 	FilterFavorites *bool `json:"filter_favorites"`
@@ -252,6 +256,10 @@ type StudioCreateInput struct {
 	URL  *string `json:"url"`
 	// This should be base64 encoded
 	Image string `json:"image"`
+}
+
+type StudioDestroyInput struct {
+	ID string `json:"id"`
 }
 
 type StudioUpdateInput struct {

--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
 )
@@ -52,6 +53,15 @@ func (qb *PerformerQueryBuilder) Update(updatedPerformer Performer, tx *sqlx.Tx)
 		return nil, err
 	}
 	return &updatedPerformer, nil
+}
+
+func (qb *PerformerQueryBuilder) Destroy(id string, tx *sqlx.Tx) error {
+	_, err := tx.Exec("DELETE FROM performers_scenes WHERE performer_id = ?", id)
+	if err != nil {
+		return err
+	}
+
+	return executeDeleteQuery("performers", id, tx)
 }
 
 func (qb *PerformerQueryBuilder) Find(id int) (*Performer, error) {

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
 )
@@ -48,6 +49,22 @@ func (qb *StudioQueryBuilder) Update(updatedStudio Studio, tx *sqlx.Tx) (*Studio
 		return nil, err
 	}
 	return &updatedStudio, nil
+}
+
+func (qb *StudioQueryBuilder) Destroy(id string, tx *sqlx.Tx) error {
+	// remove studio from scenes
+	_, err := tx.Exec("UPDATE scenes SET studio_id = null WHERE studio_id = ?", id)
+	if err != nil {
+		return err
+	}
+
+	// remove studio from scraped items
+	_, err = tx.Exec("UPDATE scraped_items SET studio_id = null WHERE studio_id = ?", id)
+	if err != nil {
+		return err
+	}
+
+	return executeDeleteQuery("studios", id, tx)
 }
 
 func (qb *StudioQueryBuilder) Find(id int, tx *sqlx.Tx) (*Studio, error) {

--- a/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   FileInput,
   Menu,
@@ -8,7 +9,7 @@ import {
   Popover,
 } from "@blueprintjs/core";
 import _ from "lodash";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "../../core/generated-graphql";
 import { NavigationUtils } from "../../utils/navigation";
@@ -28,6 +29,8 @@ interface IProps {
 }
 
 export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
+  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+
   function renderEditButton() {
     if (props.isNew) { return; }
     return (
@@ -46,7 +49,7 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
 
   function renderDeleteButton() {
     if (props.isNew || props.isEditing) { return; }
-    return <Button intent="danger" text="Delete" onClick={() => props.onDelete()} />;
+    return <Button intent="danger" text="Delete" onClick={() => setIsDeleteAlertOpen(true)} />;
   }
 
   function renderImageInput() {
@@ -87,7 +90,37 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
     );
   }
 
+  function renderDeleteAlert() {
+    var name;
+
+    if (props.performer) {
+      name = props.performer.name;
+    }
+    if (props.studio) {
+      name = props.studio.name;
+    }
+
+    return (
+      <Alert
+        cancelButtonText="Cancel"
+        confirmButtonText="Delete"
+        icon="trash"
+        intent="danger"
+        isOpen={isDeleteAlertOpen}
+        onCancel={() => setIsDeleteAlertOpen(false)}
+        onConfirm={() => props.onDelete()}
+      >
+        <p>
+          Are you sure you want to delete {name}?
+        </p>
+      </Alert>
+    );
+  }
+
+
   return (
+    <>
+    {renderDeleteAlert()}
     <Navbar>
       <Navbar.Group>
         {renderEditButton()}
@@ -100,5 +133,6 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
         {renderDeleteButton()}
       </Navbar.Group>
     </Navbar>
+    </>
   );
 };

--- a/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
@@ -20,6 +20,7 @@ interface IProps {
   isEditing: boolean;
   onToggleEdit: () => void;
   onSave: () => void;
+  onDelete: () => void;
   onImageChange: (event: React.FormEvent<HTMLInputElement>) => void;
 
   // TODO: only for performers.  make generic
@@ -41,6 +42,11 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
   function renderSaveButton() {
     if (!props.isEditing) { return; }
     return <Button intent="success" text="Save" onClick={() => props.onSave()} />;
+  }
+
+  function renderDeleteButton() {
+    if (props.isNew || props.isEditing) { return; }
+    return <Button intent="danger" text="Delete" onClick={() => props.onDelete()} />;
   }
 
   function renderImageInput() {
@@ -91,6 +97,7 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
         {renderSaveButton()}
 
         {renderScenesButton()}
+        {renderDeleteButton()}
       </Navbar.Group>
     </Navbar>
   );

--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -39,6 +39,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
   const { data, error, loading } = StashService.useFindStudio(props.match.params.id);
   const updateStudio = StashService.useStudioUpdate(getStudioInput() as GQL.StudioUpdateInput);
   const createStudio = StashService.useStudioCreate(getStudioInput() as GQL.StudioCreateInput);
+  const deleteStudio = StashService.useStudioDestroy(getStudioInput() as GQL.StudioDestroyInput);
 
   function updateStudioEditState(state: Partial<GQL.StudioDataFragment>) {
     setName(state.name);
@@ -95,6 +96,19 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     setIsLoading(false);
   }
 
+  async function onDelete() {
+    setIsLoading(true);
+    try {
+      const result = await deleteStudio();
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+    setIsLoading(false);
+    
+    // redirect to studios page
+    props.history.push(`/studios`);
+  }
+
   function onImageChange(event: React.FormEvent<HTMLInputElement>) {
     const file: File = (event.target as any).files[0];
     const reader: FileReader = new FileReader();
@@ -120,6 +134,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
             isEditing={isEditing}
             onToggleEdit={() => { setIsEditing(!isEditing); updateStudioEditState(studio); }}
             onSave={onSave}
+            onDelete={onDelete}
             onImageChange={onImageChange}
           />
           <h1 className="bp3-heading">

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -55,6 +55,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
   const { data, error, loading } = StashService.useFindPerformer(props.match.params.id);
   const updatePerformer = StashService.usePerformerUpdate(getPerformerInput() as GQL.PerformerUpdateInput);
   const createPerformer = StashService.usePerformerCreate(getPerformerInput() as GQL.PerformerCreateInput);
+  const deletePerformer = StashService.usePerformerDestroy(getPerformerInput() as GQL.PerformerDestroyInput);
 
   function updatePerformerEditState(state: Partial<GQL.PerformerDataFragment | GQL.ScrapeFreeonesScrapeFreeones>) {
     if ((state as GQL.PerformerDataFragment).favorite !== undefined) {
@@ -141,6 +142,19 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     setIsLoading(false);
   }
 
+  async function onDelete() {
+    setIsLoading(true);
+    try {
+      const result = await deletePerformer();
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+    setIsLoading(false);
+    
+    // redirect to performers page
+    props.history.push(`/performers`);
+  }
+
   function onImageChange(event: React.FormEvent<HTMLInputElement>) {
     const file: File = (event.target as any).files[0];
     const reader: FileReader = new FileReader();
@@ -218,6 +232,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
             isEditing={isEditing}
             onToggleEdit={() => { setIsEditing(!isEditing); updatePerformerEditState(performer); }}
             onSave={onSave}
+            onDelete={onDelete}
             onImageChange={onImageChange}
             onDisplayFreeOnesDialog={onDisplayFreeOnesDialog}
           />

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -133,6 +133,9 @@ export class StashService {
   public static usePerformerUpdate(input: GQL.PerformerUpdateInput) {
     return GQL.usePerformerUpdate({ variables: input });
   }
+  public static usePerformerDestroy(input: GQL.PerformerDestroyInput) {
+    return GQL.usePerformerDestroy({ variables: input });
+  }
 
   public static useSceneUpdate(input: GQL.SceneUpdateInput) {
     return GQL.useSceneUpdate({ variables: input });
@@ -143,6 +146,9 @@ export class StashService {
   }
   public static useStudioUpdate(input: GQL.StudioUpdateInput) {
     return GQL.useStudioUpdate({ variables: input });
+  }
+  public static useStudioDestroy(input: GQL.StudioDestroyInput) {
+    return GQL.useStudioDestroy({ variables: input });
   }
 
   public static useTagCreate(input: GQL.TagCreateInput) {

--- a/ui/v2/src/core/generated-graphql.tsx
+++ b/ui/v2/src/core/generated-graphql.tsx
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-// Generated in 2019-05-27T11:23:10-07:00
+// Generated in 2019-08-14T07:29:27+10:00
 export type Maybe<T> = T | undefined;
 
 export interface SceneFilterType {
@@ -188,6 +188,10 @@ export interface PerformerUpdateInput {
   image?: Maybe<string>;
 }
 
+export interface PerformerDestroyInput {
+  id: string;
+}
+
 export interface StudioCreateInput {
   name: string;
 
@@ -204,6 +208,10 @@ export interface StudioUpdateInput {
   url?: Maybe<string>;
   /** This should be base64 encoded */
   image?: Maybe<string>;
+}
+
+export interface StudioDestroyInput {
+  id: string;
 }
 
 export interface TagCreateInput {
@@ -326,6 +334,16 @@ export type PerformerUpdateMutation = {
 
 export type PerformerUpdatePerformerUpdate = PerformerDataFragment;
 
+export type PerformerDestroyVariables = {
+  id: string;
+};
+
+export type PerformerDestroyMutation = {
+  __typename?: "Mutation";
+
+  performerDestroy: boolean;
+};
+
 export type SceneMarkerCreateVariables = {
   title: string;
   seconds: number;
@@ -418,6 +436,16 @@ export type StudioUpdateMutation = {
 };
 
 export type StudioUpdateStudioUpdate = StudioDataFragment;
+
+export type StudioDestroyVariables = {
+  id: string;
+};
+
+export type StudioDestroyMutation = {
+  __typename?: "Mutation";
+
+  studioDestroy: boolean;
+};
 
 export type TagCreateVariables = {
   name: string;
@@ -1644,6 +1672,22 @@ export function usePerformerUpdate(
     PerformerUpdateVariables
   >(PerformerUpdateDocument, baseOptions);
 }
+export const PerformerDestroyDocument = gql`
+  mutation PerformerDestroy($id: ID!) {
+    performerDestroy(input: { id: $id })
+  }
+`;
+export function usePerformerDestroy(
+  baseOptions?: ReactApolloHooks.MutationHookOptions<
+    PerformerDestroyMutation,
+    PerformerDestroyVariables
+  >
+) {
+  return ReactApolloHooks.useMutation<
+    PerformerDestroyMutation,
+    PerformerDestroyVariables
+  >(PerformerDestroyDocument, baseOptions);
+}
 export const SceneMarkerCreateDocument = gql`
   mutation SceneMarkerCreate(
     $title: String!
@@ -1813,6 +1857,22 @@ export function useStudioUpdate(
     StudioUpdateMutation,
     StudioUpdateVariables
   >(StudioUpdateDocument, baseOptions);
+}
+export const StudioDestroyDocument = gql`
+  mutation StudioDestroy($id: ID!) {
+    studioDestroy(input: { id: $id })
+  }
+`;
+export function useStudioDestroy(
+  baseOptions?: ReactApolloHooks.MutationHookOptions<
+    StudioDestroyMutation,
+    StudioDestroyVariables
+  >
+) {
+  return ReactApolloHooks.useMutation<
+    StudioDestroyMutation,
+    StudioDestroyVariables
+  >(StudioDestroyDocument, baseOptions);
 }
 export const TagCreateDocument = gql`
   mutation TagCreate($name: String!) {


### PR DESCRIPTION
Partially resolves #8 

Adds a button to the performers and studios details pages to delete them.

Deleting a performer removes references to that performer from scenes.
Deleting a studio removes references to that studio from scenes and scraped items.
Delete button redirects to the performers/studios page once successful.