### PR TITLE
Fix sprite vtt panic

### DIFF
--- a/pkg/api/routes_scene.go
+++ b/pkg/api/routes_scene.go
@@ -306,15 +306,19 @@ func SceneCtx(next http.Handler) http.Handler {
 		sceneID, _ := strconv.Atoi(sceneIdentifierQueryParam)
 
 		var scene *models.Scene
-		var err error
 		qb := models.NewSceneQueryBuilder()
 		if sceneID == 0 {
-			scene, err = qb.FindByChecksum(sceneIdentifierQueryParam)
+			// determine checksum/os by the length of the query param
+			if len(sceneIdentifierQueryParam) == 32 {
+				scene, _ = qb.FindByChecksum(sceneIdentifierQueryParam)
+			} else {
+				scene, _ = qb.FindByOSHash(sceneIdentifierQueryParam)
+			}
 		} else {
-			scene, err = qb.Find(sceneID)
+			scene, _ = qb.Find(sceneID)
 		}
 
-		if err != nil {
+		if scene == nil {
 			http.Error(w, http.StatusText(404), 404)
 			return
 		}


### PR DESCRIPTION
If the sprite vtt was generated using oshash and the scene did not have an MD5, then the system would panic when trying to get the sprite image. Now determines whether MD5 or oshash is passed, using the length of the string, then calls the applicable function. Now also gives a 404 if the scene could not be found.