### PR TITLE
Add scene metadata scraping functionality

### DIFF
--- a/graphql/documents/data/scrapers.graphql
+++ b/graphql/documents/data/scrapers.graphql
@@ -1,0 +1,75 @@
+fragment ScrapedPerformerData on ScrapedPerformer {
+  name
+  url
+  birthdate
+  ethnicity
+  country
+  eye_color
+  height
+  measurements
+  fake_tits
+  career_length
+  tattoos
+  piercings
+  aliases
+}
+
+fragment ScrapedScenePerformerData on ScrapedScenePerformer {
+  id
+  name
+  url
+  twitter
+  instagram
+  birthdate
+  ethnicity
+  country
+  eye_color
+  height
+  measurements
+  fake_tits
+  career_length
+  tattoos
+  piercings
+  aliases
+}
+
+fragment ScrapedSceneStudioData on ScrapedSceneStudio {
+  id
+  name
+  url
+}
+
+fragment ScrapedSceneTagData on ScrapedSceneTag {
+  id
+  name
+}
+
+fragment ScrapedSceneData on ScrapedScene {
+  title
+  details
+  url
+  date
+
+  file {
+    size
+    duration
+    video_codec
+    audio_codec
+    width
+    height
+    framerate
+    bitrate
+  }
+
+  studio {
+    ...ScrapedSceneStudioData
+  }
+
+  tags {
+    ...ScrapedSceneTagData
+  }
+
+  performers {
+    ...ScrapedScenePerformerData
+  }
+}

--- a/graphql/documents/queries/scrapers/scrapers.graphql
+++ b/graphql/documents/queries/scrapers/scrapers.graphql
@@ -9,16 +9,16 @@ query ListPerformerScrapers {
   }
 }
 
-# query ListSceneScrapers {
-#   listSceneScrapers {
-#     id
-#     name
-#     scene {
-#       urls
-#       supported_scrapes
-#     }
-#   }
-# }
+query ListSceneScrapers {
+  listSceneScrapers {
+    id
+    name
+    scene {
+      urls
+      supported_scrapes
+    }
+  }
+}
 
 query ScrapePerformerList($scraper_id: ID!, $query: String!) {
   scrapePerformerList(scraper_id: $scraper_id, query: $query) {

--- a/graphql/documents/queries/scrapers/scrapers.graphql
+++ b/graphql/documents/queries/scrapers/scrapers.graphql
@@ -22,58 +22,30 @@ query ListPerformerScrapers {
 
 query ScrapePerformerList($scraper_id: ID!, $query: String!) {
   scrapePerformerList(scraper_id: $scraper_id, query: $query) {
-    name
-    url
-    birthdate
-    ethnicity
-    country
-    eye_color
-    height
-    measurements
-    fake_tits
-    career_length
-    tattoos
-    piercings
-    aliases
+    ...ScrapedPerformerData
   }
 }
 
 query ScrapePerformer($scraper_id: ID!, $scraped_performer: ScrapedPerformerInput!) {
   scrapePerformer(scraper_id: $scraper_id, scraped_performer: $scraped_performer) {
-    name
-    url
-    twitter
-    instagram
-    birthdate
-    ethnicity
-    country
-    eye_color
-    height
-    measurements
-    fake_tits
-    career_length
-    tattoos
-    piercings
-    aliases
+    ...ScrapedPerformerData
   }
 }
 
 query ScrapePerformerURL($url: String!) {
   scrapePerformerURL(url: $url) {
-    name
-    url
-    twitter
-    instagram
-    birthdate
-    ethnicity
-    country
-    eye_color
-    height
-    measurements
-    fake_tits
-    career_length
-    tattoos
-    piercings
-    aliases
+    ...ScrapedPerformerData
+  }
+}
+
+query ScrapeScene($scraper_id: ID!, $scene: SceneUpdateInput!) {
+  scrapeScene(scraper_id: $scraper_id, scene: $scene) {
+    ...ScrapedSceneData
+  }
+}
+
+query ScrapeSceneURL($url: String!) {
+  scrapeSceneURL(url: $url) {
+    ...ScrapedSceneData
   }
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -54,6 +54,10 @@ type Query {
   scrapePerformer(scraper_id: ID!, scraped_performer: ScrapedPerformerInput!): ScrapedPerformer
   """Scrapes a complete performer record based on a URL"""
   scrapePerformerURL(url: String!): ScrapedPerformer
+  """Scrapes a complete scene record based on an existing scene"""
+  scrapeScene(scraper_id: ID!, scene: SceneUpdateInput!): ScrapedScene
+  """Scrapes a complete performer record based on a URL"""
+  scrapeSceneURL(url: String!): ScrapedScene
 
   """Scrape a performer using Freeones"""
   scrapeFreeones(performer_name: String!): ScrapedPerformer

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -47,7 +47,7 @@ type Query {
 
   """List available scrapers"""
   listPerformerScrapers: [Scraper!]!
-  #listSceneScrapers: [Scraper!]!
+  listSceneScrapers: [Scraper!]!
   """Scrape a list of performers based on name"""
   scrapePerformerList(scraper_id: ID!, query: String!): [ScrapedPerformer!]!
   """Scrapes a complete performer record based on a scrapePerformerList result"""

--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -18,9 +18,8 @@ type Scraper {
     name: String!
     """Details for performer scraper"""
     performer: ScraperSpec
-    # TODO
-    # """Details for scene scraper"""
-    # scene: ScraperSpec
+    """Details for scene scraper"""
+    scene: ScraperSpec
 }
 
 

--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -1,7 +1,10 @@
 enum ScrapeType {
-    NAME
-    FRAGMENT
-    URL
+  """From text query""" 
+  NAME
+  """From existing object"""
+  FRAGMENT
+  """From URL"""
+  URL
 }
 
 type ScraperSpec {
@@ -18,4 +21,51 @@ type Scraper {
     # TODO
     # """Details for scene scraper"""
     # scene: ScraperSpec
+}
+
+
+type ScrapedScenePerformer {
+  """Set if performer matched"""
+  id: ID
+  name: String!
+  url: String
+  twitter: String
+  instagram: String
+  birthdate: String
+  ethnicity: String
+  country: String
+  eye_color: String
+  height: String
+  measurements: String
+  fake_tits: String
+  career_length: String
+  tattoos: String
+  piercings: String
+  aliases: String
+}
+
+type ScrapedSceneStudio {
+  """Set if studio matched"""
+  id: ID
+  name: String!
+  url: String
+}
+
+type ScrapedSceneTag {
+  """Set if tag matched"""
+  id: ID
+  name: String!
+}
+
+type ScrapedScene {
+  title: String
+  details: String
+  url: String
+  date: String
+
+  file: SceneFileType # Resolver
+
+  studio: ScrapedSceneStudio
+  tags: [ScrapedSceneTag!]
+  performers: [ScrapedScenePerformer!]
 }

--- a/pkg/api/resolver_query_scraper.go
+++ b/pkg/api/resolver_query_scraper.go
@@ -51,3 +51,11 @@ func (r *queryResolver) ScrapePerformer(ctx context.Context, scraperID string, s
 func (r *queryResolver) ScrapePerformerURL(ctx context.Context, url string) (*models.ScrapedPerformer, error) {
 	return scraper.ScrapePerformerURL(url)
 }
+
+func (r *queryResolver) ScrapeScene(ctx context.Context, scraperID string, scene models.SceneUpdateInput) (*models.ScrapedScene, error) {
+	return scraper.ScrapeScene(scraperID, scene)
+}
+
+func (r *queryResolver) ScrapeSceneURL(ctx context.Context, url string) (*models.ScrapedScene, error) {
+	return scraper.ScrapeSceneURL(url)
+}

--- a/pkg/api/resolver_query_scraper.go
+++ b/pkg/api/resolver_query_scraper.go
@@ -36,6 +36,10 @@ func (r *queryResolver) ListPerformerScrapers(ctx context.Context) ([]*models.Sc
 	return scraper.ListPerformerScrapers()
 }
 
+func (r *queryResolver) ListSceneScrapers(ctx context.Context) ([]*models.Scraper, error) {
+	return scraper.ListSceneScrapers()
+}
+
 func (r *queryResolver) ScrapePerformerList(ctx context.Context, scraperID string, query string) ([]*models.ScrapedPerformer, error) {
 	if query == "" {
 		return nil, nil

--- a/pkg/scraper/freeones.go
+++ b/pkg/scraper/freeones.go
@@ -30,10 +30,12 @@ func GetFreeonesScraper() scraperConfig {
 		PerformerByFragment: &performerByFragmentConfig{
 			performScrape: GetPerformer,
 		},
-		PerformerByURL: []*scraperByURLConfig{
-			&scraperByURLConfig{
+		PerformerByURL: []*scrapePerformerByURLConfig{
+			&scrapePerformerByURLConfig{
+				scrapeByURLConfig: scrapeByURLConfig{
+					URL: freeonesURLs,
+				},
 				performScrape: GetPerformerURL,
-				URL:           freeonesURLs,
 			},
 		},
 	}

--- a/pkg/scraper/scrapers.go
+++ b/pkg/scraper/scrapers.go
@@ -61,7 +61,7 @@ func ListPerformerScrapers() ([]*models.Scraper, error) {
 	return ret, nil
 }
 
-func findPerformerScraper(scraperID string) *scraperConfig {
+func findScraper(scraperID string) *scraperConfig {
 	// read scraper config files from the directory and cache
 	loadScrapers()
 
@@ -76,7 +76,7 @@ func findPerformerScraper(scraperID string) *scraperConfig {
 
 func ScrapePerformerList(scraperID string, query string) ([]*models.ScrapedPerformer, error) {
 	// find scraper with the provided id
-	s := findPerformerScraper(scraperID)
+	s := findScraper(scraperID)
 	if s != nil {
 		return s.ScrapePerformerNames(query)
 	}
@@ -86,7 +86,7 @@ func ScrapePerformerList(scraperID string, query string) ([]*models.ScrapedPerfo
 
 func ScrapePerformer(scraperID string, scrapedPerformer models.ScrapedPerformerInput) (*models.ScrapedPerformer, error) {
 	// find scraper with the provided id
-	s := findPerformerScraper(scraperID)
+	s := findScraper(scraperID)
 	if s != nil {
 		return s.ScrapePerformer(scrapedPerformer)
 	}
@@ -99,6 +99,110 @@ func ScrapePerformerURL(url string) (*models.ScrapedPerformer, error) {
 		if s.matchesPerformerURL(url) {
 			return s.ScrapePerformerURL(url)
 		}
+	}
+
+	return nil, nil
+}
+
+func ScrapeScene(scraperID string, scene models.SceneUpdateInput) (*models.ScrapedScene, error) {
+	// find scraper with the provided id
+	s := findScraper(scraperID)
+	if s != nil {
+		return s.ScrapeScene(scene)
+	}
+
+	return nil, errors.New("Scraper with ID " + scraperID + " not found")
+}
+
+func matchPerformer(p *models.ScrapedScenePerformer) error {
+	qb := models.NewPerformerQueryBuilder()
+
+	performers, err := qb.FindByNames([]string{p.Name}, nil)
+
+	if err != nil {
+		return err
+	}
+
+	if len(performers) != 1 {
+		// ignore - cannot match
+		return nil
+	}
+
+	id := strconv.Itoa(performers[0].ID)
+	p.ID = &id
+	return nil
+}
+
+func matchStudio(s *models.ScrapedSceneStudio) error {
+	qb := models.NewStudioQueryBuilder()
+
+	studio, err := qb.FindByName(s.Name, nil)
+
+	if err != nil {
+		return err
+	}
+
+	if studio == nil {
+		// ignore - cannot match
+		return nil
+	}
+
+	id := strconv.Itoa(studio.ID)
+	s.ID = &id
+	return nil
+}
+
+func matchTag(s *models.ScrapedSceneTag) error {
+	qb := models.NewTagQueryBuilder()
+
+	tag, err := qb.FindByName(s.Name, nil)
+
+	if err != nil {
+		return err
+	}
+
+	if tag == nil {
+		// ignore - cannot match
+		return nil
+	}
+
+	id := strconv.Itoa(tag.ID)
+	s.ID = &id
+	return nil
+}
+
+func ScrapeSceneURL(url string) (*models.ScrapedScene, error) {
+	// find scraper that matches the url given
+	s := findScraperURL(url, models.ScraperTypeScene)
+	if s != nil {
+		ret, err := s.ScrapeSceneURL(url)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range ret.Performers {
+			err = matchPerformer(p)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		for _, t := range ret.Tags {
+			err = matchTag(t)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if ret.Studio != nil {
+			err = matchStudio(ret.Studio)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return ret, nil
 	}
 
 	return nil, nil

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -107,7 +107,7 @@ func scrapePerformerURLScript(c scraperTypeConfig, url string) (*models.ScrapedP
 	return &ret, err
 }
 
-func scrapeSceneScript(c scraperTypeConfig, scene models.SceneUpdateInput) (*models.ScrapedScene, error) {
+func scrapeSceneFragmentScript(c scraperTypeConfig, scene models.SceneUpdateInput) (*models.ScrapedScene, error) {
 	inString, err := json.Marshal(scene)
 
 	if err != nil {

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -106,3 +106,27 @@ func scrapePerformerURLScript(c scraperTypeConfig, url string) (*models.ScrapedP
 
 	return &ret, err
 }
+
+func scrapeSceneScript(c scraperTypeConfig, scene models.SceneUpdateInput) (*models.ScrapedScene, error) {
+	inString, err := json.Marshal(scene)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var ret models.ScrapedScene
+
+	err = runScraperScript(c.Script, string(inString), &ret)
+
+	return &ret, err
+}
+
+func scrapeSceneURLScript(c scraperTypeConfig, url string) (*models.ScrapedScene, error) {
+	inString := `{"url": "` + url + `"}`
+
+	var ret models.ScrapedScene
+
+	err := runScraperScript(c.Script, string(inString), &ret)
+
+	return &ret, err
+}

--- a/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
@@ -45,8 +45,8 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
   const [tagIds, setTagIds] = useState<string[] | undefined>(undefined);
   const [coverImage, setCoverImage] = useState<string | undefined>(undefined);
 
-  const Scrapers = StashService.useListScrapers(GQL.ScraperType.Scene);
-  const [queryableScrapers, setQueryableScrapers] = useState<GQL.ListScrapersListScrapers[]>([]);
+  const Scrapers = StashService.useListSceneScrapers();
+  const [queryableScrapers, setQueryableScrapers] = useState<GQL.ListSceneScrapersListSceneScrapers[]>([]);
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
   const [deleteFile, setDeleteFile] = useState<boolean>(false);
@@ -62,11 +62,11 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
   const deleteScene = StashService.useSceneDestroy(getSceneDeleteInput());
 
   useEffect(() => {
-    var newQueryableScrapers : GQL.ListScrapersListScrapers[] = [];
+    var newQueryableScrapers : GQL.ListSceneScrapersListSceneScrapers[] = [];
 
-    if (!!Scrapers.data && Scrapers.data.listScrapers) {
-      newQueryableScrapers = Scrapers.data.listScrapers.filter((s) => {
-        return s.supported_scrapes.includes(GQL.ScrapeType.Object);
+    if (!!Scrapers.data && Scrapers.data.listSceneScrapers) {
+      newQueryableScrapers = Scrapers.data.listSceneScrapers.filter((s) => {
+        return s.scene && s.scene.supported_scrapes.includes(GQL.ScrapeType.Fragment);
       });
     }
 
@@ -206,7 +206,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
     ImageUtils.onImageChange(event, onImageLoad);
   }
   
-  async function onScrapeClicked(scraper : GQL.ListScrapersListScrapers) {
+  async function onScrapeClicked(scraper : GQL.ListSceneScrapersListSceneScrapers) {
     setIsLoading(true);
     try {
       const result = await StashService.queryScrapeScene(scraper.id, getSceneInput());
@@ -219,7 +219,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
     }
   }
 
-  function renderScraperMenuItem(scraper : GQL.ListScrapersListScrapers) {
+  function renderScraperMenuItem(scraper : GQL.ListSceneScrapersListSceneScrapers) {
     return (
       <MenuItem
         text={scraper.name}
@@ -246,8 +246,8 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
   }
 
   function urlScrapable(url: string) : boolean {
-    return !!url && !!Scrapers.data && Scrapers.data.listScrapers && Scrapers.data.listScrapers.some((s) => {
-      return !!s.urls && s.urls.some((u) => { return url.includes(u); });
+    return !!url && !!Scrapers.data && Scrapers.data.listSceneScrapers && Scrapers.data.listSceneScrapers.some((s) => {
+      return !!s.scene && !!s.scene.urls && s.scene.urls.some((u) => { return url.includes(u); });
     });
   }
 
@@ -270,7 +270,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
 
     if ((!performerIds || performerIds.length == 0) && scene.performers && scene.performers.length > 0) {
       let idPerfs = scene.performers.filter((p) => {
-        return p.id !== undefined;
+        return p.id !== undefined && p.id !== null;
       });
 
       if (idPerfs.length > 0) {
@@ -281,7 +281,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
 
     if ((!tagIds || tagIds.length == 0) && scene.tags && scene.tags.length > 0) {
       let idTags = scene.tags.filter((p) => {
-        return p.id !== undefined;
+        return p.id !== undefined && p.id !== null;
       });
 
       if (idTags.length > 0) {

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -221,6 +221,10 @@ export class StashService {
      return GQL.useScrapePerformer({ variables: { scraper_id: scraperId, scraped_performer: scrapedPerformer }});
   }
 
+  public static useListSceneScrapers() { 
+    return GQL.useListSceneScrapers(); 
+  }
+
   public static useScrapeFreeonesPerformers(q: string) { return GQL.useScrapeFreeonesPerformers({ variables: { q } }); }
   public static useMarkerStrings() { return GQL.useMarkerStrings(); }
   public static useAllTags() { return GQL.useAllTags(); }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -425,6 +425,25 @@ export class StashService {
     });
   }
 
+  public static queryScrapeSceneURL(url: string) {
+    return StashService.client.query<GQL.ScrapeSceneUrlQuery>({
+      query: GQL.ScrapeSceneUrlDocument,
+      variables: {
+        url: url,
+      },
+    });
+  }
+
+  public static queryScrapeScene(scraperId: string, scene: GQL.SceneUpdateInput) {
+    return StashService.client.query<GQL.ScrapeSceneQuery>({
+      query: GQL.ScrapeSceneDocument,
+      variables: {
+        scraper_id: scraperId,
+        scene: scene,
+      },
+    });
+  }
+
   public static queryMetadataScan(input: GQL.ScanMetadataInput) {
     return StashService.client.query<GQL.MetadataScanQuery>({
       query: GQL.MetadataScanDocument,


### PR DESCRIPTION
Add similar functionality to the performer scraper. 

This PR changes the schema of the scraper json configuration files. `type` - previously a single string value - becomes `types`, an array of strings. This way a single scraping configuration can apply to performers and scenes.

Also adds `get_scene_url` and `get_scene`. The former works similar to the `get_performer_url`, accepting a url and outputting the scene details. The latter accepts a full scene object and returns a scene object - meaning that the script can use whatever it needs from the scene object to get the data.

On the UI side, this change adds a scrape button to the URL field when a scrapable URL is detected. It also adds a "Scrape with..." menu button. This menu will be populated with scene scrapers for which `get_scene` is configured.

When a scene is successfully scraped, it populates the unpopulated scene fields with the scraped data. Stash will also attempt to match studio, performers and tags by name against those already in the system, and if present sets those in the resulting data. A future feature I'd like to add is to show unmatched performer, studio, tag data and allow the user to create the missing objects as needed.