### PR TITLE
Allow path separator in scene filename parser pattern

### DIFF
--- a/pkg/manager/filename_parser.go
+++ b/pkg/manager/filename_parser.go
@@ -335,9 +335,15 @@ func (h *sceneHolder) postParse() {
 }
 
 func (m parseMapper) parse(scene *models.Scene) *sceneHolder {
-	// perform matching on basename
-	// TODO - may want to handle full path at some point
+
+	// #302 - if the pattern includes a path separator, then include the entire
+	// scene path in the match. Otherwise, use the default behaviour of just
+	// the file's basename
+	// must be double \ because of the regex escaping
 	filename := filepath.Base(scene.Path)
+	if strings.Contains(m.regexString, `\\`) || strings.Contains(m.regexString, "/") {
+		filename = scene.Path
+	}
 
 	result := m.regex.FindStringSubmatch(filename)
 

--- a/ui/v2/src/components/scenes/SceneFilenameParser.tsx
+++ b/ui/v2/src/components/scenes/SceneFilenameParser.tsx
@@ -694,7 +694,7 @@ export const SceneFilenameParser: FunctionComponent<IProps> = (props: IProps) =>
           <FormGroup 
             label="Filename pattern:" 
             inline={true}
-            helperText="Use '\\' to escape literal {} characters"
+            helperText="Use '\' to escape literal {} characters"
           >
             <InputGroup
               onChange={(newValue: any) => setPattern(newValue.target.value)}


### PR DESCRIPTION
Intended to address #302 

Currently, the scene filename parser matches the regex against the basename of the scene filename only. This PR changes so that if a path separator is included in the pattern (`/` or `\\` - due to regex escaping), then the pattern is matched against the full path of the scene filename, as stored in the database.

This allows patterns such as `{}/{studio}/{title}.{ext}`, for example, but also allows the scope of the search to be applied to specific folders: `{}/specific_folder/{title}.{ext}`