### PR TITLE
Refetch tags on scene update #195

### DIFF
--- a/ui/v2/src/components/scenes/SceneDetails/SceneMarkersPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneMarkersPanel.tsx
@@ -173,7 +173,7 @@ export const SceneMarkersPanel: FunctionComponent<ISceneMarkersPanelProps> = (pr
         <FilterMultiSelect
           type="tags"
           onUpdate={(tags) => fieldProps.form.setFieldValue("tagIds", tags.map((tag) => tag.id))}
-          initialIds={!!editingMarker ? editingMarker.tags.map((tag) => tag.id) : undefined}
+          initialIds={!!editingMarker ? fieldProps.form.values.tagIds : undefined}
         />
       );
     }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -231,7 +231,7 @@ export class StashService {
     "findScenes",
     "findSceneMarkers",
     "findStudios",
-    "allTags"
+    // TODO - add "findTags" when it is implemented
   ];
 
   public static useSceneUpdate(input: GQL.SceneUpdateInput) {

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -231,13 +231,15 @@ export class StashService {
     "findScenes",
     "findSceneMarkers",
     "findStudios",
+    "allTags"
     // TODO - add "findTags" when it is implemented
   ];
 
   public static useSceneUpdate(input: GQL.SceneUpdateInput) {
     return GQL.useSceneUpdate({ 
       variables: input,
-      update: () => StashService.invalidateQueries(StashService.sceneMutationImpactedQueries)
+      update: () => StashService.invalidateQueries(StashService.sceneMutationImpactedQueries),
+      refetchQueries: ["AllTagsForFilter"]
     });
   }
 

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -176,13 +176,13 @@ export class StashService {
   ];
 
   public static useSceneMarkerCreate() {
-    return GQL.useSceneMarkerCreate(); 
+    return GQL.useSceneMarkerCreate({ refetchQueries: ["FindScene"] }); 
   }
   public static useSceneMarkerUpdate() { 
-    return GQL.useSceneMarkerUpdate(); 
+    return GQL.useSceneMarkerUpdate({ refetchQueries: ["FindScene"] }); 
   }
   public static useSceneMarkerDestroy() {
-    return GQL.useSceneMarkerDestroy(); 
+    return GQL.useSceneMarkerDestroy({ refetchQueries: ["FindScene"] }); 
   }
 
   public static useScrapeFreeonesPerformers(q: string) { return GQL.useScrapeFreeonesPerformers({ variables: { q } }); }


### PR DESCRIPTION
Fixes #195. Minor regression on #166 

Refetches `AllTagsForFilter` so that tags drop-down isn't wiped. Causes scene count on tags page to have possibly stale data.