### PR TITLE
fix(middleware): set baseURL to external host if provided

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -296,6 +296,11 @@ func BaseURLMiddleware(next http.Handler) http.Handler {
 		}
 		baseURL := scheme + "://" + r.Host
 
+		externalHost := config.GetExternalHost()
+		if externalHost != "" {
+			baseURL = externalHost
+		}
+
 		r = r.WithContext(context.WithValue(ctx, BaseURLCtxKey, baseURL))
 
 		next.ServeHTTP(w, r)

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -30,6 +30,7 @@ const MaxStreamingTranscodeSize = "max_streaming_transcode_size"
 
 const Host = "host"
 const Port = "port"
+const ExternalHost = "external_host"
 
 // Interface options
 const SoundOnPreview = "sound_on_preview"
@@ -106,6 +107,10 @@ func GetHost() string {
 
 func GetPort() int {
 	return viper.GetInt(Port)
+}
+
+func GetExternalHost() string {
+	return viper.GetString(ExternalHost)
 }
 
 func GetMaxTranscodeSize() models.StreamingResolutionEnum {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -110,13 +110,14 @@ func initFlags() {
 }
 
 func initEnvs() {
-	viper.SetEnvPrefix("stash") // will be uppercased automatically
-	viper.BindEnv("host")       // STASH_HOST
-	viper.BindEnv("port")       // STASH_PORT
-	viper.BindEnv("stash")      // STASH_STASH
-	viper.BindEnv("generated")  // STASH_GENERATED
-	viper.BindEnv("metadata")   // STASH_METADATA
-	viper.BindEnv("cache")      // STASH_CACHE
+	viper.SetEnvPrefix("stash")    // will be uppercased automatically
+	viper.BindEnv("host")          // STASH_HOST
+	viper.BindEnv("port")          // STASH_PORT
+	viper.BindEnv("external_host") // STASH_EXTERNAL_HOST
+	viper.BindEnv("stash")         // STASH_STASH
+	viper.BindEnv("generated")     // STASH_GENERATED
+	viper.BindEnv("metadata")      // STASH_METADATA
+	viper.BindEnv("cache")         // STASH_CACHE
 }
 
 func initFFMPEG() {


### PR DESCRIPTION
Added a fix for issue with reverse proxy: https://github.com/stashapp/stash/issues/368

To test this, I added `external_host: https://my.domain.com` to the config yml and created a docker image. Paths no longer contain the internal address that is inaccessible by the client.