### PR TITLE
Refresh config when paths change

### DIFF
--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
@@ -74,6 +75,8 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 	if err := config.Write(); err != nil {
 		return makeConfigGeneralResult(), err
 	}
+
+	manager.GetInstance().RefreshConfig()
 
 	return makeConfigGeneralResult(), nil
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/rs/cors"
 	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/manager/paths"
 	"github.com/stashapp/stash/pkg/models"
@@ -67,7 +68,7 @@ func Start() {
 	setupUIBox = packr.New("Setup UI Box", "../../ui/setup")
 
 	initialiseImages()
-	
+
 	r := chi.NewRouter()
 
 	r.Use(authenticateHandler())
@@ -112,7 +113,7 @@ func Start() {
 		if !config.GetCSSEnabled() {
 			return
 		}
-		
+
 		// search for custom.css in current directory, then $HOME/.stash
 		fn := config.GetCSSPath()
 		exists, _ := utils.FileExists(fn)
@@ -181,6 +182,8 @@ func Start() {
 			http.Error(w, fmt.Sprintf("there was an error saving the config file: %s", err), 500)
 			return
 		}
+
+		manager.GetInstance().RefreshConfig()
 
 		http.Redirect(w, r, "/", 301)
 	})

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -43,7 +43,7 @@ func Initialize() *singleton {
 			JSON:   &jsonUtils{},
 		}
 
-		instance.refreshConfig()
+		instance.RefreshConfig()
 
 		initFFMPEG()
 	})
@@ -131,7 +131,7 @@ func initLog() {
 	logger.Init(config.GetLogFile(), config.GetLogOut(), config.GetLogLevel())
 }
 
-func (s *singleton) refreshConfig() {
+func (s *singleton) RefreshConfig() {
 	s.Paths = paths.NewPaths()
 	if config.IsValid() {
 		_ = utils.EnsureDir(s.Paths.Generated.Screenshots)


### PR DESCRIPTION
Fixes #207 

Calls `RefreshConfig` to reset the paths object when the paths are changed at init or subsequently in the config page.