### PR TITLE
Make performer image contain

### DIFF
--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -359,7 +359,7 @@ span.block {
 .performer.image {
   height: 50vh;
   min-height: 400px;
-  background-size: cover !important;
+  background-size: contain !important;
   background-position: center !important;
   background-repeat: no-repeat !important;
 }


### PR DESCRIPTION
Fixes #349 

Simple CSS fix to changed performer image to be contain instead of cover.

Without fix:

![image](https://user-images.githubusercontent.com/53250216/73981523-7a07d380-4986-11ea-8bc8-00b8f120ca44.png)

With fix:

![image](https://user-images.githubusercontent.com/53250216/73981499-69575d80-4986-11ea-9167-c22e79eb5a2d.png)
