### PR TITLE
Add configurable maximum transcode sizes

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -2,6 +2,8 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   stashes
   databasePath
   generatedPath
+  maxTranscodeSize
+  maxStreamingTranscodeSize
   username
   password
   logFile

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -1,3 +1,12 @@
+enum StreamingResolutionEnum {
+  "240p", LOW
+  "480p", STANDARD
+  "720p", STANDARD_HD
+  "1080p", FULL_HD
+  "4k", FOUR_K
+  "Original", ORIGINAL
+}
+
 input ConfigGeneralInput {
   """Array of file paths to content"""
   stashes: [String!]
@@ -5,6 +14,10 @@ input ConfigGeneralInput {
   databasePath: String
   """Path to generated files"""
   generatedPath: String
+  """Max generated transcode size"""
+  maxTranscodeSize: StreamingResolutionEnum
+  """Max streaming transcode size"""
+  maxStreamingTranscodeSize: StreamingResolutionEnum
   """Username"""
   username: String
   """Password"""
@@ -26,6 +39,10 @@ type ConfigGeneralResult {
   databasePath: String!
   """Path to generated files"""
   generatedPath: String!
+    """Max generated transcode size"""
+  maxTranscodeSize: StreamingResolutionEnum
+  """Max streaming transcode size"""
+  maxStreamingTranscodeSize: StreamingResolutionEnum
   """Username"""
   username: String!
   """Password"""

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
 )
@@ -35,6 +35,14 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 			return makeConfigGeneralResult(), err
 		}
 		config.Set(config.Generated, input.GeneratedPath)
+	}
+
+	if input.MaxTranscodeSize != nil {
+		config.Set(config.MaxTranscodeSize, input.MaxTranscodeSize.String())
+	}
+
+	if input.MaxStreamingTranscodeSize != nil {
+		config.Set(config.MaxStreamingTranscodeSize, input.MaxStreamingTranscodeSize.String())
 	}
 
 	if input.Username != nil {

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -29,16 +29,22 @@ func makeConfigResult() *models.ConfigResult {
 
 func makeConfigGeneralResult() *models.ConfigGeneralResult {
 	logFile := config.GetLogFile()
+
+	maxTranscodeSize := config.GetMaxTranscodeSize()
+	maxStreamingTranscodeSize := config.GetMaxStreamingTranscodeSize()
+
 	return &models.ConfigGeneralResult{
-		Stashes:       config.GetStashPaths(),
-		DatabasePath:  config.GetDatabasePath(),
-		GeneratedPath: config.GetGeneratedPath(),
-		Username:      config.GetUsername(),
-		Password:      config.GetPasswordHash(),
-		LogFile:       &logFile,
-		LogOut:        config.GetLogOut(),
-		LogLevel:      config.GetLogLevel(),
-		LogAccess:     config.GetLogAccess(),
+		Stashes:                   config.GetStashPaths(),
+		DatabasePath:              config.GetDatabasePath(),
+		GeneratedPath:             config.GetGeneratedPath(),
+		MaxTranscodeSize:          &maxTranscodeSize,
+		MaxStreamingTranscodeSize: &maxStreamingTranscodeSize,
+		Username:                  config.GetUsername(),
+		Password:                  config.GetPasswordHash(),
+		LogFile:                   &logFile,
+		LogOut:                    config.GetLogOut(),
+		LogLevel:                  config.GetLogLevel(),
+		LogAccess:                 config.GetLogAccess(),
 	}
 }
 

--- a/pkg/api/routes_scene.go
+++ b/pkg/api/routes_scene.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
+	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
 )
@@ -68,7 +69,7 @@ func (rs sceneRoutes) Stream(w http.ResponseWriter, r *http.Request) {
 
 	encoder := ffmpeg.NewEncoder(manager.GetInstance().FFMPEGPath)
 
-	stream, process, err := encoder.StreamTranscode(*videoFile, startTime)
+	stream, process, err := encoder.StreamTranscode(*videoFile, startTime, config.GetMaxStreamingTranscodeSize())
 	if err != nil {
 		logger.Errorf("[stream] error transcoding video file: %s", err.Error())
 		return

--- a/pkg/ffmpeg/encoder_transcode.go
+++ b/pkg/ffmpeg/encoder_transcode.go
@@ -3,13 +3,56 @@ package ffmpeg
 import (
 	"io"
 	"os"
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
 )
 
 type TranscodeOptions struct {
-	OutputPath string
+	OutputPath       string
+	MaxTranscodeSize models.StreamingResolutionEnum
+}
+
+func calculateTranscodeScale(probeResult VideoFile, maxTranscodeSize models.StreamingResolutionEnum) string {
+	maxSize := 0
+	switch maxTranscodeSize {
+	case models.StreamingResolutionEnumLow:
+		maxSize = 240
+	case models.StreamingResolutionEnumStandard:
+		maxSize = 480
+	case models.StreamingResolutionEnumStandardHd:
+		maxSize = 720
+	case models.StreamingResolutionEnumFullHd:
+		maxSize = 1080
+	case models.StreamingResolutionEnumFourK:
+		maxSize = 2160
+	}
+
+	// get the smaller dimension of the video file
+	videoSize := probeResult.Height
+	if probeResult.Width < videoSize {
+		videoSize = probeResult.Width
+	}
+
+	// if our streaming resolution is larger than the video dimension
+	// or we are streaming the original resolution, then just set the
+	// input width
+	if maxSize >= videoSize || maxSize == 0 {
+		return "iw:-2"
+	}
+
+	// we're setting either the width or height
+	// we'll set the smaller dimesion
+	if probeResult.Width > probeResult.Height {
+		// set the height
+		return "-2:" + strconv.Itoa(maxSize)
+	}
+
+	return strconv.Itoa(maxSize) + ":-2"
 }
 
 func (e *Encoder) Transcode(probeResult VideoFile, options TranscodeOptions) {
+	scale := calculateTranscodeScale(probeResult, options.MaxTranscodeSize)
 	args := []string{
 		"-i", probeResult.Path,
 		"-c:v", "libx264",
@@ -18,7 +61,7 @@ func (e *Encoder) Transcode(probeResult VideoFile, options TranscodeOptions) {
 		"-level", "4.2",
 		"-preset", "superfast",
 		"-crf", "23",
-		"-vf", "scale=iw:-2",
+		"-vf", "scale=" + scale,
 		"-c:a", "aac",
 		"-strict", "-2",
 		options.OutputPath,
@@ -26,7 +69,8 @@ func (e *Encoder) Transcode(probeResult VideoFile, options TranscodeOptions) {
 	_, _ = e.run(probeResult, args)
 }
 
-func (e *Encoder) StreamTranscode(probeResult VideoFile, startTime string) (io.ReadCloser, *os.Process, error) {
+func (e *Encoder) StreamTranscode(probeResult VideoFile, startTime string, maxTranscodeSize models.StreamingResolutionEnum) (io.ReadCloser, *os.Process, error) {
+	scale := calculateTranscodeScale(probeResult, maxTranscodeSize)
 	args := []string{}
 
 	if startTime != "" {
@@ -36,7 +80,7 @@ func (e *Encoder) StreamTranscode(probeResult VideoFile, startTime string) (io.R
 	args = append(args,
 		"-i", probeResult.Path,
 		"-c:v", "libvpx-vp9",
-		"-vf", "scale=iw:-2",
+		"-vf", "scale="+scale,
 		"-deadline", "realtime",
 		"-cpu-used", "5",
 		"-row-mt", "1",

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -19,6 +20,9 @@ const Username = "username"
 const Password = "password"
 
 const Database = "database"
+
+const MaxTranscodeSize = "max_transcode_size"
+const MaxStreamingTranscodeSize = "max_streaming_transcode_size"
 
 const Host = "host"
 const Port = "port"
@@ -74,6 +78,28 @@ func GetHost() string {
 
 func GetPort() int {
 	return viper.GetInt(Port)
+}
+
+func GetMaxTranscodeSize() models.StreamingResolutionEnum {
+	ret := viper.GetString(MaxTranscodeSize)
+
+	// default to original
+	if ret == "" {
+		return models.StreamingResolutionEnumOriginal
+	}
+
+	return models.StreamingResolutionEnum(ret)
+}
+
+func GetMaxStreamingTranscodeSize() models.StreamingResolutionEnum {
+	ret := viper.GetString(MaxStreamingTranscodeSize)
+
+	// default to original
+	if ret == "" {
+		return models.StreamingResolutionEnumOriginal
+	}
+
+	return models.StreamingResolutionEnum(ret)
 }
 
 func GetUsername() string {

--- a/pkg/manager/task_transcode.go
+++ b/pkg/manager/task_transcode.go
@@ -1,11 +1,13 @@
 package manager
 
 import (
-	"github.com/stashapp/stash/pkg/ffmpeg"
-	"github.com/stashapp/stash/pkg/logger"
-	"github.com/stashapp/stash/pkg/models"
 	"os"
 	"sync"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/manager/config"
+	"github.com/stashapp/stash/pkg/models"
 )
 
 type GenerateTranscodeTask struct {
@@ -33,8 +35,10 @@ func (t *GenerateTranscodeTask) Start(wg *sync.WaitGroup) {
 	}
 
 	outputPath := instance.Paths.Generated.GetTmpPath(t.Scene.Checksum + ".mp4")
+	transcodeSize := config.GetMaxTranscodeSize()
 	options := ffmpeg.TranscodeOptions{
-		OutputPath: outputPath,
+		OutputPath:       outputPath,
+		MaxTranscodeSize: transcodeSize,
 	}
 	encoder := ffmpeg.NewEncoder(instance.FFMPEGPath)
 	encoder.Transcode(*videoFile, options)

--- a/ui/v2/src/components/Shared/FolderSelect/FolderSelect.tsx
+++ b/ui/v2/src/components/Shared/FolderSelect/FolderSelect.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   InputGroup,
   Spinner,
+  FormGroup,
 } from "@blueprintjs/core";
 import _ from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
@@ -76,9 +77,12 @@ export const FolderSelect: FunctionComponent<IProps> = (props: IProps) => {
     <>
       {!!error ? <h1>{error.message}</h1> : undefined}
       {renderDialog()}
-      {selectedDirectories.map((path) => {
-        return <div key={path}>{path} <a onClick={() => onRemoveDirectory(path)}>Remove</a></div>;
-      })}
+      <FormGroup>
+        {selectedDirectories.map((path) => {
+          return <div key={path}>{path} <a onClick={() => onRemoveDirectory(path)}>Remove</a></div>;
+        })}
+      </FormGroup>
+      
       <Button small={true} onClick={() => setIsDisplayingDialog(true)}>Add Directory</Button>
     </>
   );


### PR DESCRIPTION
Adds options to the configuration page to allow setting a maximum size for generated transcoded files, and for streaming transcoded files.

Default value is "Original" which uses the existing resolution of the source video. Other values are "240p", "480p", "720p", "1080p", "4K". The transcoding code uses this as the maximum size to down-scale to. If a scene has a lower resolution than the max, then that resolution is used. This scaling is applied to the height for normal landscape videos, and applied to the width for portrait videos.

Should help address the performance issues identified in #31. Related to #10. 