### PR TITLE
Remove packr2 go:generate from main #153

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,4 @@
 //go:generate go run github.com/99designs/gqlgen
-//go:generate go run github.com/gobuffalo/packr/v2/packr2
 package main
 
 import (


### PR DESCRIPTION
Fixes #153

Removes the go:generate line for packr2 from main.go. `packr2` should be run after the UI is built, which occurs later in the build lifecycle.