### PR TITLE
Make travis build and push docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,12 @@ deploy:
     on:
       repo: stashapp/stash
       branch: develop
+  # docker image build for develop release
+  - provider: script
+    script: bash ./docker/ci/x86_64/docker_push.sh development-x86_64
+    on:
+      repo: stashapp/stash
+      branch: develop
   # official master release - only build when tagged
   - provider: releases
     api_key:
@@ -73,6 +79,14 @@ deploy:
     # don't write the body. To be done manually for now. In future we might
     # want to generate the changelog or get it from a file
     name: ${STASH_VERSION}
+    on:
+      repo: stashapp/stash
+      tags: true
+      # make sure we don't release using the latest_develop tag
+      condition: $TRAVIS_TAG != latest_develop
+  # docker image build for master release
+  - provider: script
+    script: bash ./docker/ci/x86_64/docker_push.sh latest
     on:
       repo: stashapp/stash
       tags: true

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -1,0 +1,25 @@
+
+# must be built from /dist directory
+
+FROM ubuntu:18.04 as prep
+LABEL MAINTAINER="https://discord.gg/Uz29ny"
+
+RUN apt-get update && \
+    apt-get -y install curl xz-utils && \
+    apt-get autoclean -y && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl --http1.1 -o /ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
+    tar xf /ffmpeg.tar.xz && \
+    rm ffmpeg.tar.xz && \
+    mv /ffmpeg*/ /ffmpeg/
+
+FROM ubuntu:18.04 as app
+RUN apt-get update && apt-get -y install ca-certificates
+COPY --from=prep /ffmpeg/ffmpeg /ffmpeg/ffprobe /usr/bin/
+COPY /stash-linux /usr/bin/stash
+
+EXPOSE 9999
+CMD ["stash"]

--- a/docker/ci/x86_64/README.md
+++ b/docker/ci/x86_64/README.md
@@ -1,0 +1,1 @@
+This dockerfile is used by travis to build the stash image. It must be run after cross-compiling - that is, `stash-linux` must exist in the `dist` directory. This image must be built from the `dist` directory.

--- a/docker/ci/x86_64/docker_push.sh
+++ b/docker/ci/x86_64/docker_push.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DOCKER_TAG=$1
+
+# must build the image from dist directory
+echo docker build -t stashapp/stash:$DOCKER_TAG -f ./docker/ci/x86_64/Dockerfile ./dist
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+echo docker push stashapp/stash:$DOCKER_TAG


### PR DESCRIPTION
The intent of this PR is to make travis the primary controller for building and pushing the stash docker images.

Currently, the development and production dockerfiles download the stash-linux binary from the stash github repository. This creates a race condition whereby the docker instance downloads the binary before the new version has been uploaded by travis.

With this PR, we will turn off the auto-builds for develop and latest in docker hub, and travis will build and push the docker images, using the binary it previously built. 