### PR TITLE
Use justified layout for wall

### DIFF
--- a/ui/v2/package.json
+++ b/ui/v2/package.json
@@ -19,6 +19,7 @@
     "bulma": "0.7.5",
     "formik": "1.5.7",
     "graphql": "14.3.1",
+    "justified-layout": "^3.0.0",
     "localforage": "1.7.3",
     "lodash": "4.17.13",
     "node-sass": "4.12.0",

--- a/ui/v2/src/components/Wall/WallItem.tsx
+++ b/ui/v2/src/components/Wall/WallItem.tsx
@@ -11,8 +11,16 @@ interface IWallItemProps {
   scene?: GQL.SlimSceneDataFragment;
   sceneMarker?: GQL.SceneMarkerDataFragment;
   origin?: string;
+  position?: IWallItemPosition;
   onOverlay: (show: boolean) => void;
   clickHandler?: (item: GQL.SlimSceneDataFragment | GQL.SceneMarkerDataFragment) => void;
+}
+
+export interface IWallItemPosition {
+  top: number,
+  width: number,
+  height: number,
+  left: number
 }
 
 export const WallItem: FunctionComponent<IWallItemProps> = (props: IWallItemProps) => {
@@ -96,12 +104,20 @@ export const WallItem: FunctionComponent<IWallItemProps> = (props: IWallItemProp
   const className = ["scene-wall-item-container"];
   if (videoHoverHook.isHovering.current) { className.push("double-scale"); }
   const style: React.CSSProperties = {};
+
+  if (!!props.position) {
+    let position = props.position;
+    style.width = position.width;
+    style.height = position.height;
+    style.left = position.left;
+    style.top = position.top;
+  }
+
   if (!!props.origin) { style.transformOrigin = props.origin; }
   return (
-    <div className="wall grid-item">
+    <div style={style} className="wall grid-item">
       <div
         className={className.join(" ")}
-        style={style}
         onTransitionEnd={onTransitionEnd}
         onMouseEnter={() => debouncedOnMouseEnter.current()}
         onMouseMove={() => debouncedOnMouseEnter.current()}

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -43,6 +43,7 @@ code {
   &.wall {
     padding: 0;
     margin: 0;
+    position: relative;
   }
 
   & .bp3-button.favorite .bp3-icon {
@@ -75,6 +76,7 @@ code {
   &.wall {
     width: calc(20%);
     margin: 0;
+    position: static;
   }
 }
 

--- a/ui/v2/src/models/justified-layout.d.ts
+++ b/ui/v2/src/models/justified-layout.d.ts
@@ -1,0 +1,5 @@
+declare module "justified-layout" {
+  // typing module default export as `any` will allow you to access its members without compiler warning
+  var justifiedLayout: any;
+  export default justifiedLayout;
+}

--- a/ui/v2/yarn.lock
+++ b/ui/v2/yarn.lock
@@ -7286,6 +7286,13 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+justified-layout@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/justified-layout/-/justified-layout-3.0.0.tgz#f8643ac51d97cf43dd40ddf38601161968ff8165"
+  integrity sha512-xki5bVJ84HokIV47mfHdmWB56zFrQKbtrU5KHA5GoatOnRwQWGOvNtBlbW8dU0yIa3pNmCPuacuuMRPvM9p5mg==
+  dependencies:
+    merge "1.2.1"
+
 keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
@@ -7797,6 +7804,11 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+merge@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
The current wall layout has issues when portrait and landscape scenes are mixed in on the same row. The scene thumbnails end up being truncated. This change uses flickr's justified-layout to lay the scene thumbnails in a justified grid. In my opinion it results in a much cleaner layout. It's a bit hard to show the comparative results with SFW images, so you might just need to see for yourself.