### PR TITLE
Fix ffmpeg error output

### DIFF
--- a/pkg/ffmpeg/encoder_marker.go
+++ b/pkg/ffmpeg/encoder_marker.go
@@ -14,7 +14,7 @@ type SceneMarkerOptions struct {
 
 func (e *Encoder) SceneMarkerVideo(probeResult VideoFile, options SceneMarkerOptions) error {
 	args := []string{
-		"-v", "quiet",
+		"-v", "error",
 		"-ss", strconv.Itoa(options.Seconds),
 		"-t", "20",
 		"-i", probeResult.Path,
@@ -40,7 +40,7 @@ func (e *Encoder) SceneMarkerVideo(probeResult VideoFile, options SceneMarkerOpt
 
 func (e *Encoder) SceneMarkerImage(probeResult VideoFile, options SceneMarkerOptions) error {
 	args := []string{
-		"-v", "quiet",
+		"-v", "error",
 		"-ss", strconv.Itoa(options.Seconds),
 		"-t", "5",
 		"-i", probeResult.Path,

--- a/pkg/ffmpeg/encoder_scene_preview_chunk.go
+++ b/pkg/ffmpeg/encoder_scene_preview_chunk.go
@@ -2,8 +2,9 @@ package ffmpeg
 
 import (
 	"fmt"
-	"github.com/stashapp/stash/pkg/utils"
 	"strconv"
+
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 type ScenePreviewChunkOptions struct {
@@ -14,7 +15,7 @@ type ScenePreviewChunkOptions struct {
 
 func (e *Encoder) ScenePreviewVideoChunk(probeResult VideoFile, options ScenePreviewChunkOptions) {
 	args := []string{
-		"-v", "quiet",
+		"-v", "error",
 		"-ss", strconv.Itoa(options.Time),
 		"-t", "0.75",
 		"-i", probeResult.Path,
@@ -38,7 +39,7 @@ func (e *Encoder) ScenePreviewVideoChunk(probeResult VideoFile, options ScenePre
 
 func (e *Encoder) ScenePreviewVideoChunkCombine(probeResult VideoFile, concatFilePath string, outputPath string) {
 	args := []string{
-		"-v", "quiet",
+		"-v", "error",
 		"-f", "concat",
 		"-i", utils.FixWindowsPath(concatFilePath),
 		"-y",
@@ -50,7 +51,7 @@ func (e *Encoder) ScenePreviewVideoChunkCombine(probeResult VideoFile, concatFil
 
 func (e *Encoder) ScenePreviewVideoToImage(probeResult VideoFile, width int, videoPreviewPath string, outputPath string) error {
 	args := []string{
-		"-v", "quiet",
+		"-v", "error",
 		"-i", videoPreviewPath,
 		"-y",
 		"-c:v", "libwebp",

--- a/pkg/ffmpeg/encoder_screenshot.go
+++ b/pkg/ffmpeg/encoder_screenshot.go
@@ -12,7 +12,7 @@ type ScreenshotOptions struct {
 
 func (e *Encoder) Screenshot(probeResult VideoFile, options ScreenshotOptions) {
 	if options.Verbosity == "" {
-		options.Verbosity = "quiet"
+		options.Verbosity = "error"
 	}
 	if options.Quality == 0 {
 		options.Quality = 1


### PR DESCRIPTION
Setting the verbosity level to `quiet` means that even errors are suppressed. In addition, when an error does occur, the error message is written to stderr, not stdout. Changed the verbosity of the encoder calls, and changed to print stderr message in the event of an ffmpeg error. I tested this with some random files that ffmpeg doesn't like (but ffprobe is ok with). May be difficult to test unless you have some similar files.