### PR TITLE
Update browser cache when images are updated

### DIFF
--- a/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2/src/components/Studios/StudioDetails/Studio.tsx
@@ -88,6 +88,10 @@ export const Studio: FunctionComponent<IProps> = (props: IProps) => {
     try {
       if (!isNew) {
         const result = await updateStudio();
+        if (image) {
+            // Refetch image to bust browser cache
+            await fetch(`/studio/${result.data.studioUpdate.id}/image`, { cache: "reload" });
+        }
         setStudio(result.data.studioUpdate);
       } else {
         const result = await createStudio();

--- a/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/Performer.tsx
@@ -59,6 +59,10 @@ export const Performer: FunctionComponent<IPerformerProps> = (props: IPerformerP
     try {
       if (!isNew) {
         const result = await updatePerformer({variables: performer as GQL.PerformerUpdateInput});
+        if (performer.image) {
+            // Refetch image to bust browser cache
+            await fetch(`/performer/${result.data.performerUpdate.id}/image`, { cache: "reload" });
+        }
         setPerformer(result.data.performerUpdate);
       } else {
         const result = await createPerformer({variables: performer as GQL.PerformerCreateInput});


### PR DESCRIPTION
Fetching with `{ cache: reload }` forces the browser to update the local cache with a new copy. This prevents the issue where the image remains the old one after it has been updated.

I wanted to do the same for scenes, but jwplayer ignores the fact that the cache has been updated, so I left the existing method alone.