### PR TITLE
Performers, Tags and Studio from scene filename

### DIFF
--- a/graphql/documents/queries/scene.graphql
+++ b/graphql/documents/queries/scene.graphql
@@ -39,9 +39,15 @@ query ParseSceneFilenames($filter: FindFilterType!, $config: SceneParserInput!) 
       scene {
         ...SlimSceneData
       }
-      parserResult {
-        ...SlimSceneData
-      }
+      title
+      details
+      url
+      date
+      rating
+      studio_id
+      gallery_id
+      performer_ids
+      tag_ids
     }
   }
 }

--- a/graphql/documents/queries/scene.graphql
+++ b/graphql/documents/queries/scene.graphql
@@ -31,3 +31,17 @@ query FindScene($id: ID!, $checksum: String) {
     }
   }
 }
+
+query ParseSceneFilenames($filter: FindFilterType!, $config: SceneParserInput!) {
+  parseSceneFilenames(filter: $filter, config: $config) {
+    count
+    results {
+      scene {
+        ...SlimSceneData
+      }
+      parserResult {
+        ...SlimSceneData
+      }
+    }
+  }
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -7,6 +7,8 @@ type Query {
 
   findScenesByPathRegex(filter: FindFilterType): FindScenesResultType!
 
+  parseSceneFilenames(filter: FindFilterType, config: SceneParserInput!): SceneParserResultType!
+
   """A function which queries SceneMarker objects"""
   findSceneMarkers(scene_marker_filter: SceneMarkerFilterType filter: FindFilterType): FindSceneMarkersResultType!
 

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -85,8 +85,16 @@ input SceneParserInput {
 }
 
 type SceneParserResult {
-  scene: Scene!,
-  parserResult: Scene!
+  scene: Scene!
+  title: String
+  details: String
+  url: String
+  date: String
+  rating: Int
+  studio_id: ID
+  gallery_id: ID
+  performer_ids: [ID!]
+  tag_ids: [ID!]
 }
 
 type SceneParserResultType {

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -77,3 +77,19 @@ type FindScenesResultType {
   count: Int!
   scenes: [Scene!]!
 }
+
+input SceneParserInput {
+  ignoreWords: [String!],
+  whitespaceCharacters: String,
+  capitalizeTitle: Boolean
+}
+
+type SceneParserResult {
+  scene: Scene!,
+  parserResult: Scene!
+}
+
+type SceneParserResultType {
+  count: Int!
+  results: [SceneParserResult!]!
+}

--- a/pkg/api/resolver_query_find_scene.go
+++ b/pkg/api/resolver_query_find_scene.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
-	"github.com/stashapp/stash/pkg/models"
 	"strconv"
+
+	"github.com/stashapp/stash/pkg/manager"
+	"github.com/stashapp/stash/pkg/models"
 )
 
 func (r *queryResolver) FindScene(ctx context.Context, id *string, checksum *string) (*models.Scene, error) {
@@ -35,5 +37,24 @@ func (r *queryResolver) FindScenesByPathRegex(ctx context.Context, filter *model
 	return &models.FindScenesResultType{
 		Count:  total,
 		Scenes: scenes,
+	}, nil
+}
+
+func (r *queryResolver) ParseSceneFilenames(ctx context.Context, filter *models.FindFilterType, config models.SceneParserInput) (*models.SceneParserResultType, error) {
+	parser := manager.SceneFilenameParser{
+		Pattern:     *filter.Q,
+		ParserInput: config,
+		Filter:      filter,
+	}
+
+	result, count, err := parser.Parse()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.SceneParserResultType{
+		Count:   count,
+		Results: result,
 	}, nil
 }

--- a/pkg/api/resolver_query_find_scene.go
+++ b/pkg/api/resolver_query_find_scene.go
@@ -41,11 +41,7 @@ func (r *queryResolver) FindScenesByPathRegex(ctx context.Context, filter *model
 }
 
 func (r *queryResolver) ParseSceneFilenames(ctx context.Context, filter *models.FindFilterType, config models.SceneParserInput) (*models.SceneParserResultType, error) {
-	parser := manager.SceneFilenameParser{
-		Pattern:     *filter.Q,
-		ParserInput: config,
-		Filter:      filter,
-	}
+	parser := manager.NewSceneFilenameParser(filter, config)
 
 	result, count, err := parser.Parse()
 

--- a/pkg/manager/filename_parser.go
+++ b/pkg/manager/filename_parser.go
@@ -427,6 +427,8 @@ func NewSceneFilenameParser(filter *models.FindFilterType, config models.ScenePa
 }
 
 func (p *SceneFilenameParser) initWhiteSpaceRegex() {
+	compileREs()
+
 	wsChars := ""
 	if p.ParserInput.WhitespaceCharacters != nil {
 		wsChars = *p.ParserInput.WhitespaceCharacters
@@ -441,8 +443,6 @@ func (p *SceneFilenameParser) initWhiteSpaceRegex() {
 }
 
 func (p *SceneFilenameParser) Parse() ([]*models.SceneParserResult, int, error) {
-	compileREs()
-
 	// perform the query to find the scenes
 	mapper, err := newParseMapper(p.Pattern, p.ParserInput.IgnoreWords)
 

--- a/pkg/manager/filename_parser.go
+++ b/pkg/manager/filename_parser.go
@@ -1,0 +1,377 @@
+package manager
+
+import (
+	"database/sql"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type parserField struct {
+	field           string
+	fieldRegex      *regexp.Regexp
+	regex           string
+	isFullDateField bool
+}
+
+func newParserField(field string, regex string, captured bool) parserField {
+	ret := parserField{
+		field:           field,
+		isFullDateField: false,
+	}
+
+	ret.fieldRegex, _ = regexp.Compile(`\{` + ret.field + `\}`)
+
+	regexStr := regex
+
+	if captured {
+		regexStr = "(" + regexStr + ")"
+	}
+	ret.regex = regexStr
+
+	return ret
+}
+
+func newFullDateParserField(field string, regex string) parserField {
+	ret := newParserField(field, regex, true)
+	ret.isFullDateField = true
+	return ret
+}
+
+func (f parserField) replaceInPattern(pattern string) string {
+	return string(f.fieldRegex.ReplaceAll([]byte(pattern), []byte(f.regex)))
+}
+
+func (f parserField) getFieldPattern() string {
+	return "{" + f.field + "}"
+}
+
+var validFields map[string]parserField
+
+func initParserFields() {
+	if validFields != nil {
+		return
+	}
+
+	ret := make(map[string]parserField)
+
+	ret["title"] = newParserField("title", ".*", true)
+	ret["ext"] = newParserField("ext", ".*$", false)
+
+	//I = new ParserField("i", undefined, "Matches any ignored word", false);
+
+	ret["d"] = newParserField("d", `(?:\.|-|_)`, false)
+	ret["performer"] = newParserField("performer", ".*", true)
+	ret["studio"] = newParserField("studio", ".*", true)
+	ret["tag"] = newParserField("tag", ".*", true)
+
+	// date fields
+	ret["date"] = newParserField("date", `\d{4}-\d{2}-\d{2}`, true)
+	ret["yyyy"] = newParserField("yyyy", `\d{4}`, true)
+	ret["yy"] = newParserField("yy", `\d{2}`, true)
+	ret["mm"] = newParserField("mm", `\d{2}`, true)
+	ret["dd"] = newParserField("dd", `\d{2}`, true)
+	ret["yyyymmdd"] = newFullDateParserField("yyyymmdd", `\d{8}`)
+	ret["yymmdd"] = newFullDateParserField("yymmdd", `\d{6}`)
+	ret["ddmmyyyy"] = newFullDateParserField("ddmmyyyy", `\d{8}`)
+	ret["ddmmyy"] = newFullDateParserField("ddmmyy", `\d{6}`)
+	ret["mmddyyyy"] = newFullDateParserField("mmddyyyy", `\d{8}`)
+	ret["mmddyy"] = newFullDateParserField("mmddyy", `\d{6}`)
+
+	validFields = ret
+}
+
+func replacePatternWithRegex(pattern string, ignoreWords []string) string {
+	initParserFields()
+
+	for _, field := range validFields {
+		pattern = field.replaceInPattern(pattern)
+	}
+
+	ignoreClause := getIgnoreClause(ignoreWords)
+	ignoreField := newParserField("i", ignoreClause, false)
+	pattern = ignoreField.replaceInPattern(pattern)
+
+	return pattern
+}
+
+type parseMapper struct {
+	fields []string
+	regex  *regexp.Regexp
+}
+
+func getIgnoreClause(ignoreFields []string) string {
+	if len(ignoreFields) == 0 {
+		return ""
+	}
+
+	var ignoreClauses []string
+
+	regex := regexp.MustCompile(`([\-\.\(\)\[\]])`)
+	for _, v := range ignoreFields {
+		newVal := string(regex.ReplaceAllString(v, "$$1"))
+		newVal = strings.TrimSpace(newVal)
+		newVal = "(?:" + newVal + ")"
+		ignoreClauses = append(ignoreClauses, newVal)
+	}
+
+	return "(?:" + strings.Join(ignoreClauses, "|") + ")"
+}
+
+func newParseMapper(pattern string, ignoreFields []string) (*parseMapper, error) {
+	ret := &parseMapper{}
+
+	// escape control characters
+	escapeCharRE := regexp.MustCompile(`([\-\.\(\)\[\]])`)
+	regex := escapeCharRE.ReplaceAllString(pattern, `$$1`)
+
+	// replace {} with wildcard
+	braceRE := regexp.MustCompile(`\{\}`)
+	regex = braceRE.ReplaceAllString(regex, ".*")
+
+	// replace all known fields with applicable regexes
+	regex = replacePatternWithRegex(regex, ignoreFields)
+
+	// make case insensitive
+	regex = "(?i)" + regex
+
+	var err error
+
+	ret.regex, err = regexp.Compile(regex)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// find invalid fields
+	invalidRE := regexp.MustCompile(`\{[A-Za-z]+\}`)
+	foundInvalid := invalidRE.FindAllString(regex, -1)
+	if len(foundInvalid) > 0 {
+		return nil, errors.New("Invalid fields: " + strings.Join(foundInvalid, ", "))
+	}
+
+	fieldExtractor := regexp.MustCompile(`\{([A-Za-z]+)\}`)
+
+	result := fieldExtractor.FindAllStringSubmatch(pattern, -1)
+
+	var fields []string
+	for _, v := range result {
+		field := v[1]
+		fields = append(fields, field)
+	}
+
+	ret.fields = fields
+
+	return ret, nil
+}
+
+type sceneHolder struct {
+	scene  *models.Scene
+	result *models.Scene
+	yyyy   string
+	mm     string
+	dd     string
+}
+
+func newSceneHolder(scene *models.Scene) *sceneHolder {
+	sceneCopy := models.Scene{
+		ID:       scene.ID,
+		Checksum: scene.Checksum,
+		Path:     scene.Path,
+	}
+	ret := sceneHolder{
+		scene:  scene,
+		result: &sceneCopy,
+	}
+
+	return &ret
+}
+
+func validateDate(dateStr string) bool {
+	splits := strings.Split(dateStr, "-")
+	if len(splits) != 3 {
+		return false
+	}
+
+	year, _ := strconv.Atoi(splits[0])
+	month, _ := strconv.Atoi(splits[1])
+	d, _ := strconv.Atoi(splits[2])
+
+	// assume year must be between 1900 and 2100
+	if year < 1900 || year > 2100 {
+		return false
+	}
+
+	if month < 1 || month > 12 {
+		return false
+	}
+
+	// not checking individual months to ensure date is in the correct range
+	if d < 1 || d > 31 {
+		return false
+	}
+
+	return true
+}
+
+func (h *sceneHolder) setDate(field *parserField, value string) {
+	yearIndex := 0
+	yearLength := len(strings.Split(field.field, "y")) - 1
+	dateIndex := 0
+	monthIndex := 0
+
+	switch field.field {
+	case "yyyymmdd":
+	case "yymmdd":
+		monthIndex = yearLength
+		dateIndex = monthIndex + 2
+		break
+	case "ddmmyyyy":
+	case "ddmmyy":
+		monthIndex = 2
+		yearIndex = monthIndex + 2
+		break
+	case "mmddyyyy":
+	case "mmddyy":
+		dateIndex = monthIndex + 2
+		yearIndex = dateIndex + 2
+		break
+	}
+
+	yearValue := value[yearIndex : yearIndex+yearLength-1]
+	monthValue := value[monthIndex : monthIndex+1]
+	dateValue := value[dateIndex : dateIndex+1]
+
+	fullDate := yearValue + "-" + monthValue + "-" + dateValue
+
+	// ensure the date is valid
+	// only set if new value is different from the old
+	if validateDate(fullDate) && h.scene.Date.String != fullDate {
+		h.result.Date = models.SQLiteDate{
+			String: fullDate,
+			Valid:  true,
+		}
+	}
+}
+
+func (h *sceneHolder) setField(field parserField, value interface{}) {
+	if field.isFullDateField {
+		h.setDate(&field, value.(string))
+		return
+	}
+
+	switch field.field {
+	case "title":
+		h.result.Title = sql.NullString{
+			String: value.(string),
+			Valid:  true,
+		}
+		break
+	case "date":
+		if validateDate(value.(string)) {
+			h.result.Date = models.SQLiteDate{
+				String: value.(string),
+				Valid:  true,
+			}
+		}
+		break
+	case "performer":
+		// TODO
+		break
+	case "studio":
+		// TODO
+		break
+	case "tag":
+		// TODO
+		break
+	case "yyyy":
+		h.yyyy = value.(string)
+		break
+	case "yy":
+		v := value.(string)
+		v = "20" + v
+		h.yyyy = v
+		break
+	case "mm":
+		h.mm = value.(string)
+		break
+	case "dd":
+		h.dd = value.(string)
+		break
+	}
+	// TODO - other fields
+}
+
+func (h *sceneHolder) postParse() {
+	// set the date if the components are set
+	if h.yyyy != "" && h.mm != "" && h.dd != "" {
+		fullDate := h.yyyy + "-" + h.mm + "-" + h.dd
+		h.setField(validFields["date"], fullDate)
+	}
+}
+
+func (m parseMapper) parse(scene *models.Scene) *models.SceneParserResult {
+	result := m.regex.FindString(scene.Path)
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	initParserFields()
+
+	sceneHolder := newSceneHolder(scene)
+
+	for index, match := range result {
+		if index == 0 {
+			// skip entire match
+			continue
+		}
+
+		field := m.fields[index-1]
+		parserField, found := validFields[field]
+		if found {
+			sceneHolder.setField(parserField, match)
+		}
+	}
+
+	sceneHolder.postParse()
+
+	return &models.SceneParserResult{
+		Scene:        scene,
+		ParserResult: sceneHolder.result,
+	}
+}
+
+type SceneFilenameParser struct {
+	Pattern     string
+	ParserInput models.SceneParserInput
+	Filter      *models.FindFilterType
+}
+
+func (p *SceneFilenameParser) Parse() ([]*models.SceneParserResult, int, error) {
+	// perform the query to find the scenes
+	mapper, err := newParseMapper(p.Pattern, p.ParserInput.IgnoreWords)
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	p.Filter.Q = &p.Pattern
+
+	qb := models.NewSceneQueryBuilder()
+	scenes, total := qb.QueryByPathRegex(p.Filter)
+
+	var ret []*models.SceneParserResult
+	for _, scene := range scenes {
+		r := mapper.parse(scene)
+
+		if r != nil {
+			ret = append(ret, r)
+		}
+	}
+
+	return ret, total, nil
+}

--- a/pkg/manager/filename_parser.go
+++ b/pkg/manager/filename_parser.go
@@ -558,11 +558,13 @@ func (p *SceneFilenameParser) setPerformers(h sceneHolder, result *models.SceneP
 	// query for each performer
 	performersSet := make(map[int]bool)
 	for _, performerName := range h.performers {
-		performer := p.queryPerformer(performerName)
-		if performer != nil {
-			if _, found := performersSet[performer.ID]; !found {
-				result.PerformerIds = append(result.PerformerIds, strconv.Itoa(performer.ID))
-				performersSet[performer.ID] = true
+		if performerName != "" {
+			performer := p.queryPerformer(performerName)
+			if performer != nil {
+				if _, found := performersSet[performer.ID]; !found {
+					result.PerformerIds = append(result.PerformerIds, strconv.Itoa(performer.ID))
+					performersSet[performer.ID] = true
+				}
 			}
 		}
 	}
@@ -572,11 +574,13 @@ func (p *SceneFilenameParser) setTags(h sceneHolder, result *models.SceneParserR
 	// query for each performer
 	tagsSet := make(map[int]bool)
 	for _, tagName := range h.tags {
-		tag := p.queryTag(tagName)
-		if tag != nil {
-			if _, found := tagsSet[tag.ID]; !found {
-				result.TagIds = append(result.TagIds, strconv.Itoa(tag.ID))
-				tagsSet[tag.ID] = true
+		if tagName != "" {
+			tag := p.queryTag(tagName)
+			if tag != nil {
+				if _, found := tagsSet[tag.ID]; !found {
+					result.TagIds = append(result.TagIds, strconv.Itoa(tag.ID))
+					tagsSet[tag.ID] = true
+				}
 			}
 		}
 	}

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -242,7 +242,7 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		for _, studioID := range studiosFilter.Value {
 			args = append(args, studioID)
 		}
-		
+
 		whereClause, havingClause := getMultiCriterionClause("studio", "", "studio_id", studiosFilter)
 		whereClauses = appendClause(whereClauses, whereClause)
 		havingClauses = appendClause(havingClauses, havingClause)
@@ -274,14 +274,14 @@ func getMultiCriterionClause(table string, joinTable string, joinTableField stri
 	havingClause := ""
 	if criterion.Modifier == CriterionModifierIncludes {
 		// includes any of the provided ids
-		whereClause = table + ".id IN "+ getInBinding(len(criterion.Value))
+		whereClause = table + ".id IN " + getInBinding(len(criterion.Value))
 	} else if criterion.Modifier == CriterionModifierIncludesAll {
 		// includes all of the provided ids
-		whereClause = table + ".id IN "+ getInBinding(len(criterion.Value))
+		whereClause = table + ".id IN " + getInBinding(len(criterion.Value))
 		havingClause = "count(distinct " + table + ".id) IS " + strconv.Itoa(len(criterion.Value))
 	} else if criterion.Modifier == CriterionModifierExcludes {
 		// excludes all of the provided ids
-		if (joinTable != "") {
+		if joinTable != "" {
 			whereClause = "not exists (select " + joinTable + ".scene_id from " + joinTable + " where " + joinTable + ".scene_id = scenes.id and " + joinTable + "." + joinTableField + " in " + getInBinding(len(criterion.Value)) + ")"
 		} else {
 			whereClause = "not exists (select s.id from scenes as s where s.id = scenes.id and s." + joinTableField + " in " + getInBinding(len(criterion.Value)) + ")"
@@ -302,7 +302,7 @@ func (qb *SceneQueryBuilder) QueryByPathRegex(findFilter *FindFilterType) ([]*Sc
 	body := selectDistinctIDs("scenes")
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		whereClauses = append(whereClauses, "scenes.path regexp '" + *q + "'")
+		whereClauses = append(whereClauses, "scenes.path regexp '(?i)"+*q+"'")
 	}
 
 	sortAndPagination := qb.getSceneSort(findFilter) + getPagination(findFilter)
@@ -363,4 +363,3 @@ func (qb *SceneQueryBuilder) queryScenes(query string, args []interface{}, tx *s
 
 	return scenes, nil
 }
-

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -43,7 +43,7 @@ class ParserResult<T> {
   public setValue(v : Maybe<T>) {
     if (!!v) {
       this.value = v;
-      this.set = this.value !== this.originalValue;
+      this.set = !_.isEqual(this.value, this.originalValue);
     }
   }
 }
@@ -1076,8 +1076,8 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
 
     return (
       <>
-      <form autoComplete="off">
-        <div className="grid scene-parser-results">
+      <div>
+        <div className="scene-parser-results">
           <HTMLTable condensed={true}>
             <thead>
               <tr className="scene-parser-row">
@@ -1106,7 +1106,7 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
           onChangePage={(page) => onPageChanged(page)}
         />
         <Button intent="primary" text="Apply" onClick={() => onApply()}></Button>
-      </form>
+      </div>
     </>
     )
   }

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -11,7 +11,7 @@ import {
   MenuItem,
   HTMLSelect,
 } from "@blueprintjs/core";
-import React, { FunctionComponent, useEffect, useState } from "react";
+import React, { FunctionComponent, useEffect, useState, useRef } from "react";
 import { IBaseProps } from "../../models";
 import { StashService } from "../../core/StashService";
 import * as GQL from "../../core/generated-graphql";
@@ -35,37 +35,22 @@ class ParserResult<T> {
     this.originalValue = v;
     this.value = v;
   }
+
+  public setValue(v : Maybe<T>) {
+    if (!!v) {
+      this.value = v;
+      this.set = this.value !== this.originalValue;
+    }
+  }
 }
 
 class ParserField {
   public field : string;
-  public fieldRegex: RegExp;
-  public regex : string;
   public helperText? : string;
 
-  constructor(field: string, regex?: string, helperText?: string, captured?: boolean) {
-    if (regex === undefined) {
-      regex = ".*";
-    }
-
-    if (captured === undefined) {
-      captured = true;
-    }
-
+  constructor(field: string, helperText?: string) {
     this.field = field;
     this.helperText = helperText;
-
-    this.fieldRegex = new RegExp("\\{" + this.field + "\\}", "g");
-
-    var regexStr = regex;
-    if (captured) {
-      regexStr = "(" + regexStr + ")";
-    }
-    this.regex = regexStr;
-  }
-
-  public replaceInPattern(pattern : string) {
-    return pattern.replace(this.fieldRegex, this.regex);
   }
 
   public getFieldPattern() {
@@ -73,27 +58,27 @@ class ParserField {
   }
 
   static Title = new ParserField("title");
-  static Ext = new ParserField("ext", ".*$", "File extension", false);
+  static Ext = new ParserField("ext", "File extension");
 
-  static I = new ParserField("i", undefined, "Matches any ignored word", false);
-  static D = new ParserField("d", "(?:\\.|-|_)", "Matches any delimiter (.-_)", false);
+  static I = new ParserField("i", "Matches any ignored word");
+  static D = new ParserField("d", "Matches any delimiter (.-_)");
 
   static Performer = new ParserField("performer");
   static Studio = new ParserField("studio");
   static Tag = new ParserField("tag");
 
   // date fields
-  static Date = new ParserField("date", "\\d{4}-\\d{2}-\\d{2}", "YYYY-MM-DD");
-  static YYYY = new ParserField("yyyy", "\\d{4}", "Year");
-  static YY = new ParserField("yy", "\\d{2}", "Year (20YY)");
-  static MM = new ParserField("mm", "\\d{2}", "Two digit month");
-  static DD = new ParserField("dd", "\\d{2}", "Two digit date");
-  static YYYYMMDD = new ParserField("yyyymmdd", "\\d{8}");
-  static YYMMDD = new ParserField("yymmdd", "\\d{6}");
-  static DDMMYYYY = new ParserField("ddmmyyyy", "\\d{8}");
-  static DDMMYY = new ParserField("ddmmyy", "\\d{6}");
-  static MMDDYYYY = new ParserField("mmddyyyy", "\\d{8}");
-  static MMDDYY = new ParserField("mmddyy", "\\d{6}");
+  static Date = new ParserField("date", "YYYY-MM-DD");
+  static YYYY = new ParserField("yyyy", "Year");
+  static YY = new ParserField("yy", "Year (20YY)");
+  static MM = new ParserField("mm", "Two digit month");
+  static DD = new ParserField("dd", "Two digit date");
+  static YYYYMMDD = new ParserField("yyyymmdd");
+  static YYMMDD = new ParserField("yymmdd");
+  static DDMMYYYY = new ParserField("ddmmyyyy");
+  static DDMMYY = new ParserField("ddmmyy");
+  static MMDDYYYY = new ParserField("mmddyyyy");
+  static MMDDYY = new ParserField("mmddyy");
 
   static validFields = [
     ParserField.Title,
@@ -124,168 +109,31 @@ class ParserField {
     ParserField.MMDDYYYY,
     ParserField.MMDDYY
   ];
-
-  public static getParserField(field: string) {
-    return ParserField.validFields.find((f) => {
-      return f.field === field;
-    });
-  }
-
-  public static isValidField(field : string) {
-    return !!ParserField.getParserField(field);
-  }
-
-  public static isFullDateField(field : ParserField) {
-    return ParserField.fullDateFields.includes(field);
-  }
-
-  public static replacePatternWithRegex(pattern: string) {
-    ParserField.validFields.forEach((field) => {
-      pattern = field.replaceInPattern(pattern);
-    });
-    return pattern;
-  }
 }
-
-interface IPerformerQueryMap {
-  query: string,
-  results: GQL.SlimPerformerDataFragment[]
-}
-
 class SceneParserResult {
   public id: string;
   public filename: string;
   public title: ParserResult<string> = new ParserResult();
   public date: ParserResult<string> = new ParserResult();
 
-  public yyyy : ParserResult<string> = new ParserResult();
-  public mm : ParserResult<string> = new ParserResult();
-  public dd : ParserResult<string> = new ParserResult();
-
   public studioId: ParserResult<string> = new ParserResult();
   public tagIds: ParserResult<string[]> = new ParserResult();
   public performerIds: ParserResult<string[]> = new ParserResult();
 
-  public studio : string = "";
-  public performers : string[] = [];
-  public tags : string[] = [];
-
   public scene : SlimSceneDataFragment;
 
-  constructor(scene : SlimSceneDataFragment) {
-    this.id = scene.id;
-    this.filename = TextUtils.fileNameFromPath(scene.path);
-    this.title.setOriginalValue(scene.title);
-    this.date.setOriginalValue(scene.date);
+  constructor(result : GQL.ParseSceneFilenamesResults) {
+    this.scene = result.scene;
 
-    this.scene = scene;
-  }
+    this.id = this.scene.id;
+    this.filename = TextUtils.fileNameFromPath(this.scene.path);
+    this.title.setOriginalValue(this.scene.title);
+    this.date.setOriginalValue(this.scene.date);
+    // TODO - set performers
 
-  public static validateDate(dateStr: string) {
-    var splits = dateStr.split("-");
-    if (splits.length != 3) {
-      return false;
-    }
-    
-    var year = parseInt(splits[0]);
-    var month = parseInt(splits[1]);
-    var d = parseInt(splits[2]);
-
-    var date = new Date();
-    date.setMonth(month - 1);
-    date.setDate(d);
-
-    // assume year must be between 1900 and 2100
-    if (year < 1900 || year > 2100) {
-      return false;
-    }
-
-    if (month < 1 || month > 12) {
-      return false;
-    }
-
-    // not checking individual months to ensure date is in the correct range
-    if (d < 1 || d > 31) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private setDate(field: ParserField, value: string) {
-    var yearIndex = 0;
-    var yearLength = field.field.split("y").length - 1;
-    var dateIndex = 0;
-    var monthIndex = 0;
-
-    switch (field) {
-      case ParserField.YYYYMMDD:
-      case ParserField.YYMMDD:
-        monthIndex = yearLength;
-        dateIndex = monthIndex + 2;
-        break;
-      case ParserField.DDMMYYYY:
-      case ParserField.DDMMYY:
-        monthIndex = 2;
-        yearIndex = monthIndex + 2;
-        break;
-      case ParserField.MMDDYYYY:
-      case ParserField.MMDDYY:
-        dateIndex = monthIndex + 2;
-        yearIndex = dateIndex + 2;
-        break;
-    }
-
-    var yearValue = value.substring(yearIndex, yearIndex + yearLength);
-    var monthValue = value.substring(monthIndex, monthIndex + 2);
-    var dateValue = value.substring(dateIndex, dateIndex + 2);
-
-    var fullDate = yearValue + "-" + monthValue + "-" + dateValue;
-
-    // ensure the date is valid
-    // only set if new value is different from the old
-    if (SceneParserResult.validateDate(fullDate) && this.date.originalValue !== fullDate) {
-      this.date.set = true;
-      this.date.value = fullDate
-    }
-  }
-
-  public setField(field: ParserField, value: any) {
-    var parserResult : ParserResult<any> | undefined = undefined;
-
-    if (ParserField.isFullDateField(field)) {
-      this.setDate(field, value);
-      return;
-    }
-
-    switch (field) {
-      case ParserField.Title:
-        parserResult = this.title;
-        break;
-      case ParserField.Date:
-        parserResult = this.date;
-        break;
-      case ParserField.YYYY:
-        parserResult = this.yyyy;
-        break;
-      case ParserField.YY:
-        parserResult = this.yyyy;
-        value = "20" + value;
-        break;
-      case ParserField.MM:
-        parserResult = this.mm;
-        break;
-      case ParserField.DD:
-        parserResult = this.dd;
-        break;
-    }
-    // TODO - other fields
-
-    // only set if different from original value
-    if (!!parserResult && parserResult.originalValue !== value) {
-      parserResult.set = true;
-      parserResult.value = value;
-    }
+    this.title.setValue(result.title);
+    this.date.setValue(result.date);
+    // TODO - set performers
   }
 
   private static setInput(object: any, key: string, parserResult : ParserResult<any>) {
@@ -320,89 +168,6 @@ class SceneParserResult {
     return ret;
   }
 };
-
-class ParseMapper {
-  public fields : string[] = [];
-  public regex : string = "";
-  public matched : boolean = true;
-
-  constructor(pattern : string, ignoreFields : string[]) {
-    // escape control characters
-    this.regex = pattern.replace(/([\-\.\(\)\[\]])/g, "\\$1");
-
-    // replace {} with wildcard
-    this.regex = this.regex.replace(/\{\}/g, ".*");
-
-    // set ignore fields
-    ignoreFields = ignoreFields.map((s) => s.replace(/([\-\.\(\)\[\]])/g, "\\$1").trim());
-    var ignoreClause = ignoreFields.map((s) => "(?:" + s + ")").join("|");
-    ignoreClause = "(?:" + ignoreClause + ")";
-
-    ParserField.I.regex = ignoreClause;
-
-    // replace all known fields with applicable regexes
-    this.regex = ParserField.replacePatternWithRegex(this.regex);
-    
-    var ignoreField = new ParserField("i", ignoreClause, undefined, false);
-    this.regex = ignoreField.replaceInPattern(this.regex);
-
-    // find invalid fields
-    var foundInvalid = this.regex.match(/\{[A-Za-z]+\}/g);
-    if (foundInvalid) {
-      throw new Error("Invalid fields: " + foundInvalid.join(", "));
-    }
-
-    var fieldExtractor = new RegExp(/\{([A-Za-z]+)\}/);
-    var result = pattern.match(fieldExtractor);
-
-    while(!!result && result.index !== undefined) {
-      var field = result[1];
-
-      this.fields.push(field);
-      pattern = pattern.substring(result.index + result[0].length);
-      result = pattern.match(fieldExtractor);
-    } 
-  }
-
-  private postParse(scene: SceneParserResult) {
-    // set the date if the components are set
-    if (scene.yyyy.set && scene.mm.set && scene.dd.set) {
-      var fullDate = scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value;
-      if (SceneParserResult.validateDate(fullDate)) {
-        scene.setField(ParserField.Date, scene.yyyy.value + "-" + scene.mm.value + "-" + scene.dd.value);
-      }
-    }
-  }
-
-  public parse(scene : SceneParserResult) {
-    var regex = new RegExp(this.regex, "i");
-
-    var result = scene.filename.match(regex);
-
-    if(!result) {
-      return false;
-    }
-
-    var mapper = this;
-
-    result.forEach((match, index) => {
-      if (index === 0) {
-        // skip entire match
-        return;
-      }
-
-      var field = mapper.fields[index - 1];
-      var parserField = ParserField.getParserField(field);
-      if (!!parserField) {
-        scene.setField(parserField, match);
-      }
-    });
-
-    this.postParse(scene);
-
-    return true;
-  }
-}
 
 interface IParserInput {
   pattern: string,
@@ -464,7 +229,6 @@ const builtInRecipes = [
 // Add mappings for tags, performers, studio
 
 export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) => {
-  const [parser, setParser] = useState<ParseMapper | undefined>();
   const [parserResult, setParserResult] = useState<SceneParserResult[]>([]);
   const [parserInput, setParserInput] = useState<IParserInput>(initialParserInput());
 
@@ -476,6 +240,8 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
   const [totalItems, setTotalItems] = useState<number>(0);
 
   // Network state
+  // we don't want to fire off a query until find is clicked for the first time
+  const findClicked = useRef<boolean>(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const updateScenes = StashService.useScenesUpdate(getScenesUpdateData());
@@ -489,29 +255,42 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
     };
   }
 
-  function getQueryFilter(regex : string, page: number, perPage: number) : GQL.FindFilterType {
+  function getParserFilter() {
     return {
-      q: regex,
+      q: parserInput.pattern,
       page: page,
-      per_page: perPage
+      per_page: pageSize,
+      sort: "path",
+      direction: GQL.SortDirectionEnum.Asc,
+    };
+  }
+
+  function getParserInput() {
+    return {
+      ignoreWords: parserInput.ignoreWords,
+      whitespaceCharacters: parserInput.whitespaceCharacters,
+      capitalizeTitle: parserInput.capitalizeTitle
     };
   }
 
   async function onFind() {
-    setParserResult([]);
-
-    if (!parser) {
+    if (!findClicked.current) {
       return;
     }
-    
+
+    // don't let it re-call this until find is clicked again
+    findClicked.current = false;
+
+    setParserResult([]);
+
     setIsLoading(true);
     
     try {
-      const response = await StashService.querySceneByPathRegex(getQueryFilter(parser.regex, page, pageSize));
+      const response = await StashService.queryParseSceneFilenames(getParserFilter(), getParserInput());
 
-      let result = response.data.findScenesByPathRegex;
+      let result = response.data.parseSceneFilenames;
       if (!!result) {
-        parseResults(result.scenes);
+        parseResults(result.results);
         setTotalItems(result.count);
       }
     } catch (err) {
@@ -521,10 +300,9 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
     setIsLoading(false);
   }
 
-
   useEffect(() => {
     onFind();
-  }, [page, parser, parserInput]);
+  }, [page, parserInput]);
 
   useEffect(() => {
     setPage(1);
@@ -532,15 +310,7 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
   }, [pageSize])
 
   function onFindClicked(input : IParserInput) {
-    var parser;
-    try {
-      parser = new ParseMapper(input.pattern, input.ignoreWords);
-    } catch(err) {
-      ErrorUtils.handle(err);
-      return;
-    }
-
-    setParser(parser);
+    findClicked.current = true;
     setParserInput(input);
     setPage(1);
     setTotalItems(0);
@@ -563,30 +333,10 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
     setIsLoading(false);
   }
 
-  function parseResults(scenes : GQL.SlimSceneDataFragment[]) {
-    if (scenes && parser) {
-      var result = scenes.map((scene) => {
-        var parserResult = new SceneParserResult(scene);
-        if(!parser.parse(parserResult)) {
-          return undefined;
-        }
-
-        // post-process
-        if (parserResult.title && !!parserResult.title.value) {
-          if (parserInput.whitespaceCharacters) {
-            var wsRegExp = parserInput.whitespaceCharacters.replace(/([\-\.\(\)\[\]])/g, "\\$1");
-            wsRegExp = "[" + wsRegExp + "]";
-            parserResult.title.value = parserResult.title.value.replace(new RegExp(wsRegExp, "g"), " ");
-          }
-
-          if (parserInput.capitalizeTitle) {
-            parserResult.title.value = parserResult.title.value.replace(/(?:^| )\w/g, function (chr) {
-              return chr.toUpperCase();
-            });
-          }
-        }
-        
-        return parserResult;
+  function parseResults(results : GQL.ParseSceneFilenamesResults[]) {
+    if (results) {
+      var result = results.map((r) => {
+        return new SceneParserResult(r);
       }).filter((r) => !!r) as SceneParserResult[];
 
       setParserResult(result);
@@ -698,7 +448,7 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
       return item.field.includes(query);
     };
 
-    const validFields = [new ParserField("", undefined, "Wildcard")].concat(ParserField.validFields);
+    const validFields = [new ParserField("", "Wildcard")].concat(ParserField.validFields);
     
     function addParserField(field: ParserField) {
       setPattern(pattern + field.getFieldPattern());

--- a/ui/v2/src/components/select/FilterSelect.tsx
+++ b/ui/v2/src/components/select/FilterSelect.tsx
@@ -18,6 +18,7 @@ type ValidTypes =
 interface IProps extends HTMLInputProps {
   type: "performers" | "studios" | "tags";
   initialId?: string;
+  noSelectionString?: string;
   onSelectItem: (item: ValidTypes | undefined) => void;
 }
 
@@ -98,7 +99,8 @@ export const FilterSelect: React.FunctionComponent<IProps> = (props: IProps) => 
     setSelectedItem(item);
   }
 
-  const buttonText = selectedItem ? selectedItem.name : "(No selection)";
+  const noSelection = props.noSelectionString !== undefined ? props.noSelectionString : "(No selection)"
+  const buttonText = selectedItem ? selectedItem.name : noSelection;
   return (
     <InternalSelect
       items={items}

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -399,6 +399,14 @@ export class StashService {
     });
   }
 
+  public static queryParseSceneFilenames(filter: GQL.FindFilterType, config: GQL.SceneParserInput) {
+    return StashService.client.query<GQL.ParseSceneFilenamesQuery>({
+      query: GQL.ParseSceneFilenamesDocument,
+      variables: {filter: filter, config: config},
+      fetchPolicy: "network-only",
+    });
+  }
+
   public static nullToUndefined(value: any): any {
     if (_.isPlainObject(value)) {
       return _.mapValues(value, StashService.nullToUndefined);

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -264,32 +264,53 @@ span.block {
 #parser-container {
   margin: 10px auto;
   width: 75%;
-}
 
-#parser-container .inputs label {
-  width: 12em;
-}
+  & .inputs label {
+    width: 12em;
+  }
+  
+  & .inputs .bp3-input-group {
+    width: 80ch;
+  }
 
-#parser-container .inputs .bp3-input-group {
-  width: 80ch;
-}
+  & .scene-parser-results {
+    overflow-x: auto;
+  }
+  
+  & .scene-parser-row .bp3-checkbox {
+    margin: 0px -20px 0px 0px;
+  }
+  
+  & .scene-parser-row .parser-field-title input {
+    width: 50ch;
+  }
 
-.scene-parser-row .bp3-checkbox {
-  margin: 0px -20px 0px 0px;
-}
+  & .scene-parser-row .parser-field-date input {
+    width: 13ch;
+  }
 
-.scene-parser-row .title input {
-  width: 50ch;
-}
+  & .scene-parser-row .parser-field-performers input {
+    width: 20ch;
+  }
 
-.scene-parser-row input {
-  min-width: 10ch;
-}
+  & .scene-parser-row .parser-field-tags input {
+    width: 20ch;
+  }
 
-.scene-parser-row .bp3-form-group {
-  margin-bottom: 0px;
-}
+  & .scene-parser-row .parser-field-studio input {
+    width: 15ch;
+  }
+  
+  & .scene-parser-row input {
+    min-width: 10ch;
+  }
+  
+  & .scene-parser-row .bp3-form-group {
+    margin-bottom: 0px;
+  }
+  
+  & .scene-parser-row div:first-child > input {
+    margin-bottom: 5px;
+  }
 
-.scene-parser-row div:first-child > input {
-  margin-bottom: 5px;
 }


### PR DESCRIPTION
Marking as WIP until I have time to properly test.

This involved rewriting the existing filename parser from performing the parsing in the front-end, to performing it on the server. As such, the original functionality for #164 will need retesting.

Adds `{performer}`, `{tag}`, and `{studio}` fields to the filename parser. These fields work by extracting the field text, removing any delimiter characters (`.-_`) and performing a query for the resulting name. ~~It queries only for the first 10 results currently. It then attempts to case-insensitive match the name against all of the results, and sets if it is an exact match. Otherwise, it sets it to the first result.~~ For now, this matches against exact name only.

I've improved the UI to hide fields that aren't being parsed for, with the option to show these fields.

I'll try to give it a more rigorous test in the coming days, but I'd appreciate testing and feedback in the meantime.