### PR TITLE
Fix marker time setting in v2.5 UI

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
@@ -9,6 +9,7 @@ import {
   MarkerTitleSuggest
 } from "src/components/Shared";
 import { useToast } from "src/hooks";
+import { JWUtils } from "src/utils";
 
 interface IFormFields {
   title: string;
@@ -20,14 +21,12 @@ interface IFormFields {
 interface ISceneMarkerForm {
   sceneID: string;
   editingMarker?: GQL.SceneMarkerDataFragment;
-  playerPosition?: number;
   onClose: () => void;
 }
 
 export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
   sceneID,
   editingMarker,
-  playerPosition,
   onClose
 }) => {
   const [sceneMarkerCreate] = StashService.useSceneMarkerCreate();
@@ -81,7 +80,7 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
         onReset={() =>
           fieldProps.form.setFieldValue(
             "seconds",
-            Math.round(playerPosition ?? 0)
+            Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
           )
         }
         numericValue={Number.parseInt(fieldProps.field.value ?? "0", 10)}
@@ -116,7 +115,7 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
   const values: IFormFields = {
     title: editingMarker?.title ?? "",
     seconds: (
-      editingMarker?.seconds ?? Math.round(playerPosition ?? 0)
+      editingMarker?.seconds ?? Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
     ).toString(),
     primaryTagId: editingMarker?.primary_tag.id ?? "",
     tagIds: editingMarker?.tags.map(tag => tag.id) ?? []

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
@@ -115,7 +115,8 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
   const values: IFormFields = {
     title: editingMarker?.title ?? "",
     seconds: (
-      editingMarker?.seconds ?? Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
+      editingMarker?.seconds ??
+      Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
     ).toString(),
     primaryTagId: editingMarker?.primary_tag.id ?? "",
     tagIds: editingMarker?.tags.map(tag => tag.id) ?? []

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Button } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
 import { WallPanel } from "src/components/Wall/WallPanel";
-import { JWUtils } from "src/utils";
 import { PrimaryTags } from "./PrimaryTags";
 import { SceneMarkerForm } from "./SceneMarkerForm";
 
@@ -18,8 +17,6 @@ export const SceneMarkersPanel: React.FC<ISceneMarkersPanelProps> = (
   const [editingMarker, setEditingMarker] = useState<
     GQL.SceneMarkerDataFragment
   >();
-
-  const jwplayer = JWUtils.getPlayer();
 
   function onOpenEditor(marker?: GQL.SceneMarkerDataFragment) {
     setIsEditorOpen(true);
@@ -40,7 +37,6 @@ export const SceneMarkersPanel: React.FC<ISceneMarkersPanelProps> = (
       <SceneMarkerForm
         sceneID={props.scene.id}
         editingMarker={editingMarker}
-        playerPosition={jwplayer.getPlayer?.().playerPosition}
         onClose={closeEditor}
       />
     );


### PR DESCRIPTION
Fixes issue in v2.5 UI where the marker time would not be set to the current time when creating a new marker, nor would be set time button work correctly.