### PR TITLE
Clear image

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -89,11 +89,15 @@ input SceneFilterType {
 input MovieFilterType {
   """Filter to only include movies with this studio"""
   studios: MultiCriterionInput
+  """Filter to only include movies missing this property"""
+  is_missing: String
 }
 
 input StudioFilterType {
   """Filter to only include studios with this parent studio"""
   parents: MultiCriterionInput
+  """Filter to only include studios missing this property"""
+  is_missing: String
 }
 
 input GalleryFilterType {

--- a/pkg/api/images.go
+++ b/pkg/api/images.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/packr/v2"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 var performerBox *packr.Box
@@ -28,5 +29,21 @@ func getRandomPerformerImage(gender string) ([]byte, error) {
 	}
 	imageFiles := box.List()
 	index := rand.Intn(len(imageFiles))
+	return box.Find(imageFiles[index])
+}
+
+func getRandomPerformerImageUsingName(name, gender string) ([]byte, error) {
+	var box *packr.Box
+	switch strings.ToUpper(gender) {
+	case "FEMALE":
+		box = performerBox
+	case "MALE":
+		box = performerBoxMale
+	default:
+		box = performerBox
+
+	}
+	imageFiles := box.List()
+	index := utils.IntFromString(name) % uint64(len(imageFiles))
 	return box.Find(imageFiles[index])
 }

--- a/pkg/api/resolver_mutation_movie.go
+++ b/pkg/api/resolver_mutation_movie.go
@@ -19,21 +19,26 @@ func (r *mutationResolver) MovieCreate(ctx context.Context, input models.MovieCr
 	var backimageData []byte
 	var err error
 
-	if input.FrontImage == nil {
+	// HACK: if back image is being set, set the front image to the default.
+	// This is because we can't have a null front image with a non-null back image.
+	if input.FrontImage == nil && input.BackImage != nil {
 		input.FrontImage = &models.DefaultMovieImage
 	}
-	if input.BackImage == nil {
-		input.BackImage = &models.DefaultMovieImage
-	}
+
 	// Process the base 64 encoded image string
-	_, frontimageData, err = utils.ProcessBase64Image(*input.FrontImage)
-	if err != nil {
-		return nil, err
+	if input.FrontImage != nil {
+		_, frontimageData, err = utils.ProcessBase64Image(*input.FrontImage)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	// Process the base 64 encoded image string
-	_, backimageData, err = utils.ProcessBase64Image(*input.BackImage)
-	if err != nil {
-		return nil, err
+	if input.BackImage != nil {
+		_, backimageData, err = utils.ProcessBase64Image(*input.BackImage)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Populate a new movie from the input
@@ -114,12 +119,14 @@ func (r *mutationResolver) MovieUpdate(ctx context.Context, input models.MovieUp
 	}
 	var frontimageData []byte
 	var err error
+	frontImageIncluded := wasFieldIncluded(ctx, "front_image")
 	if input.FrontImage != nil {
 		_, frontimageData, err = utils.ProcessBase64Image(*input.FrontImage)
 		if err != nil {
 			return nil, err
 		}
 	}
+	backImageIncluded := wasFieldIncluded(ctx, "back_image")
 	var backimageData []byte
 	if input.BackImage != nil {
 		_, backimageData, err = utils.ProcessBase64Image(*input.BackImage)
@@ -185,25 +192,39 @@ func (r *mutationResolver) MovieUpdate(ctx context.Context, input models.MovieUp
 	}
 
 	// update image table
-	if len(frontimageData) > 0 || len(backimageData) > 0 {
-		if len(frontimageData) == 0 {
-			frontimageData, err = qb.GetFrontImage(updatedMovie.ID, tx)
-			if err != nil {
-				_ = tx.Rollback()
+	if frontImageIncluded || backImageIncluded {
+		if frontImageIncluded && backImageIncluded && len(frontimageData) == 0 && len(backimageData) == 0 {
+			// both images are being nulled. Destroy them.
+			if err := qb.DestroyMovieImages(movie.ID, tx); err != nil {
+				tx.Rollback()
 				return nil, err
 			}
-		}
-		if len(backimageData) == 0 {
-			backimageData, err = qb.GetBackImage(updatedMovie.ID, tx)
-			if err != nil {
-				_ = tx.Rollback()
-				return nil, err
+		} else {
+			if !frontImageIncluded {
+				frontimageData, err = qb.GetFrontImage(updatedMovie.ID, tx)
+				if err != nil {
+					tx.Rollback()
+					return nil, err
+				}
 			}
-		}
+			if !backImageIncluded {
+				backimageData, err = qb.GetBackImage(updatedMovie.ID, tx)
+				if err != nil {
+					tx.Rollback()
+					return nil, err
+				}
+			}
 
-		if err := qb.UpdateMovieImages(movie.ID, frontimageData, backimageData, tx); err != nil {
-			_ = tx.Rollback()
-			return nil, err
+			// HACK - if front image is null and back image is not null, then set the front image
+			// to the default image since we can't have a null front image and a non-null back image
+			if frontimageData == nil && backimageData != nil {
+				_, frontimageData, _ = utils.ProcessBase64Image(models.DefaultMovieImage)
+			}
+
+			if err := qb.UpdateMovieImages(movie.ID, frontimageData, backimageData, tx); err != nil {
+				_ = tx.Rollback()
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/api/resolver_mutation_studio.go
+++ b/pkg/api/resolver_mutation_studio.go
@@ -80,6 +80,7 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 	}
 
 	var imageData []byte
+	imageIncluded := wasFieldIncluded(ctx, "image")
 	if input.Image != nil {
 		var err error
 		_, imageData, err = utils.ProcessBase64Image(*input.Image)
@@ -123,7 +124,13 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 	// update image table
 	if len(imageData) > 0 {
 		if err := qb.UpdateStudioImage(studio.ID, imageData, tx); err != nil {
-			_ = tx.Rollback()
+			tx.Rollback()
+			return nil, err
+		}
+	} else if imageIncluded {
+		// must be unsetting
+		if err := qb.DestroyStudioImage(studio.ID, tx); err != nil {
+			tx.Rollback()
 			return nil, err
 		}
 	}

--- a/pkg/api/routes_movie.go
+++ b/pkg/api/routes_movie.go
@@ -28,6 +28,12 @@ func (rs movieRoutes) FrontImage(w http.ResponseWriter, r *http.Request) {
 	movie := r.Context().Value(movieKey).(*models.Movie)
 	qb := models.NewMovieQueryBuilder()
 	image, _ := qb.GetFrontImage(movie.ID, nil)
+
+	defaultParam := r.URL.Query().Get("default")
+	if len(image) == 0 || defaultParam == "true" {
+		_, image, _ = utils.ProcessBase64Image(models.DefaultMovieImage)
+	}
+
 	utils.ServeImage(image, w, r)
 }
 
@@ -35,6 +41,12 @@ func (rs movieRoutes) BackImage(w http.ResponseWriter, r *http.Request) {
 	movie := r.Context().Value(movieKey).(*models.Movie)
 	qb := models.NewMovieQueryBuilder()
 	image, _ := qb.GetBackImage(movie.ID, nil)
+
+	defaultParam := r.URL.Query().Get("default")
+	if len(image) == 0 || defaultParam == "true" {
+		_, image, _ = utils.ProcessBase64Image(models.DefaultMovieImage)
+	}
+
 	utils.ServeImage(image, w, r)
 }
 

--- a/pkg/api/routes_performer.go
+++ b/pkg/api/routes_performer.go
@@ -27,6 +27,12 @@ func (rs performerRoutes) Image(w http.ResponseWriter, r *http.Request) {
 	performer := r.Context().Value(performerKey).(*models.Performer)
 	qb := models.NewPerformerQueryBuilder()
 	image, _ := qb.GetPerformerImage(performer.ID, nil)
+
+	defaultParam := r.URL.Query().Get("default")
+	if len(image) == 0 || defaultParam == "true" {
+		image, _ = getRandomPerformerImageUsingName(performer.Name.String, performer.Gender.String)
+	}
+
 	utils.ServeImage(image, w, r)
 }
 

--- a/pkg/api/routes_studio.go
+++ b/pkg/api/routes_studio.go
@@ -27,6 +27,12 @@ func (rs studioRoutes) Image(w http.ResponseWriter, r *http.Request) {
 	studio := r.Context().Value(studioKey).(*models.Studio)
 	qb := models.NewStudioQueryBuilder()
 	image, _ := qb.GetStudioImage(studio.ID, nil)
+
+	defaultParam := r.URL.Query().Get("default")
+	if len(image) == 0 || defaultParam == "true" {
+		_, image, _ = utils.ProcessBase64Image(models.DefaultStudioImage)
+	}
+
 	utils.ServeImage(image, w, r)
 }
 

--- a/pkg/api/routes_tag.go
+++ b/pkg/api/routes_tag.go
@@ -29,7 +29,8 @@ func (rs tagRoutes) Image(w http.ResponseWriter, r *http.Request) {
 	image, _ := qb.GetTagImage(tag.ID, nil)
 
 	// use default image if not present
-	if len(image) == 0 {
+	defaultParam := r.URL.Query().Get("default")
+	if len(image) == 0 || defaultParam == "true" {
 		image = models.DefaultTagImage
 	}
 

--- a/pkg/models/querybuilder_movies.go
+++ b/pkg/models/querybuilder_movies.go
@@ -152,6 +152,21 @@ func (qb *MovieQueryBuilder) Query(movieFilter *MovieFilterType, findFilter *Fin
 		havingClauses = appendClause(havingClauses, havingClause)
 	}
 
+	if isMissingFilter := movieFilter.IsMissing; isMissingFilter != nil && *isMissingFilter != "" {
+		switch *isMissingFilter {
+		case "front_image":
+			body += `left join movies_images on movies_images.movie_id = movies.id
+			`
+			whereClauses = appendClause(whereClauses, "movies_images.front_image IS NULL")
+		case "back_image":
+			body += `left join movies_images on movies_images.movie_id = movies.id
+			`
+			whereClauses = appendClause(whereClauses, "movies_images.back_image IS NULL")
+		default:
+			whereClauses = appendClause(whereClauses, "movies."+*isMissingFilter+" IS NULL")
+		}
+	}
+
 	sortAndPagination := qb.getMovieSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult := executeFindQuery("movies", body, args, sortAndPagination, whereClauses, havingClauses)
 

--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -178,6 +178,10 @@ func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, fin
 		switch *isMissingFilter {
 		case "scenes":
 			query.addWhere("scenes_join.scene_id IS NULL")
+		case "image":
+			query.body += `left join performers_image on performers_image.performer_id = performers.id
+			`
+			query.addWhere("performers_image.performer_id IS NULL")
 		default:
 			query.addWhere("performers." + *isMissingFilter + " IS NULL")
 		}

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -146,6 +146,17 @@ func (qb *StudioQueryBuilder) Query(studioFilter *StudioFilterType, findFilter *
 		havingClauses = appendClause(havingClauses, havingClause)
 	}
 
+	if isMissingFilter := studioFilter.IsMissing; isMissingFilter != nil && *isMissingFilter != "" {
+		switch *isMissingFilter {
+		case "image":
+			body += `left join studios_image on studios_image.studio_id = studios.id
+			`
+			whereClauses = appendClause(whereClauses, "studios_image.studio_id IS NULL")
+		default:
+			whereClauses = appendClause(whereClauses, "studios."+*isMissingFilter+" IS NULL")
+		}
+	}
+
 	sortAndPagination := qb.getStudioSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult := executeFindQuery("studios", body, args, sortAndPagination, whereClauses, havingClauses)
 

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 )
@@ -37,4 +38,10 @@ func GenerateRandomKey(l int) string {
 	b := make([]byte, l)
 	rand.Read(b)
 	return fmt.Sprintf("%x", b)
+}
+
+func IntFromString(str string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(str))
+	return h.Sum64()
 }

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -42,8 +42,12 @@ export const Movie: React.FC = () => {
   const [isImageAlertOpen, setIsImageAlertOpen] = useState<boolean>(false);
 
   // Editing movie state
-  const [frontImage, setFrontImage] = useState<string | undefined | null>(undefined);
-  const [backImage, setBackImage] = useState<string | undefined | null>(undefined);
+  const [frontImage, setFrontImage] = useState<string | undefined | null>(
+    undefined
+  );
+  const [backImage, setBackImage] = useState<string | undefined | null>(
+    undefined
+  );
   const [name, setName] = useState<string | undefined>(undefined);
   const [aliases, setAliases] = useState<string | undefined>(undefined);
   const [duration, setDuration] = useState<number | undefined>(undefined);
@@ -433,13 +437,21 @@ export const Movie: React.FC = () => {
   }
 
   function onClearFrontImage() {
-    setFrontImage(null); 
-    setImagePreview(movie.front_image_path ? movie.front_image_path + "?default=true" : undefined);
+    setFrontImage(null);
+    setImagePreview(
+      movie.front_image_path
+        ? `${movie.front_image_path}?default=true`
+        : undefined
+    );
   }
 
   function onClearBackImage() {
-    setBackImage(null); 
-    setBackImagePreview(movie.back_image_path ? movie.back_image_path + "?default=true" : undefined);
+    setBackImage(null);
+    setBackImagePreview(
+      movie.back_image_path
+        ? `${movie.back_image_path}?default=true`
+        : undefined
+    );
   }
 
   if (isLoading) return <LoadingIndicator />;

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -42,8 +42,8 @@ export const Movie: React.FC = () => {
   const [isImageAlertOpen, setIsImageAlertOpen] = useState<boolean>(false);
 
   // Editing movie state
-  const [frontImage, setFrontImage] = useState<string | undefined>(undefined);
-  const [backImage, setBackImage] = useState<string | undefined>(undefined);
+  const [frontImage, setFrontImage] = useState<string | undefined | null>(undefined);
+  const [backImage, setBackImage] = useState<string | undefined | null>(undefined);
   const [name, setName] = useState<string | undefined>(undefined);
   const [aliases, setAliases] = useState<string | undefined>(undefined);
   const [duration, setDuration] = useState<number | undefined>(undefined);
@@ -432,6 +432,16 @@ export const Movie: React.FC = () => {
     setScrapedMovie(undefined);
   }
 
+  function onClearFrontImage() {
+    setFrontImage(null); 
+    setImagePreview(movie.front_image_path ? movie.front_image_path + "?default=true" : undefined);
+  }
+
+  function onClearBackImage() {
+    setBackImage(null); 
+    setBackImagePreview(movie.back_image_path ? movie.back_image_path + "?default=true" : undefined);
+  }
+
   if (isLoading) return <LoadingIndicator />;
 
   // TODO: CSS class
@@ -538,7 +548,9 @@ export const Movie: React.FC = () => {
           onToggleEdit={onToggleEdit}
           onSave={onSave}
           onImageChange={onFrontImageChange}
+          onClearImage={onClearFrontImage}
           onBackImageChange={onBackImageChange}
+          onClearBackImage={onClearBackImage}
           onDelete={onDelete}
         />
       </div>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -30,11 +30,14 @@ export const Performer: React.FC = () => {
   const [imagePreview, setImagePreview] = useState<string | null>();
   const [imageEncoding, setImageEncoding] = useState<boolean>(false);
   const [lightboxIsOpen, setLightboxIsOpen] = useState(false);
-  
+
   // if undefined then get the existing image
   // if null then get the default (no) image
   // otherwise get the set image
-  const activeImage = imagePreview === undefined ? performer.image_path ?? "" : imagePreview ?? performer.image_path + "?default=true";
+  const activeImage =
+    imagePreview === undefined
+      ? performer.image_path ?? ""
+      : imagePreview ?? `${performer.image_path}?default=true`;
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -27,10 +27,14 @@ export const Performer: React.FC = () => {
   const [performer, setPerformer] = useState<
     Partial<GQL.PerformerDataFragment>
   >({});
-  const [imagePreview, setImagePreview] = useState<string>();
+  const [imagePreview, setImagePreview] = useState<string | null>();
   const [imageEncoding, setImageEncoding] = useState<boolean>(false);
   const [lightboxIsOpen, setLightboxIsOpen] = useState(false);
-  const activeImage = imagePreview ?? performer.image_path ?? "";
+  
+  // if undefined then get the existing image
+  // if null then get the default (no) image
+  // otherwise get the set image
+  const activeImage = imagePreview === undefined ? performer.image_path ?? "" : imagePreview ?? performer.image_path + "?default=true";
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
@@ -47,7 +51,7 @@ export const Performer: React.FC = () => {
     if (data?.findPerformer) setPerformer(data.findPerformer);
   }, [data]);
 
-  const onImageChange = (image?: string) => setImagePreview(image);
+  const onImageChange = (image?: string | null) => setImagePreview(image);
 
   const onImageEncoding = (isEncoding = false) => setImageEncoding(isEncoding);
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -40,7 +40,7 @@ interface IPerformerDetails {
       | Partial<GQL.PerformerUpdateInput>
   ) => void;
   onDelete?: () => void;
-  onImageChange?: (image?: string) => void;
+  onImageChange?: (image?: string | null) => void;
   onImageEncoding?: (loading?: boolean) => void;
 }
 
@@ -66,7 +66,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
   // Editing performer state
-  const [image, setImage] = useState<string>();
+  const [image, setImage] = useState<string | null>();
   const [name, setName] = useState<string>();
   const [aliases, setAliases] = useState<string>();
   const [favorite, setFavorite] = useState<boolean>();
@@ -241,7 +241,6 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
   });
 
   useEffect(() => {
-    setImage(undefined);
     updatePerformerEditState(performer);
   }, [performer]);
 
@@ -563,6 +562,17 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
             isEditing={!!isEditing}
             onImageChange={onImageChangeHandler}
           />
+          {isEditing ? (
+            <Button
+              className="mr-2"
+              variant="danger"
+              onClick={() => setImage(null)}
+            >
+              Clear image
+            </Button>
+          ) : (
+            ""
+          )}
         </div>
       );
     }

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -12,6 +12,8 @@ interface IProps {
   onAutoTag?: () => void;
   onImageChange: (event: React.FormEvent<HTMLInputElement>) => void;
   onBackImageChange?: (event: React.FormEvent<HTMLInputElement>) => void;
+  onClearImage?: () => void;
+  onClearBackImage?: () => void;
   acceptSVG?: boolean;
 }
 
@@ -116,7 +118,29 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
         onImageChange={props.onImageChange}
         acceptSVG={props.acceptSVG ?? false}
       />
+      {props.isEditing && props.onClearImage ? (
+        <Button
+          className="mr-2"
+          variant="danger"
+          onClick={() => props.onClearImage!()}
+        >
+          {props.onClearBackImage ? "Clear front image" : "Clear image"}
+        </Button>
+      ) : (
+        ""
+      )}
       {renderBackImageInput()}
+      {props.isEditing && props.onClearBackImage ? (
+        <Button
+          className="mr-2"
+          variant="danger"
+          onClick={() => props.onClearBackImage!()}
+        >
+          Clear back image
+        </Button>
+      ) : (
+        ""
+      )}
       {renderAutoTagButton()}
       {renderSaveButton()}
       {renderDeleteButton()}

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -186,8 +186,10 @@ export const Studio: React.FC = () => {
   }
 
   function onClearImage() {
-    setImage(null); 
-    setImagePreview(studio.image_path ? studio.image_path + "?default=true" : undefined);
+    setImage(null);
+    setImagePreview(
+      studio.image_path ? `${studio.image_path}?default=true` : undefined
+    );
   }
 
   return (
@@ -202,11 +204,11 @@ export const Studio: React.FC = () => {
         <div className="text-center">
           {imageEncoding ? (
             <LoadingIndicator message="Encoding image..." />
-          ) : 
-            imagePreview ? (
-              <img className="logo" alt={name} src={imagePreview} />
-            ) : ""
-          }
+          ) : imagePreview ? (
+            <img className="logo" alt={name} src={imagePreview} />
+          ) : (
+            ""
+          )}
         </div>
         <Table>
           <tbody>
@@ -245,7 +247,9 @@ export const Studio: React.FC = () => {
           onToggleEdit={onToggleEdit}
           onSave={onSave}
           onImageChange={onImageChangeHandler}
-          onClearImage={() => { onClearImage() } }
+          onClearImage={() => {
+            onClearImage();
+          }}
           onAutoTag={onAutoTag}
           onDelete={onDelete}
           acceptSVG

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -35,14 +35,14 @@ export const Studio: React.FC = () => {
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
   // Editing studio state
-  const [image, setImage] = useState<string>();
+  const [image, setImage] = useState<string | null>();
   const [name, setName] = useState<string>();
   const [url, setUrl] = useState<string>();
   const [parentStudioId, setParentStudioId] = useState<string>();
 
   // Studio state
   const [studio, setStudio] = useState<Partial<GQL.StudioDataFragment>>({});
-  const [imagePreview, setImagePreview] = useState<string>();
+  const [imagePreview, setImagePreview] = useState<string | null>();
 
   const { data, error, loading } = useFindStudio(id);
   const [updateStudio] = useStudioUpdate(
@@ -185,6 +185,11 @@ export const Studio: React.FC = () => {
     updateStudioData(studio);
   }
 
+  function onClearImage() {
+    setImage(null); 
+    setImagePreview(studio.image_path ? studio.image_path + "?default=true" : undefined);
+  }
+
   return (
     <div className="row">
       <div
@@ -197,9 +202,11 @@ export const Studio: React.FC = () => {
         <div className="text-center">
           {imageEncoding ? (
             <LoadingIndicator message="Encoding image..." />
-          ) : (
-            <img className="logo" alt={name} src={imagePreview} />
-          )}
+          ) : 
+            imagePreview ? (
+              <img className="logo" alt={name} src={imagePreview} />
+            ) : ""
+          }
         </div>
         <Table>
           <tbody>
@@ -238,6 +245,7 @@ export const Studio: React.FC = () => {
           onToggleEdit={onToggleEdit}
           onSave={onSave}
           onImageChange={onImageChangeHandler}
+          onClearImage={() => { onClearImage() } }
           onAutoTag={onAutoTag}
           onDelete={onDelete}
           acceptSVG

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -34,7 +34,7 @@ export const Tag: React.FC = () => {
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
   // Editing tag state
-  const [image, setImage] = useState<string>();
+  const [image, setImage] = useState<string | null>();
   const [name, setName] = useState<string>();
 
   // Tag state
@@ -172,6 +172,11 @@ export const Tag: React.FC = () => {
     updateTagData(tag);
   }
 
+  function onClearImage() {
+    setImage(null); 
+    setImagePreview(tag.image_path ? tag.image_path + "?default=true" : undefined);
+  }
+
   return (
     <div className="row">
       <div
@@ -205,6 +210,7 @@ export const Tag: React.FC = () => {
           onToggleEdit={onToggleEdit}
           onSave={onSave}
           onImageChange={onImageChangeHandler}
+          onClearImage={() => { onClearImage() } }
           onAutoTag={onAutoTag}
           onDelete={onDelete}
           acceptSVG

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -173,8 +173,10 @@ export const Tag: React.FC = () => {
   }
 
   function onClearImage() {
-    setImage(null); 
-    setImagePreview(tag.image_path ? tag.image_path + "?default=true" : undefined);
+    setImage(null);
+    setImagePreview(
+      tag.image_path ? `${tag.image_path}?default=true` : undefined
+    );
   }
 
   return (
@@ -210,7 +212,9 @@ export const Tag: React.FC = () => {
           onToggleEdit={onToggleEdit}
           onSave={onSave}
           onImageChange={onImageChangeHandler}
-          onClearImage={() => { onClearImage() } }
+          onClearImage={() => {
+            onClearImage();
+          }}
           onAutoTag={onAutoTag}
           onDelete={onDelete}
           acceptSVG

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -16,6 +16,8 @@ export type CriterionType =
   | "performerIsMissing"
   | "galleryIsMissing"
   | "tagIsMissing"
+  | "studioIsMissing"
+  | "movieIsMissing"
   | "tags"
   | "sceneTags"
   | "performers"
@@ -62,6 +64,8 @@ export abstract class Criterion {
       case "performerIsMissing":
       case "galleryIsMissing":
       case "tagIsMissing":
+      case "studioIsMissing":
+      case "movieIsMissing":
         return "Is Missing";
       case "tags":
         return "Tags";

--- a/ui/v2.5/src/models/list-filter/criteria/is-missing.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/is-missing.ts
@@ -46,6 +46,7 @@ export class PerformerIsMissingCriterion extends IsMissingCriterion {
     "aliases",
     "gender",
     "scenes",
+    "image",
   ];
 }
 
@@ -72,4 +73,24 @@ export class TagIsMissingCriterion extends IsMissingCriterion {
 export class TagIsMissingCriterionOption implements ICriterionOption {
   public label: string = Criterion.getLabel("tagIsMissing");
   public value: CriterionType = "tagIsMissing";
+}
+
+export class StudioIsMissingCriterion extends IsMissingCriterion {
+  public type: CriterionType = "studioIsMissing";
+  public options: string[] = ["image"];
+}
+
+export class StudioIsMissingCriterionOption implements ICriterionOption {
+  public label: string = Criterion.getLabel("studioIsMissing");
+  public value: CriterionType = "studioIsMissing";
+}
+
+export class MovieIsMissingCriterion extends IsMissingCriterion {
+  public type: CriterionType = "movieIsMissing";
+  public options: string[] = ["front_image", "back_image"];
+}
+
+export class MovieIsMissingCriterionOption implements ICriterionOption {
+  public label: string = Criterion.getLabel("movieIsMissing");
+  public value: CriterionType = "movieIsMissing";
 }

--- a/ui/v2.5/src/models/list-filter/criteria/utils.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/utils.ts
@@ -14,6 +14,8 @@ import {
   SceneIsMissingCriterion,
   GalleryIsMissingCriterion,
   TagIsMissingCriterion,
+  StudioIsMissingCriterion,
+  MovieIsMissingCriterion,
 } from "./is-missing";
 import { NoneCriterion } from "./none";
 import { PerformersCriterion } from "./performers";
@@ -50,6 +52,10 @@ export function makeCriteria(type: CriterionType = "none") {
       return new GalleryIsMissingCriterion();
     case "tagIsMissing":
       return new TagIsMissingCriterion();
+    case "studioIsMissing":
+      return new StudioIsMissingCriterion();
+    case "movieIsMissing":
+      return new MovieIsMissingCriterion();
     case "tags":
       return new TagsCriterion("tags");
     case "sceneTags":

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -35,6 +35,8 @@ import {
   SceneIsMissingCriterionOption,
   GalleryIsMissingCriterionOption,
   TagIsMissingCriterionOption,
+  StudioIsMissingCriterionOption,
+  MovieIsMissingCriterionOption,
 } from "./criteria/is-missing";
 import { NoneCriterionOption } from "./criteria/none";
 import {
@@ -178,6 +180,7 @@ export class ListFilterModel {
         this.criterionOptions = [
           new NoneCriterionOption(),
           new ParentStudiosCriterionOption(),
+          new StudioIsMissingCriterionOption(),
         ];
         break;
       case FilterMode.Movies:
@@ -187,6 +190,7 @@ export class ListFilterModel {
         this.criterionOptions = [
           new NoneCriterionOption(),
           new StudiosCriterionOption(),
+          new MovieIsMissingCriterionOption(),
         ];
         break;
       case FilterMode.Galleries:
@@ -610,6 +614,8 @@ export class ListFilterModel {
           };
           break;
         }
+        case "movieIsMissing":
+          result.is_missing = (criterion as IsMissingCriterion).value;
         // no default
       }
     });
@@ -628,6 +634,8 @@ export class ListFilterModel {
           };
           break;
         }
+        case "studioIsMissing":
+          result.is_missing = (criterion as IsMissingCriterion).value;
         // no default
       }
     });


### PR DESCRIPTION
Partially resolves #660 

Adds a clear image button to the edit tags, performers, studios and movies (front and back) pages.

![image](https://user-images.githubusercontent.com/53250216/89896001-0ccc4800-dc20-11ea-9760-66e827ff2832.png)

Performer image now generates a random image using the name as a seed, and uses that image if there is none set. All other types use their default image if none is set.

Movie front image is a little bit of a hack. If the back image is set but the front image is not, then the front image will be set in the database from the default image, since the front image cannot currently be nulled, and I didn't want to add a schema change to fix it. This will mean unexpected behaviour when querying for missing front image if the back image is set.

Adds is missing image for tags, studios, performers and movies. Note that existing users will find that is missing will not find results for their existing data which had the default images populated (they aren't null). 