### PR TITLE
Move image with cover.jpg in name to first place in Galleries

### DIFF
--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -88,7 +88,7 @@ func (g *Gallery) readZipFile(index int) ([]byte, error) {
 func (g *Gallery) listZipContents() ([]*zip.File, *zip.ReadCloser, error) {
 	readCloser, err := zip.OpenReader(g.Path)
 	if err != nil {
-		logger.Warn("failed to read zip file %s", g.Path)
+		logger.Warnf("failed to read zip file %s", g.Path)
 		return nil, nil, err
 	}
 

--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -113,7 +113,10 @@ func (g *Gallery) listZipContents() ([]*zip.File, *zip.ReadCloser, error) {
 	})
 	cover := Contains(filteredFiles, "cover.jpg") // first image with cover.jpg in the name
 	if cover >= 0 {                               // will be moved to the start
-		filteredFiles = Reorder(filteredFiles, cover)
+		reorderedFiles := Reorder(filteredFiles, cover)
+		if reorderedFiles != nil {
+			return reorderedFiles, readCloser, nil
+		}
 	}
 
 	return filteredFiles, readCloser, nil

--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -127,7 +127,6 @@ func (g *Gallery) listZipContents() ([]*zip.File, *zip.ReadCloser, error) {
 func contains(a []*zip.File, x string) int {
 	for i, n := range a {
 		if strings.Contains(n.Name, x) {
-			logger.Debugf("Cover found in zip file %s.Position:%d", n.Name, i)
 			return i
 		}
 	}


### PR DESCRIPTION
Change file order in zip files to put image with _cover.jpg_ included in name at first position.
(image ending in cover.jpg  for example)

Related to #473 