### PR TITLE
Fix potential sprite generation segfault

### DIFF
--- a/pkg/manager/task_generate_sprite.go
+++ b/pkg/manager/task_generate_sprite.go
@@ -30,11 +30,11 @@ func (t *GenerateSpriteTask) Start(wg *sync.WaitGroup) {
 	imagePath := instance.Paths.Scene.GetSpriteImageFilePath(t.Scene.Checksum)
 	vttPath := instance.Paths.Scene.GetSpriteVttFilePath(t.Scene.Checksum)
 	generator, err := NewSpriteGenerator(*videoFile, imagePath, vttPath, 9, 9)
-	generator.Overwrite = t.Overwrite
 	if err != nil {
 		logger.Errorf("error creating sprite generator: %s", err.Error())
 		return
 	}
+	generator.Overwrite = t.Overwrite
 
 	if err := generator.Generate(); err != nil {
 		logger.Errorf("error generating sprite: %s", err.Error())


### PR DESCRIPTION
Setting generator property before checking for error leads to segfault if sprite generator creation fails for any reason. 