### PR TITLE
Fix scheme detection when reverse proxy is used

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -222,7 +222,7 @@ func BaseURLMiddleware(next http.Handler) http.Handler {
 		ctx := r.Context()
 
 		var scheme string
-		if strings.Compare("https", r.URL.Scheme) == 0 || r.Proto == "HTTP/2.0" {
+		if strings.Compare("https", r.URL.Scheme) == 0 || r.Proto == "HTTP/2.0" || r.Header.Get("X-Forwarded-Proto") == "https" {
 			scheme = "https"
 		} else {
 			scheme = "http"


### PR DESCRIPTION
This fixes a problem where Stash would try to use http instead of https when run behind a reverse proxy like nginx. Some reverse proxy's may need manual configuration of the header (e.g. nginx), and some set the header by default (e.g. Traefik, or Synology's Application Portal feature (which internally uses nginx too)).

Just for the sake of completeness and documentation, these are the headers you usually want to set in a reverse proxy, because many applications will rely on them. As said, some reverse proxy's set them by default, but nginx doesn't:

```nginx
location / {
    proxy_pass http://127.0.0.1:9999;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $remote_addr;
    proxy_set_header X-Forwarded-Port $server_port;
    proxy_set_header X-Forwarded-Proto $scheme;
}
```