### PR TITLE
Don't show dialog when setting front movie image

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -138,7 +138,7 @@ export const Movie: React.FC = () => {
     }
   }, [data, updateMovieData]);
 
-  function onImageLoad(imageData: string) {
+  function showImageAlert(imageData: string) {
     setImageClipboard(imageData);
     setIsImageAlertOpen(true);
   }
@@ -161,7 +161,12 @@ export const Movie: React.FC = () => {
     setBackImage(imageData);
   }
 
-  const encodingImage = ImageUtils.usePasteImage(onImageLoad, isEditing);
+  function onFrontImageLoad(imageData: string) {
+    setImagePreview(imageData);
+    setFrontImage(imageData);
+  }
+
+  const encodingImage = ImageUtils.usePasteImage(showImageAlert, isEditing);
 
   if (!isNew && !isEditing) {
     if (!data || !data.findMovie || loading) return <LoadingIndicator />;
@@ -222,8 +227,8 @@ export const Movie: React.FC = () => {
     history.push(`/movies`);
   }
 
-  function onImageChange(event: React.FormEvent<HTMLInputElement>) {
-    ImageUtils.onImageChange(event, onImageLoad);
+  function onFrontImageChange(event: React.FormEvent<HTMLInputElement>) {
+    ImageUtils.onImageChange(event, onFrontImageLoad);
   }
 
   function onBackImageChange(event: React.FormEvent<HTMLInputElement>) {
@@ -388,7 +393,7 @@ export const Movie: React.FC = () => {
           isEditing={isEditing}
           onToggleEdit={onToggleEdit}
           onSave={onSave}
-          onImageChange={onImageChange}
+          onImageChange={onFrontImageChange}
           onBackImageChange={onBackImageChange}
           onDelete={onDelete}
         />

--- a/ui/v2.5/src/utils/image.tsx
+++ b/ui/v2.5/src/utils/image.tsx
@@ -3,7 +3,12 @@ import Jimp from "jimp";
 
 const readImage = (file: File, onLoadEnd: (imageData: string) => void) => {
   const reader: FileReader = new FileReader();
-  reader.onloadend = () => onLoadEnd(reader.result as string);
+  reader.onloadend = () => {
+    // only proceed if no error encountered
+    if (!reader.error) {
+      onLoadEnd(reader.result as string);  
+    }
+  }
   reader.readAsDataURL(file);
 };
 

--- a/ui/v2.5/src/utils/image.tsx
+++ b/ui/v2.5/src/utils/image.tsx
@@ -6,9 +6,9 @@ const readImage = (file: File, onLoadEnd: (imageData: string) => void) => {
   reader.onloadend = () => {
     // only proceed if no error encountered
     if (!reader.error) {
-      onLoadEnd(reader.result as string);  
+      onLoadEnd(reader.result as string);
     }
-  }
+  };
   reader.readAsDataURL(file);
 };
 


### PR DESCRIPTION
Fixes issue where the front/back image dialog would be displayed after selecting a file when clicking the `Front Image...` button.