### PR TITLE
Allow updating tag name capitalization

### DIFF
--- a/pkg/api/resolver_mutation_tag.go
+++ b/pkg/api/resolver_mutation_tag.go
@@ -37,7 +37,7 @@ func (r *mutationResolver) TagCreate(ctx context.Context, input models.TagCreate
 	qb := models.NewTagQueryBuilder()
 
 	// ensure name is unique
-	if err := manager.EnsureTagNameUnique(newTag.Name, tx, true); err != nil {
+	if err := manager.EnsureTagNameUnique(newTag, tx); err != nil {
 		tx.Rollback()
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (r *mutationResolver) TagUpdate(ctx context.Context, input models.TagUpdate
 	}
 
 	if existing.Name != updatedTag.Name {
-		if err := manager.EnsureTagNameUnique(updatedTag.Name, tx, false); err != nil {
+		if err := manager.EnsureTagNameUnique(updatedTag, tx); err != nil {
 			tx.Rollback()
 			return nil, err
 		}

--- a/pkg/api/resolver_mutation_tag.go
+++ b/pkg/api/resolver_mutation_tag.go
@@ -37,7 +37,7 @@ func (r *mutationResolver) TagCreate(ctx context.Context, input models.TagCreate
 	qb := models.NewTagQueryBuilder()
 
 	// ensure name is unique
-	if err := manager.EnsureTagNameUnique(newTag.Name, tx); err != nil {
+	if err := manager.EnsureTagNameUnique(newTag.Name, tx, true); err != nil {
 		tx.Rollback()
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (r *mutationResolver) TagUpdate(ctx context.Context, input models.TagUpdate
 	}
 
 	if existing.Name != updatedTag.Name {
-		if err := manager.EnsureTagNameUnique(updatedTag.Name, tx); err != nil {
+		if err := manager.EnsureTagNameUnique(updatedTag.Name, tx, false); err != nil {
 			tx.Rollback()
 			return nil, err
 		}

--- a/pkg/manager/tag.go
+++ b/pkg/manager/tag.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func EnsureTagNameUnique(name string, tx *sqlx.Tx) error {
+func EnsureTagNameUnique(name string, tx *sqlx.Tx, nocase bool) error {
 	qb := models.NewTagQueryBuilder()
 
 	// ensure name is unique
-	sameNameTag, err := qb.FindByName(name, tx, true)
+	sameNameTag, err := qb.FindByName(name, tx, nocase)
 	if err != nil {
 		_ = tx.Rollback()
 		return err

--- a/pkg/manager/tag.go
+++ b/pkg/manager/tag.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func EnsureTagNameUnique(name string, tx *sqlx.Tx, nocase bool) error {
+func EnsureTagNameUnique(tag models.Tag, tx *sqlx.Tx) error {
 	qb := models.NewTagQueryBuilder()
 
 	// ensure name is unique
-	sameNameTag, err := qb.FindByName(name, tx, nocase)
+	sameNameTag, err := qb.FindByName(tag.Name, tx, true)
 	if err != nil {
 		_ = tx.Rollback()
 		return err
 	}
 
-	if sameNameTag != nil {
-		return fmt.Errorf("Tag with name '%s' already exists", name)
+	if sameNameTag != nil && tag.ID != sameNameTag.ID {
+		return fmt.Errorf("Tag with name '%s' already exists", tag.Name)
 	}
 
 	return nil


### PR DESCRIPTION
Changes `EnsureTagNameUnique` to check the id of the matched tags, and allow a mutation if the ids are the same.
Resolves #780 