### PR TITLE
Allow pasting image into performer/studio

### DIFF
--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -62,6 +62,27 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     }
   }, [studio]);
 
+  function pasteImage(e : any) {
+    if (e.clipboardData.files.length == 0) {
+      return;
+    }
+    
+    const file: File = e.clipboardData.files[0];
+    const reader: FileReader = new FileReader();
+    
+    reader.onloadend = (e) => {
+      setImagePreview(reader.result as string);
+      setImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  useEffect(() => {
+    window.addEventListener("paste", pasteImage);
+  
+    return () => window.removeEventListener("paste", pasteImage);
+  });
+
   if (!isNew && !isEditing) {
     if (!data || !data.findStudio || isLoading) { return <Spinner size={Spinner.SIZE_LARGE} />; }
     if (!!error) { return <>error...</>; }

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -97,6 +97,27 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     }
   }, [performer]);
 
+  function pasteImage(e : any) {
+    if (e.clipboardData.files.length == 0) {
+      return;
+    }
+    
+    const file: File = e.clipboardData.files[0];
+    const reader: FileReader = new FileReader();
+    
+    reader.onloadend = (e) => {
+      setImagePreview(reader.result as string);
+      setImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  useEffect(() => {
+    window.addEventListener("paste", pasteImage);
+  
+    return () => window.removeEventListener("paste", pasteImage);
+  });
+
   useEffect(() => {
     var newQueryableScrapers : GQL.ListScrapersListScrapers[] = [];
 
@@ -108,7 +129,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
 
     setQueryableScrapers(newQueryableScrapers);
 
-  }, [Scrapers.data])
+  }, [Scrapers.data]);
 
   if ((!isNew && !isEditing && (!data || !data.findPerformer)) || isLoading) {
     return <Spinner size={Spinner.SIZE_LARGE} />; 


### PR DESCRIPTION
Small quality of life change. Set a studio or performer image by copying it, then pressing Ctrl+V in the edit performer/studio page, and it will be populated with the image from the clipboard.