### PR TITLE
Scene filename to metadata parser

### DIFF
--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -54,6 +54,12 @@ mutation BulkSceneUpdate(
   }
 }
 
+mutation ScenesUpdate($input : [SceneUpdateInput!]!) {
+  scenesUpdate(input: $input) {
+    ...SceneData
+  }
+}
+
 mutation SceneDestroy($id: ID!, $delete_file: Boolean, $delete_generated : Boolean) {
   sceneDestroy(input: {id: $id, delete_file: $delete_file, delete_generated: $delete_generated})
 }

--- a/graphql/documents/queries/scene.graphql
+++ b/graphql/documents/queries/scene.graphql
@@ -7,8 +7,8 @@ query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene
   }
 }
 
-query FindScenesByFilename($filter: FindFilterType) {
-  findScenesByFilename(filter: $filter) {
+query FindScenesByPathRegex($filter: FindFilterType) {
+  findScenesByPathRegex(filter: $filter) {
     count
     scenes {
       ...SlimSceneData

--- a/graphql/documents/queries/scene.graphql
+++ b/graphql/documents/queries/scene.graphql
@@ -7,6 +7,15 @@ query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene
   }
 }
 
+query FindScenesByFilename($filter: FindFilterType) {
+  findScenesByFilename(filter: $filter) {
+    count
+    scenes {
+      ...SlimSceneData
+    }
+  }
+}
+
 query FindScene($id: ID!, $checksum: String) {
   findScene(id: $id, checksum: $checksum) {
     ...SceneData

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -5,6 +5,8 @@ type Query {
   """A function which queries Scene objects"""
   findScenes(scene_filter: SceneFilterType, scene_ids: [Int!], filter: FindFilterType): FindScenesResultType!
 
+  findScenesByFilename(filter: FindFilterType): FindScenesResultType!
+
   """A function which queries SceneMarker objects"""
   findSceneMarkers(scene_marker_filter: SceneMarkerFilterType filter: FindFilterType): FindSceneMarkersResultType!
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -81,6 +81,7 @@ type Mutation {
   sceneUpdate(input: SceneUpdateInput!): Scene
   bulkSceneUpdate(input: BulkSceneUpdateInput!): [Scene!]
   sceneDestroy(input: SceneDestroyInput!): Boolean!
+  scenesUpdate(input: [SceneUpdateInput!]!): [Scene]
 
   sceneMarkerCreate(input: SceneMarkerCreateInput!): SceneMarker
   sceneMarkerUpdate(input: SceneMarkerUpdateInput!): SceneMarker

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -5,7 +5,7 @@ type Query {
   """A function which queries Scene objects"""
   findScenes(scene_filter: SceneFilterType, scene_ids: [Int!], filter: FindFilterType): FindScenesResultType!
 
-  findScenesByFilename(filter: FindFilterType): FindScenesResultType!
+  findScenesByPathRegex(filter: FindFilterType): FindScenesResultType!
 
   """A function which queries SceneMarker objects"""
   findSceneMarkers(scene_marker_filter: SceneMarkerFilterType filter: FindFilterType): FindSceneMarkersResultType!

--- a/pkg/api/resolver_query_find_scene.go
+++ b/pkg/api/resolver_query_find_scene.go
@@ -27,3 +27,12 @@ func (r *queryResolver) FindScenes(ctx context.Context, sceneFilter *models.Scen
 		Scenes: scenes,
 	}, nil
 }
+
+func (r *queryResolver) FindScenesByFilename(ctx context.Context, filter *models.FindFilterType) (*models.FindScenesResultType, error) {
+	qb := models.NewSceneQueryBuilder()
+	scenes, total := qb.QueryByFilename(filter)
+	return &models.FindScenesResultType{
+		Count:  total,
+		Scenes: scenes,
+	}, nil
+}

--- a/pkg/api/resolver_query_find_scene.go
+++ b/pkg/api/resolver_query_find_scene.go
@@ -28,9 +28,10 @@ func (r *queryResolver) FindScenes(ctx context.Context, sceneFilter *models.Scen
 	}, nil
 }
 
-func (r *queryResolver) FindScenesByFilename(ctx context.Context, filter *models.FindFilterType) (*models.FindScenesResultType, error) {
+func (r *queryResolver) FindScenesByPathRegex(ctx context.Context, filter *models.FindFilterType) (*models.FindScenesResultType, error) {
 	qb := models.NewSceneQueryBuilder()
-	scenes, total := qb.QueryByFilename(filter)
+
+	scenes, total := qb.QueryByPathRegex(filter)
 	return &models.FindScenesResultType{
 		Count:  total,
 		Scenes: scenes,

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
-	"github.com/stashapp/stash/pkg/logger"
 )
 
 const scenesForPerformerQuery = `
@@ -292,7 +291,7 @@ func getMultiCriterionClause(table string, joinTable string, joinTableField stri
 	return whereClause, havingClause
 }
 
-func (qb *SceneQueryBuilder) QueryByFilename(findFilter *FindFilterType) ([]*Scene, int) {
+func (qb *SceneQueryBuilder) QueryByPathRegex(findFilter *FindFilterType) ([]*Scene, int) {
 	if findFilter == nil {
 		findFilter = &FindFilterType{}
 	}
@@ -303,17 +302,8 @@ func (qb *SceneQueryBuilder) QueryByFilename(findFilter *FindFilterType) ([]*Sce
 	body := selectDistinctIDs("scenes")
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		// search only by path
-		queryParam := *q
-
-		// replace path wildcard * with %
-		queryParam = strings.ReplaceAll(queryParam, "*", "%")
-
-		whereClauses = append(whereClauses, "scenes.path like '" + queryParam + "'")
+		whereClauses = append(whereClauses, "scenes.path regexp '" + *q + "'")
 	}
-
-	// TODO - remove this
-	logger.Infof("Where: %v", whereClauses)
 
 	sortAndPagination := qb.getSceneSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult := executeFindQuery("scenes", body, args, sortAndPagination, whereClauses, havingClauses)

--- a/ui/v2/src/App.tsx
+++ b/ui/v2/src/App.tsx
@@ -10,6 +10,7 @@ import { Settings } from "./components/Settings/Settings";
 import { Stats } from "./components/Stats";
 import Studios from "./components/Studios/Studios";
 import Tags from "./components/Tags/Tags";
+import { SceneFilenameParser } from "./components/scenes/SceneFilenameParser";
 
 interface IProps {}
 
@@ -27,6 +28,7 @@ export const App: FunctionComponent<IProps> = (props: IProps) => {
           <Route path="/tags" component={Tags} />
           <Route path="/studios" component={Studios} />
           <Route path="/settings" component={Settings} />
+          <Route path="/sceneFilenameParser" component={SceneFilenameParser} />
           <Route component={PageNotFound} />
         </Switch>
       </ErrorBoundary>

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -5,6 +5,7 @@ import {
   Divider,
   FormGroup,
   H4,
+  AnchorButton,
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useState } from "react";
 import { StashService } from "../../../core/StashService";
@@ -94,6 +95,13 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
           onChange={() => setNameFromMetadata(!nameFromMetadata)}
         />
         <Button id="scan" text="Scan" onClick={() => onScan()} />
+      </FormGroup>
+        <AnchorButton
+          href="/sceneFilenameParser"
+          text={"Scene Filename Parser"}
+        />
+      <FormGroup>
+
       </FormGroup>
       <Divider />
 

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -12,6 +12,7 @@ import { StashService } from "../../../core/StashService";
 import { ErrorUtils } from "../../../utils/errors";
 import { ToastUtils } from "../../../utils/toasts";
 import { GenerateButton } from "./GenerateButton";
+import { Link } from "react-router-dom";
 
 interface IProps {}
 
@@ -96,10 +97,9 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         />
         <Button id="scan" text="Scan" onClick={() => onScan()} />
       </FormGroup>
-        <AnchorButton
-          href="/sceneFilenameParser"
-          text={"Scene Filename Parser"}
-        />
+        <Link className="bp3-button" to={"/sceneFilenameParser"}>
+          Scene Filename Parser
+        </Link>
       <FormGroup>
 
       </FormGroup>

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -38,12 +38,6 @@ class ParserResult<T> {
   }
 }
 
-interface IParserField {
-  field : string;
-  fieldRegex: RegExp;
-  regex : string;
-}
-
 class ParserField {
   public field : string;
   public fieldRegex: RegExp;
@@ -172,6 +166,37 @@ class SceneParserResult {
     this.scene = scene;
   }
 
+  public static validateDate(dateStr: string) {
+    var splits = dateStr.split("-");
+    if (splits.length != 3) {
+      return false;
+    }
+    
+    var year = parseInt(splits[0]);
+    var month = parseInt(splits[1]);
+    var d = parseInt(splits[2]);
+
+    var date = new Date();
+    date.setMonth(month - 1);
+    date.setDate(d);
+
+    // assume year must be between 1900 and 2100
+    if (year < 1900 || year > 2100) {
+      return false;
+    }
+
+    if (month < 1 || month > 12) {
+      return false;
+    }
+
+    // not checking individual months to ensure date is in the correct range
+    if (d < 1 || d > 31) {
+      return false;
+    }
+
+    return true;
+  }
+
   private setDate(field: ParserField, value: string) {
     var yearIndex = 0;
     var yearLength = field.field.split("y").length - 1;
@@ -199,8 +224,14 @@ class SceneParserResult {
     var yearValue = value.substring(yearIndex, yearIndex + yearLength);
     var monthValue = value.substring(monthIndex, monthIndex + 2);
     var dateValue = value.substring(dateIndex, dateIndex + 2);
-    this.date.value = yearValue + "-" + monthValue + "-" + dateValue;
-    this.date.set = true;
+
+    var fullDate = yearValue + "-" + monthValue + "-" + dateValue;
+
+    // ensure the date is valid
+    if (SceneParserResult.validateDate(fullDate)) {
+      this.date.value = fullDate
+      this.date.set = true;
+    }
   }
 
   public setField(field: ParserField, value: any) {
@@ -314,7 +345,10 @@ class ParseMapper {
   private postParse(scene: SceneParserResult) {
     // set the date if the components are set
     if (scene.yyyy.set && scene.mm.set && scene.dd.set) {
-      scene.setField(ParserField.Date, scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
+      var fullDate = scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value;
+      if (SceneParserResult.validateDate(fullDate)) {
+        scene.setField(ParserField.Date, scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
+      }
     }
   }
 

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -8,6 +8,10 @@ import {
   HTMLTable,
   Checkbox,
   H5,
+  MenuItem,
+  Tooltip,
+  Popover,
+  HTMLSelect,
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { IBaseProps } from "../../models";
@@ -19,631 +23,812 @@ import _ from "lodash";
 import { ToastUtils } from "../../utils/toasts";
 import { ErrorUtils } from "../../utils/errors";
 import { Pagination } from "../list/Pagination";
+import { Select, ItemRenderer, ItemPredicate } from "@blueprintjs/select";
   
-  interface IProps extends IBaseProps {}
+interface IProps extends IBaseProps {}
 
-  class ParserResult<T> {
-    public value: Maybe<T>;
-    public originalValue: Maybe<T>;
-    public set: boolean = false;
+class ParserResult<T> {
+  public value: Maybe<T>;
+  public originalValue: Maybe<T>;
+  public set: boolean = false;
 
-    public setOriginalValue(v : Maybe<T>) {
-      this.originalValue = v;
-      this.value = v;
+  public setOriginalValue(v : Maybe<T>) {
+    this.originalValue = v;
+    this.value = v;
+  }
+}
+
+interface IParserField {
+  field : string;
+  fieldRegex: RegExp;
+  regex : string;
+}
+
+class ParserField {
+  public field : string;
+  public fieldRegex: RegExp;
+  public regex : string;
+  public helperText? : string;
+
+  constructor(field: string, regex?: string, helperText?: string, captured?: boolean) {
+    if (regex === undefined) {
+      regex = ".*";
+    }
+
+    if (captured === undefined) {
+      captured = true;
+    }
+
+    this.field = field;
+    this.helperText = helperText;
+
+    this.fieldRegex = new RegExp("\\{" + this.field + "\\}", "g");
+
+    var regexStr = regex;
+    if (captured) {
+      regexStr = "(" + regexStr + ")";
+    }
+    this.regex = regexStr;
+  }
+
+  public replaceInPattern(pattern : string) {
+    return pattern.replace(this.fieldRegex, this.regex);
+  }
+
+  public getFieldPattern() {
+    return "{" + this.field + "}";
+  }
+
+  static Title = new ParserField("title");
+  static Ext = new ParserField("ext", ".*$", "File extension", false);
+
+  static I = new ParserField("i", undefined, "Matches any ignored word", false);
+  static D = new ParserField("d", "(?:\\.|-|_)", "Matches any delimiter (.-_)", false);
+
+  // date fields
+  static Date = new ParserField("date", "\\d{4}-\\d{2}-\\d{2}", "YYYY-MM-DD");
+  static YYYY = new ParserField("yyyy", "\\d{4}", "Year");
+  static YY = new ParserField("yy", "\\d{2}", "Year (20YY)");
+  static MM = new ParserField("mm", "\\d{2}", "Two digit month");
+  static DD = new ParserField("dd", "\\d{2}", "Two digit date");
+  static YYYYMMDD = new ParserField("yyyymmdd", "\\d{8}");
+  static YYMMDD = new ParserField("yymmdd", "\\d{6}");
+  static DDMMYYYY = new ParserField("ddmmyyyy", "\\d{8}");
+  static DDMMYY = new ParserField("ddmmyy", "\\d{6}");
+  static MMDDYYYY = new ParserField("mmddyyyy", "\\d{8}");
+  static MMDDYY = new ParserField("mmddyy", "\\d{6}");
+
+  static validFields = [
+    ParserField.Title,
+    ParserField.Ext,
+    ParserField.D,
+    ParserField.I,
+    ParserField.Date,
+    ParserField.YYYY,
+    ParserField.YY,
+    ParserField.MM,
+    ParserField.DD,
+    ParserField.YYYYMMDD,
+    ParserField.YYMMDD,
+    ParserField.DDMMYYYY,
+    ParserField.DDMMYY,
+    ParserField.MMDDYYYY,
+    ParserField.MMDDYY
+  ]
+
+  static fullDateFields = [
+    ParserField.YYYYMMDD,
+    ParserField.YYMMDD,
+    ParserField.DDMMYYYY,
+    ParserField.DDMMYY,
+    ParserField.MMDDYYYY,
+    ParserField.MMDDYY
+  ];
+
+  public static getParserField(field: string) {
+    return ParserField.validFields.find((f) => {
+      return f.field === field;
+    });
+  }
+
+  public static isValidField(field : string) {
+    return !!ParserField.getParserField(field);
+  }
+
+  public static isFullDateField(field : ParserField) {
+    return ParserField.fullDateFields.includes(field);
+  }
+
+  public static replacePatternWithRegex(pattern: string) {
+    ParserField.validFields.forEach((field) => {
+      pattern = field.replaceInPattern(pattern);
+    });
+    return pattern;
+  }
+}
+
+class SceneParserResult {
+  public id: string;
+  public filename: string;
+  public title: ParserResult<string> = new ParserResult();
+  public date: ParserResult<string> = new ParserResult();
+
+  public yyyy : ParserResult<string> = new ParserResult();
+  public mm : ParserResult<string> = new ParserResult();
+  public dd : ParserResult<string> = new ParserResult();
+
+  public studioId: ParserResult<string> = new ParserResult();
+  public tags: ParserResult<string[]> = new ParserResult();
+  public performerIds: ParserResult<string[]> = new ParserResult();
+
+  public scene : SlimSceneDataFragment;
+
+  constructor(scene : SlimSceneDataFragment) {
+    this.id = scene.id;
+    this.filename = TextUtils.fileNameFromPath(scene.path);
+    this.title.setOriginalValue(scene.title);
+    this.date.setOriginalValue(scene.date);
+
+    this.scene = scene;
+  }
+
+  private setDate(field: ParserField, value: string) {
+    var yearIndex = 0;
+    var yearLength = field.field.split("y").length - 1;
+    var dateIndex = 0;
+    var monthIndex = 0;
+
+    switch (field) {
+      case ParserField.YYYYMMDD:
+      case ParserField.YYMMDD:
+        monthIndex = yearLength;
+        dateIndex = monthIndex + 2;
+        break;
+      case ParserField.DDMMYYYY:
+      case ParserField.DDMMYY:
+        monthIndex = 2;
+        yearIndex = monthIndex + 2;
+        break;
+      case ParserField.MMDDYYYY:
+      case ParserField.MMDDYY:
+        dateIndex = monthIndex + 2;
+        yearIndex = dateIndex + 2;
+        break;
+    }
+
+    var yearValue = value.substring(yearIndex, yearIndex + yearLength);
+    var monthValue = value.substring(monthIndex, monthIndex + 2);
+    var dateValue = value.substring(dateIndex, dateIndex + 2);
+    this.date.value = yearValue + "-" + monthValue + "-" + dateValue;
+    this.date.set = true;
+  }
+
+  public setField(field: ParserField, value: any) {
+    var parserResult : ParserResult<any> | undefined = undefined;
+
+    if (ParserField.isFullDateField(field)) {
+      this.setDate(field, value);
+      return;
+    }
+
+    switch (field) {
+      case ParserField.Title:
+        parserResult = this.title;
+        break;
+      case ParserField.Date:
+        parserResult = this.date;
+        break;
+      case ParserField.YYYY:
+        parserResult = this.yyyy;
+        break;
+      case ParserField.YY:
+        parserResult = this.yyyy;
+        value = "20" + value;
+        break;
+      case ParserField.MM:
+        parserResult = this.mm;
+        break;
+      case ParserField.DD:
+        parserResult = this.dd;
+        break;
+    }
+    // TODO - other fields
+
+    if (!!parserResult) {
+      parserResult.value = value;
+      parserResult.set = true;
     }
   }
 
-  class SceneParserResult {
-    public id: string;
-    public filename: string;
-    public title: ParserResult<string> = new ParserResult();
-    public date: ParserResult<string> = new ParserResult();
-
-    public yyyy : ParserResult<string> = new ParserResult();
-    public mm : ParserResult<string> = new ParserResult();
-    public dd : ParserResult<string> = new ParserResult();
-
-    public studioId: ParserResult<string> = new ParserResult();
-    public tags: ParserResult<string[]> = new ParserResult();
-    public performerIds: ParserResult<string[]> = new ParserResult();
-
-    public scene : SlimSceneDataFragment;
-
-    constructor(scene : SlimSceneDataFragment) {
-      this.id = scene.id;
-      this.filename = TextUtils.fileNameFromPath(scene.path);
-      this.title.setOriginalValue(scene.title);
-      this.date.setOriginalValue(scene.date);
-
-      this.scene = scene;
-    }
-
-    private setDate(format: string, value: string) {
-      var yearIndex = 0;
-      var yearLength = format.split("y").length - 1;
-      var dateIndex = 0;
-      var monthIndex = 0;
-
-      switch (format) {
-        case "yyyymmdd":
-        case "yymmdd":
-          monthIndex = yearLength;
-          dateIndex = monthIndex + 2;
-          break;
-        case "ddmmyyyy":
-        case "ddmmyy":
-          monthIndex = 2;
-          yearIndex = monthIndex + 2;
-          break;
-        case "mmddyyyy":
-        case "mmddyy":
-          dateIndex = monthIndex + 2;
-          yearIndex = dateIndex + 2;
-          break;
-      }
-
-      var yearValue = value.substring(yearIndex, yearIndex + yearLength);
-      var monthValue = value.substring(monthIndex, monthIndex + 2);
-      var dateValue = value.substring(dateIndex, dateIndex + 2);
-      this.date.value = yearValue + "-" + monthValue + "-" + dateValue;
-      this.date.set = true;
-    }
-
-    public setField(field: string, value: any) {
-      var parserResult : ParserResult<any> | undefined = undefined;
-      switch (field) {
-        case "title":
-          parserResult = this.title;
-          break;
-        case "date":
-          parserResult = this.date;
-          break;
-        case "yyyy":
-          parserResult = this.yyyy;
-          break;
-        case "yy":
-          parserResult = this.yyyy;
-          value = "20" + value;
-          break;
-        case "mm":
-          parserResult = this.mm;
-          break;
-        case "dd":
-          parserResult = this.dd;
-          break;
-        case "yyyymmdd":
-        case "yymmdd":
-        case "ddmmyyyy":
-        case "ddmmyy":
-        case "mmddyyyy":
-        case "mmddyy":
-          this.setDate(field, value);
-          return;
-      }
-      // TODO - other fields
-
-      if (!!parserResult) {
-        parserResult.value = value;
-        parserResult.set = true;
-      }
-    }
-  
-    private static setInput(object: any, key: string, parserResult : ParserResult<any>) {
-      if (parserResult.set) {
-        object[key] = parserResult.value;
-      }
-    }
-
-    public toSceneUpdateInput() {
-      var ret = {
-        id: this.id,
-        title: this.scene.title,
-        details: this.scene.details,
-        url: this.scene.url,
-        date: this.scene.date,
-        rating: this.scene.rating,
-        gallery_id: this.scene.gallery ? this.scene.gallery.id : undefined,
-        studio_id: this.scene.studio ? this.scene.studio.id : undefined,
-        performer_ids: this.scene.performers.map((performer) => performer.id),
-        tag_ids: this.scene.tags.map((tag) => tag.id)
-      };
-
-      SceneParserResult.setInput(ret, "title", this.title);
-      SceneParserResult.setInput(ret, "date", this.date);
-      // TODO - other fields as added
-
-      return ret;
-    }
-  };
-
-  class ParseMapper {
-    public fields : string[] = [];
-    public regex : string = "";
-    public matched : boolean = true;
-
-    constructor(pattern : string, ignoreFields : string[]) {
-      // escape control characters
-      this.regex = pattern.replace(/([\-\.\(\)\[\]])/g, "\\$1");
-
-      // replace {} with wildcard
-      this.regex = this.regex.replace(/\{\}/g, ".*");
-      
-      // TODO - ensure there are no unsupported {fields}
-
-      // replace date fields with applicable regexes
-      this.regex = this.regex.replace(/\{yyyy\}/g, "(\\d{4})");
-      this.regex = this.regex.replace(/\{(?:dd|mm|yy)\}/g, "(\\d{2})");
-      this.regex = this.regex.replace(/\{date\}/g, "(\\d{4}-\\d{2}-\\d{2})");
-      this.regex = this.regex.replace(/\{(?:yyyymmdd|ddmmyyyy|mmddyyyy)\}/g, "(\\d{8})");
-      this.regex = this.regex.replace(/\{(?:yymmdd|ddmmyy|mmddyy)\}/g, "(\\d{6})");
-
-      // replace {i} with ignored fields
-      ignoreFields = ignoreFields.map((s) => s.replace(/([\-\.\(\)\[\]])/g, "\\$1").trim());
-      var ignoreClause = ignoreFields.map((s) => "(?:" + s + ")").join("|");
-      ignoreClause = "(?:" + ignoreClause + ")";
-      this.regex = this.regex.replace(/\{i\}/g, ignoreClause);
-      
-      // replace remaining fields
-      this.regex = this.regex.replace(/\{[A-Za-z]+\}/g, "(.*)");
-
-      var fieldExtractor = new RegExp(/\{([A-Za-z]+)\}/);
-      var result = pattern.match(fieldExtractor);
-      
-      while(!!result && result.index !== undefined) {
-        this.fields.push(result[1]);
-        pattern = pattern.substring(result.index + result[0].length);
-        result = pattern.match(fieldExtractor);
-      } 
-    }
-
-    private postParse(scene: SceneParserResult) {
-      // set the date if the components are set
-      if (scene.yyyy.set && scene.mm.set && scene.dd.set) {
-        scene.setField("date", scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
-      }
-    }
-
-    public parse(scene : SceneParserResult) {
-      var regex = new RegExp(this.regex);
-
-      var result = scene.filename.match(regex);
-
-      if(!result) {
-        return false;
-      }
-
-      var mapper = this;
-
-      result.forEach((match, index) => {
-        if (index === 0) {
-          // skip entire match
-          return;
-        }
-
-        var field = mapper.fields[index - 1];
-        scene.setField(field, match);
-      });
-
-      this.postParse(scene);
-
-      return true;
+  private static setInput(object: any, key: string, parserResult : ParserResult<any>) {
+    if (parserResult.set) {
+      object[key] = parserResult.value;
     }
   }
 
-  interface IParserInput {
-    pattern: string,
-    ignoreWords: string[],
-    whitespaceCharacters: string,
-    capitalizeTitle: boolean
+  public toSceneUpdateInput() {
+    var ret = {
+      id: this.id,
+      title: this.scene.title,
+      details: this.scene.details,
+      url: this.scene.url,
+      date: this.scene.date,
+      rating: this.scene.rating,
+      gallery_id: this.scene.gallery ? this.scene.gallery.id : undefined,
+      studio_id: this.scene.studio ? this.scene.studio.id : undefined,
+      performer_ids: this.scene.performers.map((performer) => performer.id),
+      tag_ids: this.scene.tags.map((tag) => tag.id)
+    };
+
+    SceneParserResult.setInput(ret, "title", this.title);
+    SceneParserResult.setInput(ret, "date", this.date);
+    // TODO - other fields as added
+
+    return ret;
   }
+};
 
-  // TODO:
-  // Add {d} for delimiter characters (._-)
-  // Add mappings for tags, performers, studio
-  // Add drop-down button to add {fields}
+class ParseMapper {
+  public fields : string[] = [];
+  public regex : string = "";
+  public matched : boolean = true;
 
-  export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) => {
-    const [parser, setParser] = useState<ParseMapper | undefined>();
-    const [parserResult, setParserResult] = useState<SceneParserResult[]>([]);
-    const [parserInput, setParserInput] = useState<IParserInput>(initialParserInput());
+  constructor(pattern : string, ignoreFields : string[]) {
+    // escape control characters
+    this.regex = pattern.replace(/([\-\.\(\)\[\]])/g, "\\$1");
 
-    const [allTitleSet, setAllTitleSet] = useState<boolean>(false);
-    const [allDateSet, setAllDateSet] = useState<boolean>(false);
+    // replace {} with wildcard
+    this.regex = this.regex.replace(/\{\}/g, ".*");
+
+    // set ignore fields
+    ignoreFields = ignoreFields.map((s) => s.replace(/([\-\.\(\)\[\]])/g, "\\$1").trim());
+    var ignoreClause = ignoreFields.map((s) => "(?:" + s + ")").join("|");
+    ignoreClause = "(?:" + ignoreClause + ")";
+
+    ParserField.I.regex = ignoreClause;
+
+    // replace all known fields with applicable regexes
+    this.regex = ParserField.replacePatternWithRegex(this.regex);
     
-    const [page, setPage] = useState<number>(1);
-    const [pageSize, setPageSize] = useState<number>(20);
-    const [totalItems, setTotalItems] = useState<number>(0);
+    var ignoreField = new ParserField("i", ignoreClause, undefined, false);
+    this.regex = ignoreField.replaceInPattern(this.regex);
 
-    // Network state
-    const [isLoading, setIsLoading] = useState(false);
-
-    const updateScenes = StashService.useScenesUpdate(getScenesUpdateData());
-
-    function initialParserInput() {
-      return {
-        pattern: "{title}.{ext}",
-        ignoreWords: [],
-        whitespaceCharacters: "._",
-        capitalizeTitle: true
-      };
+    // find invalid fields
+    var foundInvalid = this.regex.match(/\{[A-Za-z]+\}/g);
+    if (foundInvalid) {
+      throw new Error("Invalid fields: " + foundInvalid.join(", "));
     }
 
-    function getQueryFilter(regex : string, page: number, perPage: number) : GQL.FindFilterType {
-      return {
-        q: regex,
-        page: page,
-        per_page: perPage
-      };
+    var fieldExtractor = new RegExp(/\{([A-Za-z]+)\}/);
+    var result = pattern.match(fieldExtractor);
+
+    while(!!result && result.index !== undefined) {
+      var field = result[1];
+
+      this.fields.push(field);
+      pattern = pattern.substring(result.index + result[0].length);
+      result = pattern.match(fieldExtractor);
+    } 
+  }
+
+  private postParse(scene: SceneParserResult) {
+    // set the date if the components are set
+    if (scene.yyyy.set && scene.mm.set && scene.dd.set) {
+      scene.setField(ParserField.Date, scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
+    }
+  }
+
+  public parse(scene : SceneParserResult) {
+    var regex = new RegExp(this.regex);
+
+    var result = scene.filename.match(regex);
+
+    if(!result) {
+      return false;
     }
 
-    async function onFind() {
-      setParserResult([]);
+    var mapper = this;
 
-      if (!parser) {
+    result.forEach((match, index) => {
+      if (index === 0) {
+        // skip entire match
         return;
       }
-      
-      setIsLoading(true);
-      
+
+      var field = mapper.fields[index - 1];
+      var parserField = ParserField.getParserField(field);
+      if (!!parserField) {
+        scene.setField(parserField, match);
+      }
+    });
+
+    this.postParse(scene);
+
+    return true;
+  }
+}
+
+interface IParserInput {
+  pattern: string,
+  ignoreWords: string[],
+  whitespaceCharacters: string,
+  capitalizeTitle: boolean
+}
+
+// TODO:
+// Add {d} for delimiter characters (._-)
+// Add mappings for tags, performers, studio
+// Add drop-down button to add {fields}
+
+export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) => {
+  const [parser, setParser] = useState<ParseMapper | undefined>();
+  const [parserResult, setParserResult] = useState<SceneParserResult[]>([]);
+  const [parserInput, setParserInput] = useState<IParserInput>(initialParserInput());
+
+  const [allTitleSet, setAllTitleSet] = useState<boolean>(false);
+  const [allDateSet, setAllDateSet] = useState<boolean>(false);
+  
+  const [page, setPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(20);
+  const [totalItems, setTotalItems] = useState<number>(0);
+
+  // Network state
+  const [isLoading, setIsLoading] = useState(false);
+
+  const updateScenes = StashService.useScenesUpdate(getScenesUpdateData());
+
+  function initialParserInput() {
+    return {
+      pattern: "{title}.{ext}",
+      ignoreWords: [],
+      whitespaceCharacters: "._",
+      capitalizeTitle: true
+    };
+  }
+
+  function getQueryFilter(regex : string, page: number, perPage: number) : GQL.FindFilterType {
+    return {
+      q: regex,
+      page: page,
+      per_page: perPage
+    };
+  }
+
+  async function onFind() {
+    setParserResult([]);
+
+    if (!parser) {
+      return;
+    }
+    
+    setIsLoading(true);
+    
+    try {
       const response = await StashService.querySceneByPathRegex(getQueryFilter(parser.regex, page, pageSize));
-      
+
       let result = response.data.findScenesByPathRegex;
       if (!!result) {
         parseResults(result.scenes);
         setTotalItems(result.count);
       }
-
-      setIsLoading(false);
+    } catch (err) {
+      ErrorUtils.handle(err);
     }
 
-    useEffect(() => {
-      onFind();
-    }, [page, parser, parserInput]);
+    setIsLoading(false);
+  }
 
-    function onFindClicked(input : IParserInput) {
-      var parser = new ParseMapper(input.pattern, input.ignoreWords);
-      setParser(parser);
-      setParserInput(input);
-      setPage(1);
-      setTotalItems(0);
+  useEffect(() => {
+    onFind();
+  }, [page, parser, parserInput]);
+
+  useEffect(() => {
+    setPage(1);
+    onFind();
+  }, [pageSize])
+
+  function onFindClicked(input : IParserInput) {
+    var parser;
+    try {
+      parser = new ParseMapper(input.pattern, input.ignoreWords);
+    } catch(err) {
+      ErrorUtils.handle(err);
+      return;
     }
 
-    function getScenesUpdateData() {
-      return parserResult.map((result) => result.toSceneUpdateInput());
+    setParser(parser);
+    setParserInput(input);
+    setPage(1);
+    setTotalItems(0);
+  }
+
+  function getScenesUpdateData() {
+    return parserResult.map((result) => result.toSceneUpdateInput());
+  }
+
+  async function onApply() {
+    setIsLoading(true);
+
+    try {
+      await updateScenes();
+      ToastUtils.success("Updated scenes");
+    } catch (e) {
+      ErrorUtils.handle(e);
     }
 
-    async function onApply() {
-      setIsLoading(true);
+    setIsLoading(false);
+  }
 
-      try {
-        await updateScenes();
-        ToastUtils.success("Updated scenes");
-      } catch (e) {
-        ErrorUtils.handle(e);
-      }
+  function parseResults(scenes : GQL.SlimSceneDataFragment[]) {
+    if (scenes && parser) {
+      var result = scenes.map((scene) => {
+        var parserResult = new SceneParserResult(scene);
+        if(!parser.parse(parserResult)) {
+          return undefined;
+        }
 
-      setIsLoading(false);
-    }
-
-    function parseResults(scenes : GQL.SlimSceneDataFragment[]) {
-      if (scenes && parser) {
-        var result = scenes.map((scene) => {
-          var parserResult = new SceneParserResult(scene);
-          if(!parser.parse(parserResult)) {
-            return undefined;
+        // post-process
+        if (parserResult.title && !!parserResult.title.value) {
+          if (parserInput.whitespaceCharacters) {
+            var wsRegExp = parserInput.whitespaceCharacters.replace(/([\-\.\(\)\[\]])/g, "\\$1");
+            wsRegExp = "[" + wsRegExp + "]";
+            parserResult.title.value = parserResult.title.value.replace(new RegExp(wsRegExp, "g"), " ");
           }
 
-          // post-process
-          if (parserResult.title && !!parserResult.title.value) {
-            if (parserInput.whitespaceCharacters) {
-              var wsRegExp = parserInput.whitespaceCharacters.replace(/([\-\.\(\)\[\]])/g, "\\$1");
-              wsRegExp = "[" + wsRegExp + "]";
-              parserResult.title.value = parserResult.title.value.replace(new RegExp(wsRegExp, "g"), " ");
-            }
-
-            if (parserInput.capitalizeTitle) {
-              parserResult.title.value = parserResult.title.value.replace(/(?:^| )\w/g, function (chr) {
-                return chr.toUpperCase();
-              });
-            }
+          if (parserInput.capitalizeTitle) {
+            parserResult.title.value = parserResult.title.value.replace(/(?:^| )\w/g, function (chr) {
+              return chr.toUpperCase();
+            });
           }
-          
-          return parserResult;
-        }).filter((r) => !!r) as SceneParserResult[];
+        }
+        
+        return parserResult;
+      }).filter((r) => !!r) as SceneParserResult[];
 
-        setParserResult(result);
-      }
+      setParserResult(result);
+    }
+  }
+
+  useEffect(() => {
+    var newAllTitleSet = !parserResult.some((r) => {
+      return !r.title.set;
+    });
+    var newAllDateSet = !parserResult.some((r) => {
+      return !r.date.set;
+    });
+
+    if (newAllTitleSet != allTitleSet) {
+      setAllTitleSet(newAllTitleSet);
+    }
+    if (newAllDateSet != allDateSet) {
+      setAllDateSet(newAllDateSet);
+    }
+  }, [parserResult]);
+
+  function onSelectAllTitleSet(selected : boolean) {
+    var newResult = [...parserResult];
+
+    newResult.forEach((r) => {
+      r.title.set = selected;
+    });
+
+    setParserResult(newResult);
+    setAllTitleSet(selected);
+  }
+
+  function onSelectAllDateSet(selected : boolean) {
+    var newResult = [...parserResult];
+
+    newResult.forEach((r) => {
+      r.date.set = selected;
+    });
+
+    setParserResult(newResult);
+    setAllDateSet(selected);
+  }
+
+  interface IParserInputProps {
+    input: IParserInput,
+    onFind: (input : IParserInput) => void
+  }
+
+  function ParserInput(props : IParserInputProps) {
+    const [pattern, setPattern] = useState<string>(props.input.pattern);
+    const [ignoreWords, setIgnoreWords] = useState<string>(props.input.ignoreWords.join(" "));
+    const [whitespaceCharacters, setWhitespaceCharacters] = useState<string>(props.input.whitespaceCharacters);
+    const [capitalizeTitle, setCapitalizeTitle] = useState<boolean>(props.input.capitalizeTitle);
+
+    function onFind() {
+      props.onFind({
+        pattern: pattern,
+        ignoreWords: ignoreWords.split(" "),
+        whitespaceCharacters: whitespaceCharacters,
+        capitalizeTitle: capitalizeTitle
+      });
     }
 
-    useEffect(() => {
-      var newAllTitleSet = !parserResult.some((r) => {
-        return !r.title.set;
-      });
-      var newAllDateSet = !parserResult.some((r) => {
-        return !r.date.set;
-      });
+    const ParserFieldSelect = Select.ofType<ParserField>();
 
-      if (newAllTitleSet != allTitleSet) {
-        setAllTitleSet(newAllTitleSet);
-      }
-      if (newAllDateSet != allDateSet) {
-        setAllDateSet(newAllDateSet);
-      }
-    }, [parserResult]);
+    const renderParserField: ItemRenderer<ParserField> = (field, { handleClick, modifiers }) => {
+        if (!modifiers.matchesPredicate) {
+          return null;
+        }
+        return (
+          <MenuItem
+              key={field.field}
+              onClick={handleClick}
+              text={field.field || "{}"}
+              label={field.helperText}
+          />
+        );
+    };
 
-    function onSelectAllTitleSet(selected : boolean) {
-      var newResult = [...parserResult];
+    const parserFieldPredicate: ItemPredicate<ParserField> = (query, item) => {
+      return item.field.includes(query);
+    };
 
-      newResult.forEach((r) => {
-        r.title.set = selected;
-      });
-
-      setParserResult(newResult);
-      setAllTitleSet(selected);
+    const validFields = [new ParserField("", undefined, "Wildcard")].concat(ParserField.validFields);
+    
+    function addParserField(field: ParserField) {
+      setPattern(pattern + field.getFieldPattern());
     }
 
-    function onSelectAllDateSet(selected : boolean) {
-      var newResult = [...parserResult];
+    const parserFieldSelect = (
+      <ParserFieldSelect
+        items={validFields}
+        onItemSelect={(item) => addParserField(item)}
+        itemRenderer={renderParserField}
+        itemPredicate={parserFieldPredicate}
+      >
+        <Button 
+          text="Add field" 
+          rightIcon="caret-down" 
+        />
+      </ParserFieldSelect>
+    );
 
-      newResult.forEach((r) => {
-        r.date.set = selected;
-      });
+    const PAGE_SIZE_OPTIONS = ["20", "40", "60", "120"];
 
-      setParserResult(newResult);
-      setAllDateSet(selected);
-    }
+    return (
+      <>
+        <FormGroup className="inputs">
+          <FormGroup label="Filename pattern:" inline={true}>
+            <InputGroup
+              onChange={(newValue: any) => setPattern(newValue.target.value)}
+              value={pattern}
+              rightElement={parserFieldSelect}
+            />
+          </FormGroup>
 
-    interface IParserInputProps {
-      input: IParserInput,
-      onFind: (input : IParserInput) => void
-    }
-
-    function ParserInput(props : IParserInputProps) {
-      const [pattern, setPattern] = useState<string>(props.input.pattern);
-      const [ignoreWords, setIgnoreWords] = useState<string>(props.input.ignoreWords.join(" "));
-      const [whitespaceCharacters, setWhitespaceCharacters] = useState<string>(props.input.whitespaceCharacters);
-      const [capitalizeTitle, setCapitalizeTitle] = useState<boolean>(props.input.capitalizeTitle);
-
-      function onFind() {
-        props.onFind({
-          pattern: pattern,
-          ignoreWords: ignoreWords.split(" "),
-          whitespaceCharacters: whitespaceCharacters,
-          capitalizeTitle: capitalizeTitle
-        });
-      }
-
-      return (
-        <>
-          <FormGroup className="inputs">
-            <FormGroup label="Filename pattern:" inline={true}>
+          <FormGroup>
+            <FormGroup label="Ignored words:" inline={true} helperText="Matches with {i}">
               <InputGroup
-                onChange={(newValue: any) => setPattern(newValue.target.value)}
-                value={pattern}
+                onChange={(newValue: any) => setIgnoreWords(newValue.target.value)}
+                value={ignoreWords}
               />
-            </FormGroup>
-
-            <FormGroup>
-              <FormGroup label="Ignored words:" inline={true} helperText="Matches with {i}">
-                <InputGroup
-                  onChange={(newValue: any) => setIgnoreWords(newValue.target.value)}
-                  value={ignoreWords}
-                />
-              </FormGroup>
-            </FormGroup>
-            
-            <FormGroup>
-              <H5>Title</H5>
-              <FormGroup label="Whitespace characters:" 
-              inline={true}
-              helperText="These characters will be replaced with whitespace in the title">
-                <InputGroup
-                  onChange={(newValue: any) => setWhitespaceCharacters(newValue.target.value)}
-                  value={whitespaceCharacters}
-                />
-              </FormGroup>
-              <Checkbox
-                label="Capitalize title"
-                checked={capitalizeTitle}
-                onChange={() => setCapitalizeTitle(!capitalizeTitle)}
-                inline={true}
-              />
-            </FormGroup>
-            
-            {/* TODO - mapping stuff will go here */}
-            <FormGroup>
-                <Button text="Find" onClick={() => onFind()} />
             </FormGroup>
           </FormGroup>
-        </>
-      );
-    }
-
-    interface ISceneParserFieldProps {
-      parserResult : ParserResult<any>
-      className? : string
-      onSetChanged : (set : boolean) => void
-      onValueChanged : (value : any) => void
-    }
-  
-    function SceneParserField(props : ISceneParserFieldProps) {
-
-      const [value, setValue] = useState<string>(props.parserResult.value);
-
-      function maybeValueChanged() {
-        if (value !== props.parserResult.value) {
-          props.onValueChanged(value);
-        }
-      }
-
-      useEffect(() => {
-        setValue(props.parserResult.value);
-      }, [props.parserResult.value]);
-
-      return (
-        <>
-          <td>
-            <Checkbox
-              checked={props.parserResult.set}
-              inline={true}
-              onChange={() => {props.onSetChanged(!props.parserResult.set)}}
-            />
-          </td>
-          <td>
-            <FormGroup>
+          
+          <FormGroup>
+            <H5>Title</H5>
+            <FormGroup label="Whitespace characters:" 
+            inline={true}
+            helperText="These characters will be replaced with whitespace in the title">
               <InputGroup
-                key="originalValue"
-                className={props.className}
-                small={true}
-                disabled={true}
-                value={props.parserResult.originalValue || ""}
-              />
-              <InputGroup
-                key="newValue"
-                className={props.className}
-                small={true}
-                onChange={(event : any) => {setValue(event.target.value)}}
-                onBlur={() => maybeValueChanged()}
-                disabled={!props.parserResult.set}
-                value={value || ""}
-                autoComplete={"new-password" /* required to prevent Chrome autofilling */}
+                onChange={(newValue: any) => setWhitespaceCharacters(newValue.target.value)}
+                value={whitespaceCharacters}
               />
             </FormGroup>
-          </td>
-        </>
-      );
-    }
-
-    interface ISceneParserRowProps {
-      scene : SceneParserResult,
-      onChange: (changedScene : SceneParserResult) => void
-    }
-
-    function SceneParserRow(props : ISceneParserRowProps) {
-
-      function changeParser(result : ParserResult<any>, set : boolean, value : any) {
-        var newParser = _.clone(result);
-        newParser.set = set;
-        newParser.value = value;
-        return newParser;
-      }
-
-      function onTitleChanged(set : boolean, value: string | undefined) {
-        var newResult = _.clone(props.scene);
-        newResult.title = changeParser(newResult.title, set, value);
-        props.onChange(newResult);
-      }
-
-      function onDateChanged(set : boolean, value: string | undefined) {
-        var newResult = _.clone(props.scene);
-        newResult.date = changeParser(newResult.date, set, value);
-        props.onChange(newResult);
-      }
-
-      return (
-        <>
-        <tr className="scene-parser-row">
-          <td style={{textAlign: "left"}}>
-            {props.scene.filename}
-          </td>
-          <SceneParserField 
-            key="title"
-            className="title" 
-            parserResult={props.scene.title}
-            onSetChanged={(set) => onTitleChanged(set, props.scene.title.value)}
-            onValueChanged={(value) => onTitleChanged(props.scene.title.set, value)}
-          />
-          <SceneParserField 
-            key="date"
-            parserResult={props.scene.date}
-            onSetChanged={(set) => onDateChanged(set, props.scene.date.value)}
-            onValueChanged={(value) => onDateChanged(props.scene.date.set, value)}
+            <Checkbox
+              label="Capitalize title"
+              checked={capitalizeTitle}
+              onChange={() => setCapitalizeTitle(!capitalizeTitle)}
+              inline={true}
             />
-          {/*<td>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>*/}
-        </tr>
-        </>
-      )
-    }
+          </FormGroup>
+          
+          {/* TODO - mapping stuff will go here */}
 
-    function onChange(scene : SceneParserResult, changedScene : SceneParserResult) {
-      var newResult = [...parserResult];
-
-      var index = newResult.indexOf(scene);
-      newResult[index] = changedScene;
-
-      setParserResult(newResult);
-    }
-
-    function renderTable() {
-      if (parserResult.length == 0) { return undefined; }
-
-      return (
-        <>
-        <form autoComplete="off">
-          <div className="grid">
-            <HTMLTable condensed={true}>
-              <thead>
-                <tr className="scene-parser-row">
-                  <th>Filename</th>
-                  <td>
-                    <Checkbox
-                      checked={allTitleSet}
-                      inline={true}
-                      onChange={() => {onSelectAllTitleSet(!allTitleSet)}}
-                    />
-                  </td>
-                  <th>Title</th>
-                  <td>
-                  <Checkbox
-                      checked={allDateSet}
-                      inline={true}
-                      onChange={() => {onSelectAllDateSet(!allDateSet)}}
-                    />
-                  </td>
-                  <th>Date</th>
-                  {/* TODO <th>Tags</th>
-                  <th>Performers</th>
-                  <th>Studio</th>*/}
-                </tr>
-              </thead>
-              <tbody>
-                {parserResult.map((scene) => 
-                  <SceneParserRow 
-                    scene={scene} 
-                    key={scene.id}
-                    onChange={(changedScene) => onChange(scene, changedScene)}/>
-                )}
-              </tbody>
-            </HTMLTable>
-          </div>
-          <Pagination
-            currentPage={page}
-            itemsPerPage={pageSize}
-            totalItems={totalItems}
-            onChangePage={(page) => setPage(page)}
-          />
-          <Button text="Apply" onClick={() => onApply()}></Button>
-        </form>
+          <FormGroup>
+              <Button text="Find" onClick={() => onFind()} />
+              <HTMLSelect
+                style={{flexBasis: "min-content"}}
+                options={PAGE_SIZE_OPTIONS}
+                onChange={(event) => setPageSize(parseInt(event.target.value))}
+                value={pageSize}
+                className="filter-item"
+              />
+          </FormGroup>
+        </FormGroup>
       </>
-      )
+    );
+  }
+
+  interface ISceneParserFieldProps {
+    parserResult : ParserResult<any>
+    className? : string
+    onSetChanged : (set : boolean) => void
+    onValueChanged : (value : any) => void
+  }
+
+  function SceneParserField(props : ISceneParserFieldProps) {
+
+    const [value, setValue] = useState<string>(props.parserResult.value);
+
+    function maybeValueChanged() {
+      if (value !== props.parserResult.value) {
+        props.onValueChanged(value);
+      }
+    }
+
+    useEffect(() => {
+      setValue(props.parserResult.value);
+    }, [props.parserResult.value]);
+
+    return (
+      <>
+        <td>
+          <Checkbox
+            checked={props.parserResult.set}
+            inline={true}
+            onChange={() => {props.onSetChanged(!props.parserResult.set)}}
+          />
+        </td>
+        <td>
+          <FormGroup>
+            <InputGroup
+              key="originalValue"
+              className={props.className}
+              small={true}
+              disabled={true}
+              value={props.parserResult.originalValue || ""}
+            />
+            <InputGroup
+              key="newValue"
+              className={props.className}
+              small={true}
+              onChange={(event : any) => {setValue(event.target.value)}}
+              onBlur={() => maybeValueChanged()}
+              disabled={!props.parserResult.set}
+              value={value || ""}
+              autoComplete={"new-password" /* required to prevent Chrome autofilling */}
+            />
+          </FormGroup>
+        </td>
+      </>
+    );
+  }
+
+  interface ISceneParserRowProps {
+    scene : SceneParserResult,
+    onChange: (changedScene : SceneParserResult) => void
+  }
+
+  function SceneParserRow(props : ISceneParserRowProps) {
+
+    function changeParser(result : ParserResult<any>, set : boolean, value : any) {
+      var newParser = _.clone(result);
+      newParser.set = set;
+      newParser.value = value;
+      return newParser;
+    }
+
+    function onTitleChanged(set : boolean, value: string | undefined) {
+      var newResult = _.clone(props.scene);
+      newResult.title = changeParser(newResult.title, set, value);
+      props.onChange(newResult);
+    }
+
+    function onDateChanged(set : boolean, value: string | undefined) {
+      var newResult = _.clone(props.scene);
+      newResult.date = changeParser(newResult.date, set, value);
+      props.onChange(newResult);
     }
 
     return (
-      <Card id="parser-container">
-        <H4>Scene Filename Parser</H4>
-        <ParserInput
-          input={parserInput}
-          onFind={(input) => onFindClicked(input)}
+      <>
+      <tr className="scene-parser-row">
+        <td style={{textAlign: "left"}}>
+          {props.scene.filename}
+        </td>
+        <SceneParserField 
+          key="title"
+          className="title" 
+          parserResult={props.scene.title}
+          onSetChanged={(set) => onTitleChanged(set, props.scene.title.value)}
+          onValueChanged={(value) => onTitleChanged(props.scene.title.set, value)}
         />
+        <SceneParserField 
+          key="date"
+          parserResult={props.scene.date}
+          onSetChanged={(set) => onDateChanged(set, props.scene.date.value)}
+          onValueChanged={(value) => onDateChanged(props.scene.date.set, value)}
+          />
+        {/*<td>
+        </td>
+        <td>
+        </td>
+        <td>
+        </td>*/}
+      </tr>
+      </>
+    )
+  }
 
-        {isLoading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
-        {renderTable()}
-      </Card>
-    );
-  };
+  function onChange(scene : SceneParserResult, changedScene : SceneParserResult) {
+    var newResult = [...parserResult];
+
+    var index = newResult.indexOf(scene);
+    newResult[index] = changedScene;
+
+    setParserResult(newResult);
+  }
+
+  function renderTable() {
+    if (parserResult.length == 0) { return undefined; }
+
+    return (
+      <>
+      <form autoComplete="off">
+        <div className="grid">
+          <HTMLTable condensed={true}>
+            <thead>
+              <tr className="scene-parser-row">
+                <th>Filename</th>
+                <td>
+                  <Checkbox
+                    checked={allTitleSet}
+                    inline={true}
+                    onChange={() => {onSelectAllTitleSet(!allTitleSet)}}
+                  />
+                </td>
+                <th>Title</th>
+                <td>
+                <Checkbox
+                    checked={allDateSet}
+                    inline={true}
+                    onChange={() => {onSelectAllDateSet(!allDateSet)}}
+                  />
+                </td>
+                <th>Date</th>
+                {/* TODO <th>Tags</th>
+                <th>Performers</th>
+                <th>Studio</th>*/}
+              </tr>
+            </thead>
+            <tbody>
+              {parserResult.map((scene) => 
+                <SceneParserRow 
+                  scene={scene} 
+                  key={scene.id}
+                  onChange={(changedScene) => onChange(scene, changedScene)}/>
+              )}
+            </tbody>
+          </HTMLTable>
+        </div>
+        <Pagination
+          currentPage={page}
+          itemsPerPage={pageSize}
+          totalItems={totalItems}
+          onChangePage={(page) => setPage(page)}
+        />
+        <Button intent="primary" text="Apply" onClick={() => onApply()}></Button>
+      </form>
+    </>
+    )
+  }
+
+  return (
+    <Card id="parser-container">
+      <H4>Scene Filename Parser</H4>
+      <ParserInput
+        input={parserInput}
+        onFind={(input) => onFindClicked(input)}
+      />
+
+      {isLoading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
+      {renderTable()}
+    </Card>
+  );
+};
   

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -358,7 +358,7 @@ class ParseMapper {
   }
 
   public parse(scene : SceneParserResult) {
-    var regex = new RegExp(this.regex);
+    var regex = new RegExp(this.regex, "i");
 
     var result = scene.filename.match(regex);
 

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -9,8 +9,6 @@ import {
   Checkbox,
   H5,
   MenuItem,
-  Tooltip,
-  Popover,
   HTMLSelect,
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useEffect, useState } from "react";
@@ -396,10 +394,57 @@ interface IParserInput {
   capitalizeTitle: boolean
 }
 
+interface IParserRecipe extends IParserInput {
+  description: string
+}
+
+const builtInRecipes = [
+  {
+    pattern: "{title}",
+    ignoreWords: [],
+    whitespaceCharacters: "",
+    capitalizeTitle: false,
+    description: "Filename"
+  },
+  {
+    pattern: "{title}.{ext}",
+    ignoreWords: [],
+    whitespaceCharacters: "",
+    capitalizeTitle: false,
+    description: "Without extension"
+  },
+  {
+    pattern: "{}.{yy}.{mm}.{dd}.{title}.XXX.{}.{ext}",
+    ignoreWords: [],
+    whitespaceCharacters: ".",
+    capitalizeTitle: true,
+    description: ""
+  },
+  {
+    pattern: "{}.{yy}.{mm}.{dd}.{title}.{ext}",
+    ignoreWords: [],
+    whitespaceCharacters: ".",
+    capitalizeTitle: true,
+    description: ""
+  },
+  {
+    pattern: "{title}.XXX.{}.{ext}",
+    ignoreWords: [],
+    whitespaceCharacters: ".",
+    capitalizeTitle: true,
+    description: ""
+  },
+  {
+    pattern: "{}.{yy}.{mm}.{dd}.{title}.{i}.{ext}",
+    ignoreWords: ["cz", "fr"],
+    whitespaceCharacters: ".",
+    capitalizeTitle: true,
+    description: "Foreign language"
+  }
+];
+
 // TODO:
-// Add {d} for delimiter characters (._-)
 // Add mappings for tags, performers, studio
-// Add drop-down button to add {fields}
 
 export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) => {
   const [parser, setParser] = useState<ParseMapper | undefined>();
@@ -588,6 +633,33 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
       });
     }
 
+    const ParserRecipeSelect = Select.ofType<IParserRecipe>();
+
+    const renderParserRecipe: ItemRenderer<IParserRecipe> = (input, { handleClick, modifiers }) => {
+      if (!modifiers.matchesPredicate) {
+        return null;
+      }
+      return (
+        <MenuItem
+            key={input.pattern}
+            onClick={handleClick}
+            text={input.pattern || "{}"}
+            label={input.description}
+        />
+      );
+    };
+
+    const parserRecipePredicate: ItemPredicate<IParserRecipe> = (query, item) => {
+      return item.pattern.includes(query);
+    };
+
+    function setParserRecipe(recipe: IParserInput) {
+      setPattern(recipe.pattern);
+      setIgnoreWords(recipe.ignoreWords.join(" "));
+      setWhitespaceCharacters(recipe.whitespaceCharacters);
+      setCapitalizeTitle(recipe.capitalizeTitle);
+    }
+  
     const ParserFieldSelect = Select.ofType<ParserField>();
 
     const renderParserField: ItemRenderer<ParserField> = (field, { handleClick, modifiers }) => {
@@ -673,6 +745,20 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
           </FormGroup>
           
           {/* TODO - mapping stuff will go here */}
+
+          <FormGroup>
+            <ParserRecipeSelect
+              items={builtInRecipes}
+              onItemSelect={(item) => setParserRecipe(item)}
+              itemRenderer={renderParserRecipe}
+              itemPredicate={parserRecipePredicate}
+            >
+              <Button 
+                text="Select Parser Recipe" 
+                rightIcon="caret-down" 
+              />
+            </ParserRecipeSelect>
+          </FormGroup>
 
           <FormGroup>
               <Button text="Find" onClick={() => onFind()} />

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -279,6 +279,11 @@ class SceneParserResult {
     }
   }
 
+  // returns true if any of its fields have set == true
+  public isChanged() {
+    return this.title.set || this.date.set;
+  }
+
   public toSceneUpdateInput() {
     var ret = {
       id: this.id,
@@ -479,7 +484,7 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
   }
 
   function getScenesUpdateData() {
-    return parserResult.map((result) => result.toSceneUpdateInput());
+    return parserResult.filter((result) => result.isChanged()).map((result) => result.toSceneUpdateInput());
   }
 
   async function onApply() {

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -1,0 +1,447 @@
+import {
+  Card,
+  FormGroup,
+  InputGroup,
+  Button,
+  H4,
+  Spinner,
+  HTMLTable,
+  Checkbox,
+  H5,
+} from "@blueprintjs/core";
+import React, { FunctionComponent, useEffect, useState, useRef } from "react";
+import { IBaseProps } from "../../models";
+import { StashService } from "../../core/StashService";
+import { SlimSceneDataFragment, Maybe } from "../../core/generated-graphql";
+import { TextUtils } from "../../utils/text";
+import _ from "lodash";
+  
+  interface IProps extends IBaseProps {}
+
+  class ParserResult<T> {
+    public value: Maybe<T>;
+    public originalValue: Maybe<T>;
+    public set: boolean = false;
+
+    public setOriginalValue(v : Maybe<T>) {
+      this.originalValue = v;
+      this.value = v;
+    }
+  }
+
+  class SceneParserResult {
+    public id: string;
+    public filename: string;
+    public title: ParserResult<string> = new ParserResult();
+    public date: ParserResult<string> = new ParserResult();
+
+    public yyyy : ParserResult<string> = new ParserResult();
+    public mm : ParserResult<string> = new ParserResult();
+    public dd : ParserResult<string> = new ParserResult();
+
+    public studioId: ParserResult<string> = new ParserResult();
+    public tags: ParserResult<string[]> = new ParserResult();
+    public performerIds: ParserResult<string[]> = new ParserResult();
+
+    constructor(scene : SlimSceneDataFragment) {
+      this.id = scene.id;
+      this.filename = TextUtils.fileNameFromPath(scene.path);
+      this.title.setOriginalValue(scene.title);
+      this.date.setOriginalValue(scene.date);
+    }
+
+    public setField(field: string, value: any) {
+      var parserResult : ParserResult<any> | undefined = undefined;
+      switch (field) {
+        case "title":
+          parserResult = this.title;
+          break;
+        case "date":
+          parserResult = this.date;
+          break;
+        case "yyyy":
+          parserResult = this.yyyy;
+          break;
+        case "yy":
+          parserResult = this.yyyy;
+          value = "20" + value;
+          break;
+        case "mm":
+          parserResult = this.mm;
+          break;
+        case "dd":
+          parserResult = this.dd;
+          break;
+        case "yyyymmdd":
+          // TODO - special case - set date
+          break;
+        case "yymmdd":
+          // TODO - special case - set date
+          break;
+        case "ddmmyyyy":
+          // TODO - special case - set date
+          break;
+        case "ddmmyy":
+          // TODO - special case - set date
+          break;
+        case "mmddyyyy":
+          // TODO - special case - set date
+          break;
+        case "mmddyy":
+          // TODO - special case - set date
+          break;
+      }
+      // TODO - other fields
+
+      if (!!parserResult) {
+        parserResult.value = value;
+        parserResult.set = true;
+      }
+    }
+  };
+
+  class ParseMapper {
+    public fields : string[] = [];
+    public regex : string = "";
+    public matched : boolean = true;
+
+    constructor(pattern : string, ignoreFields : string[]) {
+      // escape control characters
+      this.regex = pattern.replace(/([\-\.\(\)\[\]])/g, "\\$1");
+
+      // replace date fields with applicable regexes
+      this.regex = this.regex.replace(/\{yyyy\}/g, "(\\d{4})");
+
+      // replace {i} with ignored fields
+      ignoreFields = ignoreFields.map((s) => s.replace(/([\-\.\(\)\[\]])/g, "\\$1").trim());
+      var ignoreClause = ignoreFields.map((s) => "(?:" + s + ")").join("|");
+      ignoreClause = "(?:" + ignoreClause + ")";
+      this.regex = this.regex.replace(/\{i\}/g, ignoreClause);
+      
+      // replace remaining fields
+      this.regex = this.regex.replace(/\{\w+\}/g, "(.*)");
+
+      var regex = new RegExp(/\{(\w+)\}/);
+      var result = pattern.match(regex);
+      
+      while(!!result && result.index !== undefined) {
+        this.fields.push(result[1]);
+        pattern = pattern.substring(result.index + result[0].length);
+        result = pattern.match(regex);
+      } 
+    }
+
+    private postParse(scene: SceneParserResult) {
+      // set the date if the components are set
+      if (scene.yyyy.set && scene.mm.set && scene.dd.set) {
+        scene.setField("date", scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
+      }
+    }
+
+    public parse(scene : SceneParserResult) {
+      var regex = new RegExp(this.regex);
+
+      var result = scene.filename.match(regex);
+
+      if(!result) {
+        return false;
+      }
+
+      var mapper = this;
+
+      result.forEach((match, index) => {
+        if (index === 0) {
+          // skip entire match
+          return;
+        }
+
+        var field = mapper.fields[index - 1];
+        scene.setField(field, match);
+      });
+
+      this.postParse(scene);
+
+      return true;
+    }
+  }
+
+  // Outstanding issues:
+  // - cannot modify filenames without losing focus due to re-creation of elements
+  // - need to add select all/none for fields
+
+  // TODO:
+  // Add {d} for delimiter characters (._-)
+  // Add mappings for tags, performers, studio
+  // Add implementation to apply stuff
+  // Add drop-down button to add {fields}
+
+  export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) => {
+    const [pattern, setPattern] = useState<string>("{title}.{ext}");
+    const [ignoreWords, setIgnoreWords] = useState<string>("");
+    const [whitespaceCharacters, setWhitespaceCharacters] = useState<string>("._");
+    const [capitaliseTitle, setCapitaliseTitle] = useState<boolean>(true);
+    const [sceneResults, setSceneResults] = useState<SlimSceneDataFragment[]>([]);
+    const [parserResult, setParserResult] = useState<SceneParserResult[]>([]);
+
+    const [ignoreWordsStage, setIgnoreWordsStage] = useState<string>("");
+
+    // Network state
+    const [isLoading, setIsLoading] = useState(false);
+
+    function getQueryPattern() {
+      // {title}
+      var queryPattern = pattern;
+
+      // replace {..} with wildcard
+      queryPattern = queryPattern.replace(/\{.*?\}/g, "*");
+      
+      return queryPattern;
+    }
+
+    async function onFind() {
+      setIgnoreWords(ignoreWordsStage);
+      setIsLoading(true);
+      const result = await StashService.querySceneByPath(getQueryPattern());
+      
+      if (!!result.data.findScenesByFilename) {
+        setSceneResults(result.data.findScenesByFilename.scenes);
+      }
+
+      setIsLoading(false);
+    }
+
+    useEffect(() => {
+      if (sceneResults) {
+
+        var parser = new ParseMapper(pattern, ignoreWords.split(" "));
+
+        var result = sceneResults.map((scene) => {
+          var parserResult = new SceneParserResult(scene);
+          if(!parser.parse(parserResult)) {
+            return undefined;
+          }
+
+          // post-process
+          if (parserResult.title && !!parserResult.title.value) {
+            if (whitespaceCharacters) {
+              var wsRegExp = whitespaceCharacters.replace(/([\-\.\(\)\[\]])/g, "\\$1");
+              wsRegExp = "[" + wsRegExp + "]";
+              parserResult.title.value = parserResult.title.value.replace(new RegExp(wsRegExp, "g"), " ");
+            }
+
+            if (capitaliseTitle) {
+              parserResult.title.value = parserResult.title.value.replace(/(?:^| )\w/g, function (chr) {
+                return chr.toUpperCase();
+              });
+            }
+          }
+          
+          return parserResult;
+        }).filter((r) => !!r);
+
+        setParserResult(result as SceneParserResult[]);
+      }
+    }, [sceneResults, whitespaceCharacters, ignoreWords]);
+
+    interface ISceneParserFieldProps {
+      parserResult : ParserResult<any>
+      className? : string
+      onSetChanged : (set : boolean) => void
+      onValueChanged : (value : any) => void
+    }
+  
+    function SceneParserField(props : ISceneParserFieldProps) {
+      return (
+        <>
+          <td>
+            <Checkbox
+              checked={props.parserResult.set}
+              inline={true}
+              onChange={() => {props.onSetChanged(!props.parserResult.set)}}
+            />
+          </td>
+          <td>
+            <FormGroup>
+            <InputGroup
+              key="originalValue"
+              className={props.className}
+              small={true}
+              disabled={true}
+              value={props.parserResult.originalValue || ""}
+            />
+            <InputGroup
+              key="newValue"
+              className={props.className}
+              small={true}
+              onChange={(event : any) => {props.onValueChanged(event.target.value)}}
+              disabled={true /* TODO - make editable !props.parserResult.set*/}
+              value={props.parserResult.value || ""}
+            />
+            </FormGroup>
+          </td>
+        </>
+      );
+    }
+
+    interface ISceneParserRowProps {
+      scene : SceneParserResult,
+      onChange: (changedScene : SceneParserResult) => void
+    }
+
+    function SceneParserRow(props : ISceneParserRowProps) {
+
+      function changeParser(result : ParserResult<any>, set : boolean, value : any) {
+        var newParser = _.clone(result);
+        newParser.set = set;
+        newParser.value = value;
+        return newParser;
+      }
+
+      function onTitleChanged(set : boolean, value: string | undefined) {
+        var newResult = _.clone(props.scene);
+        newResult.title = changeParser(newResult.title, set, value);
+        props.onChange(newResult);
+      }
+
+      function onDateChanged(set : boolean, value: string | undefined) {
+        var newResult = _.clone(props.scene);
+        newResult.date = changeParser(newResult.date, set, value);
+        props.onChange(newResult);
+      }
+
+      return (
+        <>
+        <tr className="scene-parser-row">
+          <td style={{textAlign: "left"}}>
+            {props.scene.filename}
+          </td>
+          <SceneParserField 
+            key="title"
+            className="title" 
+            parserResult={props.scene.title}
+            onSetChanged={(set) => onTitleChanged(set, props.scene.title.value)}
+            onValueChanged={(value) => onTitleChanged(props.scene.title.set, value)}
+          />
+          <SceneParserField 
+            key="date"
+            parserResult={props.scene.date}
+            onSetChanged={(set) => onDateChanged(set, props.scene.title.value)}
+            onValueChanged={(value) => onDateChanged(props.scene.title.set, value)}
+            />
+          {/*<td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>*/}
+        </tr>
+        </>
+      )
+    }
+
+    function onChange(scene : SceneParserResult, changedScene : SceneParserResult) {
+      var newResult = [...parserResult];
+
+      var index = newResult.indexOf(scene);
+      newResult[index] = changedScene;
+
+      setParserResult(newResult);
+    }
+
+    function renderTable() {
+      if (parserResult.length == 0) { return undefined; }
+
+      return (
+        <>
+        <div className="grid">
+          <HTMLTable condensed={true}>
+            <thead>
+              <tr className="scene-parser-row">
+                <th>Filename</th>
+                <td>
+                  <Checkbox
+                    checked={true /*allTitleSet*/}
+                    inline={true}
+                    onChange={undefined /*() => {props.onSetChanged(!props.parserResult.set)}*/}
+                  />
+                </td>
+                <th>Title</th>
+                <td>
+                <Checkbox
+                    checked={true /*allDateSet*/}
+                    inline={true}
+                    onChange={undefined /*() => {props.onSetChanged(!props.parserResult.set)}*/}
+                  />
+                </td>
+                <th>Date</th>
+                {/* TODO <th>Tags</th>
+                <th>Performers</th>
+                <th>Studio</th>*/}
+              </tr>
+            </thead>
+            <tbody>
+              {parserResult.map((scene) => 
+                <SceneParserRow 
+                  scene={scene} 
+                  key={scene.id}
+                  onChange={(changedScene) => onChange(scene, changedScene)}/>
+              )}
+            </tbody>
+          </HTMLTable>
+        </div>
+        <Button text="Apply"></Button>
+      </>
+      )
+    }
+
+    return (
+      <Card id="parser-container">
+        <H4>Scene Filename Parser</H4>
+
+        <FormGroup className="inputs">
+          <FormGroup label="Filename pattern:" inline={true}>
+            <InputGroup
+              onChange={(newValue: any) => setPattern(newValue.target.value)}
+              value={pattern}
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <FormGroup label="Ignored words:" inline={true} helperText="Matches with {i}">
+              <InputGroup
+                onChange={(newValue: any) => setIgnoreWordsStage(newValue.target.value)}
+                value={ignoreWordsStage}
+              />
+            </FormGroup>
+          </FormGroup>
+          
+          <FormGroup>
+            <H5>Title</H5>
+            <FormGroup label="Whitespace characters:" 
+            inline={true}
+            helperText="These characters will be replaced with whitespace in the title">
+              <InputGroup
+                onChange={(newValue: any) => setWhitespaceCharacters(newValue.target.value)}
+                value={whitespaceCharacters}
+              />
+            </FormGroup>
+            <Checkbox
+              label="Capitalize title"
+              checked={capitaliseTitle}
+              onChange={() => setCapitaliseTitle(!capitaliseTitle)}
+              inline={true}
+            />
+          </FormGroup>
+          
+          {/* TODO - mapping stuff will go here */}
+          <FormGroup>
+              <Button text="Find" onClick={() => onFind()} />
+          </FormGroup>
+        </FormGroup>
+
+        {isLoading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
+        {renderTable()}
+      </Card>
+    );
+  };
+  

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -228,9 +228,10 @@ class SceneParserResult {
     var fullDate = yearValue + "-" + monthValue + "-" + dateValue;
 
     // ensure the date is valid
-    if (SceneParserResult.validateDate(fullDate)) {
-      this.date.value = fullDate
+    // only set if new value is different from the old
+    if (SceneParserResult.validateDate(fullDate) && this.date.originalValue !== fullDate) {
       this.date.set = true;
+      this.date.value = fullDate
     }
   }
 
@@ -265,9 +266,10 @@ class SceneParserResult {
     }
     // TODO - other fields
 
-    if (!!parserResult) {
-      parserResult.value = value;
+    // only set if different from original value
+    if (!!parserResult && parserResult.originalValue !== value) {
       parserResult.set = true;
+      parserResult.value = value;
     }
   }
 

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -592,7 +592,11 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
     return (
       <>
         <FormGroup className="inputs">
-          <FormGroup label="Filename pattern:" inline={true}>
+          <FormGroup 
+            label="Filename pattern:" 
+            inline={true}
+            helperText="Use '\\' to escape literal {} characters"
+          >
             <InputGroup
               onChange={(newValue: any) => setPattern(newValue.target.value)}
               value={pattern}

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -183,6 +183,10 @@ export class StashService {
     return GQL.useBulkSceneUpdate({ variables: input, refetchQueries: ["FindScenes"] });
   }
   
+  public static useScenesUpdate(input: GQL.SceneUpdateInput[]) {
+    return GQL.useScenesUpdate({ variables: { input : input }});
+  }
+
   public static useSceneDestroy(input: GQL.SceneDestroyInput) {
     return GQL.useSceneDestroy({ variables: input });
   }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -279,11 +279,10 @@ export class StashService {
     });
   }
 
-  public static querySceneByPath(pattern : string) {
-    // TODO - we need to specifically find by path
-    return StashService.client.query<GQL.FindScenesByFilenameQuery>({
-      query: GQL.FindScenesByFilenameDocument,
-      variables: {filter: {q: pattern}},
+  public static querySceneByPathRegex(filter: GQL.FindFilterType) {
+    return StashService.client.query<GQL.FindScenesByPathRegexQuery>({
+      query: GQL.FindScenesByPathRegexDocument,
+      variables: {filter: filter},
     });
   }
 

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -275,6 +275,14 @@ export class StashService {
     });
   }
 
+  public static querySceneByPath(pattern : string) {
+    // TODO - we need to specifically find by path
+    return StashService.client.query<GQL.FindScenesByFilenameQuery>({
+      query: GQL.FindScenesByFilenameDocument,
+      variables: {filter: {q: pattern}},
+    });
+  }
+
   public static nullToUndefined(value: any): any {
     if (_.isPlainObject(value)) {
       return _.mapValues(value, StashService.nullToUndefined);

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -260,3 +260,36 @@ span.block {
     text-decoration: underline;
   }
 }
+
+#parser-container {
+  margin: 10px auto;
+  width: 75%;
+}
+
+#parser-container .inputs label {
+  width: 12em;
+}
+
+#parser-container .inputs .bp3-input-group {
+  width: 80ch;
+}
+
+.scene-parser-row .bp3-checkbox {
+  margin: 0px -20px 0px 0px;
+}
+
+.scene-parser-row .title input {
+  width: 50ch;
+}
+
+.scene-parser-row input {
+  min-width: 10ch;
+}
+
+.scene-parser-row .bp3-form-group {
+  margin-bottom: 0px;
+}
+
+.scene-parser-row div:first-child > input {
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
Adds a new scene filename parser page that can be accessed from the Tasks settings page.

Allows the input of a filename pattern. Fields are denoted with `{fieldName}`. Wildcards are denoted with `{}`. Everything outside of fields and wildcards are used literally in the search pattern.

Currently supports setting the title and date on scenes.

Currently supports the following fields:

- `title` - text captured within is set as the title of the scene
- `ext` - matches the end of the filename. It is not captured. Does not include the last `.` character, as the pattern is more readable as `.{ext}` (in my opinion)
- `d` - matches delimiter characters `-_.`. Not captured
- `i` - matches any ignored word. Ignored words are entered as space-delimited words in the parser input. Not captured. Use this to match release artifacts like `DVDRip` or release groups.
- `date` - matches `yyyy-mm-dd` and sets the date of the scene

It also supports the following partial date fields. The date will only be set on the scene if a date string can be built using the partial date components:

- `yyyy` - four digit year
- `yy` - two digit year. Assumes the first two digits are `20`
- `mm` - two digit month
- `dd` - two digit date

Also supports the following full date fields, using the same partial date rules as above:
- `yyyymmdd`
- `yymmdd`
- `ddmmyyyy`
- `ddmmyy`
- `mmddyyyy`
- `mmddyy`

A drop-down menu is available on the pattern to insert fields, and provides explanations for non-obvious fields.

Title generation also has the following options:

- whitespace characters: these characters are replaced with whitespace (defaults to `._`, to handle filenames like `three.word.title.avi`
- capitalize words: capitalises the first letter of each word

The results are presented in a table showing the existing and generated values of the title and date fields, along with a checkbox to determine whether or not the field will be set on each scene. The title and date can also be edited manually.

Finally, the Apply button updates all of the scenes based on the set fields.

Future features for this will be to add mapping options for tags, performers and studios, and saving and loading of parser options (which will be particularly important once the former feature is added). Importing and exporting of these options would also be beneficial as well.