### PR TITLE
Fix tag query performance problems

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -344,7 +344,7 @@ func GetLogLevel() string {
 	const defaultValue = "Info"
 
 	value := viper.GetString(LogLevel)
-	if value != "Debug" && value != "Info" && value != "Warning" && value != "Error" {
+	if value != "Debug" && value != "Info" && value != "Warning" && value != "Error" && value != "Trace" {
 		value = defaultValue
 	}
 

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -311,9 +311,12 @@ func executeFindQuery(tableName string, body string, args []interface{}, sortAnd
 	}
 
 	countQuery := buildCountQuery(body)
-	countResult, countErr := runCountQuery(countQuery, args)
-
 	idsQuery := body + sortAndPagination
+
+	// Perform query and fetch result
+	logger.Tracef("SQL: %s, args: %v", idsQuery, args)
+
+	countResult, countErr := runCountQuery(countQuery, args)
 	idsResult, idsErr := runIdsQuery(idsQuery, args)
 
 	if countErr != nil {
@@ -324,9 +327,6 @@ func executeFindQuery(tableName string, body string, args []interface{}, sortAnd
 		logger.Errorf("Error executing find query with SQL: %s, args: %v, error: %s", idsQuery, args, idsErr.Error())
 		panic(idsErr)
 	}
-
-	// Perform query and fetch result
-	logger.Tracef("SQL: %s, args: %v", idsQuery, args)
 
 	return idsResult, countResult
 }

--- a/pkg/models/querybuilder_tag_test.go
+++ b/pkg/models/querybuilder_tag_test.go
@@ -169,24 +169,26 @@ func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionIn
 	}
 }
 
-func TestTagQueryMarkerCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
+// disabled due to performance issues
 
-	verifyTagMarkerCount(t, countCriterion)
+// func TestTagQueryMarkerCount(t *testing.T) {
+// 	countCriterion := models.IntCriterionInput{
+// 		Value:    1,
+// 		Modifier: models.CriterionModifierEquals,
+// 	}
 
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagMarkerCount(t, countCriterion)
+// 	verifyTagMarkerCount(t, countCriterion)
 
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagMarkerCount(t, countCriterion)
+// 	countCriterion.Modifier = models.CriterionModifierNotEquals
+// 	verifyTagMarkerCount(t, countCriterion)
 
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagMarkerCount(t, countCriterion)
-}
+// 	countCriterion.Modifier = models.CriterionModifierLessThan
+// 	verifyTagMarkerCount(t, countCriterion)
+
+// 	countCriterion.Value = 0
+// 	countCriterion.Modifier = models.CriterionModifierGreaterThan
+// 	verifyTagMarkerCount(t, countCriterion)
+// }
 
 func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.IntCriterionInput) {
 	qb := models.NewTagQueryBuilder()

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -211,16 +211,19 @@ export class ListFilterModel {
         break;
       case FilterMode.Tags:
         this.sortBy = "name";
-        // scene markers count has been disabled for now due to performance 
+        // scene markers count has been disabled for now due to performance
         // issues
-        this.sortByOptions = ["name", "scenes_count" /*, "scene_markers_count"*/];
+        this.sortByOptions = [
+          "name",
+          "scenes_count" /* , "scene_markers_count"*/,
+        ];
         this.displayModeOptions = [DisplayMode.Grid, DisplayMode.List];
         this.criterionOptions = [
           new NoneCriterionOption(),
           new TagIsMissingCriterionOption(),
           ListFilterModel.createCriterionOption("scene_count"),
           // marker count has been disabled for now due to performance issues
-          //ListFilterModel.createCriterionOption("marker_count"),
+          // ListFilterModel.createCriterionOption("marker_count"),
         ];
         break;
       default:

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -211,13 +211,16 @@ export class ListFilterModel {
         break;
       case FilterMode.Tags:
         this.sortBy = "name";
-        this.sortByOptions = ["name", "scenes_count", "scene_markers_count"];
+        // scene markers count has been disabled for now due to performance 
+        // issues
+        this.sortByOptions = ["name", "scenes_count" /*, "scene_markers_count"*/];
         this.displayModeOptions = [DisplayMode.Grid, DisplayMode.List];
         this.criterionOptions = [
           new NoneCriterionOption(),
           new TagIsMissingCriterionOption(),
           ListFilterModel.createCriterionOption("scene_count"),
-          ListFilterModel.createCriterionOption("marker_count"),
+          // marker count has been disabled for now due to performance issues
+          //ListFilterModel.createCriterionOption("marker_count"),
         ];
         break;
       default:
@@ -652,14 +655,15 @@ export class ListFilterModel {
           };
           break;
         }
-        case "marker_count": {
-          const countCrit = criterion as NumberCriterion;
-          result.marker_count = {
-            value: countCrit.value,
-            modifier: countCrit.modifier,
-          };
-          break;
-        }
+        // disabled due to performance issues
+        // case "marker_count": {
+        //   const countCrit = criterion as NumberCriterion;
+        //   result.marker_count = {
+        //     value: countCrit.value,
+        //     modifier: countCrit.modifier,
+        //   };
+        //   break;
+        // }
         // no default
       }
     });


### PR DESCRIPTION
On systems with a large number of scene markers, querying for tags takes a really long time.

I discovered the cause to be related to the join between tags and scene markers on the `primary_tag_id` column. I haven't been able to optimise this query to make the query time reasonable, so for now I am disabling querying/sorting on the tag scene marker count.

I will leave this commented out until a more permanent solution can be found. 

Also fixes some issues with the tracing code.