### PR TITLE
Add query options for tags, performers, studios #29

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -28,11 +28,11 @@ input SceneMarkerFilterType {
   """Filter to only include scene markers with this tag"""
   tag_id: ID
   """Filter to only include scene markers with these tags"""
-  tags: [ID!]
+  tags: MultiCriterionInput
   """Filter to only include scene markers attached to a scene with these tags"""
-  scene_tags: [ID!]
+  scene_tags: MultiCriterionInput
   """Filter to only include scene markers with these performers"""
-  performers: [ID!]
+  performers: MultiCriterionInput
 }
 
 input SceneFilterType {

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -45,11 +45,11 @@ input SceneFilterType {
   """Filter to only include scenes missing this property"""
   is_missing: String
   """Filter to only include scenes with this studio"""
-  studio_id: ID
+  studios: MultiCriterionInput
   """Filter to only include scenes with these tags"""
-  tags: [ID!]
-  """Filter to only include scenes with this performer"""
-  performer_id: ID
+  tags: MultiCriterionInput
+  """Filter to only include scenes with these performers"""
+  performers: MultiCriterionInput
 }
 
 enum CriterionModifier {
@@ -65,11 +65,18 @@ enum CriterionModifier {
   IS_NULL,
   """IS NOT NULL"""
   NOT_NULL,
+  """INCLUDES ALL"""
+  INCLUDES_ALL,
   INCLUDES,
   EXCLUDES,
 }
 
 input IntCriterionInput {
   value: Int!
+  modifier: CriterionModifier!
+}
+
+input MultiCriterionInput {
+  value: [ID!]
   modifier: CriterionModifier!
 }

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
+	"github.com/stashapp/stash/pkg/logger"
 )
 
 const scenesForPerformerQuery = `
@@ -218,24 +219,37 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		}
 	}
 
-	if tagsFilter := sceneFilter.Tags; len(tagsFilter) > 0 {
-		for _, tagID := range tagsFilter {
+	if tagsFilter := sceneFilter.Tags; tagsFilter != nil && len(tagsFilter.Value) > 0 {
+		for _, tagID := range tagsFilter.Value {
 			args = append(args, tagID)
 		}
 
-		whereClauses = append(whereClauses, "tags.id IN "+getInBinding(len(tagsFilter)))
-		havingClauses = append(havingClauses, "count(distinct tags.id) IS "+strconv.Itoa(len(tagsFilter)))
+		whereClause, havingClause := getMultiCriterionClause("tags", "scenes_tags", "tag_id", tagsFilter)
+		whereClauses = appendClause(whereClauses, whereClause)
+		havingClauses = appendClause(havingClauses, havingClause)
 	}
 
-	if performerID := sceneFilter.PerformerID; performerID != nil {
-		whereClauses = append(whereClauses, "performers.id = ?")
-		args = append(args, *performerID)
+	if performersFilter := sceneFilter.Performers; performersFilter != nil && len(performersFilter.Value) > 0 {
+		for _, performerID := range performersFilter.Value {
+			args = append(args, performerID)
+		}
+
+		whereClause, havingClause := getMultiCriterionClause("performers", "performers_scenes", "performer_id", performersFilter)
+		whereClauses = appendClause(whereClauses, whereClause)
+		havingClauses = appendClause(havingClauses, havingClause)
 	}
 
-	if studioID := sceneFilter.StudioID; studioID != nil {
-		whereClauses = append(whereClauses, "studio.id = ?")
-		args = append(args, *studioID)
+	if studiosFilter := sceneFilter.Studios; studiosFilter != nil && len(studiosFilter.Value) > 0 {
+		for _, studioID := range studiosFilter.Value {
+			args = append(args, studioID)
+		}
+		
+		whereClause, havingClause := getMultiCriterionClause("studio", "", "studio_id", studiosFilter)
+		whereClauses = appendClause(whereClauses, whereClause)
+		havingClauses = appendClause(havingClauses, havingClause)
 	}
+
+	logger.Infof("where %v", whereClauses)
 
 	sortAndPagination := qb.getSceneSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult := executeFindQuery("scenes", body, args, sortAndPagination, whereClauses, havingClauses)
@@ -247,6 +261,37 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 	}
 
 	return scenes, countResult
+}
+
+func appendClause(clauses []string, clause string) []string {
+	if clause != "" {
+		return append(clauses, clause)
+	}
+
+	return clauses
+}
+
+// returns where clause and having clause
+func getMultiCriterionClause(table string, joinTable string, joinTableField string, criterion *MultiCriterionInput) (string, string) {
+	whereClause := ""
+	havingClause := ""
+	if criterion.Modifier == CriterionModifierIncludes {
+		// includes any of the provided ids
+		whereClause = table + ".id IN "+ getInBinding(len(criterion.Value))
+	} else if criterion.Modifier == CriterionModifierIncludesAll {
+		// includes all of the provided ids
+		whereClause = table + ".id IN "+ getInBinding(len(criterion.Value))
+		havingClause = "count(distinct " + table + ".id) IS " + strconv.Itoa(len(criterion.Value))
+	} else if criterion.Modifier == CriterionModifierExcludes {
+		// excludes all of the provided ids
+		if (joinTable != "") {
+			whereClause = "not exists (select " + joinTable + ".scene_id from " + joinTable + " where " + joinTable + ".scene_id = scenes.id and " + joinTable + "." + joinTableField + " in " + getInBinding(len(criterion.Value)) + ")"
+		} else {
+			whereClause = "not exists (select s.id from scenes as s where s.id = scenes.id and s." + joinTableField + " in " + getInBinding(len(criterion.Value)) + ")"
+		}
+	}
+
+	return whereClause, havingClause
 }
 
 func (qb *SceneQueryBuilder) getSceneSort(findFilter *FindFilterType) string {

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
-	"github.com/stashapp/stash/pkg/logger"
 )
 
 const scenesForPerformerQuery = `
@@ -248,8 +247,6 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		whereClauses = appendClause(whereClauses, whereClause)
 		havingClauses = appendClause(havingClauses, havingClause)
 	}
-
-	logger.Infof("where %v", whereClauses)
 
 	sortAndPagination := qb.getSceneSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult := executeFindQuery("scenes", body, args, sortAndPagination, whereClauses, havingClauses)

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -85,7 +85,7 @@ func getSort(sort string, direction string, tableName string) string {
 		if tableName == "scenes" {
 			additional = ", bitrate DESC, framerate DESC, rating DESC, duration DESC"
 		} else if tableName == "scene_markers" {
-			additional = ", scene_id ASC, seconds ASC"
+			additional = ", scene_markers.scene_id ASC, scene_markers.seconds ASC"
 		}
 		return " ORDER BY " + colName + " " + direction + additional
 	}
@@ -204,9 +204,11 @@ func executeFindQuery(tableName string, body string, args []interface{}, sortAnd
 	idsResult, idsErr := runIdsQuery(idsQuery, args)
 
 	if countErr != nil {
+		logger.Errorf("Error executing count query with SQL: %s, args: %v, error: %s", countQuery, args, countErr.Error())
 		panic(countErr)
 	}
 	if idsErr != nil {
+		logger.Errorf("Error executing find query with SQL: %s, args: %v, error: %s", idsQuery, args, idsErr.Error())
 		panic(idsErr)
 	}
 

--- a/ui/v2/src/components/Stats.tsx
+++ b/ui/v2/src/components/Stats.tsx
@@ -53,9 +53,6 @@ export const Stats: FunctionComponent = () => {
       <pre>
         {`
         This is still an early version, some things are still a work in progress.
-
-        * Filters for performers and studios only supports one item, even though it's a multi select.
-
         `}
       </pre>
     </div>

--- a/ui/v2/src/components/list/AddFilter.tsx
+++ b/ui/v2/src/components/list/AddFilter.tsx
@@ -130,10 +130,14 @@ export const AddFilter: FunctionComponent<IAddFilterProps> = (props: IAddFilterP
       }
     }
     return (
-      <FormGroup>
-        {renderModifier()}
-        {renderSelect()}
-      </FormGroup>
+      <>
+        <FormGroup>
+          {renderModifier()}
+        </FormGroup>
+        <FormGroup>
+          {renderSelect()}
+        </FormGroup>
+      </>
     );
   };
 

--- a/ui/v2/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2/src/models/list-filter/criteria/criterion.ts
@@ -38,6 +38,7 @@ export abstract class Criterion<Option = any, Value = any> {
       case CriterionModifier.LessThan: return {value: CriterionModifier.LessThan, label: "Less Than"};
       case CriterionModifier.IsNull: return {value: CriterionModifier.IsNull, label: "Is NULL"};
       case CriterionModifier.NotNull: return {value: CriterionModifier.NotNull, label: "Not NULL"};
+      case CriterionModifier.IncludesAll: return {value: CriterionModifier.IncludesAll, label: "Includes All"};
       case CriterionModifier.Includes: return {value: CriterionModifier.Includes, label: "Includes"};
       case CriterionModifier.Excludes: return {value: CriterionModifier.Excludes, label: "Excludes"};
     }
@@ -60,7 +61,8 @@ export abstract class Criterion<Option = any, Value = any> {
       case CriterionModifier.IsNull: modifierString = "is null"; break;
       case CriterionModifier.NotNull: modifierString = "is not null"; break;
       case CriterionModifier.Includes: modifierString = "includes"; break;
-      case CriterionModifier.Excludes: modifierString = "exculdes"; break;
+      case CriterionModifier.IncludesAll: modifierString = "includes all"; break;
+      case CriterionModifier.Excludes: modifierString = "excludes"; break;
       default: modifierString = "";
     }
 

--- a/ui/v2/src/models/list-filter/criteria/performers.ts
+++ b/ui/v2/src/models/list-filter/criteria/performers.ts
@@ -15,8 +15,12 @@ interface IOptionType {
 export class PerformersCriterion extends Criterion<IOptionType, ILabeledId[]> {
   public type: CriterionType = "performers";
   public parameterName: string = "performers";
-  public modifier = CriterionModifier.Equals;
-  public modifierOptions = [];
+  public modifier = CriterionModifier.IncludesAll;
+  public modifierOptions = [
+    Criterion.getModifierOption(CriterionModifier.IncludesAll),
+    Criterion.getModifierOption(CriterionModifier.Includes),
+    Criterion.getModifierOption(CriterionModifier.Excludes),
+  ];
   public options: IOptionType[] = [];
   public value: ILabeledId[] = [];
 }

--- a/ui/v2/src/models/list-filter/criteria/studios.ts
+++ b/ui/v2/src/models/list-filter/criteria/studios.ts
@@ -15,8 +15,11 @@ interface IOptionType {
 export class StudiosCriterion extends Criterion<IOptionType, ILabeledId[]> {
   public type: CriterionType = "studios";
   public parameterName: string = "studios";
-  public modifier = CriterionModifier.Equals;
-  public modifierOptions = [];
+  public modifier = CriterionModifier.Includes;
+  public modifierOptions = [
+    Criterion.getModifierOption(CriterionModifier.Includes),
+    Criterion.getModifierOption(CriterionModifier.Excludes),
+  ];
   public options: IOptionType[] = [];
   public value: ILabeledId[] = [];
 }

--- a/ui/v2/src/models/list-filter/criteria/tags.ts
+++ b/ui/v2/src/models/list-filter/criteria/tags.ts
@@ -10,8 +10,12 @@ import {
 export class TagsCriterion extends Criterion<GQL.AllTagsForFilterAllTags, ILabeledId[]> {
   public type: CriterionType;
   public parameterName: string;
-  public modifier = CriterionModifier.Equals;
-  public modifierOptions = [];
+  public modifier = CriterionModifier.IncludesAll;
+  public modifierOptions = [
+    Criterion.getModifierOption(CriterionModifier.IncludesAll),
+    Criterion.getModifierOption(CriterionModifier.Includes),
+    Criterion.getModifierOption(CriterionModifier.Excludes),
+  ];
   public options: GQL.AllTagsForFilterAllTags[] = [];
   public value: ILabeledId[] = [];
 

--- a/ui/v2/src/models/list-filter/filter.ts
+++ b/ui/v2/src/models/list-filter/filter.ts
@@ -255,13 +255,16 @@ export class ListFilterModel {
     this.criteria.forEach((criterion) => {
       switch (criterion.type) {
         case "tags":
-          result.tags = (criterion as TagsCriterion).value.map((tag) => tag.id);
+          const tagsCrit = criterion as TagsCriterion;
+          result.tags = { value: tagsCrit.value.map((tag) => tag.id), modifier: tagsCrit.modifier };
           break;
         case "sceneTags":
-          result.scene_tags = (criterion as TagsCriterion).value.map((tag) => tag.id);
+          const sceneTagsCrit = criterion as TagsCriterion;
+          result.scene_tags = { value: sceneTagsCrit.value.map((tag) => tag.id), modifier: sceneTagsCrit.modifier };
           break;
         case "performers":
-          result.performers = (criterion as PerformersCriterion).value.map((performer) => performer.id);
+          const performersCrit = criterion as PerformersCriterion;
+          result.performers = { value: performersCrit.value.map((performer) => performer.id), modifier: performersCrit.modifier };
           break;
       }
     });

--- a/ui/v2/src/models/list-filter/filter.ts
+++ b/ui/v2/src/models/list-filter/filter.ts
@@ -202,8 +202,8 @@ export class ListFilterModel {
     this.criteria.forEach((criterion) => {
       switch (criterion.type) {
         case "rating":
-          const crit = criterion as RatingCriterion;
-          result.rating = { value: crit.value, modifier: crit.modifier };
+          const ratingCrit = criterion as RatingCriterion;
+          result.rating = { value: ratingCrit.value, modifier: ratingCrit.modifier };
           break;
         case "resolution": {
           switch ((criterion as ResolutionCriterion).value) {
@@ -222,13 +222,16 @@ export class ListFilterModel {
           result.is_missing = (criterion as IsMissingCriterion).value;
           break;
         case "tags":
-          result.tags = (criterion as TagsCriterion).value.map((tag) => tag.id);
+          const tagsCrit = criterion as TagsCriterion;
+          result.tags = { value: tagsCrit.value.map((tag) => tag.id), modifier: tagsCrit.modifier };
           break;
         case "performers":
-          result.performer_id = (criterion as PerformersCriterion).value[0].id; // TODO: Allow multiple
+          const perfCrit = criterion as PerformersCriterion;
+          result.performers = { value: perfCrit.value.map((perf) => perf.id), modifier: perfCrit.modifier };
           break;
         case "studios":
-          result.studio_id = (criterion as StudiosCriterion).value[0].id; // TODO: Allow multiple
+          const studCrit = criterion as StudiosCriterion;
+          result.studios = { value: studCrit.value.map((studio) => studio.id), modifier: studCrit.modifier };
           break;
       }
     });


### PR DESCRIPTION
Adds includes/excludes options for studios, and includes/includes all/excludes options for tags and performers. Resolves #29 

Includes returns scenes that include any of the values entered. (ie includes `[A,B]` returns scenes such as `[A,B], [A], [A,C], [B,C]`)
Includes all returns scenes that include all of the values entered (ie includes all `[A,B]` returns only scenes with this subset: `[A,B], [A,B,C]`, not `[A], [B,C]` and so on.
Excludes returns scenes that do not have any of the values entered (ie excludes `[A, B]` returns scenes with `[], [C],...` and not `[A], [A,B], [B], [B,C]` and so on.

I hope this wording is clear and usable enough.