### PR TITLE
Scan for files with ALLCAPS extensions

### DIFF
--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -18,18 +18,12 @@ var extensionsToScan = []string{"zip", "m4v", "mp4", "mov", "wmv", "avi", "mpg",
 var extensionsGallery = []string{"zip"}
 
 func constructGlob() string { // create a sequence for glob doublestar from our extensions
-	extLen := len(extensionsToScan)
-	glb := "{"
-	for i := 0; i < extLen-1; i++ { // append extensions and commas
-		glb += strings.ToLower(extensionsToScan[i]) + "," + strings.ToUpper(extensionsToScan[i]) + ","
+	var extList []string
+	for _, ext := range extensionsToScan {
+		extList = append(extList, strings.ToLower(ext))
+		extList = append(extList, strings.ToUpper(ext))
 	}
-	if extLen >= 1 { // append last extension without a comma at the end
-		glb += strings.ToLower(extensionsToScan[extLen-1]) + "," + strings.ToUpper(extensionsToScan[extLen-1])
-	}
-
-	glb += "}"
-	return glb
-
+	return "{" + strings.Join(extList, ",") + "}"
 }
 
 func isGallery(pathname string) bool {

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,11 +21,12 @@ func constructGlob() string { // create a sequence for glob doublestar from our 
 	extLen := len(extensionsToScan)
 	glb := "{"
 	for i := 0; i < extLen-1; i++ { // append extensions and commas
-		glb += extensionsToScan[i] + ","
+		glb += strings.ToLower(extensionsToScan[i]) + "," + strings.ToUpper(extensionsToScan[i]) + ","
 	}
-	if extLen >= 1 { // append last extension without comma
-		glb += extensionsToScan[extLen-1]
+	if extLen >= 1 { // append last extension without a comma at the end
+		glb += strings.ToLower(extensionsToScan[extLen-1]) + "," + strings.ToUpper(extensionsToScan[extLen-1])
 	}
+
 	glb += "}"
 	return glb
 

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -34,7 +34,7 @@ func constructGlob() string { // create a sequence for glob doublestar from our 
 
 func isGallery(pathname string) bool {
 	for _, ext := range extensionsGallery {
-		if filepath.Ext(pathname) == "."+ext {
+		if strings.ToLower(filepath.Ext(pathname)) == "."+strings.ToLower(ext) {
 			return true
 		}
 	}

--- a/ui/v2.5/src/components/Changelog/versions/v030.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v030.tsx
@@ -12,6 +12,7 @@ const markup = `
 *  Add support for parent/child studios.
 
 ### 🎨 Improvements
+*  Search for files which have low or upper case supported filename extensions.
 *  Add dialog when pasting movie images.
 *  Allow click and click-drag selection after selecting scene.
 *  Added multi-scene edit dialog.


### PR DESCRIPTION
_requested from the discord channel_
Enables stash to look for files with lowercase and uppercase supported extensions during the scan task. This is mostly needed for case sensitive filesystems (e.g. linux). 
It doesn't search for mixed case extensions since doing that would require either customizing doublestar glob, using another search function or generating a lot of extension combinations. If needed/wanted though this can be done also.