### PR TITLE
Fix database locked on image cover too big bug (#359)

### DIFF
--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -163,10 +163,6 @@ func (r *mutationResolver) sceneUpdate(input models.SceneUpdateInput, tx *sqlx.T
 
 	// only update the cover image if provided and everything else was successful
 	if coverImageData != nil {
-		scene, err := qb.Find(sceneID)
-		if err != nil {
-			return nil, err
-		}
 
 		err = manager.SetSceneScreenshot(scene.Checksum, coverImageData)
 		if err != nil {


### PR DESCRIPTION
Fixes #359
It seems to me that when  `scene, err := qb.Update(updatedScene, tx)` is called
it returns while  a lock is still active.
With big (filesize)  cover images the lock is still active till we reach to the call to `scene, err := qb.Find(sceneID)` and thus we get an error of database locked.
`scene` isn't actually needed  to be "found" anyway because we already have it from the call to `qb.Update` above.
