### PR TITLE
Strip debug symbols from release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ ui-validate:
 # rebuilding the UI
 .PHONY: packr
 packr:
-	env
 	packr2
 
 # runs all of the tests and checks required for a PR to be accepted

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 release: generate ui build-release
 
 pre-build:
-	$(eval DATE := $(shell go run scripts/getDate.go -mod=vendor))
+	$(eval DATE := $(shell go run -mod=vendor scripts/getDate.go))
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))
 	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest_develop))
 

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,20 @@ endif
 release: generate ui build-release
 
 pre-build:
-	$(eval DATE := $(shell go run -mod=vendor scripts/getDate.go))
+ifndef BUILD_DATE
+	$(eval BUILD_DATE := $(shell go run -mod=vendor scripts/getDate.go))
+endif
+
+ifndef GITHASH
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))
+endif
+
+ifndef STASH_VERSION
 	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest_develop))
+endif
 
 build: pre-build
-	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/pkg/api.version=$(STASH_VERSION)' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$(DATE)' -X 'github.com/stashapp/stash/pkg/api.githash=$(GITHASH)')
+	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/pkg/api.version=$(STASH_VERSION)' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$(BUILD_DATE)' -X 'github.com/stashapp/stash/pkg/api.githash=$(GITHASH)')
 	$(SET) CGO_ENABLED=1 $(SEPARATOR) go build $(OUTPUT) -mod=vendor -v -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)"
 
 # strips debug symbols from the release build
@@ -89,7 +97,7 @@ pre-ui:
 
 .PHONY: ui-only
 ui-only: pre-build
-	$(SET) REACT_APP_DATE="$(DATE)" $(SEPARATOR) \
+	$(SET) REACT_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \
 	$(SET) REACT_APP_GITHASH=$(GITHASH) $(SEPARATOR) \
 	$(SET) REACT_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
 	cd ui/v2.5 && yarn build
@@ -100,7 +108,7 @@ ui: ui-only
 
 .PHONY: ui-start
 ui-start: pre-build
-	$(SET) REACT_APP_DATE="$(DATE)" $(SEPARATOR) \
+	$(SET) REACT_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \
 	$(SET) REACT_APP_GITHASH=$(GITHASH) $(SEPARATOR) \
 	$(SET) REACT_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
 	cd ui/v2.5 && yarn start

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ endif
 LDFLAGS := $(LDFLAGS)
 ifdef OUTPUT
   OUTPUT := -o $(OUTPUT)
-  $(info $(OUTPUT))
 endif
 
 .PHONY: release pre-build install clean 
@@ -28,7 +27,7 @@ endif
 release: generate ui build-release
 
 pre-build:
-	$(eval DATE := $(shell go run scripts/getDate.go))
+	$(eval DATE := $(shell go run scripts/getDate.go -mod=vendor))
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))
 	$(eval STASH_VERSION := $(shell git describe --tags --exclude latest_develop))
 

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+BUILD_DATE=`go run -mod=vendor scripts/getDate.go`; export BUILD_DATE
+GITHASH=`git rev-parse --short HEAD`; export GITHASH
+STASH_VERSION=`git describe --tags --exclude latest_develop`; export STASH_VERSION
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1; make packr;"
 WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LDFLAGS=\"-extldflags '-static' \" OUTPUT=\"dist/stash-win.exe\" make build-release;"
 DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ OUTPUT=\"dist/stash-osx\" make build-release;"

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -3,12 +3,12 @@
 DATE=`go run -mod=vendor scripts/getDate.go`
 GITHASH=`git rev-parse --short HEAD`
 STASH_VERSION=`git describe --tags --exclude latest_develop`
-VERSION_FLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH'"
+LDFLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH' -s -w"
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1; packr2;"
-WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $VERSION_FLAGS\" -tags extended -v -mod=vendor;"
-DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ go build -o dist/stash-osx -ldflags \"$VERSION_FLAGS\" -tags extended -v -mod=vendor;"
-LINUX="echo '=== Building Linux binary ==='; go build -o dist/stash-linux -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
-RASPPI="echo '=== Building Raspberry Pi binary ==='; GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc go build -o dist/stash-pi -ldflags \"$VERSION_FLAGS\" -v -mod=vendor;"
+WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $LDFLAGS\" -tags extended -v -mod=vendor;"
+DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ go build -o dist/stash-osx -ldflags \"$LDFLAGS\" -tags extended -v -mod=vendor;"
+LINUX="echo '=== Building Linux binary ==='; go build -o dist/stash-linux -ldflags \"$LDFLAGS\" -v -mod=vendor;"
+RASPPI="echo '=== Building Raspberry Pi binary ==='; GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc go build -o dist/stash-pi -ldflags \"$LDFLAGS\" -v -mod=vendor;"
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
 
-DATE=`go run -mod=vendor scripts/getDate.go`
-GITHASH=`git rev-parse --short HEAD`
-STASH_VERSION=`git describe --tags --exclude latest_develop`
-LDFLAGS="-X 'github.com/stashapp/stash/pkg/api.version=$STASH_VERSION' -X 'github.com/stashapp/stash/pkg/api.buildstamp=$DATE' -X 'github.com/stashapp/stash/pkg/api.githash=$GITHASH' -s -w"
-SETUP="export GO111MODULE=on; export CGO_ENABLED=1; packr2;"
-WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -o dist/stash-win.exe -ldflags \"-extldflags '-static' $LDFLAGS\" -tags extended -v -mod=vendor;"
-DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ go build -o dist/stash-osx -ldflags \"$LDFLAGS\" -tags extended -v -mod=vendor;"
-LINUX="echo '=== Building Linux binary ==='; go build -o dist/stash-linux -ldflags \"$LDFLAGS\" -v -mod=vendor;"
-RASPPI="echo '=== Building Raspberry Pi binary ==='; GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc go build -o dist/stash-pi -ldflags \"$LDFLAGS\" -v -mod=vendor;"
+SETUP="export GO111MODULE=on; export CGO_ENABLED=1; make packr;"
+WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LDFLAGS=\"-extldflags '-static' \" OUTPUT=\"dist/stash-win.exe\" make build-release;"
+DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ OUTPUT=\"dist/stash-osx\" make build-release;"
+LINUX="echo '=== Building Linux binary ==='; OUTPUT=\"dist/stash-linux\" make build-release;"
+RASPPI="echo '=== Building Raspberry Pi binary ==='; GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc OUTPUT=\"dist/stash-pi\" make build-release;"
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
-BUILD_DATE=`go run -mod=vendor scripts/getDate.go`; export BUILD_DATE
-GITHASH=`git rev-parse --short HEAD`; export GITHASH
-STASH_VERSION=`git describe --tags --exclude latest_develop`; export STASH_VERSION
+BUILD_DATE=`go run -mod=vendor scripts/getDate.go`
+GITHASH=`git rev-parse --short HEAD`
+STASH_VERSION=`git describe --tags --exclude latest_develop`
+SETENV="BUILD_DATE=\"$BUILD_DATE\" GITHASH=$GITHASH STASH_VERSION=\"$STASH_VERSION\""
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1; make packr;"
-WINDOWS="echo '=== Building Windows binary ==='; GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LDFLAGS=\"-extldflags '-static' \" OUTPUT=\"dist/stash-win.exe\" make build-release;"
-DARWIN="echo '=== Building OSX binary ==='; GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ OUTPUT=\"dist/stash-osx\" make build-release;"
-LINUX="echo '=== Building Linux binary ==='; OUTPUT=\"dist/stash-linux\" make build-release;"
-RASPPI="echo '=== Building Raspberry Pi binary ==='; GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc OUTPUT=\"dist/stash-pi\" make build-release;"
+WINDOWS="echo '=== Building Windows binary ==='; $SETENV GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LDFLAGS=\"-extldflags '-static' \" OUTPUT=\"dist/stash-win.exe\" make build-release;"
+DARWIN="echo '=== Building OSX binary ==='; $SETENV GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ OUTPUT=\"dist/stash-osx\" make build-release;"
+LINUX="echo '=== Building Linux binary ==='; $SETENV OUTPUT=\"dist/stash-linux\" make build-release;"
+RASPPI="echo '=== Building Raspberry Pi binary ==='; $SETENV GOOS=linux GOARCH=arm GOARM=5 CC=arm-linux-gnueabi-gcc OUTPUT=\"dist/stash-pi\" make build-release;"
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX $RASPPI"
 


### PR DESCRIPTION
Adds a `build-release` make target, and changes the `release` target to use it. The `build-release` target adds `-s -w` ldflags when compiling, which strips out the debug symbols. This results in an executable that went from 60MB to 35MB for the Windows build.

This also includes a change to the cross-compile script to use make instead of building directly. The `-tags extended` arguments were taken out since I couldn't figure out why they were there in the first place.

~~Edit: build is broken due to an old git version in the compiler docker image. Will either update the docker image or revert the other changes for now.~~