### PR TITLE
Fix vtt for chapter display in scene players

### DIFF
--- a/pkg/utils/vtt.go
+++ b/pkg/utils/vtt.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// GetVTTTime returns a timestamp appropriate for VTT files (hh:mm:ss)
+// GetVTTTime returns a timestamp appropriate for VTT files (hh:mm:ss.mmm)
 func GetVTTTime(totalSeconds float64) (s string) {
 	totalSecondsString := strconv.FormatFloat(totalSeconds, 'f', -1, 64)
 	secondsDuration, _ := time.ParseDuration(totalSecondsString + "s")
@@ -33,6 +33,9 @@ func GetVTTTime(totalSeconds float64) (s string) {
 		s += "0"
 	}
 	s += strconv.Itoa(seconds)
+
+	// videojs requires milliseconds
+	s += ".000"
 
 	return
 }

--- a/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
@@ -91,6 +91,7 @@ export class VideoJSPlayer extends React.Component<IVideoJSPlayerProps> {
               poster={this.props.scene.paths.screenshot}
               controls 
               preload="auto">
+            <track kind="chapters" label="Markers" src={this.props.scene.paths.chapters_vtt} default></track>
           </video>
         </div>
       </div>


### PR DESCRIPTION
Fixes the VTT generation so that markers are shown correctly in the seek bar in jwplayer, and in the chapters drop-down in videojs. Note that videojs only shows the chapters drop-down if there are more than one marker in the scene.