### PR TITLE
Make title from file metadata optional

### DIFF
--- a/graphql/documents/queries/settings/metadata.graphql
+++ b/graphql/documents/queries/settings/metadata.graphql
@@ -6,8 +6,8 @@ query MetadataExport {
   metadataExport
 }
 
-query MetadataScan {
-  metadataScan
+query MetadataScan($input: ScanMetadataInput!) {
+  metadataScan(input: $input)
 }
 
 query MetadataGenerate($input: GenerateMetadataInput!) {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -57,7 +57,7 @@ type Query {
   """Start an export. Returns the job ID"""
   metadataExport: String!
   """Start a scan. Returns the job ID"""
-  metadataScan: String!
+  metadataScan(input: ScanMetadataInput!): String!
   """Start generating content. Returns the job ID"""
   metadataGenerate(input: GenerateMetadataInput!): String!
   """Clean metadata. Returns the job ID"""

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -4,3 +4,7 @@ input GenerateMetadataInput {
   markers: Boolean!
   transcodes: Boolean!
 }
+
+input ScanMetadataInput {
+  nameFromMetadata: Boolean!
+}

--- a/pkg/api/resolver_query_metadata.go
+++ b/pkg/api/resolver_query_metadata.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"context"
+
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func (r *queryResolver) MetadataScan(ctx context.Context) (string, error) {
-	manager.GetInstance().Scan()
+func (r *queryResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
+	manager.GetInstance().Scan(input.NameFromMetadata)
 	return "todo", nil
 }
 

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -89,7 +89,7 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 
 	if result.Title == "" {
 		// default title to filename
-		result.Title = filepath.Base(result.Path)
+		result.SetTitleFromPath()
 	}
 
 	result.Comment = probeJSON.Format.Tags.Comment
@@ -160,4 +160,8 @@ func (v *VideoFile) getStreamIndex(fileType string, probeJSON FFProbeJSON) int {
 	}
 
 	return -1
+}
+
+func (v *VideoFile) SetTitleFromPath() {
+	v.Title = filepath.Base(v.Path)
 }

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stashapp/stash/pkg/utils"
 )
 
-func (s *singleton) Scan() {
+func (s *singleton) Scan(nameFromMetadata bool) {
 	if s.Status != Idle {
 		return
 	}
@@ -31,7 +31,7 @@ func (s *singleton) Scan() {
 		var wg sync.WaitGroup
 		for _, path := range results {
 			wg.Add(1)
-			task := ScanTask{FilePath: path}
+			task := ScanTask{FilePath: path, NameFromMetadata: nameFromMetadata}
 			go task.Start(&wg)
 			wg.Wait()
 		}

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -16,7 +16,8 @@ import (
 )
 
 type ScanTask struct {
-	FilePath string
+	FilePath         string
+	NameFromMetadata bool
 }
 
 func (t *ScanTask) Start(wg *sync.WaitGroup) {
@@ -88,6 +89,11 @@ func (t *ScanTask) scanScene() {
 	if err != nil {
 		logger.Error(err.Error())
 		return
+	}
+
+	// Override title to be filename if nameFromMetadata is false
+	if !t.NameFromMetadata {
+		videoFile.SetTitleFromPath()
 	}
 
 	checksum, err := t.calculateChecksum()

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -175,7 +175,7 @@ type ComplexityRoot struct {
 		MetadataExport              func(childComplexity int) int
 		MetadataGenerate            func(childComplexity int, input GenerateMetadataInput) int
 		MetadataImport              func(childComplexity int) int
-		MetadataScan                func(childComplexity int) int
+		MetadataScan                func(childComplexity int, input ScanMetadataInput) int
 		SceneMarkerTags             func(childComplexity int, sceneID string) int
 		SceneWall                   func(childComplexity int, q *string) int
 		ScrapeFreeones              func(childComplexity int, performerName string) int
@@ -351,7 +351,7 @@ type QueryResolver interface {
 	Directories(ctx context.Context, path *string) ([]string, error)
 	MetadataImport(ctx context.Context) (string, error)
 	MetadataExport(ctx context.Context) (string, error)
-	MetadataScan(ctx context.Context) (string, error)
+	MetadataScan(ctx context.Context, input ScanMetadataInput) (string, error)
 	MetadataGenerate(ctx context.Context, input GenerateMetadataInput) (string, error)
 	MetadataClean(ctx context.Context) (string, error)
 	AllPerformers(ctx context.Context) ([]*Performer, error)
@@ -1156,7 +1156,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Query.MetadataScan(childComplexity), true
+		args, err := ec.field_Query_metadataScan_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.MetadataScan(childComplexity, args["input"].(ScanMetadataInput)), true
 
 	case "Query.sceneMarkerTags":
 		if e.complexity.Query.SceneMarkerTags == nil {
@@ -1887,7 +1892,7 @@ type Query {
   """Start an export. Returns the job ID"""
   metadataExport: String!
   """Start a scan. Returns the job ID"""
-  metadataScan: String!
+  metadataScan(input: ScanMetadataInput!): String!
   """Start generating content. Returns the job ID"""
   metadataGenerate(input: GenerateMetadataInput!): String!
   """Clean metadata. Returns the job ID"""
@@ -2070,6 +2075,10 @@ type FindGalleriesResultType {
   previews: Boolean!
   markers: Boolean!
   transcodes: Boolean!
+}
+
+input ScanMetadataInput {
+  nameFromMetadata: Boolean!
 }`},
 	&ast.Source{Name: "graphql/schema/types/performer.graphql", Input: `type Performer {
   id: ID!
@@ -2795,6 +2804,20 @@ func (ec *executionContext) field_Query_metadataGenerate_args(ctx context.Contex
 	var arg0 GenerateMetadataInput
 	if tmp, ok := rawArgs["input"]; ok {
 		arg0, err = ec.unmarshalNGenerateMetadataInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐGenerateMetadataInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_metadataScan_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 ScanMetadataInput
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNScanMetadataInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐScanMetadataInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -5357,10 +5380,17 @@ func (ec *executionContext) _Query_metadataScan(ctx context.Context, field graph
 		IsMethod: true,
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_metadataScan_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().MetadataScan(rctx)
+		return ec.resolvers.Query().MetadataScan(rctx, args["input"].(ScanMetadataInput))
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {
@@ -8623,6 +8653,24 @@ func (ec *executionContext) unmarshalInputPerformerUpdateInput(ctx context.Conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputScanMetadataInput(ctx context.Context, v interface{}) (ScanMetadataInput, error) {
+	var it ScanMetadataInput
+	var asMap = v.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "nameFromMetadata":
+			var err error
+			it.NameFromMetadata, err = ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputSceneFilterType(ctx context.Context, v interface{}) (SceneFilterType, error) {
 	var it SceneFilterType
 	var asMap = v.(map[string]interface{})
@@ -11452,6 +11500,10 @@ func (ec *executionContext) unmarshalNPerformerDestroyInput2githubᚗcomᚋstash
 
 func (ec *executionContext) unmarshalNPerformerUpdateInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐPerformerUpdateInput(ctx context.Context, v interface{}) (PerformerUpdateInput, error) {
 	return ec.unmarshalInputPerformerUpdateInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNScanMetadataInput2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐScanMetadataInput(ctx context.Context, v interface{}) (ScanMetadataInput, error) {
+	return ec.unmarshalInputScanMetadataInput(ctx, v)
 }
 
 func (ec *executionContext) marshalNScene2githubᚗcomᚋstashappᚋstashᚋpkgᚋmodelsᚐScene(ctx context.Context, sel ast.SelectionSet, v Scene) graphql.Marshaler {

--- a/pkg/models/generated_models.go
+++ b/pkg/models/generated_models.go
@@ -153,6 +153,10 @@ type PerformerUpdateInput struct {
 	Image *string `json:"image"`
 }
 
+type ScanMetadataInput struct {
+	NameFromMetadata bool `json:"nameFromMetadata"`
+}
+
 type SceneFileType struct {
 	Size       *string  `json:"size"`
 	Duration   *float64 `json:"duration"`

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -1,13 +1,10 @@
 import {
   Alert,
   Button,
+  Checkbox,
   Divider,
   FormGroup,
-  H1,
   H4,
-  H6,
-  InputGroup,
-  Tag,
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useState } from "react";
 import * as GQL from "../../../core/generated-graphql";
@@ -21,6 +18,7 @@ interface IProps {}
 
 export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => {
   const [isImportAlertOpen, setIsImportAlertOpen] = useState<boolean>(false);
+  const [nameFromMetadata, setNameFromMetadata] = useState<boolean>(true);
 
   function onImport() {
     setIsImportAlertOpen(false);
@@ -48,7 +46,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   async function onScan() {
     try {
-      await StashService.queryMetadataScan();
+      await StashService.queryMetadataScan({nameFromMetadata});
       ToastUtils.success("Started scan");
     } catch (e) {
       ErrorUtils.handle(e);
@@ -65,6 +63,11 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         labelFor="scan"
         inline={true}
       >
+        <Checkbox
+          checked={nameFromMetadata}
+          label="Set name from metadata (if present)"
+          onChange={() => setNameFromMetadata(!nameFromMetadata)}
+        />
         <Button id="scan" text="Scan" onClick={() => onScan()} />
       </FormGroup>
       <Divider />

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -175,9 +175,10 @@ export class StashService {
     });
   }
 
-  public static queryMetadataScan() {
+  public static queryMetadataScan(input: GQL.ScanMetadataInput) {
     return StashService.client.query<GQL.MetadataScanQuery>({
       query: GQL.MetadataScanDocument,
+      variables: { input },
       fetchPolicy: "network-only",
     });
   }

--- a/ui/v2/src/core/generated-graphql.tsx
+++ b/ui/v2/src/core/generated-graphql.tsx
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-// Generated in 2019-08-23T07:28:41+10:00
+// Generated in 2019-10-12T18:20:41+11:00
 export type Maybe<T> = T | undefined;
 
 export interface SceneFilterType {
@@ -52,6 +52,10 @@ export interface SceneMarkerFilterType {
 export interface PerformerFilterType {
   /** Filter by favorite */
   filter_favorites?: Maybe<boolean>;
+}
+
+export interface ScanMetadataInput {
+  nameFromMetadata: boolean;
 }
 
 export interface GenerateMetadataInput {
@@ -875,7 +879,9 @@ export type MetadataExportQuery = {
   metadataExport: string;
 };
 
-export type MetadataScanVariables = {};
+export type MetadataScanVariables = {
+  input: ScanMetadataInput;
+};
 
 export type MetadataScanQuery = {
   __typename?: "Query";
@@ -2425,8 +2431,8 @@ export function useMetadataExport(
   >(MetadataExportDocument, baseOptions);
 }
 export const MetadataScanDocument = gql`
-  query MetadataScan {
-    metadataScan
+  query MetadataScan($input: ScanMetadataInput!) {
+    metadataScan(input: $input)
   }
 `;
 export function useMetadataScan(


### PR DESCRIPTION
Amendment to #103 

The issue with the original PR is that most file releases that have the Title metadata set are garbage. As a result, I have a bunch of files with garbage titles, where the filename would have been a far more useful title. 

This change adds an option checkbox to the scan button to optionally ignore the metadata in the file and default the title to the base filename. 