### PR TITLE
Fix FormattedDate timezone bug

### DIFF
--- a/ui/v2.5/src/components/Changelog/Version.tsx
+++ b/ui/v2.5/src/components/Changelog/Version.tsx
@@ -36,7 +36,7 @@ const Version: React.FC<IVersionProps> = ({
             <Icon icon={open ? "angle-up" : "angle-down"} className="mr-3" />
             {version} (
             {date ? (
-              <FormattedDate value={new Date(Date.parse(date))} />
+              <FormattedDate value={date} timeZone="utc" />
             ) : (
               <FormattedMessage
                 defaultMessage="Development Version"

--- a/ui/v2.5/src/components/Changelog/versions/v030.tsx
+++ b/ui/v2.5/src/components/Changelog/versions/v030.tsx
@@ -27,6 +27,9 @@ const markup = `
 *  Show rating as stars in scene page.
 *  Add reload scrapers button.
 
+### 🐛 Bug fixes
+*  Fix formatted dates using incorrect timezone.
+
 `;
 
 export default () => <ReactMarkdown source={markup} />;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -70,7 +70,11 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
           </div>
           {props.scene.date ? (
             <h5>
-              <FormattedDate value={props.scene.date} format="long" />
+              <FormattedDate
+                value={props.scene.date}
+                format="long"
+                timeZone="utc"
+              />
             </h5>
           ) : undefined}
           {props.scene.rating ? (


### PR DESCRIPTION
When timezone isn't set to UTC FormattedDate will use the local timezone and roll the date forwards or backwards depending on time of day, leading to offset errors. 