### PR TITLE
Make ethnicity freetext and fix freeones ethnicity panic

### DIFF
--- a/pkg/scraper/freeones.go
+++ b/pkg/scraper/freeones.go
@@ -278,7 +278,9 @@ func getEthnicity(ethnicity string) string {
 	case "Asian":
 		return "asian"
 	default:
-		panic("unknown ethnicity")
+		// #367 - unknown ethnicity shouldn't cause the entire operation to
+		// fail. Just return the original string instead
+		return ethnicity
 	}
 }
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -221,12 +221,12 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
   }
 
   function renderEthnicity() {
-    return TableUtils.renderHtmlSelect({
+    return TableUtils.renderInputGroup({
       title: "Ethnicity",
       value: ethnicity,
       isEditing: !!isEditing,
-      onChange: (value: string) => setEthnicity(value),
-      selectOptions: ["white", "black", "asian", "hispanic"]
+      placeholder: "Ethnicity",
+      onChange: setEthnicity
     });
   }
 

--- a/ui/v2/src/components/performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2/src/components/performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -228,12 +228,12 @@ export const PerformerDetailsPanel: FunctionComponent<IPerformerDetailsProps> = 
   }
 
   function renderEthnicity() {
-    return TableUtils.renderHtmlSelect({
+    return TableUtils.renderInputGroup({
       title: "Ethnicity",
       value: ethnicity,
       isEditing: !!props.isEditing,
-      onChange: (value: string) => setEthnicity(value),
-      selectOptions: ["white", "black", "asian", "hispanic"],
+      placeholder: "Ethnicity",
+      onChange: setEthnicity
     });
   }
 


### PR DESCRIPTION
Fixes #367 

Makes ethnicity free-text in v2 and v2.5 UI. Changed freeones scraper to return original string if an unknown ethnicity is encountered.