### PR TITLE
Generate content for specific scenes

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -3,6 +3,7 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   databasePath
   generatedPath
   cachePath
+  previewPreset
   maxTranscodeSize
   maxStreamingTranscodeSize
   forceMkv

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -7,6 +7,16 @@ enum StreamingResolutionEnum {
   "Original", ORIGINAL
 }
 
+enum PreviewPreset {
+  "X264_ULTRAFAST", ultrafast
+  "X264_VERYFAST", veryfast
+  "X264_FAST", fast
+  "X264_MEDIUM", medium
+  "X264_SLOW", slow
+  "X264_SLOWER", slower
+  "X264_VERYSLOW", veryslow
+}
+
 input ConfigGeneralInput {
   """Array of file paths to content"""
   stashes: [String!]
@@ -16,6 +26,8 @@ input ConfigGeneralInput {
   generatedPath: String
   """Path to cache"""
   cachePath: String
+  """Preset when generating preview"""
+  previewPreset: PreviewPreset
   """Max generated transcode size"""
   maxTranscodeSize: StreamingResolutionEnum
   """Max streaming transcode size"""
@@ -53,6 +65,8 @@ type ConfigGeneralResult {
   generatedPath: String!
   """Path to cache"""
   cachePath: String!
+  """Preset when generating preview"""
+  previewPreset: PreviewPreset!
   """Max generated transcode size"""
   maxTranscodeSize: StreamingResolutionEnum
   """Max streaming transcode size"""

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -7,6 +7,13 @@ input GenerateMetadataInput {
   transcodes: Boolean!
   """gallery thumbnails for cache usage"""
   thumbnails: Boolean!
+
+  """scene ids to generate for"""
+  sceneIDs: [ID!]
+  """marker ids to generate for"""
+  markerIDs: [ID!]
+  """gallery ids to generate for"""
+  galleryIDs: [ID!]
 }
 
 input ScanMetadataInput {

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -14,6 +14,9 @@ input GenerateMetadataInput {
   markerIDs: [ID!]
   """gallery ids to generate for"""
   galleryIDs: [ID!]
+
+  """overwrite existing media"""
+  overwrite: Boolean
 }
 
 input ScanMetadataInput {

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -1,7 +1,6 @@
 input GenerateMetadataInput {
   sprites: Boolean!
   previews: Boolean!
-  previewPreset: PreviewPreset
   imagePreviews: Boolean!
   markers: Boolean!
   transcodes: Boolean!
@@ -36,14 +35,4 @@ type MetadataUpdateStatus {
   progress: Float!
   status: String!
   message: String!
-}
-
-enum PreviewPreset {
-  "X264_ULTRAFAST", ultrafast
-  "X264_VERYFAST", veryfast
-  "X264_FAST", fast
-  "X264_MEDIUM", medium
-  "X264_SLOW", slow
-  "X264_SLOWER", slower
-  "X264_VERYSLOW", veryslow
 }

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -45,6 +45,10 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 		config.Set(config.Cache, input.CachePath)
 	}
 
+	if input.PreviewPreset != nil {
+		config.Set(config.PreviewPreset, input.PreviewPreset.String())
+	}
+
 	if input.MaxTranscodeSize != nil {
 		config.Set(config.MaxTranscodeSize, input.MaxTranscodeSize.String())
 	}

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -23,7 +23,7 @@ func (r *mutationResolver) MetadataExport(ctx context.Context) (string, error) {
 }
 
 func (r *mutationResolver) MetadataGenerate(ctx context.Context, input models.GenerateMetadataInput) (string, error) {
-	manager.GetInstance().Generate(input.Sprites, input.Previews, input.PreviewPreset, input.ImagePreviews, input.Markers, input.Transcodes, input.Thumbnails)
+	manager.GetInstance().Generate(input)
 	return "todo", nil
 }
 

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -46,6 +46,7 @@ func makeConfigGeneralResult() *models.ConfigGeneralResult {
 		DatabasePath:              config.GetDatabasePath(),
 		GeneratedPath:             config.GetGeneratedPath(),
 		CachePath:                 config.GetCachePath(),
+		PreviewPreset:             config.GetPreviewPreset(),
 		MaxTranscodeSize:          &maxTranscodeSize,
 		MaxStreamingTranscodeSize: &maxStreamingTranscodeSize,
 		ForceMkv:                  config.GetForceMKV(),

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -27,6 +27,8 @@ const Database = "database"
 
 const Exclude = "exclude"
 
+const PreviewPreset = "preview_preset"
+
 const MaxTranscodeSize = "max_transcode_size"
 const MaxStreamingTranscodeSize = "max_streaming_transcode_size"
 
@@ -158,6 +160,19 @@ func GetPort() int {
 
 func GetExternalHost() string {
 	return viper.GetString(ExternalHost)
+}
+
+// GetPreviewPreset returns the preset when generating previews. Defaults to
+// Slow.
+func GetPreviewPreset() models.PreviewPreset {
+	ret := viper.GetString(PreviewPreset)
+
+	// default to slow
+	if ret == "" {
+		return models.PreviewPresetSlow
+	}
+
+	return models.PreviewPreset(ret)
 }
 
 func GetMaxTranscodeSize() models.StreamingResolutionEnum {

--- a/pkg/manager/generator_preview.go
+++ b/pkg/manager/generator_preview.go
@@ -3,11 +3,12 @@ package manager
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
-	"os"
-	"path/filepath"
 )
 
 type PreviewGenerator struct {
@@ -21,6 +22,8 @@ type PreviewGenerator struct {
 	GenerateImage bool
 
 	PreviewPreset string
+
+	Overwrite bool
 }
 
 func NewPreviewGenerator(videoFile ffmpeg.VideoFile, videoFilename string, imageFilename string, outputDirectory string, generateVideo bool, generateImage bool, previewPreset string) (*PreviewGenerator, error) {
@@ -88,7 +91,7 @@ func (g *PreviewGenerator) generateConcatFile() error {
 func (g *PreviewGenerator) generateVideo(encoder *ffmpeg.Encoder) error {
 	outputPath := filepath.Join(g.OutputDirectory, g.VideoFilename)
 	outputExists, _ := utils.FileExists(outputPath)
-	if outputExists {
+	if !g.Overwrite && outputExists {
 		return nil
 	}
 
@@ -116,7 +119,7 @@ func (g *PreviewGenerator) generateVideo(encoder *ffmpeg.Encoder) error {
 func (g *PreviewGenerator) generateImage(encoder *ffmpeg.Encoder) error {
 	outputPath := filepath.Join(g.OutputDirectory, g.ImageFilename)
 	outputExists, _ := utils.FileExists(outputPath)
-	if outputExists {
+	if !g.Overwrite && outputExists {
 		return nil
 	}
 

--- a/pkg/manager/generator_sprite.go
+++ b/pkg/manager/generator_sprite.go
@@ -2,17 +2,18 @@ package manager
 
 import (
 	"fmt"
-	"github.com/bmatcuk/doublestar"
-	"github.com/disintegration/imaging"
-	"github.com/stashapp/stash/pkg/ffmpeg"
-	"github.com/stashapp/stash/pkg/logger"
-	"github.com/stashapp/stash/pkg/utils"
 	"image"
 	"image/color"
 	"io/ioutil"
 	"math"
 	"path/filepath"
 	"strings"
+
+	"github.com/bmatcuk/doublestar"
+	"github.com/disintegration/imaging"
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 type SpriteGenerator struct {
@@ -22,6 +23,8 @@ type SpriteGenerator struct {
 	VTTOutputPath   string
 	Rows            int
 	Columns         int
+
+	Overwrite bool
 }
 
 func NewSpriteGenerator(videoFile ffmpeg.VideoFile, imageOutputPath string, vttOutputPath string, rows int, cols int) (*SpriteGenerator, error) {
@@ -60,7 +63,7 @@ func (g *SpriteGenerator) Generate() error {
 }
 
 func (g *SpriteGenerator) generateSpriteImage(encoder *ffmpeg.Encoder) error {
-	if g.imageExists() {
+	if !g.Overwrite && g.imageExists() {
 		return nil
 	}
 	logger.Infof("[generator] generating sprite image for %s", g.Info.VideoFile.Path)
@@ -112,7 +115,7 @@ func (g *SpriteGenerator) generateSpriteImage(encoder *ffmpeg.Encoder) error {
 }
 
 func (g *SpriteGenerator) generateSpriteVTT(encoder *ffmpeg.Encoder) error {
-	if g.vttExists() {
+	if !g.Overwrite && g.vttExists() {
 		return nil
 	}
 	logger.Infof("[generator] generating sprite vtt for %s", g.Info.VideoFile.Path)

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -181,10 +181,7 @@ func (s *singleton) Generate(input models.GenerateMetadataInput) {
 	//this.job.total = await ObjectionUtils.getCount(Scene);
 	instance.Paths.Generated.EnsureTmpDir()
 
-	preset := string(models.PreviewPresetSlow)
-	if input.PreviewPreset != nil && input.PreviewPreset.IsValid() {
-		preset = string(*input.PreviewPreset)
-	}
+	preset := config.GetPreviewPreset().String()
 
 	galleryIDs := utils.StringSliceToIntSlice(input.GalleryIDs)
 	sceneIDs := utils.StringSliceToIntSlice(input.SceneIDs)

--- a/pkg/manager/task_generate_gallery_thumbs.go
+++ b/pkg/manager/task_generate_gallery_thumbs.go
@@ -1,15 +1,17 @@
 package manager
 
 import (
+	"sync"
+
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager/paths"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"sync"
 )
 
 type GenerateGthumbsTask struct {
-	Gallery models.Gallery
+	Gallery   models.Gallery
+	Overwrite bool
 }
 
 func (t *GenerateGthumbsTask) Start(wg *sync.WaitGroup) {
@@ -19,7 +21,7 @@ func (t *GenerateGthumbsTask) Start(wg *sync.WaitGroup) {
 	for i := 0; i < count; i++ {
 		thumbPath := paths.GetGthumbPath(t.Gallery.Checksum, i, models.DefaultGthumbWidth)
 		exists, _ := utils.FileExists(thumbPath)
-		if exists {
+		if !t.Overwrite && exists {
 			continue
 		}
 		data := t.Gallery.GetThumbnail(i, models.DefaultGthumbWidth)

--- a/pkg/manager/task_generate_markers.go
+++ b/pkg/manager/task_generate_markers.go
@@ -13,12 +13,36 @@ import (
 )
 
 type GenerateMarkersTask struct {
-	Scene models.Scene
+	Scene  *models.Scene
+	Marker *models.SceneMarker
 }
 
 func (t *GenerateMarkersTask) Start(wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	if t.Scene != nil {
+		t.generateSceneMarkers()
+	}
+
+	if t.Marker != nil {
+		qb := models.NewSceneQueryBuilder()
+		scene, err := qb.Find(int(t.Marker.SceneID.Int64))
+		if err != nil {
+			logger.Errorf("error finding scene for marker: %s", err.Error())
+			return
+		}
+
+		videoFile, err := ffmpeg.NewVideoFile(instance.FFProbePath, t.Scene.Path)
+		if err != nil {
+			logger.Errorf("error reading video file: %s", err.Error())
+			return
+		}
+
+		t.generateMarker(videoFile, scene, t.Marker)
+	}
+}
+
+func (t *GenerateMarkersTask) generateSceneMarkers() {
 	qb := models.NewSceneMarkerQueryBuilder()
 	sceneMarkers, _ := qb.FindBySceneID(t.Scene.ID, nil)
 	if len(sceneMarkers) == 0 {
@@ -35,43 +59,49 @@ func (t *GenerateMarkersTask) Start(wg *sync.WaitGroup) {
 	markersFolder := filepath.Join(instance.Paths.Generated.Markers, t.Scene.Checksum)
 	_ = utils.EnsureDir(markersFolder)
 
-	encoder := ffmpeg.NewEncoder(instance.FFMPEGPath)
 	for i, sceneMarker := range sceneMarkers {
 		index := i + 1
 		logger.Progressf("[generator] <%s> scene marker %d of %d", t.Scene.Checksum, index, len(sceneMarkers))
 
-		seconds := int(sceneMarker.Seconds)
-		baseFilename := strconv.Itoa(seconds)
-		videoFilename := baseFilename + ".mp4"
-		imageFilename := baseFilename + ".webp"
-		videoPath := instance.Paths.SceneMarkers.GetStreamPath(t.Scene.Checksum, seconds)
-		imagePath := instance.Paths.SceneMarkers.GetStreamPreviewImagePath(t.Scene.Checksum, seconds)
-		videoExists, _ := utils.FileExists(videoPath)
-		imageExists, _ := utils.FileExists(imagePath)
+		t.generateMarker(videoFile, t.Scene, sceneMarker)
+	}
+}
 
-		options := ffmpeg.SceneMarkerOptions{
-			ScenePath: t.Scene.Path,
-			Seconds:   seconds,
-			Width:     640,
-		}
-		if !videoExists {
-			options.OutputPath = instance.Paths.Generated.GetTmpPath(videoFilename) // tmp output in case the process ends abruptly
-			if err := encoder.SceneMarkerVideo(*videoFile, options); err != nil {
-				logger.Errorf("[generator] failed to generate marker video: %s", err)
-			} else {
-				_ = os.Rename(options.OutputPath, videoPath)
-				logger.Debug("created marker video: ", videoPath)
-			}
-		}
+func (t *GenerateMarkersTask) generateMarker(videoFile *ffmpeg.VideoFile, scene *models.Scene, sceneMarker *models.SceneMarker) {
+	seconds := int(sceneMarker.Seconds)
+	baseFilename := strconv.Itoa(seconds)
+	videoFilename := baseFilename + ".mp4"
+	imageFilename := baseFilename + ".webp"
+	videoPath := instance.Paths.SceneMarkers.GetStreamPath(scene.Checksum, seconds)
+	imagePath := instance.Paths.SceneMarkers.GetStreamPreviewImagePath(scene.Checksum, seconds)
+	videoExists, _ := utils.FileExists(videoPath)
+	imageExists, _ := utils.FileExists(imagePath)
 
-		if !imageExists {
-			options.OutputPath = instance.Paths.Generated.GetTmpPath(imageFilename) // tmp output in case the process ends abruptly
-			if err := encoder.SceneMarkerImage(*videoFile, options); err != nil {
-				logger.Errorf("[generator] failed to generate marker image: %s", err)
-			} else {
-				_ = os.Rename(options.OutputPath, imagePath)
-				logger.Debug("created marker image: ", videoPath)
-			}
+	options := ffmpeg.SceneMarkerOptions{
+		ScenePath: scene.Path,
+		Seconds:   seconds,
+		Width:     640,
+	}
+
+	encoder := ffmpeg.NewEncoder(instance.FFMPEGPath)
+
+	if !videoExists {
+		options.OutputPath = instance.Paths.Generated.GetTmpPath(videoFilename) // tmp output in case the process ends abruptly
+		if err := encoder.SceneMarkerVideo(*videoFile, options); err != nil {
+			logger.Errorf("[generator] failed to generate marker video: %s", err)
+		} else {
+			_ = os.Rename(options.OutputPath, videoPath)
+			logger.Debug("created marker video: ", videoPath)
+		}
+	}
+
+	if !imageExists {
+		options.OutputPath = instance.Paths.Generated.GetTmpPath(imageFilename) // tmp output in case the process ends abruptly
+		if err := encoder.SceneMarkerImage(*videoFile, options); err != nil {
+			logger.Errorf("[generator] failed to generate marker image: %s", err)
+		} else {
+			_ = os.Rename(options.OutputPath, imagePath)
+			logger.Debug("created marker image: ", videoPath)
 		}
 	}
 }

--- a/pkg/manager/task_generate_preview.go
+++ b/pkg/manager/task_generate_preview.go
@@ -32,11 +32,12 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 		return
 	}
 
-	generator, err := NewPreviewGenerator(*videoFile, videoFilename, imageFilename, instance.Paths.Generated.Screenshots, !videoExists, t.ImagePreview, t.PreviewPreset)
+	generator, err := NewPreviewGenerator(*videoFile, videoFilename, imageFilename, instance.Paths.Generated.Screenshots, true, t.ImagePreview, t.PreviewPreset)
 	if err != nil {
 		logger.Errorf("error creating preview generator: %s", err.Error())
 		return
 	}
+	generator.Overwrite = t.Overwrite
 
 	if err := generator.Generate(); err != nil {
 		logger.Errorf("error generating preview: %s", err.Error())

--- a/pkg/manager/task_generate_preview.go
+++ b/pkg/manager/task_generate_preview.go
@@ -1,17 +1,19 @@
 package manager
 
 import (
+	"sync"
+
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"sync"
 )
 
 type GeneratePreviewTask struct {
 	Scene         models.Scene
 	ImagePreview  bool
 	PreviewPreset string
+	Overwrite     bool
 }
 
 func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
@@ -20,7 +22,7 @@ func (t *GeneratePreviewTask) Start(wg *sync.WaitGroup) {
 	videoFilename := t.videoFilename()
 	imageFilename := t.imageFilename()
 	videoExists := t.doesVideoPreviewExist(t.Scene.Checksum)
-	if (!t.ImagePreview || t.doesImagePreviewExist(t.Scene.Checksum)) && videoExists {
+	if !t.Overwrite && ((!t.ImagePreview || t.doesImagePreviewExist(t.Scene.Checksum)) && videoExists) {
 		return
 	}
 

--- a/pkg/manager/task_generate_sprite.go
+++ b/pkg/manager/task_generate_sprite.go
@@ -1,21 +1,23 @@
 package manager
 
 import (
+	"sync"
+
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
-	"sync"
 )
 
 type GenerateSpriteTask struct {
-	Scene models.Scene
+	Scene     models.Scene
+	Overwrite bool
 }
 
 func (t *GenerateSpriteTask) Start(wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	if t.doesSpriteExist(t.Scene.Checksum) {
+	if t.doesSpriteExist(t.Scene.Checksum) && !t.Overwrite {
 		return
 	}
 
@@ -28,6 +30,7 @@ func (t *GenerateSpriteTask) Start(wg *sync.WaitGroup) {
 	imagePath := instance.Paths.Scene.GetSpriteImageFilePath(t.Scene.Checksum)
 	vttPath := instance.Paths.Scene.GetSpriteVttFilePath(t.Scene.Checksum)
 	generator, err := NewSpriteGenerator(*videoFile, imagePath, vttPath, 9, 9)
+	generator.Overwrite = t.Overwrite
 	if err != nil {
 		logger.Errorf("error creating sprite generator: %s", err.Error())
 		return

--- a/pkg/manager/task_transcode.go
+++ b/pkg/manager/task_transcode.go
@@ -11,14 +11,15 @@ import (
 )
 
 type GenerateTranscodeTask struct {
-	Scene models.Scene
+	Scene     models.Scene
+	Overwrite bool
 }
 
 func (t *GenerateTranscodeTask) Start(wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	hasTranscode, _ := HasTranscode(&t.Scene)
-	if hasTranscode {
+	if !t.Overwrite && hasTranscode {
 		return
 	}
 
@@ -107,7 +108,7 @@ func (t *GenerateTranscodeTask) isTranscodeNeeded() bool {
 	}
 
 	hasTranscode, _ := HasTranscode(&t.Scene)
-	if hasTranscode {
+	if !t.Overwrite && hasTranscode {
 		return false
 	}
 	return true

--- a/pkg/models/querybuilder_gallery.go
+++ b/pkg/models/querybuilder_gallery.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strconv"
 
@@ -80,6 +81,24 @@ func (qb *GalleryQueryBuilder) Find(id int) (*Gallery, error) {
 	query := "SELECT * FROM galleries WHERE id = ? LIMIT 1"
 	args := []interface{}{id}
 	return qb.queryGallery(query, args, nil)
+}
+
+func (qb *GalleryQueryBuilder) FindMany(ids []int) ([]*Gallery, error) {
+	var galleries []*Gallery
+	for _, id := range ids {
+		gallery, err := qb.Find(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if gallery == nil {
+			return nil, fmt.Errorf("gallery with id %d not found", id)
+		}
+
+		galleries = append(galleries, gallery)
+	}
+
+	return galleries, nil
 }
 
 func (qb *GalleryQueryBuilder) FindByChecksum(checksum string, tx *sqlx.Tx) (*Gallery, error) {

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -145,6 +146,24 @@ func (qb *SceneQueryBuilder) Destroy(id string, tx *sqlx.Tx) error {
 }
 func (qb *SceneQueryBuilder) Find(id int) (*Scene, error) {
 	return qb.find(id, nil)
+}
+
+func (qb *SceneQueryBuilder) FindMany(ids []int) ([]*Scene, error) {
+	var scenes []*Scene
+	for _, id := range ids {
+		scene, err := qb.Find(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if scene == nil {
+			return nil, fmt.Errorf("scene with id %d not found", id)
+		}
+
+		scenes = append(scenes, scene)
+	}
+
+	return scenes, nil
 }
 
 func (qb *SceneQueryBuilder) find(id int, tx *sqlx.Tx) (*Scene, error) {

--- a/pkg/models/querybuilder_scene_marker.go
+++ b/pkg/models/querybuilder_scene_marker.go
@@ -2,9 +2,11 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
+	"strconv"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/database"
-	"strconv"
 )
 
 const countSceneMarkersForTagQuery = `
@@ -70,6 +72,24 @@ func (qb *SceneMarkerQueryBuilder) Find(id int) (*SceneMarker, error) {
 		return nil, err
 	}
 	return results[0], nil
+}
+
+func (qb *SceneMarkerQueryBuilder) FindMany(ids []int) ([]*SceneMarker, error) {
+	var markers []*SceneMarker
+	for _, id := range ids {
+		marker, err := qb.Find(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if marker == nil {
+			return nil, fmt.Errorf("scene marker with id %d not found", id)
+		}
+
+		markers = append(markers, marker)
+	}
+
+	return markers, nil
 }
 
 func (qb *SceneMarkerQueryBuilder) FindBySceneID(sceneID int, tx *sqlx.Tx) ([]*SceneMarker, error) {

--- a/pkg/utils/string_collections.go
+++ b/pkg/utils/string_collections.go
@@ -1,5 +1,7 @@
 package utils
 
+import "strconv"
+
 // https://gobyexample.com/collection-functions
 
 func StrIndex(vs []string, t string) int {
@@ -31,4 +33,16 @@ func StrMap(vs []string, f func(string) string) []string {
 		vsm[i] = f(v)
 	}
 	return vsm
+}
+
+// StringSliceToIntSlice converts a slice of strings to a slice of ints. If any
+// values cannot be parsed, then they are inserted into the returned slice as
+// 0.
+func StringSliceToIntSlice(ss []string) []int {
+	ret := make([]int, len(ss))
+	for i, v := range ss {
+		ret[i], _ = strconv.Atoi(v)
+	}
+
+	return ret
 }

--- a/ui/v2.5/src/components/Changelog/versions/v030.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v030.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 
 const markup = `
 ### ✨ New Features
+*  Support (re-)generation of generated content for specific scenes.
 *  Add tag thumbnails, tags grid view and tag page.
 *  Add post-scrape dialog.
 *  Add various keyboard shortcuts (see manual).

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -25,6 +25,7 @@ import { AddFilter } from "./AddFilter";
 interface IListFilterOperation {
   text: string;
   onClick: () => void;
+  isDisplayed?: () => boolean;
 }
 
 interface IListFilterProps {
@@ -363,7 +364,13 @@ export const ListFilter: React.FC<IListFilterProps> = (
     const options = [renderSelectAll(), renderSelectNone()];
 
     if (props.otherOperations) {
-      props.otherOperations.forEach((o) => {
+      props.otherOperations.filter((o) => {
+        if (!o.isDisplayed) {
+          return true;
+        }
+
+        return o.isDisplayed();
+      }).forEach((o) => {
         options.push(
           <Dropdown.Item
             key={o.text}

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -364,23 +364,25 @@ export const ListFilter: React.FC<IListFilterProps> = (
     const options = [renderSelectAll(), renderSelectNone()];
 
     if (props.otherOperations) {
-      props.otherOperations.filter((o) => {
-        if (!o.isDisplayed) {
-          return true;
-        }
+      props.otherOperations
+        .filter((o) => {
+          if (!o.isDisplayed) {
+            return true;
+          }
 
-        return o.isDisplayed();
-      }).forEach((o) => {
-        options.push(
-          <Dropdown.Item
-            key={o.text}
-            className="bg-secondary text-white"
-            onClick={o.onClick}
-          >
-            {o.text}
-          </Dropdown.Item>
-        );
-      });
+          return o.isDisplayed();
+        })
+        .forEach((o) => {
+          options.push(
+            <Dropdown.Item
+              key={o.text}
+              className="bg-secondary text-white"
+              onClick={o.onClick}
+            >
+              {o.text}
+            </Dropdown.Item>
+          );
+        });
     }
 
     if (options.length > 0) {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -130,13 +130,22 @@ export const Scene: React.FC = () => {
 
   function maybeRenderDeleteDialog() {
     if (isDeleteAlertOpen && scene) {
-      return <DeleteScenesDialog selected={[scene]} onClose={onDeleteDialogClosed} />;
+      return (
+        <DeleteScenesDialog selected={[scene]} onClose={onDeleteDialogClosed} />
+      );
     }
   }
 
   function maybeRenderSceneGenerateDialog() {
     if (isGenerateDialogOpen && scene) {
-      return <SceneGenerateDialog selectedIds={[scene.id]} onClose={() => {setIsGenerateDialogOpen(false)}} />;
+      return (
+        <SceneGenerateDialog
+          selectedIds={[scene.id]}
+          onClose={() => {
+            setIsGenerateDialogOpen(false);
+          }}
+        />
+      );
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -23,6 +23,7 @@ import { SceneDetailPanel } from "./SceneDetailPanel";
 import { OCounterButton } from "./OCounterButton";
 import { SceneMoviePanel } from "./SceneMoviePanel";
 import { DeleteScenesDialog } from "../DeleteScenesDialog";
+import { SceneGenerateDialog } from "../SceneGenerateDialog";
 
 export const Scene: React.FC = () => {
   const { id = "new" } = useParams();
@@ -42,6 +43,7 @@ export const Scene: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = useState("scene-details-panel");
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+  const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
 
   const queryParams = queryString.parse(location.search);
   const autoplay = queryParams?.autoplay === "true";
@@ -128,9 +130,13 @@ export const Scene: React.FC = () => {
 
   function maybeRenderDeleteDialog() {
     if (isDeleteAlertOpen && scene) {
-      return (
-        <DeleteScenesDialog selected={[scene]} onClose={onDeleteDialogClosed} />
-      );
+      return <DeleteScenesDialog selected={[scene]} onClose={onDeleteDialogClosed} />;
+    }
+  }
+
+  function maybeRenderSceneGenerateDialog() {
+    if (isGenerateDialogOpen && scene) {
+      return <SceneGenerateDialog selectedIds={[scene.id]} onClose={() => {setIsGenerateDialogOpen(false)}} />;
     }
   }
 
@@ -146,6 +152,13 @@ export const Scene: React.FC = () => {
           <Icon icon="ellipsis-v" />
         </Dropdown.Toggle>
         <Dropdown.Menu className="bg-secondary text-white">
+          <Dropdown.Item
+            key="generate"
+            className="bg-secondary text-white"
+            onClick={() => setIsGenerateDialogOpen(true)}
+          >
+            Generate...
+          </Dropdown.Item>
           <Dropdown.Item
             key="generate-screenshot"
             className="bg-secondary text-white"
@@ -291,6 +304,7 @@ export const Scene: React.FC = () => {
 
   return (
     <div className="row">
+      {maybeRenderSceneGenerateDialog()}
       {maybeRenderDeleteDialog()}
       <div className="scene-tabs order-xl-first order-last">
         <div className="d-none d-xl-block">

--- a/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 import { mutateMetadataGenerate } from "src/core/StashService";
-import * as GQL from "src/core/generated-graphql";
 import { Modal } from "src/components/Shared";
 import { useToast } from "src/hooks";
 
@@ -19,9 +18,6 @@ export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
   const [transcodes, setTranscodes] = useState(false);
   const [overwrite, setOverwrite] = useState(true);
   const [imagePreviews, setImagePreviews] = useState(false);
-  const [previewPreset, setPreviewPreset] = useState<string>(
-    GQL.PreviewPreset.Slow
-  );
 
   const Toast = useToast();
 
@@ -34,7 +30,6 @@ export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
         markers,
         transcodes,
         thumbnails: false,
-        previewPreset: (previewPreset as GQL.PreviewPreset) ?? undefined,
         overwrite,
         sceneIDs: props.selectedIds,
       });
@@ -77,31 +72,6 @@ export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
                 className="ml-2 flex-grow"
             />
             </div>
-            <Form.Group controlId="preview-preset" className="mt-2">
-            <Form.Label>
-                <h6>Preview encoding preset</h6>
-            </Form.Label>
-            <Form.Control
-                className="w-auto"
-                as="select"
-                value={previewPreset}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setPreviewPreset(e.currentTarget.value)
-                }
-                disabled={!previews}
-            >
-                {Object.keys(GQL.PreviewPreset).map((p) => (
-                <option value={p.toLowerCase()} key={p}>
-                    {p}
-                </option>
-                ))}
-            </Form.Control>
-            <Form.Text className="text-muted">
-                The preset regulates size, quality and encoding time of preview
-                generation. Presets beyond “slow” have diminishing returns and are
-                not recommended.
-            </Form.Text>
-            </Form.Group>
             <Form.Check
             id="sprite-task"
             checked={sprites}

--- a/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
@@ -40,7 +40,7 @@ export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
       props.onClose();
     }
   }
-  
+
   return (
     <Modal
       show
@@ -55,49 +55,49 @@ export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
     >
       <Form>
         <Form.Group>
-            <Form.Check
-                id="preview-task"
-                checked={previews}
-                label="Previews (video previews which play when hovering over a scene)"
-                onChange={() => setPreviews(!previews)}
-            />
-            <div className="d-flex flex-row">
+          <Form.Check
+            id="preview-task"
+            checked={previews}
+            label="Previews (video previews which play when hovering over a scene)"
+            onChange={() => setPreviews(!previews)}
+          />
+          <div className="d-flex flex-row">
             <div>↳</div>
             <Form.Check
-                id="image-preview-task"
-                checked={imagePreviews}
-                disabled={!previews}
-                label="Image Previews (animated WebP previews, only required if Preview Type is set to Animated Image)"
-                onChange={() => setImagePreviews(!imagePreviews)}
-                className="ml-2 flex-grow"
+              id="image-preview-task"
+              checked={imagePreviews}
+              disabled={!previews}
+              label="Image Previews (animated WebP previews, only required if Preview Type is set to Animated Image)"
+              onChange={() => setImagePreviews(!imagePreviews)}
+              className="ml-2 flex-grow"
             />
-            </div>
-            <Form.Check
+          </div>
+          <Form.Check
             id="sprite-task"
             checked={sprites}
             label="Sprites (for the scene scrubber)"
             onChange={() => setSprites(!sprites)}
-            />
-            <Form.Check
+          />
+          <Form.Check
             id="marker-task"
             checked={markers}
             label="Markers (20 second videos which begin at the given timecode)"
             onChange={() => setMarkers(!markers)}
-            />
-            <Form.Check
+          />
+          <Form.Check
             id="transcode-task"
             checked={transcodes}
             label="Transcodes (MP4 conversions of unsupported video formats)"
             onChange={() => setTranscodes(!transcodes)}
-            />
+          />
 
-            <hr />
-            <Form.Check
+          <hr />
+          <Form.Check
             id="overwrite"
             checked={overwrite}
             label="Overwrite existing generated files"
             onChange={() => setOverwrite(!overwrite)}
-            />
+          />
         </Form.Group>
       </Form>
     </Modal>

--- a/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneGenerateDialog.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+import { Form, Button } from "react-bootstrap";
+import { mutateMetadataGenerate } from "src/core/StashService";
+import * as GQL from "src/core/generated-graphql";
+import { Modal } from "src/components/Shared";
+import { useToast } from "src/hooks";
+
+interface ISceneGenerateDialogProps {
+  selectedIds: string[];
+  onClose: () => void;
+}
+
+export const SceneGenerateDialog: React.FC<ISceneGenerateDialogProps> = (
+  props: ISceneGenerateDialogProps
+) => {
+  const [sprites, setSprites] = useState(true);
+  const [previews, setPreviews] = useState(true);
+  const [markers, setMarkers] = useState(true);
+  const [transcodes, setTranscodes] = useState(false);
+  const [overwrite, setOverwrite] = useState(true);
+  const [imagePreviews, setImagePreviews] = useState(false);
+  const [previewPreset, setPreviewPreset] = useState<string>(
+    GQL.PreviewPreset.Slow
+  );
+
+  const Toast = useToast();
+
+  async function onGenerate() {
+    try {
+      await mutateMetadataGenerate({
+        sprites,
+        previews,
+        imagePreviews: previews && imagePreviews,
+        markers,
+        transcodes,
+        thumbnails: false,
+        previewPreset: (previewPreset as GQL.PreviewPreset) ?? undefined,
+        overwrite,
+        sceneIDs: props.selectedIds,
+      });
+      Toast.success({ content: "Started generating" });
+    } catch (e) {
+      Toast.error(e);
+    } finally {
+      props.onClose();
+    }
+  }
+  
+  return (
+    <Modal
+      show
+      icon="cogs"
+      header="Generate"
+      accept={{ onClick: onGenerate, text: "Generate" }}
+      cancel={{
+        onClick: () => props.onClose(),
+        text: "Cancel",
+        variant: "secondary",
+      }}
+    >
+      <Form>
+        <Form.Group>
+            <Form.Check
+                id="preview-task"
+                checked={previews}
+                label="Previews (video previews which play when hovering over a scene)"
+                onChange={() => setPreviews(!previews)}
+            />
+            <div className="d-flex flex-row">
+            <div>↳</div>
+            <Form.Check
+                id="image-preview-task"
+                checked={imagePreviews}
+                disabled={!previews}
+                label="Image Previews (animated WebP previews, only required if Preview Type is set to Animated Image)"
+                onChange={() => setImagePreviews(!imagePreviews)}
+                className="ml-2 flex-grow"
+            />
+            </div>
+            <Form.Group controlId="preview-preset" className="mt-2">
+            <Form.Label>
+                <h6>Preview encoding preset</h6>
+            </Form.Label>
+            <Form.Control
+                className="w-auto"
+                as="select"
+                value={previewPreset}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setPreviewPreset(e.currentTarget.value)
+                }
+                disabled={!previews}
+            >
+                {Object.keys(GQL.PreviewPreset).map((p) => (
+                <option value={p.toLowerCase()} key={p}>
+                    {p}
+                </option>
+                ))}
+            </Form.Control>
+            <Form.Text className="text-muted">
+                The preset regulates size, quality and encoding time of preview
+                generation. Presets beyond “slow” have diminishing returns and are
+                not recommended.
+            </Form.Text>
+            </Form.Group>
+            <Form.Check
+            id="sprite-task"
+            checked={sprites}
+            label="Sprites (for the scene scrubber)"
+            onChange={() => setSprites(!sprites)}
+            />
+            <Form.Check
+            id="marker-task"
+            checked={markers}
+            label="Markers (20 second videos which begin at the given timecode)"
+            onChange={() => setMarkers(!markers)}
+            />
+            <Form.Check
+            id="transcode-task"
+            checked={transcodes}
+            label="Transcodes (MP4 conversions of unsupported video formats)"
+            onChange={() => setTranscodes(!transcodes)}
+            />
+
+            <hr />
+            <Form.Check
+            id="overwrite"
+            checked={overwrite}
+            label="Overwrite existing generated files"
+            onChange={() => setOverwrite(!overwrite)}
+            />
+        </Form.Group>
+      </Form>
+    </Modal>
+  );
+};

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import _ from "lodash";
 import { useHistory } from "react-router-dom";
 import {
@@ -14,6 +14,8 @@ import { SceneCard } from "./SceneCard";
 import { SceneListTable } from "./SceneListTable";
 import { EditScenesDialog } from "./EditScenesDialog";
 import { DeleteScenesDialog } from "./DeleteScenesDialog";
+import { showWhenSelected } from "src/hooks/ListHook";
+import { SceneGenerateDialog } from "./SceneGenerateDialog";
 
 interface ISceneList {
   subComponent?: boolean;
@@ -25,11 +27,18 @@ export const SceneList: React.FC<ISceneList> = ({
   filterHook,
 }) => {
   const history = useHistory();
+  const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
+
   const otherOperations = [
     {
       text: "Play Random",
       onClick: playRandom,
     },
+    {
+      text: "Generate...",
+      onClick: generate,
+      isDisplayed: showWhenSelected,
+    }
   ];
 
   const addKeybinds = (
@@ -82,6 +91,22 @@ export const SceneList: React.FC<ISceneList> = ({
     }
   }
 
+  async function generate() {
+    setIsGenerateDialogOpen(true);
+  }
+
+  function maybeRenderSceneGenerateDialog(
+    selectedIds: Set<string>
+  ) {
+    if (isGenerateDialogOpen) {
+      return (
+        <>
+          <SceneGenerateDialog selectedIds={Array.from(selectedIds.values())} onClose={() => {setIsGenerateDialogOpen(false)}} />
+        </>
+      );
+    }
+  }
+
   function renderEditScenesDialog(
     selectedScenes: SlimSceneDataFragment[],
     onClose: (applied: boolean) => void
@@ -123,7 +148,7 @@ export const SceneList: React.FC<ISceneList> = ({
     );
   }
 
-  function renderContent(
+  function renderScenes(
     result: FindScenesQueryResult,
     filter: ListFilterModel,
     selectedIds: Set<string>,
@@ -147,6 +172,20 @@ export const SceneList: React.FC<ISceneList> = ({
     if (filter.displayMode === DisplayMode.Wall) {
       return <WallPanel scenes={result.data.findScenes.scenes} />;
     }
+  }
+
+  function renderContent(
+    result: FindScenesQueryResult,
+    filter: ListFilterModel,
+    selectedIds: Set<string>,
+    zoomIndex: number
+  ) {
+    return (
+      <>
+        {maybeRenderSceneGenerateDialog(selectedIds)}
+        {renderScenes(result, filter, selectedIds, zoomIndex)}
+      </>
+    )
   }
 
   return listData.template;

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -9,12 +9,12 @@ import { queryFindScenes } from "src/core/StashService";
 import { useScenesList } from "src/hooks";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
+import { showWhenSelected } from "src/hooks/ListHook";
 import { WallPanel } from "../Wall/WallPanel";
 import { SceneCard } from "./SceneCard";
 import { SceneListTable } from "./SceneListTable";
 import { EditScenesDialog } from "./EditScenesDialog";
 import { DeleteScenesDialog } from "./DeleteScenesDialog";
-import { showWhenSelected } from "src/hooks/ListHook";
 import { SceneGenerateDialog } from "./SceneGenerateDialog";
 
 interface ISceneList {
@@ -38,7 +38,7 @@ export const SceneList: React.FC<ISceneList> = ({
       text: "Generate...",
       onClick: generate,
       isDisplayed: showWhenSelected,
-    }
+    },
   ];
 
   const addKeybinds = (
@@ -95,13 +95,16 @@ export const SceneList: React.FC<ISceneList> = ({
     setIsGenerateDialogOpen(true);
   }
 
-  function maybeRenderSceneGenerateDialog(
-    selectedIds: Set<string>
-  ) {
+  function maybeRenderSceneGenerateDialog(selectedIds: Set<string>) {
     if (isGenerateDialogOpen) {
       return (
         <>
-          <SceneGenerateDialog selectedIds={Array.from(selectedIds.values())} onClose={() => {setIsGenerateDialogOpen(false)}} />
+          <SceneGenerateDialog
+            selectedIds={Array.from(selectedIds.values())}
+            onClose={() => {
+              setIsGenerateDialogOpen(false);
+            }}
+          />
         </>
       );
     }
@@ -185,7 +188,7 @@ export const SceneList: React.FC<ISceneList> = ({
         {maybeRenderSceneGenerateDialog(selectedIds)}
         {renderScenes(result, filter, selectedIds, zoomIndex)}
       </>
-    )
+    );
   }
 
   return listData.template;

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -17,6 +17,9 @@ export const SettingsConfigurationPanel: React.FC = () => {
     undefined
   );
   const [cachePath, setCachePath] = useState<string | undefined>(undefined);
+  const [previewPreset, setPreviewPreset] = useState<string>(
+    GQL.PreviewPreset.Slow
+  );
   const [maxTranscodeSize, setMaxTranscodeSize] = useState<
     GQL.StreamingResolutionEnum | undefined
   >(undefined);
@@ -44,6 +47,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
     databasePath,
     generatedPath,
     cachePath,
+    previewPreset: (previewPreset as GQL.PreviewPreset) ?? undefined,
     maxTranscodeSize,
     maxStreamingTranscodeSize,
     forceMkv,
@@ -68,6 +72,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
       setDatabasePath(conf.general.databasePath);
       setGeneratedPath(conf.general.generatedPath);
       setCachePath(conf.general.cachePath);
+      setPreviewPreset(conf.general.previewPreset);
       setMaxTranscodeSize(conf.general.maxTranscodeSize ?? undefined);
       setMaxStreamingTranscodeSize(
         conf.general.maxStreamingTranscodeSize ?? undefined
@@ -275,9 +280,31 @@ export const SettingsConfigurationPanel: React.FC = () => {
       <Form.Group>
         <h4>Video</h4>
         <Form.Group id="transcode-size">
+          <h6>Preview encoding preset</h6>
+          <Form.Control
+            className="w-auto input-control"
+            as="select"
+            value={previewPreset}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setPreviewPreset(e.currentTarget.value)
+            }
+          >
+            {Object.keys(GQL.PreviewPreset).map((p) => (
+            <option value={p.toLowerCase()} key={p}>
+                {p}
+            </option>
+            ))}
+          </Form.Control>
+          <Form.Text className="text-muted">
+              The preset regulates size, quality and encoding time of preview
+              generation. Presets beyond “slow” have diminishing returns and are
+              not recommended.
+          </Form.Text>
+        </Form.Group>
+        <Form.Group id="transcode-size">
           <h6>Maximum transcode size</h6>
           <Form.Control
-            className="col col-sm-6 input-control"
+            className="w-auto input-control"
             as="select"
             onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
               setMaxTranscodeSize(translateQuality(event.currentTarget.value))
@@ -297,7 +324,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
         <Form.Group id="streaming-transcode-size">
           <h6>Maximum streaming transcode size</h6>
           <Form.Control
-            className="col col-sm-6 input-control"
+            className="w-auto input-control"
             as="select"
             onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
               setMaxStreamingTranscodeSize(

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -286,19 +286,19 @@ export const SettingsConfigurationPanel: React.FC = () => {
             as="select"
             value={previewPreset}
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            setPreviewPreset(e.currentTarget.value)
+              setPreviewPreset(e.currentTarget.value)
             }
           >
             {Object.keys(GQL.PreviewPreset).map((p) => (
-            <option value={p.toLowerCase()} key={p}>
+              <option value={p.toLowerCase()} key={p}>
                 {p}
-            </option>
+              </option>
             ))}
           </Form.Control>
           <Form.Text className="text-muted">
-              The preset regulates size, quality and encoding time of preview
-              generation. Presets beyond “slow” have diminishing returns and are
-              not recommended.
+            The preset regulates size, quality and encoding time of preview
+            generation. Presets beyond “slow” have diminishing returns and are
+            not recommended.
           </Form.Text>
         </Form.Group>
         <Form.Group id="transcode-size">

--- a/ui/v2.5/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsTasksPanel/GenerateButton.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Button, Form } from "react-bootstrap";
 import { mutateMetadataGenerate } from "src/core/StashService";
-import { PreviewPreset } from "src/core/generated-graphql";
 import { useToast } from "src/hooks";
 
 export const GenerateButton: React.FC = () => {
@@ -12,9 +11,6 @@ export const GenerateButton: React.FC = () => {
   const [transcodes, setTranscodes] = useState(false);
   const [thumbnails, setThumbnails] = useState(false);
   const [imagePreviews, setImagePreviews] = useState(false);
-  const [previewPreset, setPreviewPreset] = useState<string>(
-    PreviewPreset.Slow
-  );
 
   async function onGenerate() {
     try {
@@ -25,7 +21,6 @@ export const GenerateButton: React.FC = () => {
         markers,
         transcodes,
         thumbnails,
-        previewPreset: (previewPreset as PreviewPreset) ?? undefined,
       });
       Toast.success({ content: "Started generating" });
     } catch (e) {
@@ -53,31 +48,6 @@ export const GenerateButton: React.FC = () => {
             className="ml-2 flex-grow"
           />
         </div>
-        <Form.Group controlId="preview-preset" className="mt-2">
-          <Form.Label>
-            <h6>Preview encoding preset</h6>
-          </Form.Label>
-          <Form.Control
-            as="select"
-            value={previewPreset}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-              setPreviewPreset(e.currentTarget.value)
-            }
-            disabled={!previews}
-            className="col-1"
-          >
-            {Object.keys(PreviewPreset).map((p) => (
-              <option value={p.toLowerCase()} key={p}>
-                {p}
-              </option>
-            ))}
-          </Form.Control>
-          <Form.Text className="text-muted">
-            The preset regulates size, quality and encoding time of preview
-            generation. Presets beyond “slow” have diminishing returns and are
-            not recommended.
-          </Form.Text>
-        </Form.Group>
         <Form.Check
           id="sprite-task"
           checked={sprites}

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -51,6 +51,11 @@ interface IListHookOperation<T> {
     filter: ListFilterModel,
     selectedIds: Set<string>
   ) => void;
+  isDisplayed?: (
+    result: T,
+    filter: ListFilterModel,
+    selectedIds: Set<string>
+  ) => boolean;
 }
 
 interface IListHookOptions<T, E> {
@@ -346,6 +351,13 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
           onClick: () => {
             o.onClick(result, filter, selectedIds);
           },
+          isDisplayed: () => {
+            if (o.isDisplayed) {
+              return o.isDisplayed(result, filter, selectedIds);
+            }
+
+            return true;
+          }
         };
       })
     : undefined;
@@ -594,3 +606,10 @@ export const useTagsList = (
     getSelectedData: (result: FindTagsQueryResult, selectedIds: Set<string>) =>
       getSelectedData(result?.data?.findTags?.tags ?? [], selectedIds),
   });
+
+  export const showWhenSelected = (
+    result: FindScenesQueryResult,
+    filter: ListFilterModel,
+    selectedIds: Set<string>) => {
+      return selectedIds.size > 0;
+    };

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -357,7 +357,7 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
             }
 
             return true;
-          }
+          },
         };
       })
     : undefined;
@@ -607,9 +607,10 @@ export const useTagsList = (
       getSelectedData(result?.data?.findTags?.tags ?? [], selectedIds),
   });
 
-  export const showWhenSelected = (
-    result: FindScenesQueryResult,
-    filter: ListFilterModel,
-    selectedIds: Set<string>) => {
-      return selectedIds.size > 0;
-    };
+export const showWhenSelected = (
+  result: FindScenesQueryResult,
+  filter: ListFilterModel,
+  selectedIds: Set<string>
+) => {
+  return selectedIds.size > 0;
+};


### PR DESCRIPTION
Resolves #279 

Adds a `Generate...` entry to the dropdown menu in the scenes page when at least one scene is selected.

![image](https://user-images.githubusercontent.com/53250216/87753812-cc5af380-c846-11ea-9025-3ab242694b60.png)

Also adds an entry to the ellipsis menu in the scene page.

![image](https://user-images.githubusercontent.com/53250216/87753851-e1d01d80-c846-11ea-9d5e-40e451d15370.png)

Clicking on the entry opens up the Generate dialog, which has the same options as in the Tasks page:

![image](https://user-images.githubusercontent.com/53250216/87753888-f7454780-c846-11ea-9353-a811368681b6.png)

It also adds an `Overwrite` option so that the relevant content can be overwritten.

I have moved the `Preview Preset` option to the configuration, since I think it is a better fit there than per generate operation.