### PR TITLE
Prefer modified performer image over scraped one

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -106,7 +106,8 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     updatePerformerEditState(state);
 
     // image is a base64 string
-    if ((state as GQL.ScrapedPerformerDataFragment).image !== undefined) {
+    // #404: don't overwrite image if it has been modified by the user
+    if (image === undefined && (state as GQL.ScrapedPerformerDataFragment).image !== undefined) {
       const imageStr = (state as GQL.ScrapedPerformerDataFragment).image;
       setImage(imageStr ?? undefined);
       if (onImageChange) {


### PR DESCRIPTION
Fixes #404

Changes the performer UI scraping behaviour so that if the user has modified the performer image in the UI - either by copy/paste or manually browsing - then the image will not be replaced with the scraped image. A side effect of this is that scraping twice on the one edit performer page will result in the image not being replaced during the second scrape.