### PR TITLE
Fix Windows database.Reset

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -38,10 +39,20 @@ func Initialize(databasePath string) {
 	DB = conn
 }
 
-func Reset(databasePath string) {
-	_ = DB.Close()
-	_ = os.Remove(databasePath)
+func Reset(databasePath string) error {
+	err := DB.Close()
+
+	if err != nil {
+		return errors.New("Error closing database: " + err.Error())
+	}
+
+	err = os.Remove(databasePath)
+	if err != nil {
+		return errors.New("Error removing database: " + err.Error())
+	}
+
 	Initialize(databasePath)
+	return nil
 }
 
 // Migrate the database
@@ -71,6 +82,7 @@ func runMigrations(databasePath string) {
 			panic(err.Error())
 		}
 	}
+	m.Close()
 }
 
 func registerRegexpFunc() {

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -3,6 +3,10 @@ package manager
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/logger"
@@ -10,9 +14,6 @@ import (
 	"github.com/stashapp/stash/pkg/manager/jsonschema"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"strconv"
-	"sync"
-	"time"
 )
 
 type ImportTask struct {
@@ -34,7 +35,12 @@ func (t *ImportTask) Start(wg *sync.WaitGroup) {
 	}
 	t.Scraped = scraped
 
-	database.Reset(config.GetDatabasePath())
+	err := database.Reset(config.GetDatabasePath())
+
+	if err != nil {
+		logger.Errorf("Error resetting database: %s", err.Error())
+		return
+	}
 
 	ctx := context.TODO()
 


### PR DESCRIPTION
Added `error` return value to `database.Reset()`. Added `close` call to `runMigrations`. Adding this allowed the database file to be closed properly and the import to run successfully in Windows.