### PR TITLE
Add useful links to about page

### DIFF
--- a/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
@@ -87,16 +87,16 @@ export const SettingsAboutPanel: FunctionComponent<IProps> = (props: IProps) => 
       <HTMLTable>
         <tbody>
           <tr>
-            <td>Stash home at <a href="https://github.com/stashapp/stash">Github</a></td>
+            <td>Stash home at <a href="https://github.com/stashapp/stash" target="_blank">Github</a></td>
           </tr>
           <tr>
-            <td>Stash <a href="https://github.com/stashapp/stash/wiki">Wiki</a> page</td>
+            <td>Stash <a href="https://github.com/stashapp/stash/wiki" target="_blank">Wiki</a> page</td>
           </tr>
           <tr>
-            <td>Join our <a href="https://discord.gg/2TsNFKt">Discord</a> channel</td>
+            <td>Join our <a href="https://discord.gg/2TsNFKt" target="_blank">Discord</a> channel</td>
           </tr>
           <tr>
-            <td>Support us through <a href="https://opencollective.com/stashapp">Open Collective</a></td>
+            <td>Support us through <a href="https://opencollective.com/stashapp" target="_blank">Open Collective</a></td>
           </tr>
         </tbody>
       </HTMLTable>

--- a/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsAboutPanel.tsx
@@ -84,12 +84,27 @@ export const SettingsAboutPanel: FunctionComponent<IProps> = (props: IProps) => 
   return (
     <>
       <H4>About</H4>
+      <HTMLTable>
+        <tbody>
+          <tr>
+            <td>Stash home at <a href="https://github.com/stashapp/stash">Github</a></td>
+          </tr>
+          <tr>
+            <td>Stash <a href="https://github.com/stashapp/stash/wiki">Wiki</a> page</td>
+          </tr>
+          <tr>
+            <td>Join our <a href="https://discord.gg/2TsNFKt">Discord</a> channel</td>
+          </tr>
+          <tr>
+            <td>Support us through <a href="https://opencollective.com/stashapp">Open Collective</a></td>
+          </tr>
+        </tbody>
+      </HTMLTable>
       {!data || loading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
       {!!error ? <span>{error.message}</span> : undefined}
       {!!errorLatest ? <span>{errorLatest.message}</span> : undefined}
       {renderVersion()}
       {!dataLatest || loadingLatest || networkStatus === 4 ? <Spinner size={Spinner.SIZE_SMALL} /> : <>{renderLatestVersion()}</>}
-
     </>
   );
 };


### PR DESCRIPTION
add some useful urls like github homepage,wiki,discord and open collective
![about](https://user-images.githubusercontent.com/48220860/72557371-4535be80-38a9-11ea-88a9-a30f75496810.png)

closes #320 
