### PR TITLE
Make performer image position top

### DIFF
--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -360,7 +360,7 @@ span.block {
   height: 50vh;
   min-height: 400px;
   background-size: cover !important;
-  background-position: center !important;
+  background-position: top !important;
   background-repeat: no-repeat !important;
 }
 


### PR DESCRIPTION
Fixes #349 

Simple CSS fix to change performer image position to be top instead of center. Means that performer images will crop off the bottom, rather than from around the center point.

Without fix:

![image](https://user-images.githubusercontent.com/53250216/73981523-7a07d380-4986-11ea-8bc8-00b8f120ca44.png)

With fix:

![image](https://user-images.githubusercontent.com/53250216/74115735-a2046a80-4c04-11ea-917b-6aae858f45a7.png)
