### PR TITLE
Add cache breaker for screenshot using modtime

### DIFF
--- a/pkg/api/resolver_model_scene.go
+++ b/pkg/api/resolver_model_scene.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"github.com/stashapp/stash/pkg/api/urlbuilders"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/models"
@@ -64,7 +65,7 @@ func (r *sceneResolver) File(ctx context.Context, obj *models.Scene) (*models.Sc
 func (r *sceneResolver) Paths(ctx context.Context, obj *models.Scene) (*models.ScenePathsType, error) {
 	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 	builder := urlbuilders.NewSceneURLBuilder(baseURL, obj.ID)
-	screenshotPath := builder.GetScreenshotURL()
+	screenshotPath := builder.GetScreenshotURL(obj.UpdatedAt.Timestamp)
 	previewPath := builder.GetStreamPreviewURL()
 	streamPath := builder.GetStreamURL()
 	webpPath := builder.GetStreamPreviewImageURL()

--- a/pkg/api/urlbuilders/scene.go
+++ b/pkg/api/urlbuilders/scene.go
@@ -1,6 +1,9 @@
 package urlbuilders
 
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
 
 type SceneURLBuilder struct {
 	BaseURL string
@@ -30,8 +33,8 @@ func (b SceneURLBuilder) GetSpriteVTTURL() string {
 	return b.BaseURL + "/scene/" + b.SceneID + "_thumbs.vtt"
 }
 
-func (b SceneURLBuilder) GetScreenshotURL() string {
-	return b.BaseURL + "/scene/" + b.SceneID + "/screenshot"
+func (b SceneURLBuilder) GetScreenshotURL(updateTime time.Time) string {
+	return b.BaseURL + "/scene/" + b.SceneID + "/screenshot?" + strconv.FormatInt(updateTime.Unix(), 10)
 }
 
 func (b SceneURLBuilder) GetChaptersVTTURL() string {


### PR DESCRIPTION
Fixes #270 

Adds a cache-breaker query parameter to the generated screenshot url based on the modification time of the scene. When the scene is updated (and the cover image possibly changed) then the query parameter value will change, ensuring that the latest copy of the cover image is downloaded.