### PR TITLE
Fix scene-card jumping

### DIFF
--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -160,8 +160,7 @@ textarea.text-input {
 
     .tag-card-image,
     .gallery-card-image {
-      max-height:
-      480px;
+      max-height: 480px;
     }
   }
 }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -99,57 +99,78 @@ textarea.text-input {
   .zoom-0 {
     width: 240px;
 
-    .scene-card-video,
-    .gallery-card-image,
-    .tag-card-image {
+    .scene-card-video {
       height: 135px;
     }
 
     .portrait {
       height: 180px;
     }
+
+    .gallery-card-image,
+    .tag-card-image {
+      max-height: 180px;
+    }
   }
 
   .zoom-1 {
     width: 320px;
 
-    .scene-card-video,
-    .gallery-card-image,
-    .tag-card-image {
+    .scene-card-video {
       height: 180px;
     }
 
     .portrait {
       height: 240px;
     }
+
+    .gallery-card-image,
+    .tag-card-image {
+      max-height: 240px;
+    }
   }
 
   .zoom-2 {
     width: 480px;
 
-    .scene-card-video,
-    .gallery-card-image,
-    .tag-card-image {
+    .scene-card-video {
       height: 270px;
     }
 
     .portrait {
       height: 360px;
     }
+
+    .gallery-card-image,
+    .tag-card-image {
+      max-height: 360px;
+    }
   }
 
   .zoom-3 {
     width: 640px;
 
-    .scene-card-video,
-    .gallery-card-image,
-    .tag-card-image {
+    .scene-card-video {
       height: 360px;
     }
 
     .portrait {
       height: 480px;
     }
+
+    .tag-card-image,
+    .gallery-card-image {
+      max-height:
+      480px;
+    }
+  }
+}
+
+.scene-card-video {
+  object-fit: cover;
+
+  &.portrait {
+    object-fit: contain;
   }
 }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -102,10 +102,10 @@ textarea.text-input {
     .scene-card-video,
     .gallery-card-image,
     .tag-card-image {
-      max-height: 180px;
+      height: 135px;
     }
 
-    .previewable.portrait {
+    .portrait {
       height: 180px;
     }
   }
@@ -116,10 +116,10 @@ textarea.text-input {
     .scene-card-video,
     .gallery-card-image,
     .tag-card-image {
-      max-height: 240px;
+      height: 180px;
     }
 
-    .previewable.portrait {
+    .portrait {
       height: 240px;
     }
   }
@@ -130,10 +130,10 @@ textarea.text-input {
     .scene-card-video,
     .gallery-card-image,
     .tag-card-image {
-      max-height: 360px;
+      height: 270px;
     }
 
-    .previewable.portrait {
+    .portrait {
       height: 360px;
     }
   }
@@ -144,7 +144,7 @@ textarea.text-input {
     .scene-card-video,
     .gallery-card-image,
     .tag-card-image {
-      max-height: 480px;
+      height: 360px;
     }
 
     .portrait {


### PR DESCRIPTION
Recent Chrome versions seem to have a weird geometry jump when going from poster to video, which causes the layout to shift if the geometry isn't fixed. This also happens when the poster is different dimensions than the video, which can frequently happen when using a scraper to replace the poster.

To resolve this I've fixated the height to 16/9 dimensions. There's still some visual jumping when the thumb is hovered, but it doesn't shift the layout anymore so it's less distracting. To prevent bars on landscape posters that aren't 16/9 I've added `object-fit: cover` . It works reasonably well even when the poster is square.

A more permanent solution will hopefully result from fixing #576.

Resolves #763.