### PR TITLE
Prevent invalid date tag in video file from aborting scan

### DIFF
--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -236,7 +236,7 @@ func NewVideoFile(ffprobePath string, videoPath string) (*VideoFile, error) {
 
 	probeJSON := &FFProbeJSON{}
 	if err := json.Unmarshal(out, probeJSON); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error unmarshalling video data for <%s>: %s", videoPath, err.Error())
 	}
 
 	return parse(videoPath, probeJSON)
@@ -244,7 +244,7 @@ func NewVideoFile(ffprobePath string, videoPath string) (*VideoFile, error) {
 
 func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 	if probeJSON == nil {
-		return nil, fmt.Errorf("failed to get ffprobe json")
+		return nil, fmt.Errorf("failed to get ffprobe json for <%s>", filePath)
 	}
 
 	result := &VideoFile{}
@@ -273,7 +273,7 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 	result.Duration = math.Round(duration*100) / 100
 	fileStat, err := os.Stat(filePath)
 	if err != nil {
-		logger.Errorf("Error statting file: %v", err)
+		logger.Errorf("Error statting file <%s>: %s", filePath, err.Error())
 		return nil, err
 	}
 	result.Size = fileStat.Size()

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -47,10 +47,6 @@ func (t *ScanTask) scanGallery() {
 		return
 	}
 
-	ok, err := utils.IsZipFileUncompressed(t.FilePath)
-	if err == nil && !ok {
-		logger.Warnf("%s is using above store (0) level compression.", t.FilePath)
-	}
 	checksum, err := t.calculateChecksum()
 	if err != nil {
 		logger.Error(err.Error())
@@ -82,6 +78,12 @@ func (t *ScanTask) scanGallery() {
 
 		// don't create gallery if it has no images
 		if newGallery.CountFiles() > 0 {
+			// only warn when creating the gallery
+			ok, err := utils.IsZipFileUncompressed(t.FilePath)
+			if err == nil && !ok {
+				logger.Warnf("%s is using above store (0) level compression.", t.FilePath)
+			}
+
 			logger.Infof("%s doesn't exist.  Creating new item...", t.FilePath)
 			_, err = qb.Create(newGallery, tx)
 		}
@@ -251,7 +253,7 @@ func (t *ScanTask) scanScene() {
 
 	var checksum string
 
-	logger.Infof("%s not found.  Calculating oshash...", t.FilePath)
+	logger.Infof("%s not found. Calculating oshash...", t.FilePath)
 	oshash, err := utils.OSHashFromFilePath(t.FilePath)
 	if err != nil {
 		logger.Error(err.Error())
@@ -289,9 +291,9 @@ func (t *ScanTask) scanScene() {
 	if scene != nil {
 		exists, _ := utils.FileExists(scene.Path)
 		if exists {
-			logger.Infof("%s already exists.  Duplicate of %s ", t.FilePath, scene.Path)
+			logger.Infof("%s already exists. Duplicate of %s", t.FilePath, scene.Path)
 		} else {
-			logger.Infof("%s already exists.  Updating path...", t.FilePath)
+			logger.Infof("%s already exists. Updating path...", t.FilePath)
 			scenePartial := models.ScenePartial{
 				ID:   scene.ID,
 				Path: &t.FilePath,
@@ -299,7 +301,7 @@ func (t *ScanTask) scanScene() {
 			_, err = qb.Update(scenePartial, tx)
 		}
 	} else {
-		logger.Infof("%s doesn't exist.  Creating new item...", t.FilePath)
+		logger.Infof("%s doesn't exist. Creating new item...", t.FilePath)
 		currentTime := time.Now()
 		newScene := models.Scene{
 			Checksum:   sql.NullString{String: checksum, Valid: checksum != ""},
@@ -342,7 +344,6 @@ func (t *ScanTask) makeScreenshots(probeResult *ffmpeg.VideoFile, checksum strin
 	normalExists, _ := utils.FileExists(normalPath)
 
 	if thumbExists && normalExists {
-		logger.Debug("Screenshots already exist for this path... skipping")
 		return
 	}
 

--- a/pkg/models/json_time.go
+++ b/pkg/models/json_time.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -14,15 +15,21 @@ type JSONTime struct {
 	time.Time
 }
 
-func (jt *JSONTime) UnmarshalJSON(b []byte) (err error) {
+func (jt *JSONTime) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), "\"")
 	if s == "null" {
 		jt.Time = time.Time{}
-		return
+		return nil
 	}
 
+	// #731 - returning an error here causes the entire JSON parse to fail for ffprobe.
+	// Changing so that it logs a warning instead.
+	var err error
 	jt.Time, err = utils.ParseDateStringAsTime(s)
-	return
+	if err != nil {
+		logger.Warnf("error unmarshalling JSONTime: %s", err.Error())
+	}
+	return nil
 }
 
 func (jt *JSONTime) MarshalJSON() ([]byte, error) {

--- a/ui/v2.5/src/components/Changelog/versions/v040.md
+++ b/ui/v2.5/src/components/Changelog/versions/v040.md
@@ -11,6 +11,7 @@
 * Re-show preview thumbnail when mousing away from scene card.
 
 ### 🐛 Bug fixes
+* Fix invalid date tag preventing video file from being scanned.
 * Fix incorrect date timezone.
 * Fix search filters not persisting for studios, markers and galleries.
 * Fix pending thumbnail on wall items on mobile platforms.


### PR DESCRIPTION
Fixes #731 

Some files have a malformed date tag in their metadata. This would cause the ffprobe unmarshal to fail. I have changed `JSONTime` to log a warning instead of returning an error when unmarshalling a malformed date. In addition, I've improved the logging to provide the filename for ffprobe errors, and tidied some of the scan logging to be cleaner and less verbose.