### PR TITLE
Fix panic when version check times out

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -124,12 +124,12 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 
 	release := githubReleasesResponse{}
 
-	if response.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Github API request failed: %s", response.Status)
-	}
-
 	if err != nil {
 		return "", "", fmt.Errorf("Github API request failed: %s", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("Github API request failed: %s", response.Status)
 	}
 
 	defer response.Body.Close()


### PR DESCRIPTION
Stash current panics if the check version request times out. This is because it was checking for the response status before `err`, so `response` may have been nil.