### PR TITLE
Maintain filter parameters in session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.3.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/h2non/filetype v1.0.8
+	// this is required for generate
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/rs/cors v1.6.0

--- a/ui/v2/src/components/list/Pagination.tsx
+++ b/ui/v2/src/components/list/Pagination.tsx
@@ -78,8 +78,9 @@ export class Pagination extends React.Component<IPaginationProps, IPaginationSta
 
     const pagerState = this.getPagerState(this.props.totalItems, page, this.props.itemsPerPage);
 
-    if (page < 1) { page = 1; }
+    // rearranged this so that the minimum page number is 1, not 0
     if (page > pagerState.totalPages) { page = pagerState.totalPages; }
+    if (page < 1) { page = 1; }
 
     this.setState(pagerState);
     if (propagate) { this.props.onChangePage(page); }

--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -103,7 +103,7 @@ export class ListHook {
     const [totalCount, setTotalCount] = useState<number>(0);
     const [zoomIndex, setZoomIndex] = useState<number>(1);
 
-    const interfaceForage = useInterfaceLocalForage();
+    const [interfaceForage, setInterfaceForage] = useInterfaceLocalForage();
     const forageInitialised = useRef<boolean>(false);
 
     const filterListImpl = getFilterListImpl(options.filterMode);
@@ -181,7 +181,7 @@ export class ListHook {
           location.search = filter.makeQueryParameters();
           options.props.history.replace(location);
 
-          interfaceForage.setData((d) => {
+          setInterfaceForage((d) => {
             const dataClone = _.cloneDeep(d);
             dataClone!.queries[options.filterMode] = {
               filter: location.search,
@@ -192,7 +192,7 @@ export class ListHook {
           });
         }
       }
-    }, [result.data, filter, options.subComponent, options.filterMode, options.props.history, interfaceForage.setData]);
+    }, [result.data, filter, options.subComponent, options.filterMode, options.props.history, setInterfaceForage]);
 
     function onChangePageSize(pageSize: number) {
       const newFilter = _.cloneDeep(filter);

--- a/ui/v2/src/hooks/ListHook.tsx
+++ b/ui/v2/src/hooks/ListHook.tsx
@@ -366,7 +366,7 @@ export class ListHook {
           filter={filter}
         />
         {options.renderSelectedOptions && selectedIds.size > 0 ? options.renderSelectedOptions(result, selectedIds) : undefined}
-        {result.loading || !forageInitialised.current ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
+        {result.loading || (!options.subComponent && !forageInitialised.current) ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
         {result.error ? <h1>{result.error.message}</h1> : undefined}
         {options.renderContent(result, filter, selectedIds, zoomIndex)}
         <Pagination

--- a/ui/v2/src/hooks/LocalForage.ts
+++ b/ui/v2/src/hooks/LocalForage.ts
@@ -18,7 +18,7 @@ interface ILocalForage<T> {
   loading: boolean;
 }
 
-export function useInterfaceLocalForage(): ILocalForage<IInterfaceConfig | undefined> {
+export function useInterfaceLocalForage(): [ILocalForage<IInterfaceConfig | undefined>, React.Dispatch<React.SetStateAction<IInterfaceConfig | undefined>>] {
   const result = useLocalForage("interface");
   // Set defaults
   React.useEffect(() => {
@@ -31,7 +31,7 @@ export function useInterfaceLocalForage(): ILocalForage<IInterfaceConfig | undef
       });
     }
   });
-  return result;
+  return [result, result.setData];
 }
 
 function useLocalForage(item: string): ILocalForage<ValidTypes> {

--- a/ui/v2/src/hooks/LocalForage.ts
+++ b/ui/v2/src/hooks/LocalForage.ts
@@ -6,6 +6,7 @@ interface IInterfaceWallConfig {
 }
 export interface IInterfaceConfig {
   wall: IInterfaceWallConfig;
+  queries: any;
 }
 
 type ValidTypes = IInterfaceConfig | undefined;
@@ -25,6 +26,7 @@ export function useInterfaceLocalForage(): ILocalForage<IInterfaceConfig | undef
         wall: {
           // nothing here currently
         },
+        queries: {}
       });
     }
   });

--- a/ui/v2/src/hooks/LocalForage.ts
+++ b/ui/v2/src/hooks/LocalForage.ts
@@ -22,13 +22,17 @@ export function useInterfaceLocalForage(): [ILocalForage<IInterfaceConfig | unde
   const result = useLocalForage("interface");
   // Set defaults
   React.useEffect(() => {
-    if (result.data === undefined) {
+    if (!result.data) {
       result.setData({
         wall: {
           // nothing here currently
         },
         queries: {}
       });
+    } else if (!result.data.queries) {
+      let newData = Object.assign({}, result.data);
+      newData.queries = {};
+      result.setData(newData);
     }
   });
   return [result, result.setData];

--- a/ui/v2/src/hooks/LocalForage.ts
+++ b/ui/v2/src/hooks/LocalForage.ts
@@ -1,6 +1,6 @@
 import localForage from "localforage";
 import _ from "lodash";
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 
 interface IInterfaceWallConfig {
 }
@@ -15,6 +15,7 @@ interface ILocalForage<T> {
   data: T;
   setData: React.Dispatch<React.SetStateAction<T>>;
   error: Error | null;
+  loading: boolean;
 }
 
 export function useInterfaceLocalForage(): ILocalForage<IInterfaceConfig | undefined> {
@@ -35,6 +36,8 @@ export function useInterfaceLocalForage(): ILocalForage<IInterfaceConfig | undef
 
 function useLocalForage(item: string): ILocalForage<ValidTypes> {
   const [json, setJson] = React.useState<ValidTypes>(undefined);
+  const [err, setErr] = React.useState(null);
+  const [loaded, setLoaded] = React.useState<boolean>(false);
 
   const prevJson = React.useRef<ValidTypes>(undefined);
   React.useEffect(() => {
@@ -47,7 +50,6 @@ function useLocalForage(item: string): ILocalForage<ValidTypes> {
     runAsync();
   });
 
-  const [err, setErr] = React.useState(null);
   React.useEffect(() => {
     async function runAsync() {
       try {
@@ -60,9 +62,10 @@ function useLocalForage(item: string): ILocalForage<ValidTypes> {
       } catch (error) {
         setErr(error);
       }
+      setLoaded(true);
     }
     runAsync();
   });
 
-  return {data: json, setData: setJson, error: err};
+  return {data: json, setData: setJson, error: err, loading: !loaded};
 }

--- a/ui/v2/src/models/list-filter/filter.ts
+++ b/ui/v2/src/models/list-filter/filter.ts
@@ -46,7 +46,6 @@ export class ListFilterModel {
   public displayModeOptions: DisplayMode[] = [];
   public criterionOptions: ICriterionOption[] = [];
   public criteria: Array<Criterion<any, any>> = [];
-  public totalCount: number = 0;
   public randomSeed: number = -1;
 
   private static createCriterionOption(criterion: CriterionType) {

--- a/ui/v2/src/models/list-filter/filter.ts
+++ b/ui/v2/src/models/list-filter/filter.ts
@@ -29,6 +29,7 @@ interface IQueryParameters {
   disp?: string;
   q?: string;
   p?: string;
+  perPage?: string;
   c?: string[];
 }
 
@@ -180,6 +181,9 @@ export class ListFilterModel {
     if (params.p !== undefined) {
       this.currentPage = Number(params.p);
     }
+    if (params.perPage !== undefined) {
+      this.itemsPerPage = Number(params.perPage);
+    }
 
     if (params.c !== undefined) {
       this.criteria = [];
@@ -241,6 +245,7 @@ export class ListFilterModel {
       disp: this.displayMode,
       q: this.searchTerm,
       p: this.currentPage,
+      perPage: this.itemsPerPage,
       c: encodedCriteria,
     };
     return queryString.stringify(result, {encode: false});


### PR DESCRIPTION
Changes so that the last query parameters are stored in local browser storage. This means that if you navigate to another page, then click back onto Scenes, for example, it will show the results of the last query you ran, including the page you were on. This is overridden if you go to a URL with the search parameters included.

For incognito browsers, this will only last as long as the browser instance is running. For non-incognito browsers, this should be persisted between sessions.

This forms a sort-of workaround for #99 