### PR TITLE
Add 0.2.1 changelog

### DIFF
--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useChangelogStorage } from "src/hooks";
 import Version from "./Version";
-import { V010, V011, V020 } from "./versions";
+import { V010, V011, V020, V021 } from "./versions";
 
 const Changelog: React.FC = () => {
   const [{ data, loading }, setOpenState] = useChangelogStorage();
@@ -21,6 +21,15 @@ const Changelog: React.FC = () => {
   return (
     <>
       <h1 className="mb-4">Changelog:</h1>
+      <Version
+        version="v0.2.1"
+        date="2020-06-10"
+        openState={openState}
+        setOpenState={setVersionOpenState}
+        defaultOpen
+      >
+        <V021 />
+      </Version>
       <Version
         version="v0.2.0"
         date="2020-06-06"

--- a/ui/v2.5/src/components/Changelog/versions/index.ts
+++ b/ui/v2.5/src/components/Changelog/versions/index.ts
@@ -1,3 +1,4 @@
 export { default as V010 } from "./v010";
 export { default as V011 } from "./v011";
 export { default as V020 } from "./v020";
+export { default as V021 } from "./v021";

--- a/ui/v2.5/src/components/Changelog/versions/v021.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v021.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+
+const markup = `
+### 🐛 Bug fixes
+*  Fix max loop duration not working.
+*  Fix URL sanitization on non-Chrome browsers.
+
+`;
+
+export default () => <ReactMarkdown source={markup} />;


### PR DESCRIPTION
Adds the recent bug fixes to a new 0.2.1 entry. I've left 0.2.0 open by default since the information there is important.