### PR TITLE
Don't play video after failover

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -154,7 +154,6 @@ export class ScenePlayerImpl extends React.Component<
       // eslint-disable-next-line no-console
       console.log("Trying next source in playlist");
       this.player.load(this.playlist);
-      this.player.play();
     }
   }
 


### PR DESCRIPTION
Fixes #714 

If a video stream failed to play and the UI used the failover to load the next stream, then the newly loaded stream would be played automatically. Removed call to `play` after loading the next stream.