### PR TITLE
Scene ui improvements

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -17,6 +17,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   wallShowTitle
   maximumLoopDuration
   autostartVideo
+  showStudioAsText
   css
   cssEnabled
 }

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -66,6 +66,8 @@ input ConfigInterfaceInput {
   maximumLoopDuration: Int
   """If true, video will autostart on load in the scene player"""
   autostartVideo: Boolean
+  """If true, studio overlays will be shown as text instead of logo images"""
+  showStudioAsText: Boolean
   """Custom CSS"""
   css: String
   cssEnabled: Boolean
@@ -80,6 +82,8 @@ type ConfigInterfaceResult {
   maximumLoopDuration: Int
   """If true, video will autostart on load in the scene player"""
   autostartVideo: Boolean
+   """If true, studio overlays will be shown as text instead of logo images"""
+  showStudioAsText: Boolean
   """Custom CSS"""
   css: String
   cssEnabled: Boolean

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -98,6 +98,10 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input models.
 		config.Set(config.AutostartVideo, *input.AutostartVideo)
 	}
 
+	if input.ShowStudioAsText != nil {
+		config.Set(config.ShowStudioAsText, *input.ShowStudioAsText)
+	}
+
 	css := ""
 
 	if input.CSS != nil {

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -53,6 +53,7 @@ func makeConfigInterfaceResult() *models.ConfigInterfaceResult {
 	wallShowTitle := config.GetWallShowTitle()
 	maximumLoopDuration := config.GetMaximumLoopDuration()
 	autostartVideo := config.GetAutostartVideo()
+	showStudioAsText := config.GetShowStudioAsText()
 	css := config.GetCSS()
 	cssEnabled := config.GetCSSEnabled()
 
@@ -61,6 +62,7 @@ func makeConfigInterfaceResult() *models.ConfigInterfaceResult {
 		WallShowTitle:       &wallShowTitle,
 		MaximumLoopDuration: &maximumLoopDuration,
 		AutostartVideo:      &autostartVideo,
+		ShowStudioAsText:    &showStudioAsText,
 		CSS:                 &css,
 		CSSEnabled:          &cssEnabled,
 	}

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -35,6 +35,7 @@ const SoundOnPreview = "sound_on_preview"
 const WallShowTitle = "wall_show_title"
 const MaximumLoopDuration = "maximum_loop_duration"
 const AutostartVideo = "autostart_video"
+const ShowStudioAsText = "show_studio_as_text"
 const CSSEnabled = "cssEnabled"
 
 // Logging options
@@ -189,6 +190,11 @@ func GetMaximumLoopDuration() int {
 func GetAutostartVideo() bool {
 	viper.SetDefault(AutostartVideo, false)
 	return viper.GetBool(AutostartVideo)
+}
+
+func GetShowStudioAsText() bool {
+	viper.SetDefault(ShowStudioAsText, false)
+	return viper.GetBool(ShowStudioAsText)
 }
 
 func GetCSSPath() string {

--- a/ui/v2/src/components/Settings/SettingsInterfacePanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsInterfacePanel.tsx
@@ -22,6 +22,7 @@ export const SettingsInterfacePanel: FunctionComponent<IProps> = () => {
   const [wallShowTitle, setWallShowTitle] = useState<boolean>();
   const [maximumLoopDuration, setMaximumLoopDuration] = useState<number>(0);
   const [autostartVideo, setAutostartVideo] = useState<boolean>();
+  const [showStudioAsText, setShowStudioAsText] = useState<boolean>();
   const [css, setCSS] = useState<string>();
   const [cssEnabled, setCSSEnabled] = useState<boolean>();
 
@@ -30,6 +31,7 @@ export const SettingsInterfacePanel: FunctionComponent<IProps> = () => {
     wallShowTitle,
     maximumLoopDuration,
     autostartVideo,
+    showStudioAsText,
     css,
     cssEnabled
   });
@@ -42,6 +44,7 @@ export const SettingsInterfacePanel: FunctionComponent<IProps> = () => {
       setWallShowTitle(iCfg.wallShowTitle !== undefined ? iCfg.wallShowTitle : true);
       setMaximumLoopDuration(iCfg.maximumLoopDuration || 0);
       setAutostartVideo(iCfg.autostartVideo !== undefined ? iCfg.autostartVideo : false);
+      setShowStudioAsText(iCfg.showStudioAsText !== undefined ? iCfg.showStudioAsText : false);
       setCSS(config.data.configuration.interface.css || "");
       setCSSEnabled(config.data.configuration.interface.cssEnabled || false);
     }
@@ -78,6 +81,18 @@ export const SettingsInterfacePanel: FunctionComponent<IProps> = () => {
         />
       </FormGroup>
 
+      <FormGroup
+        label="Scene List"
+      >
+        <Checkbox
+          checked={showStudioAsText}
+          label="Show Studios as text"
+          onChange={() => {
+            setShowStudioAsText(!showStudioAsText)
+          }}
+        />
+      </FormGroup>
+      
       <FormGroup
         label="Scene Player"
       >

--- a/ui/v2/src/components/list/AddFilter.tsx
+++ b/ui/v2/src/components/list/AddFilter.tsx
@@ -5,6 +5,7 @@ import {
   FormGroup,
   HTMLSelect,
   InputGroup,
+  Tooltip,
 } from "@blueprintjs/core";
 import _ from "lodash";
 import React, { FunctionComponent, useEffect, useRef, useState } from "react";
@@ -188,7 +189,19 @@ export const AddFilter: FunctionComponent<IAddFilterProps> = (props: IAddFilterP
   const title = !props.editingCriterion ? "Add Filter" : "Update Filter";
   return (
     <>
-      <Button onClick={() => onToggle()} active={isOpen} large={true}>Filter</Button>
+      <Tooltip
+        hoverOpenDelay={200}
+        content="Filter"
+      >
+        <Button 
+          icon="filter"
+          onClick={() => onToggle()} 
+          active={isOpen} 
+          large={true}
+        >
+        </Button>
+      </Tooltip>
+      
       <Dialog isOpen={isOpen} onClose={() => onToggle()} title={title}>
         <div className="dialog-content">
           {maybeRenderFilterSelect()}

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -118,7 +118,6 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
           active={props.filter.displayMode === option}
           onClick={() => onChangeDisplayMode(option)}
           icon={getIcon(option)}
-          minimal={true}
         />
       </Tooltip>
     ));

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Tag,
   Tooltip,
+  Slider,
 } from "@blueprintjs/core";
 import { debounce } from "lodash";
 import React, { FunctionComponent, SyntheticEvent, useEffect, useRef, useState } from "react";
@@ -26,6 +27,8 @@ interface IListFilterProps {
   onChangeDisplayMode: (displayMode: DisplayMode) => void;
   onAddCriterion: (criterion: Criterion, oldId?: string) => void;
   onRemoveCriterion: (criterion: Criterion) => void;
+  zoomIndex?: number;
+  onChangeZoom?: (zoomIndex: number) => void;
   onSelectAll?: () => void;
   onSelectNone?: () => void;
   filter: ListFilterModel;
@@ -188,6 +191,29 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
     );
   }
 
+  function onChangeZoom(v : number) {
+    if (props.onChangeZoom) {
+      props.onChangeZoom(v);
+    }
+  } 
+
+  function maybeRenderZoom() {
+    if (props.onChangeZoom) {
+      return (
+        <span className="zoom-slider">
+          <Slider 
+            min={0}
+            value={props.zoomIndex}
+            initialValue={props.zoomIndex}
+            max={3}
+            labelRenderer={false}
+            onChange={(v) => onChangeZoom(v)}
+          />
+      </span>
+      );
+    }
+  }
+
   function render() {
     return (
       <>
@@ -235,6 +261,8 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
           <ButtonGroup className="filter-item">
             {renderDisplayModeOptions()}
           </ButtonGroup>
+
+          {maybeRenderZoom()}
 
           <ButtonGroup className="filter-item">
             {renderSelectAllNone()}

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -155,40 +155,40 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
 
   function renderSelectAll() {
     if (props.onSelectAll) {
-      return (
-        <Tooltip
-          content="Select All"
-          hoverOpenDelay={200}
-        >
-          <Button 
-            onClick={() => onSelectAll()} 
-            icon="tick"
-          />
-        </Tooltip>
-      );
+      return <MenuItem onClick={() => onSelectAll()} text="Select All" />;
     }
   }
 
   function renderSelectNone() {
     if (props.onSelectNone) {
-      return (
-        <Tooltip
-          content="Select None"
-          hoverOpenDelay={200}
-        >
-          <Button onClick={() => onSelectNone()} icon="square"/>
-        </Tooltip>
-      );
+      return <MenuItem onClick={() => onSelectNone()} text="Select None" />;
     }
   }
 
-  function renderSelectAllNone() {
-    return (
-      <>
-      {renderSelectAll()}
-      {renderSelectNone()}
-      </>
-    );
+  function renderMore() {
+    let options = [];
+    options.push(renderSelectAll());
+    options.push(renderSelectNone());
+    options = options.filter((o) => !!o);
+
+    let menuItems = options as JSX.Element[];
+
+    function renderMoreOptions() {
+      return (
+        <>
+        {menuItems}
+        </>
+      )
+    }
+
+    if (menuItems.length > 0) {
+      return (
+        <Popover position="bottom">
+          <Button icon="more"/>
+          <Menu>{renderMoreOptions()}</Menu>
+        </Popover>
+      );
+    }
   }
 
   function onChangeZoom(v : number) {
@@ -265,7 +265,7 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
           {maybeRenderZoom()}
 
           <ButtonGroup className="filter-item">
-            {renderSelectAllNone()}
+            {renderMore()}
           </ButtonGroup>
         </div>
         <div style={{display: "flex", justifyContent: "center", margin: "10px auto"}}>

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -9,6 +9,7 @@ import {
   MenuItem,
   Popover,
   Tag,
+  Tooltip,
 } from "@blueprintjs/core";
 import { debounce } from "lodash";
 import React, { FunctionComponent, SyntheticEvent, useEffect, useRef, useState } from "react";
@@ -111,13 +112,15 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
       }
     }
     return props.filter.displayModeOptions.map((option) => (
-      <Button
-        key={option}
-        active={props.filter.displayMode === option}
-        onClick={() => onChangeDisplayMode(option)}
-        icon={getIcon(option)}
-        text={getLabel(option)}
-      />
+      <Tooltip content={getLabel(option)} hoverOpenDelay={200}>
+        <Button
+          key={option}
+          active={props.filter.displayMode === option}
+          onClick={() => onChangeDisplayMode(option)}
+          icon={getIcon(option)}
+          minimal={true}
+        />
+      </Tooltip>
     ));
   }
 
@@ -150,13 +153,30 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
 
   function renderSelectAll() {
     if (props.onSelectAll) {
-      return <Button onClick={() => onSelectAll()} text="Select All"/>;
+      return (
+        <Tooltip
+          content="Select All"
+          hoverOpenDelay={200}
+        >
+          <Button 
+            onClick={() => onSelectAll()} 
+            icon="tick"
+          />
+        </Tooltip>
+      );
     }
   }
 
   function renderSelectNone() {
     if (props.onSelectNone) {
-      return <Button onClick={() => onSelectNone()} text="Select None"/>;
+      return (
+        <Tooltip
+          content="Select None"
+          hoverOpenDelay={200}
+        >
+          <Button onClick={() => onSelectNone()} icon="square"/>
+        </Tooltip>
+      );
     }
   }
 
@@ -188,18 +208,23 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
             value={props.filter.itemsPerPage}
             className="filter-item"
           />
-          <ControlGroup className="filter-item">
-            <AnchorButton
-              rightIcon={props.filter.sortDirection === "asc" ? "caret-up" : "caret-down"}
-              onClick={onChangeSortDirection}
-            >
-              {props.filter.sortDirection === "asc" ? "Ascending" : "Descending"}
-            </AnchorButton>
+          <ButtonGroup className="filter-item">
             <Popover position="bottom">
               <Button large={true}>{props.filter.sortBy}</Button>
               <Menu>{renderSortByOptions()}</Menu>
             </Popover>
-          </ControlGroup>
+            
+            <Tooltip 
+              content={props.filter.sortDirection === "asc" ? "Ascending" : "Descending"}
+              hoverOpenDelay={200}
+            >
+              <Button
+                rightIcon={props.filter.sortDirection === "asc" ? "caret-up" : "caret-down"}
+                onClick={onChangeSortDirection}
+              />
+            </Tooltip>
+            
+          </ButtonGroup>
 
           <AddFilter
             filter={props.filter}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -18,6 +18,7 @@ import { TextUtils } from "../../utils/text";
 import { TagLink } from "../Shared/TagLink";
 import { SceneHelpers } from "./helpers";
 import { ZoomUtils } from "../../utils/zoom";
+import { StashService } from "../../core/StashService";
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
@@ -30,6 +31,8 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
   const [previewPath, setPreviewPath] = useState<string | undefined>(undefined);
   const videoHoverHook = VideoHoverHook.useVideoHover({resetOnMouseLeave: false});
   
+  const config = StashService.useConfiguration();
+  const showStudioAsText = !!config.data && !!config.data.configuration ? config.data.configuration.interface.showStudioAsText : false;
 
   function maybeRenderRatingBanner() {
     if (!props.scene.rating) { return; }
@@ -54,16 +57,25 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       return;
     }
 
-    const style: React.CSSProperties = {
+    let style: React.CSSProperties = {
       backgroundImage: `url('${props.scene.studio.image_path}')`,
     };
+
+    let text = "";
+
+    if (showStudioAsText) {
+      style = {};
+      text = props.scene.studio.name;
+    }
 
     return (
       <div className={`scene-studio-overlay`}>
         <Link
           to={`/studios/${props.scene.studio.id}`}
           style={style}
-        />
+        >
+          {text}
+        </Link>
       </div>
     );
   }

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -158,13 +158,27 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     setPreviewPath("");
   }
 
-
-  function getVideoClassName() {
-    let ret = "preview";
+  function isPortrait() {
     let file = props.scene.file;
     let width = file.width ? file.width : 0;
     let height = file.height ? file.height : 0;
-    if (height > width) {
+    return height > width;
+  }
+
+  function getLinkClassName() {
+    let ret = "image previewable";
+    
+    if (isPortrait()) {
+      ret += " portrait";
+    }
+
+    return ret;
+  }
+
+  function getVideoClassName() {
+    let ret = "preview";
+    
+    if (isPortrait()) {
       ret += " portrait";
     }
 
@@ -186,7 +200,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         onChange={() => props.onSelectedChanged(!props.selected, shiftKey)}
         onClick={(event: React.MouseEvent<HTMLInputElement, MouseEvent>) => { shiftKey = event.shiftKey; event.stopPropagation(); } }
       />
-      <Link to={`/scenes/${props.scene.id}`} className="image previewable">
+      <Link to={`/scenes/${props.scene.id}`} className={getLinkClassName()}>
         <div className="video-container">
           {maybeRenderRatingBanner()}
           {maybeRenderSceneSpecsOverlay()}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -128,6 +128,19 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     setPreviewPath("");
   }
 
+
+  function getVideoClassName() {
+    let ret = "preview";
+    let file = props.scene.file;
+    let width = file.width ? file.width : 0;
+    let height = file.height ? file.height : 0;
+    if (height > width) {
+      ret += " portrait";
+    }
+
+    return ret;
+  }
+
   var shiftKey = false;
 
   return (
@@ -144,11 +157,13 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         onClick={(event: React.MouseEvent<HTMLInputElement, MouseEvent>) => { shiftKey = event.shiftKey; event.stopPropagation(); } }
       />
       <Link to={`/scenes/${props.scene.id}`} className="image previewable">
-        {maybeRenderRatingBanner()}
-        {maybeRenderSceneSpecsOverlay()}
-        <video className="preview" loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
-          {!!previewPath ? <source src={previewPath} /> : ""}
-        </video>
+        <div className="video-container">
+          {maybeRenderRatingBanner()}
+          {maybeRenderSceneSpecsOverlay()}
+          <video className={getVideoClassName()} loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
+            {!!previewPath ? <source src={previewPath} /> : ""}
+          </video>
+        </div>
       </Link>
       <div className="card-section">
         <H4 style={{textOverflow: "ellipsis", overflow: "hidden"}}>

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -175,7 +175,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
   return (
     <Card
-      className="grid-item"
+      className="grid-item scene-card"
       elevation={Elevation.ONE}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -17,10 +17,12 @@ import { ColorUtils } from "../../utils/color";
 import { TextUtils } from "../../utils/text";
 import { TagLink } from "../Shared/TagLink";
 import { SceneHelpers } from "./helpers";
+import { ZoomUtils } from "../../utils/zoom";
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
   selected: boolean | undefined;
+  zoomIndex: number;
   onSelectedChanged: (selected : boolean, shiftKey : boolean) => void;
 }
 
@@ -189,7 +191,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
   return (
     <Card
-      className="grid-item scene-card"
+      className={"grid-item scene-card " + ZoomUtils.classForZoom(props.zoomIndex)}
       elevation={Elevation.ONE}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -67,9 +67,20 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
   function maybeRenderPerformerPopoverButton() {
     if (props.scene.performers.length <= 0) { return; }
 
-    const performers = props.scene.performers.map((performer) => (
-      <TagLink key={performer.id} performer={performer} />
-    ));
+    const performers = props.scene.performers.map((performer) => {
+      return (
+        <>
+        <div className="performer-tag-container">
+          <Link
+            to={`/performers/${performer.id}`}
+            className="performer-tag previewable image"
+            style={{backgroundImage: `url(${performer.image_path})`}}
+          ></Link>
+          <TagLink key={performer.id} performer={performer} />
+        </div>
+        </>
+      );
+    });
     return (
       <Popover interactionKind={"hover"} position="bottom">
         <Button

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -47,6 +47,25 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     );
   }
 
+  function maybeRenderSceneStudioOverlay() {
+    if (!props.scene.studio) {
+      return;
+    }
+
+    const style: React.CSSProperties = {
+      backgroundImage: `url('${props.scene.studio.image_path}')`,
+    };
+
+    return (
+      <div className={`scene-studio-overlay`}>
+        <Link
+          to={`/studios/${props.scene.studio.id}`}
+          style={style}
+        />
+      </div>
+    );
+  }
+
   function maybeRenderTagPopoverButton() {
     if (props.scene.tags.length <= 0) { return; }
 
@@ -171,6 +190,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         <div className="video-container">
           {maybeRenderRatingBanner()}
           {maybeRenderSceneSpecsOverlay()}
+          {maybeRenderSceneStudioOverlay()}
           <video className={getVideoClassName()} loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
             {!!previewPath ? <source src={previewPath} /> : ""}
           </video>
@@ -185,8 +205,6 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       </div>
 
       {maybeRenderPopoverButtonGroup()}
-
-      {SceneHelpers.maybeRenderStudio(props.scene, 50, true)}
     </Card>
   );
 };

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -38,6 +38,15 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     );
   }
 
+  function maybeRenderSceneSpecsOverlay() {
+    return (
+      <div className={`scene-specs-overlay`}>
+        {!!props.scene.file.height ? <span className={`overlay-resolution`}> {TextUtils.resolution(props.scene.file.height)}</span> : undefined}
+        {props.scene.file.duration !== undefined && props.scene.file.duration >= 1 ? TextUtils.secondsToTimestamp(props.scene.file.duration) : ""}
+      </div>
+    );
+  }
+
   function maybeRenderTagPopoverButton() {
     if (props.scene.tags.length <= 0) { return; }
 
@@ -136,6 +145,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       />
       <Link to={`/scenes/${props.scene.id}`} className="image previewable">
         {maybeRenderRatingBanner()}
+        {maybeRenderSceneSpecsOverlay()}
         <video className="preview" loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
           {!!previewPath ? <source src={previewPath} /> : ""}
         </video>
@@ -150,14 +160,6 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
       {maybeRenderPopoverButtonGroup()}
 
-      <Divider />
-      <span className="card-section centered">
-        {props.scene.file.size !== undefined ? TextUtils.fileSize(parseInt(props.scene.file.size, 10)) : ""}
-        &nbsp;|&nbsp;
-        {props.scene.file.duration !== undefined ? TextUtils.secondsToTimestamp(props.scene.file.duration) : ""}
-        &nbsp;|&nbsp;
-        {props.scene.file.width} x {props.scene.file.height}
-      </span>
       {SceneHelpers.maybeRenderStudio(props.scene, 50, true)}
     </Card>
   );

--- a/ui/v2/src/components/scenes/SceneList.tsx
+++ b/ui/v2/src/components/scenes/SceneList.tsx
@@ -17,6 +17,7 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
   const listData = ListHook.useList({
     filterMode: FilterMode.Scenes,
     props,
+    zoomable: true,
     renderContent,
     renderSelectedOptions
   });
@@ -45,23 +46,24 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
     );
   }
 
-  function renderSceneCard(scene : SlimSceneDataFragment, selectedIds: Set<string>) {
+  function renderSceneCard(scene : SlimSceneDataFragment, selectedIds: Set<string>, zoomIndex: number) {
     return (
       <SceneCard 
         key={scene.id} 
         scene={scene} 
+        zoomIndex={zoomIndex}
         selected={selectedIds.has(scene.id)}
         onSelectedChanged={(selected: boolean, shiftKey: boolean) => listData.onSelectChange(scene.id, selected, shiftKey)}
       />
     )
   }
 
-  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel, selectedIds: Set<string>) {
+  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel, selectedIds: Set<string>, zoomIndex: number) {
     if (!result.data || !result.data.findScenes) { return; }
     if (filter.displayMode === DisplayMode.Grid) {
       return (
         <div className="grid">
-          {result.data.findScenes.scenes.map((scene) => renderSceneCard(scene, selectedIds))}
+          {result.data.findScenes.scenes.map((scene) => renderSceneCard(scene, selectedIds, zoomIndex))}
         </div>
       );
     } else if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -21,7 +21,8 @@ export interface IListHookData {
 export interface IListHookOptions {
   filterMode: FilterMode;
   props: IBaseProps;
-  renderContent: (result: QueryHookResult<any, any>, filter: ListFilterModel, selectedIds: Set<string>) => JSX.Element | undefined;
+  zoomable?: boolean
+  renderContent: (result: QueryHookResult<any, any>, filter: ListFilterModel, selectedIds: Set<string>, zoomIndex: number) => JSX.Element | undefined;
   renderSelectedOptions?: (result: QueryHookResult<any, any>, selectedIds: Set<string>) => JSX.Element | undefined;
 }
 
@@ -31,6 +32,7 @@ export class ListHook {
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [lastClickedId, setLastClickedId] = useState<string | undefined>(undefined);
     const [totalCount, setTotalCount] = useState<number>(0);
+    const [zoomIndex, setZoomIndex] = useState<number>(1);
 
     // Update the filter when the query parameters change
     useEffect(() => {
@@ -254,6 +256,10 @@ export class ListHook {
       setLastClickedId(undefined);
     }
 
+    function onChangeZoom(newZoomIndex : number) {
+      setZoomIndex(newZoomIndex);
+    }
+
     const template = (
       <div>
         <ListFilter
@@ -266,12 +272,14 @@ export class ListHook {
           onRemoveCriterion={onRemoveCriterion}
           onSelectAll={onSelectAll}
           onSelectNone={onSelectNone}
+          zoomIndex={options.zoomable ? zoomIndex : undefined}
+          onChangeZoom={options.zoomable ? onChangeZoom : undefined}
           filter={filter}
         />
         {options.renderSelectedOptions && selectedIds.size > 0 ? options.renderSelectedOptions(result, selectedIds) : undefined}
         {result.loading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
         {result.error ? <h1>{result.error.message}</h1> : undefined}
-        {options.renderContent(result, filter, selectedIds)}
+        {options.renderContent(result, filter, selectedIds, zoomIndex)}
         <Pagination
           itemsPerPage={filter.itemsPerPage}
           currentPage={filter.currentPage}

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -85,6 +85,8 @@ code {
   width: calc(100% + 40px);
   margin: -20px 0 0 -20px;
   position: relative;
+  height: 240px;
+  max-height: 80vh;
 }
 
 .grid-item label.card-select {
@@ -95,12 +97,24 @@ code {
   opacity: 0.5;
 }
 
+.video-container {
+  width: 100%;
+  height: 100%;
+}
+
 video.preview {
   // height: 225px; // slows down the page
   width: 100%;
   // width: calc(100% + 40px);
   // margin: -20px 0 0 -20px;
   object-fit: cover;
+  margin: 0 auto;
+  display: block;
+}
+
+video.preview.portrait {
+  height: 100%;
+  width: auto;
 }
 
 .filter-item, .operation-item {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -85,8 +85,11 @@ code {
   width: calc(100% + 40px);
   margin: -20px 0 0 -20px;
   position: relative;
+  max-height: 240px;
+}
+
+.previewable.portrait {
   height: 240px;
-  max-height: 80vh;
 }
 
 .grid-item label.card-select {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -161,6 +161,23 @@ video.preview {
   text-align: center;
 }
 
+.scene-specs-overlay {
+  display: block;
+  position: absolute;
+  bottom: 1em;
+  right: .7em;
+  font-weight: 400;
+  color: #f5f8fa;
+  letter-spacing: -.03em;
+  text-shadow: 0 0 3px #000;
+}
+
+.overlay-resolution {
+  font-weight: 900;
+  text-transform: uppercase;
+  margin-right:.3em;
+}
+
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -254,6 +254,23 @@ span.block {
   background-repeat: no-repeat !important;
 }
 
+.performer-tag-container {
+  max-width: 100%;
+  height: 100%;
+  display: inline-block;
+  text-align: center;
+  margin: 5px;
+}
+
+.performer-tag.image {
+  max-height: 150px;
+  max-width: 100%;
+  background-size: cover !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  margin: 0 auto;
+}
+
 .studio.image {
   height: 100px;
   background-size: contain !important;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -197,7 +197,7 @@ video.preview.portrait {
   font-weight: 400;
   width: 40%;
   height: 20%;
-  opacity: 75%;
+  opacity: 0.75;
   z-index: 9;
 }
 

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -186,6 +186,27 @@ video.preview.portrait {
   text-shadow: 0 0 3px #000;
 }
 
+.scene-studio-overlay {
+  display: block;
+  position: absolute;
+  top: .7em;
+  right: .7em;
+  font-weight: 400;
+  width: 40%;
+  height: 20%;
+  opacity: 75%;
+  z-index: 9;
+}
+
+.scene-studio-overlay a {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  display: inline-block;
+  background-position: right top;
+  background-repeat: no-repeat;
+}
+
 .overlay-resolution {
   font-weight: 900;
   text-transform: uppercase;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -227,6 +227,11 @@ video.preview.portrait {
     opacity: 0;
     transition: opacity 0.5s;
   }
+
+  .scene-studio-overlay:hover {
+    opacity: 0.75;
+    transition: opacity 0.5s;
+  }
 }
 
 #jwplayer-container {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -235,7 +235,7 @@ video.preview.portrait {
   position: absolute;
   top: .7em;
   right: .7em;
-  font-weight: 400;
+  font-weight: 900;
   width: 40%;
   height: 20%;
   opacity: 0.75;
@@ -249,6 +249,11 @@ video.preview.portrait {
   display: inline-block;
   background-position: right top;
   background-repeat: no-repeat;
+  letter-spacing: -.03em;
+  text-shadow: 0 0 3px #000;
+  text-align: right;
+  text-decoration: none;
+  color: #f5f8fa;
 }
 
 .overlay-resolution {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -38,7 +38,7 @@ code {
   flex-flow: row wrap;
   justify-content: center;
   margin: $pt-grid-size $pt-grid-size 0 0;
-  padding: 0 calc(10%);
+  padding: 0 100px;
 
   &.wall {
     padding: 0;
@@ -67,7 +67,7 @@ code {
 
 .grid-item {
   // flex: auto;
-  width: calc(25% - 1.5em);
+  width: 320px;
   min-width: 185px;
   margin: 0px 0 $pt-grid-size $pt-grid-size;
   overflow: hidden;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -292,19 +292,15 @@ span.block {
 }
 
 .performer-tag-container {
-  max-width: 100%;
-  height: 100%;
-  display: inline-block;
-  text-align: center;
   margin: 5px;
 }
 
 .performer-tag.image {
-  max-height: 150px;
-  max-width: 100%;
-  background-size: cover !important;
-  background-position: center !important;
-  background-repeat: no-repeat !important;
+  height: 150px;
+  width: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   margin: 0 auto;
 }
 

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -76,6 +76,47 @@ code {
     width: calc(20%);
     margin: 0;
   }
+
+  &.zoom-0 {
+    width: 240px;
+
+    & .previewable {
+      max-height: 180px;
+    }
+    & .previewable.portrait {
+      height: 180px;
+    }
+  }
+  &.zoom-1 {
+    width: 320px;
+
+    & .previewable {
+      max-height: 240px;
+    }
+    & .previewable.portrait {
+      height: 240px;
+    }
+  }
+  &.zoom-2 {
+    width: 480px;
+
+    & .previewable {
+      max-height: 360px;
+    }
+    & .previewable.portrait {
+      height: 360px;
+    }
+  }
+  &.zoom-3 {
+    width: 640px;
+
+    & .previewable {
+      max-height: 480px;
+    }
+    & .previewable.portrait {
+      height: 480px;
+    }
+  }
 }
 
 .previewable {
@@ -416,5 +457,14 @@ span.block {
   & #scrape-url-button {
     float: right;
     height: 30px;
+  }
+}
+
+.zoom-slider {
+  margin: auto 5px;
+  width: 100px;
+
+  & .bp3-slider {
+    min-width: 100%;
   }
 }

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -213,6 +213,19 @@ video.preview.portrait {
   margin-right:.3em;
 }
 
+.scene-card {
+  & .scene-specs-overlay, .rating-banner, .scene-studio-overlay {
+    transition: opacity 0.5s;
+  }
+}
+
+.scene-card:hover {
+  & .scene-specs-overlay, .rating-banner, .scene-studio-overlay {
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+}
+
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;

--- a/ui/v2/src/utils/text.ts
+++ b/ui/v2/src/utils/text.ts
@@ -18,7 +18,17 @@ export class TextUtils {
   }
 
   public static secondsToTimestamp(seconds: number): string {
-    return new Date(seconds * 1000).toISOString().substr(11, 8);
+    let ret = new Date(seconds * 1000).toISOString().substr(11, 8);
+
+    if (ret.startsWith("00")) {
+      // strip hours if under one hour
+      ret = ret.substr(3);
+    }
+    if (ret.startsWith("0")) {
+      // for duration under a minute, leave one leading zero
+      ret = ret.substr(1);
+    }
+    return ret;
   }
 
   public static fileNameFromPath(path: string): string {

--- a/ui/v2/src/utils/zoom.ts
+++ b/ui/v2/src/utils/zoom.ts
@@ -1,0 +1,6 @@
+export class ZoomUtils {
+  public static classForZoom(zoomIndex: number): string {
+    return "zoom-" + zoomIndex;
+  }
+}
+  


### PR DESCRIPTION
This is a collection of UI improvements for the scene list page. The improvements come from #220 and #108 
Each improvement is done as a separate commit so that we can pick and choose which to include.

### Scene card overlays
I lifted the code from @echo6ix 's fork and tidied it up. It removes the filesize, duration and resolution from below the thumbnail, and overlays the resolution and duration to the bottom right of the thumbnail. See below:

![image](https://user-images.githubusercontent.com/53250216/69834361-f5198300-128d-11ea-94f6-33d768d47d0f.png)

### Handling portrait videos
I've been trying to get a consistent height shown for the scene videos when there is a mix of portrait and landscape videos. The CSS has proved a bit of a nightmare. Here is the result so far:

![image](https://user-images.githubusercontent.com/53250216/69834497-dbc50680-128e-11ea-971f-a47bf2ffc743.png)

The intent is to line up the thumbnails so that the title appears in the same place vertically. This appears to be working correctly, though I notice a bit of a performance hit, so I'm going to need to revisit it. Note also that the presence of the details field moves the divider down.

### Filter controls

I removed the text where possible. I'm not sold on how it looks - I think it needs further refinement.

![image](https://user-images.githubusercontent.com/53250216/69834586-67d72e00-128f-11ea-9a2f-e74238f5b1a0.png)

The filter and sort buttons I think are improved. The view buttons are ok. The select all/none buttons I think don't really look that good. I'm wondering if there is a better way to present those buttons. I don't know why the tooltip is so damn large.

# Scene performer thumbnails

Probably my favourite of the new things:

![image](https://user-images.githubusercontent.com/53250216/69834716-44f94980-1290-11ea-91bc-db45a6848d75.png)

Fairly self explanatory. 

Suggestions and feedback welcomed.
