### PR TITLE
Add O-counter

### DIFF
--- a/graphql/documents/data/scene-slim.graphql
+++ b/graphql/documents/data/scene-slim.graphql
@@ -6,6 +6,7 @@ fragment SlimSceneData on Scene {
   url
   date
   rating
+  o_counter
   path
 
   file {

--- a/graphql/documents/data/scene.graphql
+++ b/graphql/documents/data/scene.graphql
@@ -6,6 +6,7 @@ fragment SceneData on Scene {
   url
   date
   rating
+  o_counter
   path
 
   file {

--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -62,6 +62,18 @@ mutation ScenesUpdate($input : [SceneUpdateInput!]!) {
   }
 }
 
+mutation SceneIncrementO($id: ID!) {
+  sceneIncrementO(id: $id) 
+}
+
+mutation SceneDecrementO($id: ID!) {
+  sceneDecrementO(id: $id)
+}
+
+mutation SceneResetO($id: ID!) {
+  sceneResetO(id: $id)
+}
+
 mutation SceneDestroy($id: ID!, $delete_file: Boolean, $delete_generated : Boolean) {
   sceneDestroy(input: {id: $id, delete_file: $delete_file, delete_generated: $delete_generated})
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -107,6 +107,13 @@ type Mutation {
   sceneDestroy(input: SceneDestroyInput!): Boolean!
   scenesUpdate(input: [SceneUpdateInput!]!): [Scene]
 
+  """Increments the o-counter for a scene. Returns the new value"""
+  sceneIncrementO(id: ID!): Int!
+  """Decrements the o-counter for a scene. Returns the new value"""
+  sceneDecrementO(id: ID!): Int!
+  """Resets the o-counter for a scene to 0. Returns the new value"""
+  sceneResetO(id: ID!): Int!
+
   sceneMarkerCreate(input: SceneMarkerCreateInput!): SceneMarker
   sceneMarkerUpdate(input: SceneMarkerUpdateInput!): SceneMarker
   sceneMarkerDestroy(id: ID!): Boolean!

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -62,6 +62,8 @@ input SceneMarkerFilterType {
 input SceneFilterType {
   """Filter by rating"""
   rating: IntCriterionInput
+  """Filter by o-counter"""
+  o_counter: IntCriterionInput
   """Filter by resolution"""
   resolution: ResolutionEnum
   """Filter by duration (in seconds)"""

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -26,6 +26,7 @@ type Scene {
   url: String
   date: String
   rating: Int
+  o_counter: Int
   path: String!
 
   file: SceneFileType! # Resolver

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -422,3 +422,63 @@ func changeMarker(ctx context.Context, changeType int, changedMarker models.Scen
 
 	return sceneMarker, nil
 }
+
+func (r *mutationResolver) SceneIncrementO(ctx context.Context, id string) (int, error) {
+	sceneID, _ := strconv.Atoi(id)
+
+	tx := database.DB.MustBeginTx(ctx, nil)
+	qb := models.NewSceneQueryBuilder()
+
+	newVal, err := qb.IncrementOCounter(sceneID, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+
+	// Commit
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	return newVal, nil
+}
+
+func (r *mutationResolver) SceneDecrementO(ctx context.Context, id string) (int, error) {
+	sceneID, _ := strconv.Atoi(id)
+
+	tx := database.DB.MustBeginTx(ctx, nil)
+	qb := models.NewSceneQueryBuilder()
+
+	newVal, err := qb.DecrementOCounter(sceneID, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+
+	// Commit
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	return newVal, nil
+}
+
+func (r *mutationResolver) SceneResetO(ctx context.Context, id string) (int, error) {
+	sceneID, _ := strconv.Atoi(id)
+
+	tx := database.DB.MustBeginTx(ctx, nil)
+	qb := models.NewSceneQueryBuilder()
+
+	newVal, err := qb.ResetOCounter(sceneID, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+
+	// Commit
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	return newVal, nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -17,7 +17,7 @@ import (
 )
 
 var DB *sqlx.DB
-var appSchemaVersion uint = 2
+var appSchemaVersion uint = 3
 
 const sqlite3Driver = "sqlite3_regexp"
 

--- a/pkg/database/migrations/3_o_counter.up.sql
+++ b/pkg/database/migrations/3_o_counter.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scenes` ADD COLUMN `o_counter` tinyint not null default 0;

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -15,6 +15,7 @@ type Scene struct {
 	URL        sql.NullString  `db:"url" json:"url"`
 	Date       SQLiteDate      `db:"date" json:"date"`
 	Rating     sql.NullInt64   `db:"rating" json:"rating"`
+	OCounter   int             `db:"o_counter" json:"o_counter"`
 	Size       sql.NullString  `db:"size" json:"size"`
 	Duration   sql.NullFloat64 `db:"duration" json:"duration"`
 	VideoCodec sql.NullString  `db:"video_codec" json:"video_codec"`

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -232,6 +232,14 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		}
 	}
 
+	if oCounter := sceneFilter.OCounter; oCounter != nil {
+		clause, count := getIntCriterionWhereClause("scenes.o_counter", *sceneFilter.OCounter)
+		whereClauses = append(whereClauses, clause)
+		if count == 1 {
+			args = append(args, sceneFilter.OCounter.Value)
+		}
+	}
+
 	if durationFilter := sceneFilter.Duration; durationFilter != nil {
 		clause, thisArgs := getDurationWhereClause(*durationFilter)
 		whereClauses = append(whereClauses, clause)

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -76,6 +76,60 @@ func (qb *SceneQueryBuilder) Update(updatedScene ScenePartial, tx *sqlx.Tx) (*Sc
 	return qb.find(updatedScene.ID, tx)
 }
 
+func (qb *SceneQueryBuilder) IncrementOCounter(id int, tx *sqlx.Tx) (int, error) {
+	ensureTx(tx)
+	_, err := tx.Exec(
+		`UPDATE scenes SET o_counter = o_counter + 1 WHERE scenes.id = ?`,
+		id,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	scene, err := qb.find(id, tx)
+	if err != nil {
+		return 0, err
+	}
+
+	return scene.OCounter, nil
+}
+
+func (qb *SceneQueryBuilder) DecrementOCounter(id int, tx *sqlx.Tx) (int, error) {
+	ensureTx(tx)
+	_, err := tx.Exec(
+		`UPDATE scenes SET o_counter = o_counter - 1 WHERE scenes.id = ? and scenes.o_counter > 0`,
+		id,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	scene, err := qb.find(id, tx)
+	if err != nil {
+		return 0, err
+	}
+
+	return scene.OCounter, nil
+}
+
+func (qb *SceneQueryBuilder) ResetOCounter(id int, tx *sqlx.Tx) (int, error) {
+	ensureTx(tx)
+	_, err := tx.Exec(
+		`UPDATE scenes SET o_counter = 0 WHERE scenes.id = ?`,
+		id,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	scene, err := qb.find(id, tx)
+	if err != nil {
+		return 0, err
+	}
+
+	return scene.OCounter, nil
+}
+
 func (qb *SceneQueryBuilder) Destroy(id string, tx *sqlx.Tx) error {
 	return executeDeleteQuery("scenes", id, tx)
 }

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -95,7 +95,7 @@ func getSort(sort string, direction string, tableName string) string {
 
 	const randomSeedPrefix = "random_"
 
-	if strings.Contains(sort, "_count") {
+	if strings.HasSuffix(sort, "_count") {
 		var relationTableName = strings.Split(sort, "_")[0] // TODO: pluralize?
 		colName := getColumn(relationTableName, "id")
 		return " ORDER BY COUNT(distinct " + colName + ") " + direction

--- a/ui/v2/src/components/scenes/OCounterButton.tsx
+++ b/ui/v2/src/components/scenes/OCounterButton.tsx
@@ -32,7 +32,7 @@ export const OCounterButton: FunctionComponent<IOCounterButtonProps> = (props: I
       <Popover 
         interactionKind={"hover"} 
         hoverOpenDelay={1000} 
-        position="top" 
+        position="bottom" 
         disabled={props.loading} 
         onOpening={props.onMenuOpened}
         onClosing={props.onMenuClosed}

--- a/ui/v2/src/components/scenes/OCounterButton.tsx
+++ b/ui/v2/src/components/scenes/OCounterButton.tsx
@@ -1,0 +1,50 @@
+import React, { FunctionComponent } from "react";
+import { Button, Popover, Menu, MenuItem } from "@blueprintjs/core";
+import { Icons } from "../../utils/icons";
+
+export interface IOCounterButtonProps {
+  loading: boolean
+  value: number
+  onIncrement: () => void
+  onDecrement: () => void
+  onReset: () => void
+  onMenuOpened?: () => void
+  onMenuClosed?: () => void
+}
+
+export const OCounterButton: FunctionComponent<IOCounterButtonProps> = (props: IOCounterButtonProps) => {
+  function renderButton() {
+    return (
+      <Button
+        loading={props.loading}
+        icon={Icons.sweatDrops()}
+        text={props.value}
+        minimal={true}
+        onClick={props.onIncrement}
+        disabled={props.loading}
+      />
+    );
+  }
+
+  if (props.value) {
+    // just render the button by itself
+    return (
+      <Popover 
+        interactionKind={"hover"} 
+        hoverOpenDelay={1000} 
+        position="top" 
+        disabled={props.loading} 
+        onOpening={props.onMenuOpened}
+        onClosing={props.onMenuClosed}
+      >
+        {renderButton()}
+        <Menu>
+          <MenuItem text="Decrement" icon="minus" onClick={props.onDecrement}/>
+          <MenuItem text="Reset" icon="disable" onClick={props.onReset}/>
+        </Menu>
+      </Popover>
+    );
+  } else {
+    return renderButton();
+  }
+}

--- a/ui/v2/src/components/scenes/SceneCard.tsx
+++ b/ui/v2/src/components/scenes/SceneCard.tsx
@@ -17,6 +17,7 @@ import { TextUtils } from "../../utils/text";
 import { TagLink } from "../Shared/TagLink";
 import { ZoomUtils } from "../../utils/zoom";
 import { StashService } from "../../core/StashService";
+import { Icons } from "../../utils/icons";
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
@@ -142,10 +143,22 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
     );
   }
 
+  function maybeRenderOCounter() {
+    if (props.scene.o_counter) {
+      return (
+        <Button
+          icon={Icons.sweatDrops()}
+          text={props.scene.o_counter}
+        />
+      )
+    }
+  }
+
   function maybeRenderPopoverButtonGroup() {
     if (props.scene.tags.length > 0 ||
         props.scene.performers.length > 0 ||
-        props.scene.scene_markers.length > 0) {
+        props.scene.scene_markers.length > 0 ||
+        props.scene.o_counter) {
       return (
         <>
           <Divider />
@@ -153,6 +166,7 @@ export const SceneCard: FunctionComponent<ISceneCardProps> = (props: ISceneCardP
             {maybeRenderTagPopoverButton()}
             {maybeRenderPerformerPopoverButton()}
             {maybeRenderSceneMarkerPopoverButton()}
+            {maybeRenderOCounter()}
           </ButtonGroup>
         </>
       );

--- a/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
@@ -17,7 +17,7 @@ import { SceneFileInfoPanel } from "./SceneFileInfoPanel";
 import { SceneMarkersPanel } from "./SceneMarkersPanel";
 import { ScenePerformerPanel } from "./ScenePerformerPanel";
 import { ErrorUtils } from "../../../utils/errors";
-import { IOCounterButtonProps } from "../OCounterButton";
+import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
 
 interface ISceneProps extends IBaseProps {}
 
@@ -114,13 +114,13 @@ export const Scene: FunctionComponent<ISceneProps> = (props: ISceneProps) => {
 
   return (
     <>
-      <ScenePlayer scene={modifiedScene} timestamp={timestamp} autoplay={autoplay} oCounter={oCounterProps}/>
+      <ScenePlayer scene={modifiedScene} timestamp={timestamp} autoplay={autoplay}/>
       <Card id="details-container">
         <Tabs
           renderActiveTabPanelOnly={true}
           large={true}
         >
-            <Tab id="scene-details-panel" title="Details" panel={<SceneDetailPanel scene={modifiedScene} oCounter={oCounterProps} />} />
+            <Tab id="scene-details-panel" title="Details" panel={<SceneDetailPanel scene={modifiedScene} />} />
             <Tab
               id="scene-markers-panel"
               title="Markers"
@@ -150,6 +150,11 @@ export const Scene: FunctionComponent<ISceneProps> = (props: ISceneProps) => {
                   onUpdate={(newScene) => setScene(newScene)} 
                   onDelete={() => props.history.push("/scenes")}
                 />}
+            />
+
+            <Tabs.Expander />
+            <OCounterButton
+              {...oCounterProps}
             />
         </Tabs>
       </Card>

--- a/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
@@ -16,6 +16,8 @@ import { SceneEditPanel } from "./SceneEditPanel";
 import { SceneFileInfoPanel } from "./SceneFileInfoPanel";
 import { SceneMarkersPanel } from "./SceneMarkersPanel";
 import { ScenePerformerPanel } from "./ScenePerformerPanel";
+import { ErrorUtils } from "../../../utils/errors";
+import { IOCounterButtonProps } from "../OCounterButton";
 
 interface ISceneProps extends IBaseProps {}
 
@@ -24,7 +26,13 @@ export const Scene: FunctionComponent<ISceneProps> = (props: ISceneProps) => {
   const [autoplay, setAutoplay] = useState<boolean>(false);
   const [scene, setScene] = useState<Partial<GQL.SceneDataFragment>>({});
   const [isLoading, setIsLoading] = useState(false);
-  const { data, error, loading } = StashService.useFindScene(props.match.params.id);
+  const { data, error, loading, refetch } = StashService.useFindScene(props.match.params.id);
+
+  const [oLoading, setOLoading] = useState(false);
+
+  const incrementO = StashService.useSceneIncrementO(scene.id || "0");
+  const decrementO = StashService.useSceneDecrementO(scene.id || "0");
+  const resetO = StashService.useSceneResetO(scene.id || "0");
 
   useEffect(() => {
     setIsLoading(loading);
@@ -54,15 +62,65 @@ export const Scene: FunctionComponent<ISceneProps> = (props: ISceneProps) => {
     Object.assign({scene_marker_tags: data.sceneMarkerTags}, scene) as GQL.SceneDataFragment; // TODO Hack from angular
   if (!!error) { return <>error...</>; }
 
+  function updateOCounter(newValue: number) {
+    const modifiedScene = Object.assign({}, scene);
+    modifiedScene.o_counter = newValue;
+    setScene(modifiedScene);
+  }
+
+  async function onIncrementClick() {
+    try {
+      setOLoading(true);
+      const result = await incrementO();
+      updateOCounter(result.data.sceneIncrementO);
+    } catch (e) {
+      ErrorUtils.handle(e);
+    } finally {
+      setOLoading(false);
+    }
+  }
+
+  async function onDecrementClick() {
+    try {
+      setOLoading(true);
+      const result = await decrementO();
+      updateOCounter(result.data.sceneDecrementO);
+    } catch (e) {
+      ErrorUtils.handle(e);
+    } finally {
+      setOLoading(false);
+    }
+  }
+
+  async function onResetClick() {
+    try {
+      setOLoading(true);
+      const result = await resetO();
+      updateOCounter(result.data.sceneResetO);
+    } catch (e) {
+      ErrorUtils.handle(e);
+    } finally {
+      setOLoading(false);
+    }
+  }
+
+  const oCounterProps : IOCounterButtonProps = {
+    loading: oLoading,
+    value: scene.o_counter || 0,
+    onIncrement: onIncrementClick,
+    onDecrement: onDecrementClick,
+    onReset: onResetClick
+  }
+
   return (
     <>
-      <ScenePlayer scene={modifiedScene} timestamp={timestamp} autoplay={autoplay}/>
+      <ScenePlayer scene={modifiedScene} timestamp={timestamp} autoplay={autoplay} oCounter={oCounterProps}/>
       <Card id="details-container">
         <Tabs
           renderActiveTabPanelOnly={true}
           large={true}
         >
-            <Tab id="scene-details-panel" title="Details" panel={<SceneDetailPanel scene={modifiedScene} />} />
+            <Tab id="scene-details-panel" title="Details" panel={<SceneDetailPanel scene={modifiedScene} oCounter={oCounterProps} />} />
             <Tab
               id="scene-markers-panel"
               title="Markers"

--- a/ui/v2/src/components/scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneDetailPanel.tsx
@@ -8,9 +8,11 @@ import * as GQL from "../../../core/generated-graphql";
 import { TextUtils } from "../../../utils/text";
 import { TagLink } from "../../Shared/TagLink";
 import { SceneHelpers } from "../helpers";
+import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;
+  oCounter: IOCounterButtonProps;
 }
 
 export const SceneDetailPanel: FunctionComponent<ISceneDetailProps> = (props: ISceneDetailProps) => {
@@ -37,17 +39,34 @@ export const SceneDetailPanel: FunctionComponent<ISceneDetailProps> = (props: IS
     );
   }
 
+  function renderOCounter() {
+    return (
+      <OCounterButton 
+        {...props.oCounter}
+      />
+    )
+  }
+
   return (
     <>
+    {renderOCounter()}
     {SceneHelpers.maybeRenderStudio(props.scene, 70, false)}
       <H1 className="bp3-heading">
         {!!props.scene.title ? props.scene.title : TextUtils.fileNameFromPath(props.scene.path)}
+        <span className="name-icons">
+          {renderOCounter()}
+        </span>
       </H1>
+      
+      {renderOCounter()}
       {!!props.scene.date ? <H4>{props.scene.date}</H4> : undefined}
       {!!props.scene.rating ? <H6>Rating: {props.scene.rating}</H6> : undefined}
       {!!props.scene.file.height ? <H6>Resolution: {TextUtils.resolution(props.scene.file.height)}</H6> : undefined}
       {renderDetails()}
       {renderTags()}
+      <div>
+        {renderOCounter()}
+      </div>
     </>
   );
 };

--- a/ui/v2/src/components/scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneDetailPanel.tsx
@@ -8,11 +8,9 @@ import * as GQL from "../../../core/generated-graphql";
 import { TextUtils } from "../../../utils/text";
 import { TagLink } from "../../Shared/TagLink";
 import { SceneHelpers } from "../helpers";
-import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;
-  oCounter: IOCounterButtonProps;
 }
 
 export const SceneDetailPanel: FunctionComponent<ISceneDetailProps> = (props: ISceneDetailProps) => {
@@ -39,34 +37,18 @@ export const SceneDetailPanel: FunctionComponent<ISceneDetailProps> = (props: IS
     );
   }
 
-  function renderOCounter() {
-    return (
-      <OCounterButton 
-        {...props.oCounter}
-      />
-    )
-  }
-
   return (
     <>
-    {renderOCounter()}
     {SceneHelpers.maybeRenderStudio(props.scene, 70, false)}
       <H1 className="bp3-heading">
         {!!props.scene.title ? props.scene.title : TextUtils.fileNameFromPath(props.scene.path)}
-        <span className="name-icons">
-          {renderOCounter()}
-        </span>
       </H1>
       
-      {renderOCounter()}
       {!!props.scene.date ? <H4>{props.scene.date}</H4> : undefined}
       {!!props.scene.rating ? <H6>Rating: {props.scene.rating}</H6> : undefined}
       {!!props.scene.file.height ? <H6>Resolution: {TextUtils.resolution(props.scene.file.height)}</H6> : undefined}
       {renderDetails()}
       {renderTags()}
-      <div>
-        {renderOCounter()}
-      </div>
     </>
   );
 };

--- a/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
@@ -5,7 +5,6 @@ import * as GQL from "../../../core/generated-graphql";
 import { SceneHelpers } from "../helpers";
 import { ScenePlayerScrubber } from "./ScenePlayerScrubber";
 import { StashService } from "../../../core/StashService";
-import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
 
 interface IScenePlayerProps {
   scene: GQL.SceneDataFragment;
@@ -15,11 +14,9 @@ interface IScenePlayerProps {
   onSeeked?: any;
   onTime?: any;
   config?: GQL.ConfigInterfaceDataFragment;
-  oCounter: IOCounterButtonProps;
 }
 interface IScenePlayerState {
   scrubberPosition: number;
-  oCounterMenuOpen: boolean;
 }
 
 @HotkeysTarget
@@ -36,10 +33,7 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     this.onScrubberSeek = this.onScrubberSeek.bind(this);
     this.onScrubberScrolled = this.onScrubberScrolled.bind(this);
 
-    this.state = {
-      scrubberPosition: 0,
-      oCounterMenuOpen: false
-    };
+    this.state = {scrubberPosition: 0};
   }
 
   public componentDidUpdate(prevProps: IScenePlayerProps) {
@@ -73,13 +67,6 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
             onSeek={this.onScrubberSeek}
             onScrolled={this.onScrubberScrolled}
           />
-          <div id="o-counter-container" className={this.state.oCounterMenuOpen ? "menu-open" : undefined}>
-            <OCounterButton 
-              {...this.props.oCounter} 
-              onMenuOpened={() => this.setOCounterMenuOpen(true)}
-              onMenuClosed={() => this.setOCounterMenuOpen(false)}
-            />
-          </div>
         </div>
       </>
     );
@@ -192,18 +179,9 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     }
   }
 
-  private setScrubberPosition(position: any) {
-    this.setState({scrubberPosition: position, oCounterMenuOpen: this.state.oCounterMenuOpen});
-  }
-
-  private setOCounterMenuOpen(value : boolean) {
-    console.log("Setting menu open to : " + value);
-    this.setState({scrubberPosition: this.state.scrubberPosition, oCounterMenuOpen: value});
-  }
-
   private onSeeked() {
     const position = this.player.getPosition();
-    this.setScrubberPosition(position);
+    this.setState({scrubberPosition: position});
     this.player.play();
   }
 
@@ -212,7 +190,7 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     const difference = Math.abs(position - this.lastTime);
     if (difference > 1) {
       this.lastTime = position;
-      this.setScrubberPosition(position);
+      this.setState({scrubberPosition: position});
     }
   }
 
@@ -228,9 +206,5 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
 export const ScenePlayer: FunctionComponent<IScenePlayerProps> = (props: IScenePlayerProps) => {
     const config = StashService.useConfiguration();
 
-    return (
-      <>
-      <ScenePlayerImpl {...props} config={config.data && config.data.configuration ? config.data.configuration.interface : undefined}/>
-      </>
-    );
+    return <ScenePlayerImpl {...props} config={config.data && config.data.configuration ? config.data.configuration.interface : undefined}/>
 }

--- a/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2/src/components/scenes/ScenePlayer/ScenePlayer.tsx
@@ -5,6 +5,7 @@ import * as GQL from "../../../core/generated-graphql";
 import { SceneHelpers } from "../helpers";
 import { ScenePlayerScrubber } from "./ScenePlayerScrubber";
 import { StashService } from "../../../core/StashService";
+import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
 
 interface IScenePlayerProps {
   scene: GQL.SceneDataFragment;
@@ -14,9 +15,11 @@ interface IScenePlayerProps {
   onSeeked?: any;
   onTime?: any;
   config?: GQL.ConfigInterfaceDataFragment;
+  oCounter: IOCounterButtonProps;
 }
 interface IScenePlayerState {
   scrubberPosition: number;
+  oCounterMenuOpen: boolean;
 }
 
 @HotkeysTarget
@@ -33,7 +36,10 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     this.onScrubberSeek = this.onScrubberSeek.bind(this);
     this.onScrubberScrolled = this.onScrubberScrolled.bind(this);
 
-    this.state = {scrubberPosition: 0};
+    this.state = {
+      scrubberPosition: 0,
+      oCounterMenuOpen: false
+    };
   }
 
   public componentDidUpdate(prevProps: IScenePlayerProps) {
@@ -67,6 +73,13 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
             onSeek={this.onScrubberSeek}
             onScrolled={this.onScrubberScrolled}
           />
+          <div id="o-counter-container" className={this.state.oCounterMenuOpen ? "menu-open" : undefined}>
+            <OCounterButton 
+              {...this.props.oCounter} 
+              onMenuOpened={() => this.setOCounterMenuOpen(true)}
+              onMenuClosed={() => this.setOCounterMenuOpen(false)}
+            />
+          </div>
         </div>
       </>
     );
@@ -179,9 +192,18 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     }
   }
 
+  private setScrubberPosition(position: any) {
+    this.setState({scrubberPosition: position, oCounterMenuOpen: this.state.oCounterMenuOpen});
+  }
+
+  private setOCounterMenuOpen(value : boolean) {
+    console.log("Setting menu open to : " + value);
+    this.setState({scrubberPosition: this.state.scrubberPosition, oCounterMenuOpen: value});
+  }
+
   private onSeeked() {
     const position = this.player.getPosition();
-    this.setState({scrubberPosition: position});
+    this.setScrubberPosition(position);
     this.player.play();
   }
 
@@ -190,7 +212,7 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
     const difference = Math.abs(position - this.lastTime);
     if (difference > 1) {
       this.lastTime = position;
-      this.setState({scrubberPosition: position});
+      this.setScrubberPosition(position);
     }
   }
 
@@ -206,5 +228,9 @@ export class ScenePlayerImpl extends React.Component<IScenePlayerProps, IScenePl
 export const ScenePlayer: FunctionComponent<IScenePlayerProps> = (props: IScenePlayerProps) => {
     const config = StashService.useConfiguration();
 
-    return <ScenePlayerImpl {...props} config={config.data && config.data.configuration ? config.data.configuration.interface : undefined}/>
+    return (
+      <>
+      <ScenePlayerImpl {...props} config={config.data && config.data.configuration ? config.data.configuration.interface : undefined}/>
+      </>
+    );
 }

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -315,6 +315,24 @@ export class StashService {
     return GQL.useScenesUpdate({ variables: { input: input } });
   }
 
+  public static useSceneIncrementO(id: string) {
+    return GQL.useSceneIncrementO({
+      variables: {id: id}
+    });
+  }
+
+  public static useSceneDecrementO(id: string) {
+    return GQL.useSceneDecrementO({
+      variables: {id: id}
+    });
+  }
+
+  public static useSceneResetO(id: string) {
+    return GQL.useSceneResetO({
+      variables: {id: id}
+    });
+  }
+
   public static useSceneDestroy(input: GQL.SceneDestroyInput) {
     return GQL.useSceneDestroy({
       variables: input,

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -305,6 +305,25 @@ video.preview.portrait {
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;
+  position: relative;
+
+  & #o-counter-container {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+
+  & #o-counter-container.menu-open {
+    opacity: 0.75;
+    transition: opacity 0.5s;
+  }
+}
+
+#jwplayer-container:hover #o-counter-container {
+  opacity: 0.75;
+  transition: opacity 0.5s;
 }
 
 .video-js {
@@ -484,8 +503,6 @@ span.block {
     font-size: 1.2em;
 
     & .name-icons {
-      margin-left: 10px;
-
       & .not-favorite .bp3-icon {
         color: rgba(191, 204, 214, 0.5) !important;
       }
@@ -499,6 +516,10 @@ span.block {
   & .alias {
     font-weight: bold;
   }
+}
+
+.name-icons {
+  margin-left: 10px;
 }
 
 #performer-details {

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -305,25 +305,6 @@ video.preview.portrait {
 #jwplayer-container {
   margin: 10px auto;
   width: 75%;
-  position: relative;
-
-  & #o-counter-container {
-    position: absolute;
-    left: 10px;
-    top: 10px;
-    opacity: 0;
-    transition: opacity 0.5s;
-  }
-
-  & #o-counter-container.menu-open {
-    opacity: 0.75;
-    transition: opacity 0.5s;
-  }
-}
-
-#jwplayer-container:hover #o-counter-container {
-  opacity: 0.75;
-  transition: opacity 0.5s;
 }
 
 .video-js {
@@ -503,6 +484,8 @@ span.block {
     font-size: 1.2em;
 
     & .name-icons {
+      margin-left: 10px;
+    
       & .not-favorite .bp3-icon {
         color: rgba(191, 204, 214, 0.5) !important;
       }
@@ -516,10 +499,6 @@ span.block {
   & .alias {
     font-weight: bold;
   }
-}
-
-.name-icons {
-  margin-left: 10px;
 }
 
 #performer-details {

--- a/ui/v2/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2/src/models/list-filter/criteria/criterion.ts
@@ -6,6 +6,7 @@ import { DurationUtils } from "../../../utils/duration";
 export type CriterionType =
   "none" |
   "rating" |
+  "o_counter" |
   "resolution" |
   "duration" |
   "favorite" |
@@ -33,6 +34,7 @@ export abstract class Criterion<Option = any, Value = any> {
     switch (type) {
       case "none": return "None";
       case "rating": return "Rating";
+      case "o_counter": return "O-Counter";
       case "resolution": return "Resolution";
       case "duration": return "Duration";
       case "favorite": return "Favorite";

--- a/ui/v2/src/models/list-filter/criteria/utils.ts
+++ b/ui/v2/src/models/list-filter/criteria/utils.ts
@@ -16,6 +16,7 @@ export function makeCriteria(type: CriterionType = "none") {
   switch (type) {
     case "none": return new NoneCriterion();
     case "rating": return new RatingCriterion();
+    case "o_counter": return new NumberCriterion(type, type);
     case "resolution": return new ResolutionCriterion();
     case "duration": return new DurationCriterion(type, type);
     case "favorite": return new FavoriteCriterion();

--- a/ui/v2/src/models/list-filter/filter.ts
+++ b/ui/v2/src/models/list-filter/filter.ts
@@ -56,7 +56,7 @@ export class ListFilterModel {
     switch (filterMode) {
       case FilterMode.Scenes:
         if (!!this.sortBy === false) { this.sortBy = "date"; }
-        this.sortByOptions = ["title", "path", "rating", "date", "filesize", "duration", "framerate", "bitrate", "random"];
+        this.sortByOptions = ["title", "path", "rating", "o_counter", "date", "filesize", "duration", "framerate", "bitrate", "random"];
         this.displayModeOptions = [
           DisplayMode.Grid,
           DisplayMode.List,
@@ -65,6 +65,7 @@ export class ListFilterModel {
         this.criterionOptions = [
           new NoneCriterionOption(),
           new RatingCriterionOption(),
+          ListFilterModel.createCriterionOption("o_counter"),
           new ResolutionCriterionOption(),
           ListFilterModel.createCriterionOption("duration"),
           new HasMarkersCriterionOption(),
@@ -154,7 +155,7 @@ export class ListFilterModel {
     const params = rawParms as IQueryParameters;
     if (params.sortby !== undefined) {
       this.sortBy = params.sortby;
-
+      
       // parse the random seed if provided
       const randomPrefix = "random_";
       if (this.sortBy && this.sortBy.startsWith(randomPrefix)) {
@@ -234,7 +235,7 @@ export class ListFilterModel {
       encodedCriteria.push(jsonCriterion);
     });
 
-    
+
     const result = {
       sortby: this.getSortBy(),
       sortdir: this.sortDirection,
@@ -253,7 +254,7 @@ export class ListFilterModel {
       q: this.searchTerm,
       page: this.currentPage,
       per_page: this.itemsPerPage,
-      sort: this.getSortBy(),
+      sort: this.sortBy,
       direction: this.sortDirection === "asc" ? SortDirectionEnum.Asc : SortDirectionEnum.Desc,
     };
   }
@@ -266,6 +267,10 @@ export class ListFilterModel {
           const ratingCrit = criterion as RatingCriterion;
           result.rating = { value: ratingCrit.value, modifier: ratingCrit.modifier };
           break;
+        case "o_counter":
+            const oCounterCrit = criterion as NumberCriterion;
+            result.o_counter = { value: oCounterCrit.value, modifier: oCounterCrit.modifier };
+            break;
         case "resolution": {
           switch ((criterion as ResolutionCriterion).value) {
             case "240p": result.resolution = ResolutionEnum.Low; break;

--- a/ui/v2/src/utils/icons.tsx
+++ b/ui/v2/src/utils/icons.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export class Icons {
+  public static sweatDrops() {
+    return (
+      <span className="bp3-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" style={{transform: "rotate(360deg)"}} preserveAspectRatio="xMidYMid meet" viewBox="0 0 36 36">
+          <path fill="currentColor" d="M22.855.758L7.875 7.024l12.537 9.733c2.633 2.224 6.377 2.937 9.77 1.518c4.826-2.018 7.096-7.576 5.072-12.413C33.232 1.024 27.68-1.261 22.855.758zm-9.962 17.924L2.05 10.284L.137 23.529a7.993 7.993 0 0 0 2.958 7.803a8.001 8.001 0 0 0 9.798-12.65zm15.339 7.015l-8.156-4.69l-.033 9.223c-.088 2 .904 3.98 2.75 5.041a5.462 5.462 0 0 0 7.479-2.051c1.499-2.644.589-6.013-2.04-7.523z"/>
+          <rect x="0" y="0" width="36" height="36" fill="rgba(0, 0, 0, 0)" />
+        </svg>
+      </span>
+    );
+  }
+}


### PR DESCRIPTION
Adds an "o-counter". This is represented as a 💦 looking icon. When the counter is > 0, then it is included in the scene card:

![image](https://user-images.githubusercontent.com/53250216/73116656-22349a00-3f8e-11ea-85fa-525360b720b0.png)

On the scene details page, I have implemented a button for the counter. My default, it shows the icon and counter value. When clicked, this button increments the counter. If the button is hovered for 1 second, and the counter value > 0, then a popover menu is shown with decrement and reset items:

![image](https://user-images.githubusercontent.com/53250216/73116711-01207900-3f8f-11ea-94b6-9a4f247b26ea.png)

I need advice as to where to put this button in the scene details page. Below is a screenshot of possible placements:

![image](https://user-images.githubusercontent.com/53250216/73116840-3ded6f80-3f91-11ea-89b5-7cc844760e1b.png)

To me the best here is probably on the tabs line. We could also right-align it:

![image](https://user-images.githubusercontent.com/53250216/73116860-a0df0680-3f91-11ea-9d82-b3f22a168299.png)

Another option is overlaying the button on the scene player when the player is moused-over:

![image](https://user-images.githubusercontent.com/53250216/73116737-83a93880-3f8f-11ea-999f-1c1e31404982.png)

The button is not shown in the fullscreen view.

Let me know where you'd like it placed.

TODO:
- add filter for o-counter (<, >, !=, =)
- add button functionality to the scene card (so that you can click the o-counter button from the scene query page)
- add an operation on the scene query page to reset o-counter for selected scenes
