### PR TITLE
Upload pull request builds to transfer.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ after_success:
 - export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}"
 - docker pull stashapp/compiler:develop
 - sh ./scripts/cross-compile.sh ${STASH_VERSION}
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request.sh; fi'
 before_deploy:
 - if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
 - git tag -f ${STASH_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ script:
 #- make lint
 #- make vet
 - make it
-before_deploy:
-- if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
+after_success:
+- if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; elif [ "$TRAVIS_BRANCH" != "master" ]; then export TAG_SUFFIX="_$TRAVIS_BRANCH"; fi
 - export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}"
 - docker pull stashapp/compiler:develop
 - sh ./scripts/cross-compile.sh ${STASH_VERSION}
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request; fi'
+before_deploy:
+- if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
 - git tag -f ${STASH_VERSION}
 - git push -f --tags
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# assumes cross-compile.sh has already been run successfully
+function uploadFile(file) {
+    BASENAME="$(basename "${FILE}")"
+    curl --upload-file $FILE "https://transfer.sh/$BASENAME"
+}
+
+uploadFile("dist/stash-osx")
+uploadFile("dist/stash-win.exe")
+uploadFile("dist/stash-linux")


### PR DESCRIPTION
Adds a script to upload the binaries built from a pull request to transfer.sh. The URL is output in the build log. By submitting this pull request, I'm hoping that it will test successfully.

I'm not sold on the idea of uploading three large binaries for every build of every pull request, but this (hopefully) shows that it can be done.

Related to #139 