### PR TITLE
Add test and integration tests to the Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod text eol=lf
+go.sum text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
 script:
 #- make lint
 #- make vet
-- go test -mod=vendor
+- make test
+- if [ "$TRAVIS_BRANCH" = "master" ]; then make it; fi
 before_deploy:
 - if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
 - export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 #- make lint
 #- make vet
 - make test
-- if [ "$TRAVIS_BRANCH" = "master" ]; then make it; fi
+- make it
 before_deploy:
 - if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
 - export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
 script:
 #- make lint
 #- make vet
-- make test
 - make it
 before_deploy:
 - if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,12 @@ vet:
 lint:
 	revive -config revive.toml -exclude ./vendor/...  ./...
 
+# runs unit tests - excluding integration tests
 .PHONY: test
 test: 
 	go test -mod=vendor ./...
 
+# runs all tests - including integration tests
 .PHONY: it
 it:
 	go test -mod=vendor -tags=integration ./...

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ vet:
 lint:
 	revive -config revive.toml -exclude ./vendor/...  ./...
 
+.PHONY: test
+test: 
+	go test -mod=vendor ./...
+
+.PHONY: it
+it:
+	go test -mod=vendor -tags=integration ./...
+
 .PHONY: ui
 ui:
 	cd ui/v2 && yarn build

--- a/pkg/manager/generator.go
+++ b/pkg/manager/generator.go
@@ -3,13 +3,14 @@ package manager
 import (
 	"bytes"
 	"fmt"
-	"github.com/stashapp/stash/pkg/ffmpeg"
-	"github.com/stashapp/stash/pkg/logger"
-	"github.com/stashapp/stash/pkg/utils"
 	"math"
 	"os/exec"
 	"runtime"
 	"strconv"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 type GeneratorInfo struct {
@@ -84,7 +85,7 @@ func (g *GeneratorInfo) configure() error {
 	// Something seriously wrong with this file
 	if numberOfFrames == 0 || !utils.IsValidFloat64(framerate) {
 		logger.Errorf(
-			"number of frames or framerate is 0.  nb_frames <%s> framerate <%s> duration <%s>",
+			"number of frames or framerate is 0.  nb_frames <%s> framerate <%f> duration <%f>",
 			videoStream.NbFrames,
 			framerate,
 			g.VideoFile.Duration,


### PR DESCRIPTION
Currently, travis runs `go test` which only tests the top-level package. Added `test` and `it` targets to the Makefile. `test` performs unit tests on the entire package tree. `it` performs integration tests (denoted in the test files with `// +build integration`).

I've changed the travis file to run `make test` on all builds, and `make it` on master builds, though this could possibly be changed to include the develop branch as well.

The change to `generator.go` was the result of running `make test` finding an error. This was latent due to travis running `go test` only.

Finally, I've added a `gitattributes` file to prevent the `go.mod` and `go.sum` files from showing as modified on Windows after a build. 