### PR TITLE
Allow uploading of custom scene covers

### DIFF
--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -8,7 +8,8 @@ mutation SceneUpdate(
   $studio_id: ID,
   $gallery_id: ID,
   $performer_ids: [ID!] = [],
-  $tag_ids: [ID!] = []) {
+  $tag_ids: [ID!] = [],
+  $cover_image: String) {
 
   sceneUpdate(input: {
                         id: $id,
@@ -20,7 +21,8 @@ mutation SceneUpdate(
                         studio_id: $studio_id,
                         gallery_id: $gallery_id,
                         performer_ids: $performer_ids,
-                        tag_ids: $tag_ids
+                        tag_ids: $tag_ids,
+                        cover_image: $cover_image
                       }) {
       ...SceneData
   }

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -51,6 +51,8 @@ input SceneUpdateInput {
   gallery_id: ID
   performer_ids: [ID!]
   tag_ids: [ID!]
+  """This should be base64 encoded"""
+  cover_image: String
 }
 
 input BulkSceneUpdateInput {

--- a/pkg/manager/scene_screenshot.go
+++ b/pkg/manager/scene_screenshot.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"os"
+
+	"github.com/disintegration/imaging"
+
+	// needed to decode other image formats
+	_ "image/gif"
+	_ "image/png"
+)
+
+func writeImage(path string, imageData []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(imageData)
+	return err
+}
+
+func writeThumbnail(path string, thumbnail image.Image) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return jpeg.Encode(f, thumbnail, nil)
+}
+
+func SetSceneScreenshot(checksum string, imageData []byte) error {
+	thumbPath := instance.Paths.Scene.GetThumbnailScreenshotPath(checksum)
+	normalPath := instance.Paths.Scene.GetScreenshotPath(checksum)
+
+	img, _, err := image.Decode(bytes.NewReader(imageData))
+	if err != nil {
+		return err
+	}
+
+	// resize to 320 width maintaining aspect ratio, for the thumbnail
+	const width = 320
+	origWidth := img.Bounds().Max.X
+	origHeight := img.Bounds().Max.Y
+	height := width / origWidth * origHeight
+
+	thumbnail := imaging.Resize(img, width, height, imaging.Lanczos)
+	err = writeThumbnail(thumbPath, thumbnail)
+	if err != nil {
+		return err
+	}
+
+	err = writeImage(normalPath, imageData)
+
+	return err
+}

--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -16,6 +16,7 @@ import { ErrorUtils } from "../../../utils/errors";
 import { TableUtils } from "../../../utils/table";
 import { DetailsEditNavbar } from "../../Shared/DetailsEditNavbar";
 import { ToastUtils } from "../../../utils/toasts";
+import { ImageUtils } from "../../../utils/image";
 
 interface IProps extends IBaseProps {}
 
@@ -62,22 +63,13 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     }
   }, [studio]);
 
-  function pasteImage(e : any) {
-    if (e.clipboardData.files.length == 0) {
-      return;
-    }
-    
-    const file: File = e.clipboardData.files[0];
-    const reader: FileReader = new FileReader();
-    
-    reader.onloadend = (e) => {
-      setImagePreview(reader.result as string);
-      setImage(reader.result as string);
-    };
-    reader.readAsDataURL(file);
+  function onImageLoad(this: FileReader) {
+    setImagePreview(this.result as string);
+    setImage(this.result as string);
   }
 
   useEffect(() => {
+    const pasteImage = (e: any) => { ImageUtils.pasteImage(e, onImageLoad) }
     window.addEventListener("paste", pasteImage);
   
     return () => window.removeEventListener("paste", pasteImage);
@@ -144,14 +136,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
   }
 
   function onImageChange(event: React.FormEvent<HTMLInputElement>) {
-    const file: File = (event.target as any).files[0];
-    const reader: FileReader = new FileReader();
-
-    reader.onloadend = (e) => {
-      setImagePreview(reader.result as string);
-      setImage(reader.result as string);
-    };
-    reader.readAsDataURL(file);
+    ImageUtils.onImageChange(event, onImageLoad);
   }
 
   // TODO: CSS class

--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -68,12 +68,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     setImage(this.result as string);
   }
 
-  useEffect(() => {
-    const pasteImage = (e: any) => { ImageUtils.pasteImage(e, onImageLoad) }
-    window.addEventListener("paste", pasteImage);
-  
-    return () => window.removeEventListener("paste", pasteImage);
-  });
+  ImageUtils.addPasteImageHook(onImageLoad);
 
   if (!isNew && !isEditing) {
     if (!data || !data.findStudio || isLoading) { return <Spinner size={Spinner.SIZE_LARGE} />; }

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -18,6 +18,7 @@ import { ScrapePerformerSuggest } from "../../select/ScrapePerformerSuggest";
 import { DetailsEditNavbar } from "../../Shared/DetailsEditNavbar";
 import { ToastUtils } from "../../../utils/toasts";
 import { EditableTextUtils } from "../../../utils/editabletext";
+import { ImageUtils } from "../../../utils/image";
 
 interface IPerformerProps extends IBaseProps {}
 
@@ -99,22 +100,13 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     }
   }, [performer]);
 
-  function pasteImage(e : any) {
-    if (e.clipboardData.files.length == 0) {
-      return;
-    }
-    
-    const file: File = e.clipboardData.files[0];
-    const reader: FileReader = new FileReader();
-    
-    reader.onloadend = (e) => {
-      setImagePreview(reader.result as string);
-      setImage(reader.result as string);
-    };
-    reader.readAsDataURL(file);
+  function onImageLoad(this: FileReader) {
+    setImagePreview(this.result as string);
+    setImage(this.result as string);
   }
 
   useEffect(() => {
+    const pasteImage = (e: any) => { ImageUtils.pasteImage(e, onImageLoad) }
     window.addEventListener("paste", pasteImage);
   
     return () => window.removeEventListener("paste", pasteImage);
@@ -208,14 +200,7 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
   }
 
   function onImageChange(event: React.FormEvent<HTMLInputElement>) {
-    const file: File = (event.target as any).files[0];
-    const reader: FileReader = new FileReader();
-
-    reader.onloadend = (e) => {
-      setImagePreview(reader.result as string);
-      setImage(reader.result as string);
-    };
-    reader.readAsDataURL(file);
+    ImageUtils.onImageChange(event, onImageLoad);
   }
 
   function onDisplayFreeOnesDialog(scraper: GQL.ListPerformerScrapersListPerformerScrapers) {

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -105,13 +105,8 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     setImage(this.result as string);
   }
 
-  useEffect(() => {
-    const pasteImage = (e: any) => { ImageUtils.pasteImage(e, onImageLoad) }
-    window.addEventListener("paste", pasteImage);
+  ImageUtils.addPasteImageHook(onImageLoad);
   
-    return () => window.removeEventListener("paste", pasteImage);
-  });
-
   useEffect(() => {
     var newQueryableScrapers : GQL.ListPerformerScrapersListPerformerScrapers[] = [];
 

--- a/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
@@ -8,6 +8,9 @@ import {
   InputGroup,
   Spinner,
   TextArea,
+  Collapse,
+  Icon,
+  FileInput,
 } from "@blueprintjs/core";
 import _ from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
@@ -18,6 +21,7 @@ import { ToastUtils } from "../../../utils/toasts";
 import { FilterMultiSelect } from "../../select/FilterMultiSelect";
 import { FilterSelect } from "../../select/FilterSelect";
 import { ValidGalleriesSelect } from "../../select/ValidGalleriesSelect";
+import { ImageUtils } from "../../../utils/image";
 
 interface IProps {
   scene: GQL.SceneDataFragment;
@@ -36,10 +40,14 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
   const [studioId, setStudioId] = useState<string | undefined>(undefined);
   const [performerIds, setPerformerIds] = useState<string[] | undefined>(undefined);
   const [tagIds, setTagIds] = useState<string[] | undefined>(undefined);
+  const [coverImage, setCoverImage] = useState<string | undefined>(undefined);
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
   const [deleteFile, setDeleteFile] = useState<boolean>(false);
   const [deleteGenerated, setDeleteGenerated] = useState<boolean>(true);
+
+  const [isCoverImageOpen, setIsCoverImageOpen] = useState<boolean>(false);
+  const [coverImagePreview, setCoverImagePreview] = useState<string | undefined>(undefined);
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
@@ -64,7 +72,10 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
 
   useEffect(() => {
     updateSceneEditState(props.scene);
+    setCoverImagePreview(props.scene.paths.screenshot);
   }, [props.scene]);
+
+  ImageUtils.addPasteImageHook(onImageLoad);
 
   // if (!isNew && !isEditing) {
   //   if (!data || !data.findPerformer || isLoading) { return <Spinner size={Spinner.SIZE_LARGE} />; }
@@ -83,6 +94,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
       studio_id: studioId,
       performer_ids: performerIds,
       tag_ids: tagIds,
+      cover_image: coverImage,
     };
   }
 
@@ -166,6 +178,15 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
     );
   }
 
+  function onImageLoad(this: FileReader) {
+    setCoverImagePreview(this.result as string);
+    setCoverImage(this.result as string);
+  }
+
+  function onCoverImageChange(event: React.FormEvent<HTMLInputElement>) {
+    ImageUtils.onImageChange(event, onImageLoad);
+  }
+
   return (
     <>
       {renderDeleteAlert()}
@@ -231,6 +252,18 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
         <FormGroup label="Tags">
           {renderMultiSelect("tags", tagIds)}
         </FormGroup>
+
+        <div className="bp3-form-group">
+          <label className="bp3-label collapsible-label" onClick={() => setIsCoverImageOpen(!isCoverImageOpen)}>
+            <Icon className="label-icon" icon={isCoverImageOpen ? "chevron-down" : "chevron-right"}/>
+            <span>Cover Image</span>
+          </label>
+          <Collapse isOpen={isCoverImageOpen}>
+            <img className="scene-cover" src={coverImagePreview} />
+            <FileInput text="Choose image..." onInputChange={onCoverImageChange} inputProps={{accept: ".jpg,.jpeg,.png"}} />
+          </Collapse>
+        </div>
+        
       </div>
       <Button className="edit-button" text="Save" intent="primary" onClick={() => onSave()}/>
       <Button className="edit-button" text="Delete" intent="danger" onClick={() => setIsDeleteAlertOpen(true)}/>

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -478,6 +478,26 @@ span.block {
   font-weight: 300;
 }
 
+.scene-cover {
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  max-width: 100%;
+}
+
+.collapsible-label {
+  cursor: pointer;
+}
+
+.label-icon {
+  margin-right: 0.3em;
+  vertical-align: middle;
+
+  & +span {
+    vertical-align: middle;
+  }
+}
+
 @media only screen and (max-width: 768px) {
   // collapse menu items into sidemenu
   .collapsible-navlink {

--- a/ui/v2/src/utils/image.tsx
+++ b/ui/v2/src/utils/image.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+export class ImageUtils {
+
+  private static readImage(file: File, onLoadEnd: (this: FileReader) => any) {
+    const reader: FileReader = new FileReader();
+    
+    reader.onloadend = onLoadEnd;
+    reader.readAsDataURL(file);
+  }
+
+  public static onImageChange(event: React.FormEvent<HTMLInputElement>, onLoadEnd: (this: FileReader) => any) {
+    const file: File = (event.target as any).files[0];
+    ImageUtils.readImage(file, onLoadEnd);
+  }
+    
+  public static pasteImage(e : any, onLoadEnd: (this: FileReader) => any) {
+    if (e.clipboardData.files.length == 0) {
+      return;
+    }
+    
+    const file: File = e.clipboardData.files[0];
+    ImageUtils.readImage(file, onLoadEnd);
+  }
+}

--- a/ui/v2/src/utils/image.tsx
+++ b/ui/v2/src/utils/image.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 export class ImageUtils {
 
@@ -21,5 +21,14 @@ export class ImageUtils {
     
     const file: File = e.clipboardData.files[0];
     ImageUtils.readImage(file, onLoadEnd);
+  }
+
+  public static addPasteImageHook(onLoadEnd: (this: FileReader) => any) {
+    useEffect(() => {
+      const pasteImage = (e: any) => { ImageUtils.pasteImage(e, onLoadEnd) }
+      window.addEventListener("paste", pasteImage);
+    
+      return () => window.removeEventListener("paste", pasteImage);
+    });
   }
 }


### PR DESCRIPTION
Adds a "Cover Image" section to the Edit Scene page. This is an expandable section that is collapsed by default, as follows:

![image](https://user-images.githubusercontent.com/53250216/70763872-c16c4c00-1da9-11ea-9e6d-5561ee62b0ff.png)

Expanding this shows the current cover image, with a file selector to select a new cover image:

![image](https://user-images.githubusercontent.com/53250216/70763914-dfd24780-1da9-11ea-9887-aceb2eec49a2.png)

Like the other image selection pages, Ctrl-V with an image in the clipboard will paste the image directly.

Note that saving the scene after updating the cover image does not update the cover image in the video player until the page is reloaded.

Should address #35 