### PR TITLE
Don't redirect login to migrate page

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -383,7 +383,8 @@ func DatabaseCheckMiddleware(next http.Handler) http.Handler {
 		ext := path.Ext(r.URL.Path)
 		shouldRedirect := ext == "" && r.Method == "GET"
 		if shouldRedirect && database.NeedsMigration() {
-			if !strings.HasPrefix(r.URL.Path, "/migrate") {
+			// #451 - don't redirect if loading login page
+			if !strings.HasPrefix(r.URL.Path, "/migrate") && !strings.HasPrefix(r.URL.Path, "/login") {
 				http.Redirect(w, r, "/migrate", 301)
 				return
 			}


### PR DESCRIPTION
Fixes #451 

Changed so that the database check middleware does not redirect to the `/migrate` URL if `/login` was attempted to be accessed, since the user must login before migrating.