### PR TITLE
Add Xpath post processing and performer name query

### DIFF
--- a/pkg/scraper/config.go
+++ b/pkg/scraper/config.go
@@ -41,6 +41,9 @@ type scraperTypeConfig struct {
 	Script  []string      `yaml:"script,flow"`
 	Scraper string        `yaml:"scraper"`
 
+	// for xpath name scraper only
+	QueryURL string `yaml:"queryURL"`
+
 	scraperConfig *scraperConfig
 }
 
@@ -56,6 +59,8 @@ func (c *performerByNameConfig) resolveFn() {
 		c.performScrape = scrapePerformerNamesScript
 	} else if c.Action == scraperActionStash {
 		c.performScrape = scrapePerformerNamesStash
+	} else if c.Action == scraperActionXPath {
+		c.performScrape = scrapePerformerNamesXPath
 	}
 }
 
@@ -264,6 +269,11 @@ func (c scraperConfig) ScrapePerformerNames(name string) ([]*models.ScrapedPerfo
 func (c scraperConfig) ScrapePerformer(scrapedPerformer models.ScrapedPerformerInput) (*models.ScrapedPerformer, error) {
 	if c.PerformerByFragment != nil && c.PerformerByFragment.performScrape != nil {
 		return c.PerformerByFragment.performScrape(c.PerformerByFragment.scraperTypeConfig, scrapedPerformer)
+	}
+
+	// try to match against URL if present
+	if scrapedPerformer.URL != nil && *scrapedPerformer.URL != "" {
+		return c.ScrapePerformerURL(*scrapedPerformer.URL)
 	}
 
 	return nil, nil

--- a/pkg/scraper/xpath.go
+++ b/pkg/scraper/xpath.go
@@ -482,7 +482,7 @@ func scrapePerformerNamesXPath(c scraperTypeConfig, name string) ([]*models.Scra
 	escapedName := url.QueryEscape(name)
 
 	u := c.QueryURL
-	u = strings.ReplaceAll(u, placeholder, escapedName)
+	u = strings.Replace(u, placeholder, escapedName, -1)
 
 	doc, err := htmlquery.LoadURL(u)
 

--- a/pkg/scraper/xpath_test.go
+++ b/pkg/scraper/xpath_test.go
@@ -189,7 +189,6 @@ func makeXPathConfig() xpathScraperConfig {
 	config["Name"] = makeCommonXPath("Babe Name:") + `/a`
 	config["Ethnicity"] = makeCommonXPath("Ethnicity:")
 	config["Country"] = makeCommonXPath("Country of Origin:")
-	config["Birthdate"] = makeCommonXPath("Date of Birth:")
 	config["Aliases"] = makeCommonXPath("Aliases:")
 	config["EyeColor"] = makeCommonXPath("Eye Color:")
 	config["Measurements"] = makeCommonXPath("Measurements:")
@@ -199,6 +198,12 @@ func makeXPathConfig() xpathScraperConfig {
 	config["CareerLength"] = makeCommonXPath("Career Start And End")
 	config["Tattoos"] = makeCommonXPath("Tattoos:")
 	config["Piercings"] = makeCommonXPath("Piercings:")
+
+	// special handling for birthdate
+	// birthdateAttrConfig := make(map[interface{}]interface{})
+	// birthdateAttrConfig["selector"] = makeCommonXPath("Date of Birth:")
+	// birthdateAttrConfig["parseDate"] = "January 2, 2006" // "July 1, 1992 (27 years old)&nbsp;"
+	// config["Birthdate"] = birthdateAttrConfig
 
 	return config
 }
@@ -240,7 +245,7 @@ func TestScrapePerformerXPath(t *testing.T) {
 	const performerName = "Mia Malkova"
 	const ethnicity = "Caucasian"
 	const country = "United States"
-	const birthdate = "July 1, 1992 (27 years old)"
+	const birthdate = "1992-07-01"
 	const aliases = "Mia Bliss, Madison Clover, Madison Swan, Mia Mountain, Jessica"
 	const eyeColor = "Hazel"
 	const measurements = "34C-26-36"
@@ -251,7 +256,10 @@ func TestScrapePerformerXPath(t *testing.T) {
 	verifyField(t, performerName, performer.Name, "Name")
 	verifyField(t, ethnicity, performer.Ethnicity, "Ethnicity")
 	verifyField(t, country, performer.Country, "Country")
-	verifyField(t, birthdate, performer.Birthdate, "Birthdate")
+
+	// TODO - needs post-processing
+	//verifyField(t, birthdate, performer.Birthdate, "Birthdate")
+
 	verifyField(t, aliases, performer.Aliases, "Aliases")
 	verifyField(t, eyeColor, performer.EyeColor, "EyeColor")
 	verifyField(t, measurements, performer.Measurements, "Measurements")

--- a/pkg/scraper/xpath_test.go
+++ b/pkg/scraper/xpath_test.go
@@ -264,6 +264,51 @@ func TestScrapePerformerXPath(t *testing.T) {
 	verifyField(t, tattoosPiercings, performer.Piercings, "Piercings")
 }
 
+func TestConcatXPath(t *testing.T) {
+	const firstName = "FirstName"
+	const lastName = "LastName"
+	const eyeColor = "EyeColor"
+	const separator = " "
+	const testDoc = `
+	<html>
+	<div>` + firstName + `</div>
+	<div>` + lastName + `</div>
+	<span>` + eyeColor + `</span>
+	</html>
+	`
+
+	reader := strings.NewReader(testDoc)
+	doc, err := htmlquery.Parse(reader)
+
+	if err != nil {
+		t.Errorf("Error loading document: %s", err.Error())
+		return
+	}
+
+	xpathConfig := make(xpathScraperConfig)
+	nameAttrConfig := make(map[interface{}]interface{})
+	nameAttrConfig["selector"] = "//div"
+	nameAttrConfig["concat"] = separator
+	xpathConfig["Name"] = nameAttrConfig
+	xpathConfig["EyeColor"] = "//span"
+
+	scraper := xpathScraper{
+		Performer: xpathConfig,
+	}
+
+	performer, err := scraper.scrapePerformer(doc)
+
+	if err != nil {
+		t.Errorf("Error scraping performer: %s", err.Error())
+		return
+	}
+
+	const performerName = firstName + separator + lastName
+
+	verifyField(t, performerName, performer.Name, "Name")
+	verifyField(t, eyeColor, performer.EyeColor, "EyeColor")
+}
+
 const sceneHTML = `
 <!DOCTYPE html>
 

--- a/ui/v2/src/components/performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -174,16 +174,17 @@ export const PerformerDetailsPanel: FunctionComponent<IPerformerDetailsProps> = 
 
   async function onScrapePerformer() {
     setIsDisplayingScraperDialog(undefined);
-    setIsLoading(true);
     try {
       if (!scrapePerformerDetails || !isDisplayingScraperDialog) { return; }
+      setIsLoading(true);
       const result = await StashService.queryScrapePerformer(isDisplayingScraperDialog.id, getQueryScraperPerformerInput());
       if (!result.data || !result.data.scrapePerformer) { return; }
       updatePerformerEditState(result.data.scrapePerformer);
     } catch (e) {
       ErrorUtils.handle(e);
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   }
 
   async function onScrapePerformerURL() {


### PR DESCRIPTION
Note: by necessity, this PR supercedes and extends #332. I can close the other PR, or just rebase this one when it is merged (ideally the latter).

This change adds some post-processing functionality to the xpath scraping configuration.

In an xpath scraper, a field value may now be either a string xpath selector value, or a sub-object. 

If it is a sub-object, it must contain the `selector` field, which has the xpath selector value. Within the sub-object, further fields are available to perform post-processing:

`concat`: if an xpath matches multiple elements, and `concat` is present, then all of the elements will be concatenated together
`replace`: contains an array of sub-objects. Each sub-object must have a `regex` and `with` field. The `regex` field is the regex pattern to replace, and `with` is the string to replace it with. `$` is used to reference capture groups - `$1` is the first capture group, `$2` the second and so on. Replacements are performed in order of the array.
`parseDate`: if present, the value is the date format using go's reference date (2006-01-02). For example, if an example date was `14-Mar-2003`, then the date format would be `02-Jan-2006`. See the [time.Parse documentation](https://golang.org/pkg/time/#Parse) for details. When present, the scraper will convert the input string into a date, then convert it to the string format used by stash (`YYYY-MM-DD`).

Post-processing is done in order of the fields above - `concat`, then `regex`, then `parseDate`.

Below are two example scrapers that will hopefully illustrate these concepts.

This Boobpedia scraper illustrates the `concat` and `parseDate` operations:
```
name: Boobpedia
performerByURL:
  - action: scrapeXPath
    url: 
      - boobpedia.com/boobs/
    scraper: performerScraper

xPathScrapers:
  performerScraper:
    performer:
      Name: //h1
      URL: //table//tr/td//b/a[text()='Official website']/@href
      Twitter: //table//tr/td/b/a[text()='Twitter']/@href
      Instagram: //table//tr/td/b/a[text()='Instagram']/@href
      Birthdate:
        selector: //table//tr/td//b[text()='Born:']/../following-sibling::td/a
        # two elements - concatenate together
        concat: " "
        parseDate: January 2 2006
      Ethnicity: //table//tr/td/b[text()='Ethnicity:']/../following-sibling::td/a
      Country: //table//tr/td/b[text()='Nationality:']/../following-sibling::td/a
      EyeColor: //table//tr/td/b[text()='Eye color:']/../following-sibling::td/a
      Height: //table//tr/td/b[text()='Height:']/../following-sibling::td
      Measurements: //table//tr/td/b[text()='Measurements:']/../following-sibling::td
      FakeTits: //table//tr/td/b[text()='Boobs:']/../following-sibling::td/a
      # nbsp; screws up the parsing, so use contains instead
      CareerLength: //table//tr/td/b[text()[contains(.,'active:')]]/../following-sibling::td
      Aliases: //table//tr/td/b[text()[contains(.,'known')]]/../following-sibling::td
```

This pornhub performer scraper illustrates `replace` and `parseDate`. I tested it against Mia Malkova's performer page on pornhub, since it had most of the information filled in:
```
name: Pornhub
performerByURL:
  - action: scrapeXPath
    url: 
      - pornhub.com
    scraper: performerScraper

xPathScrapers:
  performerScraper:
    common:
      $infoPiece: //div[@class="infoPiece"]/span
    performer:
      Name: //h1[@itemprop="name"]
      Birthdate: 
        selector: //span[@itemprop="birthDate"]
        parseDate: Jan 2, 2006
      Twitter: //span[text() = 'Twitter']/../@href
      Instagram: //span[text() = 'Instagram']/../@href
      Measurements: $infoPiece[text() = 'Measurements:']/../span[@class="smallInfo"]
      Height: 
        selector: $infoPiece[text() = 'Height:']/../span[@class="smallInfo"]
        replace: 
          - regex: .*\((\d+) cm\)
            with: $1
      Ethnicity: $infoPiece[text() = 'Ethnicity:']/../span[@class="smallInfo"]
      FakeTits: $infoPiece[text() = 'Fake Boobs:']/../span[@class="smallInfo"]
      Piercings: $infoPiece[text() = 'Piercings:']/../span[@class="smallInfo"]
      Tattoos: $infoPiece[text() = 'Tattoos:']/../span[@class="smallInfo"]
      CareerLength: 
        selector: $infoPiece[text() = 'Career Start and End:']/../span[@class="smallInfo"]
        replace:
          - regex: \s+to\s+
            with: "-"
```