### PR TITLE
Use inputgroup instead of editabletext in performer/studio edit pages

### DIFF
--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -183,7 +183,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
 
           <HTMLTable style={{width: "100%"}}>
             <tbody>
-              {TableUtils.renderEditableTextTableRow({title: "URL", value: url, isEditing, onChange: setUrl})}
+              {TableUtils.renderInputGroup({title: "URL", value: url, isEditing, onChange: setUrl})}
             </tbody>
           </HTMLTable>
         </div>

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -5,6 +5,7 @@ import {
   EditableText,
   HTMLTable,
   Spinner,
+  FormGroup,
 } from "@blueprintjs/core";
 import _ from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
@@ -16,6 +17,7 @@ import { TableUtils } from "../../../utils/table";
 import { ScrapePerformerSuggest } from "../../select/ScrapePerformerSuggest";
 import { DetailsEditNavbar } from "../../Shared/DetailsEditNavbar";
 import { ToastUtils } from "../../../utils/toasts";
+import { EditableTextUtils } from "../../../utils/editabletext";
 
 interface IPerformerProps extends IBaseProps {}
 
@@ -299,7 +301,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
   }
 
   function maybeRenderScrapeButton() {
-    if (!url || !urlScrapable(url)) {
+    if (!url || !isEditing || !urlScrapable(url)) {
       return undefined;
     }
     return (
@@ -319,13 +321,9 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
           {maybeRenderScrapeButton()}
         </td>
         <td>
-          <EditableText
-            disabled={!isEditing}
-            value={url}
-            placeholder="URL"
-            multiline={true}
-            onChange={(newValue) => setUrl(newValue)}
-          />
+          {EditableTextUtils.renderInputGroup({
+            value: url, isEditing, onChange: setUrl, placeholder: "URL"
+          })}
         </td>
       </tr>
     );
@@ -360,13 +358,11 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
             />
           </h1>
           <h6 className="bp3-heading">
-            <span style={{fontWeight: 300}}>Aliases: </span>
-            <EditableText
-              disabled={!isEditing}
-              value={aliases}
-              placeholder="Aliases"
-              onChange={(value) => setAliases(value)}
-            />
+            <FormGroup className="aliases-field" inline={true} label="Aliases:">
+              {EditableTextUtils.renderInputGroup({
+                value: aliases, isEditing: isEditing, placeholder: "Aliases", onChange: setAliases
+              })}
+            </FormGroup>
           </h6>
           <div>
             <span style={{fontWeight: 300}}>Favorite:</span>
@@ -381,29 +377,29 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
 
           <HTMLTable id="performer-details" style={{width: "100%"}}>
             <tbody>
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Birthdate (YYYY-MM-DD)", value: birthdate, isEditing, onChange: setBirthdate})}
               {renderEthnicity()}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Eye Color", value: eyeColor, isEditing, onChange: setEyeColor})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Country", value: country, isEditing, onChange: setCountry})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Height (CM)", value: height, isEditing, onChange: setHeight})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Measurements", value: measurements, isEditing, onChange: setMeasurements})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Fake Tits", value: fakeTits, isEditing, onChange: setFakeTits})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Career Length", value: careerLength, isEditing, onChange: setCareerLength})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Tattoos", value: tattoos, isEditing, onChange: setTattoos})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Piercings", value: piercings, isEditing, onChange: setPiercings})}
               {renderURLField()}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Twitter", value: twitter, isEditing, onChange: setTwitter})}
-              {TableUtils.renderEditableTextTableRow(
+              {TableUtils.renderInputGroup(
                 {title: "Instagram", value: instagram, isEditing, onChange: setInstagram})}
             </tbody>
           </HTMLTable>

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -473,3 +473,7 @@ span.block {
     min-width: 100%;
   }
 }
+
+.aliases-field > label{
+  font-weight: 300;
+}

--- a/ui/v2/src/utils/editabletext.tsx
+++ b/ui/v2/src/utils/editabletext.tsx
@@ -1,0 +1,71 @@
+import { HTMLSelect, InputGroup, IOptionProps, TextArea, Label } from "@blueprintjs/core";
+import React from "react";
+
+export class EditableTextUtils {
+  public static renderTextArea(options: {
+    value: string | undefined,
+    isEditing: boolean,
+    onChange: ((value: string) => void)
+  }) {
+    let element: JSX.Element;
+    if (options.isEditing) {
+      element = (
+        <TextArea
+          fill={true}
+          onChange={(newValue) => options.onChange(newValue.target.value)}
+          value={options.value}
+        />
+      );
+    } else {
+      element = <p className="pre">{options.value}</p>;
+    }
+    return element;
+  }
+
+  public static renderInputGroup(options: {
+    value: string | undefined,
+    isEditing: boolean,
+    placeholder?: string,
+    onChange: ((value: string) => void),
+  }) {
+    let element: JSX.Element;
+    if (options.isEditing) {
+      element = (
+        <InputGroup
+          onChange={(newValue: any) => options.onChange(newValue.target.value)}
+          value={options.value}
+          placeholder={options.placeholder}
+        />
+      );
+    } else {
+      element = <Label>{options.value}</Label>;
+    }
+    return element;
+  }
+
+  public static renderHtmlSelect(options: {
+    value: string | number | undefined,
+    isEditing: boolean,
+    onChange: ((value: string) => void),
+    selectOptions: Array<string | number | IOptionProps>,
+  }) {
+    let stringValue = options.value;
+    if (typeof stringValue === "number") {
+      stringValue = stringValue.toString();
+    }
+
+    let element: JSX.Element;
+    if (options.isEditing) {
+      element = (
+        <HTMLSelect
+          options={options.selectOptions}
+          onChange={(event) => options.onChange(event.target.value)}
+          value={stringValue}
+        />
+      );
+    } else {
+      element = <span>{options.value}</span>;
+    }
+    return element;
+  }
+}

--- a/ui/v2/src/utils/table.tsx
+++ b/ui/v2/src/utils/table.tsx
@@ -1,7 +1,9 @@
 import { EditableText, HTMLSelect, InputGroup, IOptionProps, TextArea } from "@blueprintjs/core";
 import React from "react";
+import { EditableTextUtils } from "./editabletext";
 import { FilterMultiSelect } from "../components/select/FilterMultiSelect";
 import { FilterSelect } from "../components/select/FilterSelect";
+import _ from "lodash";
 
 export class TableUtils {
   public static renderEditableTextTableRow(options: {
@@ -36,23 +38,12 @@ export class TableUtils {
     isEditing: boolean,
     onChange: ((value: string) => void),
   }) {
-    let element: JSX.Element;
-    if (options.isEditing) {
-      element = (
-        <TextArea
-          fill={true}
-          onChange={(newValue) => options.onChange(newValue.target.value)}
-          value={options.value}
-        />
-      );
-    } else {
-      element = <p className="pre">{options.value}</p>;
-    }
+    
     return (
       <tr>
         <td>{options.title}</td>
         <td>
-          {element}
+          {EditableTextUtils.renderTextArea(options)}
         </td>
       </tr>
     );
@@ -60,26 +51,18 @@ export class TableUtils {
 
   public static renderInputGroup(options: {
     title: string,
+    placeholder?: string,
     value: string | undefined,
     isEditing: boolean,
     onChange: ((value: string) => void),
   }) {
-    let element: JSX.Element;
-    if (options.isEditing) {
-      element = (
-        <InputGroup
-          onChange={(newValue: any) => options.onChange(newValue.target.value)}
-          value={options.value}
-        />
-      );
-    } else {
-      element = <span>{options.value}</span>;
-    }
+    let optionsCopy = _.clone(options);
+    optionsCopy.placeholder = options.placeholder || options.title;
     return (
       <tr>
         <td>{options.title}</td>
         <td>
-          {element}
+          {EditableTextUtils.renderInputGroup(optionsCopy)}
         </td>
       </tr>
     );
@@ -92,28 +75,11 @@ export class TableUtils {
     onChange: ((value: string) => void),
     selectOptions: Array<string | number | IOptionProps>,
   }) {
-    let stringValue = options.value;
-    if (typeof stringValue === "number") {
-      stringValue = stringValue.toString();
-    }
-
-    let element: JSX.Element;
-    if (options.isEditing) {
-      element = (
-        <HTMLSelect
-          options={options.selectOptions}
-          onChange={(event) => options.onChange(event.target.value)}
-          value={stringValue}
-        />
-      );
-    } else {
-      element = <span>{options.value}</span>;
-    }
     return (
       <tr>
         <td>{options.title}</td>
         <td>
-          {element}
+          {EditableTextUtils.renderHtmlSelect(options)}
         </td>
       </tr>
     );


### PR DESCRIPTION
Changes the performer and studio edit pages to use input group instead of editableText. Editable text has an issue where clicking on a different window then returning loses focus on the field. I also noticed that it resized the fields when clicking onto or away from the fields. This change shows a bare value when not in edit mode, and the input group when in edit mode. This means that the placeholder values won't be visible in read mode when there is no value for a given field.

I have left the name fields as editable text, since these are heading values and don't look as nice as input group fields. I can look at styling them larger if needed, but for now I think it should be ok.

This PR also includes a fix that hides the scrape URL button when in read mode.

Fixes #247 