### PR TITLE
Add develop branch releases and display version tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ script:
 #- make vet
 - go test -mod=vendor
 before_deploy:
+- if [ "$TRAVIS_BRANCH" = "develop"]; then export TAG_SUFFIX="_dev; fi
+- export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}""
 - docker pull stashappdev/compiler
 - sh ./scripts/cross-compile.sh
-- git tag -f v0.0.0-alpha
+- git tag -f ${STASH_VERSION}
 - git push -f --tags
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')
 deploy:
@@ -37,7 +39,8 @@ deploy:
   body: ${RELEASE_DATE}
   on:
     repo: stashapp/stash
-    branch: master
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^(master|develop)$
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_deploy:
 - if [ "$TRAVIS_BRANCH" = "develop"]; then export TAG_SUFFIX="_dev; fi
 - export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}""
 - docker pull stashappdev/compiler
-- sh ./scripts/cross-compile.sh
+- sh ./scripts/cross-compile.sh ${STASH_VERSION}
 - git tag -f ${STASH_VERSION}
 - git push -f --tags
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')

--- a/graphql/documents/queries/misc.graphql
+++ b/graphql/documents/queries/misc.graphql
@@ -61,7 +61,8 @@ query Logs {
 }
 query Version {
   version {
-    hash,
+    version
+    hash
     build_time
   }
 }

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -1,4 +1,5 @@
 type Version {
+  version: String
   hash: String!
   build_time: String!
 }

--- a/pkg/api/resolver.go
+++ b/pkg/api/resolver.go
@@ -108,9 +108,10 @@ func (r *queryResolver) Stats(ctx context.Context) (*models.StatsResultType, err
 }
 
 func (r *queryResolver) Version(ctx context.Context) (*models.Version, error) {
-	hash, buildtime := GetVersion()
+	version, hash, buildtime := GetVersion()
 
 	return &models.Version{
+		Version:   &version,
 		Hash:      hash,
 		BuildTime: buildtime,
 	}, nil
@@ -173,7 +174,7 @@ func (r *queryResolver) ScrapeFreeonesPerformerList(ctx context.Context, query s
 // method determines if it was omitted altogether.
 func wasFieldIncluded(ctx context.Context, field string) bool {
 	rctx := graphql.GetRequestContext(ctx)
-	
+
 	_, ret := rctx.Variables[field]
 	return ret
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stashapp/stash/pkg/utils"
 )
 
+var version string = ""
 var buildstamp string = ""
 var githash string = ""
 
@@ -67,7 +68,7 @@ func Start() {
 	setupUIBox = packr.New("Setup UI Box", "../../ui/setup")
 
 	initialiseImages()
-	
+
 	r := chi.NewRouter()
 
 	r.Use(authenticateHandler())
@@ -112,7 +113,7 @@ func Start() {
 		if !config.GetCSSEnabled() {
 			return
 		}
-		
+
 		// search for custom.css in current directory, then $HOME/.stash
 		fn := config.GetCSSPath()
 		exists, _ := utils.FileExists(fn)
@@ -224,11 +225,15 @@ func Start() {
 }
 
 func printVersion() {
-	fmt.Printf("stash version: %s (%s)\n", githash, buildstamp)
+	versionString := githash
+	if version != "" {
+		versionString = version + " (" + versionString + ")"
+	}
+	fmt.Printf("stash version: %s - %s\n", versionString, buildstamp)
 }
 
-func GetVersion() (string, string) {
-	return githash, buildstamp
+func GetVersion() (string, string, string) {
+	return version, githash, buildstamp
 }
 
 func makeTLSConfig() *tls.Config {

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+STASH_VERSION="$1"
+
 DATE=`go run -mod=vendor scripts/getDate.go`
 GITHASH=`git rev-parse --short HEAD`
 VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -2,8 +2,7 @@
 
 DATE=`go run -mod=vendor scripts/getDate.go`
 GITHASH=`git rev-parse --short HEAD`
-VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"
-
+VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1;"
 WINDOWS="GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ packr2 build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"
 DARWIN="GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ packr2 build -o dist/stash-osx -ldflags \"$VERSION_FLAGS\" -tags extended -v -mod=vendor;"

--- a/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
@@ -16,12 +16,23 @@ interface IProps {}
 export const SettingsAboutPanel: FunctionComponent<IProps> = (props: IProps) => {
   const { data, error, loading } = StashService.useVersion();
 
+  function maybeRenderTag() {
+    if (!data || !data.version || !data.version.version) { return; }
+    return (
+      <tr>
+        <td>Version:</td>
+        <td>{data.version.version}</td>
+      </tr>
+    );
+  }
+
   function renderVersion() {
     if (!data || !data.version) { return; }
     return (
       <>
       <HTMLTable>
         <tbody>
+          {maybeRenderTag()}
           <tr>
             <td>Build hash:</td>
             <td>{data.version.hash}</td>


### PR DESCRIPTION
Adds the develop branch to the releases, tagging as v0.0.0-alpha_dev. Also adds the version tag to the startup message and the version UI page.