### PR TITLE
Change autotag to not overwrite existing studio

### DIFF
--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -95,7 +95,8 @@ func (t *AutoTagStudioTask) autoTagStudio() {
 	tx := database.DB.MustBeginTx(ctx, nil)
 
 	for _, scene := range scenes {
-		if scene.StudioID.Int64 == int64(t.studio.ID) {
+		// #306 - don't overwrite studio if already present
+		if scene.StudioID.Valid {
 			// don't modify
 			continue
 		}


### PR DESCRIPTION
Changes the behaviour of the autotagger so that it no longer overwrites the studio of a scene if it is already set.

Should resolve #306 