### PR TITLE
Delete marker preview on marker change or delete

### DIFF
--- a/pkg/manager/scene.go
+++ b/pkg/manager/scene.go
@@ -122,6 +122,27 @@ func DeleteGeneratedSceneFiles(scene *models.Scene) {
 	}
 }
 
+func DeleteSceneMarkerFiles(scene *models.Scene, seconds int) {
+	videoPath := GetInstance().Paths.SceneMarkers.GetStreamPath(scene.Checksum, seconds)
+	imagePath := GetInstance().Paths.SceneMarkers.GetStreamPreviewImagePath(scene.Checksum, seconds)
+
+	exists, _ := utils.FileExists(videoPath)
+	if exists {
+		err := os.Remove(videoPath)
+		if err != nil {
+			logger.Warnf("Could not delete file %s: %s", videoPath, err.Error())
+		}
+	}
+
+	exists, _ = utils.FileExists(imagePath)
+	if exists {
+		err := os.Remove(imagePath)
+		if err != nil {
+			logger.Warnf("Could not delete file %s: %s", videoPath, err.Error())
+		}
+	}
+}
+
 func DeleteSceneFile(scene *models.Scene) {
 	// kill any running encoders
 	KillRunningStreams(scene.Path)


### PR DESCRIPTION
Delete the marker previews when the timestamp changes or if the marker is deleted. 

Does not check for other markers at the same timestamp, so it may result in marker previews being generated when there are other scene markers at the same timestamp. I think this is a pretty niche corner case, is unlikely to come up, and is very easy to remedy, so I'm not going to add an explicit check.

Closes #385 