### PR TITLE
Add link to gthub releases to about page

### DIFF
--- a/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
@@ -52,6 +52,9 @@ export const SettingsAboutPanel: FunctionComponent<IProps> = (props: IProps) => 
       {!data || loading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
       {!!error ? <span>error.message</span> : undefined}
       {renderVersion()}
+      <p>
+        New updates might be available on <a href="https://github.com/stashapp/stash/releases">GitHub</a>.
+      </p>
     </>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52797608/71445727-19913f80-2714-11ea-95ce-2e699b9424b3.png)
I would prefer to actually check the github page for newer releases and possibly even a button to update, but I don't know where and how to propperly implement this. If anyone want's to give me a hint, feel free :)