### PR TITLE
[WIP/RFC] Add rudimentary "watch count" scene attribute

### DIFF
--- a/graphql/documents/data/scene-slim.graphql
+++ b/graphql/documents/data/scene-slim.graphql
@@ -6,6 +6,7 @@ fragment SlimSceneData on Scene {
   url
   date
   rating
+  watch_count
   path
 
   file {

--- a/graphql/documents/data/scene.graphql
+++ b/graphql/documents/data/scene.graphql
@@ -6,6 +6,7 @@ fragment SceneData on Scene {
   url
   date
   rating
+  watch_count
   path
 
   file {

--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -9,7 +9,8 @@ mutation SceneUpdate(
   $gallery_id: ID,
   $performer_ids: [ID!] = [],
   $tag_ids: [ID!] = [],
-  $cover_image: String) {
+  $cover_image: String,
+  $watch_count: Int) {
 
   sceneUpdate(input: {
                         id: $id,
@@ -22,7 +23,8 @@ mutation SceneUpdate(
                         gallery_id: $gallery_id,
                         performer_ids: $performer_ids,
                         tag_ids: $tag_ids,
-                        cover_image: $cover_image
+                        cover_image: $cover_image,
+                        watch_count: $watch_count
                       }) {
       ...SceneData
   }

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -27,6 +27,7 @@ type Scene {
   date: String
   rating: Int
   path: String!
+  watch_count: Int
 
   file: SceneFileType! # Resolver
   paths: ScenePathsType! # Resolver
@@ -37,6 +38,11 @@ type Scene {
   studio: Studio
   tags: [Tag!]!
   performers: [Performer!]!
+}
+
+input SceneWatchIncrementInput {
+  clientMutationId: String
+  id: ID!
 }
 
 input SceneUpdateInput {
@@ -51,6 +57,7 @@ input SceneUpdateInput {
   gallery_id: ID
   performer_ids: [ID!]
   tag_ids: [ID!]
+  watch_count: Int
   """This should be base64 encoded"""
   cover_image: String
 }

--- a/pkg/api/resolver_model_scene.go
+++ b/pkg/api/resolver_model_scene.go
@@ -46,6 +46,14 @@ func (r *sceneResolver) Rating(ctx context.Context, obj *models.Scene) (*int, er
 	return nil, nil
 }
 
+func (r *sceneResolver) WatchCount(ctx context.Context, obj *models.Scene) (*int, error) {
+	if obj.WatchCount.Valid {
+		watch_count := int(obj.WatchCount.Int64)
+		return &watch_count, nil
+	}
+	return nil, nil
+}
+
 func (r *sceneResolver) File(ctx context.Context, obj *models.Scene) (*models.SceneFileType, error) {
 	width := int(obj.Width.Int64)
 	height := int(obj.Height.Int64)

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -85,6 +85,12 @@ func (r *mutationResolver) sceneUpdate(input models.SceneUpdateInput, tx *sqlx.T
 		updatedScene.Rating = &sql.NullInt64{Valid: false}
 	}
 
+	if input.WatchCount != nil {
+		updatedScene.WatchCount = &sql.NullInt64{Int64: int64(*input.WatchCount), Valid: true}
+	} else {
+		updatedScene.WatchCount = &sql.NullInt64{Valid: false}
+	}
+
 	if input.StudioID != nil {
 		studioID, _ := strconv.ParseInt(*input.StudioID, 10, 64)
 		updatedScene.StudioID = &sql.NullInt64{Int64: studioID, Valid: true}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -17,7 +17,7 @@ import (
 )
 
 var DB *sqlx.DB
-var appSchemaVersion uint = 1
+var appSchemaVersion uint = 2
 
 const sqlite3Driver = "sqlite3_regexp"
 

--- a/pkg/database/migrations/2_watchcount.down.sql
+++ b/pkg/database/migrations/2_watchcount.down.sql
@@ -1,0 +1,46 @@
+--
+
+PRAGMA foreign_keys=OFF;
+
+ALTER TABLE `scenes` RENAME TO `scenes_old`;
+DROP INDEX IF EXISTS `scenes_path_unique`;
+DROP INDEX IF EXISTS `scenes_checksum_unique`;
+DROP INDEX IF EXISTS `index_scenes_on_studio_id`;
+
+CREATE TABLE `scenes` (
+  `id` integer not null primary key autoincrement,
+  `path` varchar(510) not null,
+  `checksum` varchar(255) not null,
+  `title` varchar(255),
+  `details` text,
+  `url` varchar(255),
+  `date` date,
+  `rating` tinyint,
+  `size` varchar(255),
+  `duration` float,
+  `video_codec` varchar(255),
+  `audio_codec` varchar(255),
+  `width` tinyint,
+  `height` tinyint,
+  `framerate` float,
+  `bitrate` integer,
+  `studio_id` integer,
+  `created_at` datetime not null,
+  `updated_at` datetime not null,
+  foreign key(`studio_id`) references `studios`(`id`) on delete CASCADE
+);
+CREATE UNIQUE INDEX `scenes_path_unique` on `scenes` (`path`);
+CREATE UNIQUE INDEX `scenes_checksum_unique` on `scenes` (`checksum`);
+CREATE INDEX `index_scenes_on_studio_id` on `scenes` (`studio_id`);
+
+INSERT INTO `scenes` (id, path, checksum, title, details, url, date,
+rating, size, duration, video_codec, audio_codec, width, height, framerate,
+bitrate, studio_id, created_at, updated_at)
+SELECT id, path, checksum, title, details, url, date,
+rating, size, duration, video_codec, audio_codec, width, height, framerate,
+bitrate, studio_id, created_at, updated_at
+FROM `scenes_old`;
+
+DROP TABLE `scenes_old`;
+
+PRAGMA foreign_keys=ON;

--- a/pkg/database/migrations/2_watchcount.up.sql
+++ b/pkg/database/migrations/2_watchcount.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scenes` ADD COLUMN `watch_count` tinyint;

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -14,6 +14,7 @@ type Scene struct {
 	URL        sql.NullString  `db:"url" json:"url"`
 	Date       SQLiteDate      `db:"date" json:"date"`
 	Rating     sql.NullInt64   `db:"rating" json:"rating"`
+	WatchCount sql.NullInt64   `db:"watch_count" json:"watch_count"`
 	Size       sql.NullString  `db:"size" json:"size"`
 	Duration   sql.NullFloat64 `db:"duration" json:"duration"`
 	VideoCodec sql.NullString  `db:"video_codec" json:"video_codec"`
@@ -36,6 +37,7 @@ type ScenePartial struct {
 	URL        *sql.NullString  `db:"url" json:"url"`
 	Date       *SQLiteDate      `db:"date" json:"date"`
 	Rating     *sql.NullInt64   `db:"rating" json:"rating"`
+	WatchCount *sql.NullInt64   `db:"watch_count" json:"watch_count"`
 	Size       *sql.NullString  `db:"size" json:"size"`
 	Duration   *sql.NullFloat64 `db:"duration" json:"duration"`
 	VideoCodec *sql.NullString  `db:"video_codec" json:"video_codec"`

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -46,6 +46,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
   function maybeRenderSceneSpecsOverlay() {
     return (
       <div className={`scene-specs-overlay`}>
+        {!!props.scene.watch_count ? TextUtils.watchCount(props.scene.watch_count) : undefined}
         {!!props.scene.file.height ? <span className={`overlay-resolution`}> {TextUtils.resolution(props.scene.file.height)}</span> : undefined}
         {props.scene.file.duration !== undefined && props.scene.file.duration >= 1 ? TextUtils.secondsToTimestamp(props.scene.file.duration) : ""}
       </div>

--- a/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneEditPanel.tsx
@@ -25,6 +25,7 @@ import { FilterMultiSelect } from "../../select/FilterMultiSelect";
 import { FilterSelect } from "../../select/FilterSelect";
 import { ValidGalleriesSelect } from "../../select/ValidGalleriesSelect";
 import { ImageUtils } from "../../../utils/image";
+import { watch } from "fs";
 
 interface IProps {
   scene: GQL.SceneDataFragment;
@@ -39,6 +40,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
   const [url, setUrl] = useState<string | undefined>(undefined);
   const [date, setDate] = useState<string | undefined>(undefined);
   const [rating, setRating] = useState<number | undefined>(undefined);
+  const [watch_count, setWatchCount] = useState<number | undefined>(undefined);
   const [galleryId, setGalleryId] = useState<string | undefined>(undefined);
   const [studioId, setStudioId] = useState<string | undefined>(undefined);
   const [performerIds, setPerformerIds] = useState<string[] | undefined>(undefined);
@@ -83,6 +85,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
     setUrl(state.url);
     setDate(state.date);
     setRating(state.rating == null ? NaN : state.rating);
+    setWatchCount(state.watch_count == null ? NaN : state.watch_count);
     setGalleryId(state.gallery ? state.gallery.id : undefined);
     setStudioId(state.studio ? state.studio.id : undefined);
     setPerformerIds(perfIds);
@@ -109,6 +112,7 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
       url,
       date,
       rating,
+      watch_count: watch_count,
       gallery_id: galleryId,
       studio_id: studioId,
       performer_ids: performerIds,
@@ -354,6 +358,13 @@ export const SceneEditPanel: FunctionComponent<IProps> = (props: IProps) => {
           <InputGroup
             onChange={(newValue: any) => setDate(newValue.target.value)}
             value={date}
+          />
+        </FormGroup>
+
+        <FormGroup label="Watch Count">
+          <InputGroup
+            onChange={(newValue: any) => setWatchCount(parseInt(newValue.target.value, 10))}
+            value={watch_count ? watch_count.toString() : "0"}
           />
         </FormGroup>
 

--- a/ui/v2/src/utils/text.ts
+++ b/ui/v2/src/utils/text.ts
@@ -56,6 +56,10 @@ export class TextUtils {
     return `${megabits.toFixed(2)} megabits per second`;
   }
 
+  public static watchCount(watch_count: number) {
+    return `${watch_count} 👁`;
+  }
+
   public static resolution(height: number) {
     if (height >= 240 && height < 480) {
       return "240p";


### PR DESCRIPTION
This is still pretty rudimentary (and mainly intended, at the moment, to spur a bit of discussion as a response to/more functional alternative to #291), but hey, it works. And doesn't seem to trash data on migrations. Success!

Currently it's just an inert number that doesn't auto-increment, or provide a "+1" button (mostly because I can't figure out a good place to put such a thing in the current UI), so don't actually merge this in.