### PR TITLE
Add scene auto-tagging from filename

### DIFF
--- a/graphql/documents/queries/settings/metadata.graphql
+++ b/graphql/documents/queries/settings/metadata.graphql
@@ -14,6 +14,10 @@ query MetadataGenerate($input: GenerateMetadataInput!) {
   metadataGenerate(input: $input)
 }
 
+query MetadataAutoTag($input: AutoTagMetadataInput!) {
+  metadataAutoTag(input: $input)
+}
+
 query MetadataClean {
   metadataClean
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -75,6 +75,8 @@ type Query {
   metadataScan(input: ScanMetadataInput!): String!
   """Start generating content. Returns the job ID"""
   metadataGenerate(input: GenerateMetadataInput!): String!
+  """Start auto-tagging. Returns the job ID"""
+  metadataAutoTag(input: AutoTagMetadataInput!): String!
   """Clean metadata. Returns the job ID"""
   metadataClean: String!
 

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -9,6 +9,15 @@ input ScanMetadataInput {
   nameFromMetadata: Boolean!
 }
 
+input AutoTagMetadataInput {
+  """IDs of performers to tag files with, or "*" for all"""
+  performers: [String!]
+  """IDs of studios to tag files with, or "*" for all"""
+  studios: [String!]
+  """IDs of tags to tag files with, or "*" for all"""
+  tags: [String!]
+}
+
 type MetadataUpdateStatus {
   progress: Float!
 	status: String!

--- a/pkg/api/resolver_query_metadata.go
+++ b/pkg/api/resolver_query_metadata.go
@@ -27,6 +27,11 @@ func (r *queryResolver) MetadataGenerate(ctx context.Context, input models.Gener
 	return "todo", nil
 }
 
+func (r *queryResolver) MetadataAutoTag(ctx context.Context, input models.AutoTagMetadataInput) (string, error) {
+	manager.GetInstance().AutoTag(input.Performers, input.Studios, input.Tags)
+	return "todo", nil
+}
+
 func (r *queryResolver) MetadataClean(ctx context.Context) (string, error) {
 	manager.GetInstance().Clean()
 	return "todo", nil

--- a/pkg/manager/job_status.go
+++ b/pkg/manager/job_status.go
@@ -10,6 +10,7 @@ const (
 	Generate JobStatus = 4
 	Clean    JobStatus = 5
 	Scrape   JobStatus = 6
+	AutoTag  JobStatus = 7
 )
 
 func (s JobStatus) String() string {
@@ -26,6 +27,8 @@ func (s JobStatus) String() string {
 		statusMessage = "Scan"
 	case Generate:
 		statusMessage = "Generate"
+	case AutoTag:
+		statusMessage = "Auto Tag"
 	}
 
 	return statusMessage

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -33,12 +33,13 @@ func (t *AutoTagPerformerTask) autoTagPerformer() {
 	jqb := models.NewJoinsQueryBuilder()
 
 	regex := getQueryRegex(t.performer.Name.String)
-	filter := models.FindFilterType{
-		Q: &regex,
-	}
 
-	logger.Infof("Using regex '%s' to search for scenes", regex)
-	scenes, _ := qb.QueryByPathRegex(&filter)
+	scenes, err := qb.QueryAllByPathRegex(regex)
+
+	if err != nil {
+		logger.Infof("Error querying scenes with regex '%s': %s", regex, err.Error())
+		return
+	}
 
 	ctx := context.TODO()
 	tx := database.DB.MustBeginTx(ctx, nil)
@@ -77,11 +78,13 @@ func (t *AutoTagStudioTask) autoTagStudio() {
 	qb := models.NewSceneQueryBuilder()
 
 	regex := getQueryRegex(t.studio.Name.String)
-	filter := models.FindFilterType{
-		Q: &regex,
-	}
 
-	scenes, _ := qb.QueryByPathRegex(&filter)
+	scenes, err := qb.QueryAllByPathRegex(regex)
+
+	if err != nil {
+		logger.Infof("Error querying scenes with regex '%s': %s", regex, err.Error())
+		return
+	}
 
 	ctx := context.TODO()
 	tx := database.DB.MustBeginTx(ctx, nil)
@@ -131,11 +134,13 @@ func (t *AutoTagTagTask) autoTagTag() {
 	jqb := models.NewJoinsQueryBuilder()
 
 	regex := getQueryRegex(t.tag.Name)
-	filter := models.FindFilterType{
-		Q: &regex,
-	}
 
-	scenes, _ := qb.QueryByPathRegex(&filter)
+	scenes, err := qb.QueryAllByPathRegex(regex)
+
+	if err != nil {
+		logger.Infof("Error querying scenes with regex '%s': %s", regex, err.Error())
+		return
+	}
 
 	ctx := context.TODO()
 	tx := database.DB.MustBeginTx(ctx, nil)

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -1,0 +1,147 @@
+package manager
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"sync"
+
+	"github.com/stashapp/stash/pkg/database"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type AutoTagPerformerTask struct {
+	performer *models.Performer
+}
+
+func (t *AutoTagPerformerTask) Start(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	t.autoTagPerformer()
+}
+
+func getQueryRegex(name string) string {
+	return strings.ReplaceAll(name, " ", `(?: |\.|-|_)?`)
+}
+
+func (t *AutoTagPerformerTask) autoTagPerformer() {
+	qb := models.NewSceneQueryBuilder()
+	jqb := models.NewJoinsQueryBuilder()
+
+	regex := getQueryRegex(t.performer.Name.String)
+	filter := models.FindFilterType{
+		Q: &regex,
+	}
+
+	scenes, _ := qb.QueryByPathRegex(&filter)
+
+	ctx := context.TODO()
+	tx := database.DB.MustBeginTx(ctx, nil)
+
+	for _, scene := range scenes {
+		logger.Infof("Adding performer '%s' to scene '%s'", t.performer.Name.String, scene.Title.String)
+		err := jqb.AddPerformerScene(scene.ID, t.performer.ID, tx)
+
+		if err != nil {
+			logger.Infof("Error adding performer to scene: %s", err.Error())
+			tx.Rollback()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Infof("Error adding performer to scene: %s", err.Error())
+		return
+	}
+}
+
+type AutoTagStudioTask struct {
+	studio *models.Studio
+}
+
+func (t *AutoTagStudioTask) Start(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	t.autoTagStudio()
+}
+
+func (t *AutoTagStudioTask) autoTagStudio() {
+	qb := models.NewSceneQueryBuilder()
+
+	regex := getQueryRegex(t.studio.Name.String)
+	filter := models.FindFilterType{
+		Q: &regex,
+	}
+
+	scenes, _ := qb.QueryByPathRegex(&filter)
+
+	ctx := context.TODO()
+	tx := database.DB.MustBeginTx(ctx, nil)
+
+	for _, scene := range scenes {
+		logger.Infof("Adding studio '%s' to scene '%s'", t.studio.Name.String, scene.Title.String)
+
+		// set the studio id
+		studioID := sql.NullInt64{Int64: int64(t.studio.ID), Valid: true}
+		scenePartial := models.ScenePartial{
+			ID:       scene.ID,
+			StudioID: &studioID,
+		}
+
+		_, err := qb.Update(scenePartial, tx)
+
+		if err != nil {
+			logger.Infof("Error adding studio to scene: %s", err.Error())
+			tx.Rollback()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Infof("Error adding studio to scene: %s", err.Error())
+		return
+	}
+}
+
+type AutoTagTagTask struct {
+	tag *models.Tag
+}
+
+func (t *AutoTagTagTask) Start(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	t.autoTagTag()
+}
+
+func (t *AutoTagTagTask) autoTagTag() {
+	qb := models.NewSceneQueryBuilder()
+	jqb := models.NewJoinsQueryBuilder()
+
+	regex := getQueryRegex(t.tag.Name)
+	filter := models.FindFilterType{
+		Q: &regex,
+	}
+
+	scenes, _ := qb.QueryByPathRegex(&filter)
+
+	ctx := context.TODO()
+	tx := database.DB.MustBeginTx(ctx, nil)
+
+	for _, scene := range scenes {
+		logger.Infof("Adding tag '%s' to scene '%s'", t.tag.Name, scene.Title.String)
+
+		err := jqb.AddSceneTag(scene.ID, t.tag.ID, tx)
+
+		if err != nil {
+			logger.Infof("Error adding tag to scene: %s", err.Error())
+			tx.Rollback()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logger.Infof("Error adding tag to scene: %s", err.Error())
+		return
+	}
+}

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -22,7 +22,7 @@ func (t *AutoTagPerformerTask) Start(wg *sync.WaitGroup) {
 }
 
 func getQueryRegex(name string) string {
-	return strings.ReplaceAll(name, " ", `(?: |\.|-|_)?`)
+	return strings.Replace(name, " ", `(?: |\.|-|_)?`, -1)
 }
 
 func (t *AutoTagPerformerTask) autoTagPerformer() {

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -40,7 +40,7 @@ func (t *AutoTagPerformerTask) autoTagPerformer() {
 	tx := database.DB.MustBeginTx(ctx, nil)
 
 	for _, scene := range scenes {
-		logger.Infof("Adding performer '%s' to scene '%s'", t.performer.Name.String, scene.Title.String)
+		logger.Infof("Adding performer '%s' to scene '%s'", t.performer.Name.String, scene.GetTitle())
 		err := jqb.AddPerformerScene(scene.ID, t.performer.ID, tx)
 
 		if err != nil {
@@ -80,7 +80,7 @@ func (t *AutoTagStudioTask) autoTagStudio() {
 	tx := database.DB.MustBeginTx(ctx, nil)
 
 	for _, scene := range scenes {
-		logger.Infof("Adding studio '%s' to scene '%s'", t.studio.Name.String, scene.Title.String)
+		logger.Infof("Adding studio '%s' to scene '%s'", t.studio.Name.String, scene.GetTitle())
 
 		// set the studio id
 		studioID := sql.NullInt64{Int64: int64(t.studio.ID), Valid: true}
@@ -129,7 +129,7 @@ func (t *AutoTagTagTask) autoTagTag() {
 	tx := database.DB.MustBeginTx(ctx, nil)
 
 	for _, scene := range scenes {
-		logger.Infof("Adding tag '%s' to scene '%s'", t.tag.Name, scene.Title.String)
+		logger.Infof("Adding tag '%s' to scene '%s'", t.tag.Name, scene.GetTitle())
 
 		err := jqb.AddSceneTag(scene.ID, t.tag.ID, tx)
 

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -22,9 +22,14 @@ func (t *AutoTagPerformerTask) Start(wg *sync.WaitGroup) {
 }
 
 func getQueryRegex(name string) string {
-	const separator = `[.\-_ ]`
+	const separatorChars = `.\-_ `
+	// handle path separators
+	const endSeparatorChars = separatorChars + `\\/`
+	const separator = `[` + separatorChars + `]`
+	const endSeparator = `[` + endSeparatorChars + `]`
+
 	ret := strings.Replace(name, " ", separator+"*", -1)
-	ret = "(?:^|" + separator + "+)" + ret + "(?:$|" + separator + "+)"
+	ret = "(?:^|" + endSeparator + "+)" + ret + "(?:$|" + endSeparator + "+)"
 	return ret
 }
 

--- a/pkg/manager/task_autotag_test.go
+++ b/pkg/manager/task_autotag_test.go
@@ -1,0 +1,333 @@
+// +build integration
+
+package manager
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/database"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
+
+	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jmoiron/sqlx"
+)
+
+const testName = "Foo Bar"
+const testExtension = ".mp4"
+
+var testSeparators = []string{
+	".",
+	"-",
+	"_",
+	" ",
+}
+
+func generateNamePatterns(name string, separator string) []string {
+	var ret []string
+	ret = append(ret, fmt.Sprintf("%s%saaa"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("aaa%s%s"+testExtension, separator, name))
+	ret = append(ret, fmt.Sprintf("aaa%s%s%sbbb"+testExtension, separator, name, separator))
+
+	return ret
+}
+
+func generateFalseNamePattern(name string, separator string) string {
+	splitted := strings.Split(name, " ")
+
+	return fmt.Sprintf("%s%saaa%s%s"+testExtension, splitted[0], separator, separator, splitted[1])
+}
+
+func testTeardown(databaseFile string) {
+	err := database.DB.Close()
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Remove(databaseFile)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func runTests(m *testing.M) int {
+	// create the database file
+	f, err := ioutil.TempFile("", "*.sqlite")
+	if err != nil {
+		panic(fmt.Sprintf("Could not create temporary file: %s", err.Error()))
+	}
+
+	f.Close()
+	databaseFile := f.Name()
+	database.Initialize(databaseFile)
+
+	// defer close and delete the database
+	defer testTeardown(databaseFile)
+
+	err = populateDB()
+	if err != nil {
+		panic(fmt.Sprintf("Could not populate database: %s", err.Error()))
+	} else {
+		// run the tests
+		return m.Run()
+	}
+}
+
+func TestMain(m *testing.M) {
+	ret := runTests(m)
+	os.Exit(ret)
+}
+
+func createPerformer(tx *sqlx.Tx) error {
+	// create the performer
+	pqb := models.NewPerformerQueryBuilder()
+
+	performer := models.Performer{
+		Image:    []byte{0, 1, 2},
+		Checksum: testName,
+		Name:     sql.NullString{Valid: true, String: testName},
+		Favorite: sql.NullBool{Valid: true, Bool: false},
+	}
+
+	_, err := pqb.Create(performer, tx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createStudio(tx *sqlx.Tx) error {
+	// create the studio
+	qb := models.NewStudioQueryBuilder()
+
+	studio := models.Studio{
+		Image:    []byte{0, 1, 2},
+		Checksum: testName,
+		Name:     sql.NullString{Valid: true, String: testName},
+	}
+
+	_, err := qb.Create(studio, tx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createTag(tx *sqlx.Tx) error {
+	// create the studio
+	qb := models.NewTagQueryBuilder()
+
+	tag := models.Tag{
+		Name: testName,
+	}
+
+	_, err := qb.Create(tag, tx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createScenes(tx *sqlx.Tx) error {
+	sqb := models.NewSceneQueryBuilder()
+
+	// create the scenes
+	var scenePatterns []string
+	var falseScenePatterns []string
+	for _, separator := range testSeparators {
+		scenePatterns = append(scenePatterns, generateNamePatterns(testName, separator)...)
+		scenePatterns = append(scenePatterns, generateNamePatterns(strings.ToLower(testName), separator)...)
+		if separator != " " {
+			scenePatterns = append(scenePatterns, generateNamePatterns(strings.Replace(testName, " ", separator, -1), separator)...)
+		}
+		falseScenePatterns = append(falseScenePatterns, generateFalseNamePattern(testName, separator))
+	}
+
+	for _, fn := range scenePatterns {
+		err := createScene(sqb, tx, fn, true)
+		if err != nil {
+			return err
+		}
+	}
+	for _, fn := range falseScenePatterns {
+		err := createScene(sqb, tx, fn, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createScene(sqb models.SceneQueryBuilder, tx *sqlx.Tx, name string, expectedResult bool) error {
+	scene := models.Scene{
+		Checksum: utils.MD5FromString(name),
+		Path:     name,
+	}
+
+	// if expectedResult is true then we expect it to match, set the title accordingly
+	if expectedResult {
+		scene.Title = sql.NullString{Valid: true, String: name}
+	}
+
+	_, err := sqb.Create(scene, tx)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create scene with name '%s': %s", name, err.Error())
+	}
+
+	return nil
+}
+
+func populateDB() error {
+	ctx := context.TODO()
+	tx := database.DB.MustBeginTx(ctx, nil)
+
+	err := createPerformer(tx)
+	if err != nil {
+		return err
+	}
+
+	err = createStudio(tx)
+	if err != nil {
+		return err
+	}
+
+	err = createTag(tx)
+	if err != nil {
+		return err
+	}
+
+	err = createScenes(tx)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestParsePerformers(t *testing.T) {
+	pqb := models.NewPerformerQueryBuilder()
+	performers, err := pqb.All()
+
+	if err != nil {
+		t.Errorf("Error getting performer: %s", err)
+		return
+	}
+
+	task := AutoTagPerformerTask{
+		performer: performers[0],
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	task.Start(&wg)
+
+	// verify that scenes were tagged correctly
+	sqb := models.NewSceneQueryBuilder()
+
+	scenes, err := sqb.All()
+
+	for _, scene := range scenes {
+		performers, err := pqb.FindBySceneID(scene.ID, nil)
+
+		if err != nil {
+			t.Errorf("Error getting scene performers: %s", err.Error())
+			return
+		}
+
+		// title is only set on scenes where we expect performer to be set
+		if scene.Title.String == scene.Path && len(performers) == 0 {
+			t.Errorf("Did not set performer '%s' for path '%s'", testName, scene.Path)
+		} else if scene.Title.String != scene.Path && len(performers) > 0 {
+			t.Errorf("Incorrectly set performer '%s' for path '%s'", testName, scene.Path)
+		}
+	}
+}
+
+func TestParseStudios(t *testing.T) {
+	studioQuery := models.NewStudioQueryBuilder()
+	studios, err := studioQuery.All()
+
+	if err != nil {
+		t.Errorf("Error getting studio: %s", err)
+		return
+	}
+
+	task := AutoTagStudioTask{
+		studio: studios[0],
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	task.Start(&wg)
+
+	// verify that scenes were tagged correctly
+	sqb := models.NewSceneQueryBuilder()
+
+	scenes, err := sqb.All()
+
+	for _, scene := range scenes {
+		// title is only set on scenes where we expect studio to be set
+		if scene.Title.String == scene.Path && scene.StudioID.Int64 != int64(studios[0].ID) {
+			t.Errorf("Did not set studio '%s' for path '%s'", testName, scene.Path)
+		} else if scene.Title.String != scene.Path && scene.StudioID.Int64 == int64(studios[0].ID) {
+			t.Errorf("Incorrectly set studio '%s' for path '%s'", testName, scene.Path)
+		}
+	}
+}
+
+func TestParseTags(t *testing.T) {
+	tagQuery := models.NewTagQueryBuilder()
+	tags, err := tagQuery.All()
+
+	if err != nil {
+		t.Errorf("Error getting performer: %s", err)
+		return
+	}
+
+	task := AutoTagTagTask{
+		tag: tags[0],
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	task.Start(&wg)
+
+	// verify that scenes were tagged correctly
+	sqb := models.NewSceneQueryBuilder()
+
+	scenes, err := sqb.All()
+
+	for _, scene := range scenes {
+		tags, err := tagQuery.FindBySceneID(scene.ID, nil)
+
+		if err != nil {
+			t.Errorf("Error getting scene tags: %s", err.Error())
+			return
+		}
+
+		// title is only set on scenes where we expect performer to be set
+		if scene.Title.String == scene.Path && len(tags) == 0 {
+			t.Errorf("Did not set tag '%s' for path '%s'", testName, scene.Path)
+		} else if scene.Title.String != scene.Path && len(tags) > 0 {
+			t.Errorf("Incorrectly set tag '%s' for path '%s'", testName, scene.Path)
+		}
+	}
+}

--- a/pkg/manager/task_autotag_test.go
+++ b/pkg/manager/task_autotag_test.go
@@ -36,6 +36,12 @@ func generateNamePatterns(name string, separator string) []string {
 	ret = append(ret, fmt.Sprintf("%s%saaa"+testExtension, name, separator))
 	ret = append(ret, fmt.Sprintf("aaa%s%s"+testExtension, separator, name))
 	ret = append(ret, fmt.Sprintf("aaa%s%s%sbbb"+testExtension, separator, name, separator))
+	ret = append(ret, fmt.Sprintf("dir/%s%saaa"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("dir\\%s%saaa"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("%s%saaa/dir/bbb"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("%s%saaa\\dir\\bbb"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("dir/%s%s/aaa"+testExtension, name, separator))
+	ret = append(ret, fmt.Sprintf("dir\\%s%s\\aaa"+testExtension, name, separator))
 
 	return ret
 }

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"path/filepath"
 )
 
 type Scene struct {
@@ -27,7 +28,7 @@ type Scene struct {
 }
 
 type ScenePartial struct {
-	ID         int             `db:"id" json:"id"`
+	ID         int              `db:"id" json:"id"`
 	Checksum   *string          `db:"checksum" json:"checksum"`
 	Path       *string          `db:"path" json:"path"`
 	Title      *sql.NullString  `db:"title" json:"title"`
@@ -46,4 +47,12 @@ type ScenePartial struct {
 	StudioID   *sql.NullInt64   `db:"studio_id,omitempty" json:"studio_id"`
 	CreatedAt  *SQLiteTimestamp `db:"created_at" json:"created_at"`
 	UpdatedAt  *SQLiteTimestamp `db:"updated_at" json:"updated_at"`
+}
+
+func (s Scene) GetTitle() string {
+	if s.Title.String != "" {
+		return s.Title.String
+	}
+
+	return filepath.Base(s.Path)
 }

--- a/pkg/models/querybuilder_joins.go
+++ b/pkg/models/querybuilder_joins.go
@@ -62,19 +62,22 @@ func (qb *JoinsQueryBuilder) CreatePerformersScenes(newJoins []PerformersScenes,
 	return nil
 }
 
-func (qb *JoinsQueryBuilder) AddPerformerScene(sceneID int, performerID int, tx *sqlx.Tx) error {
+// AddPerformerScene adds a performer to a scene. It does not make any change
+// if the performer already exists on the scene. It returns true if scene
+// performer was added.
+func (qb *JoinsQueryBuilder) AddPerformerScene(sceneID int, performerID int, tx *sqlx.Tx) (bool, error) {
 	ensureTx(tx)
 
 	existingPerformers, err := qb.GetScenePerformers(sceneID, tx)
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// ensure not already present
 	for _, p := range existingPerformers {
 		if p.PerformerID == performerID && p.SceneID == sceneID {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -84,7 +87,9 @@ func (qb *JoinsQueryBuilder) AddPerformerScene(sceneID int, performerID int, tx 
 	}
 	performerJoins := append(existingPerformers, performerJoin)
 
-	return qb.UpdatePerformersScenes(sceneID, performerJoins, tx)
+	err = qb.UpdatePerformersScenes(sceneID, performerJoins, tx)
+
+	return err == nil, err
 }
 
 func (qb *JoinsQueryBuilder) UpdatePerformersScenes(sceneID int, updatedJoins []PerformersScenes, tx *sqlx.Tx) error {
@@ -166,19 +171,21 @@ func (qb *JoinsQueryBuilder) UpdateScenesTags(sceneID int, updatedJoins []Scenes
 	return qb.CreateScenesTags(updatedJoins, tx)
 }
 
-func (qb *JoinsQueryBuilder) AddSceneTag(sceneID int, tagID int, tx *sqlx.Tx) error {
+// AddSceneTag adds a tag to a scene. It does not make any change if the tag
+// already exists on the scene. It returns true if scene tag was added.
+func (qb *JoinsQueryBuilder) AddSceneTag(sceneID int, tagID int, tx *sqlx.Tx) (bool, error) {
 	ensureTx(tx)
 
 	existingTags, err := qb.GetSceneTags(sceneID, tx)
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// ensure not already present
 	for _, p := range existingTags {
 		if p.TagID == tagID && p.SceneID == sceneID {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -188,7 +195,9 @@ func (qb *JoinsQueryBuilder) AddSceneTag(sceneID int, tagID int, tx *sqlx.Tx) er
 	}
 	tagJoins := append(existingTags, tagJoin)
 
-	return qb.UpdateScenesTags(sceneID, tagJoins, tx)
+	err = qb.UpdateScenesTags(sceneID, tagJoins, tx)
+
+	return err == nil, err
 }
 
 func (qb *JoinsQueryBuilder) DestroyScenesTags(sceneID int, tx *sqlx.Tx) error {

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -291,6 +291,30 @@ func getMultiCriterionClause(table string, joinTable string, joinTableField stri
 	return whereClause, havingClause
 }
 
+func (qb *SceneQueryBuilder) QueryAllByPathRegex(regex string) ([]*Scene, error) {
+	var args []interface{}
+	body := selectDistinctIDs("scenes") + " WHERE scenes.path regexp '(?i)" + regex + "'"
+
+	idsResult, err := runIdsQuery(body, args)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var scenes []*Scene
+	for _, id := range idsResult {
+		scene, err := qb.Find(id)
+
+		if err != nil {
+			return nil, err
+		}
+
+		scenes = append(scenes, scene)
+	}
+
+	return scenes, nil
+}
+
 func (qb *SceneQueryBuilder) QueryByPathRegex(findFilter *FindFilterType) ([]*Scene, int) {
 	if findFilter == nil {
 		findFilter = &FindFilterType{}

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -25,6 +25,10 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
   const [status, setStatus] = useState<string>("");
   const [progress, setProgress] = useState<number | undefined>(undefined);
 
+  const [autoTagPerformers, setAutoTagPerformers] = useState<boolean>(true);
+  const [autoTagStudios, setAutoTagStudios] = useState<boolean>(true);
+  const [autoTagTags, setAutoTagTags] = useState<boolean>(true);
+
   const jobStatus = StashService.useJobStatus();
   const metadataUpdate = StashService.useMetadataUpdate();
 
@@ -42,6 +46,8 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         return "Exporting to JSON";
       case "Import":
         return "Importing from JSON";
+      case "Auto Tag":
+        return "Auto tagging scenes";
     }
 
     return "Idle";
@@ -130,6 +136,25 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
     }
   }
 
+  function getAutoTagInput() {
+    var wildcard = ["*"];
+    return {
+      performers: autoTagPerformers ? wildcard : [],
+      studios: autoTagStudios ? wildcard : [],
+      tags: autoTagTags ? wildcard : []
+    }
+  }
+
+  async function onAutoTag() {
+    try {
+      await StashService.queryMetadataAutoTag(getAutoTagInput());
+      ToastUtils.success("Started auto tagging");
+      jobStatus.refetch();
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+  }
+
   function maybeRenderStop() {
     if (!status || status === "Idle") {
       return undefined;
@@ -180,11 +205,38 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         />
         <Button id="scan" text="Scan" onClick={() => onScan()} />
       </FormGroup>
+
+      <Divider />
+
+      <H4>Auto Tagging</H4>
+
+      <FormGroup
+        helperText="Auto-tag content based on filenames."
+        labelFor="autoTag"
+        inline={true}
+      >
+        <Checkbox
+          checked={autoTagPerformers}
+          label="Performers"
+          onChange={() => setAutoTagPerformers(!autoTagPerformers)}
+        />
+        <Checkbox
+          checked={autoTagStudios}
+          label="Studios"
+          onChange={() => setAutoTagStudios(!autoTagStudios)}
+        />
+        <Checkbox
+          checked={autoTagTags}
+          label="Tags"
+          onChange={() => setAutoTagTags(!autoTagTags)}
+        />
+        <Button id="autoTag" text="Auto Tag" onClick={() => onAutoTag()} />
+      </FormGroup>
+
+      <FormGroup>
         <Link className="bp3-button" to={"/sceneFilenameParser"}>
           Scene Filename Parser
         </Link>
-      <FormGroup>
-
       </FormGroup>
       <Divider />
 

--- a/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2/src/components/Shared/DetailsEditNavbar.tsx
@@ -22,6 +22,7 @@ interface IProps {
   onToggleEdit: () => void;
   onSave: () => void;
   onDelete: () => void;
+  onAutoTag?: () => void;
   onImageChange: (event: React.FormEvent<HTMLInputElement>) => void;
 
   // TODO: only for performers.  make generic
@@ -82,6 +83,15 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
     );
   }
 
+  function renderAutoTagButton() {
+    if (props.isNew || props.isEditing) { return; }
+    if (!!props.onAutoTag) {
+      return (<Button text="Auto Tag" onClick={() => {
+        if (props.onAutoTag) { props.onAutoTag() }
+      }}></Button>)
+    }
+  }
+
   function renderScenesButton() {
     if (props.isEditing) { return; }
     let linkSrc: string = "#";
@@ -136,6 +146,7 @@ export const DetailsEditNavbar: FunctionComponent<IProps> = (props: IProps) => {
         {renderImageInput()}
         {renderSaveButton()}
 
+        {renderAutoTagButton()}
         {renderScenesButton()}
         {renderDeleteButton()}
       </Navbar.Group>

--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -15,6 +15,7 @@ import { IBaseProps } from "../../../models";
 import { ErrorUtils } from "../../../utils/errors";
 import { TableUtils } from "../../../utils/table";
 import { DetailsEditNavbar } from "../../Shared/DetailsEditNavbar";
+import { ToastUtils } from "../../../utils/toasts";
 
 interface IProps extends IBaseProps {}
 
@@ -96,6 +97,18 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     setIsLoading(false);
   }
 
+  async function onAutoTag() {
+    if (!studio || !studio.id) {
+      return;
+    }
+    try {
+      await StashService.queryMetadataAutoTag({ studios: [studio.id]});
+      ToastUtils.success("Started auto tagging");
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+  }
+
   async function onDelete() {
     setIsLoading(true);
     try {
@@ -135,6 +148,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
             onToggleEdit={() => { setIsEditing(!isEditing); updateStudioEditState(studio); }}
             onSave={onSave}
             onDelete={onDelete}
+            onAutoTag={onAutoTag}
             onImageChange={onImageChange}
           />
           <h1 className="bp3-heading">

--- a/ui/v2/src/components/Tags/TagList.tsx
+++ b/ui/v2/src/components/Tags/TagList.tsx
@@ -77,6 +77,18 @@ export const TagList: FunctionComponent<IProps> = (props: IProps) => {
     }
   }
 
+  async function onAutoTag(tag : GQL.TagDataFragment) {
+    if (!tag) {
+      return;
+    }
+    try {
+      await StashService.queryMetadataAutoTag({ tags: [tag.id]});
+      ToastUtils.success("Started auto tagging");
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+  }
+
   async function onDelete() {
     try {
       await deleteTag();
@@ -115,6 +127,7 @@ export const TagList: FunctionComponent<IProps> = (props: IProps) => {
       <div key={tag.id} className="tag-list-row">
         <span onClick={() => setEditingTag(tag)}>{tag.name}</span>
         <div style={{float: "right"}}>
+          <Button text="Auto Tag" onClick={() => onAutoTag(tag)}></Button>
           <Link className="bp3-button" to={NavigationUtils.makeTagScenesUrl(tag)}>Scenes: {tag.scene_count}</Link>
           <Link className="bp3-button" to={NavigationUtils.makeTagSceneMarkersUrl(tag)}>
             Markers: {tag.scene_marker_count}

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -15,6 +15,7 @@ import { ErrorUtils } from "../../../utils/errors";
 import { TableUtils } from "../../../utils/table";
 import { ScrapePerformerSuggest } from "../../select/ScrapePerformerSuggest";
 import { DetailsEditNavbar } from "../../Shared/DetailsEditNavbar";
+import { ToastUtils } from "../../../utils/toasts";
 
 interface IPerformerProps extends IBaseProps {}
 
@@ -171,6 +172,18 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     props.history.push(`/performers`);
   }
 
+  async function onAutoTag() {
+    if (!performer || !performer.id) {
+      return;
+    }
+    try {
+      await StashService.queryMetadataAutoTag({ performers: [performer.id]});
+      ToastUtils.success("Started auto tagging");
+    } catch (e) {
+      ErrorUtils.handle(e);
+    }
+  }
+
   function onImageChange(event: React.FormEvent<HTMLInputElement>) {
     const file: File = (event.target as any).files[0];
     const reader: FileReader = new FileReader();
@@ -315,6 +328,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
             onImageChange={onImageChange}
             scrapers={queryableScrapers}
             onDisplayScraperDialog={onDisplayFreeOnesDialog}
+            onAutoTag={onAutoTag}
           />
           <h1 className="bp3-heading">
             <EditableText

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -411,6 +411,14 @@ export class StashService {
     });
   }
 
+  public static queryMetadataAutoTag(input: GQL.AutoTagMetadataInput) {
+    return StashService.client.query<GQL.MetadataAutoTagQuery>({
+      query: GQL.MetadataAutoTagDocument,
+      variables: { input },
+      fetchPolicy: "network-only",
+    });
+  }
+
   public static queryMetadataGenerate(input: GQL.GenerateMetadataInput) {
     return StashService.client.query<GQL.MetadataGenerateQuery>({
       query: GQL.MetadataGenerateDocument,


### PR DESCRIPTION
Adds an "Auto tag" section to the tasks settings page. Here you can tick whether to include performers, studios and tags. Clicking the button starts the auto-tagging job.

![image](https://user-images.githubusercontent.com/53250216/68918971-66543300-07c4-11ea-935c-3f58b8bc2123.png)

The auto-tagger loops through all of the performers/studios/tags in the database, and searches for scenes that match the following the name - using the following regex to handle word separators: `(?: |\.|-|_)?`. For each scene it finds, it adds the performer/studio/tag to the scene.

Also adds buttons to the performer/studio and tags pages which runs the auto-tag process for a specific performer/studio/tag.

![image](https://user-images.githubusercontent.com/53250216/68918999-7f5ce400-07c4-11ea-9aec-105d8a97fd93.png)

![image](https://user-images.githubusercontent.com/53250216/68919021-900d5a00-07c4-11ea-9b30-7ccc8d2db7c4.png)

Should resolve #6 and #34 