### PR TITLE
Fix ffmpeg/ffprobe downloads

### DIFF
--- a/pkg/ffmpeg/downloader.go
+++ b/pkg/ffmpeg/downloader.go
@@ -39,14 +39,24 @@ func GetPaths(configDirectory string) (string, string) {
 }
 
 func Download(configDirectory string) error {
-	url := getFFMPEGURL()
+	for _, url := range getFFMPEGURL() {
+		err := DownloadSingle(configDirectory, url)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DownloadSingle(configDirectory, url string) error {
 	if url == "" {
 		return fmt.Errorf("no ffmpeg url for this platform")
 	}
 
 	// Configure where we want to download the archive
 	urlExt := path.Ext(url)
-	archivePath := filepath.Join(configDirectory, "ffmpeg"+urlExt)
+	urlBase := path.Base(url)
+	archivePath := filepath.Join(configDirectory, urlBase)
 	_ = os.Remove(archivePath) // remove archive if it already exists
 	out, err := os.Create(archivePath)
 	if err != nil {
@@ -83,19 +93,21 @@ func Download(configDirectory string) error {
 	return nil
 }
 
-func getFFMPEGURL() string {
+func getFFMPEGURL() []string {
+	urls := []string{""}
 	switch runtime.GOOS {
 	case "darwin":
-		return "https://ffmpeg.zeranoe.com/builds/macos64/static/ffmpeg-4.1-macos64-static.zip"
+		urls = []string{"https://evermeet.cx/ffmpeg/ffmpeg-4.3.1.zip", "https://evermeet.cx/ffmpeg/ffprobe-4.3.1.zip"}
 	case "linux":
-		// TODO: untar this
-		//return "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
-		return ""
+		// TODO: get appropriate arch (arm,arm64,amd64) and xz untar from https://johnvansickle.com/ffmpeg/
+		//       or get the ffmpeg,ffprobe zip repackaged ones from  https://ffbinaries.com/downloads
+		urls = []string{""}
 	case "windows":
-		return "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.1-win64-static.zip"
+		urls = []string{"https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"}
 	default:
-		return ""
+		urls = []string{""}
 	}
+	return urls
 }
 
 func getFFMPEGFilename() string {


### PR DESCRIPTION
Updated download code to get ffmpeg binaries from different sources since zeranoe's builds are no more available.
It now fetches the 4.3.1 versions from gyan for windows and evermeet for macos.
Tested by disabling the ffmpeg detection and forcing the GOOS switch.
An actual test of the windows/macos build will be needed.
