### PR TITLE
Don't error in IsStreamable resolver

### DIFF
--- a/pkg/api/resolver_model_scene.go
+++ b/pkg/api/resolver_model_scene.go
@@ -82,7 +82,9 @@ func (r *sceneResolver) Paths(ctx context.Context, obj *models.Scene) (*models.S
 }
 
 func (r *sceneResolver) IsStreamable(ctx context.Context, obj *models.Scene) (bool, error) {
-	return manager.IsStreamable(obj)
+	// ignore error
+	ret, _ := manager.IsStreamable(obj)
+	return ret, nil
 }
 
 func (r *sceneResolver) SceneMarkers(ctx context.Context, obj *models.Scene) ([]*models.SceneMarker, error) {


### PR DESCRIPTION
`IsStreamable` resolver emits an error if it cannot read the source file. Makes the entire graphql request fail if the source file can't be read. This means that the UI fails when loading up a scene where the file is missing. Also means I can't browse scenes from someone else's database ;)