### PR TITLE
Fix infinite load issue

### DIFF
--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -29,7 +29,6 @@ interface IListFilterOperation {
 }
 
 interface IListFilterProps {
-  subComponent?: boolean;
   onFilterUpdate: (newFilter: ListFilterModel) => void;
   zoomIndex?: number;
   onChangeZoom?: (zoomIndex: number) => void;
@@ -105,7 +104,7 @@ export const ListFilter: React.FC<IListFilterProps> = (
     Mousetrap.bind("s a", () => onSelectAll());
     Mousetrap.bind("s n", () => onSelectNone());
 
-    if (!props.subComponent && props.itemsSelected) {
+    if (props.itemsSelected) {
       Mousetrap.bind("e", () => {
         if (props.onEdit) {
           props.onEdit();
@@ -130,7 +129,7 @@ export const ListFilter: React.FC<IListFilterProps> = (
       Mousetrap.unbind("s a");
       Mousetrap.unbind("s n");
 
-      if (!props.subComponent && props.itemsSelected) {
+      if (props.itemsSelected) {
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       }

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScenesPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScenesPanel.tsx
@@ -42,7 +42,7 @@ export const MovieScenesPanel: React.FC<IMovieScenesPanel> = ({ movie }) => {
   }
 
   if (movie && movie.id) {
-    return <SceneList subComponent filterHook={filterHook} />;
+    return <SceneList filterHook={filterHook} />;
   }
   return <></>;
 };

--- a/ui/v2.5/src/components/Movies/Movies.tsx
+++ b/ui/v2.5/src/components/Movies/Movies.tsx
@@ -6,7 +6,7 @@ import { MovieList } from "./MovieList";
 const Movies = () => (
   <Switch>
     <Route exact path="/movies" component={MovieList} />
-    <Route path="/movies/:id" component={Movie} />
+    <Route path="/movies/:id/:tab?" component={Movie} />
   </Switch>
 );
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -20,7 +20,7 @@ import { PerformerScenesPanel } from "./PerformerScenesPanel";
 export const Performer: React.FC = () => {
   const Toast = useToast();
   const history = useHistory();
-  const { id = "new" } = useParams();
+  const { tab = "details", id = "new" } = useParams();
   const isNew = id === "new";
 
   // Performer state
@@ -42,12 +42,21 @@ export const Performer: React.FC = () => {
   // Network state
   const [isLoading, setIsLoading] = useState(false);
 
-  const [activeTabKey, setActiveTabKey] = useState("details");
-
   const { data, error } = useFindPerformer(id);
   const [updatePerformer] = usePerformerUpdate();
   const [createPerformer] = usePerformerCreate();
   const [deletePerformer] = usePerformerDestroy();
+
+  const activeTabKey =
+    tab === "scenes" || tab === "edit" || tab === "operations"
+      ? tab
+      : "details";
+  const setActiveTabKey = (newTab: string) => {
+    if (tab !== newTab) {
+      const tabParam = newTab === "details" ? "" : `/${newTab}`;
+      history.push(`/performers/${id}${tabParam}`);
+    }
+  };
 
   useEffect(() => {
     setIsLoading(false);
@@ -128,7 +137,7 @@ export const Performer: React.FC = () => {
   const renderTabs = () => (
     <Tabs
       activeKey={activeTabKey}
-      onSelect={(k: string) => setActiveTabKey(k)}
+      onSelect={setActiveTabKey}
       id="performer-details"
       unmountOnExit
     >

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
@@ -43,5 +43,5 @@ export const PerformerScenesPanel: React.FC<IPerformerDetailsProps> = ({
     return filter;
   }
 
-  return <SceneList subComponent filterHook={filterHook} />;
+  return <SceneList filterHook={filterHook} />;
 };

--- a/ui/v2.5/src/components/Performers/Performers.tsx
+++ b/ui/v2.5/src/components/Performers/Performers.tsx
@@ -6,7 +6,7 @@ import { PerformerList } from "./PerformerList";
 const Performers = () => (
   <Switch>
     <Route exact path="/performers" component={PerformerList} />
-    <Route path="/performers/:id" component={Performer} />
+    <Route path="/performers/:id/:tab?" component={Performer} />
   </Switch>
 );
 

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -18,14 +18,10 @@ import { DeleteScenesDialog } from "./DeleteScenesDialog";
 import { SceneGenerateDialog } from "./SceneGenerateDialog";
 
 interface ISceneList {
-  subComponent?: boolean;
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
 }
 
-export const SceneList: React.FC<ISceneList> = ({
-  subComponent,
-  filterHook,
-}) => {
+export const SceneList: React.FC<ISceneList> = ({ filterHook }) => {
   const history = useHistory();
   const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
 
@@ -61,7 +57,6 @@ export const SceneList: React.FC<ISceneList> = ({
     renderContent,
     renderEditDialog: renderEditScenesDialog,
     renderDeleteDialog: renderDeleteScenesDialog,
-    subComponent,
     filterHook,
     addKeybinds,
   });

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -10,14 +10,10 @@ import { DisplayMode } from "src/models/list-filter/types";
 import { WallPanel } from "../Wall/WallPanel";
 
 interface ISceneMarkerList {
-  subComponent?: boolean;
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
 }
 
-export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
-  subComponent,
-  filterHook,
-}) => {
+export const SceneMarkerList: React.FC<ISceneMarkerList> = ({ filterHook }) => {
   const history = useHistory();
   const otherOperations = [
     {
@@ -42,7 +38,6 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
   const listData = useSceneMarkersList({
     otherOperations,
     renderContent,
-    subComponent,
     filterHook,
     addKeybinds,
   });

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -27,7 +27,7 @@ import { StudioChildrenPanel } from "./StudioChildrenPanel";
 export const Studio: React.FC = () => {
   const history = useHistory();
   const Toast = useToast();
-  const { id = "new" } = useParams();
+  const { tab = "details", id = "new" } = useParams();
   const isNew = id === "new";
 
   // Editing state
@@ -192,6 +192,14 @@ export const Studio: React.FC = () => {
     );
   }
 
+  const activeTabKey = tab === "childstudios" ? tab : "scenes";
+  const setActiveTabKey = (newTab: string) => {
+    if (tab !== newTab) {
+      const tabParam = newTab === "scenes" ? "" : `/${newTab}`;
+      history.push(`/studios/${id}${tabParam}`);
+    }
+  };
+
   return (
     <div className="row">
       <div
@@ -257,11 +265,16 @@ export const Studio: React.FC = () => {
       </div>
       {!isNew && (
         <div className="col col-md-8">
-          <Tabs id="studio-tabs" mountOnEnter>
-            <Tab eventKey="studio-scenes-panel" title="Scenes">
+          <Tabs
+            id="studio-tabs"
+            mountOnEnter
+            activeKey={activeTabKey}
+            onSelect={setActiveTabKey}
+          >
+            <Tab eventKey="scenes" title="Scenes">
               <StudioScenesPanel studio={studio} />
             </Tab>
-            <Tab eventKey="studio-children-panel" title="Child Studios">
+            <Tab eventKey="childstudios" title="Child Studios">
               <StudioChildrenPanel studio={studio} />
             </Tab>
           </Tabs>

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
@@ -41,5 +41,5 @@ export const StudioScenesPanel: React.FC<IStudioScenesPanel> = ({ studio }) => {
     return filter;
   }
 
-  return <SceneList subComponent filterHook={filterHook} />;
+  return <SceneList filterHook={filterHook} />;
 };

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -16,7 +16,6 @@ export const StudioList: React.FC<IStudioList> = ({
 }) => {
   const listData = useStudiosList({
     renderContent,
-    subComponent: fromParent,
     filterHook,
   });
 

--- a/ui/v2.5/src/components/Studios/Studios.tsx
+++ b/ui/v2.5/src/components/Studios/Studios.tsx
@@ -6,7 +6,7 @@ import { StudioList } from "./StudioList";
 const Studios = () => (
   <Switch>
     <Route exact path="/studios" component={StudioList} />
-    <Route path="/studios/:id" component={Studio} />
+    <Route path="/studios/:id/:tab?" component={Studio} />
   </Switch>
 );
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -26,7 +26,7 @@ import { TagMarkersPanel } from "./TagMarkersPanel";
 export const Tag: React.FC = () => {
   const history = useHistory();
   const Toast = useToast();
-  const { id = "new" } = useParams();
+  const { tab = "scenes", id = "new" } = useParams();
   const isNew = id === "new";
 
   // Editing state
@@ -45,6 +45,14 @@ export const Tag: React.FC = () => {
   const [updateTag] = useTagUpdate(getTagInput() as GQL.TagUpdateInput);
   const [createTag] = useTagCreate(getTagInput() as GQL.TagUpdateInput);
   const [deleteTag] = useTagDestroy(getTagInput() as GQL.TagUpdateInput);
+
+  const activeTabKey = tab === "markers" ? tab : "scenes";
+  const setActiveTabKey = (newTab: string) => {
+    if (tab !== newTab) {
+      const tabParam = newTab === "scenes" ? "" : `/${newTab}`;
+      history.push(`/tags/${id}${tabParam}`);
+    }
+  };
 
   // set up hotkeys
   useEffect(() => {
@@ -222,11 +230,16 @@ export const Tag: React.FC = () => {
       </div>
       {!isNew && (
         <div className="col col-md-8">
-          <Tabs id="tag-tabs" mountOnEnter>
-            <Tab eventKey="tag-scenes-panel" title="Scenes">
+          <Tabs
+            id="tag-tabs"
+            mountOnEnter
+            activeKey={activeTabKey}
+            onSelect={setActiveTabKey}
+          >
+            <Tab eventKey="scenes" title="Scenes">
               <TagScenesPanel tag={tag} />
             </Tab>
-            <Tab eventKey="tag-markers-panel" title="Markers">
+            <Tab eventKey="markers" title="Markers">
               <TagMarkersPanel tag={tag} />
             </Tab>
           </Tabs>

--- a/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
@@ -41,5 +41,5 @@ export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({ tag }) => {
     return filter;
   }
 
-  return <SceneMarkerList subComponent filterHook={filterHook} />;
+  return <SceneMarkerList filterHook={filterHook} />;
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
@@ -41,5 +41,5 @@ export const TagScenesPanel: React.FC<ITagScenesPanel> = ({ tag }) => {
     return filter;
   }
 
-  return <SceneList subComponent filterHook={filterHook} />;
+  return <SceneList filterHook={filterHook} />;
 };

--- a/ui/v2.5/src/components/Tags/Tags.tsx
+++ b/ui/v2.5/src/components/Tags/Tags.tsx
@@ -6,7 +6,7 @@ import { TagList } from "./TagList";
 const Tags = () => (
   <Switch>
     <Route exact path="/tags" component={TagList} />
-    <Route path="/tags/:id" component={Tag} />
+    <Route path="/tags/:id/:tab?" component={Tag} />
   </Switch>
 );
 

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -59,7 +59,6 @@ interface IListHookOperation<T> {
 }
 
 interface IListHookOptions<T, E> {
-  subComponent?: boolean;
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   zoomable?: boolean;
   selectable?: boolean;
@@ -112,10 +111,7 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
   const history = useHistory();
   const location = useLocation();
   const [filter, setFilter] = useState<ListFilterModel>(
-    new ListFilterModel(
-      options.filterMode,
-      options.subComponent ? undefined : queryString.parse(location.search)
-    )
+    new ListFilterModel(options.filterMode, queryString.parse(location.search))
   );
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -197,9 +193,6 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
     if (interfaceState.loading) return;
     if (!forageInitialised) setForageInitialised(true);
 
-    // Don't use query parameters for sub-components
-    if (options.subComponent) return;
-
     const storedQuery = interfaceState.data?.queries?.[options.filterMode];
     if (!storedQuery) return;
 
@@ -236,7 +229,6 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
     interfaceState.loading,
     history,
     location.search,
-    options.subComponent,
     options.filterMode,
     forageInitialised,
     updateInterfaceConfig,
@@ -254,12 +246,10 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
 
   function updateQueryParams(listFilter: ListFilterModel) {
     setFilter(listFilter);
-    if (!options.subComponent) {
-      const newLocation = { ...location };
-      newLocation.search = listFilter.makeQueryParameters();
-      history.replace(newLocation);
-      updateInterfaceConfig(listFilter);
-    }
+    const newLocation = { ...location };
+    newLocation.search = listFilter.makeQueryParameters();
+    history.replace(newLocation);
+    updateInterfaceConfig(listFilter);
   }
 
   function onChangePage(page: number) {
@@ -425,7 +415,6 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
   const template = (
     <div>
       <ListFilter
-        subComponent={options.subComponent}
         onFilterUpdate={updateQueryParams}
         onSelectAll={options.selectable ? onSelectAll : undefined}
         onSelectNone={options.selectable ? onSelectNone : undefined}


### PR DESCRIPTION
Selecting random sort in a scene subcomponent causes the app to lock up indefinitely due to the random seed not being saved to the query string, which regenerates it infinitely.

Resolved by removing the subcomponent logic and saving all listfilter state to the query string. Added some tab routing logic to make the query string a bit cleaner when not on the scene tab.

Closes #747.