### PR TITLE
Use parameters for regex queries

### DIFF
--- a/pkg/manager/task_autotag_test.go
+++ b/pkg/manager/task_autotag_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-const testName = "Foo Bar"
+const testName = "Foo's Bar"
 const testExtension = ".mp4"
 
 var testSeparators = []string{

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -293,7 +293,9 @@ func getMultiCriterionClause(table string, joinTable string, joinTableField stri
 
 func (qb *SceneQueryBuilder) QueryAllByPathRegex(regex string) ([]*Scene, error) {
 	var args []interface{}
-	body := selectDistinctIDs("scenes") + " WHERE scenes.path regexp '(?i)" + regex + "'"
+	body := selectDistinctIDs("scenes") + " WHERE scenes.path regexp ?"
+
+	args = append(args, "(?i)"+regex)
 
 	idsResult, err := runIdsQuery(body, args)
 
@@ -326,7 +328,8 @@ func (qb *SceneQueryBuilder) QueryByPathRegex(findFilter *FindFilterType) ([]*Sc
 	body := selectDistinctIDs("scenes")
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		whereClauses = append(whereClauses, "scenes.path regexp '(?i)"+*q+"'")
+		whereClauses = append(whereClauses, "scenes.path regexp ?")
+		args = append(args, "(?i)"+*q)
 	}
 
 	sortAndPagination := qb.getSceneSort(findFilter) + getPagination(findFilter)


### PR DESCRIPTION
Fixes #307 

Changes the regex queries to use parameters for the regex queries, instead of embedding it in the sql query string.