### PR TITLE
Fix navbar height

### DIFF
--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -157,7 +157,7 @@ export const MainNavbar: React.FC = () => {
           ))}
         </Nav>
       </Navbar.Collapse>
-      <Nav className="order-2">
+      <Nav className="order-2 flex-row">
         <div className="d-none d-sm-block">{newButton}</div>
         <LinkContainer exact to="/settings" onClick={() => setExpanded(false)}>
           <Button className="minimal settings-button">


### PR DESCRIPTION
Resolves #480.

I tried making the navbar not fixed, but that causes the burger menu to shove the entire page down when it opens, so I dropped it.