### PR TITLE
Reset to first page when changing sort by

### DIFF
--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -112,6 +112,7 @@ export class ListHook {
     function onChangeSortBy(sortBy: string) {
       const newFilter = _.cloneDeep(filter);
       newFilter.sortBy = sortBy;
+      newFilter.currentPage = 1;
       setFilter(newFilter);
     }
 


### PR DESCRIPTION
Addresses #122 

Very simple fix to reset the query to the first page when changing the sort by field. It does seem not intuitive to stay on the same page number when changing the sort by field. I wasn't sure about resetting the page when changing the sort direction (it currently does not), so I left it as is.