### PR TITLE
Set title, details and date from scene file metadata

### DIFF
--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +29,8 @@ type VideoFile struct {
 	VideoStream *FFProbeStream
 
 	Path         string
+	Title        string
+	Comment      string
 	Container    string
 	Duration     float64
 	StartTime    float64
@@ -82,6 +85,14 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 	//} // TODO nil_or_unsupported.(video_stream) && nil_or_unsupported.(audio_stream)
 
 	result.Path = filePath
+	result.Title = probeJSON.Format.Tags.Title
+
+	if result.Title == "" {
+		// default title to filename
+		result.Title = filepath.Base(result.Path)
+	}
+
+	result.Comment = probeJSON.Format.Tags.Comment
 
 	result.Bitrate, _ = strconv.ParseInt(probeJSON.Format.BitRate, 10, 64)
 	result.Container = probeJSON.Format.FormatName

--- a/pkg/ffmpeg/types.go
+++ b/pkg/ffmpeg/types.go
@@ -22,6 +22,8 @@ type FFProbeJSON struct {
 			Encoder          string          `json:"encoder"`
 			MajorBrand       string          `json:"major_brand"`
 			MinorVersion     string          `json:"minor_version"`
+			Title            string          `json:"title"`
+			Comment          string          `json:"comment"`
 		} `json:"tags"`
 	} `json:"format"`
 	Streams []FFProbeStream `json:"streams"`

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -1,13 +1,14 @@
 package manager
 
 import (
+	"path/filepath"
+	"sync"
+
 	"github.com/bmatcuk/doublestar"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"path/filepath"
-	"sync"
 )
 
 func (s *singleton) Scan() {
@@ -34,6 +35,8 @@ func (s *singleton) Scan() {
 			go task.Start(&wg)
 			wg.Wait()
 		}
+
+		logger.Info("Finished scan")
 	}()
 }
 

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -3,15 +3,16 @@ package manager
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"path/filepath"
-	"strconv"
-	"sync"
-	"time"
 )
 
 type ScanTask struct {
@@ -104,6 +105,9 @@ func (t *ScanTask) scanScene() {
 		newScene := models.Scene{
 			Checksum:   checksum,
 			Path:       t.FilePath,
+			Title:      sql.NullString{String: videoFile.Title, Valid: true},
+			Details:    sql.NullString{String: videoFile.Comment, Valid: true},
+			Date:       models.SQLiteDate{String: videoFile.CreationTime.Format("2006-01-02")},
 			Duration:   sql.NullFloat64{Float64: videoFile.Duration, Valid: true},
 			VideoCodec: sql.NullString{String: videoFile.VideoCodec, Valid: true},
 			AudioCodec: sql.NullString{String: videoFile.AudioCodec, Valid: true},


### PR DESCRIPTION
During scan, sets the title of a scene from the title field in the files metadata, or defaults to the file's base name (instead of being an empty string currently). Sets the date to the creation date in the metadata. Sets the Details field from the Comment field in the file's metadata.

Within Windows, I was also able to set the rating and tags fields in an mp4 file, but wasn't able to extract this information out again using ffprobe.
