### PR TITLE
Add check version functionality

### DIFF
--- a/graphql/documents/queries/misc.graphql
+++ b/graphql/documents/queries/misc.graphql
@@ -66,3 +66,10 @@ query Version {
     build_time
   }
 }
+
+query LatestVersion {
+  latestversion {
+    shorthash
+    url
+  }
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -96,6 +96,9 @@ type Query {
 
   # Version
   version: Version!
+  
+  # LatestVersion
+  latestversion: ShortVersion!
 }
 
 type Mutation {

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -3,3 +3,8 @@ type Version {
   hash: String!
   build_time: String!
 }
+
+type ShortVersion {
+  shorthash: String!
+  url: String!
+}

--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stashapp/stash/pkg/logger"
+	"io/ioutil"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+//we use the github REST V3 API as no login is required
+const apiURL string = "https://api.github.com/repos/stashapp/stash/tags"
+const apiReleases string = "https://api.github.com/repos/stashapp/stash/releases"
+const apiAcceptHeader string = "application/vnd.github.v3+json"
+
+var stashReleases = func() map[string]string {
+	return map[string]string{
+		"windows/amd64": "stash-win.exe",
+		"linux/amd64":   "stash-linux",
+		"darwin/amd64":  "stash-osx",
+		"linux/arm":     "stash-pi",
+	}
+}
+
+type githubTagResponse struct {
+	Name        string
+	Zipball_url string
+	Tarball_url string
+	Commit      struct {
+		Sha string
+		Url string
+	}
+	Node_id string
+}
+
+type githubReleasesResponse struct {
+	Url              string
+	Assets_url       string
+	Upload_url       string
+	Html_url         string
+	Id               int64
+	Node_id          string
+	Tag_name         string
+	Target_commitish string
+	Name             string
+	Draft            bool
+	Author           githubAuthor
+	Prerelease       bool
+	Created_at       string
+	Published_at     string
+	Assets           []githubAsset
+	Tarball_url      string
+	Zipball_url      string
+	Body             string
+}
+
+type githubAuthor struct {
+	Login               string
+	Id                  int64
+	Node_id             string
+	Avatar_url          string
+	Gravatar_id         string
+	Url                 string
+	Html_url            string
+	Followers_url       string
+	Following_url       string
+	Gists_url           string
+	Starred_url         string
+	Subscriptions_url   string
+	Organizations_url   string
+	Repos_url           string
+	Events_url          string
+	Received_events_url string
+	Type                string
+	Site_admin          bool
+}
+
+type githubAsset struct {
+	Url                  string
+	Id                   int64
+	Node_id              string
+	Name                 string
+	Label                string
+	Uploader             githubAuthor
+	Content_type         string
+	State                string
+	Size                 int64
+	Download_count       int64
+	Created_at           string
+	Updated_at           string
+	Browser_download_url string
+}
+
+//gets latest version (git commit hash) from github API
+//the repo's tags are used to find the latest version
+//of the "master" or "develop" branch
+func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease string, err error) {
+
+	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	wantedRelease := stashReleases()[platform]
+
+	branch, _, _ := GetVersion()
+	if branch == "" {
+		return "", "", fmt.Errorf("Stash doesn't have a version. Version check not supported.")
+	}
+
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+
+	req, _ := http.NewRequest("GET", apiReleases, nil)
+
+	req.Header.Add("Accept", apiAcceptHeader) // gh api recommendation , send header with api version
+	response, err := client.Do(req)
+
+	input := make([]githubReleasesResponse, 0)
+
+	if err != nil {
+		return "", "", fmt.Errorf("Github API request failed: %s", err)
+	} else {
+
+		defer response.Body.Close()
+
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return "", "", fmt.Errorf("Github API read response failed: %s", err)
+		} else {
+			err = json.Unmarshal(data, &input)
+			if err != nil {
+				return "", "", fmt.Errorf("Unmarshalling Github API response failed: %s", err)
+			} else {
+
+				for _, ghApi := range input {
+					if ghApi.Tag_name == branch {
+
+						if shortHash {
+							latestVersion = ghApi.Target_commitish[0:7] //shorthash is first 7 digits of git commit hash
+						} else {
+							latestVersion = ghApi.Target_commitish
+						}
+						if wantedRelease != "" {
+							for _, asset := range ghApi.Assets {
+								if asset.Name == wantedRelease {
+									latestRelease = asset.Browser_download_url
+									break
+								}
+
+							}
+						}
+						break
+					}
+				}
+
+			}
+		}
+		if latestVersion == "" {
+			return "", "", fmt.Errorf("No version found for \"%s\"", branch)
+		}
+	}
+	return latestVersion, latestRelease, nil
+
+}
+
+func printLatestVersion() {
+	_, githash, _ = GetVersion()
+	latest, _, err := GetLatestVersion(true)
+	if err != nil {
+		logger.Errorf("Couldn't find latest version: %s", err)
+	} else {
+		if githash == latest {
+			logger.Infof("Version: (%s) is already the latest released.", latest)
+		} else {
+			logger.Infof("New version: (%s) available.", latest)
+		}
+	}
+
+}

--- a/pkg/api/resolver.go
+++ b/pkg/api/resolver.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/99designs/gqlgen/graphql"
-
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 )
 
@@ -114,6 +114,21 @@ func (r *queryResolver) Version(ctx context.Context) (*models.Version, error) {
 		Hash:      hash,
 		BuildTime: buildtime,
 	}, nil
+}
+
+//Gets latest version (git shorthash commit for now)
+func (r *queryResolver) Latestversion(ctx context.Context) (*models.ShortVersion, error) {
+	ver, url, err := GetLatestVersion(true)
+	if err == nil {
+		logger.Infof("Retrieved latest hash: %s", ver)
+	} else {
+		logger.Errorf("Error while retrieving latest hash: %s", err)
+	}
+
+	return &models.ShortVersion{
+		Shorthash: ver,
+		URL:       url,
+	}, err
 }
 
 // Get scene marker tags which show up under the video.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -216,6 +216,7 @@ func Start() {
 
 		go func() {
 			printVersion()
+			printLatestVersion()
 			logger.Infof("stash is listening on " + address)
 			logger.Infof("stash is running at https://" + displayAddress + "/")
 			logger.Fatal(httpsServer.ListenAndServeTLS("", ""))
@@ -228,6 +229,7 @@ func Start() {
 
 		go func() {
 			printVersion()
+			printLatestVersion()
 			logger.Infof("stash is listening on " + address)
 			logger.Infof("stash is running at http://" + displayAddress + "/")
 			logger.Fatal(server.ListenAndServe())

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -195,15 +195,15 @@ export class StashService {
     });
   }
 
-  public static useFindGallery(id: string) { return GQL.useFindGallery({variables: {id}}); }
-  public static useFindScene(id: string) { return GQL.useFindScene({variables: {id}}); }
+  public static useFindGallery(id: string) { return GQL.useFindGallery({ variables: { id } }); }
+  public static useFindScene(id: string) { return GQL.useFindScene({ variables: { id } }); }
   public static useFindPerformer(id: string) {
     const skip = id === "new" ? true : false;
-    return GQL.useFindPerformer({variables: {id}, skip});
+    return GQL.useFindPerformer({ variables: { id }, skip });
   }
   public static useFindStudio(id: string) {
     const skip = id === "new" ? true : false;
-    return GQL.useFindStudio({variables: {id}, skip});
+    return GQL.useFindStudio({ variables: { id }, skip });
   }
 
   // TODO - scene marker manipulation functions are handled differently
@@ -215,27 +215,27 @@ export class StashService {
   ];
 
   public static useSceneMarkerCreate() {
-    return GQL.useSceneMarkerCreate({ refetchQueries: ["FindScene"] }); 
+    return GQL.useSceneMarkerCreate({ refetchQueries: ["FindScene"] });
   }
-  public static useSceneMarkerUpdate() { 
-    return GQL.useSceneMarkerUpdate({ refetchQueries: ["FindScene"] }); 
+  public static useSceneMarkerUpdate() {
+    return GQL.useSceneMarkerUpdate({ refetchQueries: ["FindScene"] });
   }
   public static useSceneMarkerDestroy() {
-    return GQL.useSceneMarkerDestroy({ refetchQueries: ["FindScene"] }); 
+    return GQL.useSceneMarkerDestroy({ refetchQueries: ["FindScene"] });
   }
 
-  public static useListPerformerScrapers() { 
-    return GQL.useListPerformerScrapers(); 
+  public static useListPerformerScrapers() {
+    return GQL.useListPerformerScrapers();
   }
-  public static useScrapePerformerList(scraperId: string, q : string) { 
-    return GQL.useScrapePerformerList({ variables: { scraper_id: scraperId, query: q }}); 
+  public static useScrapePerformerList(scraperId: string, q: string) {
+    return GQL.useScrapePerformerList({ variables: { scraper_id: scraperId, query: q } });
   }
-  public static useScrapePerformer(scraperId: string, scrapedPerformer : GQL.ScrapedPerformerInput) {
-     return GQL.useScrapePerformer({ variables: { scraper_id: scraperId, scraped_performer: scrapedPerformer }});
+  public static useScrapePerformer(scraperId: string, scrapedPerformer: GQL.ScrapedPerformerInput) {
+    return GQL.useScrapePerformer({ variables: { scraper_id: scraperId, scraped_performer: scrapedPerformer } });
   }
 
-  public static useListSceneScrapers() { 
-    return GQL.useListSceneScrapers(); 
+  public static useListSceneScrapers() {
+    return GQL.useListSceneScrapers();
   }
 
   public static useScrapeFreeonesPerformers(q: string) { return GQL.useScrapeFreeonesPerformers({ variables: { q } }); }
@@ -245,13 +245,14 @@ export class StashService {
   public static useAllPerformersForFilter() { return GQL.useAllPerformersForFilter(); }
   public static useAllStudiosForFilter() { return GQL.useAllStudiosForFilter(); }
   public static useValidGalleriesForScene(sceneId: string) {
-    return GQL.useValidGalleriesForScene({variables: {scene_id: sceneId}});
+    return GQL.useValidGalleriesForScene({ variables: { scene_id: sceneId } });
   }
   public static useStats() { return GQL.useStats(); }
   public static useVersion() { return GQL.useVersion(); }
+  public static useLatestVersion() { return GQL.useLatestVersion({ notifyOnNetworkStatusChange: true, errorPolicy: 'ignore' }); }
 
   public static useConfiguration() { return GQL.useConfiguration(); }
-  public static useDirectories(path?: string) { return GQL.useDirectories({ variables: { path }}); }
+  public static useDirectories(path?: string) { return GQL.useDirectories({ variables: { path } }); }
 
   private static performerMutationImpactedQueries = [
     "findPerformers",
@@ -260,6 +261,8 @@ export class StashService {
     "allPerformers"
   ];
 
+  }
+  
   public static usePerformerCreate() {
     return GQL.usePerformerCreate({ 
       update: () => StashService.invalidateQueries(StashService.performerMutationImpactedQueries)
@@ -286,7 +289,7 @@ export class StashService {
   ];
 
   public static useSceneUpdate(input: GQL.SceneUpdateInput) {
-    return GQL.useSceneUpdate({ 
+    return GQL.useSceneUpdate({
       variables: input,
       update: () => StashService.invalidateQueries(StashService.sceneMutationImpactedQueries),
       refetchQueries: ["AllTagsForFilter"]
@@ -303,18 +306,18 @@ export class StashService {
   ];
 
   public static useBulkSceneUpdate(input: GQL.BulkSceneUpdateInput) {
-    return GQL.useBulkSceneUpdate({ 
-      variables: input, 
+    return GQL.useBulkSceneUpdate({
+      variables: input,
       update: () => StashService.invalidateQueries(StashService.sceneBulkMutationImpactedQueries)
     });
   }
-  
+
   public static useScenesUpdate(input: GQL.SceneUpdateInput[]) {
-    return GQL.useScenesUpdate({ variables: { input : input }});
+    return GQL.useScenesUpdate({ variables: { input: input } });
   }
 
   public static useSceneDestroy(input: GQL.SceneDestroyInput) {
-    return GQL.useSceneDestroy({ 
+    return GQL.useSceneDestroy({
       variables: input,
       update: () => StashService.invalidateQueries(StashService.sceneMutationImpactedQueries)
     });
@@ -327,22 +330,22 @@ export class StashService {
   ];
 
   public static useStudioCreate(input: GQL.StudioCreateInput) {
-    return GQL.useStudioCreate({ 
+    return GQL.useStudioCreate({
       variables: input,
       update: () => StashService.invalidateQueries(StashService.studioMutationImpactedQueries)
     });
   }
 
   public static useStudioUpdate(input: GQL.StudioUpdateInput) {
-    return GQL.useStudioUpdate({ 
+    return GQL.useStudioUpdate({
       variables: input,
       update: () => StashService.invalidateQueries(StashService.studioMutationImpactedQueries)
     });
   }
 
   public static useStudioDestroy(input: GQL.StudioDestroyInput) {
-    return GQL.useStudioDestroy({ 
-      variables: input, 
+    return GQL.useStudioDestroy({
+      variables: input,
       update: () => StashService.invalidateQueries(StashService.studioMutationImpactedQueries)
     });
   }
@@ -355,22 +358,22 @@ export class StashService {
   ];
 
   public static useTagCreate(input: GQL.TagCreateInput) {
-    return GQL.useTagCreate({ 
-      variables: input, 
+    return GQL.useTagCreate({
+      variables: input,
       refetchQueries: ["AllTags"],
       update: () => StashService.invalidateQueries(StashService.tagMutationImpactedQueries)
     });
   }
   public static useTagUpdate(input: GQL.TagUpdateInput) {
-    return GQL.useTagUpdate({ 
-      variables: input, 
+    return GQL.useTagUpdate({
+      variables: input,
       refetchQueries: ["AllTags"],
       update: () => StashService.invalidateQueries(StashService.tagMutationImpactedQueries)
     });
   }
   public static useTagDestroy(input: GQL.TagDestroyInput) {
-    return GQL.useTagDestroy({ 
-      variables: input, 
+    return GQL.useTagDestroy({
+      variables: input,
       refetchQueries: ["AllTags"],
       update: () => StashService.invalidateQueries(StashService.tagMutationImpactedQueries)
     });
@@ -506,14 +509,14 @@ export class StashService {
   public static querySceneByPathRegex(filter: GQL.FindFilterType) {
     return StashService.client.query<GQL.FindScenesByPathRegexQuery>({
       query: GQL.FindScenesByPathRegexDocument,
-      variables: {filter: filter},
+      variables: { filter: filter },
     });
   }
 
   public static queryParseSceneFilenames(filter: GQL.FindFilterType, config: GQL.SceneParserInput) {
     return StashService.client.query<GQL.ParseSceneFilenamesQuery>({
       query: GQL.ParseSceneFilenamesDocument,
-      variables: {filter: filter, config: config},
+      variables: { filter: filter, config: config },
       fetchPolicy: "network-only",
     });
   }
@@ -531,5 +534,5 @@ export class StashService {
     return value;
   }
 
-  private constructor() {}
+  private constructor() { }
 }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -261,7 +261,6 @@ export class StashService {
     "allPerformers"
   ];
 
-  }
   
   public static usePerformerCreate() {
     return GQL.usePerformerCreate({ 


### PR DESCRIPTION
Adds initial support for new version checking. Mentioned also in #288 
As it is now it uses the github api to get the shorthash commits from the repo tags.
It matches the current version ( `v0.0.0-alpha` or 'v0.0.0-alpha_dev' ) to the respective repo tags and gets the related commit hash from there.If it's different than the local that means that a new release build is available. 
It first prints a message in the console when the app is started and you can see it also when you open the about tab from the settings.An extra button is also available for manual checking.

for dev testing the build , since version is added through TRAVIS you need to add it to the ldflags in the Makefile
`-X 'github.com/stashapp/stash/pkg/api.version=v0.0.0-alpha_dev' `
or
`-X 'github.com/stashapp/stash/pkg/api.version=v0.0.0-alpha'`


![console](https://user-images.githubusercontent.com/48220860/71551775-b3e4d200-29f7-11ea-9298-b1a2d2ba0e42.png)

![ui](https://user-images.githubusercontent.com/48220860/71551777-c65f0b80-29f7-11ea-9782-6c546a21f984.png)
