### PR TITLE
Calculate and print job totals for scan and generate tasks

### DIFF
--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -70,7 +70,7 @@ func (s *singleton) Scan(nameFromMetadata bool) {
 		}
 
 		total := len(results)
-		logger.Infof("Starting scan of %d files.%d New files found", total, s.neededScan(results))
+		logger.Infof("Starting scan of %d files. %d New files found", total, s.neededScan(results))
 
 		var wg sync.WaitGroup
 		s.Status.Progress = 0
@@ -156,7 +156,7 @@ func (s *singleton) Generate(sprites bool, previews bool, markers bool, transcod
 			return
 		}
 		totalsNeeded := s.neededGenerate(scenes, sprites, previews, markers, transcodes)
-		logger.Infof("Generate Starting.Generating %d sprites %d previews %d markers %d transcodes", totalsNeeded.sprites, totalsNeeded.previews, totalsNeeded.markers, totalsNeeded.transcodes)
+		logger.Infof("Generating %d sprites %d previews %d markers %d transcodes", totalsNeeded.sprites, totalsNeeded.previews, totalsNeeded.markers, totalsNeeded.transcodes)
 
 		for i, scene := range scenes {
 			s.Status.setProgress(i, total)

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -70,7 +70,7 @@ func (s *singleton) Scan(nameFromMetadata bool) {
 		}
 
 		total := len(results)
-		logger.Infof("Starting scan of %d files", total)
+		logger.Infof("Starting scan of %d files.%d New files found", total, s.neededScan(results))
 
 		var wg sync.WaitGroup
 		s.Status.Progress = 0
@@ -155,6 +155,8 @@ func (s *singleton) Generate(sprites bool, previews bool, markers bool, transcod
 			logger.Info("Stopping due to user request")
 			return
 		}
+		totalsNeeded := s.neededGenerate(scenes, sprites, previews, markers, transcodes)
+		logger.Infof("Generate Starting.Generating %d sprites %d previews %d markers %d transcodes", totalsNeeded.sprites, totalsNeeded.previews, totalsNeeded.markers, totalsNeeded.transcodes)
 
 		for i, scene := range scenes {
 			s.Status.setProgress(i, total)
@@ -260,4 +262,58 @@ func (s *singleton) returnToIdleState() {
 	s.Status.SetStatus(Idle)
 	s.Status.indefiniteProgress()
 	s.Status.stopping = false
+}
+
+func (s *singleton) neededScan(paths []string) int64 {
+	var neededScans int64 = 0
+
+	for _, path := range paths {
+		task := ScanTask{FilePath: path}
+		if !task.doesPathExist() {
+			neededScans++
+		}
+	}
+	return neededScans
+}
+
+type totalsGenerate struct {
+	sprites    int64
+	previews   int64
+	markers    int64
+	transcodes int64
+}
+
+func (s *singleton) neededGenerate(scenes []*models.Scene, sprites, previews, markers, transcodes bool) *totalsGenerate {
+
+	var totals totalsGenerate
+	for _, scene := range scenes {
+		if scene != nil {
+			if sprites {
+				task := GenerateSpriteTask{Scene: *scene}
+				if !task.doesSpriteExist(task.Scene.Checksum) {
+					totals.sprites++
+				}
+			}
+
+			if previews {
+				task := GeneratePreviewTask{Scene: *scene}
+				if !task.doesPreviewExist(task.Scene.Checksum) {
+					totals.previews++
+				}
+			}
+
+			if markers {
+				task := GenerateMarkersTask{Scene: *scene}
+				totals.markers += int64(task.isMarkerNeeded())
+
+			}
+			if transcodes {
+				task := GenerateTranscodeTask{Scene: *scene}
+				if task.isTranscodeNeeded() {
+					totals.transcodes++
+				}
+			}
+		}
+	}
+	return &totals
 }

--- a/pkg/manager/task_generate_markers.go
+++ b/pkg/manager/task_generate_markers.go
@@ -75,3 +75,27 @@ func (t *GenerateMarkersTask) Start(wg *sync.WaitGroup) {
 		}
 	}
 }
+
+func (t *GenerateMarkersTask) isMarkerNeeded() int {
+
+	markers := 0
+	qb := models.NewSceneMarkerQueryBuilder()
+	sceneMarkers, _ := qb.FindBySceneID(t.Scene.ID, nil)
+	if len(sceneMarkers) == 0 {
+		return 0
+	}
+
+	for _, sceneMarker := range sceneMarkers {
+		seconds := int(sceneMarker.Seconds)
+		videoPath := instance.Paths.SceneMarkers.GetStreamPath(t.Scene.Checksum, seconds)
+		imagePath := instance.Paths.SceneMarkers.GetStreamPreviewImagePath(t.Scene.Checksum, seconds)
+		videoExists, _ := utils.FileExists(videoPath)
+		imageExists, _ := utils.FileExists(imagePath)
+
+		if (!videoExists) || (!imageExists) {
+			markers++
+		}
+
+	}
+	return markers
+}

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -205,3 +205,20 @@ func (t *ScanTask) calculateChecksum() (string, error) {
 	logger.Debugf("Checksum calculated: %s", checksum)
 	return checksum, nil
 }
+
+func (t *ScanTask) doesPathExist() bool {
+	if filepath.Ext(t.FilePath) == ".zip" {
+		qb := models.NewGalleryQueryBuilder()
+		gallery, _ := qb.FindByPath(t.FilePath)
+		if gallery != nil {
+			return true
+		}
+	} else {
+		qb := models.NewSceneQueryBuilder()
+		scene, _ := qb.FindByPath(t.FilePath)
+		if scene != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/manager/task_transcode.go
+++ b/pkg/manager/task_transcode.go
@@ -49,3 +49,18 @@ func (t *GenerateTranscodeTask) Start(wg *sync.WaitGroup) {
 	logger.Debugf("[transcode] <%s> created transcode: %s", t.Scene.Checksum, outputPath)
 	return
 }
+
+func (t *GenerateTranscodeTask) isTranscodeNeeded() bool {
+
+	videoCodec := t.Scene.VideoCodec.String
+	hasTranscode, _ := HasTranscode(&t.Scene)
+
+	if ffmpeg.IsValidCodec(videoCodec) {
+		return false
+	}
+
+	if hasTranscode {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Calculates the number of new files we need to scan for the scan task and the total number of sprites,previews,transcodes,markers we need to generate.