### PR TITLE
Fix `sanitizeURL`

### DIFF
--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -119,11 +119,11 @@ const sanitiseURL = (url?: string, siteURL?: URL) => {
   if (siteURL) {
     // if url starts with the site host, then prepend the protocol
     if (url.startsWith(siteURL.host)) {
-      return siteURL.protocol + url;
+      return `${siteURL.protocol}//${url}`;
     }
 
     // otherwise, construct the url from the protocol, host and passed url
-    return `${siteURL.protocol}${siteURL.host}/${url}`;
+    return `${siteURL.protocol}//${siteURL.host}/${url}`;
   }
 
   // just prepend the protocol - assume https


### PR DESCRIPTION
**Fixes this bug:**
Sanitized URLs can become malformed - missing `//` after the protocol

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/66393006/83951285-152b8f80-a839-11ea-8cba-23b71a44d75d.png)

</details>

**Code I tested this with:**

<details>
<summary>Details</summary>

```js
const twitterURL = new URL("https://www.twitter.com");
const instagramURL = new URL("https://www.instagram.com");

const sanitiseURL = (url, siteURL) => {
  if (!url) {
    return url;
  }

  if (url.startsWith("http://") || url.startsWith("https://")) {
    // just return the entire URL
    return url;
  }

  if (siteURL) {
    // if url starts with the site host, then prepend the protocol
    if (url.startsWith(siteURL.host)) {
      return `${siteURL.protocol}//${url}`;
    }

    // otherwise, construct the url from the protocol, host and passed url
    return `${siteURL.protocol}//${siteURL.host}/${url}`;
  }

  // just prepend the protocol - assume https
  return `https://${url}`;
};

const test = (url1, url2) => console.log(sanitiseURL(url1, url2));

test('mytest', twitterURL);
test('www.twitter.com/mytest', twitterURL);
test('http://www.twitter.com/mytest?u=e123', twitterURL);
test('https://twitter.com/mytest?u=e123', twitterURL);
test('twitter.com/mytest?');

test('mytest', instagramURL);
test('www.instagram.com/mytest', instagramURL);
test('http://www.instagram.com/mytest?u=e123', instagramURL);
test('https://instagram.com/mytest?u=e123', instagramURL);
test('instagram.com/mytest?');
```

</details>