### PR TITLE
Fix markers not autoplaying

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -95,9 +95,6 @@ export class ScenePlayerImpl extends React.Component<
 
   private onReady() {
     this.player = JWUtils.getPlayer();
-    if (this.props.timestamp > 0) {
-      this.player.seek(this.props.timestamp);
-    }
 
     this.player.on("error", (err: any) => {
       if (err && err.code === 224003) {
@@ -113,6 +110,12 @@ export class ScenePlayerImpl extends React.Component<
       ) {
         // treat this as a decoding error and try the next source
         this.handleError();
+      }
+    });
+
+    this.player.on("playlist", () => {
+      if (this.props.timestamp > 0) {
+        this.player.seek(this.props.timestamp);
       }
     });
   }
@@ -152,6 +155,12 @@ export class ScenePlayerImpl extends React.Component<
       console.log("Trying next source in playlist");
       this.player.load(this.playlist);
       this.player.play();
+
+      this.player.on("firstFrame", () => {
+        if (this.props.timestamp > 0) {
+          this.player.seek(this.props.timestamp);
+        }
+      });
     }
   }
 
@@ -210,6 +219,7 @@ export class ScenePlayerImpl extends React.Component<
 
     const seekHook = (seekToPosition: number, _videoTag: HTMLVideoElement) => {
       if (
+        !_videoTag.src ||
         ScenePlayerImpl.isDirectStream(_videoTag.src) ||
         _videoTag.src.endsWith(".m3u8")
       ) {

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -113,7 +113,7 @@ export class ScenePlayerImpl extends React.Component<
       }
     });
 
-    this.player.on("playlist", () => {
+    this.player.on("firstFrame", () => {
       if (this.props.timestamp > 0) {
         this.player.seek(this.props.timestamp);
       }
@@ -155,12 +155,6 @@ export class ScenePlayerImpl extends React.Component<
       console.log("Trying next source in playlist");
       this.player.load(this.playlist);
       this.player.play();
-
-      this.player.on("firstFrame", () => {
-        if (this.props.timestamp > 0) {
-          this.player.seek(this.props.timestamp);
-        }
-      });
     }
   }
 
@@ -265,7 +259,8 @@ export class ScenePlayerImpl extends React.Component<
       primary: "html5",
       autostart:
         this.props.autoplay ||
-        (this.props.config ? this.props.config.autostartVideo : false),
+        (this.props.config ? this.props.config.autostartVideo : false) ||
+        this.props.timestamp > 0,
       repeat,
       playbackRateControls: true,
       playbackRates: [0.75, 1, 1.5, 2, 3, 4],


### PR DESCRIPTION
Combined `firstFrame` event behaviour into single declaration. Added auto-start behaviour when navigating to a timestamp. 

Fixes #687 

The original problem was frustratingly intermittent, but I can't seem to reproduce it with this change, so I hope it has resolved it.