### PR TITLE
Changelog

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -55,6 +55,7 @@
     "react-images": "0.5.19",
     "react-intl": "^4.5.1",
     "react-jw-player": "1.19.1",
+    "react-markdown": "^4.3.1",
     "react-photo-gallery": "^8.0.0",
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",

--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -1,16 +1,52 @@
 import React from 'react';
+import { useChangelogStorage } from 'src/hooks';
 import Version from './Version';
+import { V010, V011, V020 } from './versions';
 
 const Changelog: React.FC = () => {
+  const [{ data, loading }, setOpenState] = useChangelogStorage();
+
+  if (loading)
+    return <></>;
+
+  const openState = data?.versions ?? {};
+
+  const setVersionOpenState = (key: string, state: boolean) => setOpenState({
+    versions: {
+      ...openState,
+      [key]: state
+    }
+  });
+
   return (
-    <div>
-      <h4>Changelog:</h4>
+    <>
+      <h1 className="mb-4">Changelog:</h1>
       <Version
-        header="v0.2.0 - WIP"
+        version="v0.2.0"
+        date="Development Version"
+        openState={openState}
+        setOpenState={setVersionOpenState}
         defaultOpen
-      />
-      <Version header="v0.1.0 - 2020-02-24" />
-    </div>
+      >
+        <V020 />
+      </Version>
+      <Version
+        version="v0.1.1"
+        date="2020-02-25"
+        openState={openState}
+        setOpenState={setVersionOpenState}
+      >
+        <V011 />
+      </Version>
+      <Version
+        version="v0.1.0"
+        date="2020-02-24"
+        openState={openState}
+        setOpenState={setVersionOpenState}
+      >
+        <V010 />
+      </Version>
+    </>
   );
 }
 

--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
-import { useChangelogStorage } from 'src/hooks';
-import Version from './Version';
-import { V010, V011, V020 } from './versions';
+import React from "react";
+import { useChangelogStorage } from "src/hooks";
+import Version from "./Version";
+import { V010, V011, V020 } from "./versions";
 
 const Changelog: React.FC = () => {
   const [{ data, loading }, setOpenState] = useChangelogStorage();
 
-  if (loading)
-    return <></>;
+  if (loading) return <></>;
 
   const openState = data?.versions ?? {};
 
-  const setVersionOpenState = (key: string, state: boolean) => setOpenState({
-    versions: {
-      ...openState,
-      [key]: state
-    }
-  });
+  const setVersionOpenState = (key: string, state: boolean) =>
+    setOpenState({
+      versions: {
+        ...openState,
+        [key]: state,
+      },
+    });
 
   return (
     <>
@@ -48,6 +48,6 @@ const Changelog: React.FC = () => {
       </Version>
     </>
   );
-}
+};
 
 export default Changelog;

--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -23,7 +23,6 @@ const Changelog: React.FC = () => {
       <h1 className="mb-4">Changelog:</h1>
       <Version
         version="v0.2.0"
-        date="Development Version"
         openState={openState}
         setOpenState={setVersionOpenState}
         defaultOpen

--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Version from './Version';
+
+const Changelog: React.FC = () => {
+  return (
+    <div>
+      <h4>Changelog:</h4>
+      <Version
+        header="v0.2.0 - WIP"
+        defaultOpen
+      />
+      <Version header="v0.1.0 - 2020-02-24" />
+    </div>
+  );
+}
+
+export default Changelog;

--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -1,20 +1,29 @@
-import React, { useState } from 'react';
-import { Button, Card, Collapse } from 'react-bootstrap';
-import { Icon } from 'src/components/Shared';
+import React, { useState } from "react";
+import { Button, Card, Collapse } from "react-bootstrap";
+import { Icon } from "src/components/Shared";
 
 interface IVersionProps {
   version: string;
   date: string;
-  defaultOpen?: boolean
+  defaultOpen?: boolean;
   setOpenState: (key: string, state: boolean) => void;
   openState: Record<string, boolean>;
 }
 
-const Version: React.FC<IVersionProps> = ({version, date, defaultOpen, openState, setOpenState, children}) => {
-  const [open, setOpen] = useState(defaultOpen ?? openState[version+date] ?? false);
+const Version: React.FC<IVersionProps> = ({
+  version,
+  date,
+  defaultOpen,
+  openState,
+  setOpenState,
+  children,
+}) => {
+  const [open, setOpen] = useState(
+    defaultOpen ?? openState[version + date] ?? false
+  );
 
   const updateState = () => {
-    setOpenState(version+date, !open);
+    setOpenState(version + date, !open);
     setOpen(!open);
   };
 
@@ -22,7 +31,7 @@ const Version: React.FC<IVersionProps> = ({version, date, defaultOpen, openState
     <Card className="changelog-version">
       <Card.Header>
         <h4 className="changelog-version-header d-flex align-items-center">
-          <Icon icon={open ? 'angle-up' : 'angle-down'} />
+          <Icon icon={open ? "angle-up" : "angle-down"} />
           <Button onClick={updateState} variant="link">
             {version} ({date})
           </Button>
@@ -30,13 +39,11 @@ const Version: React.FC<IVersionProps> = ({version, date, defaultOpen, openState
       </Card.Header>
       <Card.Body>
         <Collapse in={open}>
-          <div className="changelog-version-body">
-            {children}
-          </div>
+          <div className="changelog-version-body">{children}</div>
         </Collapse>
       </Card.Body>
     </Card>
   );
-}
+};
 
 export default Version;

--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import { Button, Collapse } from 'react-bootstrap';
+
+interface IVersionProps {
+  header: string;
+  defaultOpen?: boolean
+}
+
+
+const Version: React.FC<IVersionProps> = ({header, defaultOpen = false, children}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div>
+      <h4><Button onClick={() => setOpen(!open)} variant="link">{header}</Button></h4>
+      <Collapse in={open}>{children}</Collapse>
+    </div>
+  );
+}
+
+export default Version;

--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { Button, Card, Collapse } from "react-bootstrap";
+import { FormattedDate, FormattedMessage } from "react-intl";
 import { Icon } from "src/components/Shared";
 
 interface IVersionProps {
   version: string;
-  date: string;
+  date?: string;
   defaultOpen?: boolean;
   setOpenState: (key: string, state: boolean) => void;
   openState: Record<string, boolean>;
@@ -33,7 +34,16 @@ const Version: React.FC<IVersionProps> = ({
         <h4 className="changelog-version-header d-flex align-items-center">
           <Icon icon={open ? "angle-up" : "angle-down"} />
           <Button onClick={updateState} variant="link">
-            {version} ({date})
+            {version} (
+            {date ? (
+              <FormattedDate value={new Date(Date.parse(date))} />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Development Version"
+                id="developmentVersion"
+              />
+            )}
+            )
           </Button>
         </h4>
       </Card.Header>

--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -1,19 +1,41 @@
 import React, { useState } from 'react';
-import { Button, Collapse } from 'react-bootstrap';
+import { Button, Card, Collapse } from 'react-bootstrap';
+import { Icon } from 'src/components/Shared';
 
 interface IVersionProps {
-  header: string;
+  version: string;
+  date: string;
   defaultOpen?: boolean
+  setOpenState: (key: string, state: boolean) => void;
+  openState: Record<string, boolean>;
 }
 
+const Version: React.FC<IVersionProps> = ({version, date, defaultOpen, openState, setOpenState, children}) => {
+  const [open, setOpen] = useState(defaultOpen ?? openState[version+date] ?? false);
 
-const Version: React.FC<IVersionProps> = ({header, defaultOpen = false, children}) => {
-  const [open, setOpen] = useState(defaultOpen);
+  const updateState = () => {
+    setOpenState(version+date, !open);
+    setOpen(!open);
+  };
+
   return (
-    <div>
-      <h4><Button onClick={() => setOpen(!open)} variant="link">{header}</Button></h4>
-      <Collapse in={open}>{children}</Collapse>
-    </div>
+    <Card className="changelog-version">
+      <Card.Header>
+        <h4 className="changelog-version-header d-flex align-items-center">
+          <Icon icon={open ? 'angle-up' : 'angle-down'} />
+          <Button onClick={updateState} variant="link">
+            {version} ({date})
+          </Button>
+        </h4>
+      </Card.Header>
+      <Card.Body>
+        <Collapse in={open}>
+          <div className="changelog-version-body">
+            {children}
+          </div>
+        </Collapse>
+      </Card.Body>
+    </Card>
   );
 }
 

--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -32,8 +32,8 @@ const Version: React.FC<IVersionProps> = ({
     <Card className="changelog-version">
       <Card.Header>
         <h4 className="changelog-version-header d-flex align-items-center">
-          <Icon icon={open ? "angle-up" : "angle-down"} />
           <Button onClick={updateState} variant="link">
+            <Icon icon={open ? "angle-up" : "angle-down"} className="mr-3" />
             {version} (
             {date ? (
               <FormattedDate value={new Date(Date.parse(date))} />

--- a/ui/v2.5/src/components/Changelog/styles.scss
+++ b/ui/v2.5/src/components/Changelog/styles.scss
@@ -6,6 +6,14 @@
     color: inherit;
     font-size: inherit;
     font-weight: inherit;
+
+    &:focus {
+      text-decoration: unset;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .card,
@@ -15,7 +23,7 @@
 
   ul {
     list-style-type: none;
-    padding-left: 1rem;
+    padding-left: .5rem;
   }
 
   &-version {

--- a/ui/v2.5/src/components/Changelog/styles.scss
+++ b/ui/v2.5/src/components/Changelog/styles.scss
@@ -8,6 +8,11 @@
     font-weight: inherit;
   }
 
+  .card,
+  .card-body {
+    padding: 0;
+  }
+
   ul {
     list-style-type: none;
     padding-left: 1rem;
@@ -21,10 +26,5 @@
     &-header {
       color: $text-color;
     }
-  }
-
-  .card,
-  .card-body {
-    padding: 0;
   }
 }

--- a/ui/v2.5/src/components/Changelog/styles.scss
+++ b/ui/v2.5/src/components/Changelog/styles.scss
@@ -23,7 +23,7 @@
 
   ul {
     list-style-type: none;
-    padding-left: .5rem;
+    padding-left: 0.5rem;
   }
 
   &-version {

--- a/ui/v2.5/src/components/Changelog/styles.scss
+++ b/ui/v2.5/src/components/Changelog/styles.scss
@@ -1,0 +1,30 @@
+.changelog {
+  margin-bottom: 4rem;
+  margin-top: 4rem;
+
+  .btn {
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  ul {
+    list-style-type: none;
+    padding-left: 1rem;
+  }
+
+  &-version {
+    &-body {
+      padding: 1rem 2rem;
+    }
+
+    &-header {
+      color: $text-color;
+    }
+  }
+
+  .card,
+  .card-body {
+    padding: 0;
+  }
+}

--- a/ui/v2.5/src/components/Changelog/versions/index.ts
+++ b/ui/v2.5/src/components/Changelog/versions/index.ts
@@ -1,3 +1,3 @@
-export { default as V010 } from './v010';
-export { default as V011 } from './v011';
-export { default as V020 } from './v020';
+export { default as V010 } from "./v010";
+export { default as V011 } from "./v011";
+export { default as V020 } from "./v020";

--- a/ui/v2.5/src/components/Changelog/versions/index.ts
+++ b/ui/v2.5/src/components/Changelog/versions/index.ts
@@ -1,0 +1,3 @@
+export { default as V010 } from './v010';
+export { default as V011 } from './v011';
+export { default as V020 } from './v020';

--- a/ui/v2.5/src/components/Changelog/versions/v010.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v010.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import React from "react";
+import ReactMarkdown from "react-markdown";
 
 const markup = `
 ### ✨ New Features
@@ -52,6 +52,4 @@ const markup = `
 * Fix usage of Box.Bytes causing depreciation message
 `;
 
-export default () => (
-  <ReactMarkdown source={markup} />
-);
+export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v010.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v010.tsx
@@ -17,7 +17,7 @@ const markup = `
 * Add "O-" (or "splooge-") counter
 * Add external_host option
 
-### ⚡️Improvements
+### 🎨 Improvements
 
 * Improve scene wall layout
 * Read config from current working directory before user profile directory

--- a/ui/v2.5/src/components/Changelog/versions/v010.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v010.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+const markup = `
+### ✨ New Features
+
+* Configurable custom performer scrapers
+* Support looping of short videos.
+* Optionally auto-start videos.
+* Add scene auto-tagging from filename
+* Add Play random button to scenes and scene markers page
+* Allow uploading of custom scene covers
+* Configurable custom scene metadata scrapers
+* Add "Open Random" to performer list
+* Add scenes tab to performer page
+* Add version check
+* Add "O-" (or "splooge-") counter
+* Add external_host option
+
+### ⚡️Improvements
+
+* Improve scene wall layout
+* Read config from current working directory before user profile directory
+* Upload pull request builds to transfer.sh
+* Save interface options
+* Change marker time input to mm:ss
+* Allow pasting image into performer/studio
+* Scene UI improvements
+* Update JWPlayer to 8.11.5
+* Beautify scene list table
+* Add responsive menu
+* Make scene metadata from file metadata optional
+* Add transcode seeking support to JWPlayer and remove video.js
+* Allow exclusion patterns for scanning
+* Support scraping from other stash instances
+* Display both server address and listening address in log
+* Add scene duration filter
+* Add useful links to about page
+* Generate a new order when selecting random sorting
+* Maintain filter parameters in session
+* Change thumbnail default size and resize algorithm
+* Improve caching of static files and performer images
+* Improve position and cropping of performer images
+* Improve stats page
+
+### 🐛 Bug fixes
+
+* Fix importing on Windows
+* Fix previews sometimes taking a long time to generate
+* Fix input fields losing focus when switching between windows
+* Fix VTT for chapter display in scene players
+* Fix usage of Box.Bytes causing depreciation message
+`;
+
+export default () => (
+  <ReactMarkdown source={markup} />
+);

--- a/ui/v2.5/src/components/Changelog/versions/v011.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v011.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 
 const markup = `
-**Fix version checking.**
+### 🐛 Bug fixes
+Fix version checking.
 `;
 
 export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v011.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v011.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import React from "react";
+import ReactMarkdown from "react-markdown";
 
 const markup = `
 **Fix version checking.**
 `;
 
-export default () => (
-  <ReactMarkdown source={markup} />
-);
+export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v011.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v011.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+const markup = `
+**Fix version checking.**
+`;
+
+export default () => (
+  <ReactMarkdown source={markup} />
+);

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -2,62 +2,64 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 
 const markup = `
-💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been completed.**
+#### 💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been completed.**
+
 &nbsp;
+### ✨ New Features
+*  Movies are now supported.
+*  Responsive layout for mobile phones.
+*  Add support for image scraping.
+*  Allow user to regenerate scene cover based on timestamp.
+*  Autoassociate galleries to scenes when scanning.
+*  Configurable scraper user agent string.
+*  Backup database if a migration is needed.
+*  Add modes for performer/tag for bulk scene editing.
+*  Add gender support for performer.
+*  Add SVG studio image support, and studio image caching.
+*  Enable sorting for galleries.
+*  Add scene rating to scene filename parser.
+*  Replace basic auth with cookie authentication.
+*  Add detection of container/video_codec/audio_codec compatibility for live file streaming or transcoding.
+*  Move image with cover.jpg in name to first place in Galleries.
+*  Add "reshuffle button" when sortby is random.
+*  Implement clean for missing galleries.
+*  Add parser support for 3-letter month.
+*  Add is-missing tags filter.
 
-#### Major Changes:
-* ✨ [Movies](/movies) are now supported.
-* 💄 Responsive layout for mobile phones.
-* ⚡️ Performance improvements and improved video support.
-* 📝 Support for localized text, dates and numbers.
+### 🎨 Improvements
+*  Performance improvements and improved video support.
+*  Support for localized text, dates and numbers.
+*  Replace Blueprint with react-bootstrap.
+*  Add image count to gallery list.
+*  Update prettier to v2.0.1 and enable for SCSS.
+*  Add library size to main stats page.
+*  Add slim endpoints for entities to speed up filters.
+*  Export performance optimization.
+*  Add random male performer image.
+*  Added various missing filters to performer page.
+*  Add index/total count to end of pagination buttons.
+*  Refactor build.
+*  Add flags for performer countries.
+*  Querybuilder integration tests.
+*  Overhaul look and feel of folder select.
+*  Add changelog to start page.
 
-#### Full list of changes:
+### 🐛 Bug fixes
+*  Update performer image in UI when it's replaced.
+*  Fix performer height filter.
+*  Fix error when viewing scenes related to objects with illegal characters in name.
+*  Fix to allow scene to be removed when attached to a movie.
+*  Make ethnicity freetext and fix freeones ethnicity panic.
+*  Fix to filter on movies from performer filter to movie filter.
+*  Delete marker preview on marker change or delete.
+*  Prefer modified performer image over scraped one.
+*  Don't redirect login to migrate page.
+*  Performer and Movie UI fixes and improvements.
+*  Include gender in performer scraper results.
+*  Include scene o-counter in import/export.
+*  Make image extension check in zip files case insensitive.
+*  Freeones scraper tweaks.
 
-* ✨ Add support for image scraping.
-* ✨ Allow user to regenerate scene cover based on timestamp.
-* ♻️ Replace Blueprint with react-bootstrap.
-* 🐛 Update performer image in UI when it's replaced.
-* 🐛 Fix performer height filter.
-* 🐛 Fix error when viewing scenes related to objects with illegal characters in name.
-* ✨ Autoassociate galleries to scenes when scanning.
-* ✨ Configurable scraper user agent string.
-* ✨ Backup database if a migration is needed.
-* ✨ Add modes for performer/tag for bulk scene editing.
-* ✨ Add gender support for performer.
-* 🐛 Fix to allow scene to be removed when attached to a movie.
-* 🐛 Make ethnicity freetext and fix freeones ethnicity panic.
-* 💄 Add image count to gallery list.
-* ✨ Add SVG studio image support, and studio image caching.
-* 🐛 Fix to filter on movies from performer filter to movie filter.
-* 🎨 Update prettier to v2.0.1 and enable for SCSS.
-* 💄 Add library size to main stats page.
-* ✨ Enable sorting for galleries.
-* ✨ Add scene rating to scene filename parser.
-* ✨ Replace basic auth with cookie authentication.
-* 🐛 Added various missing filters to performer page.
-* ✨ Add detection of container/video_codec/audio_codec compatibility for live file streaming or transcoding.
-* 🐛 Delete marker preview on marker change or delete.
-* 🐛 Prefer modified performer image over scraped one.
-* 🐛 Don't redirect login to migrate page.
-* 🐛 Performer and Movie UI fixes and improvements.
-* 🐛 Include gender in performer scraper results.
-* ⚡️ Add slim endpoints for entities to speed up filters.
-* 🐛 Include scene o-counter in import/export.
-* ⚡️ Export performance optimization.
-* ✨ Move image with cover.jpg in name to first place in Galleries.
-* ✨ Add "reshuffle button" when sortby is random.
-* ✨ Implement clean for missing galleries.
-* 💄 Add random male performer image.
-* ✨ Add parser support for 3-letter month.
-* 💄 Add index/total count to end of pagination buttons.
-* 🐛 Make image extension check in zip files case insensitive.
-* ♻️ Refactor build.
-* 💄 Add flags for performer countries.
-* 🐛 Freeones scraper tweaks.
-* ✅ Querybuilder integration tests.
-* ✨ Add is-missing tags filter.
-* 💄 Overhaul look and feel of folder select.
-* 📝 Add changelog to start page.
 `;
 
 export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import React from "react";
+import ReactMarkdown from "react-markdown";
 
 const markup = `
 💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been run.**
@@ -59,6 +59,4 @@ const markup = `
 * 💄 Overhaul look and feel of folder select.
 `;
 
-export default () => (
-  <ReactMarkdown source={markup} />
-);
+export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 
 const markup = `
-💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been run.**
+💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been completed.**
 &nbsp;
 
 #### Major Changes:

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+const markup = `
+💥 **Note: After upgrading performance will be degraded until a full [scan](/settings?tab=tasks) has been run.**
+&nbsp;
+
+#### Major Changes:
+* ✨ [Movies](/movies) are now supported.
+* 💄 Responsive layout for mobile phones.
+* ⚡️ Performance improvements and improved video support.
+* 📝 Support for localized text, dates and numbers.
+
+#### Full list of changes:
+
+* ✨ Add support for image scraping.
+* ✨ Allow user to regenerate scene cover based on timestamp.
+* ♻️ Replace Blueprint with react-bootstrap.
+* 🐛 Update performer image in UI when it's replaced.
+* 🐛 Fix performer height filter.
+* 🐛 Fix error when viewing scenes related to objects with illegal characters in name.
+* ✨ Autoassociate galleries to scenes when scanning.
+* ✨ Configurable scraper user agent string.
+* ✨ Backup database if a migration is needed.
+* ✨ Add modes for performer/tag for bulk scene editing.
+* ✨ Add gender support for performer.
+* 🐛 Fix to allow scene to be removed when attached to a movie.
+* 🐛 Make ethnicity freetext and fix freeones ethnicity panic.
+* 💄 Add image count to gallery list.
+* ✨ Add SVG studio image support, and studio image caching.
+* 🐛 Fix to filter on movies from performer filter to movie filter.
+* 🎨 Update prettier to v2.0.1 and enable for SCSS.
+* 💄 Add library size to main stats page.
+* ✨ Enable sorting for galleries.
+* ✨ Add scene rating to scene filename parser.
+* ✨ Replace basic auth with cookie authentication.
+* 🐛 Added various missing filters to performer page.
+* ✨ Add detection of container/video_codec/audio_codec compatibility for live file streaming or transcoding.
+* 🐛 Delete marker preview on marker change or delete.
+* 🐛 Prefer modified performer image over scraped one.
+* 🐛 Don't redirect login to migrate page.
+* 🐛 Performer and Movie UI fixes and improvements.
+* 🐛 Include gender in performer scraper results.
+* ⚡️ Add slim endpoints for entities to speed up filters.
+* 🐛 Include scene o-counter in import/export.
+* ⚡️ Export performance optimization.
+* ✨ Move image with cover.jpg in name to first place in Galleries.
+* ✨ Add "reshuffle button" when sortby is random.
+* ✨ Implement clean for missing galleries.
+* 💄 Add random male performer image.
+* ✨ Add parser support for 3-letter month.
+* 💄 Add index/total count to end of pagination buttons.
+* 🐛 Make image extension check in zip files case insensitive.
+* ♻️ Refactor build.
+* 💄 Add flags for performer countries.
+* 🐛 Freeones scraper tweaks.
+* ✅ Querybuilder integration tests.
+* ✨ Add is-missing tags filter.
+* 💄 Overhaul look and feel of folder select.
+`;
+
+export default () => (
+  <ReactMarkdown source={markup} />
+);

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -57,6 +57,7 @@ const markup = `
 * ✅ Querybuilder integration tests.
 * ✨ Add is-missing tags filter.
 * 💄 Overhaul look and feel of folder select.
+* 📝 Add changelog to start page.
 `;
 
 export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Changelog/versions/v020.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v020.tsx
@@ -31,14 +31,12 @@ const markup = `
 *  Support for localized text, dates and numbers.
 *  Replace Blueprint with react-bootstrap.
 *  Add image count to gallery list.
-*  Update prettier to v2.0.1 and enable for SCSS.
 *  Add library size to main stats page.
 *  Add slim endpoints for entities to speed up filters.
 *  Export performance optimization.
 *  Add random male performer image.
 *  Added various missing filters to performer page.
 *  Add index/total count to end of pagination buttons.
-*  Refactor build.
 *  Add flags for performer countries.
 *  Querybuilder integration tests.
 *  Overhaul look and feel of folder select.
@@ -48,17 +46,13 @@ const markup = `
 *  Update performer image in UI when it's replaced.
 *  Fix performer height filter.
 *  Fix error when viewing scenes related to objects with illegal characters in name.
-*  Fix to allow scene to be removed when attached to a movie.
 *  Make ethnicity freetext and fix freeones ethnicity panic.
-*  Fix to filter on movies from performer filter to movie filter.
 *  Delete marker preview on marker change or delete.
 *  Prefer modified performer image over scraped one.
-*  Don't redirect login to migrate page.
-*  Performer and Movie UI fixes and improvements.
 *  Include gender in performer scraper results.
 *  Include scene o-counter in import/export.
 *  Make image extension check in zip files case insensitive.
-*  Freeones scraper tweaks.
+*  Update built-in Freeones scraper for new API.
 
 `;
 

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useStats } from "src/core/StashService";
 import { FormattedMessage, FormattedNumber } from "react-intl";
 import { LoadingIndicator } from "src/components/Shared";
+import Changelog from "src/components/Changelog/Changelog";
 
 export const Stats: React.FC = () => {
   const { data, error, loading } = useStats();
@@ -72,6 +73,9 @@ export const Stats: React.FC = () => {
             <FormattedMessage id="tags" defaultMessage="Tags" />
           </p>
         </div>
+      </div>
+      <div className="changelog col col-sm-8 mx-sm-auto">
+        <Changelog />
       </div>
     </div>
   );

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -73,10 +73,8 @@ function useLocalForage<T>(
   return [{ data, error, loading: isLoading }, setData];
 }
 
-export const useInterfaceLocalForage = () => (
-  useLocalForage<IInterfaceConfig>("interface")
-);
+export const useInterfaceLocalForage = () =>
+  useLocalForage<IInterfaceConfig>("interface");
 
-export const useChangelogStorage = () => (
-  useLocalForage<IChangelogConfig>("changelog")
-);
+export const useChangelogStorage = () =>
+  useLocalForage<IChangelogConfig>("changelog");

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -14,8 +14,9 @@ export interface IInterfaceConfig {
   queries?: Record<string, IInterfaceQueryConfig>;
 }
 
-type ValidTypes = IInterfaceConfig;
-type Key = "interface";
+export interface IChangelogConfig {
+  versions: Record<string, boolean>;
+}
 
 interface ILocalForage<T> {
   data?: T;
@@ -24,13 +25,13 @@ interface ILocalForage<T> {
 }
 
 const Loading: Record<string, boolean> = {};
-const Cache: Record<string, ValidTypes> = {};
+const Cache: Record<string, {}> = {};
 
-function useLocalForage(
-  key: Key
-): [ILocalForage<ValidTypes>, Dispatch<SetStateAction<ValidTypes>>] {
+function useLocalForage<T>(
+  key: string
+): [ILocalForage<T>, Dispatch<SetStateAction<T>>] {
   const [error, setError] = React.useState(null);
-  const [data, setData] = React.useState(Cache[key]);
+  const [data, setData] = React.useState<T>(Cache[key] as T);
   const [loading, setLoading] = React.useState(Loading[key]);
 
   useEffect(() => {
@@ -42,7 +43,7 @@ function useLocalForage(
           setData(parsed);
           Cache[key] = parsed;
         } else {
-          setData({});
+          setData({} as T);
           Cache[key] = {};
         }
         setError(null);
@@ -72,9 +73,10 @@ function useLocalForage(
   return [{ data, error, loading: isLoading }, setData];
 }
 
-export function useInterfaceLocalForage(): [
-  ILocalForage<IInterfaceConfig>,
-  Dispatch<SetStateAction<IInterfaceConfig>>
-] {
-  return useLocalForage("interface");
-}
+export const useInterfaceLocalForage = () => (
+  useLocalForage<IInterfaceConfig>("interface")
+);
+
+export const useChangelogStorage = () => (
+  useLocalForage<IChangelogConfig>("changelog")
+);

--- a/ui/v2.5/src/hooks/index.ts
+++ b/ui/v2.5/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { default as useToast } from "./Toast";
-export { useInterfaceLocalForage } from "./LocalForage";
+export { useInterfaceLocalForage, useChangelogStorage } from "./LocalForage";
 export { useVideoHover } from "./VideoHover";
 export {
   useScenesList,

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -1,6 +1,7 @@
 @import "styles/theme";
 @import "styles/range";
 @import "styles/scrollbars";
+@import "src/components/Changelog/styles.scss";
 @import "src/components/Galleries/styles.scss";
 @import "src/components/List/styles.scss";
 @import "src/components/Movies/styles.scss";
@@ -25,10 +26,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 4rem 0 0 0;
-}
-
-a {
-  color: $primary;
 }
 
 code,

--- a/ui/v2.5/src/locale/de.json
+++ b/ui/v2.5/src/locale/de.json
@@ -1,4 +1,5 @@
 {
+  "developmentVersion": "",
   "galleries": "Galerien",
   "library-size": "",
   "markers": "",
@@ -7,5 +8,6 @@
   "performers": "Künstler",
   "scenes": "Szenen",
   "studios": "Studios",
-  "tags": "Etiketten"
+  "tags": "Etiketten",
+  "up-dir": ""
 }

--- a/ui/v2.5/src/locale/en.json
+++ b/ui/v2.5/src/locale/en.json
@@ -1,4 +1,5 @@
 {
+  "developmentVersion": "Development Version",
   "galleries": "Galleries",
   "library-size": "Library size",
   "markers": "Markers",
@@ -7,5 +8,6 @@
   "performers": "Performers",
   "scenes": "Scenes",
   "studios": "Studios",
-  "tags": "Tags"
+  "tags": "Tags",
+  "up-dir": "Up a directory"
 }

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -5540,7 +5540,7 @@ dom-helpers@^5.0.1, dom-helpers@^5.1.0, dom-helpers@^5.1.2:
     "@babel/runtime" "^7.6.3"
     csstype "^2.6.7"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
@@ -5577,6 +5577,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -5592,6 +5599,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
+  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-case@^3.0.3:
   version "3.0.3"
@@ -7317,6 +7333,16 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
+html-to-react@^1.3.4:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.2.tgz#7b628ab56cd63a52f2d0b79d0fa838a51f088a57"
+  integrity sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 html-webpack-plugin@4.0.0-beta.11:
   version "4.0.0-beta.11"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz#3059a69144b5aecef97708196ca32f9e68677715"
@@ -7340,6 +7366,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -7841,7 +7877,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5:
+is-buffer@^1.0.2, is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -9157,6 +9193,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -9412,6 +9453,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 mdast-util-compact@^2.0.0:
   version "2.0.1"
@@ -10462,6 +10510,18 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -11789,6 +11849,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -11951,6 +12016,11 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+react-is@^16.8.6:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-jw-player@1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/react-jw-player/-/react-jw-player-1.19.1.tgz#1d4ff99d3a5850ed4a628dbc6c473149c5490e1c"
@@ -11962,6 +12032,20 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-overlays@^3.1.2:
   version "3.1.3"
@@ -12460,6 +12544,27 @@ relay-runtime@9.1.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
 
 remark-parse@^8.0.0:
   version "8.0.2"
@@ -14284,6 +14389,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 unified@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.0.0.tgz#12b099f97ee8b36792dbad13d278ee2f696eed1d"
@@ -14337,10 +14454,22 @@ unist-util-find-all-after@^3.0.1:
   dependencies:
     unist-util-is "^4.0.0"
 
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
 unist-util-is@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.2.tgz#c7d1341188aa9ce5b3cff538958de9895f14a5de"
   integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -14349,12 +14478,29 @@ unist-util-remove-position@^2.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz#5a3866e7138d55974b640ec69a94bc19e0f3fa12"
   integrity sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
 
 unist-util-visit-parents@^3.0.0:
   version "3.0.2"
@@ -14363,6 +14509,13 @@ unist-util-visit-parents@^3.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unist-util-visit@^2.0.0:
   version "2.0.2"
@@ -14581,10 +14734,22 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
 vfile-location@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.0.1.tgz#d78677c3546de0f7cd977544c367266764d31bb3"
   integrity sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
 
 vfile-message@^2.0.0:
   version "2.0.4"
@@ -14593,6 +14758,16 @@ vfile-message@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vfile@^4.0.0:
   version "4.1.0"
@@ -15120,6 +15295,11 @@ ws@^6.1.2, ws@^6.2.1:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Adds a markdown based changelog to the start page. I've used [gitmojis](https://gitmoji.carloscuesta.me/) to denote change "type".  Changes for v0.1.0 are copied from release page, changes for 0.2.0 are pulled from the commit log. I've omitted fixes for features that are implemented in v0.2.0.

Suggestions for changes very welcome!

Also tweaked the localForage hook slightly so it's a bit easier to init new storage types, and changed the default anchor color since the dark blue is very hard to read.

Resolves #504.

![image](https://user-images.githubusercontent.com/25374869/81507480-05825f00-92fe-11ea-8777-09191438238e.png)
