### PR TITLE
Update stats page

### DIFF
--- a/ui/v2/src/components/Stats.tsx
+++ b/ui/v2/src/components/Stats.tsx
@@ -8,35 +8,35 @@ export const Stats: FunctionComponent = () => {
   function renderStats() {
     if (!data || !data.stats) { return; }
     return (
-      <nav id="details-container" className="level">
+      <nav id="details-container" className="level stats">
         <div className="level-item has-text-centered">
           <div>
-            <p className="heading">Scenes</p>
             <p className="title">{data.stats.scene_count}</p>
+            <p className="heading">Scenes</p>
           </div>
         </div>
         <div className="level-item has-text-centered">
           <div>
-            <p className="heading">Galleries</p>
             <p className="title">{data.stats.gallery_count}</p>
+            <p className="heading">Galleries</p>
           </div>
         </div>
         <div className="level-item has-text-centered">
           <div>
-            <p className="heading">Performers</p>
             <p className="title">{data.stats.performer_count}</p>
+            <p className="heading">Performers</p>
           </div>
         </div>
         <div className="level-item has-text-centered">
           <div>
-            <p className="heading">Studios</p>
             <p className="title">{data.stats.studio_count}</p>
+            <p className="heading">Studios</p>
           </div>
         </div>
         <div className="level-item has-text-centered">
           <div>
-            <p className="heading">Tags</p>
             <p className="title">{data.stats.tag_count}</p>
+            <p className="heading">Tags</p>
           </div>
         </div>
       </nav>
@@ -48,13 +48,6 @@ export const Stats: FunctionComponent = () => {
       {!data || loading ? <Spinner size={Spinner.SIZE_LARGE} /> : undefined}
       {!!error ? <span>error.message</span> : undefined}
       {renderStats()}
-
-      <h3>Notes</h3>
-      <pre>
-        {`
-        This is still an early version, some things are still a work in progress.
-        `}
-      </pre>
     </div>
   );
 };

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -601,7 +601,7 @@ span.block {
 
 .stats {
   & p.title {
-    font-size: 4em;
+    font-size: 3vw;
     text-align: center;
   }
   

--- a/ui/v2/src/index.scss
+++ b/ui/v2/src/index.scss
@@ -598,3 +598,15 @@ span.block {
     transition: margin-left 0.5s;
   }
 }
+
+.stats {
+  & p.title {
+    font-size: 4em;
+    text-align: center;
+  }
+  
+  & p.heading {
+    text-align: center;
+    text-transform: uppercase;
+  }
+}


### PR DESCRIPTION
Makes the stats page more like the old rails version. Removes the notes - we're not specifically in WIP mode.

![image](https://user-images.githubusercontent.com/53250216/74390144-737cce80-4e54-11ea-9eb5-6a588d10fe31.png)

Font size scales with viewport width (you will need to view the full size images to tell the difference):

![image](https://user-images.githubusercontent.com/53250216/74390160-8394ae00-4e54-11ea-878a-1a292a44caa6.png)
