### PR TITLE
Add cache headers to static files and etags to performer images

### DIFF
--- a/pkg/api/routes_performer.go
+++ b/pkg/api/routes_performer.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"github.com/go-chi/chi"
 	"github.com/stashapp/stash/pkg/models"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 type performerRoutes struct{}
@@ -23,6 +26,16 @@ func (rs performerRoutes) Routes() chi.Router {
 
 func (rs performerRoutes) Image(w http.ResponseWriter, r *http.Request) {
 	performer := r.Context().Value(performerKey).(*models.Performer)
+	etag := fmt.Sprintf("%x", md5.Sum(performer.Image))
+
+	if match := r.Header.Get("If-None-Match"); match != "" {
+		if strings.Contains(match, etag) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
+	w.Header().Add("Etag", etag)
 	_, _ = w.Write(performer.Image)
 }
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -196,6 +196,10 @@ func Start() {
 			data, _ := uiBox.Find("index.html")
 			_, _ = w.Write(data)
 		} else {
+			isStatic, _ := path.Match("/static/*/*", r.URL.Path)
+			if isStatic {
+				w.Header().Add("Cache-Control", "max-age=604800000")
+			}
 			http.FileServer(uiBox).ServeHTTP(w, r)
 		}
 	})


### PR DESCRIPTION
Adds one week cache headers to all files served from /static/*/*. All of the css/js assets are hashed by webpack, so there's no risk of a stale cache.

Also adds etags to performer images based on the md5 of the image. Since the tag is the hash it should also never go stale.

Both taken together shaves the load time of my `/performers`page from 1500 to ~500ms when the cache is hot.