### PR TITLE
[RFC] Fix query toolbar, performer/studio/movie page styling improvements

### DIFF
--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -12,8 +12,7 @@ import {
   SafeAnchorProps,
   InputGroup,
   FormControl,
-  Col,
-  Row,
+  ButtonToolbar,
 } from "react-bootstrap";
 
 import { Icon } from "src/components/Shared";
@@ -190,22 +189,26 @@ export const ListFilter: React.FC<IListFilterProps> = (
       }
     }
 
-    return props.filter.displayModeOptions.map((option) => (
-      <OverlayTrigger
-        key={option}
-        overlay={
-          <Tooltip id="display-mode-tooltip">{getLabel(option)}</Tooltip>
-        }
-      >
-        <Button
-          variant="secondary"
-          active={props.filter.displayMode === option}
-          onClick={() => onChangeDisplayMode(option)}
-        >
-          <Icon icon={getIcon(option)} />
-        </Button>
-      </OverlayTrigger>
-    ));
+    return (
+      <>
+        {props.filter.displayModeOptions.map((option) => (
+          <OverlayTrigger
+            key={option}
+            overlay={
+              <Tooltip id="display-mode-tooltip">{getLabel(option)}</Tooltip>
+            }
+          >
+            <Button
+              variant="secondary"
+              active={props.filter.displayMode === option}
+              onClick={() => onChangeDisplayMode(option)}
+            >
+              <Icon icon={getIcon(option)} />
+            </Button>
+          </OverlayTrigger>
+        ))}
+      </>
+    );
   }
 
   function renderFilterTags() {
@@ -319,8 +322,9 @@ export const ListFilter: React.FC<IListFilterProps> = (
   function maybeRenderZoom() {
     if (props.onChangeZoom) {
       return (
+        <div className="align-middle">
         <Form.Control
-          className="zoom-slider d-none d-sm-inline-flex"
+          className="zoom-slider d-none d-sm-inline-flex ml-3"
           type="range"
           min={0}
           max={3}
@@ -329,6 +333,7 @@ export const ListFilter: React.FC<IListFilterProps> = (
             onChangeZoom(Number.parseInt(e.currentTarget.value, 10))
           }
         />
+        </div>
       );
     }
   }
@@ -364,111 +369,98 @@ export const ListFilter: React.FC<IListFilterProps> = (
   function render() {
     return (
       <>
-        <div className="form-row align-items-center justify-content-center">
-          <Col sm={12} md={6} xl={4} lg={5} className="my-1">
-            <Row className="justify-content-center">
-              <Col xs={6} className="px-1">
-                <InputGroup>
-                  <FormControl
-                    placeholder="Search..."
-                    defaultValue={props.filter.searchTerm}
-                    onInput={onChangeQuery}
-                    className="bg-secondary text-white border-secondary"
-                  />
+        <ButtonToolbar className="align-items-center justify-content-center">
+          <ButtonGroup className="mr-3 my-1">
+            <InputGroup className="mr-2">
+              <FormControl
+                placeholder="Search..."
+                defaultValue={props.filter.searchTerm}
+                onInput={onChangeQuery}
+                className="bg-secondary text-white border-secondary"
+              />
 
-                  <InputGroup.Append>
-                    <AddFilter
-                      filter={props.filter}
-                      onAddCriterion={onAddCriterion}
-                      onCancel={onCancelAddCriterion}
-                      editingCriterion={editingCriterion}
-                    />
-                  </InputGroup.Append>
-                </InputGroup>
-              </Col>
+              <InputGroup.Append>
+                <AddFilter
+                  filter={props.filter}
+                  onAddCriterion={onAddCriterion}
+                  onCancel={onCancelAddCriterion}
+                  editingCriterion={editingCriterion}
+                />
+              </InputGroup.Append>
+            </InputGroup>
 
-              <Col xs="auto" className="px-1">
-                <ButtonGroup>
-                  <Dropdown as={ButtonGroup}>
-                    <Dropdown.Toggle split variant="secondary" id="more-menu">
-                      {props.filter.sortBy}
-                    </Dropdown.Toggle>
-                    <Dropdown.Menu className="bg-secondary text-white">
-                      {renderSortByOptions()}
-                    </Dropdown.Menu>
-                    <OverlayTrigger
-                      overlay={
-                        <Tooltip id="sort-direction-tooltip">
-                          {props.filter.sortDirection === SortDirectionEnum.Asc
-                            ? "Ascending"
-                            : "Descending"}
-                        </Tooltip>
-                      }
-                    >
-                      <Button
-                        variant="secondary"
-                        onClick={onChangeSortDirection}
-                      >
-                        <Icon
-                          icon={
-                            props.filter.sortDirection === SortDirectionEnum.Asc
-                              ? "caret-up"
-                              : "caret-down"
-                          }
-                        />
-                      </Button>
-                    </OverlayTrigger>
-                    {props.filter.sortBy === "random" && (
-                      <OverlayTrigger
-                        overlay={
-                          <Tooltip id="sort-reshuffle-tooltip">
-                            Reshuffle
-                          </Tooltip>
-                        }
-                      >
-                        <Button
-                          variant="secondary"
-                          onClick={onReshuffleRandomSort}
-                        >
-                          <Icon icon="random" />
-                        </Button>
-                      </OverlayTrigger>
-                    )}
-                  </Dropdown>
-                </ButtonGroup>
-              </Col>
-
-              <Col xs="auto" className="px-1">
-                <Form.Control
-                  as="select"
-                  onChange={onChangePageSize}
-                  value={props.filter.itemsPerPage.toString()}
-                  className="btn-secondary"
+            <Dropdown as={ButtonGroup} className="mr-2">
+              <Dropdown.Toggle split variant="secondary" id="more-menu">
+                {props.filter.sortBy}
+              </Dropdown.Toggle>
+              <Dropdown.Menu className="bg-secondary text-white">
+                {renderSortByOptions()}
+              </Dropdown.Menu>
+              <OverlayTrigger
+                overlay={
+                  <Tooltip id="sort-direction-tooltip">
+                    {props.filter.sortDirection === SortDirectionEnum.Asc
+                      ? "Ascending"
+                      : "Descending"}
+                  </Tooltip>
+                }
+              >
+                <Button
+                  variant="secondary"
+                  onClick={onChangeSortDirection}
                 >
-                  {PAGE_SIZE_OPTIONS.map((s) => (
-                    <option value={s} key={s}>
-                      {s}
-                    </option>
-                  ))}
-                </Form.Control>
-              </Col>
-            </Row>
-          </Col>
+                  <Icon
+                    icon={
+                      props.filter.sortDirection === SortDirectionEnum.Asc
+                        ? "caret-up"
+                        : "caret-down"
+                    }
+                  />
+                </Button>
+              </OverlayTrigger>
+              {props.filter.sortBy === "random" && (
+                <OverlayTrigger
+                  overlay={
+                    <Tooltip id="sort-reshuffle-tooltip">
+                      Reshuffle
+                    </Tooltip>
+                  }
+                >
+                  <Button
+                    variant="secondary"
+                    onClick={onReshuffleRandomSort}
+                  >
+                    <Icon icon="random" />
+                  </Button>
+                </OverlayTrigger>
+              )}
+            </Dropdown>
 
-          <Col sm={12} md="auto" className="my-1">
-            <Row className="align-items-center justify-content-center">
-              {maybeRenderSelectedButtons()}
+            <Form.Control
+              as="select"
+              onChange={onChangePageSize}
+              value={props.filter.itemsPerPage.toString()}
+              className="btn-secondary mr-1"
+            >
+              {PAGE_SIZE_OPTIONS.map((s) => (
+                <option value={s} key={s}>
+                  {s}
+                </option>
+              ))}
+            </Form.Control>
+          </ButtonGroup>
 
-              <ButtonGroup className="mr-3">{renderMore()}</ButtonGroup>
+          <ButtonGroup className="mr-3 my-1">
+            {maybeRenderSelectedButtons()}
+            {renderMore()}
+          </ButtonGroup>
+          
+          <ButtonGroup className="my-1">
+            {renderDisplayModeOptions()}
+            {maybeRenderZoom()}
+          </ButtonGroup>
+        </ButtonToolbar>
 
-              <ButtonGroup className="mr-3">
-                {renderDisplayModeOptions()}
-              </ButtonGroup>
-
-              <ButtonGroup>{maybeRenderZoom()}</ButtonGroup>
-            </Row>
-          </Col>
-        </div>
         <div className="d-flex justify-content-center">
           {renderFilterTags()}
         </div>

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -323,16 +323,16 @@ export const ListFilter: React.FC<IListFilterProps> = (
     if (props.onChangeZoom) {
       return (
         <div className="align-middle">
-        <Form.Control
-          className="zoom-slider d-none d-sm-inline-flex ml-3"
-          type="range"
-          min={0}
-          max={3}
-          defaultValue={1}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            onChangeZoom(Number.parseInt(e.currentTarget.value, 10))
-          }
-        />
+          <Form.Control
+            className="zoom-slider d-none d-sm-inline-flex ml-3"
+            type="range"
+            min={0}
+            max={3}
+            defaultValue={1}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onChangeZoom(Number.parseInt(e.currentTarget.value, 10))
+            }
+          />
         </div>
       );
     }
@@ -405,10 +405,7 @@ export const ListFilter: React.FC<IListFilterProps> = (
                   </Tooltip>
                 }
               >
-                <Button
-                  variant="secondary"
-                  onClick={onChangeSortDirection}
-                >
+                <Button variant="secondary" onClick={onChangeSortDirection}>
                   <Icon
                     icon={
                       props.filter.sortDirection === SortDirectionEnum.Asc
@@ -421,15 +418,10 @@ export const ListFilter: React.FC<IListFilterProps> = (
               {props.filter.sortBy === "random" && (
                 <OverlayTrigger
                   overlay={
-                    <Tooltip id="sort-reshuffle-tooltip">
-                      Reshuffle
-                    </Tooltip>
+                    <Tooltip id="sort-reshuffle-tooltip">Reshuffle</Tooltip>
                   }
                 >
-                  <Button
-                    variant="secondary"
-                    onClick={onReshuffleRandomSort}
-                  >
+                  <Button variant="secondary" onClick={onReshuffleRandomSort}>
                     <Icon icon="random" />
                   </Button>
                 </OverlayTrigger>
@@ -454,7 +446,7 @@ export const ListFilter: React.FC<IListFilterProps> = (
             {maybeRenderSelectedButtons()}
             {renderMore()}
           </ButtonGroup>
-          
+
           <ButtonGroup className="my-1">
             {renderDisplayModeOptions()}
             {maybeRenderZoom()}

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -189,26 +189,22 @@ export const ListFilter: React.FC<IListFilterProps> = (
       }
     }
 
-    return (
-      <>
-        {props.filter.displayModeOptions.map((option) => (
-          <OverlayTrigger
-            key={option}
-            overlay={
-              <Tooltip id="display-mode-tooltip">{getLabel(option)}</Tooltip>
-            }
-          >
-            <Button
-              variant="secondary"
-              active={props.filter.displayMode === option}
-              onClick={() => onChangeDisplayMode(option)}
-            >
-              <Icon icon={getIcon(option)} />
-            </Button>
-          </OverlayTrigger>
-        ))}
-      </>
-    );
+    return props.filter.displayModeOptions.map((option) => (
+      <OverlayTrigger
+        key={option}
+        overlay={
+          <Tooltip id="display-mode-tooltip">{getLabel(option)}</Tooltip>
+        }
+      >
+        <Button
+          variant="secondary"
+          active={props.filter.displayMode === option}
+          onClick={() => onChangeDisplayMode(option)}
+        >
+          <Icon icon={getIcon(option)} />
+        </Button>
+      </OverlayTrigger>
+    ));
   }
 
   function renderFilterTags() {

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -10,9 +10,9 @@
 }
 
 input[type="range"].zoom-slider {
+  height: 100%;
+  margin: 0;
   max-width: 60px;
   padding-left: 0;
   padding-right: 0;
-  margin: 0;
-  height: 100%;
 }

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -9,8 +9,10 @@
   }
 }
 
-.zoom-slider {
+input[type="range"].zoom-slider {
   max-width: 60px;
   padding-left: 0;
   padding-right: 0;
+  margin: 0;
+  height: 100%;
 }

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -201,9 +201,7 @@ export const Movie: React.FC = () => {
   // TODO: CSS class
   return (
     <div className="row">
-      <div
-        className="movie-details col"
-      >
+      <div className="movie-details col">
         {isNew && <h2>Add Movie</h2>}
         <div className="logo w-100">
           {encodingFrontImage || encodingBackImage ? (

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -9,7 +9,6 @@ import {
   useMovieDestroy,
 } from "src/core/StashService";
 import { useParams, useHistory } from "react-router-dom";
-import cx from "classnames";
 import {
   DetailsEditNavbar,
   LoadingIndicator,

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -203,9 +203,7 @@ export const Movie: React.FC = () => {
   return (
     <div className="row">
       <div
-        className={cx("movie-details", "col", {
-          "col ml-sm-5": !isNew,
-        })}
+        className="movie-details col"
       >
         {isNew && <h2>Add Movie</h2>}
         <div className="logo w-100">
@@ -312,7 +310,7 @@ export const Movie: React.FC = () => {
         />
       </div>
       {!isNew && (
-        <div className="col-12 col-sm-8">
+        <div className="col-lg-8 col-md-7">
           <MovieScenesPanel movie={movie} />
         </div>
       )}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -154,7 +154,7 @@ export const Performer: React.FC = () => {
   }
 
   const renderIcons = () => (
-    <span className="name-icons d-block d-sm-inline">
+    <span className="name-icons">
       <Button
         className={cx(
           "minimal",
@@ -241,7 +241,7 @@ export const Performer: React.FC = () => {
 
   return (
     <div id="performer-page" className="row">
-      <div className="image-container col-sm-4 offset-sm-1 d-none d-sm-block">
+      <div className="image-container col-md-4 text-center">
         {imageEncoding ? (
           <LoadingIndicator message="Encoding image..." />
         ) : (
@@ -250,9 +250,9 @@ export const Performer: React.FC = () => {
           </Button>
         )}
       </div>
-      <div className="col col-sm-6">
+      <div className="col col-md-8 col-lg-7 col-xl-6">
         <div className="row">
-          <div className="performer-head col-6 col-sm-12">
+          <div className="performer-head col">
             <h2>
               <CountryFlag country={performer.country} className="mr-2" />
               {performer.name}

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -12,7 +12,7 @@
   overflow: hidden;
 
   .image-container .performer {
-    max-height: 960px;
+    max-height: calc(100vh - 6rem);
     max-width: 100%;
   }
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -170,16 +170,18 @@ export const Studio: React.FC = () => {
     <div className="row">
       <div
         className={cx("studio-details", {
-          "col ml-sm-5": !isNew,
+          "col-md-4": !isNew,
           "col-8": isNew,
         })}
       >
         {isNew && <h2>Add Studio</h2>}
+        <div className="text-center">
         {imageEncoding ? (
           <LoadingIndicator message="Encoding image..." />
         ) : (
-          <img className="logo w-100" alt={name} src={imagePreview} />
+          <img className="logo" alt={name} src={imagePreview} />
         )}
+        </div>
         <Table>
           <tbody>
             {TableUtils.renderInputGroup({
@@ -223,7 +225,7 @@ export const Studio: React.FC = () => {
         />
       </div>
       {!isNew && (
-        <div className="col-12 col-sm-8">
+        <div className="col col-md-8">
           <Tabs id="studio-tabs" mountOnEnter>
             <Tab eventKey="studio-scenes-panel" title="Scenes">
               <StudioScenesPanel studio={studio} />

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -176,11 +176,11 @@ export const Studio: React.FC = () => {
       >
         {isNew && <h2>Add Studio</h2>}
         <div className="text-center">
-        {imageEncoding ? (
-          <LoadingIndicator message="Encoding image..." />
-        ) : (
-          <img className="logo" alt={name} src={imagePreview} />
-        )}
+          {imageEncoding ? (
+            <LoadingIndicator message="Encoding image..." />
+          ) : (
+            <img className="logo" alt={name} src={imagePreview} />
+          )}
         </div>
         <Table>
           <tbody>

--- a/ui/v2.5/src/components/Studios/styles.scss
+++ b/ui/v2.5/src/components/Studios/styles.scss
@@ -1,7 +1,7 @@
 .studio-details {
   .logo {
+    margin-bottom: 4rem;
     max-height: 50vh;
     max-width: 100%;
-    margin-bottom: 4rem
   }
 }

--- a/ui/v2.5/src/components/Studios/styles.scss
+++ b/ui/v2.5/src/components/Studios/styles.scss
@@ -1,5 +1,7 @@
 .studio-details {
   .logo {
-    margin: 4rem 0;
+    max-height: 50vh;
+    max-width: 100%;
+    margin-bottom: 4rem
   }
 }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -442,6 +442,10 @@ div.dropdown-menu {
   white-space: "pre-wrap";
 }
 
+.btn-toolbar .form-control {
+  width: inherit;
+}
+
 .stats {
   &-element {
     flex-grow: 1;


### PR DESCRIPTION
Changed the query bar to use ButtonToolbar with ButtonGroups, rather than messing around with columns. Before and after images follow:
(on larger screens):

![image](https://user-images.githubusercontent.com/53250216/85530686-78972900-b651-11ea-9da7-ad5739a5e5a6.png)
![image](https://user-images.githubusercontent.com/53250216/85530614-6ae1a380-b651-11ea-83e0-74bf0ea8c9cb.png)
Note that the text field now maintains the same size regardless of screen width.

(on smaller screens)
![image](https://user-images.githubusercontent.com/53250216/85530896-a41a1380-b651-11ea-9331-cba45aec9dbb.png)
![image](https://user-images.githubusercontent.com/53250216/85530862-9cf30580-b651-11ea-97d6-10875cd98d45.png)

These break appropriately when used as a sub-component, like in the performers page.

The Performer page has been adjusted so that the performer image is centred in its column and has a maximum height that is less than the viewport height. It still needs a little further refinement, but imo looks a bit better at all sizes.

The studio page no longer makes the logo fill the width. Again, this page needs another refinement pass, but I think it looks better.

The movie page has also been adjusted to look better in smaller viewports.