### PR TITLE
Add "Open Random" to performer list

### DIFF
--- a/ui/v2/src/components/performers/PerformerList.tsx
+++ b/ui/v2/src/components/performers/PerformerList.tsx
@@ -8,15 +8,39 @@ import { ListFilterModel } from "../../models/list-filter/filter";
 import { DisplayMode, FilterMode } from "../../models/list-filter/types";
 import { PerformerCard } from "./PerformerCard";
 import { PerformerListTable } from "./PerformerListTable";
+import { StashService } from "../../core/StashService";
 
 interface IPerformerListProps extends IBaseProps {}
 
 export const PerformerList: FunctionComponent<IPerformerListProps> = (props: IPerformerListProps) => {
+  const otherOperations = [
+    {
+      text: "Open Random",
+      onClick: getRandom,
+    }
+  ];
+  
   const listData = ListHook.useList({
     filterMode: FilterMode.Performers,
     props,
+    otherOperations: otherOperations,
     renderContent,
   });
+
+  async function getRandom(result: QueryHookResult<FindPerformersQuery, FindPerformersVariables>, filter: ListFilterModel) {
+    if (result.data && result.data.findPerformers) {
+      let count = result.data.findPerformers.count;
+      let index = Math.floor(Math.random() * count);
+      let filterCopy = _.cloneDeep(filter);
+      filterCopy.itemsPerPage = 1;
+      filterCopy.currentPage = index + 1;
+      const singleResult = await StashService.queryFindPerformers(filterCopy);
+      if (singleResult && singleResult.data && singleResult.data.findPerformers && singleResult.data.findPerformers.performers.length === 1) {
+        let id = singleResult!.data!.findPerformers!.performers[0]!.id;
+        props.history.push("/performers/" + id);
+      }
+    }
+  }
 
   function renderContent(
     result: QueryHookResult<FindPerformersQuery, FindPerformersVariables>, filter: ListFilterModel) {

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -182,6 +182,19 @@ export class StashService {
     });
   }
 
+  public static queryFindPerformers(filter: ListFilterModel) {
+    let performerFilter = {};
+    performerFilter = filter.makePerformerFilter();
+
+    return StashService.client.query<GQL.FindPerformersQuery>({
+      query: GQL.FindPerformersDocument,
+      variables: {
+        filter: filter.makeFindFilter(),
+        performer_filter: performerFilter,
+      }
+    });
+  }
+
   public static useFindGallery(id: string) { return GQL.useFindGallery({variables: {id}}); }
   public static useFindScene(id: string) { return GQL.useFindScene({variables: {id}}); }
   public static useFindPerformer(id: string) {


### PR DESCRIPTION
Adds an "Open Random" item to the more operations list on the performer list.

Mostly cribbing directly off WithoutPants' work (#255), so, uses the current filter and navigates to a random performer's page.