### PR TITLE
[BUG] Fix previews generation bug

### DIFF
--- a/pkg/ffmpeg/encoder_scene_preview_chunk.go
+++ b/pkg/ffmpeg/encoder_scene_preview_chunk.go
@@ -17,8 +17,8 @@ func (e *Encoder) ScenePreviewVideoChunk(probeResult VideoFile, options ScenePre
 	args := []string{
 		"-v", "error",
 		"-ss", strconv.Itoa(options.Time),
-		"-t", "0.75",
 		"-i", probeResult.Path,
+		"-t", "0.75",
 		"-max_muxing_queue_size", "1024", // https://trac.ffmpeg.org/ticket/6375
 		"-y",
 		"-c:v", "libx264",


### PR DESCRIPTION
During the preview generation task on some files (very small percentage) the process seemed to take too much time to complete.
Upon investigation it  seems that the trimmed files to be concatenated had weird durations / timings and so the resulting mp4 file generated had also weird fps (0.001) making the generate task stuck to a single scene for hours.
Simply changing the order of the ffmpeg  `-t` parameter after the input `-i` fixes all weird occurences and goes past the problematic files as it should.
I couldn't find anything in common for the files affected (original,reencodes,mp4,webm ) , i could only verify through discord that the specific change is indeed generating correct previews with the problematic media files.