### PR TITLE
Fix usage of Box.Bytes causing depreciation message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ ifeq ($(OS),Windows_NT)
   SET := set
 endif
 
+release: generate ui build
+
 build:
 	$(eval DATE := $(shell go run scripts/getDate.go))
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -129,7 +129,7 @@ func Start() {
 	r.HandleFunc("/setup*", func(w http.ResponseWriter, r *http.Request) {
 		ext := path.Ext(r.URL.Path)
 		if ext == ".html" || ext == "" {
-			data := setupUIBox.Bytes("index.html")
+			data, _ := setupUIBox.Find("index.html")
 			_, _ = w.Write(data)
 		} else {
 			r.URL.Path = strings.Replace(r.URL.Path, "/setup", "", 1)
@@ -193,7 +193,7 @@ func Start() {
 	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
 		ext := path.Ext(r.URL.Path)
 		if ext == ".html" || ext == "" {
-			data := uiBox.Bytes("index.html")
+			data, _ := uiBox.Find("index.html")
 			_, _ = w.Write(data)
 		} else {
 			http.FileServer(uiBox).ServeHTTP(w, r)


### PR DESCRIPTION
Save the trees, use less logspace.

This is basically directly mocked off of how packr currently implements .Bytes (by passing the args to .Find and then ignoring the second part of the 2-tuple).

I'm also sneaking in a `release` target into the make file that effectively mimics what the project readme states should be done to make a release build. Don't tell anyone. It'll be our secret.