### PR TITLE
Apply xpath parseDate after subScraper

### DIFF
--- a/pkg/scraper/xpath.go
+++ b/pkg/scraper/xpath.go
@@ -240,8 +240,8 @@ func (c xpathScraperAttrConfig) applySubScraper(value string) string {
 func (c xpathScraperAttrConfig) postProcess(value string) string {
 	// perform regex replacements first
 	value = c.replaceRegex(value)
-	value = c.parseDate(value)
 	value = c.applySubScraper(value)
+	value = c.parseDate(value)
 
 	return value
 }


### PR DESCRIPTION
Moves parseDate processing after subscraper.
This is needed so that we can fetch dates from external urls.
One example is the bangbros site that has scene dates in search results but not in scene pages.
The bangbros scraper can be then adjusted like this
```
name: "BangBros"
sceneByURL:
  - action: scrapeXPath
    url:
      - https://bangbros.com/
    scraper: sceneScraper
xPathScrapers:
  sceneScraper:
    scene:
      Title: //div[@class="ps-vdoHdd"]/h1/text()
      Details: //div[@class="vdoDesc"]/text()
      Tags:
        Name:
          selector: //div[@class="vdoTags"]/a/text()
      Performers:
        Name: //div[@class="vdoCast"]/a[position()>1]/text()
      Image:
        selector: //img[@id="player-overlay-image"]/@src
        replace:
          - regex: ^
            with: "https:"
      Studio:
        Name: //div[@class="vdoCast"]/a[1]/text()
      Date:
        selector: //div[@class="vdoCast" and contains(text(), "Release:")]
        replace:
          - regex: "^Release: "
            with: "https://bangbros.com/search/"
        subScraper:
          selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
        parseDate: Jan 2, 2006
        
# Last Updated June 9, 2020
```