### PR TITLE
Make tags editing more obvious

### DIFF
--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -182,9 +182,14 @@ span.block {
 
   & .tag-list-row {
     margin: 10px;
+    cursor: pointer;
 
     & .bp3-button {
       margin: 0 10px;
     }
+  }
+
+  & .tag-list-row:hover {
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
Resolves #104 

CSS change to make cursor a pointer for the tag list rows, and to show an underline when hovered.