### PR TITLE
Reload scrapers button

### DIFF
--- a/graphql/documents/mutations/scrapers.graphql
+++ b/graphql/documents/mutations/scrapers.graphql
@@ -1,0 +1,3 @@
+mutation ReloadScrapers {
+  reloadScrapers
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -53,6 +53,7 @@ type Query {
   """List available scrapers"""
   listPerformerScrapers: [Scraper!]!
   listSceneScrapers: [Scraper!]!
+
   """Scrape a list of performers based on name"""
   scrapePerformerList(scraper_id: ID!, query: String!): [ScrapedPerformer!]!
   """Scrapes a complete performer record based on a scrapePerformerList result"""
@@ -152,6 +153,9 @@ type Mutation {
   metadataAutoTag(input: AutoTagMetadataInput!): String!
   """Clean metadata. Returns the job ID"""
   metadataClean: String!
+
+  """Reload scrapers"""
+  reloadScrapers: Boolean!
 
   stopJob: Boolean!
 }

--- a/pkg/api/resolver_mutation_scraper.go
+++ b/pkg/api/resolver_mutation_scraper.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"context"
+
+	"github.com/stashapp/stash/pkg/scraper"
+)
+
+func (r *mutationResolver) ReloadScrapers(ctx context.Context) (bool, error) {
+	err := scraper.ReloadScrapers()
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/scraper/scrapers.go
+++ b/pkg/scraper/scrapers.go
@@ -50,6 +50,12 @@ func loadScrapers() ([]scraperConfig, error) {
 	return scrapers, nil
 }
 
+func ReloadScrapers() error {
+	scrapers = nil
+	_, err := loadScrapers()
+	return err
+}
+
 func ListPerformerScrapers() ([]*models.Scraper, error) {
 	// read scraper config files from the directory and cache
 	scrapers, err := loadScrapers()

--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useChangelogStorage } from "src/hooks";
 import Version from "./Version";
-import { V010, V011, V020, V021 } from "./versions";
+import { V010, V011, V020, V021, V030 } from "./versions";
 
 const Changelog: React.FC = () => {
   const [{ data, loading }, setOpenState] = useChangelogStorage();
@@ -22,11 +22,18 @@ const Changelog: React.FC = () => {
     <>
       <h1 className="mb-4">Changelog:</h1>
       <Version
+        version="v0.3.0"
+        openState={openState}
+        setOpenState={setVersionOpenState}
+        defaultOpen
+      >
+        <V030 />
+      </Version>
+      <Version
         version="v0.2.1"
         date="2020-06-10"
         openState={openState}
         setOpenState={setVersionOpenState}
-        defaultOpen
       >
         <V021 />
       </Version>
@@ -35,7 +42,6 @@ const Changelog: React.FC = () => {
         date="2020-06-06"
         openState={openState}
         setOpenState={setVersionOpenState}
-        defaultOpen
       >
         <V020 />
       </Version>

--- a/ui/v2.5/src/components/Changelog/versions/index.ts
+++ b/ui/v2.5/src/components/Changelog/versions/index.ts
@@ -2,3 +2,4 @@ export { default as V010 } from "./v010";
 export { default as V011 } from "./v011";
 export { default as V020 } from "./v020";
 export { default as V021 } from "./v021";
+export { default as V030 } from "./v030";

--- a/ui/v2.5/src/components/Changelog/versions/v030.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v030.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+
+const markup = `
+### 🎨 Improvements
+*  Add reload scrapers button.
+
+`;
+
+export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -233,7 +233,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     setIsLoading(true);
     try {
       await mutateReloadScrapers();
-      
+
       // reload the performer scrapers
       await Scrapers.refetch();
     } catch (e) {
@@ -321,19 +321,13 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
                     </Button>
                   </div>
                 ))
-              : ""
-            }
+              : ""}
             <div>
-              <Button
-                className="minimal"
-                onClick={() => onReloadScrapers()}
-              >
+              <Button className="minimal" onClick={() => onReloadScrapers()}>
                 <span className="fa-icon">
-                  <Icon icon="sync-alt" ></Icon>
+                  <Icon icon="sync-alt" />
                 </span>
-                <span>
-                  Reload scrapers
-                </span>
+                <span>Reload scrapers</span>
               </Button>
             </div>
           </div>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -11,6 +11,7 @@ import {
   stringToGender,
   queryScrapePerformer,
   queryScrapePerformerURL,
+  mutateReloadScrapers,
 } from "src/core/StashService";
 import {
   Icon,
@@ -224,8 +225,22 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     ImageUtils.onImageChange(event, onImageLoad);
   }
 
-  function onDisplayFreeOnesDialog(scraper: GQL.Scraper) {
+  function onDisplayScrapeDialog(scraper: GQL.Scraper) {
     setIsDisplayingScraperDialog(scraper);
+  }
+
+  async function onReloadScrapers() {
+    setIsLoading(true);
+    try {
+      await mutateReloadScrapers();
+      
+      // reload the performer scrapers
+      await Scrapers.refetch();
+    } catch (e) {
+      Toast.error(e);
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   function getQueryScraperPerformerInput() {
@@ -300,13 +315,27 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
                     <Button
                       key={s.name}
                       className="minimal"
-                      onClick={() => onDisplayFreeOnesDialog(s)}
+                      onClick={() => onDisplayScrapeDialog(s)}
                     >
                       {s.name}
                     </Button>
                   </div>
                 ))
-              : ""}
+              : ""
+            }
+            <div>
+              <Button
+                className="minimal"
+                onClick={() => onReloadScrapers()}
+              >
+                <span className="fa-icon">
+                  <Icon icon="sync-alt" ></Icon>
+                </span>
+                <span>
+                  Reload scrapers
+                </span>
+              </Button>
+            </div>
           </div>
         </Popover.Content>
       </Popover>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -286,10 +286,6 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
   }
 
   function renderScraperMenu() {
-    if (!queryableScrapers || queryableScrapers.length === 0) {
-      return;
-    }
-
     return (
       <DropdownButton id="scene-scrape" title="Scrape with...">
         {queryableScrapers.map((s) => (

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -275,7 +275,7 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     setIsLoading(true);
     try {
       await mutateReloadScrapers();
-      
+
       // reload the performer scrapers
       await Scrapers.refetch();
     } catch (e) {
@@ -299,11 +299,9 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
         ))}
         <Dropdown.Item onClick={() => onReloadScrapers()}>
           <span className="fa-icon">
-            <Icon icon="sync-alt" ></Icon>
+            <Icon icon="sync-alt" />
           </span>
-          <span>
-            Reload scrapers
-          </span>
+          <span>Reload scrapers</span>
         </Dropdown.Item>
       </DropdownButton>
     );

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -9,6 +9,7 @@ import {
   useListSceneScrapers,
   useSceneUpdate,
   useSceneDestroy,
+  mutateReloadScrapers,
 } from "src/core/StashService";
 import {
   PerformerSelect,
@@ -270,6 +271,20 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     }
   }
 
+  async function onReloadScrapers() {
+    setIsLoading(true);
+    try {
+      await mutateReloadScrapers();
+      
+      // reload the performer scrapers
+      await Scrapers.refetch();
+    } catch (e) {
+      Toast.error(e);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   function renderScraperMenu() {
     if (!queryableScrapers || queryableScrapers.length === 0) {
       return;
@@ -282,6 +297,14 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
             {s.name}
           </Dropdown.Item>
         ))}
+        <Dropdown.Item onClick={() => onReloadScrapers()}>
+          <span className="fa-icon">
+            <Icon icon="sync-alt" ></Icon>
+          </span>
+          <span>
+            Reload scrapers
+          </span>
+        </Dropdown.Item>
       </DropdownButton>
     );
   }

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -410,6 +410,11 @@ export const queryScrapeScene = (
     },
   });
 
+export const mutateReloadScrapers = () =>
+  client.mutate<GQL.ReloadScrapersMutation>({
+    mutation: GQL.ReloadScrapersDocument,
+  });
+
 export const mutateMetadataScan = (input: GQL.ScanMetadataInput) =>
   client.mutate<GQL.MetadataScanMutation>({
     mutation: GQL.MetadataScanDocument,

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -424,7 +424,8 @@ div.dropdown-menu {
   }
 }
 
-.popover-body .btn .fa-icon {
+.popover-body .btn .fa-icon,
+.dropdown-item .fa-icon {
   margin-left: 0;
 }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -424,6 +424,10 @@ div.dropdown-menu {
   }
 }
 
+.popover-body .btn .fa-icon {
+  margin-left: 0;
+}
+
 .brand-icon {
   padding: 3px 6px;
 


### PR DESCRIPTION
Adds an entry in the scrapers button to refresh loaded scrapers. This is for when scrapers are modified, added or removed. Changes to the scrapers will not come into effect until the scrapers are reloaded or the system is restarted.