### PR TITLE
Add polyfill for number unit formatting

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
+    "@formatjs/intl-numberformat": "^4.2.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -4,9 +4,9 @@ import { IntlProvider } from "react-intl";
 import { ToastProvider } from "src/hooks/Toast";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
-import '@formatjs/intl-numberformat/polyfill';
-import '@formatjs/intl-numberformat/dist/locale-data/en';
-import '@formatjs/intl-numberformat/dist/locale-data/en-GB';
+import "@formatjs/intl-numberformat/polyfill";
+import "@formatjs/intl-numberformat/dist/locale-data/en";
+import "@formatjs/intl-numberformat/dist/locale-data/en-GB";
 
 import locales from "src/locale";
 import { useConfiguration } from "src/core/StashService";

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -4,6 +4,9 @@ import { IntlProvider } from "react-intl";
 import { ToastProvider } from "src/hooks/Toast";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
+import '@formatjs/intl-numberformat/polyfill';
+import '@formatjs/intl-numberformat/dist/locale-data/en';
+import '@formatjs/intl-numberformat/dist/locale-data/en-GB';
 
 import locales from "src/locale";
 import { useConfiguration } from "src/core/StashService";

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -1718,6 +1718,13 @@
   dependencies:
     "@formatjs/intl-utils" "^2.2.4"
 
+"@formatjs/intl-numberformat@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-numberformat/-/intl-numberformat-4.2.1.tgz#76abb5e949142331310aa059e305e9ec65e07243"
+  integrity sha512-UFFCeTno+kCdzvgkjqj7kmupm3KLhWT3DLdsFeiubvkthN00o3CAkSidJCngzwMVuXv40lmcr/TXqgpgxgwKmg==
+  dependencies:
+    "@formatjs/intl-utils" "^3.1.0"
+
 "@formatjs/intl-relativetimeformat@^4.5.14":
   version "4.5.14"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.14.tgz#8ec90d536031b0b38446a261e627cca3f4978ae2"
@@ -1736,6 +1743,11 @@
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.4.tgz#fe62a96799d1f7dbe621fd38a4bd2e5a6a16cb0e"
   integrity sha512-83fsJywew0o9wQsW3VuEp33HRiFd0qbQDyFFnwZCwk59eLZ33CtKyJ5ofKMrU2KK6hk1zaIdzisrZeoNfmI3Tw==
+
+"@formatjs/intl-utils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-3.1.0.tgz#759012e2e444f7fbeb61f5148a8d95202713d82e"
+  integrity sha512-Q7+ksGpN6Dzp+W4qPai6OcUJ6pka2jPICJ0WlStFdy1RKGm90basrjSmox4xUR9DnMsWE5AfaiSu95nohCTLXw==
 
 "@fortawesome/fontawesome-common-types@^0.2.28":
   version "0.2.28"


### PR DESCRIPTION
Units are not yet supported in Firefox and Safari, but it will be part of the spec so there's no reason not  to use it.