### PR TITLE
Fix transcoded video player position

### DIFF
--- a/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
@@ -135,7 +135,11 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
       };
 
       getCurrentTimeHook = (_videoTag: any) => {
-        return _videoTag.currentTime + _videoTag.start;
+        let start = _videoTag.start
+        if (!start) {
+          start = 0;
+        }
+        return _videoTag.currentTime + start;
       }
     }
 

--- a/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
@@ -135,10 +135,7 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
       };
 
       getCurrentTimeHook = (_videoTag: any) => {
-        let start = _videoTag.start
-        if (!start) {
-          start = 0;
-        }
+        let start = _videoTag.start || 0;
         return _videoTag.currentTime + start;
       }
     }


### PR DESCRIPTION
Fixes issue where transcoded videos weren't showing the position correctly until seek is used on the video.