### PR TITLE
Fix panic on import with existing scene

### DIFF
--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -443,7 +443,7 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 		scene, err := qb.Create(newScene, tx)
 		if err != nil {
 			_ = tx.Rollback()
-			logger.Errorf("[scenes] <%s> failed to create: %s", scene.Checksum, err.Error())
+			logger.Errorf("[scenes] <%s> failed to create: %s", mappingJSON.Checksum, err.Error())
 			return
 		}
 		if scene.ID == 0 {


### PR DESCRIPTION
To reproduce, export then re-import into the same database. The first scene fails to import due to the unique constraint on the checksum. However, this was causing a panic because the `scene` value was nil and being dereferenced for the log text.