### PR TITLE
Install ca-certificates in Docker container

### DIFF
--- a/docker/production/x86_64/Dockerfile
+++ b/docker/production/x86_64/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:18.04 as prep
 LABEL MAINTAINER="leopere [at] nixc [dot] us"
 
 RUN apt-get update && \
-    apt-get -y install curl xz-utils ca-certificates -y && \
-    update-ca-certificates && \
+    apt-get -y install curl xz-utils && \
     apt-get autoclean -y && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /
@@ -16,7 +15,9 @@ RUN curl -L -o /stash $(curl -s https://api.github.com/repos/stashapp/stash/rele
     mv /ffmpeg*/ /ffmpeg/
 
 FROM ubuntu:18.04 as app
-RUN adduser stash --gecos GECOS --shell /bin/bash --disabled-password --home /home/stash
+RUN apt-get update && \
+    apt-get -y install ca-certificates && \
+    adduser stash --gecos GECOS --shell /bin/bash --disabled-password --home /home/stash
 COPY --from=prep /stash /ffmpeg/ffmpeg /ffmpeg/ffprobe /usr/bin/
 EXPOSE 9999
 CMD ["stash"]


### PR DESCRIPTION
I believe this was accidentally added to the wrong build stage in https://github.com/stashapp/stash/commit/30a2a2cf0035ac2113afbbe69db8bfc81abee069. The package is not needed during the build process, but for the final container. Without the `ca-certificates` package, Stash will crash and return the following error message when the scrape feature is used:

```
FATA[0024] Get https://www.freeones.com/suggestions.php?q=&t=1: x509: certificate signed by unknown authority
```

This fixes https://github.com/stashapp/stash/issues/61 (this time for real).