### PR TITLE
Fix folder selector link color

### DIFF
--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -86,7 +86,7 @@
 
     .btn-link {
       border: none;
-      color: black;
+      color: white;
       font-weight: 400;
       padding: 0;
     }


### PR DESCRIPTION
Colors haven't been updated since the modal changed color scheme, and black on dark blue is very hard to see. 