### PR TITLE
Include scene o-counter in import/export

### DIFF
--- a/pkg/manager/jsonschema/scene.go
+++ b/pkg/manager/jsonschema/scene.go
@@ -40,6 +40,7 @@ type Scene struct {
 	URL        string          `json:"url,omitempty"`
 	Date       string          `json:"date,omitempty"`
 	Rating     int             `json:"rating,omitempty"`
+	OCounter   int             `json:"o_counter,omitempty"`
 	Details    string          `json:"details,omitempty"`
 	Gallery    string          `json:"gallery,omitempty"`
 	Performers []string        `json:"performers,omitempty"`

--- a/pkg/manager/task_export.go
+++ b/pkg/manager/task_export.go
@@ -103,6 +103,9 @@ func (t *ExportTask) ExportScenes(ctx context.Context) {
 		if scene.Rating.Valid {
 			newSceneJSON.Rating = int(scene.Rating.Int64)
 		}
+
+		newSceneJSON.OCounter = scene.OCounter
+
 		if scene.Details.Valid {
 			newSceneJSON.Details = scene.Details.String
 		}

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -489,6 +489,8 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 			if sceneJSON.Rating != 0 {
 				newScene.Rating = sql.NullInt64{Int64: int64(sceneJSON.Rating), Valid: true}
 			}
+
+			newScene.OCounter = sceneJSON.OCounter
 			newScene.CreatedAt = models.SQLiteTimestamp{Timestamp: t.getTimeFromJSONTime(sceneJSON.CreatedAt)}
 			newScene.UpdatedAt = models.SQLiteTimestamp{Timestamp: t.getTimeFromJSONTime(sceneJSON.UpdatedAt)}
 

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -49,10 +49,10 @@ func NewSceneQueryBuilder() SceneQueryBuilder {
 func (qb *SceneQueryBuilder) Create(newScene Scene, tx *sqlx.Tx) (*Scene, error) {
 	ensureTx(tx)
 	result, err := tx.NamedExec(
-		`INSERT INTO scenes (checksum, path, title, details, url, date, rating, size, duration, video_codec,
+		`INSERT INTO scenes (checksum, path, title, details, url, date, rating, o_counter, size, duration, video_codec,
                     			    audio_codec, format, width, height, framerate, bitrate, studio_id, cover,
                     				created_at, updated_at)
-				VALUES (:checksum, :path, :title, :details, :url, :date, :rating, :size, :duration, :video_codec,
+				VALUES (:checksum, :path, :title, :details, :url, :date, :rating, :o_counter, :size, :duration, :video_codec,
 					:audio_codec, :format, :width, :height, :framerate, :bitrate, :studio_id, :cover,
 				        :created_at, :updated_at)
 		`,

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -182,7 +182,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
       return (
         <div>
           <Button className="minimal">
-            <SweatDrops />
+            <span className="fa-icon"><SweatDrops /></span>
             <span>{props.scene.o_counter}</span>
           </Button>
         </div>


### PR DESCRIPTION
Add o-counter to export/import.

Also fixes the display of the o-counter label in scene cards.