### PR TITLE
Skip Intro for video previews

### DIFF
--- a/pkg/manager/generator_preview.go
+++ b/pkg/manager/generator_preview.go
@@ -93,8 +93,9 @@ func (g *PreviewGenerator) generateVideo(encoder *ffmpeg.Encoder) error {
 	}
 
 	stepSize := int(g.Info.VideoFile.Duration / float64(g.Info.ChunkCount))
+	twoPercent := int(g.Info.VideoFile.Duration * 0.02)
 	for i := 0; i < g.Info.ChunkCount; i++ {
-		time := i * stepSize
+		time := i * stepSize + twoPercent
 		num := fmt.Sprintf("%.3d", i)
 		filename := "preview" + num + ".mp4"
 		chunkOutputPath := instance.Paths.Generated.GetTmpPath(filename)


### PR DESCRIPTION
Entire credit goes to Fonzie#5266 on discord, but he suggested the above code as a way to skip the beginning portion of video previews as that is often disclaimers or title cards for the scene. Since this blanketly applies the skip, it would impact scenes without these intros, but I think the skip is small enough that it should not make a difference for those scenes. 

I think it is worth analyzing if 2% is the best way to skip the intro. We could offset by a static amount of time (30 seconds) to deal with shorter videos or bump up the 2%. Not sure on this.

Code is what Fonzie suggested, but it seems to make sense to me unless it has impact on other areas as well. I just moved the twoPercent variable out of the for loop since I didn't think it needed to be calculated each time.

I think this is a crude solution to #634 , but it should solve most people's usecases. To meet the requirements for that Feature Request would require more work, and it may create additional complexity with limited benefit