### PR TITLE
Use parameter binding for all queries

### DIFF
--- a/pkg/models/querybuilder_gallery.go
+++ b/pkg/models/querybuilder_gallery.go
@@ -119,7 +119,9 @@ func (qb *GalleryQueryBuilder) Query(findFilter *FindFilterType) ([]*Gallery, in
 
 	if q := findFilter.Q; q != nil && *q != "" {
 		searchColumns := []string{"galleries.path", "galleries.checksum"}
-		whereClauses = append(whereClauses, getSearch(searchColumns, *q))
+		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
+		whereClauses = append(whereClauses, clause)
+		args = append(args, thisArgs...)
 	}
 
 	sortAndPagination := qb.getGallerySort(findFilter) + getPagination(findFilter)

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -221,7 +221,9 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 
 	if q := findFilter.Q; q != nil && *q != "" {
 		searchColumns := []string{"scenes.title", "scenes.details", "scenes.path", "scenes.checksum", "scene_markers.title"}
-		whereClauses = append(whereClauses, getSearch(searchColumns, *q))
+		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
+		whereClauses = append(whereClauses, clause)
+		args = append(args, thisArgs...)
 	}
 
 	if rating := sceneFilter.Rating; rating != nil {

--- a/pkg/models/querybuilder_scene_marker.go
+++ b/pkg/models/querybuilder_scene_marker.go
@@ -227,7 +227,9 @@ func (qb *SceneMarkerQueryBuilder) Query(sceneMarkerFilter *SceneMarkerFilterTyp
 
 	if q := findFilter.Q; q != nil && *q != "" {
 		searchColumns := []string{"scene_markers.title", "scene.title"}
-		whereClauses = append(whereClauses, getSearch(searchColumns, *q))
+		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
+		whereClauses = append(whereClauses, clause)
+		args = append(args, thisArgs...)
 	}
 
 	if tagID := sceneMarkerFilter.TagID; tagID != nil {

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -137,29 +137,6 @@ func getRandomSort(tableName string, direction string, seed float64) string {
 	return " ORDER BY " + "(substr(" + colName + " * " + randomSortString + ", length(" + colName + ") + 2))" + " " + direction
 }
 
-func getSearch(columns []string, q string) string {
-	// TODO - susceptible to SQL injection
-	var likeClauses []string
-	queryWords := strings.Split(q, " ")
-	trimmedQuery := strings.Trim(q, "\"")
-	if trimmedQuery == q {
-		// Search for any word
-		for _, word := range queryWords {
-			for _, column := range columns {
-				likeClauses = append(likeClauses, column+" LIKE '%"+word+"%'")
-			}
-		}
-	} else {
-		// Search the exact query
-		for _, column := range columns {
-			likeClauses = append(likeClauses, column+" LIKE '%"+trimmedQuery+"%'")
-		}
-	}
-	likes := strings.Join(likeClauses, " OR ")
-
-	return "(" + likes + ")"
-}
-
 func getSearchBinding(columns []string, q string, not bool) (string, []interface{}) {
 	var likeClauses []string
 	var args []interface{}

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -108,7 +108,9 @@ func (qb *StudioQueryBuilder) Query(findFilter *FindFilterType) ([]*Studio, int)
 
 	if q := findFilter.Q; q != nil && *q != "" {
 		searchColumns := []string{"studios.name"}
-		whereClauses = append(whereClauses, getSearch(searchColumns, *q))
+		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
+		whereClauses = append(whereClauses, clause)
+		args = append(args, thisArgs...)
 	}
 
 	sortAndPagination := qb.getStudioSort(findFilter) + getPagination(findFilter)

--- a/pkg/models/querybuilder_tag.go
+++ b/pkg/models/querybuilder_tag.go
@@ -147,7 +147,9 @@ func (qb *TagQueryBuilder) Query(findFilter *FindFilterType) ([]*Tag, int) {
 
 	if q := findFilter.Q; q != nil && *q != "" {
 		searchColumns := []string{"tags.name"}
-		whereClauses = append(whereClauses, getSearch(searchColumns, *q))
+		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
+		whereClauses = append(whereClauses, clause)
+		args = append(args, thisArgs...)
 	}
 
 	sortAndPagination := qb.getTagSort(findFilter) + getPagination(findFilter)


### PR DESCRIPTION
Using native paremeter binding prevents injection attacks and issues with quotes in search strings. Removed the old `getSearch` function since it shouldn't be used anymore. 