### PR TITLE
Make auto tagger matching more flexible

### DIFF
--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -24,12 +24,10 @@ func (t *AutoTagPerformerTask) Start(wg *sync.WaitGroup) {
 func getQueryRegex(name string) string {
 	const separatorChars = `.\-_ `
 	// handle path separators
-	const endSeparatorChars = separatorChars + `\\/`
 	const separator = `[` + separatorChars + `]`
-	const endSeparator = `[` + endSeparatorChars + `]`
 
 	ret := strings.Replace(name, " ", separator+"*", -1)
-	ret = "(?:^|" + endSeparator + "+)" + ret + "(?:$|" + endSeparator + "+)"
+	ret = `(?:^|_|[^\w\d])` + ret + `(?:$|_|[^\w\d])`
 	return ret
 }
 

--- a/pkg/manager/task_autotag_test.go
+++ b/pkg/manager/task_autotag_test.go
@@ -36,7 +36,15 @@ var testSeparators = []string{
 	" ",
 }
 
-func generateNamePatterns(name string, separator string) []string {
+var testEndSeparators = []string{
+	"{",
+	"}",
+	"(",
+	")",
+	",",
+}
+
+func generateNamePatterns(name, separator string) []string {
 	var ret []string
 	ret = append(ret, fmt.Sprintf("%s%saaa"+testExtension, name, separator))
 	ret = append(ret, fmt.Sprintf("aaa%s%s"+testExtension, separator, name))
@@ -152,13 +160,20 @@ func createScenes(tx *sqlx.Tx) error {
 	// create the scenes
 	var scenePatterns []string
 	var falseScenePatterns []string
-	for _, separator := range testSeparators {
+
+	separators := append(testSeparators, testEndSeparators...)
+
+	for _, separator := range separators {
 		scenePatterns = append(scenePatterns, generateNamePatterns(testName, separator)...)
 		scenePatterns = append(scenePatterns, generateNamePatterns(strings.ToLower(testName), separator)...)
+		falseScenePatterns = append(falseScenePatterns, generateFalseNamePattern(testName, separator))
+	}
+
+	// add test cases for intra-name separators
+	for _, separator := range testSeparators {
 		if separator != " " {
 			scenePatterns = append(scenePatterns, generateNamePatterns(strings.Replace(testName, " ", separator, -1), separator)...)
 		}
-		falseScenePatterns = append(falseScenePatterns, generateFalseNamePattern(testName, separator))
 	}
 
 	for _, fn := range scenePatterns {


### PR DESCRIPTION
Fixes #483 

Changes the auto tagger regex to be a bit more flexible when matching. The boundary pattern is changed to be any non-alphanumeric character. The intra-name separators are unchanged, so it won't match something like `firstname[lastname`, but it should match something like `{firstname.lastname}`.