### PR TITLE
Use wss if origin uses https

### DIFF
--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -23,8 +23,11 @@ export class StashService {
 
       if (process.env.REACT_APP_HTTPS === "true") {
         platformUrl.protocol = "https:";
-        wsPlatformUrl.protocol = "wss:";
       }
+    }
+
+    if (platformUrl.protocol === "https:") {
+      wsPlatformUrl.protocol = "wss:";
     }
     const url = platformUrl.toString().slice(0, -1) + "/graphql";
     const wsUrl = wsPlatformUrl.toString().slice(0, -1) + "/graphql";


### PR DESCRIPTION
Fixes #160 (hopefully)

Sets (always) the protocol for the websocket connection to wss if the origin connection protocol is https.  I don't have https set up to test this.