### PR TITLE
Improve oshash collision detection and logging

### DIFF
--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -255,17 +255,20 @@ func (t *ScanTask) scanScene() {
 		}
 	}
 
-	sceneHash := oshash
-
 	// check for scene by checksum and oshash - MD5 should be
 	// redundant, but check both
 	if checksum != "" {
-		sceneHash = checksum
-		scene, _ = qb.FindByChecksum(sceneHash)
+		scene, _ = qb.FindByChecksum(checksum)
 	}
 
 	if scene == nil {
-		scene, _ = qb.FindByOSHash(sceneHash)
+		scene, _ = qb.FindByOSHash(oshash)
+	}
+
+	sceneHash := oshash
+
+	if t.fileNamingAlgorithm == models.HashAlgorithmMd5 {
+		sceneHash = checksum
 	}
 
 	t.makeScreenshots(videoFile, sceneHash)

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -256,14 +256,16 @@ func (t *ScanTask) scanScene() {
 	}
 
 	sceneHash := oshash
-	if t.fileNamingAlgorithm == models.HashAlgorithmMd5 {
+
+	// check for scene by checksum and oshash - MD5 should be
+	// redundant, but check both
+	if checksum != "" {
 		sceneHash = checksum
 		scene, _ = qb.FindByChecksum(sceneHash)
-	} else if t.fileNamingAlgorithm == models.HashAlgorithmOshash {
+	}
+
+	if scene == nil {
 		scene, _ = qb.FindByOSHash(sceneHash)
-	} else {
-		logger.Error("unknown file naming algorithm")
-		return
 	}
 
 	t.makeScreenshots(videoFile, sceneHash)


### PR DESCRIPTION
Log the colliding file when adding hash to an existing scene. Check both oshash and MD5 (if populated) for collisions.