### PR TITLE
Add slim endpoints for entities to speed up filters

### DIFF
--- a/graphql/documents/queries/misc.graphql
+++ b/graphql/documents/queries/misc.graphql
@@ -19,24 +19,24 @@ query AllTags {
 }
 
 query AllPerformersForFilter {
-  allPerformers {
+  allPerformersSlim {
     ...SlimPerformerData
   }
 }
 
 query AllStudiosForFilter {
-  allStudios {
+  allStudiosSlim {
     ...SlimStudioData
   }
 }
 query AllMoviesForFilter {
-  allMovies {
+  allMoviesSlim {
     ...SlimMovieData
   }
 }
 
 query AllTagsForFilter {
-  allTags {
+  allTagsSlim {
     id
     name
   }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -86,6 +86,13 @@ type Query {
   allMovies: [Movie!]!
   allTags: [Tag!]!
 
+  # Get everything with minimal metadata
+
+  allPerformersSlim: [Performer!]!
+  allStudiosSlim: [Studio!]!
+  allMoviesSlim: [Movie!]!
+  allTagsSlim: [Tag!]!
+
   # Version
   version: Version!
   

--- a/pkg/api/resolver_query_find_movie.go
+++ b/pkg/api/resolver_query_find_movie.go
@@ -26,3 +26,8 @@ func (r *queryResolver) AllMovies(ctx context.Context) ([]*models.Movie, error) 
 	qb := models.NewMovieQueryBuilder()
 	return qb.All()
 }
+
+func (r *queryResolver) AllMoviesSlim(ctx context.Context) ([]*models.Movie, error) {
+	qb := models.NewMovieQueryBuilder()
+	return qb.AllSlim()
+}

--- a/pkg/api/resolver_query_find_performer.go
+++ b/pkg/api/resolver_query_find_performer.go
@@ -25,3 +25,8 @@ func (r *queryResolver) AllPerformers(ctx context.Context) ([]*models.Performer,
 	qb := models.NewPerformerQueryBuilder()
 	return qb.All()
 }
+
+func (r *queryResolver) AllPerformersSlim(ctx context.Context) ([]*models.Performer, error) {
+	qb := models.NewPerformerQueryBuilder()
+	return qb.AllSlim()
+}

--- a/pkg/api/resolver_query_find_studio.go
+++ b/pkg/api/resolver_query_find_studio.go
@@ -25,3 +25,8 @@ func (r *queryResolver) AllStudios(ctx context.Context) ([]*models.Studio, error
 	qb := models.NewStudioQueryBuilder()
 	return qb.All()
 }
+
+func (r *queryResolver) AllStudiosSlim(ctx context.Context) ([]*models.Studio, error) {
+	qb := models.NewStudioQueryBuilder()
+	return qb.AllSlim()
+}

--- a/pkg/api/resolver_query_find_tag.go
+++ b/pkg/api/resolver_query_find_tag.go
@@ -16,3 +16,8 @@ func (r *queryResolver) AllTags(ctx context.Context) ([]*models.Tag, error) {
 	qb := models.NewTagQueryBuilder()
 	return qb.All()
 }
+
+func (r *queryResolver) AllTagsSlim(ctx context.Context) ([]*models.Tag, error) {
+	qb := models.NewTagQueryBuilder()
+	return qb.AllSlim()
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -19,7 +19,7 @@ import (
 
 var DB *sqlx.DB
 var dbPath string
-var appSchemaVersion uint = 6
+var appSchemaVersion uint = 7
 var databaseSchemaVersion uint
 
 const sqlite3Driver = "sqlite3_regexp"

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -1,8 +1,7 @@
-PRAGMA foreign_keys = OFF;
 DROP INDEX `performers_checksum_unique`;
 DROP INDEX `index_performers_on_name`;
 DROP INDEX `index_performers_on_checksum`;
-ALTER TABLE performers RENAME TO temp_old_performers;
+ALTER TABLE `performers` RENAME TO `temp_old_performers`;
 CREATE TABLE `performers` (
   `id` integer not null primary key autoincrement,
   `checksum` varchar(255) not null,
@@ -30,53 +29,74 @@ CREATE TABLE `performers` (
 CREATE UNIQUE INDEX `performers_checksum_unique` on `performers` (`checksum`);
 CREATE INDEX `index_performers_on_name` on `performers` (`name`);
 CREATE INDEX `index_performers_on_checksum` on `performers` (`checksum`);
-INSERT INTO performers (
-  id,
-  checksum,
-  name,
-  gender,
-  url,
-  twitter,
-  instagram,
-  birthdate,
-  ethnicity,
-  country,
-  eye_color,
-  height,
-  measurements,
-  fake_tits,
-  career_length,
-  tattoos,
-  piercings,
-  aliases,
-  favorite,
-  created_at,
-  updated_at,
-  image
+INSERT INTO `performers` (
+  `id`,
+  `checksum`,
+  `name`,
+  `gender`,
+  `url`,
+  `twitter`,
+  `instagram`,
+  `birthdate`,
+  `ethnicity`,
+  `country`,
+  `eye_color`,
+  `height`,
+  `measurements`,
+  `fake_tits`,
+  `career_length`,
+  `tattoos`,
+  `piercings`,
+  `aliases`,
+  `favorite`,
+  `created_at`,
+  `updated_at`,
+  `image`
 )
 SELECT 
-  id,
-  checksum,
-  name,
-  gender,
-  url,
-  twitter,
-  instagram,
-  birthdate,
-  ethnicity,
-  country,
-  eye_color,
-  height,
-  measurements,
-  fake_tits,
-  career_length,
-  tattoos,
-  piercings,
-  aliases,
-  favorite,
-  created_at,
-  updated_at,
-  image
-FROM temp_old_performers;
-DROP TABLE temp_old_performers;
-PRAGMA foreign_keys = ON;
+  `id`,
+  `checksum`,
+  `name`,
+  `gender`,
+  `url`,
+  `twitter`,
+  `instagram`,
+  `birthdate`,
+  `ethnicity`,
+  `country`,
+  `eye_color`,
+  `height`,
+  `measurements`,
+  `fake_tits`,
+  `career_length`,
+  `tattoos`,
+  `piercings`,
+  `aliases`,
+  `favorite`,
+  `created_at`,
+  `updated_at`,
+  `image`
+FROM `temp_old_performers`;
+
+DROP INDEX `index_performers_scenes_on_scene_id`;
+DROP INDEX `index_performers_scenes_on_performer_id`;
+ALTER TABLE performers_scenes RENAME TO temp_old_performers_scenes;
+CREATE TABLE `performers_scenes` (
+  `performer_id` integer,
+  `scene_id` integer,
+  foreign key(`performer_id`) references `performers`(`id`),
+  foreign key(`scene_id`) references `scenes`(`id`)
+);
+CREATE INDEX `index_performers_scenes_on_scene_id` on `performers_scenes` (`scene_id`);
+CREATE INDEX `index_performers_scenes_on_performer_id` on `performers_scenes` (`performer_id`);
+INSERT INTO `performers_scenes` (
+  `performer_id`,
+  `scene_id`
+)
+SELECT 
+  `performer_id`,
+  `scene_id`
+FROM `temp_old_performers_scenes`;
+
+DROP TABLE `temp_old_performers`;
+DROP TABLE `temp_old_performers_scenes`;

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -100,3 +100,5 @@ FROM `temp_old_performers_scenes`;
 
 DROP TABLE `temp_old_performers`;
 DROP TABLE `temp_old_performers_scenes`;
+
+VACUUM;

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -1,0 +1,84 @@
+BEGIN TRANSACTION;
+PRAGMA foreign_keys = OFF;
+DROP INDEX `performers_checksum_unique`;
+DROP INDEX `index_performers_on_name`;
+DROP INDEX `index_performers_on_checksum`;
+ALTER TABLE performers RENAME TO temp_old_performers;
+CREATE TABLE `performers` (
+  `id` integer not null primary key autoincrement,
+  `checksum` varchar(255) not null,
+  `name` varchar(255),
+  `gender` varchar(20),
+  `url` varchar(255),
+  `twitter` varchar(255),
+  `instagram` varchar(255),
+  `birthdate` date,
+  `ethnicity` varchar(255),
+  `country` varchar(255),
+  `eye_color` varchar(255),
+  `height` varchar(255),
+  `measurements` varchar(255),
+  `fake_tits` varchar(255),
+  `career_length` varchar(255),
+  `tattoos` varchar(255),
+  `piercings` varchar(255),
+  `aliases` varchar(255),
+  `favorite` boolean not null default '0',
+  `created_at` datetime not null,
+  `updated_at` datetime not null,
+  `image` blob not null
+);
+CREATE UNIQUE INDEX `performers_checksum_unique` on `performers` (`checksum`);
+CREATE INDEX `index_performers_on_name` on `performers` (`name`);
+CREATE INDEX `index_performers_on_checksum` on `performers` (`checksum`);
+INSERT INTO performers (
+  id,
+  checksum,
+  name,
+  gender,
+  url,
+  twitter,
+  instagram,
+  birthdate,
+  ethnicity,
+  country,
+  eye_color,
+  height,
+  measurements,
+  fake_tits,
+  career_length,
+  tattoos,
+  piercings,
+  aliases,
+  favorite,
+  created_at,
+  updated_at,
+  image
+)
+SELECT 
+  id,
+  checksum,
+  name,
+  gender,
+  url,
+  twitter,
+  instagram,
+  birthdate,
+  ethnicity,
+  country,
+  eye_color,
+  height,
+  measurements,
+  fake_tits,
+  career_length,
+  tattoos,
+  piercings,
+  aliases,
+  favorite,
+  created_at,
+  updated_at,
+  image
+FROM temp_old_performers;
+DROP TABLE temp_old_performers;
+PRAGMA foreign_keys = ON;
+COMMIT TRANSACTION;

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -28,7 +28,6 @@ CREATE TABLE `performers` (
 );
 CREATE UNIQUE INDEX `performers_checksum_unique` on `performers` (`checksum`);
 CREATE INDEX `index_performers_on_name` on `performers` (`name`);
-CREATE INDEX `index_performers_on_checksum` on `performers` (`checksum`);
 INSERT INTO `performers` (
   `id`,
   `checksum`,

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -100,5 +100,3 @@ FROM `temp_old_performers_scenes`;
 
 DROP TABLE `temp_old_performers`;
 DROP TABLE `temp_old_performers_scenes`;
-
-VACUUM;

--- a/pkg/database/migrations/7_performer_optimization.up.sql
+++ b/pkg/database/migrations/7_performer_optimization.up.sql
@@ -1,4 +1,3 @@
-BEGIN TRANSACTION;
 PRAGMA foreign_keys = OFF;
 DROP INDEX `performers_checksum_unique`;
 DROP INDEX `index_performers_on_name`;
@@ -81,4 +80,3 @@ SELECT
 FROM temp_old_performers;
 DROP TABLE temp_old_performers;
 PRAGMA foreign_keys = ON;
-COMMIT TRANSACTION;

--- a/pkg/models/querybuilder_movies.go
+++ b/pkg/models/querybuilder_movies.go
@@ -109,6 +109,10 @@ func (qb *MovieQueryBuilder) All() ([]*Movie, error) {
 	return qb.queryMovies(selectAll("movies")+qb.getMovieSort(nil), nil, nil)
 }
 
+func (qb *MovieQueryBuilder) AllSlim() ([]*Movie, error) {
+	return qb.queryMovies("SELECT movies.id, movies.name FROM movies "+qb.getMovieSort(nil), nil, nil)
+}
+
 func (qb *MovieQueryBuilder) Query(findFilter *FindFilterType) ([]*Movie, int) {
 	if findFilter == nil {
 		findFilter = &FindFilterType{}

--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -105,6 +105,10 @@ func (qb *PerformerQueryBuilder) All() ([]*Performer, error) {
 	return qb.queryPerformers(selectAll("performers")+qb.getPerformerSort(nil), nil, nil)
 }
 
+func (qb *PerformerQueryBuilder) AllSlim() ([]*Performer, error) {
+	return qb.queryPerformers("SELECT performers.id, performers.name, performers.gender FROM performers " + qb.getPerformerSort(nil), nil, nil)
+}
+
 func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, findFilter *FindFilterType) ([]*Performer, int) {
 	if performerFilter == nil {
 		performerFilter = &PerformerFilterType{}

--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -106,7 +106,7 @@ func (qb *PerformerQueryBuilder) All() ([]*Performer, error) {
 }
 
 func (qb *PerformerQueryBuilder) AllSlim() ([]*Performer, error) {
-	return qb.queryPerformers("SELECT performers.id, performers.name, performers.gender FROM performers " + qb.getPerformerSort(nil), nil, nil)
+	return qb.queryPerformers("SELECT performers.id, performers.name, performers.gender FROM performers "+qb.getPerformerSort(nil), nil, nil)
 }
 
 func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, findFilter *FindFilterType) ([]*Performer, int) {

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -93,6 +93,10 @@ func (qb *StudioQueryBuilder) All() ([]*Studio, error) {
 	return qb.queryStudios(selectAll("studios")+qb.getStudioSort(nil), nil, nil)
 }
 
+func (qb *StudioQueryBuilder) AllSlim() ([]*Studio, error) {
+	return qb.queryStudios("SELECT studios.id, studios.name FROM studios " + qb.getStudioSort(nil), nil, nil)
+}
+
 func (qb *StudioQueryBuilder) Query(findFilter *FindFilterType) ([]*Studio, int) {
 	if findFilter == nil {
 		findFilter = &FindFilterType{}

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -94,7 +94,7 @@ func (qb *StudioQueryBuilder) All() ([]*Studio, error) {
 }
 
 func (qb *StudioQueryBuilder) AllSlim() ([]*Studio, error) {
-	return qb.queryStudios("SELECT studios.id, studios.name FROM studios " + qb.getStudioSort(nil), nil, nil)
+	return qb.queryStudios("SELECT studios.id, studios.name FROM studios "+qb.getStudioSort(nil), nil, nil)
 }
 
 func (qb *StudioQueryBuilder) Query(findFilter *FindFilterType) ([]*Studio, int) {

--- a/pkg/models/querybuilder_tag.go
+++ b/pkg/models/querybuilder_tag.go
@@ -136,6 +136,10 @@ func (qb *TagQueryBuilder) All() ([]*Tag, error) {
 	return qb.queryTags(selectAll("tags")+qb.getTagSort(nil), nil, nil)
 }
 
+func (qb *TagQueryBuilder) AllSlim() ([]*Tag, error) {
+	return qb.queryTags("SELECT tags.id, tags.name FROM tags "+qb.getTagSort(nil), nil, nil)
+}
+
 func (qb *TagQueryBuilder) Query(findFilter *FindFilterType) ([]*Tag, int) {
 	if findFilter == nil {
 		findFilter = &FindFilterType{}

--- a/pkg/models/querybuilder_tag.go
+++ b/pkg/models/querybuilder_tag.go
@@ -33,7 +33,7 @@ func (qb *TagQueryBuilder) Create(newTag Tag, tx *sqlx.Tx) (*Tag, error) {
 	if err := tx.Get(&newTag, `SELECT * FROM tags WHERE id = ? LIMIT 1`, studioID); err != nil {
 		return nil, err
 	}
-	
+
 	return &newTag, nil
 }
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMovieTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMovieTable.tsx
@@ -17,11 +17,11 @@ export const SceneMovieTable: React.FunctionComponent<IProps> = (
 ) => {
   const { data } = StashService.useAllMoviesForFilter();
 
-  const items = !!data && !!data.allMovies ? data.allMovies : [];
+  const items = !!data && !!data.allMoviesSlim ? data.allMoviesSlim : [];
   let itemsFilter: ValidTypes[] = [];
 
   if (!!props.movieSceneIndexes && !!items) {
-    props.movieSceneIndexes.forEach((index, movieId) => {
+    props.movieSceneIndexes.forEach((_index, movieId) => {
       itemsFilter = itemsFilter.concat(items.filter((x) => x.id === movieId));
     });
   }

--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -183,7 +183,7 @@ export const FilterSelect: React.FC<IFilterProps & ITypeProps> = (props) =>
 export const PerformerSelect: React.FC<IFilterProps> = (props) => {
   const { data, loading } = StashService.useAllPerformersForFilter();
 
-  const normalizedData = data?.allPerformers ?? [];
+  const normalizedData = data?.allPerformersSlim ?? [];
   const items: Option[] = normalizedData.map((item) => ({
     value: item.id,
     label: item.name ?? "",
@@ -216,7 +216,7 @@ export const PerformerSelect: React.FC<IFilterProps> = (props) => {
 export const StudioSelect: React.FC<IFilterProps> = (props) => {
   const { data, loading } = StashService.useAllStudiosForFilter();
 
-  const normalizedData = data?.allStudios ?? [];
+  const normalizedData = data?.allStudiosSlim ?? [];
 
   const items = (normalizedData.length > 0
     ? [{ name: "None", id: "0" }, ...normalizedData]
@@ -254,7 +254,7 @@ export const StudioSelect: React.FC<IFilterProps> = (props) => {
 export const MovieSelect: React.FC<IFilterProps> = (props) => {
   const { data, loading } = StashService.useAllMoviesForFilter();
 
-  const normalizedData = data?.allMovies ?? [];
+  const normalizedData = data?.allMoviesSlim ?? [];
 
   const items = (normalizedData.length > 0
     ? [{ name: "None", id: "0" }, ...normalizedData]
@@ -299,7 +299,7 @@ export const TagSelect: React.FC<IFilterProps> = (props) => {
 
   const selectedTags = props.ids ?? selectedIds;
 
-  const tags = data?.allTags ?? [];
+  const tags = data?.allTagsSlim ?? [];
   const selected = tags
     .filter((tag) => selectedTags.indexOf(tag.id) !== -1)
     .map((tag) => ({ value: tag.id, label: tag.name }));


### PR DESCRIPTION
Should resolve issue #452 

In my library with 123 performers and 1MB-ish performer images it speeds up AllPerformersForFilters from 0.4s to 0.04s.  For 549 studios it speeds up from 0.08s to 0.02s.

I considered changing the dropdowns to fetch on demand, but considering that scenes can have arbitrary amount of performers attached, it would likely make page load significantly slower in many instances.