### PR TITLE
Fix version check for v0.1.0+

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -96,6 +96,39 @@ type githubTagResponse struct {
 	Node_id string
 }
 
+func makeGithubRequest(url string, output interface{}) error {
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+
+	req, _ := http.NewRequest("GET", url, nil)
+
+	req.Header.Add("Accept", apiAcceptHeader) // gh api recommendation , send header with api version
+	response, err := client.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("Github API request failed: %s", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("Github API request failed: %s", response.Status)
+	}
+
+	defer response.Body.Close()
+
+	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("Github API read response failed: %s", err)
+	}
+
+	err = json.Unmarshal(data, output)
+	if err != nil {
+		return fmt.Errorf("Unmarshalling Github API response failed: %s", err)
+	}
+
+	return nil
+}
+
 // GetLatestVersion gets latest version (git commit hash) from github API
 // If running a build from the "master" branch, then the latest full release
 // is used, otherwise it uses the release that is tagged with "latest_develop"
@@ -117,10 +150,6 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 		usePreRelease = true
 	}
 
-	client := &http.Client{
-		Timeout: 3 * time.Second,
-	}
-
 	url := apiReleases
 	if !usePreRelease {
 		// just get the latest full release
@@ -129,40 +158,17 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 		// get the release tagged with the development tag
 		url += "/tags/" + developmentTag
 	}
-	req, _ := http.NewRequest("GET", url, nil)
-
-	req.Header.Add("Accept", apiAcceptHeader) // gh api recommendation , send header with api version
-	response, err := client.Do(req)
 
 	release := githubReleasesResponse{}
+	err = makeGithubRequest(url, &release)
 
 	if err != nil {
-		return "", "", fmt.Errorf("Github API request failed: %s", err)
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Github API request failed: %s", response.Status)
-	}
-
-	defer response.Body.Close()
-
-	data, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", "", fmt.Errorf("Github API read response failed: %s", err)
-	}
-	err = json.Unmarshal(data, &release)
-	if err != nil {
-		return "", "", fmt.Errorf("Unmarshalling Github API response failed: %s", err)
+		return "", "", err
 	}
 
 	if release.Prerelease == usePreRelease {
-		if len(release.Target_commitish) != 40 { // sha is not present in the commit
-			latestVersion = getShaFromTags(shortHash, version)
-		} else if shortHash {
-			latestVersion = release.Target_commitish[0:7] //shorthash is first 7 digits of git commit hash
-		} else {
-			latestVersion = release.Target_commitish
-		}
+		latestVersion = getReleaseHash(release, shortHash, usePreRelease)
+
 		if wantedRelease != "" {
 			for _, asset := range release.Assets {
 				if asset.Name == wantedRelease {
@@ -177,6 +183,20 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 		return "", "", fmt.Errorf("No version found for \"%s\"", version)
 	}
 	return latestVersion, latestRelease, nil
+}
+
+func getReleaseHash(release githubReleasesResponse, shortHash bool, usePreRelease bool) string {
+	// the /latest API call doesn't return the hash in target_commitish
+	// also add sanity check in case Target_commitish is not 40 characters
+	if !usePreRelease || len(release.Target_commitish) != 40 {
+		return getShaFromTags(shortHash, release.Tag_name)
+	}
+
+	if shortHash {
+		return release.Target_commitish[0:7] //shorthash is first 7 digits of git commit hash
+	}
+
+	return release.Target_commitish
 }
 
 func printLatestVersion() {
@@ -196,48 +216,27 @@ func printLatestVersion() {
 // get sha from the github api tags endpoint
 // returns the sha1 hash/shorthash or "" if something's wrong
 func getShaFromTags(shortHash bool, name string) string {
-	client := &http.Client{
-		Timeout: 3 * time.Second,
+	url := apiTags
+	tags := []githubTagResponse{}
+	err := makeGithubRequest(url, &tags)
+
+	if err != nil {
+		logger.Errorf("Github Tags Api %v", err)
+		return ""
 	}
 
-	url := apiTags
-	req, _ := http.NewRequest("GET", url, nil)
-
-	req.Header.Add("Accept", apiAcceptHeader) // gh api recommendation , send header with api version
-	response, err := client.Do(req)
-	if err != nil {
-		logger.Errorf("Gihub Tags Api %v", err)
-		return ""
-	} else {
-		defer response.Body.Close()
-
-		data, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			logger.Errorf("Gihub Tags Api %v", err)
-			return ""
-		} else {
-			tags := []githubTagResponse{}
-			err = json.Unmarshal(data, &tags)
-			if err != nil {
-				logger.Errorf("Gihub Tags Api %v", err)
+	for _, tag := range tags {
+		if tag.Name == name {
+			if len(tag.Commit.Sha) != 40 {
 				return ""
-			} else {
-				for _, tag := range tags {
-					if tag.Name == name {
-						if len(tag.Commit.Sha) != 40 {
-							return ""
-						}
-						if shortHash {
-							return tag.Commit.Sha[0:7] //shorthash is first 7 digits of git commit hash
-						} else {
-							return tag.Commit.Sha
-						}
-					}
-				}
 			}
+			if shortHash {
+				return tag.Commit.Sha[0:7] //shorthash is first 7 digits of git commit hash
+			}
+
+			return tag.Commit.Sha
 		}
 	}
 
 	return ""
-
 }


### PR DESCRIPTION
Fix `panic: runtime error: slice bounds out of range`
Adding the tag to the master release changed the target_commitish part of the version in the releases endpoint to "master" from the sha value it had before
The only place to look for the sha value for v.0.1.0 ( "master ") is now the tags endpoint of github api and the commit.sha part specific
So if we don't have the sha from the releases endpoint we fallback to a call to the tags endpoint using the `version` as the tag name