### PR TITLE
Overhaul look and feel of folder select

### DIFF
--- a/graphql/documents/queries/settings/config.graphql
+++ b/graphql/documents/queries/settings/config.graphql
@@ -4,6 +4,10 @@ query Configuration {
   }
 }
 
-query Directories($path: String) {
-  directories(path: $path)
+query Directory($path: String) {
+  directory(path: $path) {
+      path
+      parent
+      directories
+  }
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -73,7 +73,7 @@ type Query {
   """Returns the current, complete configuration"""
   configuration: ConfigResult!
   """Returns an array of paths for the given path"""
-  directories(path: String): [String!]!
+  directory(path: String): Directory!
 
   # Metadata
 

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -117,3 +117,10 @@ type ConfigResult {
   general: ConfigGeneralResult!
   interface: ConfigInterfaceResult!
 }
+
+"""Directory structure of a path"""
+type Directory {
+    path: String!
+    parent: String
+    directories: [String!]!
+}

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -12,12 +12,18 @@ func (r *queryResolver) Configuration(ctx context.Context) (*models.ConfigResult
 	return makeConfigResult(), nil
 }
 
-func (r *queryResolver) Directories(ctx context.Context, path *string) ([]string, error) {
+func (r *queryResolver) Directory(ctx context.Context, path *string) (*models.Directory, error) {
 	var dirPath = ""
 	if path != nil {
 		dirPath = *path
 	}
-	return utils.ListDir(dirPath), nil
+	currentDir := utils.GetDir(dirPath)
+
+	return &models.Directory{
+		Path:        currentDir,
+		Parent:      utils.GetParent(currentDir),
+		Directories: utils.ListDir(currentDir),
+	}, nil
 }
 
 func makeConfigResult() *models.ConfigResult {

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -96,15 +96,6 @@ func EmptyDir(path string) error {
 
 // ListDir will return the contents of a given directory path as a string slice
 func ListDir(path string) []string {
-	if path == "" {
-		path = GetHomeDirectory()
-	}
-
-	absolutePath, err := filepath.Abs(path)
-	if err == nil {
-		path = absolutePath
-	}
-
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		path = filepath.Dir(path)
@@ -132,4 +123,26 @@ func GetHomeDirectory() string {
 		panic(err)
 	}
 	return currentUser.HomeDir
+}
+
+func GetDir(path string) string {
+	if path == "" {
+		path = GetHomeDirectory()
+	}
+
+	absolutePath, err := filepath.Abs(path)
+	if err == nil {
+		path = absolutePath
+	}
+	return absolutePath
+}
+
+func GetParent(path string) *string {
+	isRoot := path[len(path)-1:] == "/"
+	if isRoot {
+		return nil
+	} else {
+		parentPath := filepath.Clean(path + "/..")
+		return &parentPath
+	}
 }

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -75,3 +75,41 @@
   min-width: 0;
   position: relative;
 }
+
+.folder-list {
+  list-style-type: none;
+  margin: 0;
+  padding-top: 1rem;
+
+  &-item {
+    white-space: nowrap;
+
+    .btn-link {
+      border: none;
+      color: black;
+      font-weight: 400;
+      padding: 0;
+    }
+
+    &:last-child::before {
+      content: "└ \1F4C1";
+    }
+
+    &::before {
+      content: "├ \1F4C1";
+      display: inline-block;
+      padding-right: 1rem;
+      transform: scale(1.5);
+    }
+  }
+
+  &-parent {
+    &::before {
+      visibility: hidden;
+    }
+
+    .btn-link {
+      font-weight: 500;
+    }
+  }
+}

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -173,8 +173,8 @@ export const useLatestVersion = () =>
   });
 
 export const useConfiguration = () => GQL.useConfigurationQuery();
-export const useDirectories = (path?: string) =>
-  GQL.useDirectoriesQuery({ variables: { path } });
+export const useDirectory = (path?: string) =>
+  GQL.useDirectoryQuery({ variables: { path } });
 
 export const performerMutationImpactedQueries = [
   "findPerformers",


### PR DESCRIPTION
Expanded the graphql payload so we know the starting directory, and whether there's a parent directory we can navigate to. 

Also spruced up the look a bit.

![image](https://user-images.githubusercontent.com/25374869/81403027-ceac1d80-9132-11ea-87a0-336e0a25f350.png)
