### PR TITLE
Show localhost in console output instead of 0.0.0.0

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -200,6 +200,12 @@ func Start() {
 		}
 	})
 
+	displayHost := config.GetHost()
+	if displayHost == "0.0.0.0" {
+		displayHost = "localhost"
+	}
+	displayAddress := displayHost + ":" + strconv.Itoa(config.GetPort())
+
 	address := config.GetHost() + ":" + strconv.Itoa(config.GetPort())
 	if tlsConfig := makeTLSConfig(); tlsConfig != nil {
 		httpsServer := &http.Server{
@@ -210,7 +216,7 @@ func Start() {
 
 		go func() {
 			printVersion()
-			logger.Infof("stash is running on HTTPS at https://" + address + "/")
+			logger.Infof("stash is running on HTTPS at https://" + displayAddress + "/")
 			logger.Fatal(httpsServer.ListenAndServeTLS("", ""))
 		}()
 	} else {
@@ -221,7 +227,7 @@ func Start() {
 
 		go func() {
 			printVersion()
-			logger.Infof("stash is running on HTTP at http://" + address + "/")
+			logger.Infof("stash is running on HTTP at http://" + displayAddress + "/")
 			logger.Fatal(server.ListenAndServe())
 		}()
 	}


### PR DESCRIPTION
0.0.0.0 is not a valid address, and can be confusing to novice users. In most cases localhost is more correct.