### PR TITLE
Use --frozen-lockfile in travis calls to yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GO111MODULE=on
 before_install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
-- travis_retry yarn --cwd ui/v2 install
+- travis_retry yarn --cwd ui/v2 install --frozen-lockfile
 - make generate
 - CI=false yarn --cwd ui/v2 build # TODO: Fix warnings
 #- go get -v github.com/mgechev/revive

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow [this README.md in the docker directory.](docker/production/README.md)
 
 Stash supports macOS, Windows, and Linux.  Download the [latest release here](https://github.com/stashapp/stash/releases).
 
-Run the executable (double click the exe on windows or run `./stash-osx` / `./stash-linux` from the terminal on macOS / Linux) and navigate to either https://localhost:9999 or http://localhost:9998 to get started.
+Run the executable (double click the exe on windows or run `./stash-osx` / `./stash-linux` from the terminal on macOS / Linux) and navigate to either https://localhost:9999 or http://localhost:9999 to get started.
 
 *Note for Windows users:* Running the app might present a security prompt since the binary isn't signed yet.  Just click more info and then the "run anyway" button.
 
@@ -69,7 +69,7 @@ Join the [Discord server](https://discord.gg/2TsNFKt).
     * Go Install: `go get github.com/gobuffalo/packr/v2/packr2@v2.0.2`
     * [Binary Download](https://github.com/gobuffalo/packr/releases)
 * [Yarn](https://yarnpkg.com/en/docs/install) - Yarn package manager
-    * Run `yarn install` in the `stash/ui/v2` folder (before running make generate for first time).
+    * Run `yarn install --frozen-lockfile` in the `stash/ui/v2` folder (before running make generate for first time).
 
 NOTE: You may need to run the `go get` commands outside the project directory to avoid modifying the projects module file.
 


### PR DESCRIPTION
Updates the travis configuration to use `--frozen-lockfile` in the `yarn install` call, to ensure that node dependencies are deterministic across builds. I've also updated the README file to include the option in the `yarn install` instructions, and to update the http port to the correct one.