### PR TITLE
Add exclude file from scan feature

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -10,6 +10,7 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   logOut
   logLevel
   logAccess
+  excludes
 }
 
 fragment ConfigInterfaceData on ConfigInterfaceResult {

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -30,7 +30,7 @@ input ConfigGeneralInput {
   logLevel: String!
   """Whether to log http access"""
   logAccess: Boolean!
-  """Array of file regexp to exlude from scan"""
+  """Array of file regexp to exclude from Scan"""
   excludes: [String!]
 }
 
@@ -57,7 +57,7 @@ type ConfigGeneralResult {
   logLevel: String!
   """Whether to log http access"""
   logAccess: Boolean!
-  """Array of file regexp to exlude from scan"""
+  """Array of file regexp to exclude from Scan"""
   excludes: [String!]!
 }
 

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -30,6 +30,8 @@ input ConfigGeneralInput {
   logLevel: String!
   """Whether to log http access"""
   logAccess: Boolean!
+  """Array of file regexp to exlude from scan"""
+  excludes: [String!]
 }
 
 type ConfigGeneralResult {
@@ -55,6 +57,8 @@ type ConfigGeneralResult {
   logLevel: String!
   """Whether to log http access"""
   logAccess: Boolean!
+  """Array of file regexp to exlude from scan"""
+  excludes: [String!]!
 }
 
 input ConfigInterfaceInput {

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -72,6 +72,10 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 		logger.SetLogLevel(input.LogLevel)
 	}
 
+	if input.Excludes != nil {
+		config.Set(config.Exclude, input.Excludes)
+	}
+
 	if err := config.Write(); err != nil {
 		return makeConfigGeneralResult(), err
 	}

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -45,6 +45,7 @@ func makeConfigGeneralResult() *models.ConfigGeneralResult {
 		LogOut:                    config.GetLogOut(),
 		LogLevel:                  config.GetLogLevel(),
 		LogAccess:                 config.GetLogAccess(),
+		Excludes:                  config.GetExcludes(),
 	}
 }
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -23,6 +23,7 @@ const Password = "password"
 const Database = "database"
 
 const ScrapersPath = "scrapers_path"
+const Exclude = "exclude"
 
 const MaxTranscodeSize = "max_transcode_size"
 const MaxStreamingTranscodeSize = "max_streaming_transcode_size"
@@ -89,6 +90,10 @@ func GetDefaultScrapersPath() string {
 	fn := filepath.Join(configDir, "scrapers")
 
 	return fn
+}
+
+func GetExcludes() []string {
+	return viper.GetStringSlice(Exclude)
 }
 
 func GetScrapersPath() string {

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -508,10 +508,10 @@ func excludeFiles(files []string, patterns []string) ([]string, int) {
 		for _, pattern := range patterns {
 			reg, err := regexp.Compile(strings.ToLower(pattern))
 			if err != nil {
-				logger.Errorf("Aborting Exclude:%v", err)
-				return files, 0
+				logger.Errorf("Exclude :%v", err)
+			} else {
+				fileRegexps = append(fileRegexps, reg)
 			}
-			fileRegexps = append(fileRegexps, reg)
 		}
 
 		if len(fileRegexps) == 0 {
@@ -521,7 +521,6 @@ func excludeFiles(files []string, patterns []string) ([]string, int) {
 		for i := 0; i < len(files); i++ {
 			match := false
 			for _, regPattern := range fileRegexps {
-				//if pattern matches remove file from list
 				if regPattern.Match([]byte(strings.ToLower(files[i]))) {
 					logger.Infof("File %s excluded from scan ", files[i])
 					match = true
@@ -530,6 +529,7 @@ func excludeFiles(files []string, patterns []string) ([]string, int) {
 				}
 
 			}
+			//if pattern doesn't match add file to list
 			if !match {
 				results = append(results, files[i])
 			}

--- a/pkg/manager/manager_tasks_test.go
+++ b/pkg/manager/manager_tasks_test.go
@@ -1,0 +1,59 @@
+package manager
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestExcludeFiles(t *testing.T) {
+
+	filenames := []string{
+		"/stash/videos/filename.mp4",
+		"/stash/videos/new filename.mp4",
+		"filename sample.mp4",
+		"/stash/videos/exclude/not wanted.webm",
+		"/stash/videos/exclude/not wanted2.webm",
+		"/somewhere/trash/not wanted.wmv",
+		"/disk2/stash/videos/exclude/!!wanted!!.avi",
+		"/disk2/stash/videos/xcl/not wanted.avi",
+		"/stash/videos/partial.file.001.webm",
+		"/stash/videos/partial.file.002.webm",
+		"/stash/videos/partial.file.003.webm",
+		"/stash/videos/sample file.mkv",
+		"/stash/videos/.ckRVp1/.still_encoding.mp4",
+		"c:\\stash\\videos\\exclude\\filename  windows.mp4",
+		"c:\\stash\\videos\\filename  windows.mp4",
+		"c:\\stash\\videos\\filename  windows sample.mp4"}
+
+	var excludeTests = []struct {
+		testPattern []string
+		expected    int
+	}{
+		{[]string{"sample\\.mp4$", "trash", "\\.[\\d]{3}\\.webm$"}, 6}, //generic
+		{[]string{"no_match\\.mp4"}, 0},                                //no match
+		{[]string{"^/stash/videos/exclude/", "/videos/xcl/"}, 3},       //linux
+		{[]string{"/\\.[[:word:]]+/"}, 1},                              //linux hidden dirs (handbrake unraid issue?)
+		{[]string{"c:\\\\stash\\\\videos\\\\exclude"}, 1},              //windows
+		{[]string{"\\/[/invalid"}, 0},                                  //invalid pattern
+	}
+	for _, test := range excludeTests {
+		err := runExclude(filenames, test.testPattern, test.expected)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func runExclude(filenames []string, patterns []string, expCount int) error {
+
+	files, count := excludeFiles(filenames, patterns)
+
+	if count != expCount {
+		return fmt.Errorf("Was expecting %d, found %d", expCount, count)
+	}
+	if len(files) != len(filenames)-expCount {
+		return fmt.Errorf("Returned list should have %d files, not %d ", len(filenames)-expCount, len(files))
+	}
+
+	return nil
+}

--- a/pkg/manager/manager_tasks_test.go
+++ b/pkg/manager/manager_tasks_test.go
@@ -23,10 +23,10 @@ func TestExcludeFiles(t *testing.T) {
 		"/stash/videos/.ckRVp1/.still_encoding.mp4",
 		"c:\\stash\\videos\\exclude\\filename  windows.mp4",
 		"c:\\stash\\videos\\filename  windows.mp4",
-		"\\\\\\\\network\\\\videos\\\\filename  windows network.mp4",
-		"\\\\\\\\network\\\\share\\\\windows network wanted.mp4",
-		"\\\\\\\\network\\\\share\\\\windows network wanted sample.mp4",
-		"\\\\\\\\network\\\\private\\\\windows.network.skip.mp4"}
+		"\\\\network\\videos\\filename  windows network.mp4",
+		"\\\\network\\share\\windows network wanted.mp4",
+		"\\\\network\\share\\windows network wanted sample.mp4",
+		"\\\\network\\private\\windows.network.skip.mp4"}
 
 	var excludeTests = []struct {
 		testPattern []string
@@ -39,9 +39,9 @@ func TestExcludeFiles(t *testing.T) {
 		{[]string{"c:\\\\stash\\\\videos\\\\exclude"}, 1},              //windows
 		{[]string{"\\/[/invalid"}, 0},                                  //invalid pattern
 		{[]string{"\\/[/invalid", "sample\\.[[:alnum:]]+$"}, 3},        //invalid pattern but continue
-		{[]string{"^\\\\\\\\\\\\\\\\network"}, 4},                      //windows net share
-		{[]string{"\\\\\\\\private\\\\\\\\"}, 1},                       //windows net share
-		{[]string{"\\\\\\\\private\\\\\\\\", "sample\\.mp4"}, 3},       //windows net share
+		{[]string{"^\\\\\\\\network"}, 4},                              //windows net share
+		{[]string{"\\\\private\\\\"}, 1},                               //windows net share
+		{[]string{"\\\\private\\\\", "sample\\.mp4"}, 3},               //windows net share
 	}
 	for _, test := range excludeTests {
 		err := runExclude(filenames, test.testPattern, test.expected)

--- a/pkg/manager/manager_tasks_test.go
+++ b/pkg/manager/manager_tasks_test.go
@@ -19,11 +19,14 @@ func TestExcludeFiles(t *testing.T) {
 		"/stash/videos/partial.file.001.webm",
 		"/stash/videos/partial.file.002.webm",
 		"/stash/videos/partial.file.003.webm",
-		"/stash/videos/sample file.mkv",
+		"/stash/videos/sample file sample.mkv",
 		"/stash/videos/.ckRVp1/.still_encoding.mp4",
 		"c:\\stash\\videos\\exclude\\filename  windows.mp4",
 		"c:\\stash\\videos\\filename  windows.mp4",
-		"c:\\stash\\videos\\filename  windows sample.mp4"}
+		"\\\\\\\\network\\\\videos\\\\filename  windows network.mp4",
+		"\\\\\\\\network\\\\share\\\\windows network wanted.mp4",
+		"\\\\\\\\network\\\\share\\\\windows network wanted sample.mp4",
+		"\\\\\\\\network\\\\private\\\\windows.network.skip.mp4"}
 
 	var excludeTests = []struct {
 		testPattern []string
@@ -35,6 +38,10 @@ func TestExcludeFiles(t *testing.T) {
 		{[]string{"/\\.[[:word:]]+/"}, 1},                              //linux hidden dirs (handbrake unraid issue?)
 		{[]string{"c:\\\\stash\\\\videos\\\\exclude"}, 1},              //windows
 		{[]string{"\\/[/invalid"}, 0},                                  //invalid pattern
+		{[]string{"\\/[/invalid", "sample\\.[[:alnum:]]+$"}, 3},        //invalid pattern but continue
+		{[]string{"^\\\\\\\\\\\\\\\\network"}, 4},                      //windows net share
+		{[]string{"\\\\\\\\private\\\\\\\\"}, 1},                       //windows net share
+		{[]string{"\\\\\\\\private\\\\\\\\", "sample\\.mp4"}, 3},       //windows net share
 	}
 	for _, test := range excludeTests {
 		err := runExclude(filenames, test.testPattern, test.expected)

--- a/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -81,20 +81,20 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
       const ret = ( idx !== i ) ? regex : value ;
       return ret
       })
-  setExcludes(newExcludes);
+    setExcludes(newExcludes);
   }
 
-  function excludeRemoveRegex(idx: number){
-  const newExcludes = excludes.filter((regex, i) => i!== idx );
+  function excludeRemoveRegex(idx: number) {
+    const newExcludes = excludes.filter((regex, i) => i!== idx );
 
-  setExcludes(newExcludes);
+    setExcludes(newExcludes);
   }
 
-  function excludeAddRegex(){
-  const demo = "sample\\.mp4$"
-  const newExcludes = excludes.concat(demo);
+  function excludeAddRegex() {
+    const demo = "sample\\.mp4$"
+    const newExcludes = excludes.concat(demo);
 
-  setExcludes(newExcludes);
+    setExcludes(newExcludes);
   }
 
 
@@ -178,21 +178,20 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
         <FormGroup
           label="Excluded Patterns"
           helperText="Regexps of files/paths to exclude from Scan"
-
         >
 
        { (excludes) ? excludes.map((regexp, i) => {
-                                            return(
-                                              <InputGroup
-                                              value={regexp}
-                                              onChange={(e: any) => excludeRegexChanged(i, e.target.value)}
-                                              rightElement={<Button icon="minus" intent="danger" onClick={(e: any) => excludeRemoveRegex(i)} />}
-                                              />
-                                              );
-                                            })   : null
+                                                    return(
+                                                      <InputGroup
+                                                      value={regexp}
+                                                      onChange={(e: any) => excludeRegexChanged(i, e.target.value)}
+                                                      rightElement={<Button icon="minus" minimal={true} intent="danger" onClick={(e: any) => excludeRemoveRegex(i)} />}
+                                                      />
+                                                    );
+                                                  }) : null
        }
 
-          <Button icon="plus" onClick={(e: any) => excludeAddRegex()} />
+          <Button icon="plus" minimal={true} onClick={(e: any) => excludeAddRegex()} />
         </FormGroup>
       </FormGroup>
       

--- a/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -181,14 +181,14 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
         >
 
        { (excludes) ? excludes.map((regexp, i) => {
-                                                    return(
-                                                      <InputGroup
-                                                      value={regexp}
-                                                      onChange={(e: any) => excludeRegexChanged(i, e.target.value)}
-                                                      rightElement={<Button icon="minus" minimal={true} intent="danger" onClick={(e: any) => excludeRemoveRegex(i)} />}
-                                                      />
-                                                    );
-                                                  }) : null
+         return(
+           <InputGroup
+             value={regexp}
+             onChange={(e: any) => excludeRegexChanged(i, e.target.value)}
+             rightElement={<Button icon="minus" minimal={true} intent="danger" onClick={(e: any) => excludeRemoveRegex(i)} />}
+           />
+           );
+         }) : null
        }
 
           <Button icon="plus" minimal={true} onClick={(e: any) => excludeAddRegex()} />

--- a/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -33,7 +33,8 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
   const [logOut, setLogOut] = useState<boolean>(true);
   const [logLevel, setLogLevel] = useState<string>("Info");
   const [logAccess, setLogAccess] = useState<boolean>(true);
-
+  const [excludes, setExcludes] = useState<(string)[]>([]);
+	
   const { data, error, loading } = StashService.useConfiguration();
 
   const updateGeneralConfig = StashService.useConfigureGeneral({
@@ -48,6 +49,8 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
     logOut,
     logLevel,
     logAccess,
+    excludes,
+
   });
 
   useEffect(() => {
@@ -65,12 +68,35 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
       setLogOut(conf.general.logOut);
       setLogLevel(conf.general.logLevel);
       setLogAccess(conf.general.logAccess);
+      setExcludes(conf.general.excludes);
     }
   }, [data]);
 
   function onStashesChanged(directories: string[]) {
     setStashes(directories);
   }
+
+  function excludeRegexChanged(idx: number,value: string) {
+	const newExcludes = excludes.map((regex,i)=> {  
+		const ret = ( idx !== i ) ? regex : value ;
+		return ret
+		})
+ 	setExcludes(newExcludes);
+  }
+
+  function excludeRemoveRegex(idx: number){
+	const newExcludes = excludes.filter((regex,i) => i!== idx );
+		
+ 	setExcludes(newExcludes);
+  }
+
+  function excludeAddRegex(){
+	const demo = "sample\\.mp4$"
+	const newExcludes = excludes.concat(demo);
+		
+ 	setExcludes(newExcludes);
+  }
+
 
   async function onSave() {
     try {
@@ -147,6 +173,25 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
           helperText="Directory location for the generated files (scene markers, scene previews, sprites, etc)"
         >
           <InputGroup value={generatedPath} onChange={(e: any) => setGeneratedPath(e.target.value)} />
+        </FormGroup>
+	  
+	<FormGroup
+          label="Excluded Patterns"
+ 	  helperText="Regexps of files/paths to exclude from Scan"
+	>
+	
+	{  (excludes) ? excludes.map((regexp,i) => {
+		return	(
+			<InputGroup 
+			value={regexp} 
+			onChange={(e: any) => excludeRegexChanged(i,e.target.value)} 
+			rightElement={<Button icon="remove" onClick={(e: any) => excludeRemoveRegex(i)} />}
+			/>
+		);
+	})   : null
+	}
+
+	<Button icon="add"   onClick={(e: any) => excludeAddRegex()} />
         </FormGroup>
       </FormGroup>
       

--- a/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -34,7 +34,7 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
   const [logLevel, setLogLevel] = useState<string>("Info");
   const [logAccess, setLogAccess] = useState<boolean>(true);
   const [excludes, setExcludes] = useState<(string)[]>([]);
-	
+
   const { data, error, loading } = StashService.useConfiguration();
 
   const updateGeneralConfig = StashService.useConfigureGeneral({
@@ -76,25 +76,25 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
     setStashes(directories);
   }
 
-  function excludeRegexChanged(idx: number,value: string) {
-	const newExcludes = excludes.map((regex,i)=> {  
-		const ret = ( idx !== i ) ? regex : value ;
-		return ret
-		})
- 	setExcludes(newExcludes);
+  function excludeRegexChanged(idx: number, value: string) {
+    const newExcludes = excludes.map((regex, i)=> {
+      const ret = ( idx !== i ) ? regex : value ;
+      return ret
+      })
+  setExcludes(newExcludes);
   }
 
   function excludeRemoveRegex(idx: number){
-	const newExcludes = excludes.filter((regex,i) => i!== idx );
-		
- 	setExcludes(newExcludes);
+  const newExcludes = excludes.filter((regex, i) => i!== idx );
+
+  setExcludes(newExcludes);
   }
 
   function excludeAddRegex(){
-	const demo = "sample\\.mp4$"
-	const newExcludes = excludes.concat(demo);
-		
- 	setExcludes(newExcludes);
+  const demo = "sample\\.mp4$"
+  const newExcludes = excludes.concat(demo);
+
+  setExcludes(newExcludes);
   }
 
 
@@ -174,24 +174,25 @@ export const SettingsConfigurationPanel: FunctionComponent<IProps> = (props: IPr
         >
           <InputGroup value={generatedPath} onChange={(e: any) => setGeneratedPath(e.target.value)} />
         </FormGroup>
-	  
-	<FormGroup
-          label="Excluded Patterns"
- 	  helperText="Regexps of files/paths to exclude from Scan"
-	>
-	
-	{  (excludes) ? excludes.map((regexp,i) => {
-		return	(
-			<InputGroup 
-			value={regexp} 
-			onChange={(e: any) => excludeRegexChanged(i,e.target.value)} 
-			rightElement={<Button icon="remove" onClick={(e: any) => excludeRemoveRegex(i)} />}
-			/>
-		);
-	})   : null
-	}
 
-	<Button icon="add"   onClick={(e: any) => excludeAddRegex()} />
+        <FormGroup
+          label="Excluded Patterns"
+          helperText="Regexps of files/paths to exclude from Scan"
+
+        >
+
+       { (excludes) ? excludes.map((regexp, i) => {
+                                            return(
+                                              <InputGroup
+                                              value={regexp}
+                                              onChange={(e: any) => excludeRegexChanged(i, e.target.value)}
+                                              rightElement={<Button icon="minus" intent="danger" onClick={(e: any) => excludeRemoveRegex(i)} />}
+                                              />
+                                              );
+                                            })   : null
+       }
+
+          <Button icon="plus" onClick={(e: any) => excludeAddRegex()} />
         </FormGroup>
       </FormGroup>
       


### PR DESCRIPTION
Added a basic regexp pattern matching file exclusion.
You can add the patterns in the config file or directly from the UI

For the config file 
```
exclude: 
- "sample\\.mp4$"
- "/\\.[[:word:]]+/"
- "c:\\\\stash\\\\videos\\\\exclude"
- "^/stash/videos/exclude/"
- "exclude/"
```
the first excludes all files ending in `sample.mp4`
the second hidden directories `/.directory/`
the third should work for windows based directories (the \ needs double escaping)
 and so on

If added through the UI you don't need to escape the `\` character 

![exl](https://user-images.githubusercontent.com/48220860/70762364-ef757000-1d58-11ea-8e3c-c90d9263e9b0.png)




