### PR TITLE
Add Raspberry Pi binary to builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
   - dist/stash-osx
   - dist/stash-win.exe
   - dist/stash-linux
+  - dist/stash-pi
   skip_cleanup: true
   overwrite: true
   body: ${RELEASE_DATE}

--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -2,11 +2,11 @@ FROM golang:1.11.5
 
 LABEL maintainer="stashappdev@gmail.com"
 
-ENV GORELEASER_VERSION=0.95.0
-ENV GORELEASER_SHA=4f3b9fc978a3677806ebd959096a1f976a7c7bb5fbdf7a9a1d01554c8c5c31c5
+#ENV GORELEASER_VERSION=0.95.0
+#ENV GORELEASER_SHA=4f3b9fc978a3677806ebd959096a1f976a7c7bb5fbdf7a9a1d01554c8c5c31c5
 
-ENV GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz
-ENV GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE}
+#ENV GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz
+#ENV GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE}
 
 ENV PACKR2_VERSION=2.0.2
 ENV PACKR2_SHA=f95ff4c96d7a28813220df030ad91700b8464fe292ab3e1dc9582305c2a338d2
@@ -14,25 +14,34 @@ ENV PACKR2_DOWNLOAD_FILE=packr_${PACKR2_VERSION}_linux_amd64.tar.gz
 ENV PACKR2_DOWNLOAD_URL=https://github.com/gobuffalo/packr/releases/download/v${PACKR2_VERSION}/${PACKR2_DOWNLOAD_FILE}
 
 # Install tools
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+
 RUN apt-get update && \
     apt-get install -y automake autogen \
     libtool libxml2-dev uuid-dev libssl-dev bash \
     patch make tar xz-utils bzip2 gzip sed cpio \
 	gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
-        gcc-arm-linux-gnueabi --no-install-recommends || exit 1; \
+        gcc-arm-linux-gnueabi nodejs yarn --no-install-recommends || exit 1; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Cross compile setup
 ENV OSX_SDK_VERSION 	10.11
 ENV OSX_SDK_DOWNLOAD_FILE=MacOSX${OSX_SDK_VERSION}.sdk.tar.xz
-ENV OSX_SDK_DOWNLOAD_URL=https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/${OSX_SDK_DOWNLOAD_FILE}
-ENV OSX_SDK_SHA=89aa34dfe5bcbc7d53d3c55a84b35ac810ecfbcdd16a64c9667992b0c36c60c4
+ENV OSX_SDK_DOWNLOAD_URL=https://s3.dockerproject.org/darwin/v2/${OSX_SDK_DOWNLOAD_FILE}
+ENV OSX_SDK_SHA=694a66095a3514328e970b14978dc78c0f4d170e590fa7b2c3d3674b75f0b713
 ENV OSX_SDK     		MacOSX$OSX_SDK_VERSION.sdk
 ENV OSX_NDK_X86 		/usr/local/osx-ndk-x86
 
+RUN  echo "testing"
+RUN  wget ${OSX_SDK_DOWNLOAD_URL}
 COPY ${OSX_SDK_DOWNLOAD_FILE} /go
-RUN  wget ${OSX_SDK_DOWNLOAD_URL}; \
-     echo "$OSX_SDK_SHA $OSX_SDK_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
+RUN  echo $OSX_SDK_SHA
+RUN  sha256sum $OSX_SDK_DOWNLOAD_FILE
+RUN  echo "$OSX_SDK_SHA $OSX_SDK_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
      git clone https://github.com/tpoechtrager/osxcross.git && \
      git -C osxcross checkout c47ff0aeed1a7d0e1f884812fc170e415f05be5a || exit 1; \
      mv $OSX_SDK_DOWNLOAD_FILE osxcross/tarballs/ && \
@@ -46,17 +55,17 @@ RUN mkdir -p /root/.ssh; \
     chmod 0700 /root/.ssh; \
     ssh-keyscan github.com > /root/.ssh/known_hosts;
 
-RUN  wget ${GORELEASER_DOWNLOAD_URL}; \
-			echo "$GORELEASER_SHA $GORELEASER_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
-			tar -xzf $GORELEASER_DOWNLOAD_FILE -C /usr/bin/ goreleaser; \
-			rm $GORELEASER_DOWNLOAD_FILE;
+#RUN  wget ${GORELEASER_DOWNLOAD_URL}; \
+#			echo "$GORELEASER_SHA $GORELEASER_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
+#			tar -xzf $GORELEASER_DOWNLOAD_FILE -C /usr/bin/ goreleaser; \
+#			rm $GORELEASER_DOWNLOAD_FILE;
 
 RUN  wget ${PACKR2_DOWNLOAD_URL}; \
 			echo "$PACKR2_SHA $PACKR2_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
 			tar -xzf $PACKR2_DOWNLOAD_FILE -C /usr/bin/ packr2; \
 			rm $PACKR2_DOWNLOAD_FILE;
 
-CMD ["goreleaser", "-v"]
+#CMD ["goreleaser", "-v"]
 CMD ["packr2", "version"]
 
 

--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && \
     apt-get install -y automake autogen \
     libtool libxml2-dev uuid-dev libssl-dev bash \
     patch make tar xz-utils bzip2 gzip sed cpio \
-	gcc-multilib g++-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev --no-install-recommends || exit 1; \
+	gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
+        gcc-arm-linux-gnueabi --no-install-recommends || exit 1; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Cross compile setup

--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -24,18 +24,21 @@ RUN apt-get update && \
 
 # Cross compile setup
 ENV OSX_SDK_VERSION 	10.11
+ENV OSX_SDK_DOWNLOAD_FILE=MacOSX${OSX_SDK_VERSION}.sdk.tar.xz
+ENV OSX_SDK_DOWNLOAD_URL=https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/${OSX_SDK_DOWNLOAD_FILE}
+ENV OSX_SDK_SHA=89aa34dfe5bcbc7d53d3c55a84b35ac810ecfbcdd16a64c9667992b0c36c60c4
 ENV OSX_SDK     		MacOSX$OSX_SDK_VERSION.sdk
 ENV OSX_NDK_X86 		/usr/local/osx-ndk-x86
-ENV OSX_SDK_PATH 		/$OSX_SDK.tar.gz
 
-COPY $OSX_SDK.tar.gz /go
-
-RUN git clone https://github.com/tpoechtrager/osxcross.git && \
-    git -C osxcross checkout c47ff0aeed1a7d0e1f884812fc170e415f05be5a || exit 1; \
-    mv $OSX_SDK.tar.gz osxcross/tarballs/ && \
-    UNATTENDED=yes SDK_VERSION=${OSX_SDK_VERSION} OSX_VERSION_MIN=10.9 osxcross/build.sh || exit 1; \
-    mv osxcross/target $OSX_NDK_X86; \
-    rm -rf osxcross;
+COPY ${OSX_SDK_DOWNLOAD_FILE} /go
+RUN  wget ${OSX_SDK_DOWNLOAD_URL}; \
+     echo "$OSX_SDK_SHA $OSX_SDK_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
+     git clone https://github.com/tpoechtrager/osxcross.git && \
+     git -C osxcross checkout c47ff0aeed1a7d0e1f884812fc170e415f05be5a || exit 1; \
+     mv $OSX_SDK_DOWNLOAD_FILE osxcross/tarballs/ && \
+     UNATTENDED=yes SDK_VERSION=${OSX_SDK_VERSION} OSX_VERSION_MIN=10.9 osxcross/build.sh || exit 1; \
+     mv osxcross/target $OSX_NDK_X86; \
+     rm -rf osxcross;
 
 ENV PATH $OSX_NDK_X86/bin:$PATH
 

--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -2,12 +2,6 @@ FROM golang:1.11.5
 
 LABEL maintainer="stashappdev@gmail.com"
 
-#ENV GORELEASER_VERSION=0.95.0
-#ENV GORELEASER_SHA=4f3b9fc978a3677806ebd959096a1f976a7c7bb5fbdf7a9a1d01554c8c5c31c5
-
-#ENV GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz
-#ENV GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE}
-
 ENV PACKR2_VERSION=2.0.2
 ENV PACKR2_SHA=f95ff4c96d7a28813220df030ad91700b8464fe292ab3e1dc9582305c2a338d2
 ENV PACKR2_DOWNLOAD_FILE=packr_${PACKR2_VERSION}_linux_amd64.tar.gz
@@ -24,26 +18,23 @@ RUN apt-get update && \
     apt-get install -y automake autogen \
     libtool libxml2-dev uuid-dev libssl-dev bash \
     patch make tar xz-utils bzip2 gzip sed cpio \
-	gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
-        gcc-arm-linux-gnueabi nodejs yarn --no-install-recommends || exit 1; \
+	gcc-6-multilib g++-6-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
+	gcc-arm-linux-gnueabi libc-dev-armel-cross linux-libc-dev-armel-cross \
+	nodejs yarn --no-install-recommends || exit 1; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Cross compile setup
 ENV OSX_SDK_VERSION 	10.11
 ENV OSX_SDK_DOWNLOAD_FILE=MacOSX${OSX_SDK_VERSION}.sdk.tar.xz
-ENV OSX_SDK_DOWNLOAD_URL=https://s3.dockerproject.org/darwin/v2/${OSX_SDK_DOWNLOAD_FILE}
-ENV OSX_SDK_SHA=694a66095a3514328e970b14978dc78c0f4d170e590fa7b2c3d3674b75f0b713
+ENV OSX_SDK_DOWNLOAD_URL=https://github.com/ndeloof/golang-cross/raw/113fix/${OSX_SDK_DOWNLOAD_FILE}
+ENV OSX_SDK_SHA=98cdd56e0f6c1f9e1af25e11dd93d2e7d306a4aa50430a2bc6bc083ac67efbb8
 ENV OSX_SDK     		MacOSX$OSX_SDK_VERSION.sdk
 ENV OSX_NDK_X86 		/usr/local/osx-ndk-x86
 
-RUN  echo "testing"
 RUN  wget ${OSX_SDK_DOWNLOAD_URL}
-COPY ${OSX_SDK_DOWNLOAD_FILE} /go
-RUN  echo $OSX_SDK_SHA
-RUN  sha256sum $OSX_SDK_DOWNLOAD_FILE
 RUN  echo "$OSX_SDK_SHA $OSX_SDK_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
      git clone https://github.com/tpoechtrager/osxcross.git && \
-     git -C osxcross checkout c47ff0aeed1a7d0e1f884812fc170e415f05be5a || exit 1; \
+     git -C osxcross checkout a9317c18a3a457ca0a657f08cc4d0d43c6cf8953 || exit 1; \
      mv $OSX_SDK_DOWNLOAD_FILE osxcross/tarballs/ && \
      UNATTENDED=yes SDK_VERSION=${OSX_SDK_VERSION} OSX_VERSION_MIN=10.9 osxcross/build.sh || exit 1; \
      mv osxcross/target $OSX_NDK_X86; \
@@ -55,17 +46,11 @@ RUN mkdir -p /root/.ssh; \
     chmod 0700 /root/.ssh; \
     ssh-keyscan github.com > /root/.ssh/known_hosts;
 
-#RUN  wget ${GORELEASER_DOWNLOAD_URL}; \
-#			echo "$GORELEASER_SHA $GORELEASER_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
-#			tar -xzf $GORELEASER_DOWNLOAD_FILE -C /usr/bin/ goreleaser; \
-#			rm $GORELEASER_DOWNLOAD_FILE;
-
 RUN  wget ${PACKR2_DOWNLOAD_URL}; \
 			echo "$PACKR2_SHA $PACKR2_DOWNLOAD_FILE" | sha256sum -c - || exit 1; \
 			tar -xzf $PACKR2_DOWNLOAD_FILE -C /usr/bin/ packr2; \
 			rm $PACKR2_DOWNLOAD_FILE;
 
-#CMD ["goreleaser", "-v"]
 CMD ["packr2", "version"]
 
 

--- a/docker/compiler/Makefile
+++ b/docker/compiler/Makefile
@@ -1,6 +1,6 @@
 user=stashappdev
 repo=compiler
-version=1
+version=2
 
 latest:
 	docker build -t ${user}/${repo}:latest .

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -12,4 +12,4 @@ RASPPI="GOOS=linux GOARCH=arm GOARM=5 packr2 build -o dist/stash-pi -ldflags \"$
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 
-docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash stashappdev/compiler:1 /bin/bash -c "$COMMAND"
+docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash stashappdev/compiler:2 /bin/bash -c "$COMMAND"

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -8,7 +8,7 @@ SETUP="export GO111MODULE=on; export CGO_ENABLED=1;"
 WINDOWS="GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ packr2 build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"
 DARWIN="GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ packr2 build -o dist/stash-osx -ldflags \"$VERSION_FLAGS\" -tags extended -v -mod=vendor;"
 LINUX="packr2 build -o dist/stash-linux -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
-RASPPI="GOOS=linux GOARCH=arm GOARM=5 packr2 build -o dist/stash-pi -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
+RASPPI="GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc packr2 build -o dist/stash-pi -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -8,7 +8,8 @@ SETUP="export GO111MODULE=on; export CGO_ENABLED=1;"
 WINDOWS="GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ packr2 build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"
 DARWIN="GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ packr2 build -o dist/stash-osx -ldflags \"$VERSION_FLAGS\" -tags extended -v -mod=vendor;"
 LINUX="packr2 build -o dist/stash-linux -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
+RASPPI="GOOS=linux GOARCH=arm GOARM=5 packr2 build -o dist/stash-pi -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
 
-COMMAND="$SETUP $WINDOWS $DARWIN $LINUX"
+COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 
 docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash stashappdev/compiler:1 /bin/bash -c "$COMMAND"


### PR DESCRIPTION
It is possible to build Raspberry Pi binaries if `gcc-arm-linux-gnueabi` is installed within the compiler docker. I've added the necessary scripting to build, but I've not been able test properly due to being unable to build the Dockerfile.

The docker file the presence of `/usr/local/osx-ndk-x86/MacOSX10.11.sdk.tar.gz`. This appears to be generated by `create_osx_sdk.sh`, but that script looks like it needs to be run on MacOSX with Xcode7 installed? I've changed the docker file to download the SDK file from github, but I'm still running into errors. 

```
extracting MacOSX10.11.sdk.tar.xz ...
compiling wrapper ...

testing o32-clang ... osxcross: error: cannot find libc++ headers
osxcross: error: while detecting target

exiting with abnormal exit code (1)
run 'OCDEBUG=1 ./build.sh' to enable debug messages
removing stale locks...
if it is happening the first time, then just re-run the script
```

If I can get the docker image built, I'm confident that I can get Raspberry Pi binaries built. If anyone has the time and inclination that can investigate this further, I'd be very appreciative. Otherwise, I'll keep hammering at it when I find time.