### PR TITLE
Make scene metadata from file metadata optional

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -6,7 +6,7 @@ input GenerateMetadataInput {
 }
 
 input ScanMetadataInput {
-  nameFromMetadata: Boolean!
+  useFileMetadata: Boolean!
 }
 
 input AutoTagMetadataInput {

--- a/pkg/api/resolver_query_metadata.go
+++ b/pkg/api/resolver_query_metadata.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (r *queryResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
-	manager.GetInstance().Scan(input.NameFromMetadata)
+	manager.GetInstance().Scan(input.UseFileMetadata)
 	return "todo", nil
 }
 

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -56,7 +56,7 @@ func (t *TaskStatus) updated() {
 	t.LastUpdate = time.Now()
 }
 
-func (s *singleton) Scan(nameFromMetadata bool) {
+func (s *singleton) Scan(useFileMetadata bool) {
 	if s.Status.Status != Idle {
 		return
 	}
@@ -90,7 +90,7 @@ func (s *singleton) Scan(nameFromMetadata bool) {
 				return
 			}
 			wg.Add(1)
-			task := ScanTask{FilePath: path, NameFromMetadata: nameFromMetadata}
+			task := ScanTask{FilePath: path, UseFileMetadata: useFileMetadata}
 			go task.Start(&wg)
 			wg.Wait()
 		}

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -21,7 +21,7 @@ interface IProps {}
 export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => {
   const [isImportAlertOpen, setIsImportAlertOpen] = useState<boolean>(false);
   const [isCleanAlertOpen, setIsCleanAlertOpen] = useState<boolean>(false);
-  const [nameFromMetadata, setNameFromMetadata] = useState<boolean>(true);
+  const [useFileMetadata, setUseFileMetadata] = useState<boolean>(false);
   const [status, setStatus] = useState<string>("");
   const [progress, setProgress] = useState<number | undefined>(undefined);
 
@@ -128,7 +128,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   async function onScan() {
     try {
-      await StashService.queryMetadataScan({nameFromMetadata});
+      await StashService.queryMetadataScan({useFileMetadata: useFileMetadata});
       ToastUtils.success("Started scan");
       jobStatus.refetch();
     } catch (e) {
@@ -199,9 +199,9 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         inline={true}
       >
         <Checkbox
-          checked={nameFromMetadata}
-          label="Set name from metadata (if present)"
-          onChange={() => setNameFromMetadata(!nameFromMetadata)}
+          checked={useFileMetadata}
+          label="Set name, date, details from metadata (if present)"
+          onChange={() => setUseFileMetadata(!useFileMetadata)}
         />
         <Button id="scan" text="Scan" onClick={() => onScan()} />
       </FormGroup>


### PR DESCRIPTION
This change extends #136 to make all of the file-based metadata extraction optional, since it is frequently incorrect. It makes all of the behaviour introduced in #103 optional, with the exception of the title defaulting to the filename. The checkbox in the settings for this has been renamed to "Set name, date, details from metadata (if present)" and is now unchecked by default.