### PR TITLE
Use referer on xpath getImage, apply printHTML to subscraper also

### DIFF
--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -64,7 +64,14 @@ func getImage(url string) (*string, error) {
 	}
 
 	// assume is a URL for now
+
+	// set the host of the URL as the referer
+	if req.URL.Scheme != "" {
+		req.Header.Set("Referer", req.URL.Scheme+"://"+req.Host)
+	}
+
 	resp, err := client.Do(req)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In some cases like the below scraper mentioned in discord, images are protected by referer and so we get a `403 access denied` instead of the actual image.
Adding a referer based on the host of the image's url seems to get us the picture.
```yaml
name: AmateurAllure
sceneByURL:
  - action: scrapeXPath
    url:
      - amateurallure.com/tour/scenes/
      - amateurallure.com/tour/search
    scraper: sceneScraper
xPathScrapers:
  sceneScraper:
    common:
      $sceneinfo: //div[@class="scene-info"]
      $title: //span[@class='title_bar_hilite']
    scene:
      Title: $title
      Date:
        selector: //div[@class='cell update_date']
        parseDate: 01/02/2006
      Details: //span[@class='update_description']
      Tags:
        Name: //span[@class='update_tags']//a/text()
      Performers:
        Name: //span[@class='update_models']//a
      Image:
        selector: $title
        replace:
          - regex: \s
            with: "+"
          - regex: ^
            with: "https://www.amateurallure.com/tour/search.php?st=advanced&qall=&qany=&qex="
        subScraper:
            selector: //img/@srcset
            replace:
              - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
                with: https://www.amateurallure.com$1
debug:
  printHTML: true     

# Last Updated July 09, 2020
```
_scraper is not yet fully tested, only used as a reference for the specific issue_
(test url:  `https://www.amateurallure.com/tour/scenes/elsa-dream-jean-blonde-teen-princess-sucks-fucks-swallows-sperm-pov_vids.html`)

I extended also the usage of 
```yaml
debug:
  printHTML: true     
```
to work for the subScraper