### PR TITLE
Change cross compiler to fixed version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 #- make lint
 - make fmt-check vet it
 after_success:
-- docker pull stashapp/compiler:develop
+- docker pull stashapp/compiler:3
 - sh ./scripts/cross-compile.sh
 - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sh ./scripts/upload-pull-request.sh; fi'
 before_deploy:

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -14,4 +14,4 @@ LINUX_ARM32v6="echo '=== Building Linux (armv6 | Raspberry Pi 1) binary ==='; $S
 
 COMMAND="$SETUP $WINDOWS $DARWIN $LINUX_AMD64 $LINUX_ARM64v8 $LINUX_ARM32v7 $LINUX_ARM32v6 echo '=== Build complete ==='"
 
-docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash stashapp/compiler:develop /bin/bash -c "$COMMAND"
+docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash stashapp/compiler:3 /bin/bash -c "$COMMAND"


### PR DESCRIPTION
Changed `cross-compile.sh` to use a specific fixed version of the cross-compiler docker image. Version 3 of the image has been pushed to docker hub using the current image.