### PR TITLE
Show static image if wall video missing

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v040.md
+++ b/ui/v2.5/src/components/Changelog/versions/v040.md
@@ -6,6 +6,7 @@
 * Add selective scene export.
 
 ### 🎨 Improvements
+* Show static image on scene wall if preview video is missing.
 * Add path filter to scene and gallery query.
 * Add button to hide left panel on scene page.
 * Add link to parent studio in studio page.

--- a/ui/v2.5/src/components/Wall/WallItem.tsx
+++ b/ui/v2.5/src/components/Wall/WallItem.tsx
@@ -46,14 +46,6 @@ const Preview: React.FC<{
 
   if (!previews) return <div />;
 
-  if (isMissing) {
-    return (
-      <div className="wall-item-media wall-item-missing">
-        Pending preview generation
-      </div>
-    );
-  }
-
   const image = (
     <img
       alt=""
@@ -80,6 +72,19 @@ const Preview: React.FC<{
       ref={videoElement}
     />
   );
+
+  if (isMissing) {
+    // show the image if the video preview is unavailable
+    if (previews.image) {
+      return image;
+    }
+
+    return (
+      <div className="wall-item-media wall-item-missing">
+        Pending preview generation
+      </div>
+    );
+  }
 
   if (previewType === "video") {
     return video;


### PR DESCRIPTION
The scene wall view currently shows a "Pending preview generation" message for each wall item where the video is missing. This change makes it so that it displays the static screenshot image (if available) if the video is missing, so you can still see what the scene is.