### PR TITLE
Prepare for 0.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ deploy:
     skip_cleanup: true
     overwrite: true
     name: "${STASH_VERSION}: Latest development build"
-    body: This is always the latest committed version on the develop branch. Use as your own risk!
+    body: ${RELEASE_DATE}\n This is always the latest committed version on the develop branch. Use as your own risk!
     prerelease: true
     on:
       repo: stashapp/stash

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,12 @@ script:
 #- make vet
 - make it
 after_success:
-- if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; elif [ "$TRAVIS_BRANCH" != "master" ]; then export TAG_SUFFIX="_$TRAVIS_BRANCH"; fi
-- export STASH_VERSION="v0.0.0-alpha${TAG_SUFFIX}"
 - docker pull stashapp/compiler:develop
-- sh ./scripts/cross-compile.sh ${STASH_VERSION}
+- sh ./scripts/cross-compile.sh
 - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request.sh; fi'
 before_deploy:
-- if [ "$TRAVIS_BRANCH" = "develop" ]; then export TAG_SUFFIX="_dev"; fi
-- git tag -f ${STASH_VERSION}
-- git push -f --tags
+# push the latest tag when on the develop branch
+- if [ "$TRAVIS_BRANCH" = "develop" ]; then git tag -f latest; git push -f --tags; fi
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success:
 - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request.sh; fi'
 before_deploy:
 # push the latest tag when on the develop branch
-- if [ "$TRAVIS_BRANCH" = "develop" ]; then git tag -f latest; git push -f --tags; fi
+- if [ "$TRAVIS_BRANCH" = "develop" ]; then git tag -f latest_develop; git push -f --tags; fi
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,22 +25,50 @@ before_deploy:
 # push the latest tag when on the develop branch
 - if [ "$TRAVIS_BRANCH" = "develop" ]; then git tag -f latest_develop; git push -f --tags; fi
 - export RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')
+- export STASH_VERSION=$(git describe --tags --exclude latest_develop)
+# set TRAVIS_TAG explcitly to the version so that it doesn't pick up latest_develop
+- if [ "$TRAVIS_BRANCH" = "master"]; then export TRAVIS_TAG=${STASH_VERSION}; fi
 deploy:
-  provider: releases
-  api_key:
-    secure: tGJ2q62CfPdayid2qEtW2aGRhMgCl3lBXYYQqp3eH0vFgIIf6cs7IDX7YC/x3XKMEQ/iMLZmtCXZvSTqNrD6Sk7MSnt30GIs+4uxIZDnnd8mV5X3K4n4gjD+NAORc4DrQBvUGrYMKJsR5gtkH0nu6diWb1o1If7OiJEuCPRhrmQYcza7NUdABnA9Z2wn2RNUV9Ga33WUCqLMEU5GtNBlfQPiP/khCQrqn/ocR6wUjYut3J6YagzqH4wsfJi3glHyWtowcNIw1LZi5zFxHD/bRBT4Tln7yypkjWNq9eQILA6i6kRUGf7ggyTx26/k8n4tnu+QD0vVh4EcjlThpU/LGyUXzKrrxjRwaDZnM0oYxg5AfHcBuAiAdo0eWnV3lEWRfTJMIVb9MPf4qDmzR4RREfB5OXOxwq3ODeCcJE8sTIMD/wBPZrlqS/QrRpND2gn2X4snkVukN9t9F4CMTFMtVSzFV7TDJW5E5Lq6VEExulteQhs6kcK9NRPNAaLgRQAw7X9kVWfDtiGUP+fE2i8F9Bo8bm7sOT5O5VPMPykx3EgeNg1IqIgMTCsMlhMJT4xBJoQUgmd2wWyf3Ryw+P+sFgdb5Sd7+lFgJBjMUUoOxMxAOiEgdFvCXcr+/Udyz2RdtetU1/6VzXzLPcKOw0wubZeBkISqu7o9gpfdMP9Eq00=
-  file:
-  - dist/stash-osx
-  - dist/stash-win.exe
-  - dist/stash-linux
-  - dist/stash-pi
-  skip_cleanup: true
-  overwrite: true
-  body: ${RELEASE_DATE}
-  on:
-    repo: stashapp/stash
-    all_branches: true
-    condition: $TRAVIS_BRANCH =~ ^(master|develop)$
+  # latest develop release
+  - provider: releases
+    api_key:
+      secure: tGJ2q62CfPdayid2qEtW2aGRhMgCl3lBXYYQqp3eH0vFgIIf6cs7IDX7YC/x3XKMEQ/iMLZmtCXZvSTqNrD6Sk7MSnt30GIs+4uxIZDnnd8mV5X3K4n4gjD+NAORc4DrQBvUGrYMKJsR5gtkH0nu6diWb1o1If7OiJEuCPRhrmQYcza7NUdABnA9Z2wn2RNUV9Ga33WUCqLMEU5GtNBlfQPiP/khCQrqn/ocR6wUjYut3J6YagzqH4wsfJi3glHyWtowcNIw1LZi5zFxHD/bRBT4Tln7yypkjWNq9eQILA6i6kRUGf7ggyTx26/k8n4tnu+QD0vVh4EcjlThpU/LGyUXzKrrxjRwaDZnM0oYxg5AfHcBuAiAdo0eWnV3lEWRfTJMIVb9MPf4qDmzR4RREfB5OXOxwq3ODeCcJE8sTIMD/wBPZrlqS/QrRpND2gn2X4snkVukN9t9F4CMTFMtVSzFV7TDJW5E5Lq6VEExulteQhs6kcK9NRPNAaLgRQAw7X9kVWfDtiGUP+fE2i8F9Bo8bm7sOT5O5VPMPykx3EgeNg1IqIgMTCsMlhMJT4xBJoQUgmd2wWyf3Ryw+P+sFgdb5Sd7+lFgJBjMUUoOxMxAOiEgdFvCXcr+/Udyz2RdtetU1/6VzXzLPcKOw0wubZeBkISqu7o9gpfdMP9Eq00=
+    file:
+    - dist/stash-osx
+    - dist/stash-win.exe
+    - dist/stash-linux
+    - dist/stash-pi
+    skip_cleanup: true
+    overwrite: true
+    name: "${STASH_VERSION}: Latest development build"
+    body: This is always the latest committed version on the develop branch. Use as your own risk!
+    prerelease: true
+    on:
+      repo: stashapp/stash
+      branches: develop
+  # official master release - only build when tagged
+  - provider: releases
+    api_key:
+      secure: tGJ2q62CfPdayid2qEtW2aGRhMgCl3lBXYYQqp3eH0vFgIIf6cs7IDX7YC/x3XKMEQ/iMLZmtCXZvSTqNrD6Sk7MSnt30GIs+4uxIZDnnd8mV5X3K4n4gjD+NAORc4DrQBvUGrYMKJsR5gtkH0nu6diWb1o1If7OiJEuCPRhrmQYcza7NUdABnA9Z2wn2RNUV9Ga33WUCqLMEU5GtNBlfQPiP/khCQrqn/ocR6wUjYut3J6YagzqH4wsfJi3glHyWtowcNIw1LZi5zFxHD/bRBT4Tln7yypkjWNq9eQILA6i6kRUGf7ggyTx26/k8n4tnu+QD0vVh4EcjlThpU/LGyUXzKrrxjRwaDZnM0oYxg5AfHcBuAiAdo0eWnV3lEWRfTJMIVb9MPf4qDmzR4RREfB5OXOxwq3ODeCcJE8sTIMD/wBPZrlqS/QrRpND2gn2X4snkVukN9t9F4CMTFMtVSzFV7TDJW5E5Lq6VEExulteQhs6kcK9NRPNAaLgRQAw7X9kVWfDtiGUP+fE2i8F9Bo8bm7sOT5O5VPMPykx3EgeNg1IqIgMTCsMlhMJT4xBJoQUgmd2wWyf3Ryw+P+sFgdb5Sd7+lFgJBjMUUoOxMxAOiEgdFvCXcr+/Udyz2RdtetU1/6VzXzLPcKOw0wubZeBkISqu7o9gpfdMP9Eq00=
+    file:
+    - dist/stash-osx
+    - dist/stash-win.exe
+    - dist/stash-linux
+    - dist/stash-pi
+    # make the release a draft so the maintainers can confirm before releasing
+    draft: true
+    skip_cleanup: true
+    overwrite: true
+    # don't write the body. To be done manually for now. In future we might 
+    # want to generate the changelog or get it from a file
+    name: ${STASH_VERSION}
+    on:
+      repo: stashapp/stash
+      branches: master
+      tags: true
+      # make sure we don't release using the latest_develop tag
+      condition: $TRAVIS_TAG != latest_develop
+      
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ release: generate ui build
 build:
 	$(eval DATE := $(shell go run scripts/getDate.go))
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))
-	$(SET) CGO_ENABLED=1 $(SEPARATOR) go build -mod=vendor -v -ldflags "-X 'github.com/stashapp/stash/pkg/api.buildstamp=$(DATE)' -X 'github.com/stashapp/stash/pkg/api.githash=$(GITHASH)'"
+	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest))
+	$(SET) CGO_ENABLED=1 $(SEPARATOR) go build -mod=vendor -v -ldflags "-X 'github.com/stashapp/stash/pkg/api.version=$(STASH_VERSION)' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$(DATE)' -X 'github.com/stashapp/stash/pkg/api.githash=$(GITHASH)'"
 
 install:
 	packr2 install

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ release: generate ui build
 build:
 	$(eval DATE := $(shell go run scripts/getDate.go))
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))
-	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest))
+	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest_develop))
 	$(SET) CGO_ENABLED=1 $(SEPARATOR) go build -mod=vendor -v -ldflags "-X 'github.com/stashapp/stash/pkg/api.version=$(STASH_VERSION)' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$(DATE)' -X 'github.com/stashapp/stash/pkg/api.githash=$(GITHASH)'"
 
 install:

--- a/docker/production/x86_64/Dockerfile
+++ b/docker/production/x86_64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -L -o /stash $(curl -s https://api.github.com/repos/stashapp/stash/releases | grep -F 'latest/stash-linux' | grep download | head -n 1 | cut -d'"' -f4) && \
+RUN curl -L -o /stash $(curl -s https://api.github.com/repos/stashapp/stash/releases | grep -F 'latest_develop/stash-linux' | grep download | head -n 1 | cut -d'"' -f4) && \
     chmod +x /stash && \
     curl -o /ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
     tar xf /ffmpeg.tar.xz && \

--- a/docker/production/x86_64/Dockerfile
+++ b/docker/production/x86_64/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -L -o /stash $(curl -s https://api.github.com/repos/stashapp/stash/releases | grep -F 'stash-linux' | grep download | head -n 1 | cut -d'"' -f4) && \
+RUN curl -L -o /stash $(curl -s https://api.github.com/repos/stashapp/stash/releases | grep -F 'latest/stash-linux' | grep download | head -n 1 | cut -d'"' -f4) && \
     chmod +x /stash && \
     curl -o /ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
     tar xf /ffmpeg.tar.xz && \

--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -13,7 +13,6 @@ import (
 )
 
 //we use the github REST V3 API as no login is required
-const apiURL string = "https://api.github.com/repos/stashapp/stash/tags"
 const apiReleases string = "https://api.github.com/repos/stashapp/stash/releases"
 const apiAcceptHeader string = "application/vnd.github.v3+json"
 const developmentTag string = "latest_develop"
@@ -25,17 +24,6 @@ var stashReleases = func() map[string]string {
 		"darwin/amd64":  "stash-osx",
 		"linux/arm":     "stash-pi",
 	}
-}
-
-type githubTagResponse struct {
-	Name        string
-	Zipball_url string
-	Tarball_url string
-	Commit      struct {
-		Sha string
-		Url string
-	}
-	Node_id string
 }
 
 type githubReleasesResponse struct {

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-STASH_VERSION="$1"
-
 DATE=`go run -mod=vendor scripts/getDate.go`
 GITHASH=`git rev-parse --short HEAD`
+STASH_VERSION=`git describe --tags --exclude latest`
 VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1;"
 WINDOWS="GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ packr2 build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -2,7 +2,7 @@
 
 DATE=`go run -mod=vendor scripts/getDate.go`
 GITHASH=`git rev-parse --short HEAD`
-STASH_VERSION=`git describe --tags --exclude latest`
+STASH_VERSION=`git describe --tags --exclude latest_develop`
 VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1;"
 WINDOWS="GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ packr2 build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -5,7 +5,8 @@ uploadFile()
 {
     FILE=$1
     BASENAME="$(basename "${FILE}")"
-    uploadedTo=`curl --upload-file $FILE "https://transfer.sh/$BASENAME"`
+    # abort if it takes more than two minutes to upload
+    uploadedTo=`curl -m 120 --upload-file $FILE "https://transfer.sh/$BASENAME"`
     echo "$BASENAME uploaded to url: $uploadedTo"
 }
 


### PR DESCRIPTION
Version is now generated in the Makefile and `cross-compile.sh` script, and uses `git describe --tags --exclude latest_develop` to generate a version string. From the `git describe` help page:

> If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.

The latest develop release is now tagged with `latest_develop`. It will be named for the version string generated above.

Builds on the `master` branch will now only be released if the commit is tagged with a tag that is not `latest_develop`. Builds on this branch will be done as a `draft` allowing maintainers to confirm the release before making it publicly available. It also allows changelogs to be filled in as needed.

Changed the check version code so that it determines whether it is a development build by checking the version string. If the version string contains the generated suffixes, then it must be a development build. For development builds, it now calls the github API `/repos/stashapp/stash/releases/tags/latest_develop` endpoint, which returns the release for the `latest_develop` tag. For release builds, it now calls the github API `/repos/stashapp/stash/releases/latest` endpoint, which returns the most recent full release.

