### PR TITLE
Fix performer card name truncation

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -29,7 +29,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     <Card className="performer-card">
       <Link to={`/performers/${performer.id}`}>
         <img
-          className="image-thumbnail card-image"
+          className="performer-card-image"
           alt={performer.name ?? ""}
           src={performer.image_path ?? ""}
         />

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -64,6 +64,7 @@
     min-width: 11.25rem;
     object-fit: cover;
     object-position: top;
+    width: 100%;
   }
 
   .flag-icon {

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -57,6 +57,15 @@
 }
 
 .performer-card {
+  width: 20rem;
+
+  &-image {
+    height: 30rem;
+    min-width: 11.25rem;
+    object-fit: cover;
+    object-position: top;
+  }
+
   .flag-icon {
     bottom: 1rem;
     height: 2rem;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -247,9 +247,14 @@ textarea.scene-description {
     width: 2rem;
   }
 
-  .scene-performers .card-image {
-    height: 22.5rem;
-    width: 15rem;
+  .scene-performers {
+    .performer-card {
+      width: 15rem;
+
+      &-image {
+        height: 22.5rem;
+      }
+    }
   }
 }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -236,12 +236,6 @@ div.dropdown-menu {
   object-position: top;
 }
 
-.card-image {
-  height: 30rem;
-  min-width: 11.25rem;
-  width: 20rem;
-}
-
 .edit-button {
   margin-right: 10px;
 }


### PR DESCRIPTION
Shuffled performer-card styles around so the width is defined on the card rather than the image, that way truncations works again. Also renamed `card-image` to `performer-card-image` to clarify that it only applies to those cards.