### PR TITLE
Fix clean and scan bugs

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -45,10 +45,11 @@ func CalculateMD5(path string) (string, error) {
 }
 
 func FileExists(path string) bool {
-	_, err := openSourceImage(path)
+	f, err := openSourceImage(path)
 	if err != nil {
 		return false
 	}
+	defer f.Close()
 
 	return true
 }

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -657,7 +657,7 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 
 	return symwalk.Walk(s.Path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			logger.Debugf("error scanning %s: %s", path, err.Error())
+			logger.Warnf("error scanning %s: %s", path, err.Error())
 			return nil
 		}
 

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -656,6 +656,11 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 	excludeImg := config.GetImageExcludes()
 
 	return symwalk.Walk(s.Path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logger.Debugf("error scanning %s: %s", path, err.Error())
+			return nil
+		}
+
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
Leaving the file open in FileExists causes the system to run out of free file handles, so the clean stops with a db error.

Also added handling of symwalk errors. Current golang versions have an issue on modern linux kernels that causes it to randomly throw errors when trying to stat files. There's not much we can do to fix it, but at least this allows the scan to run rather than panic, and logs the error so the user is aware.