### PR TITLE
Speed up tag count queries

### DIFF
--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -35,10 +35,10 @@ WHERE movies_join.movie_id = ?
 GROUP BY scenes.id
 `
 
-var scenesForTagQuery = selectAll(sceneTable) + `
-LEFT JOIN scenes_tags as tags_join on tags_join.scene_id = scenes.id
-WHERE tags_join.tag_id = ?
-GROUP BY scenes.id
+var countScenesForTagQuery = `
+SELECT tag_id AS id FROM scenes_tags
+WHERE scenes_tags.tag_id = ?
+GROUP BY scenes_tags.scene_id
 `
 
 type SceneQueryBuilder struct{}
@@ -212,7 +212,7 @@ func (qb *SceneQueryBuilder) CountByStudioID(studioID int) (int, error) {
 
 func (qb *SceneQueryBuilder) CountByTagID(tagID int) (int, error) {
 	args := []interface{}{tagID}
-	return runCountQuery(buildCountQuery(scenesForTagQuery), args)
+	return runCountQuery(buildCountQuery(countScenesForTagQuery), args)
 }
 
 func (qb *SceneQueryBuilder) Wall(q *string) ([]*Scene, error) {

--- a/pkg/models/querybuilder_scene_marker.go
+++ b/pkg/models/querybuilder_scene_marker.go
@@ -7,12 +7,10 @@ import (
 	"strconv"
 )
 
-const sceneMarkersForTagQuery = `
-SELECT scene_markers.* FROM scene_markers
+const countSceneMarkersForTagQuery = `
+SELECT scene_markers.id FROM scene_markers
 LEFT JOIN scene_markers_tags as tags_join on tags_join.scene_marker_id = scene_markers.id
-LEFT JOIN tags on tags_join.tag_id = tags.id
-LEFT JOIN tags AS ptj ON ptj.id = scene_markers.primary_tag_id
-WHERE tags.id = ? OR ptj.id = ?
+WHERE tags_join.tag_id = ? OR scene_markers.primary_tag_id = ?
 GROUP BY scene_markers.id
 `
 
@@ -87,7 +85,7 @@ func (qb *SceneMarkerQueryBuilder) FindBySceneID(sceneID int, tx *sqlx.Tx) ([]*S
 
 func (qb *SceneMarkerQueryBuilder) CountByTagID(tagID int) (int, error) {
 	args := []interface{}{tagID, tagID}
-	return runCountQuery(buildCountQuery(sceneMarkersForTagQuery), args)
+	return runCountQuery(buildCountQuery(countSceneMarkersForTagQuery), args)
 }
 
 func (qb *SceneMarkerQueryBuilder) GetMarkerStrings(q *string, sort *string) ([]*MarkerStringsResultType, error) {

--- a/pkg/models/querybuilder_scene_marker_test.go
+++ b/pkg/models/querybuilder_scene_marker_test.go
@@ -32,10 +32,37 @@ func TestMarkerFindBySceneID(t *testing.T) {
 	assert.Len(t, markers, 0)
 }
 
+func TestMarkerCountByTagID(t *testing.T) {
+	mqb := models.NewSceneMarkerQueryBuilder()
+
+	markerCount, err := mqb.CountByTagID(tagIDs[tagIdxWithPrimaryMarker])
+
+	if err != nil {
+		t.Fatalf("error calling CountByTagID: %s", err.Error())
+	}
+
+	assert.Equal(t, 1, markerCount)
+
+	markerCount, err = mqb.CountByTagID(tagIDs[tagIdxWithMarker])
+
+	if err != nil {
+		t.Fatalf("error calling CountByTagID: %s", err.Error())
+	}
+
+	assert.Equal(t, 1, markerCount)
+
+	markerCount, err = mqb.CountByTagID(0)
+
+	if err != nil {
+		t.Fatalf("error calling CountByTagID: %s", err.Error())
+	}
+
+	assert.Equal(t, 0, markerCount)
+}
+
 // TODO Update
 // TODO Destroy
 // TODO Find
-// TODO CountByTagID
 // TODO GetMarkerStrings
 // TODO Wall
 // TODO Query


### PR DESCRIPTION
Only counts ids rather than the entire table contents, which is significantly faster. 500ms -> 30ms on my end.