### PR TITLE
Fix edge case preview generation, tweak preview generation preset

### DIFF
--- a/pkg/ffmpeg/encoder_scene_preview_chunk.go
+++ b/pkg/ffmpeg/encoder_scene_preview_chunk.go
@@ -16,8 +16,8 @@ type ScenePreviewChunkOptions struct {
 func (e *Encoder) ScenePreviewVideoChunk(probeResult VideoFile, options ScenePreviewChunkOptions) {
 	args := []string{
 		"-v", "error",
-		"-ss", strconv.Itoa(options.Time),
 		"-i", probeResult.Path,
+		"-ss", strconv.Itoa(options.Time),
 		"-t", "0.75",
 		"-max_muxing_queue_size", "1024", // https://trac.ffmpeg.org/ticket/6375
 		"-y",
@@ -25,7 +25,7 @@ func (e *Encoder) ScenePreviewVideoChunk(probeResult VideoFile, options ScenePre
 		"-pix_fmt", "yuv420p",
 		"-profile:v", "high",
 		"-level", "4.2",
-		"-preset", "veryslow",
+		"-preset", "slow",
 		"-crf", "21",
 		"-threads", "4",
 		"-vf", fmt.Sprintf("scale=%v:-2", options.Width),


### PR DESCRIPTION
On some cases the mp4 previews generated have timing "issues" making the webps generated from them huge while also taking a lot of time to generate.
You can identify files like that if you look at the screenshots directory and sort by desc size. The mp4 with the same name as the webp that is affected will show abnormal fps eg 0.01 instead of 25.
For already existing problematic files the webp AND the mp4 preview must be deleted from the screenshots folder and regenerated.
I also changed the x264 ffmpeg preset ( for the preview generation) from very slow to slow as the huge difference in encoding time isn't justified by the marginal ( if existant ) difference in visual quality.