### PR TITLE
Add index/total count to end of pagination buttons

### DIFF
--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -121,5 +121,5 @@ export const PaginationIndex: React.FC<IPaginationIndexProps> = ({
   const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
   const indexText:string = `${intl.formatNumber(firstItemCount)}-${intl.formatNumber(lastItemCount)} of ${intl.formatNumber(totalItems)}`;
 
-  return <span className="filter-container paginationIndex" onClick={onClick}>{indexText}</span>
+  return <span className="filter-container text-muted paginationIndex" onClick={onClick}>{indexText}</span>
 };

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -9,20 +9,20 @@ interface IPaginationProps {
   onChangePage: (page: number) => void;
 }
 
+interface IPaginationIndexProps {
+  itemsPerPage: number;
+  currentPage: number;
+  totalItems: number;
+  onClick?: () => void;
+}
+
 export const Pagination: React.FC<IPaginationProps> = ({
   itemsPerPage,
   currentPage,
   totalItems,
   onChangePage,
 }) => {
-  const intl = useIntl();
-
   const totalPages = Math.ceil(totalItems / itemsPerPage);
-
-  // Build the pagination index string
-  const firstItemCount:number = Math.min((currentPage-1)*itemsPerPage+1, totalItems);
-  const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
-  const indexText:string = `${intl.formatNumber(firstItemCount)}-${intl.formatNumber(lastItemCount)} of ${intl.formatNumber(totalItems)}`;
 
   let startPage: number;
   let endPage: number;
@@ -104,12 +104,22 @@ export const Pagination: React.FC<IPaginationProps> = ({
         <span className="d-none d-sm-inline">Last</span>
         <span className="d-inline d-sm-none">&#x300b;</span>
       </Button>
-      <Button
-        variant="secondary"
-        disabled={true}
-      >
-        {indexText}
-      </Button>
     </ButtonGroup>
   );
+};
+
+export const PaginationIndex: React.FC<IPaginationIndexProps> = ({
+  itemsPerPage,
+  currentPage,
+  totalItems,
+  onClick
+}) => {
+  const intl = useIntl();
+
+  // Build the pagination index string
+  const firstItemCount:number = Math.min((currentPage-1)*itemsPerPage+1, totalItems);
+  const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
+  const indexText:string = `${intl.formatNumber(firstItemCount)}-${intl.formatNumber(lastItemCount)} of ${intl.formatNumber(totalItems)}`;
+
+  return <span className="filter-container paginationIndex" onClick={onClick}>{indexText}</span>
 };

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
+import { useIntl } from "react-intl";
 
 interface IPaginationProps {
   itemsPerPage: number;
@@ -14,12 +15,14 @@ export const Pagination: React.FC<IPaginationProps> = ({
   totalItems,
   onChangePage,
 }) => {
+  const intl = useIntl();
+
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   // Build the pagination index string
   const firstItemCount:number = Math.min((currentPage-1)*itemsPerPage+1, totalItems);
   const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
-  const indexText:string = `${firstItemCount}-${lastItemCount} of ${totalItems}`;
+  const indexText:string = `${intl.formatNumber(firstItemCount)}-${intl.formatNumber(lastItemCount)} of ${intl.formatNumber(totalItems)}`;
 
   let startPage: number;
   let endPage: number;

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -16,6 +16,11 @@ export const Pagination: React.FC<IPaginationProps> = ({
 }) => {
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
+  // Build the n-m/total string
+  const firstItemCount:number = (currentPage-1)*itemsPerPage+1;
+  const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
+  const indexText:string = `${firstItemCount}-${lastItemCount}/${totalItems}`;
+
   let startPage: number;
   let endPage: number;
   if (totalPages <= 10) {
@@ -95,6 +100,12 @@ export const Pagination: React.FC<IPaginationProps> = ({
       >
         <span className="d-none d-sm-inline">Last</span>
         <span className="d-inline d-sm-none">&#x300b;</span>
+      </Button>
+      <Button
+        variant="secondary"
+        disabled={true}
+      >
+        {indexText}
       </Button>
     </ButtonGroup>
   );

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -16,10 +16,10 @@ export const Pagination: React.FC<IPaginationProps> = ({
 }) => {
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  // Build the n-m/total string
+  // Build the pagination index string
   const firstItemCount:number = Math.min((currentPage-1)*itemsPerPage+1, totalItems);
   const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
-  const indexText:string = `${firstItemCount}-${lastItemCount}/${totalItems}`;
+  const indexText:string = `${firstItemCount}-${lastItemCount} of ${totalItems}`;
 
   let startPage: number;
   let endPage: number;

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -17,7 +17,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   // Build the n-m/total string
-  const firstItemCount:number = (currentPage-1)*itemsPerPage+1;
+  const firstItemCount:number = Math.min((currentPage-1)*itemsPerPage+1, totalItems);
   const lastItemCount:number = Math.min(firstItemCount+(itemsPerPage-1), totalItems);
   const indexText:string = `${firstItemCount}-${lastItemCount}/${totalItems}`;
 

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -24,7 +24,7 @@ import {
 } from "src/hooks/LocalForage";
 import { LoadingIndicator } from "src/components/Shared";
 import { ListFilter } from "src/components/List/ListFilter";
-import { Pagination } from "src/components/List/Pagination";
+import { Pagination, PaginationIndex } from "src/components/List/Pagination";
 import { StashService } from "src/core/StashService";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
 import { ListFilterModel } from "src/models/list-filter/filter";
@@ -357,6 +357,19 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
     }
   }
 
+  function maybeRenderPaginationIndex() {
+    if (!result.loading && !result.error) {
+      return (
+        <PaginationIndex
+          itemsPerPage={filter.itemsPerPage}
+          currentPage={filter.currentPage}
+          totalItems={totalCount}
+          onClick={() => {}}
+        />
+      );
+    }
+  }
+
   function maybeRenderPagination() {
     if (!result.loading && !result.error) {
       return (
@@ -394,6 +407,7 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
       {(result.loading || !forageInitialised) && <LoadingIndicator />}
       {result.error && <h1>{result.error.message}</h1>}
       {maybeRenderContent()}
+      {maybeRenderPaginationIndex()}
       {maybeRenderPagination()}
     </div>
   );


### PR DESCRIPTION
Very simple, just chucks a fake button on the end of the pagination buttons. Looked a bit awkward by itself on the no-pagination case, so left it out there, but hopefully most folks know how to count up to 40.