### PR TITLE
Treat empty string columns as missing

### DIFF
--- a/pkg/models/querybuilder_image.go
+++ b/pkg/models/querybuilder_image.go
@@ -327,7 +327,7 @@ func (qb *ImageQueryBuilder) Query(imageFilter *ImageFilterType, findFilter *Fin
 		case "tags":
 			query.addWhere("tags_join.image_id IS NULL")
 		default:
-			query.addWhere("images." + *isMissingFilter + " IS NULL")
+			query.addWhere("images." + *isMissingFilter + " IS NULL OR TRIM(images." + *isMissingFilter + ") = ''")
 		}
 	}
 

--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -220,7 +220,7 @@ func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, fin
 			`
 			query.addWhere("performers_image.performer_id IS NULL")
 		default:
-			query.addWhere("performers." + *isMissingFilter + " IS NULL")
+			query.addWhere("performers." + *isMissingFilter + " IS NULL OR TRIM(performers." + *isMissingFilter + ") = ''")
 		}
 	}
 

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -362,7 +362,7 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		case "tags":
 			query.addWhere("tags_join.scene_id IS NULL")
 		default:
-			query.addWhere("scenes." + *isMissingFilter + " IS NULL")
+			query.addWhere("scenes." + *isMissingFilter + " IS NULL OR TRIM(scenes." + *isMissingFilter + ") = ''")
 		}
 	}
 

--- a/ui/v2.5/src/components/Changelog/versions/v040.md
+++ b/ui/v2.5/src/components/Changelog/versions/v040.md
@@ -15,6 +15,7 @@
 * Improved gallery layout.
 * Add hover delay before scene preview is played.
 * Re-show preview thumbnail when mousing away from scene card.
+* Include empty fields in isMissing filter
 
 ### 🐛 Bug fixes
 * Fix invalid date tag preventing video file from being scanned.

--- a/ui/v2.5/src/components/Changelog/versions/v040.md
+++ b/ui/v2.5/src/components/Changelog/versions/v040.md
@@ -6,6 +6,7 @@
 * Add selective scene export.
 
 ### 🎨 Improvements
+* Include empty fields in isMissing filter
 * Add path filter to scene and gallery query.
 * Add button to hide left panel on scene page.
 * Add link to parent studio in studio page.
@@ -15,7 +16,6 @@
 * Improved gallery layout.
 * Add hover delay before scene preview is played.
 * Re-show preview thumbnail when mousing away from scene card.
-* Include empty fields in isMissing filter
 
 ### 🐛 Bug fixes
 * Fix invalid date tag preventing video file from being scanned.


### PR DESCRIPTION
String fields don't get nulled when they are wiped so no longer get caught by the isMissing `IS NULL` check.