### PR TITLE
Generate cover image

### DIFF
--- a/graphql/documents/mutations/metadata.graphql
+++ b/graphql/documents/mutations/metadata.graphql
@@ -1,0 +1,27 @@
+mutation MetadataImport {
+  metadataImport
+}
+
+mutation MetadataExport {
+  metadataExport
+}
+
+mutation MetadataScan($input: ScanMetadataInput!) {
+  metadataScan(input: $input)
+}
+
+mutation MetadataGenerate($input: GenerateMetadataInput!) {
+  metadataGenerate(input: $input)
+}
+
+mutation MetadataAutoTag($input: AutoTagMetadataInput!) {
+  metadataAutoTag(input: $input)
+}
+
+mutation MetadataClean {
+  metadataClean
+}
+
+mutation StopJob {
+  stopJob
+}

--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -79,3 +79,7 @@ mutation SceneResetO($id: ID!) {
 mutation SceneDestroy($id: ID!, $delete_file: Boolean, $delete_generated : Boolean) {
   sceneDestroy(input: {id: $id, delete_file: $delete_file, delete_generated: $delete_generated})
 }
+
+mutation SceneGenerateScreenshot($id: ID!, $at: Float) {
+  sceneGenerateScreenshot(id: $id, at: $at)
+}

--- a/graphql/documents/queries/settings/metadata.graphql
+++ b/graphql/documents/queries/settings/metadata.graphql
@@ -1,35 +1,7 @@
-query MetadataImport {
-  metadataImport
-}
-
-query MetadataExport {
-  metadataExport
-}
-
-query MetadataScan($input: ScanMetadataInput!) {
-  metadataScan(input: $input)
-}
-
-query MetadataGenerate($input: GenerateMetadataInput!) {
-  metadataGenerate(input: $input)
-}
-
-query MetadataAutoTag($input: AutoTagMetadataInput!) {
-  metadataAutoTag(input: $input)
-}
-
-query MetadataClean {
-  metadataClean
-}
-
 query JobStatus {
   jobStatus {
     progress
     status
     message
   }
-}
-
-query StopJob {
-  stopJob
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -77,21 +77,7 @@ type Query {
 
   # Metadata
 
-  """Start an import. Returns the job ID"""
-  metadataImport: String!
-  """Start an export. Returns the job ID"""
-  metadataExport: String!
-  """Start a scan. Returns the job ID"""
-  metadataScan(input: ScanMetadataInput!): String!
-  """Start generating content. Returns the job ID"""
-  metadataGenerate(input: GenerateMetadataInput!): String!
-  """Start auto-tagging. Returns the job ID"""
-  metadataAutoTag(input: AutoTagMetadataInput!): String!
-  """Clean metadata. Returns the job ID"""
-  metadataClean: String!
-
   jobStatus: MetadataUpdateStatus!
-  stopJob: Boolean!
 
   # Get everything
 
@@ -143,6 +129,21 @@ type Mutation {
   """Change general configuration options"""
   configureGeneral(input: ConfigGeneralInput!): ConfigGeneralResult!
   configureInterface(input: ConfigInterfaceInput!): ConfigInterfaceResult!
+
+  """Start an import. Returns the job ID"""
+  metadataImport: String!
+  """Start an export. Returns the job ID"""
+  metadataExport: String!
+  """Start a scan. Returns the job ID"""
+  metadataScan(input: ScanMetadataInput!): String!
+  """Start generating content. Returns the job ID"""
+  metadataGenerate(input: GenerateMetadataInput!): String!
+  """Start auto-tagging. Returns the job ID"""
+  metadataAutoTag(input: AutoTagMetadataInput!): String!
+  """Clean metadata. Returns the job ID"""
+  metadataClean: String!
+
+  stopJob: Boolean!
 }
 
 type Subscription {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -106,6 +106,9 @@ type Mutation {
   """Resets the o-counter for a scene to 0. Returns the new value"""
   sceneResetO(id: ID!): Int!
 
+  """Generates screenshot at specified time in seconds. Leave empty to generate default screenshot"""
+  sceneGenerateScreenshot(id: ID!, at: Float): String!
+
   sceneMarkerCreate(input: SceneMarkerCreateInput!): SceneMarker
   sceneMarkerUpdate(input: SceneMarkerUpdateInput!): SceneMarker
   sceneMarkerDestroy(id: ID!): Boolean!

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+
+	"github.com/stashapp/stash/pkg/manager"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *mutationResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
+	manager.GetInstance().Scan(input.UseFileMetadata)
+	return "todo", nil
+}
+
+func (r *mutationResolver) MetadataImport(ctx context.Context) (string, error) {
+	manager.GetInstance().Import()
+	return "todo", nil
+}
+
+func (r *mutationResolver) MetadataExport(ctx context.Context) (string, error) {
+	manager.GetInstance().Export()
+	return "todo", nil
+}
+
+func (r *mutationResolver) MetadataGenerate(ctx context.Context, input models.GenerateMetadataInput) (string, error) {
+	manager.GetInstance().Generate(input.Sprites, input.Previews, input.Markers, input.Transcodes)
+	return "todo", nil
+}
+
+func (r *mutationResolver) MetadataAutoTag(ctx context.Context, input models.AutoTagMetadataInput) (string, error) {
+	manager.GetInstance().AutoTag(input.Performers, input.Studios, input.Tags)
+	return "todo", nil
+}
+
+func (r *mutationResolver) MetadataClean(ctx context.Context) (string, error) {
+	manager.GetInstance().Clean()
+	return "todo", nil
+}
+
+func (r *mutationResolver) JobStatus(ctx context.Context) (*models.MetadataUpdateStatus, error) {
+	status := manager.GetInstance().Status
+	ret := models.MetadataUpdateStatus{
+		Progress: status.Progress,
+		Status:   status.Status.String(),
+		Message:  "",
+	}
+
+	return &ret, nil
+}
+
+func (r *mutationResolver) StopJob(ctx context.Context) (bool, error) {
+	return manager.GetInstance().Status.Stop(), nil
+}

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -500,3 +500,13 @@ func (r *mutationResolver) SceneResetO(ctx context.Context, id string) (int, err
 
 	return newVal, nil
 }
+
+func (r *mutationResolver) SceneGenerateScreenshot(ctx context.Context, id string, at *float64) (string, error) {
+	if at != nil {
+		manager.GetInstance().GenerateScreenshot(id, *at)
+	} else {
+		manager.GetInstance().GenerateDefaultScreenshot(id)
+	}
+
+	return "todo", nil
+}

--- a/pkg/api/resolver_query_metadata.go
+++ b/pkg/api/resolver_query_metadata.go
@@ -7,36 +7,6 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func (r *queryResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
-	manager.GetInstance().Scan(input.UseFileMetadata)
-	return "todo", nil
-}
-
-func (r *queryResolver) MetadataImport(ctx context.Context) (string, error) {
-	manager.GetInstance().Import()
-	return "todo", nil
-}
-
-func (r *queryResolver) MetadataExport(ctx context.Context) (string, error) {
-	manager.GetInstance().Export()
-	return "todo", nil
-}
-
-func (r *queryResolver) MetadataGenerate(ctx context.Context, input models.GenerateMetadataInput) (string, error) {
-	manager.GetInstance().Generate(input.Sprites, input.Previews, input.Markers, input.Transcodes)
-	return "todo", nil
-}
-
-func (r *queryResolver) MetadataAutoTag(ctx context.Context, input models.AutoTagMetadataInput) (string, error) {
-	manager.GetInstance().AutoTag(input.Performers, input.Studios, input.Tags)
-	return "todo", nil
-}
-
-func (r *queryResolver) MetadataClean(ctx context.Context) (string, error) {
-	manager.GetInstance().Clean()
-	return "todo", nil
-}
-
 func (r *queryResolver) JobStatus(ctx context.Context) (*models.MetadataUpdateStatus, error) {
 	status := manager.GetInstance().Status
 	ret := models.MetadataUpdateStatus{
@@ -46,8 +16,4 @@ func (r *queryResolver) JobStatus(ctx context.Context) (*models.MetadataUpdateSt
 	}
 
 	return &ret, nil
-}
-
-func (r *queryResolver) StopJob(ctx context.Context) (bool, error) {
-	return manager.GetInstance().Status.Stop(), nil
 }

--- a/pkg/ffmpeg/encoder_screenshot.go
+++ b/pkg/ffmpeg/encoder_screenshot.go
@@ -10,7 +10,7 @@ type ScreenshotOptions struct {
 	Verbosity  string
 }
 
-func (e *Encoder) Screenshot(probeResult VideoFile, options ScreenshotOptions) {
+func (e *Encoder) Screenshot(probeResult VideoFile, options ScreenshotOptions) error {
 	if options.Verbosity == "" {
 		options.Verbosity = "error"
 	}
@@ -28,5 +28,7 @@ func (e *Encoder) Screenshot(probeResult VideoFile, options ScreenshotOptions) {
 		"-f", "image2",
 		options.OutputPath,
 	}
-	_, _ = e.run(probeResult, args)
+	_, err := e.run(probeResult, args)
+
+	return err
 }

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -196,10 +196,7 @@ func (s *singleton) Generate(sprites bool, previews bool, markers bool, transcod
 			}
 
 			if previews {
-				task := GeneratePreviewTask{
-					Scene:     *scene,
-					Operation: PreviewTaskOpAll,
-				}
+				task := GeneratePreviewTask{Scene: *scene}
 				go task.Start(&wg)
 			}
 
@@ -253,15 +250,9 @@ func (s *singleton) generateScreenshot(sceneId string, at *float64) {
 			return
 		}
 
-		task := GeneratePreviewTask{
-			Scene: *scene,
-		}
-
-		if at == nil {
-			task.Operation = PreviewTaskOpDefaultScreenshot
-		} else {
-			task.Operation = PreviewTaskOpScreenshot
-			task.ScreenshotAt = *at
+		task := GenerateScreenshotTask{
+			Scene:        *scene,
+			ScreenshotAt: at,
 		}
 
 		var wg sync.WaitGroup

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -196,7 +196,10 @@ func (s *singleton) Generate(sprites bool, previews bool, markers bool, transcod
 			}
 
 			if previews {
-				task := GeneratePreviewTask{Scene: *scene}
+				task := GeneratePreviewTask{
+					Scene:     *scene,
+					Operation: PreviewTaskOpAll,
+				}
 				go task.Start(&wg)
 			}
 
@@ -212,6 +215,61 @@ func (s *singleton) Generate(sprites bool, previews bool, markers bool, transcod
 
 			wg.Wait()
 		}
+		logger.Infof("Generate finished")
+	}()
+}
+
+func (s *singleton) GenerateDefaultScreenshot(sceneId string) {
+	s.generateScreenshot(sceneId, nil)
+}
+
+func (s *singleton) GenerateScreenshot(sceneId string, at float64) {
+	s.generateScreenshot(sceneId, &at)
+}
+
+// generate default screenshot if at is nil
+func (s *singleton) generateScreenshot(sceneId string, at *float64) {
+	if s.Status.Status != Idle {
+		return
+	}
+	s.Status.SetStatus(Generate)
+	s.Status.indefiniteProgress()
+
+	qb := models.NewSceneQueryBuilder()
+	instance.Paths.Generated.EnsureTmpDir()
+
+	go func() {
+		defer s.returnToIdleState()
+
+		sceneIdInt, err := strconv.Atoi(sceneId)
+		if err != nil {
+			logger.Errorf("Error parsing scene id %s: %s", sceneId, err.Error())
+			return
+		}
+
+		scene, err := qb.Find(sceneIdInt)
+		if err != nil || scene == nil {
+			logger.Errorf("failed to get scene for generate")
+			return
+		}
+
+		task := GeneratePreviewTask{
+			Scene: *scene,
+		}
+
+		if at == nil {
+			task.Operation = PreviewTaskOpDefaultScreenshot
+		} else {
+			task.Operation = PreviewTaskOpScreenshot
+			task.ScreenshotAt = *at
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go task.Start(&wg)
+
+		wg.Wait()
+
 		logger.Infof("Generate finished")
 	}()
 }

--- a/pkg/manager/screenshot.go
+++ b/pkg/manager/screenshot.go
@@ -1,0 +1,16 @@
+package manager
+
+import (
+	"github.com/stashapp/stash/pkg/ffmpeg"
+)
+
+func makeScreenshot(probeResult ffmpeg.VideoFile, outputPath string, quality int, width int, time float64) {
+	encoder := ffmpeg.NewEncoder(instance.FFMPEGPath)
+	options := ffmpeg.ScreenshotOptions{
+		OutputPath: outputPath,
+		Quality:    quality,
+		Time:       time,
+		Width:      width,
+	}
+	encoder.Screenshot(probeResult, options)
+}

--- a/pkg/manager/task_generate_preview.go
+++ b/pkg/manager/task_generate_preview.go
@@ -1,15 +1,31 @@
 package manager
 
 import (
+	"context"
+	"io/ioutil"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"sync"
+)
+
+type GeneratePreviewTaskOperation int
+
+const (
+	PreviewTaskOpAll GeneratePreviewTaskOperation = iota
+	PreviewTaskOpDefaultScreenshot
+	PreviewTaskOpScreenshot
 )
 
 type GeneratePreviewTask struct {
-	Scene models.Scene
+	Scene        models.Scene
+	Operation    GeneratePreviewTaskOperation
+	ScreenshotAt float64
 }
 
 func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
@@ -17,9 +33,6 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 
 	videoFilename := t.videoFilename()
 	imageFilename := t.imageFilename()
-	if t.doesPreviewExist(t.Scene.Checksum) {
-		return
-	}
 
 	videoFile, err := ffmpeg.NewVideoFile(instance.FFProbePath, t.Scene.Path)
 	if err != nil {
@@ -33,10 +46,82 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 		return
 	}
 
-	if err := generator.Generate(); err != nil {
+	switch t.Operation {
+	case PreviewTaskOpAll:
+		if !t.doesPreviewExist(t.Scene.Checksum) {
+			err = generator.Generate()
+		}
+	case PreviewTaskOpDefaultScreenshot:
+		err = generator.GenerateDefaultImage()
+		if err == nil {
+			err = t.makeScreenshots()
+		}
+	case PreviewTaskOpScreenshot:
+		err = generator.GenerateImageAt(t.ScreenshotAt)
+		if err == nil {
+			err = t.makeScreenshots()
+		}
+	}
+
+	if err != nil {
 		logger.Errorf("error generating preview: %s", err.Error())
 		return
 	}
+}
+
+func (t *GeneratePreviewTask) makeScreenshots() error {
+	checksum := t.Scene.Checksum
+	normalPath := instance.Paths.Scene.GetScreenshotPath(checksum)
+
+	probeResult, err := ffmpeg.NewVideoFile(instance.FFProbePath, t.Scene.Path)
+
+	if err != nil {
+		return err
+	}
+
+	at := t.ScreenshotAt
+	if t.Operation == PreviewTaskOpDefaultScreenshot {
+		at = float64(probeResult.Duration) * 0.2
+	}
+
+	// we'll generate the screenshot, grab the generated data and set it
+	// in the database. We'll use SetSceneScreenshot to set the data
+	// which also generates the thumbnail
+	makeScreenshot(*probeResult, normalPath, 2, probeResult.Width, at)
+
+	f, err := os.Open(normalPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	coverImageData, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.TODO()
+	tx := database.DB.MustBeginTx(ctx, nil)
+
+	qb := models.NewSceneQueryBuilder()
+	updatedTime := time.Now()
+	updatedScene := models.ScenePartial{
+		ID:        t.Scene.ID,
+		UpdatedAt: &models.SQLiteTimestamp{Timestamp: updatedTime},
+	}
+
+	updatedScene.Cover = &coverImageData
+	err = SetSceneScreenshot(t.Scene.Checksum, coverImageData)
+	_, err = qb.Update(updatedScene, tx)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (t *GeneratePreviewTask) doesPreviewExist(sceneChecksum string) bool {

--- a/pkg/manager/task_generate_preview.go
+++ b/pkg/manager/task_generate_preview.go
@@ -1,31 +1,15 @@
 package manager
 
 import (
-	"context"
-	"io/ioutil"
-	"os"
-	"sync"
-	"time"
-
-	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-)
-
-type GeneratePreviewTaskOperation int
-
-const (
-	PreviewTaskOpAll GeneratePreviewTaskOperation = iota
-	PreviewTaskOpDefaultScreenshot
-	PreviewTaskOpScreenshot
+	"sync"
 )
 
 type GeneratePreviewTask struct {
-	Scene        models.Scene
-	Operation    GeneratePreviewTaskOperation
-	ScreenshotAt float64
+	Scene models.Scene
 }
 
 func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
@@ -33,6 +17,9 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 
 	videoFilename := t.videoFilename()
 	imageFilename := t.imageFilename()
+	if t.doesPreviewExist(t.Scene.Checksum) {
+		return
+	}
 
 	videoFile, err := ffmpeg.NewVideoFile(instance.FFProbePath, t.Scene.Path)
 	if err != nil {
@@ -46,82 +33,10 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 		return
 	}
 
-	switch t.Operation {
-	case PreviewTaskOpAll:
-		if !t.doesPreviewExist(t.Scene.Checksum) {
-			err = generator.Generate()
-		}
-	case PreviewTaskOpDefaultScreenshot:
-		err = generator.GenerateDefaultImage()
-		if err == nil {
-			err = t.makeScreenshots()
-		}
-	case PreviewTaskOpScreenshot:
-		err = generator.GenerateImageAt(t.ScreenshotAt)
-		if err == nil {
-			err = t.makeScreenshots()
-		}
-	}
-
-	if err != nil {
+	if err := generator.Generate(); err != nil {
 		logger.Errorf("error generating preview: %s", err.Error())
 		return
 	}
-}
-
-func (t *GeneratePreviewTask) makeScreenshots() error {
-	checksum := t.Scene.Checksum
-	normalPath := instance.Paths.Scene.GetScreenshotPath(checksum)
-
-	probeResult, err := ffmpeg.NewVideoFile(instance.FFProbePath, t.Scene.Path)
-
-	if err != nil {
-		return err
-	}
-
-	at := t.ScreenshotAt
-	if t.Operation == PreviewTaskOpDefaultScreenshot {
-		at = float64(probeResult.Duration) * 0.2
-	}
-
-	// we'll generate the screenshot, grab the generated data and set it
-	// in the database. We'll use SetSceneScreenshot to set the data
-	// which also generates the thumbnail
-	makeScreenshot(*probeResult, normalPath, 2, probeResult.Width, at)
-
-	f, err := os.Open(normalPath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	coverImageData, err := ioutil.ReadAll(f)
-	if err != nil {
-		return err
-	}
-
-	ctx := context.TODO()
-	tx := database.DB.MustBeginTx(ctx, nil)
-
-	qb := models.NewSceneQueryBuilder()
-	updatedTime := time.Now()
-	updatedScene := models.ScenePartial{
-		ID:        t.Scene.ID,
-		UpdatedAt: &models.SQLiteTimestamp{Timestamp: updatedTime},
-	}
-
-	updatedScene.Cover = &coverImageData
-	err = SetSceneScreenshot(t.Scene.Checksum, coverImageData)
-	_, err = qb.Update(updatedScene, tx)
-	if err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (t *GeneratePreviewTask) doesPreviewExist(sceneChecksum string) bool {

--- a/pkg/manager/task_generate_screenshot.go
+++ b/pkg/manager/task_generate_screenshot.go
@@ -1,0 +1,43 @@
+package manager
+
+import (
+	"sync"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type GenerateScreenshotTask struct {
+	Scene        models.Scene
+	ScreenshotAt *float64
+}
+
+func (t *GenerateScreenshotTask) Start(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	scenePath := t.Scene.Path
+	probeResult, err := ffmpeg.NewVideoFile(instance.FFProbePath, scenePath)
+
+	if err != nil {
+		logger.Error(err.Error())
+		return
+	}
+
+	var at float64
+	if t.ScreenshotAt == nil {
+		at = float64(probeResult.Duration) * 0.2
+	} else {
+		at = *t.ScreenshotAt
+	}
+
+	checksum := t.Scene.Checksum
+	thumbPath := instance.Paths.Scene.GetThumbnailScreenshotPath(checksum)
+	normalPath := instance.Paths.Scene.GetScreenshotPath(checksum)
+
+	logger.Debugf("Creating thumbnail for %s", scenePath)
+	makeScreenshot(*probeResult, thumbPath, 5, 320, at)
+
+	logger.Debugf("Creating screenshot for %s", scenePath)
+	makeScreenshot(*probeResult, normalPath, 2, probeResult.Width, at)
+}

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -177,26 +177,17 @@ func (t *ScanTask) makeScreenshots(probeResult *ffmpeg.VideoFile, checksum strin
 		logger.Infof("Regenerating images for %s", t.FilePath)
 	}
 
+	at := float64(probeResult.Duration) * 0.2
+
 	if !thumbExists {
 		logger.Debugf("Creating thumbnail for %s", t.FilePath)
-		t.makeScreenshot(*probeResult, thumbPath, 5, 320)
+		makeScreenshot(*probeResult, thumbPath, 5, 320, at)
 	}
 
 	if !normalExists {
 		logger.Debugf("Creating screenshot for %s", t.FilePath)
-		t.makeScreenshot(*probeResult, normalPath, 2, probeResult.Width)
+		makeScreenshot(*probeResult, normalPath, 2, probeResult.Width, at)
 	}
-}
-
-func (t *ScanTask) makeScreenshot(probeResult ffmpeg.VideoFile, outputPath string, quality int, width int) {
-	encoder := ffmpeg.NewEncoder(instance.FFMPEGPath)
-	options := ffmpeg.ScreenshotOptions{
-		OutputPath: outputPath,
-		Quality:    quality,
-		Time:       float64(probeResult.Duration) * 0.2,
-		Width:      width,
-	}
-	encoder.Screenshot(probeResult, options)
 }
 
 func (t *ScanTask) calculateChecksum() (string, error) {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerOperationsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerOperationsPanel.tsx
@@ -18,7 +18,7 @@ export const PerformerOperationsPanel: React.FC<IPerformerOperationsProps> = ({
       return;
     }
     try {
-      await StashService.queryMetadataAutoTag({ performers: [performer.id] });
+      await StashService.mutateMetadataAutoTag({ performers: [performer.id] });
       Toast.success({ content: "Started auto tagging" });
     } catch (e) {
       Toast.error(e);

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -14,6 +14,7 @@ import { SceneFileInfoPanel } from "./SceneFileInfoPanel";
 import { SceneEditPanel } from "./SceneEditPanel";
 import { SceneDetailPanel } from "./SceneDetailPanel";
 import { OCounterButton } from "./OCounterButton";
+import { SceneOperationsPanel } from "./SceneOperationsPanel";
 
 export const Scene: React.FC = () => {
   const { id = "new" } = useParams();
@@ -142,6 +143,11 @@ export const Scene: React.FC = () => {
               scene={scene}
               onUpdate={newScene => setScene(newScene)}
               onDelete={() => history.push("/scenes")}
+            />
+          </Tab>
+          <Tab eventKey="scene-operations-panel" title="Operations">
+            <SceneOperationsPanel 
+              scene={scene} 
             />
           </Tab>
         </Tabs>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneOperationsPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneOperationsPanel.tsx
@@ -1,0 +1,45 @@
+import { Button } from "react-bootstrap";
+import React, { FunctionComponent } from "react";
+import * as GQL from "src/core/generated-graphql";
+import { StashService } from "src/core/StashService";
+import { useToast } from "src/hooks";
+
+interface IOperationsPanelProps {
+  scene: GQL.SceneDataFragment;
+  playerPosition?: number;
+}
+
+export const SceneOperationsPanel: FunctionComponent<IOperationsPanelProps> = (props: IOperationsPanelProps) => {
+  const Toast = useToast();
+  const [generateScreenshot] = StashService.useSceneGenerateScreenshot();
+
+  async function onGenerateScreenshot() {
+    await generateScreenshot({
+      variables: {
+        id: props.scene.id,
+        at: props.playerPosition
+      }
+    });
+    Toast.success({ content: "Generating screenshot" });
+  }
+
+  async function onGenerateDefaultScreenshot() {
+    await generateScreenshot({
+      variables: {
+        id: props.scene.id,
+      }
+    });
+    Toast.success({ content: "Generating screenshot" });
+  }
+
+  return (
+    <>
+      <Button className="edit-button" onClick={() => onGenerateScreenshot()}>
+        Generate thumbnail from current
+      </Button>
+      <Button className="edit-button" onClick={() => onGenerateDefaultScreenshot()}>
+        Generate default thumbnail
+      </Button>
+    </>
+  );
+};

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneOperationsPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneOperationsPanel.tsx
@@ -3,30 +3,21 @@ import React, { FunctionComponent } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { StashService } from "src/core/StashService";
 import { useToast } from "src/hooks";
+import { JWUtils } from "src/utils";
 
 interface IOperationsPanelProps {
   scene: GQL.SceneDataFragment;
-  playerPosition?: number;
 }
 
 export const SceneOperationsPanel: FunctionComponent<IOperationsPanelProps> = (props: IOperationsPanelProps) => {
   const Toast = useToast();
   const [generateScreenshot] = StashService.useSceneGenerateScreenshot();
 
-  async function onGenerateScreenshot() {
+  async function onGenerateScreenshot(at?: number) {
     await generateScreenshot({
       variables: {
         id: props.scene.id,
-        at: props.playerPosition
-      }
-    });
-    Toast.success({ content: "Generating screenshot" });
-  }
-
-  async function onGenerateDefaultScreenshot() {
-    await generateScreenshot({
-      variables: {
-        id: props.scene.id,
+        at: at
       }
     });
     Toast.success({ content: "Generating screenshot" });
@@ -34,10 +25,10 @@ export const SceneOperationsPanel: FunctionComponent<IOperationsPanelProps> = (p
 
   return (
     <>
-      <Button className="edit-button" onClick={() => onGenerateScreenshot()}>
+      <Button className="edit-button" onClick={() => onGenerateScreenshot(JWUtils.getPlayer().getPosition())}>
         Generate thumbnail from current
       </Button>
-      <Button className="edit-button" onClick={() => onGenerateDefaultScreenshot()}>
+      <Button className="edit-button" onClick={() => onGenerateScreenshot()}>
         Generate default thumbnail
       </Button>
     </>

--- a/ui/v2.5/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
@@ -12,7 +12,7 @@ export const GenerateButton: React.FC = () => {
 
   async function onGenerate() {
     try {
-      await StashService.queryMetadataGenerate({
+      await StashService.mutateMetadataGenerate({
         sprites,
         previews,
         markers,

--- a/ui/v2.5/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -68,7 +68,7 @@ export const SettingsTasksPanel: React.FC = () => {
 
   function onImport() {
     setIsImportAlertOpen(false);
-    StashService.queryMetadataImport().then(() => {
+    StashService.mutateMetadataImport().then(() => {
       jobStatus.refetch();
     });
   }
@@ -91,7 +91,7 @@ export const SettingsTasksPanel: React.FC = () => {
 
   function onClean() {
     setIsCleanAlertOpen(false);
-    StashService.queryMetadataClean().then(() => {
+    StashService.mutateMetadataClean().then(() => {
       jobStatus.refetch();
     });
   }
@@ -115,7 +115,7 @@ export const SettingsTasksPanel: React.FC = () => {
 
   async function onScan() {
     try {
-      await StashService.queryMetadataScan({ useFileMetadata });
+      await StashService.mutateMetadataScan({ useFileMetadata });
       Toast.success({ content: "Started scan" });
       jobStatus.refetch();
     } catch (e) {
@@ -134,7 +134,7 @@ export const SettingsTasksPanel: React.FC = () => {
 
   async function onAutoTag() {
     try {
-      await StashService.queryMetadataAutoTag(getAutoTagInput());
+      await StashService.mutateMetadataAutoTag(getAutoTagInput());
       Toast.success({ content: "Started auto tagging" });
       jobStatus.refetch();
     } catch (e) {
@@ -153,7 +153,7 @@ export const SettingsTasksPanel: React.FC = () => {
           id="stop"
           variant="danger"
           onClick={() =>
-            StashService.queryStopJob().then(() => jobStatus.refetch())
+            StashService.mutateStopJob().then(() => jobStatus.refetch())
           }
         >
           Stop
@@ -277,7 +277,7 @@ export const SettingsTasksPanel: React.FC = () => {
           variant="secondary"
           type="submit"
           onClick={() =>
-            StashService.queryMetadataExport().then(() => {
+            StashService.mutateMetadataExport().then(() => {
               jobStatus.refetch();
             })
           }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -115,7 +115,7 @@ export const Studio: React.FC = () => {
   async function onAutoTag() {
     if (!studio.id) return;
     try {
-      await StashService.queryMetadataAutoTag({ studios: [studio.id] });
+      await StashService.mutateMetadataAutoTag({ studios: [studio.id] });
       Toast.success({ content: "Started auto tagging" });
     } catch (e) {
       Toast.error(e);

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -62,7 +62,7 @@ export const TagList: React.FC = () => {
   async function onAutoTag(tag: GQL.TagDataFragment) {
     if (!tag) return;
     try {
-      await StashService.queryMetadataAutoTag({ tags: [tag.id] });
+      await StashService.mutateMetadataAutoTag({ tags: [tag.id] });
       Toast.success({ content: "Started auto tagging" });
     } catch (e) {
       Toast.error(e);

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -407,6 +407,12 @@ export class StashService {
     });
   }
 
+  public static useSceneGenerateScreenshot() {
+    return GQL.useSceneGenerateScreenshotMutation({ 
+      update: () => StashService.invalidateQueries(["findScenes"]),
+    });
+  }
+
   private static studioMutationImpactedQueries = [
     "findStudios",
     "findScenes",
@@ -506,10 +512,9 @@ export class StashService {
     });
   }
 
-  public static queryStopJob() {
-    return StashService.client.query<GQL.StopJobQuery>({
-      query: GQL.StopJobDocument,
-      fetchPolicy: "network-only"
+  public static mutateStopJob() {
+    return StashService.client.mutate<GQL.StopJobMutation>({
+      mutation: GQL.StopJobDocument,
     });
   }
 
@@ -566,48 +571,42 @@ export class StashService {
     });
   }
 
-  public static queryMetadataScan(input: GQL.ScanMetadataInput) {
-    return StashService.client.query<GQL.MetadataScanQuery>({
-      query: GQL.MetadataScanDocument,
+  public static mutateMetadataScan(input: GQL.ScanMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataScanMutation>({
+      mutation: GQL.MetadataScanDocument,
       variables: { input },
-      fetchPolicy: "network-only"
     });
   }
 
-  public static queryMetadataAutoTag(input: GQL.AutoTagMetadataInput) {
-    return StashService.client.query<GQL.MetadataAutoTagQuery>({
-      query: GQL.MetadataAutoTagDocument,
+  public static mutateMetadataAutoTag(input: GQL.AutoTagMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataAutoTagMutation>({
+      mutation: GQL.MetadataAutoTagDocument,
       variables: { input },
-      fetchPolicy: "network-only"
     });
   }
 
-  public static queryMetadataGenerate(input: GQL.GenerateMetadataInput) {
-    return StashService.client.query<GQL.MetadataGenerateQuery>({
-      query: GQL.MetadataGenerateDocument,
+  public static mutateMetadataGenerate(input: GQL.GenerateMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataGenerateMutation>({
+      mutation: GQL.MetadataGenerateDocument,
       variables: { input },
-      fetchPolicy: "network-only"
     });
   }
 
-  public static queryMetadataClean() {
-    return StashService.client.query<GQL.MetadataCleanQuery>({
-      query: GQL.MetadataCleanDocument,
-      fetchPolicy: "network-only"
+  public static mutateMetadataClean() {
+    return StashService.client.mutate<GQL.MetadataCleanMutation>({
+      mutation: GQL.MetadataCleanDocument,
     });
   }
 
-  public static queryMetadataExport() {
-    return StashService.client.query<GQL.MetadataExportQuery>({
-      query: GQL.MetadataExportDocument,
-      fetchPolicy: "network-only"
+  public static mutateMetadataExport() {
+    return StashService.client.mutate<GQL.MetadataExportMutation>({
+      mutation: GQL.MetadataExportDocument,
     });
   }
 
-  public static queryMetadataImport() {
-    return StashService.client.query<GQL.MetadataImportQuery>({
-      query: GQL.MetadataImportDocument,
-      fetchPolicy: "network-only"
+  public static mutateMetadataImport() {
+    return StashService.client.mutate<GQL.MetadataImportMutation>({
+      mutation: GQL.MetadataImportDocument,
     });
   }
 

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
@@ -18,7 +18,7 @@ export const GenerateButton: FunctionComponent<IProps> = () => {
 
   async function onGenerate() {
     try {
-      await StashService.queryMetadataGenerate({sprites, previews, markers, transcodes});
+      await StashService.mutateMetadataGenerate({sprites, previews, markers, transcodes});
       ToastUtils.success("Started generating");
     } catch (e) {
       ErrorUtils.handle(e);

--- a/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -78,7 +78,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   function onImport() {
     setIsImportAlertOpen(false);
-    StashService.queryMetadataImport().then(() => { jobStatus.refetch()});
+    StashService.mutateMetadataImport().then(() => { jobStatus.refetch()});
   }
 
   function renderImportAlert() {
@@ -102,7 +102,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   function onClean() {
     setIsCleanAlertOpen(false);
-    StashService.queryMetadataClean().then(() => { jobStatus.refetch()});
+    StashService.mutateMetadataClean().then(() => { jobStatus.refetch()});
   }
 
   function renderCleanAlert() {
@@ -127,7 +127,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   async function onScan() {
     try {
-      await StashService.queryMetadataScan({useFileMetadata: useFileMetadata});
+      await StashService.mutateMetadataScan({useFileMetadata: useFileMetadata});
       ToastUtils.success("Started scan");
       jobStatus.refetch();
     } catch (e) {
@@ -146,7 +146,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
 
   async function onAutoTag() {
     try {
-      await StashService.queryMetadataAutoTag(getAutoTagInput());
+      await StashService.mutateMetadataAutoTag(getAutoTagInput());
       ToastUtils.success("Started auto tagging");
       jobStatus.refetch();
     } catch (e) {
@@ -162,7 +162,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
     return (
       <>
       <FormGroup>
-        <Button id="stop" text="Stop" intent="danger" onClick={() => StashService.queryStopJob().then(() => jobStatus.refetch())} />
+        <Button id="stop" text="Stop" intent="danger" onClick={() => StashService.mutateStopJob().then(() => jobStatus.refetch())} />
       </FormGroup>
       </>
     );
@@ -256,7 +256,7 @@ export const SettingsTasksPanel: FunctionComponent<IProps> = (props: IProps) => 
         labelFor="export"
         inline={true}
       >
-        <Button id="export" text="Export" onClick={() => StashService.queryMetadataExport().then(() => { jobStatus.refetch()})} />
+        <Button id="export" text="Export" onClick={() => StashService.mutateMetadataExport().then(() => { jobStatus.refetch()})} />
       </FormGroup>
 
       <FormGroup

--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -109,7 +109,7 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
       return;
     }
     try {
-      await StashService.queryMetadataAutoTag({ studios: [studio.id]});
+      await StashService.mutateMetadataAutoTag({ studios: [studio.id]});
       ToastUtils.success("Started auto tagging");
     } catch (e) {
       ErrorUtils.handle(e);

--- a/ui/v2/src/components/Tags/TagList.tsx
+++ b/ui/v2/src/components/Tags/TagList.tsx
@@ -76,7 +76,7 @@ export const TagList: FunctionComponent<IProps> = (props: IProps) => {
       return;
     }
     try {
-      await StashService.queryMetadataAutoTag({ tags: [tag.id]});
+      await StashService.mutateMetadataAutoTag({ tags: [tag.id]});
       ToastUtils.success("Started auto tagging");
     } catch (e) {
       ErrorUtils.handle(e);

--- a/ui/v2/src/components/performers/PerformerDetails/PerformerOperationsPanel.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/PerformerOperationsPanel.tsx
@@ -18,7 +18,7 @@ export const PerformerOperationsPanel: FunctionComponent<IPerformerOperationsPro
         return;
     }
     try {
-        await StashService.queryMetadataAutoTag({ performers: [props.performer.id]});
+        await StashService.mutateMetadataAutoTag({ performers: [props.performer.id]});
         ToastUtils.success("Started auto tagging");
     } catch (e) {
         ErrorUtils.handle(e);

--- a/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/Scene.tsx
@@ -19,6 +19,7 @@ import { ScenePerformerPanel } from "./ScenePerformerPanel";
 import { SceneMoviePanel } from "./SceneMoviePanel";
 import { ErrorUtils } from "../../../utils/errors";
 import { IOCounterButtonProps, OCounterButton } from "../OCounterButton";
+import { SceneOperationsPanel } from "./SceneOperationsPanel";
 
 interface ISceneProps extends IBaseProps {}
 
@@ -158,6 +159,14 @@ export const Scene: FunctionComponent<ISceneProps> = (props: ISceneProps) => {
                   scene={modifiedScene} 
                   onUpdate={(newScene) => setScene(newScene)} 
                   onDelete={() => props.history.push("/scenes")}
+                />}
+            />
+            <Tab
+              id="scene-operations-panel"
+              title="Operations"
+              panel={
+                <SceneOperationsPanel 
+                  scene={modifiedScene} 
                 />}
             />
 

--- a/ui/v2/src/components/scenes/SceneDetails/SceneOperationsPanel.tsx
+++ b/ui/v2/src/components/scenes/SceneDetails/SceneOperationsPanel.tsx
@@ -1,0 +1,47 @@
+import {
+    Button,
+  } from "@blueprintjs/core";
+  import React, { FunctionComponent } from "react";
+  import * as GQL from "../../../core/generated-graphql";
+  import { StashService } from "../../../core/StashService";
+  import { SceneHelpers } from "../helpers";
+import { ToastUtils } from "../../../utils/toasts";
+  
+  interface IOperationsPanelProps {
+    scene: GQL.SceneDataFragment;
+  }
+  
+  export const SceneOperationsPanel: FunctionComponent<IOperationsPanelProps> = (props: IOperationsPanelProps) => {
+
+    const jwplayer = SceneHelpers.getPlayer();
+    const generateScreenshot = StashService.useSceneGenerateScreenshot();
+
+    async function onGenerateScreenshot() {
+      let position = jwplayer.getPosition();
+
+      await generateScreenshot({
+        variables: {
+          id: props.scene.id,
+          at: position
+        }
+      });
+      ToastUtils.success("Generating screenshot");
+    }
+    
+    async function onGenerateDefaultScreenshot() {
+      await generateScreenshot({
+        variables: {
+          id: props.scene.id,
+        }
+      });
+      ToastUtils.success("Generating screenshot");
+    }
+
+    return (
+      <>
+        <Button className="edit-button" text="Generate thumbnail from current" onClick={() => onGenerateScreenshot()}/>
+        <Button className="edit-button" text="Generate default thumbnail" onClick={() => onGenerateDefaultScreenshot()}/>
+      </>
+    );
+  };
+  

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -355,6 +355,12 @@ export class StashService {
     });
   }
 
+  public static useSceneGenerateScreenshot() {
+    return GQL.useSceneGenerateScreenshot({ 
+      update: () => StashService.invalidateQueries(["findScenes"]),
+    });
+  }
+
   private static studioMutationImpactedQueries = [
     "findStudios",
     "findScenes",

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -476,7 +476,6 @@ export class StashService {
   public static mutateStopJob() {
     return StashService.client.mutate<GQL.StopJobMutation>({
       mutation: GQL.StopJobDocument,
-      fetchPolicy: "network-only",
     });
   }
 
@@ -531,7 +530,6 @@ export class StashService {
     return StashService.client.mutate<GQL.MetadataScanMutation>({
       mutation: GQL.MetadataScanDocument,
       variables: { input },
-      fetchPolicy: "network-only",
     });
   }
 
@@ -539,7 +537,6 @@ export class StashService {
     return StashService.client.mutate<GQL.MetadataAutoTagMutation>({
       mutation: GQL.MetadataAutoTagDocument,
       variables: { input },
-      fetchPolicy: "network-only",
     });
   }
 
@@ -547,28 +544,24 @@ export class StashService {
     return StashService.client.mutate<GQL.MetadataGenerateMutation>({
       mutation: GQL.MetadataGenerateDocument,
       variables: { input },
-      fetchPolicy: "network-only",
     });
   }
 
   public static mutateMetadataClean() {
     return StashService.client.mutate<GQL.MetadataCleanMutation>({
       mutation: GQL.MetadataCleanDocument,
-      fetchPolicy: "network-only",
     });
   }
 
   public static mutateMetadataExport() {
     return StashService.client.mutate<GQL.MetadataExportMutation>({
       mutation: GQL.MetadataExportDocument,
-      fetchPolicy: "network-only",
     });
   }
 
   public static mutateMetadataImport() {
     return StashService.client.mutate<GQL.MetadataImportMutation>({
       mutation: GQL.MetadataImportDocument,
-      fetchPolicy: "network-only",
     });
   }
 

--- a/ui/v2/src/core/StashService.ts
+++ b/ui/v2/src/core/StashService.ts
@@ -467,9 +467,9 @@ export class StashService {
     });
   }
 
-  public static queryStopJob() {
-    return StashService.client.query<GQL.StopJobQuery>({
-      query: GQL.StopJobDocument,
+  public static mutateStopJob() {
+    return StashService.client.mutate<GQL.StopJobMutation>({
+      mutation: GQL.StopJobDocument,
       fetchPolicy: "network-only",
     });
   }
@@ -521,47 +521,47 @@ export class StashService {
     });
   }
 
-  public static queryMetadataScan(input: GQL.ScanMetadataInput) {
-    return StashService.client.query<GQL.MetadataScanQuery>({
-      query: GQL.MetadataScanDocument,
+  public static mutateMetadataScan(input: GQL.ScanMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataScanMutation>({
+      mutation: GQL.MetadataScanDocument,
       variables: { input },
       fetchPolicy: "network-only",
     });
   }
 
-  public static queryMetadataAutoTag(input: GQL.AutoTagMetadataInput) {
-    return StashService.client.query<GQL.MetadataAutoTagQuery>({
-      query: GQL.MetadataAutoTagDocument,
+  public static mutateMetadataAutoTag(input: GQL.AutoTagMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataAutoTagMutation>({
+      mutation: GQL.MetadataAutoTagDocument,
       variables: { input },
       fetchPolicy: "network-only",
     });
   }
 
-  public static queryMetadataGenerate(input: GQL.GenerateMetadataInput) {
-    return StashService.client.query<GQL.MetadataGenerateQuery>({
-      query: GQL.MetadataGenerateDocument,
+  public static mutateMetadataGenerate(input: GQL.GenerateMetadataInput) {
+    return StashService.client.mutate<GQL.MetadataGenerateMutation>({
+      mutation: GQL.MetadataGenerateDocument,
       variables: { input },
       fetchPolicy: "network-only",
     });
   }
 
-  public static queryMetadataClean() {
-    return StashService.client.query<GQL.MetadataCleanQuery>({
-      query: GQL.MetadataCleanDocument,
+  public static mutateMetadataClean() {
+    return StashService.client.mutate<GQL.MetadataCleanMutation>({
+      mutation: GQL.MetadataCleanDocument,
       fetchPolicy: "network-only",
     });
   }
 
-  public static queryMetadataExport() {
-    return StashService.client.query<GQL.MetadataExportQuery>({
-      query: GQL.MetadataExportDocument,
+  public static mutateMetadataExport() {
+    return StashService.client.mutate<GQL.MetadataExportMutation>({
+      mutation: GQL.MetadataExportDocument,
       fetchPolicy: "network-only",
     });
   }
 
-  public static queryMetadataImport() {
-    return StashService.client.query<GQL.MetadataImportQuery>({
-      query: GQL.MetadataImportDocument,
+  public static mutateMetadataImport() {
+    return StashService.client.mutate<GQL.MetadataImportMutation>({
+      mutation: GQL.MetadataImportDocument,
       fetchPolicy: "network-only",
     });
   }


### PR DESCRIPTION
Resolves #9 

Note: this change also moves the scan/generate/import/export operations from `query` to `mutation`, since these are mutating operations. This will impact external scripts using these operations.

Adds a new tab to the scene page - Operations. Within this tab, there are two buttons. One generates the cover image for the scene based on the current position of the scene player, the other generates the cover image using the default settings.

Note that a page refresh may be required to see the updated images after generation, due to caching.