### PR TITLE
Fix max loop duration not working

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -107,7 +107,7 @@ export class ScenePlayerImpl extends React.Component<
   }
 
   private shouldRepeat(scene: GQL.SceneDataFragment) {
-    const maxLoopDuration = this.state?.config.maximumLoopDuration ?? 0;
+    const maxLoopDuration = this.props?.config?.maximumLoopDuration ?? 0;
     return (
       !!scene.file.duration &&
       !!maxLoopDuration &&


### PR DESCRIPTION
*Note:* hotfix directly to master

Fixes #603 

Fixes the UI to correctly loop videos that are under the max loop duration.