### PR TITLE
[WIP] Responsive UI changes

### DIFF
--- a/ui/v2/src/App.tsx
+++ b/ui/v2/src/App.tsx
@@ -16,11 +16,7 @@ import { Sidebar } from "./components/Sidebar";
 interface IProps {}
 
 export const App: FunctionComponent<IProps> = (props: IProps) => {
-  const [menuOpen, setMenuOpen] = useState<boolean>(getInitialMenuState());
-
-  function getInitialMenuState() {
-    return window.innerWidth > 768;
-  }
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
   function getSidebarClosedClass() {
     if (!menuOpen) {

--- a/ui/v2/src/App.tsx
+++ b/ui/v2/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import { Route, Switch } from "react-router-dom";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import Galleries from "./components/Galleries/Galleries";
@@ -11,26 +11,44 @@ import { Stats } from "./components/Stats";
 import Studios from "./components/Studios/Studios";
 import Tags from "./components/Tags/Tags";
 import { SceneFilenameParser } from "./components/scenes/SceneFilenameParser";
+import { Sidebar } from "./components/Sidebar";
 
 interface IProps {}
 
 export const App: FunctionComponent<IProps> = (props: IProps) => {
+  const [menuOpen, setMenuOpen] = useState<boolean>(getInitialMenuState());
+
+  function getInitialMenuState() {
+    return window.innerWidth > 768;
+  }
+
+  function getSidebarClosedClass() {
+    if (!menuOpen) {
+      return " sidebar-closed";
+    }
+
+    return "";
+  }
+
   return (
     <div className="bp3-dark">
       <ErrorBoundary>
-        <MainNavbar />
-        <Switch>
-          <Route exact={true} path="/" component={Stats} />
-          <Route path="/scenes" component={Scenes} />
-          {/* <Route path="/scenes/:id" component={Scene} /> */}
-          <Route path="/galleries" component={Galleries} />
-          <Route path="/performers" component={Performers} />
-          <Route path="/tags" component={Tags} />
-          <Route path="/studios" component={Studios} />
-          <Route path="/settings" component={Settings} />
-          <Route path="/sceneFilenameParser" component={SceneFilenameParser} />
-          <Route component={PageNotFound} />
-        </Switch>
+        <MainNavbar onMenuToggle={() => setMenuOpen(!menuOpen)}/>
+        <Sidebar className={getSidebarClosedClass()}/>
+        <div className={"main" + getSidebarClosedClass()}>
+          <Switch>
+            <Route exact={true} path="/" component={Stats} />
+            <Route path="/scenes" component={Scenes} />
+            {/* <Route path="/scenes/:id" component={Scene} /> */}
+            <Route path="/galleries" component={Galleries} />
+            <Route path="/performers" component={Performers} />
+            <Route path="/tags" component={Tags} />
+            <Route path="/studios" component={Studios} />
+            <Route path="/settings" component={Settings} />
+            <Route path="/sceneFilenameParser" component={SceneFilenameParser} />
+            <Route component={PageNotFound} />
+          </Switch>
+        </div>
       </ErrorBoundary>
     </div>
   );

--- a/ui/v2/src/components/MainNavbar.tsx
+++ b/ui/v2/src/components/MainNavbar.tsx
@@ -3,12 +3,15 @@ import {
   NavbarDivider,
   NavbarGroup,
   NavbarHeading,
+  Button,
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
 import useLocation from "react-use/lib/useLocation";
 
-interface IProps {}
+interface IProps {
+  onMenuToggle() : void
+}
 
 export const MainNavbar: FunctionComponent<IProps> = (props) => {
   const [newButtonPath, setNewButtonPath] = useState<string | undefined>(undefined);
@@ -46,76 +49,79 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
   }
 
   return (
-    <Navbar fixedToTop={true}>
-      <div>
-        <NavbarGroup align="left">
-          <NavbarHeading><Link to="/" className="bp3-button bp3-minimal">Stash</Link></NavbarHeading>
-          <NavbarDivider />
+    <>
+      <Navbar fixedToTop={true}>
+        <div>
+          <NavbarGroup align="left">
+            <Button icon="menu" onClick={() => props.onMenuToggle()}/>
+            <NavbarHeading><Link to="/" className="bp3-button bp3-minimal">Stash</Link></NavbarHeading>
+            <NavbarDivider />
 
-          <NavLink
-            exact={true}
-            to="/scenes"
-            className="bp3-button bp3-minimal bp3-icon-video"
-            activeClassName="bp3-active"
-          >
-            Scenes
-          </NavLink>
+            {/* <NavLink
+              exact={true}
+              to="/scenes"
+              className="bp3-button bp3-minimal bp3-icon-video"
+              activeClassName="bp3-active"
+            >
+              Scenes
+            </NavLink>
 
-          <NavLink
-            exact={true}
-            to="/scenes/markers"
-            className="bp3-button bp3-minimal bp3-icon-map-marker"
-            activeClassName="bp3-active"
-          >
-            Markers
-          </NavLink>
+            <NavLink
+              exact={true}
+              to="/scenes/markers"
+              className="bp3-button bp3-minimal bp3-icon-map-marker"
+              activeClassName="bp3-active"
+            >
+              Markers
+            </NavLink>
 
-          <NavLink
-            exact={true}
-            to="/galleries"
-            className="bp3-button bp3-minimal bp3-icon-media"
-            activeClassName="bp3-active"
-          >
-            Galleries
-          </NavLink>
+            <NavLink
+              exact={true}
+              to="/galleries"
+              className="bp3-button bp3-minimal bp3-icon-media"
+              activeClassName="bp3-active"
+            >
+              Galleries
+            </NavLink>
 
-          <NavLink
-            exact={true}
-            to="/performers"
-            className="bp3-button bp3-minimal bp3-icon-person"
-            activeClassName="bp3-active"
-          >
-            Performers
-          </NavLink>
+            <NavLink
+              exact={true}
+              to="/performers"
+              className="bp3-button bp3-minimal bp3-icon-person"
+              activeClassName="bp3-active"
+            >
+              Performers
+            </NavLink>
 
-          <NavLink
-            exact={true}
-            to="/studios"
-            className="bp3-button bp3-minimal bp3-icon-mobile-video"
-            activeClassName="bp3-active"
-          >
-            Studios
-          </NavLink>
+            <NavLink
+              exact={true}
+              to="/studios"
+              className="bp3-button bp3-minimal bp3-icon-mobile-video"
+              activeClassName="bp3-active"
+            >
+              Studios
+            </NavLink>
 
-          <NavLink
-            exact={true}
-            to="/tags"
-            className="bp3-button bp3-minimal bp3-icon-tag"
-            activeClassName="bp3-active"
-          >
-            Tags
-          </NavLink>
-        </NavbarGroup>
-        <NavbarGroup align="right">
-          {renderNewButton()}
-          <NavLink
-            exact={true}
-            to="/settings"
-            className="bp3-button bp3-minimal bp3-icon-cog"
-            activeClassName="bp3-active"
-          />
-        </NavbarGroup>
-      </div>
-    </Navbar>
+            <NavLink
+              exact={true}
+              to="/tags"
+              className="bp3-button bp3-minimal bp3-icon-tag"
+              activeClassName="bp3-active"
+            >
+              Tags
+            </NavLink> */}
+          </NavbarGroup>
+          <NavbarGroup align="right">
+            {renderNewButton()}
+            <NavLink
+              exact={true}
+              to="/settings"
+              className="bp3-button bp3-minimal bp3-icon-cog"
+              activeClassName="bp3-active"
+            />
+          </NavbarGroup>
+        </div>
+      </Navbar>
+    </>
   );
 };

--- a/ui/v2/src/components/MainNavbar.tsx
+++ b/ui/v2/src/components/MainNavbar.tsx
@@ -53,14 +53,14 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
       <Navbar fixedToTop={true}>
         <div>
           <NavbarGroup align="left">
-            <Button icon="menu" onClick={() => props.onMenuToggle()}/>
+            <Button className="menu-button" icon="menu" onClick={() => props.onMenuToggle()}/>
             <NavbarHeading><Link to="/" className="bp3-button bp3-minimal">Stash</Link></NavbarHeading>
             <NavbarDivider />
 
-            {/* <NavLink
+            <NavLink
               exact={true}
               to="/scenes"
-              className="bp3-button bp3-minimal bp3-icon-video"
+              className="bp3-button bp3-minimal bp3-icon-video collapsible-navlink"
               activeClassName="bp3-active"
             >
               Scenes
@@ -69,7 +69,7 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
             <NavLink
               exact={true}
               to="/scenes/markers"
-              className="bp3-button bp3-minimal bp3-icon-map-marker"
+              className="bp3-button bp3-minimal bp3-icon-map-marker collapsible-navlink"
               activeClassName="bp3-active"
             >
               Markers
@@ -78,7 +78,7 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
             <NavLink
               exact={true}
               to="/galleries"
-              className="bp3-button bp3-minimal bp3-icon-media"
+              className="bp3-button bp3-minimal bp3-icon-media collapsible-navlink"
               activeClassName="bp3-active"
             >
               Galleries
@@ -87,7 +87,7 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
             <NavLink
               exact={true}
               to="/performers"
-              className="bp3-button bp3-minimal bp3-icon-person"
+              className="bp3-button bp3-minimal bp3-icon-person collapsible-navlink"
               activeClassName="bp3-active"
             >
               Performers
@@ -96,7 +96,7 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
             <NavLink
               exact={true}
               to="/studios"
-              className="bp3-button bp3-minimal bp3-icon-mobile-video"
+              className="bp3-button bp3-minimal bp3-icon-mobile-video collapsible-navlink"
               activeClassName="bp3-active"
             >
               Studios
@@ -105,11 +105,11 @@ export const MainNavbar: FunctionComponent<IProps> = (props) => {
             <NavLink
               exact={true}
               to="/tags"
-              className="bp3-button bp3-minimal bp3-icon-tag"
+              className="bp3-button bp3-minimal bp3-icon-tag collapsible-navlink"
               activeClassName="bp3-active"
             >
               Tags
-            </NavLink> */}
+            </NavLink>
           </NavbarGroup>
           <NavbarGroup align="right">
             {renderNewButton()}

--- a/ui/v2/src/components/Sidebar.tsx
+++ b/ui/v2/src/components/Sidebar.tsx
@@ -1,0 +1,50 @@
+import {
+  MenuItem,
+  Menu,
+} from "@blueprintjs/core";
+import React, { FunctionComponent } from "react";
+
+interface IProps {
+  className: string
+}
+
+export const Sidebar: FunctionComponent<IProps> = (props) => {
+  return (
+    <>
+      <div className={"sidebar" + props.className}>
+        <Menu large={true}>
+          <MenuItem
+            icon="video"
+            text="Scenes"
+            href="/scenes"
+          />
+          <MenuItem
+            href="/scenes/markers"
+            icon="map-marker"
+            text="Markers"
+          />
+          <MenuItem
+            href="/galleries"
+            icon="media"
+            text="Galleries"
+          />
+          <MenuItem
+            href="/performers"
+            icon="person"
+            text="Performers"
+          />
+          <MenuItem
+            href="/studios"
+            icon="mobile-video"
+            text="Studios"
+          />
+          <MenuItem
+            href="/tags"
+            icon="tag"
+            text="Tags"
+          />
+        </Menu>
+      </div>
+    </>
+  );
+};

--- a/ui/v2/src/components/list/AddFilter.tsx
+++ b/ui/v2/src/components/list/AddFilter.tsx
@@ -197,7 +197,6 @@ export const AddFilter: FunctionComponent<IAddFilterProps> = (props: IAddFilterP
           icon="filter"
           onClick={() => onToggle()} 
           active={isOpen} 
-          large={true}
         >
         </Button>
       </Tooltip>

--- a/ui/v2/src/components/list/AddFilter.tsx
+++ b/ui/v2/src/components/list/AddFilter.tsx
@@ -5,6 +5,7 @@ import {
   FormGroup,
   HTMLSelect,
   InputGroup,
+  Tooltip,
 } from "@blueprintjs/core";
 import _ from "lodash";
 import React, { FunctionComponent, useEffect, useRef, useState } from "react";
@@ -188,7 +189,19 @@ export const AddFilter: FunctionComponent<IAddFilterProps> = (props: IAddFilterP
   const title = !props.editingCriterion ? "Add Filter" : "Update Filter";
   return (
     <>
-      <Button onClick={() => onToggle()} active={isOpen} large={true}>Filter</Button>
+      <Tooltip
+        hoverOpenDelay={200}
+        content="Filter"
+      >
+        <Button 
+          icon="filter"
+          onClick={() => onToggle()} 
+          active={isOpen} 
+          large={true}
+        >
+        </Button>
+      </Tooltip>
+      
       <Dialog isOpen={isOpen} onClose={() => onToggle()} title={title}>
         <div className="dialog-content">
           {maybeRenderFilterSelect()}

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -118,7 +118,6 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
           active={props.filter.displayMode === option}
           onClick={() => onChangeDisplayMode(option)}
           icon={getIcon(option)}
-          minimal={true}
         />
       </Tooltip>
     ));

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -176,13 +176,13 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
 
   function renderSelectAll() {
     if (props.onSelectAll) {
-      return <MenuItem onClick={() => onSelectAll()} text="Select All" />;
+      return <MenuItem key="Select All" onClick={() => onSelectAll()} text="Select All" />;
     }
   }
 
   function renderSelectNone() {
     if (props.onSelectNone) {
-      return <MenuItem onClick={() => onSelectNone()} text="Select None" />;
+      return <MenuItem key="Select None" onClick={() => onSelectNone()} text="Select None" />;
     }
   }
 

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   Tag,
   Tooltip,
+  Slider,
 } from "@blueprintjs/core";
 import { debounce } from "lodash";
 import React, { FunctionComponent, SyntheticEvent, useEffect, useRef, useState } from "react";
@@ -26,6 +27,8 @@ interface IListFilterProps {
   onChangeDisplayMode: (displayMode: DisplayMode) => void;
   onAddCriterion: (criterion: Criterion, oldId?: string) => void;
   onRemoveCriterion: (criterion: Criterion) => void;
+  zoomIndex?: number;
+  onChangeZoom?: (zoomIndex: number) => void;
   onSelectAll?: () => void;
   onSelectNone?: () => void;
   filter: ListFilterModel;
@@ -188,6 +191,29 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
     );
   }
 
+  function onChangeZoom(v : number) {
+    if (props.onChangeZoom) {
+      props.onChangeZoom(v);
+    }
+  } 
+
+  function maybeRenderZoom() {
+    if (props.onChangeZoom) {
+      return (
+        <span className="zoom-slider">
+          <Slider 
+            min={0}
+            value={props.zoomIndex}
+            initialValue={props.zoomIndex}
+            max={3}
+            labelRenderer={false}
+            onChange={(v) => onChangeZoom(v)}
+          />
+      </span>
+      );
+    }
+  }
+
   function render() {
     return (
       <>
@@ -235,6 +261,8 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
           <ButtonGroup className="filter-item">
             {renderDisplayModeOptions()}
           </ButtonGroup>
+
+          {maybeRenderZoom()}
 
           <ButtonGroup className="filter-item">
             {renderSelectAllNone()}

--- a/ui/v2/src/components/list/ListFilter.tsx
+++ b/ui/v2/src/components/list/ListFilter.tsx
@@ -9,6 +9,7 @@ import {
   MenuItem,
   Popover,
   Tag,
+  Tooltip,
 } from "@blueprintjs/core";
 import { debounce } from "lodash";
 import React, { FunctionComponent, SyntheticEvent, useEffect, useRef, useState } from "react";
@@ -111,13 +112,15 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
       }
     }
     return props.filter.displayModeOptions.map((option) => (
-      <Button
-        key={option}
-        active={props.filter.displayMode === option}
-        onClick={() => onChangeDisplayMode(option)}
-        icon={getIcon(option)}
-        text={getLabel(option)}
-      />
+      <Tooltip content={getLabel(option)} hoverOpenDelay={200}>
+        <Button
+          key={option}
+          active={props.filter.displayMode === option}
+          onClick={() => onChangeDisplayMode(option)}
+          icon={getIcon(option)}
+          minimal={true}
+        />
+      </Tooltip>
     ));
   }
 
@@ -150,13 +153,30 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
 
   function renderSelectAll() {
     if (props.onSelectAll) {
-      return <Button onClick={() => onSelectAll()} text="Select All"/>;
+      return (
+        <Tooltip
+          content="Select All"
+          hoverOpenDelay={200}
+        >
+          <Button 
+            onClick={() => onSelectAll()} 
+            icon="tick"
+          />
+        </Tooltip>
+      );
     }
   }
 
   function renderSelectNone() {
     if (props.onSelectNone) {
-      return <Button onClick={() => onSelectNone()} text="Select None"/>;
+      return (
+        <Tooltip
+          content="Select None"
+          hoverOpenDelay={200}
+        >
+          <Button onClick={() => onSelectNone()} icon="square"/>
+        </Tooltip>
+      );
     }
   }
 
@@ -188,18 +208,23 @@ export const ListFilter: FunctionComponent<IListFilterProps> = (props: IListFilt
             value={props.filter.itemsPerPage}
             className="filter-item"
           />
-          <ControlGroup className="filter-item">
-            <AnchorButton
-              rightIcon={props.filter.sortDirection === "asc" ? "caret-up" : "caret-down"}
-              onClick={onChangeSortDirection}
-            >
-              {props.filter.sortDirection === "asc" ? "Ascending" : "Descending"}
-            </AnchorButton>
+          <ButtonGroup className="filter-item">
             <Popover position="bottom">
               <Button large={true}>{props.filter.sortBy}</Button>
               <Menu>{renderSortByOptions()}</Menu>
             </Popover>
-          </ControlGroup>
+            
+            <Tooltip 
+              content={props.filter.sortDirection === "asc" ? "Ascending" : "Descending"}
+              hoverOpenDelay={200}
+            >
+              <Button
+                rightIcon={props.filter.sortDirection === "asc" ? "caret-up" : "caret-down"}
+                onClick={onChangeSortDirection}
+              />
+            </Tooltip>
+            
+          </ButtonGroup>
 
           <AddFilter
             filter={props.filter}

--- a/ui/v2/src/components/list/Pagination.tsx
+++ b/ui/v2/src/components/list/Pagination.tsx
@@ -36,25 +36,25 @@ export class Pagination extends React.Component<IPaginationProps, IPaginationSta
     if (!this.state || !this.state.pages || this.state.pages.length <= 1) { return null; }
 
     return (
-      <ButtonGroup large={true} className="filter-container">
+      <ButtonGroup large={true} className="operation-container">
         <Button
-          text="First"
+          icon="double-chevron-left"
           disabled={this.props.currentPage === 1}
           onClick={() => this.setPage(1)}
         />
         <Button
-          text="Previous"
+          icon="chevron-left"
           disabled={this.props.currentPage === 1}
           onClick={() => this.setPage(this.props.currentPage - 1)}
         />
         {this.renderPageButtons()}
         <Button
-          text="Next"
+          icon="chevron-right"
           disabled={this.props.currentPage === this.state.totalPages}
           onClick={() => this.setPage(this.props.currentPage + 1)}
         />
         <Button
-          text="Last"
+          icon="double-chevron-right"
           disabled={this.props.currentPage === this.state.totalPages}
           onClick={() => this.setPage(this.state.totalPages)}
         />
@@ -86,25 +86,31 @@ export class Pagination extends React.Component<IPaginationProps, IPaginationSta
   }
 
   private getPagerState(totalItems: number, currentPage: number, pageSize: number) {
+    let pagesToDisplay = 10;
+
+    if (window.innerWidth < 600) {
+      pagesToDisplay = 4;
+    }
+
     const totalPages = Math.ceil(totalItems / pageSize);
 
     let startPage: number;
     let endPage: number;
-    if (totalPages <= 10) {
+    if (totalPages <= pagesToDisplay) {
       // less than 10 total pages so show all
       startPage = 1;
       endPage = totalPages;
     } else {
       // more than 10 total pages so calculate start and end pages
-      if (currentPage <= 6) {
+      if (currentPage <= pagesToDisplay / 2 + 1) {
         startPage = 1;
-        endPage = 10;
-      } else if (currentPage + 4 >= totalPages) {
-        startPage = totalPages - 9;
+        endPage = pagesToDisplay;
+      } else if (currentPage + pagesToDisplay / 2 - 1 >= totalPages) {
+        startPage = totalPages - pagesToDisplay + 1;
         endPage = totalPages;
       } else {
-        startPage = currentPage - 5;
-        endPage = currentPage + 4;
+        startPage = currentPage - pagesToDisplay / 2;
+        endPage = currentPage + pagesToDisplay / 2 - 1;
       }
     }
 

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -158,13 +158,27 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     setPreviewPath("");
   }
 
-
-  function getVideoClassName() {
-    let ret = "preview";
+  function isPortrait() {
     let file = props.scene.file;
     let width = file.width ? file.width : 0;
     let height = file.height ? file.height : 0;
-    if (height > width) {
+    return height > width;
+  }
+
+  function getLinkClassName() {
+    let ret = "image previewable";
+    
+    if (isPortrait()) {
+      ret += " portrait";
+    }
+
+    return ret;
+  }
+
+  function getVideoClassName() {
+    let ret = "preview";
+    
+    if (isPortrait()) {
       ret += " portrait";
     }
 
@@ -186,7 +200,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         onChange={() => props.onSelectedChanged(!props.selected, shiftKey)}
         onClick={(event: React.MouseEvent<HTMLInputElement, MouseEvent>) => { shiftKey = event.shiftKey; event.stopPropagation(); } }
       />
-      <Link to={`/scenes/${props.scene.id}`} className="image previewable">
+      <Link to={`/scenes/${props.scene.id}`} className={getLinkClassName()}>
         <div className="video-container">
           {maybeRenderRatingBanner()}
           {maybeRenderSceneSpecsOverlay()}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -128,6 +128,19 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     setPreviewPath("");
   }
 
+
+  function getVideoClassName() {
+    let ret = "preview";
+    let file = props.scene.file;
+    let width = file.width ? file.width : 0;
+    let height = file.height ? file.height : 0;
+    if (height > width) {
+      ret += " portrait";
+    }
+
+    return ret;
+  }
+
   var shiftKey = false;
 
   return (
@@ -144,11 +157,13 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         onClick={(event: React.MouseEvent<HTMLInputElement, MouseEvent>) => { shiftKey = event.shiftKey; event.stopPropagation(); } }
       />
       <Link to={`/scenes/${props.scene.id}`} className="image previewable">
-        {maybeRenderRatingBanner()}
-        {maybeRenderSceneSpecsOverlay()}
-        <video className="preview" loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
-          {!!previewPath ? <source src={previewPath} /> : ""}
-        </video>
+        <div className="video-container">
+          {maybeRenderRatingBanner()}
+          {maybeRenderSceneSpecsOverlay()}
+          <video className={getVideoClassName()} loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
+            {!!previewPath ? <source src={previewPath} /> : ""}
+          </video>
+        </div>
       </Link>
       <div className="card-section">
         <H4 style={{textOverflow: "ellipsis", overflow: "hidden"}}>

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -175,7 +175,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
   return (
     <Card
-      className="grid-item"
+      className="grid-item scene-card"
       elevation={Elevation.ONE}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -17,10 +17,12 @@ import { ColorUtils } from "../../utils/color";
 import { TextUtils } from "../../utils/text";
 import { TagLink } from "../Shared/TagLink";
 import { SceneHelpers } from "./helpers";
+import { ZoomUtils } from "../../utils/zoom";
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
   selected: boolean | undefined;
+  zoomIndex: number;
   onSelectedChanged: (selected : boolean, shiftKey : boolean) => void;
 }
 
@@ -189,7 +191,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
   return (
     <Card
-      className="grid-item scene-card"
+      className={"grid-item scene-card " + ZoomUtils.classForZoom(props.zoomIndex)}
       elevation={Elevation.ONE}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -67,9 +67,20 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
   function maybeRenderPerformerPopoverButton() {
     if (props.scene.performers.length <= 0) { return; }
 
-    const performers = props.scene.performers.map((performer) => (
-      <TagLink key={performer.id} performer={performer} />
-    ));
+    const performers = props.scene.performers.map((performer) => {
+      return (
+        <>
+        <div className="performer-tag-container">
+          <Link
+            to={`/performers/${performer.id}`}
+            className="performer-tag previewable image"
+            style={{backgroundImage: `url(${performer.image_path})`}}
+          ></Link>
+          <TagLink key={performer.id} performer={performer} />
+        </div>
+        </>
+      );
+    });
     return (
       <Popover interactionKind={"hover"} position="bottom">
         <Button

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -47,6 +47,25 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     );
   }
 
+  function maybeRenderSceneStudioOverlay() {
+    if (!props.scene.studio) {
+      return;
+    }
+
+    const style: React.CSSProperties = {
+      backgroundImage: `url('${props.scene.studio.image_path}')`,
+    };
+
+    return (
+      <div className={`scene-studio-overlay`}>
+        <Link
+          to={`/studios/${props.scene.studio.id}`}
+          style={style}
+        />
+      </div>
+    );
+  }
+
   function maybeRenderTagPopoverButton() {
     if (props.scene.tags.length <= 0) { return; }
 
@@ -171,6 +190,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
         <div className="video-container">
           {maybeRenderRatingBanner()}
           {maybeRenderSceneSpecsOverlay()}
+          {maybeRenderSceneStudioOverlay()}
           <video className={getVideoClassName()} loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
             {!!previewPath ? <source src={previewPath} /> : ""}
           </video>
@@ -185,8 +205,6 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       </div>
 
       {maybeRenderPopoverButtonGroup()}
-
-      {SceneHelpers.maybeRenderStudio(props.scene, 50, true)}
     </Card>
   );
 };

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -38,6 +38,15 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     );
   }
 
+  function maybeRenderSceneSpecsOverlay() {
+    return (
+      <div className={`scene-specs-overlay`}>
+        {!!props.scene.file.height ? <span className={`overlay-resolution`}> {TextUtils.resolution(props.scene.file.height)}</span> : undefined}
+        {props.scene.file.duration !== undefined && props.scene.file.duration >= 1 ? TextUtils.secondsToTimestamp(props.scene.file.duration) : ""}
+      </div>
+    );
+  }
+
   function maybeRenderTagPopoverButton() {
     if (props.scene.tags.length <= 0) { return; }
 
@@ -136,6 +145,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
       />
       <Link to={`/scenes/${props.scene.id}`} className="image previewable">
         {maybeRenderRatingBanner()}
+        {maybeRenderSceneSpecsOverlay()}
         <video className="preview" loop={true} poster={props.scene.paths.screenshot || ""} ref={videoHoverHook.videoEl}>
           {!!previewPath ? <source src={previewPath} /> : ""}
         </video>
@@ -150,14 +160,6 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
 
       {maybeRenderPopoverButtonGroup()}
 
-      <Divider />
-      <span className="card-section centered">
-        {props.scene.file.size !== undefined ? TextUtils.fileSize(parseInt(props.scene.file.size, 10)) : ""}
-        &nbsp;|&nbsp;
-        {props.scene.file.duration !== undefined ? TextUtils.secondsToTimestamp(props.scene.file.duration) : ""}
-        &nbsp;|&nbsp;
-        {props.scene.file.width} x {props.scene.file.height}
-      </span>
       {SceneHelpers.maybeRenderStudio(props.scene, 50, true)}
     </Card>
   );

--- a/ui/v2/src/components/scenes/SceneList.tsx
+++ b/ui/v2/src/components/scenes/SceneList.tsx
@@ -18,6 +18,7 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
     filterMode: FilterMode.Scenes,
     props,
     zoomable: true,
+    selectable: true,
     renderContent,
     renderSelectedOptions
   });

--- a/ui/v2/src/components/scenes/SceneList.tsx
+++ b/ui/v2/src/components/scenes/SceneList.tsx
@@ -17,6 +17,7 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
   const listData = ListHook.useList({
     filterMode: FilterMode.Scenes,
     props,
+    zoomable: true,
     renderContent,
     renderSelectedOptions
   });
@@ -45,23 +46,24 @@ export const SceneList: FunctionComponent<ISceneListProps> = (props: ISceneListP
     );
   }
 
-  function renderSceneCard(scene : SlimSceneDataFragment, selectedIds: Set<string>) {
+  function renderSceneCard(scene : SlimSceneDataFragment, selectedIds: Set<string>, zoomIndex: number) {
     return (
       <SceneCard 
         key={scene.id} 
         scene={scene} 
+        zoomIndex={zoomIndex}
         selected={selectedIds.has(scene.id)}
         onSelectedChanged={(selected: boolean, shiftKey: boolean) => listData.onSelectChange(scene.id, selected, shiftKey)}
       />
     )
   }
 
-  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel, selectedIds: Set<string>) {
+  function renderContent(result: QueryHookResult<FindScenesQuery, FindScenesVariables>, filter: ListFilterModel, selectedIds: Set<string>, zoomIndex: number) {
     if (!result.data || !result.data.findScenes) { return; }
     if (filter.displayMode === DisplayMode.Grid) {
       return (
         <div className="grid">
-          {result.data.findScenes.scenes.map((scene) => renderSceneCard(scene, selectedIds))}
+          {result.data.findScenes.scenes.map((scene) => renderSceneCard(scene, selectedIds, zoomIndex))}
         </div>
       );
     } else if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -21,7 +21,8 @@ export interface IListHookData {
 export interface IListHookOptions {
   filterMode: FilterMode;
   props: IBaseProps;
-  renderContent: (result: QueryHookResult<any, any>, filter: ListFilterModel, selectedIds: Set<string>) => JSX.Element | undefined;
+  zoomable?: boolean
+  renderContent: (result: QueryHookResult<any, any>, filter: ListFilterModel, selectedIds: Set<string>, zoomIndex: number) => JSX.Element | undefined;
   renderSelectedOptions?: (result: QueryHookResult<any, any>, selectedIds: Set<string>) => JSX.Element | undefined;
 }
 
@@ -31,6 +32,7 @@ export class ListHook {
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [lastClickedId, setLastClickedId] = useState<string | undefined>(undefined);
     const [totalCount, setTotalCount] = useState<number>(0);
+    const [zoomIndex, setZoomIndex] = useState<number>(1);
 
     // Update the filter when the query parameters change
     useEffect(() => {
@@ -254,6 +256,10 @@ export class ListHook {
       setLastClickedId(undefined);
     }
 
+    function onChangeZoom(newZoomIndex : number) {
+      setZoomIndex(newZoomIndex);
+    }
+
     const template = (
       <div>
         <ListFilter
@@ -266,12 +272,14 @@ export class ListHook {
           onRemoveCriterion={onRemoveCriterion}
           onSelectAll={onSelectAll}
           onSelectNone={onSelectNone}
+          zoomIndex={options.zoomable ? zoomIndex : undefined}
+          onChangeZoom={options.zoomable ? onChangeZoom : undefined}
           filter={filter}
         />
         {options.renderSelectedOptions && selectedIds.size > 0 ? options.renderSelectedOptions(result, selectedIds) : undefined}
         {result.loading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
         {result.error ? <h1>{result.error.message}</h1> : undefined}
-        {options.renderContent(result, filter, selectedIds)}
+        {options.renderContent(result, filter, selectedIds, zoomIndex)}
         <Pagination
           itemsPerPage={filter.itemsPerPage}
           currentPage={filter.currentPage}

--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -21,7 +21,8 @@ export interface IListHookData {
 export interface IListHookOptions {
   filterMode: FilterMode;
   props: IBaseProps;
-  zoomable?: boolean
+  zoomable?: boolean;
+  selectable?: boolean;
   renderContent: (result: QueryHookResult<any, any>, filter: ListFilterModel, selectedIds: Set<string>, zoomIndex: number) => JSX.Element | undefined;
   renderSelectedOptions?: (result: QueryHookResult<any, any>, selectedIds: Set<string>) => JSX.Element | undefined;
 }
@@ -270,8 +271,8 @@ export class ListHook {
           onChangeDisplayMode={onChangeDisplayMode}
           onAddCriterion={onAddCriterion}
           onRemoveCriterion={onRemoveCriterion}
-          onSelectAll={onSelectAll}
-          onSelectNone={onSelectNone}
+          onSelectAll={options.selectable ? onSelectAll : undefined}
+          onSelectNone={options.selectable ? onSelectNone : undefined}
           zoomIndex={options.zoomable ? zoomIndex : undefined}
           onChangeZoom={options.zoomable ? onChangeZoom : undefined}
           filter={filter}

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -85,6 +85,8 @@ code {
   width: calc(100% + 40px);
   margin: -20px 0 0 -20px;
   position: relative;
+  height: 240px;
+  max-height: 80vh;
 }
 
 .grid-item label.card-select {
@@ -95,12 +97,24 @@ code {
   opacity: 0.5;
 }
 
+.video-container {
+  width: 100%;
+  height: 100%;
+}
+
 video.preview {
   // height: 225px; // slows down the page
   width: 100%;
   // width: calc(100% + 40px);
   // margin: -20px 0 0 -20px;
   object-fit: cover;
+  margin: 0 auto;
+  display: block;
+}
+
+video.preview.portrait {
+  height: 100%;
+  width: auto;
 }
 
 .filter-item, .operation-item {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -85,8 +85,11 @@ code {
   width: calc(100% + 40px);
   margin: -20px 0 0 -20px;
   position: relative;
+  max-height: 240px;
+}
+
+.previewable.portrait {
   height: 240px;
-  max-height: 80vh;
 }
 
 .grid-item label.card-select {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -161,6 +161,23 @@ video.preview {
   text-align: center;
 }
 
+.scene-specs-overlay {
+  display: block;
+  position: absolute;
+  bottom: 1em;
+  right: .7em;
+  font-weight: 400;
+  color: #f5f8fa;
+  letter-spacing: -.03em;
+  text-shadow: 0 0 3px #000;
+}
+
+.overlay-resolution {
+  font-weight: 900;
+  text-transform: uppercase;
+  margin-right:.3em;
+}
+
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -182,10 +182,15 @@ video.preview.portrait {
   }
 }
 
-.filter-container, .operation-container {
+.operation-container {
   display: flex;
   justify-content: center;
   margin: 10px auto;
+}
+
+.bp3-navbar.filter-container {
+  background-color: $dark-gray2;
+  z-index: 9;
 }
 
 .card-section {
@@ -466,5 +471,12 @@ span.block {
 
   & .bp3-slider {
     min-width: 100%;
+  }
+}
+
+// don't show zoom-slider when under 768px
+@media only screen and (max-width: 768px) {
+  .zoom-slider {
+    display: none;
   }
 }

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -65,56 +65,73 @@ code {
   }
 }
 
-.grid-item {
-  // flex: auto;
-  width: 320px;
-  min-width: 185px;
-  margin: 0px 0 $pt-grid-size $pt-grid-size;
-  overflow: hidden;
-
-  &.wall {
-    width: calc(20%);
-    margin: 0;
-  }
-
-  &.zoom-0 {
-    width: 240px;
-
-    & .previewable {
-      max-height: 180px;
-    }
-    & .previewable.portrait {
-      height: 180px;
-    }
-  }
-  &.zoom-1 {
+@media only screen and (min-width: 768px) {
+  .grid-item {
+    // flex: auto;
     width: 320px;
+    min-width: 185px;
+    margin: 0px 0 $pt-grid-size $pt-grid-size;
+    overflow: hidden;
 
-    & .previewable {
-      max-height: 240px;
+    &.wall {
+      width: calc(20%);
+      margin: 0;
+      position: static;
     }
-    & .previewable.portrait {
-      height: 240px;
+
+    &.zoom-0 {
+      width: 240px;
+
+      & .previewable {
+        max-height: 180px;
+      }
+      & .previewable.portrait {
+        height: 180px;
+      }
+    }
+    &.zoom-1 {
+      width: 320px;
+
+      & .previewable {
+        max-height: 240px;
+      }
+      & .previewable.portrait {
+        height: 240px;
+      }
+    }
+    &.zoom-2 {
+      width: 480px;
+
+      & .previewable {
+        max-height: 360px;
+      }
+      & .previewable.portrait {
+        height: 360px;
+      }
+    }
+    &.zoom-3 {
+      width: 640px;
+
+      & .previewable {
+        max-height: 480px;
+      }
+      & .previewable.portrait {
+        height: 480px;
+      }
     }
   }
-  &.zoom-2 {
-    width: 480px;
+}
 
-    & .previewable {
-      max-height: 360px;
-    }
-    & .previewable.portrait {
-      height: 360px;
-    }
-  }
-  &.zoom-3 {
-    width: 640px;
+@media only screen and (max-width: 768px) {
+  .grid-item {
+    width: 90%;
+    margin: 0px 0 $pt-grid-size $pt-grid-size;
+    overflow: hidden;
 
-    & .previewable {
-      max-height: 480px;
-    }
-    & .previewable.portrait {
-      height: 480px;
+    &.wall {
+      width: calc(20%);
+      margin: 0;
+      position: static;
     }
   }
 }
@@ -501,6 +518,13 @@ span.block {
 .sidebar.sidebar-closed {
   left: -200px;
   transition: left 0.5s;
+}
+
+@media only screen and (max-width: 600px) {
+  .grid {
+    width: 100%;
+    padding: 0;
+  }
 }
 
 // overlay menu on smaller devices

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -254,6 +254,23 @@ span.block {
   background-repeat: no-repeat !important;
 }
 
+.performer-tag-container {
+  max-width: 100%;
+  height: 100%;
+  display: inline-block;
+  text-align: center;
+  margin: 5px;
+}
+
+.performer-tag.image {
+  max-height: 150px;
+  max-width: 100%;
+  background-size: cover !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  margin: 0 auto;
+}
+
 .studio.image {
   height: 100px;
   background-size: contain !important;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -197,7 +197,7 @@ video.preview.portrait {
   font-weight: 400;
   width: 40%;
   height: 20%;
-  opacity: 75%;
+  opacity: 0.75;
   z-index: 9;
 }
 

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -186,6 +186,27 @@ video.preview.portrait {
   text-shadow: 0 0 3px #000;
 }
 
+.scene-studio-overlay {
+  display: block;
+  position: absolute;
+  top: .7em;
+  right: .7em;
+  font-weight: 400;
+  width: 40%;
+  height: 20%;
+  opacity: 75%;
+  z-index: 9;
+}
+
+.scene-studio-overlay a {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  display: inline-block;
+  background-position: right top;
+  background-repeat: no-repeat;
+}
+
 .overlay-resolution {
   font-weight: 900;
   text-transform: uppercase;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -227,6 +227,11 @@ video.preview.portrait {
     opacity: 0;
     transition: opacity 0.5s;
   }
+
+  .scene-studio-overlay:hover {
+    opacity: 0.75;
+    transition: opacity 0.5s;
+  }
 }
 
 #jwplayer-container {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -480,3 +480,33 @@ span.block {
     display: none;
   }
 }
+
+
+.sidebar {
+  position: fixed;
+  top: 50px;
+  bottom: 0;
+  left: 0;
+  width: 200px;
+  background-color: #394b59;
+  transition: left 0.5s;
+  z-index: 11;
+}
+
+.sidebar.sidebar-closed {
+  left: -200px;
+  transition: left 0.5s;
+}
+
+// overlay menu on smaller devices
+@media only screen and (min-width: 768px) {
+  .main {
+    margin-left: 200px;
+    transition: margin-left 0.5s;
+  }
+  
+  .main.sidebar-closed {
+    margin-left: 0px;
+    transition: margin-left 0.5s;
+  }
+}

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -38,7 +38,7 @@ code {
   flex-flow: row wrap;
   justify-content: center;
   margin: $pt-grid-size $pt-grid-size 0 0;
-  padding: 0 calc(10%);
+  padding: 0 100px;
 
   &.wall {
     padding: 0;
@@ -67,7 +67,7 @@ code {
 
 .grid-item {
   // flex: auto;
-  width: calc(25% - 1.5em);
+  width: 320px;
   min-width: 185px;
   margin: 0px 0 $pt-grid-size $pt-grid-size;
   overflow: hidden;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -292,19 +292,15 @@ span.block {
 }
 
 .performer-tag-container {
-  max-width: 100%;
-  height: 100%;
-  display: inline-block;
-  text-align: center;
   margin: 5px;
 }
 
 .performer-tag.image {
-  max-height: 150px;
-  max-width: 100%;
-  background-size: cover !important;
-  background-position: center !important;
-  background-repeat: no-repeat !important;
+  height: 150px;
+  width: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   margin: 0 auto;
 }
 

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -76,6 +76,47 @@ code {
     width: calc(20%);
     margin: 0;
   }
+
+  &.zoom-0 {
+    width: 240px;
+
+    & .previewable {
+      max-height: 180px;
+    }
+    & .previewable.portrait {
+      height: 180px;
+    }
+  }
+  &.zoom-1 {
+    width: 320px;
+
+    & .previewable {
+      max-height: 240px;
+    }
+    & .previewable.portrait {
+      height: 240px;
+    }
+  }
+  &.zoom-2 {
+    width: 480px;
+
+    & .previewable {
+      max-height: 360px;
+    }
+    & .previewable.portrait {
+      height: 360px;
+    }
+  }
+  &.zoom-3 {
+    width: 640px;
+
+    & .previewable {
+      max-height: 480px;
+    }
+    & .previewable.portrait {
+      height: 480px;
+    }
+  }
 }
 
 .previewable {
@@ -416,5 +457,14 @@ span.block {
   & #scrape-url-button {
     float: right;
     height: 30px;
+  }
+}
+
+.zoom-slider {
+  margin: auto 5px;
+  width: 100px;
+
+  & .bp3-slider {
+    min-width: 100%;
   }
 }

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -474,9 +474,14 @@ span.block {
   }
 }
 
-// don't show zoom-slider when under 768px
 @media only screen and (max-width: 768px) {
+  // don't show zoom-slider when under 768px
   .zoom-slider {
+    display: none;
+  }
+
+  // collapse menu items into sidemenu
+  .collapsible-navlink {
     display: none;
   }
 }
@@ -500,6 +505,11 @@ span.block {
 
 // overlay menu on smaller devices
 @media only screen and (min-width: 768px) {
+  // hide menu button on larger devices
+  .menu-button {
+    display: none;
+  }
+
   .main {
     margin-left: 200px;
     transition: margin-left 0.5s;

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -213,6 +213,19 @@ video.preview.portrait {
   margin-right:.3em;
 }
 
+.scene-card {
+  & .scene-specs-overlay, .rating-banner, .scene-studio-overlay {
+    transition: opacity 0.5s;
+  }
+}
+
+.scene-card:hover {
+  & .scene-specs-overlay, .rating-banner, .scene-studio-overlay {
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+}
+
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;

--- a/ui/v2/src/utils/text.ts
+++ b/ui/v2/src/utils/text.ts
@@ -18,7 +18,17 @@ export class TextUtils {
   }
 
   public static secondsToTimestamp(seconds: number): string {
-    return new Date(seconds * 1000).toISOString().substr(11, 8);
+    let ret = new Date(seconds * 1000).toISOString().substr(11, 8);
+
+    if (ret.startsWith("00")) {
+      // strip hours if under one hour
+      ret = ret.substr(3);
+    }
+    if (ret.startsWith("0")) {
+      // for duration under a minute, leave one leading zero
+      ret = ret.substr(1);
+    }
+    return ret;
   }
 
   public static fileNameFromPath(path: string): string {

--- a/ui/v2/src/utils/zoom.ts
+++ b/ui/v2/src/utils/zoom.ts
@@ -1,0 +1,6 @@
+export class ZoomUtils {
+  public static classForZoom(zoomIndex: number): string {
+    return "zoom-" + zoomIndex;
+  }
+}
+  


### PR DESCRIPTION
This is an extension of the #232 branch. I've looked at doing a larger overhaul to try to make the stash UI more small-screen-friendly. 

Specific changes here are to convert the filter bar into a navbar with left and right aligned elements, add a small-device specific menu of the top navbar items, change first/last/previous/next pagination buttons to use icons instead, and use a smaller number of pages on smaller devices.

This may possibly replace #232 if we're happy with the additions, or I can attempt to split everything up.