### PR TITLE
Add modes for performer/tag for bulk scene editing

### DIFF
--- a/graphql/documents/mutations/scene.graphql
+++ b/graphql/documents/mutations/scene.graphql
@@ -39,8 +39,8 @@ mutation BulkSceneUpdate(
   $rating: Int,
   $studio_id: ID,
   $gallery_id: ID,
-  $performer_ids: [ID!],
-  $tag_ids: [ID!]) {
+  $performer_ids: BulkUpdateIds,
+  $tag_ids: BulkUpdateIds) {
 
   bulkSceneUpdate(input: {
                         ids: $ids,

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -68,6 +68,17 @@ input SceneUpdateInput {
   cover_image: String
 }
 
+enum BulkUpdateIdMode {
+  SET
+  ADD
+  REMOVE
+}
+
+input BulkUpdateIds {
+  ids: [ID!]
+  mode: BulkUpdateIdMode!
+}
+
 input BulkSceneUpdateInput {
   clientMutationId: String
   ids: [ID!]
@@ -78,8 +89,8 @@ input BulkSceneUpdateInput {
   rating: Int
   studio_id: ID
   gallery_id: ID
-  performer_ids: [ID!]
-  tag_ids: [ID!]
+  performer_ids: BulkUpdateIds
+  tag_ids: BulkUpdateIds
 }
 
 input SceneDestroyInput {

--- a/ui/v2.5/src/components/Shared/MultiSet.tsx
+++ b/ui/v2.5/src/components/Shared/MultiSet.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+import * as GQL from "src/core/generated-graphql";
+import { FilterSelect } from "./Select";
+import { Button, InputGroup } from "react-bootstrap";
+import { Icon } from "src/components/Shared";
+
+type ValidTypes =
+  | GQL.SlimPerformerDataFragment
+  | GQL.Tag
+  | GQL.SlimStudioDataFragment;
+
+interface IMultiSetProps {
+  type: "performers" | "studios" | "tags";
+  ids?: string[];
+  mode: GQL.BulkUpdateIdMode;
+  onUpdate: (items: ValidTypes[]) => void;
+  onSetMode: (mode: GQL.BulkUpdateIdMode) => void;
+}
+
+const MultiSet: React.FunctionComponent<IMultiSetProps> = (props: IMultiSetProps) => {
+  function onUpdate(items: ValidTypes[]) {
+    props.onUpdate(items);
+  }
+
+  function getModeIcon() {
+    switch(props.mode) {
+      case GQL.BulkUpdateIdMode.Set:
+        return "pencil-alt";
+      case GQL.BulkUpdateIdMode.Add:
+        return "plus";
+      case GQL.BulkUpdateIdMode.Remove:
+        return "times";
+    }
+  }
+
+  function getModeText() {
+    switch(props.mode) {
+      case GQL.BulkUpdateIdMode.Set:
+        return "Set";
+      case GQL.BulkUpdateIdMode.Add:
+        return "Add";
+      case GQL.BulkUpdateIdMode.Remove:
+        return "Remove";
+    }
+  }
+
+  function nextMode() {
+    switch(props.mode) {
+      case GQL.BulkUpdateIdMode.Set:
+        return GQL.BulkUpdateIdMode.Add;
+      case GQL.BulkUpdateIdMode.Add:
+        return GQL.BulkUpdateIdMode.Remove;
+      case GQL.BulkUpdateIdMode.Remove:
+        return GQL.BulkUpdateIdMode.Set;
+    }
+  }
+
+  return (
+    <InputGroup className="multi-set">
+      <InputGroup.Prepend>
+        <Button 
+          size="sm"
+          variant="secondary"
+          onClick={() => props.onSetMode(nextMode())}
+          title={getModeText()}
+        >
+          <Icon icon={getModeIcon()} className="fa-fw" />
+        </Button>
+      </InputGroup.Prepend>
+      
+      <FilterSelect
+        type={props.type}
+        isMulti
+        isClearable={false}
+        onSelect={onUpdate}
+        ids={props.ids ?? []}
+      />
+    </InputGroup>
+  );
+};
+
+export default MultiSet;

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -68,3 +68,10 @@
     padding: 0;
   }
 }
+
+.multi-set > div.input-group-prepend + div  {
+  position: relative;
+  flex: 1 1;
+  min-width: 0;
+  margin-bottom: 0;
+}

--- a/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
+++ b/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
@@ -13,6 +13,7 @@ import { StashService } from "../../core/StashService";
 import * as GQL from "../../core/generated-graphql";
 import { ErrorUtils } from "../../utils/errors";
 import { ToastUtils } from "../../utils/toasts";
+import { FilterMultiSet, MultiSetMode } from "../select/FilterMultiSet";
 
 interface IListOperationProps {
   selected: GQL.SlimSceneDataFragment[],
@@ -22,7 +23,9 @@ interface IListOperationProps {
 export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (props: IListOperationProps) => {
   const [rating, setRating] = useState<string>("");
   const [studioId, setStudioId] = useState<string | undefined>(undefined);
+  const [performerMode, setPerformerMode] = React.useState<MultiSetMode>(MultiSetMode.ADD);
   const [performerIds, setPerformerIds] = useState<string[] | undefined>(undefined);
+  const [tagMode, setTagMode] = React.useState<MultiSetMode>(MultiSetMode.ADD);
   const [tagIds, setTagIds] = useState<string[] | undefined>(undefined);
 
   const updateScenes = StashService.useBulkSceneUpdate(getSceneInput());
@@ -241,8 +244,14 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
   }, [props.selected]);
 
   function renderMultiSelect(type: "performers" | "tags", initialIds: string[] | undefined) {
+    let mode = MultiSetMode.ADD;
+    switch (type) {
+      case "performers": mode = performerMode; break;
+      case "tags": mode = tagMode; break;
+    }
+
     return (
-      <FilterMultiSelect
+      <FilterMultiSet
         type={type}
         onUpdate={(items) => {
           const ids = items.map((i) => i.id);
@@ -251,7 +260,14 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
             case "tags": setTagIds(ids); break;
           }
         }}
+        onSetMode={(mode) => {
+          switch (type) {
+            case "performers": setPerformerMode(mode); break;
+            case "tags": setTagMode(mode); break;
+          }
+        }}
         initialIds={initialIds}
+        mode={mode}
       />
     );
   }

--- a/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
+++ b/ui/v2/src/components/scenes/SceneSelectedOptions.tsx
@@ -8,12 +8,11 @@ import {
 } from "@blueprintjs/core";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { FilterSelect } from "../select/FilterSelect";
-import { FilterMultiSelect } from "../select/FilterMultiSelect";
 import { StashService } from "../../core/StashService";
 import * as GQL from "../../core/generated-graphql";
 import { ErrorUtils } from "../../utils/errors";
 import { ToastUtils } from "../../utils/toasts";
-import { FilterMultiSet, MultiSetMode } from "../select/FilterMultiSet";
+import { FilterMultiSet } from "../select/FilterMultiSet";
 
 interface IListOperationProps {
   selected: GQL.SlimSceneDataFragment[],
@@ -23,9 +22,9 @@ interface IListOperationProps {
 export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (props: IListOperationProps) => {
   const [rating, setRating] = useState<string>("");
   const [studioId, setStudioId] = useState<string | undefined>(undefined);
-  const [performerMode, setPerformerMode] = React.useState<MultiSetMode>(MultiSetMode.ADD);
+  const [performerMode, setPerformerMode] = React.useState<GQL.BulkUpdateIdMode>(GQL.BulkUpdateIdMode.Add);
   const [performerIds, setPerformerIds] = useState<string[] | undefined>(undefined);
-  const [tagMode, setTagMode] = React.useState<MultiSetMode>(MultiSetMode.ADD);
+  const [tagMode, setTagMode] = React.useState<GQL.BulkUpdateIdMode>(GQL.BulkUpdateIdMode.Add);
   const [tagIds, setTagIds] = useState<string[] | undefined>(undefined);
 
   const updateScenes = StashService.useBulkSceneUpdate(getSceneInput());
@@ -33,6 +32,13 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
   // Network state
   const [isLoading, setIsLoading] = useState(false);
 
+  function makeBulkUpdateIds(ids: string[], mode: GQL.BulkUpdateIdMode) : GQL.BulkUpdateIds {
+    return {
+      mode,
+      ids
+    };
+  }
+  
   function getSceneInput() : GQL.BulkSceneUpdateInput {
     // need to determine what we are actually setting on each scene
     var aggregateRating = getRating(props.selected);
@@ -73,27 +79,27 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
     }
     
     // if performerIds are empty
-    if (!performerIds || performerIds.length === 0) {
+    if (performerMode == GQL.BulkUpdateIdMode.Set && (!performerIds || performerIds.length === 0)) {
       // and all scenes have the same ids,
       if (aggregatePerformerIds.length > 0) {
         // then unset the performerIds, otherwise ignore
-        sceneInput.performer_ids = performerIds;
+        sceneInput.performer_ids = makeBulkUpdateIds(performerIds || [], performerMode);
       }
     } else {
       // if performerIds non-empty, then we are setting them
-      sceneInput.performer_ids = performerIds;
+      sceneInput.performer_ids = makeBulkUpdateIds(performerIds || [], performerMode);
     }
     
     // if tagIds non-empty, then we are setting them
-    if (!tagIds || tagIds.length === 0) {
+    if (tagMode == GQL.BulkUpdateIdMode.Set && (!tagIds || tagIds.length === 0)) {
       // and all scenes have the same ids,
       if (aggregateTagIds.length > 0) {
         // then unset the tagIds, otherwise ignore
-        sceneInput.tag_ids = tagIds;
+        sceneInput.tag_ids = makeBulkUpdateIds(tagIds || [], tagMode);
       }
     } else {
       // if tagIds non-empty, then we are setting them
-      sceneInput.tag_ids = tagIds;
+      sceneInput.tag_ids = makeBulkUpdateIds(tagIds || [], tagMode);
     }
 
     return sceneInput;
@@ -235,16 +241,21 @@ export const SceneSelectedOptions: FunctionComponent<IListOperationProps> = (pro
     
     setRating(rating);
     setStudioId(studioId);
-    setPerformerIds(performerIds);
-    setTagIds(tagIds);
+    if (performerMode == GQL.BulkUpdateIdMode.Set) {
+      setPerformerIds(performerIds);
+    }
+
+    if (tagMode == GQL.BulkUpdateIdMode.Set) {
+      setTagIds(tagIds);
+    }
   }
 
   useEffect(() => {
     updateScenesEditState(props.selected);
-  }, [props.selected]);
+  }, [props.selected, performerMode, tagMode]);
 
   function renderMultiSelect(type: "performers" | "tags", initialIds: string[] | undefined) {
-    let mode = MultiSetMode.ADD;
+    let mode = GQL.BulkUpdateIdMode.Add;
     switch (type) {
       case "performers": mode = performerMode; break;
       case "tags": mode = tagMode; break;

--- a/ui/v2/src/components/select/FilterMultiSet.tsx
+++ b/ui/v2/src/components/select/FilterMultiSet.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import { MenuItem, ControlGroup, Button } from "@blueprintjs/core";
+import { IMultiSelectProps, ItemPredicate, ItemRenderer, MultiSelect } from "@blueprintjs/select";
+import * as GQL from "../../core/generated-graphql";
+import { StashService } from "../../core/StashService";
+import { HTMLInputProps } from "../../models";
+import { ErrorUtils } from "../../utils/errors";
+import { ToastUtils } from "../../utils/toasts";
+import { FilterMultiSelect } from "./FilterMultiSelect";
+
+const InternalPerformerMultiSelect = MultiSelect.ofType<GQL.AllPerformersForFilterAllPerformers>();
+const InternalTagMultiSelect = MultiSelect.ofType<GQL.AllTagsForFilterAllTags>();
+const InternalStudioMultiSelect = MultiSelect.ofType<GQL.AllStudiosForFilterAllStudios>();
+const InternalMovieMultiSelect = MultiSelect.ofType<GQL.AllMoviesForFilterAllMovies>();
+
+type ValidTypes =
+  GQL.AllPerformersForFilterAllPerformers |
+  GQL.AllTagsForFilterAllTags |
+  GQL.AllMoviesForFilterAllMovies | 
+  GQL.AllStudiosForFilterAllStudios;
+
+export enum MultiSetMode {
+    SET = "Set",
+    ADD = "Add",
+    REMOVE = "Remove"
+}
+
+interface IFilterMultiSetProps {
+  type: "performers" | "studios" | "movies" | "tags";
+  initialIds?: string[];
+  mode: MultiSetMode;
+  onUpdate: (items: ValidTypes[]) => void;
+  onSetMode: (mode: MultiSetMode) => void;
+}
+
+export const FilterMultiSet: React.FunctionComponent<IFilterMultiSetProps> = (props: IFilterMultiSetProps) => {
+  function onUpdate(items: ValidTypes[]) {
+    props.onUpdate(items);
+  }
+
+  function getModeIcon() {
+    switch(props.mode) {
+      case MultiSetMode.SET:
+        return "edit";
+      case MultiSetMode.ADD:
+        return "plus";
+      case MultiSetMode.REMOVE:
+        return "cross";
+    }
+  }
+
+  function nextMode() {
+    switch(props.mode) {
+      case MultiSetMode.SET:
+        return MultiSetMode.ADD;
+      case MultiSetMode.ADD:
+        return MultiSetMode.REMOVE;
+      case MultiSetMode.REMOVE:
+        return MultiSetMode.SET;
+    }
+  }
+
+  return (
+    <ControlGroup>
+      <Button 
+        icon={getModeIcon()} 
+        minimal={true} 
+        onClick={() => props.onSetMode(nextMode())}
+        title={props.mode}
+      />
+      <FilterMultiSelect
+        type={props.type}
+        initialIds={props.initialIds}
+        onUpdate={onUpdate}
+      />
+    </ControlGroup>
+  );
+};

--- a/ui/v2/src/components/select/FilterMultiSet.tsx
+++ b/ui/v2/src/components/select/FilterMultiSet.tsx
@@ -1,18 +1,8 @@
 import * as React from "react";
 
-import { MenuItem, ControlGroup, Button } from "@blueprintjs/core";
-import { IMultiSelectProps, ItemPredicate, ItemRenderer, MultiSelect } from "@blueprintjs/select";
+import { ControlGroup, Button } from "@blueprintjs/core";
 import * as GQL from "../../core/generated-graphql";
-import { StashService } from "../../core/StashService";
-import { HTMLInputProps } from "../../models";
-import { ErrorUtils } from "../../utils/errors";
-import { ToastUtils } from "../../utils/toasts";
 import { FilterMultiSelect } from "./FilterMultiSelect";
-
-const InternalPerformerMultiSelect = MultiSelect.ofType<GQL.AllPerformersForFilterAllPerformers>();
-const InternalTagMultiSelect = MultiSelect.ofType<GQL.AllTagsForFilterAllTags>();
-const InternalStudioMultiSelect = MultiSelect.ofType<GQL.AllStudiosForFilterAllStudios>();
-const InternalMovieMultiSelect = MultiSelect.ofType<GQL.AllMoviesForFilterAllMovies>();
 
 type ValidTypes =
   GQL.AllPerformersForFilterAllPerformers |
@@ -20,18 +10,12 @@ type ValidTypes =
   GQL.AllMoviesForFilterAllMovies | 
   GQL.AllStudiosForFilterAllStudios;
 
-export enum MultiSetMode {
-    SET = "Set",
-    ADD = "Add",
-    REMOVE = "Remove"
-}
-
 interface IFilterMultiSetProps {
   type: "performers" | "studios" | "movies" | "tags";
   initialIds?: string[];
-  mode: MultiSetMode;
+  mode: GQL.BulkUpdateIdMode;
   onUpdate: (items: ValidTypes[]) => void;
-  onSetMode: (mode: MultiSetMode) => void;
+  onSetMode: (mode: GQL.BulkUpdateIdMode) => void;
 }
 
 export const FilterMultiSet: React.FunctionComponent<IFilterMultiSetProps> = (props: IFilterMultiSetProps) => {
@@ -41,23 +25,34 @@ export const FilterMultiSet: React.FunctionComponent<IFilterMultiSetProps> = (pr
 
   function getModeIcon() {
     switch(props.mode) {
-      case MultiSetMode.SET:
+      case GQL.BulkUpdateIdMode.Set:
         return "edit";
-      case MultiSetMode.ADD:
+      case GQL.BulkUpdateIdMode.Add:
         return "plus";
-      case MultiSetMode.REMOVE:
+      case GQL.BulkUpdateIdMode.Remove:
         return "cross";
+    }
+  }
+
+  function getModeText() {
+    switch(props.mode) {
+      case GQL.BulkUpdateIdMode.Set:
+        return "Set";
+      case GQL.BulkUpdateIdMode.Add:
+        return "Add";
+      case GQL.BulkUpdateIdMode.Remove:
+        return "Remove";
     }
   }
 
   function nextMode() {
     switch(props.mode) {
-      case MultiSetMode.SET:
-        return MultiSetMode.ADD;
-      case MultiSetMode.ADD:
-        return MultiSetMode.REMOVE;
-      case MultiSetMode.REMOVE:
-        return MultiSetMode.SET;
+      case GQL.BulkUpdateIdMode.Set:
+        return GQL.BulkUpdateIdMode.Add;
+      case GQL.BulkUpdateIdMode.Add:
+        return GQL.BulkUpdateIdMode.Remove;
+      case GQL.BulkUpdateIdMode.Remove:
+        return GQL.BulkUpdateIdMode.Set;
     }
   }
 
@@ -67,7 +62,7 @@ export const FilterMultiSet: React.FunctionComponent<IFilterMultiSetProps> = (pr
         icon={getModeIcon()} 
         minimal={true} 
         onClick={() => props.onSetMode(nextMode())}
-        title={props.mode}
+        title={getModeText()}
       />
       <FilterMultiSelect
         type={props.type}


### PR DESCRIPTION
Resolves #250 

Adds a button to the performer and tag controls in the bulk scene update UI. This button shows the current mode of the operation - Add, Remove and Set. The set mode overwrites the existing ids with the ids supplied. Add and Remove are iterative operations using existing data.

Added to version 2 and 2.5 UI.