### PR TITLE
Fix loading issue in galleries and redirect on gallery creation

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -22,7 +22,7 @@ export const Gallery: React.FC = () => {
   const history = useHistory();
   const isNew = id === "new";
 
-  const [gallery, setGallery] = useState<Partial<GQL.GalleryDataFragment>>({});
+  const [gallery, setGallery] = useState<GQL.GalleryDataFragment>();
   const { data, error, loading } = useFindGallery(id);
 
   const [activeTabKey, setActiveTabKey] = useState("gallery-details-panel");
@@ -183,6 +183,12 @@ export const Gallery: React.FC = () => {
     };
   });
 
+  if (loading || !gallery || !data?.findGallery) {
+    return <LoadingIndicator />;
+  }
+
+  if (error) return <div>{error.message}</div>;
+
   if (isNew)
     return (
       <div className="row new-view">
@@ -198,12 +204,6 @@ export const Gallery: React.FC = () => {
         </div>
       </div>
     );
-
-  if (loading || !gallery || !data?.findGallery) {
-    return <LoadingIndicator />;
-  }
-
-  if (error) return <div>{error.message}</div>;
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -182,8 +182,7 @@ export const Gallery: React.FC = () => {
     return <LoadingIndicator />;
   }
 
-  if (error)
-    return <ErrorMessage error={error.message} />
+  if (error) return <ErrorMessage error={error.message} />;
 
   if (isNew)
     return (
@@ -201,7 +200,15 @@ export const Gallery: React.FC = () => {
     );
 
   if (!gallery)
-    return <ErrorMessage error={<>No gallery with id <i>{id}</i> found.</>} />
+    return (
+      <ErrorMessage
+        error={
+          <>
+            No gallery with id <i>{id}</i> found.
+          </>
+        }
+      />
+    );
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useHistory, Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import { useFindGallery } from "src/core/StashService";
-import { LoadingIndicator, Icon } from "src/components/Shared";
+import { ErrorMessage, LoadingIndicator, Icon } from "src/components/Shared";
 import { TextUtils } from "src/utils";
 import * as Mousetrap from "mousetrap";
 import { GalleryEditPanel } from "./GalleryEditPanel";
@@ -125,6 +125,7 @@ export const Gallery: React.FC = () => {
           <Tab.Pane eventKey="gallery-edit-panel" title="Edit">
             <GalleryEditPanel
               isVisible={activeTabKey === "gallery-edit-panel"}
+              isNew={false}
               gallery={gallery}
               onUpdate={(newGallery) => setGallery(newGallery)}
               onDelete={() => setIsDeleteAlertOpen(true)}
@@ -183,11 +184,12 @@ export const Gallery: React.FC = () => {
     };
   });
 
-  if (loading || !gallery || !data?.findGallery) {
+  if (loading) {
     return <LoadingIndicator />;
   }
 
-  if (error) return <div>{error.message}</div>;
+  if (error)
+    return <ErrorMessage error={error.message} />
 
   if (isNew)
     return (
@@ -195,15 +197,18 @@ export const Gallery: React.FC = () => {
         <div className="col-6">
           <h2>Create Gallery</h2>
           <GalleryEditPanel
-            gallery={gallery}
+            isNew
+            gallery={undefined}
             isVisible
-            isNew={isNew}
             onUpdate={(newGallery) => setGallery(newGallery)}
             onDelete={() => setIsDeleteAlertOpen(true)}
           />
         </div>
       </div>
     );
+
+  if (!gallery || !data?.findGallery)
+    return <ErrorMessage error={<>No gallery with id <i>{id}</i> found.</>} />
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -200,15 +200,7 @@ export const Gallery: React.FC = () => {
     );
 
   if (!gallery)
-    return (
-      <ErrorMessage
-        error={
-          <>
-            No gallery with id <i>{id}</i> found.
-          </>
-        }
-      />
-    );
+    return <ErrorMessage error={`No gallery with id ${id} found.`} />;
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -1,7 +1,6 @@
 import { Tab, Nav, Dropdown } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { useParams, useHistory, Link } from "react-router-dom";
-import * as GQL from "src/core/generated-graphql";
 import { useFindGallery } from "src/core/StashService";
 import { ErrorMessage, LoadingIndicator, Icon } from "src/components/Shared";
 import { TextUtils } from "src/utils";
@@ -22,8 +21,8 @@ export const Gallery: React.FC = () => {
   const history = useHistory();
   const isNew = id === "new";
 
-  const [gallery, setGallery] = useState<GQL.GalleryDataFragment>();
   const { data, error, loading } = useFindGallery(id);
+  const gallery = data?.findGallery;
 
   const [activeTabKey, setActiveTabKey] = useState("gallery-details-panel");
   const activeRightTabKey = tab === "images" || tab === "add" ? tab : "images";
@@ -35,10 +34,6 @@ export const Gallery: React.FC = () => {
   };
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (data?.findGallery) setGallery(data.findGallery);
-  }, [data]);
 
   function onDeleteDialogClosed(deleted: boolean) {
     setIsDeleteAlertOpen(false);
@@ -127,7 +122,6 @@ export const Gallery: React.FC = () => {
               isVisible={activeTabKey === "gallery-edit-panel"}
               isNew={false}
               gallery={gallery}
-              onUpdate={(newGallery) => setGallery(newGallery)}
               onDelete={() => setIsDeleteAlertOpen(true)}
             />
           </Tab.Pane>
@@ -200,14 +194,13 @@ export const Gallery: React.FC = () => {
             isNew
             gallery={undefined}
             isVisible
-            onUpdate={(newGallery) => setGallery(newGallery)}
             onDelete={() => setIsDeleteAlertOpen(true)}
           />
         </div>
       </div>
     );
 
-  if (!gallery || !data?.findGallery)
+  if (!gallery)
     return <ErrorMessage error={<>No gallery with id <i>{id}</i> found.</>} />
 
   return (

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -14,14 +14,22 @@ import { FormUtils, EditableTextUtils } from "src/utils";
 import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 
 interface IProps {
-  gallery: GQL.GalleryDataFragment;
   isVisible: boolean;
-  isNew?: boolean;
   onUpdate: (gallery: GQL.GalleryDataFragment) => void;
   onDelete: () => void;
 }
 
-export const GalleryEditPanel: React.FC<IProps> = (props: IProps) => {
+interface INewProps {
+  isNew: true;
+  gallery: undefined;
+};
+
+interface IExistingProps {
+  isNew: false;
+  gallery: GQL.GalleryDataFragment;
+};
+
+export const GalleryEditPanel: React.FC<IProps & (INewProps|IExistingProps)> = (props) => {
   const Toast = useToast();
   const history = useHistory();
   const [title, setTitle] = useState<string>();
@@ -85,15 +93,15 @@ export const GalleryEditPanel: React.FC<IProps> = (props: IProps) => {
     }
   });
 
-  function updateGalleryEditState(state: Partial<GQL.GalleryDataFragment>) {
-    const perfIds = state.performers?.map((performer) => performer.id);
-    const tIds = state.tags ? state.tags.map((tag) => tag.id) : undefined;
+  function updateGalleryEditState(state?: GQL.GalleryDataFragment) {
+    const perfIds = state?.performers?.map((performer) => performer.id);
+    const tIds = state?.tags ? state?.tags.map((tag) => tag.id) : undefined;
 
-    setTitle(state.title ?? undefined);
-    setDetails(state.details ?? undefined);
-    setUrl(state.url ?? undefined);
-    setDate(state.date ?? undefined);
-    setRating(state.rating === null ? NaN : state.rating);
+    setTitle(state?.title ?? undefined);
+    setDetails(state?.details ?? undefined);
+    setUrl(state?.url ?? undefined);
+    setDate(state?.date ?? undefined);
+    setRating(state?.rating === null ? NaN : state?.rating);
     setStudioId(state?.studio?.id ?? undefined);
     setPerformerIds(perfIds);
     setTagIds(tIds);
@@ -106,7 +114,7 @@ export const GalleryEditPanel: React.FC<IProps> = (props: IProps) => {
 
   function getGalleryInput() {
     return {
-      id: props.isNew ? undefined : props.gallery.id!,
+      id: props.isNew ? undefined : props.gallery.id,
       title,
       details,
       url,

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
 import { Button, Form, Col, Row } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
 import { useGalleryCreate, useGalleryUpdate } from "src/core/StashService";
@@ -13,7 +14,7 @@ import { FormUtils, EditableTextUtils } from "src/utils";
 import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 
 interface IProps {
-  gallery: Partial<GQL.GalleryDataFragment>;
+  gallery: GQL.GalleryDataFragment;
   isVisible: boolean;
   isNew?: boolean;
   onUpdate: (gallery: GQL.GalleryDataFragment) => void;
@@ -22,6 +23,7 @@ interface IProps {
 
 export const GalleryEditPanel: React.FC<IProps> = (props: IProps) => {
   const Toast = useToast();
+  const history = useHistory();
   const [title, setTitle] = useState<string>();
   const [details, setDetails] = useState<string>();
   const [url, setUrl] = useState<string>();
@@ -123,6 +125,7 @@ export const GalleryEditPanel: React.FC<IProps> = (props: IProps) => {
         const result = await createGallery();
         if (result.data?.galleryCreate) {
           props.onUpdate(result.data.galleryCreate);
+          history.push(`/galleries/${result.data.galleryCreate.id}`);
           Toast.success({ content: "Created gallery" });
         }
       } else {

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -15,7 +15,6 @@ import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 
 interface IProps {
   isVisible: boolean;
-  onUpdate: (gallery: GQL.GalleryDataFragment) => void;
   onDelete: () => void;
 }
 
@@ -132,14 +131,12 @@ export const GalleryEditPanel: React.FC<IProps & (INewProps|IExistingProps)> = (
       if (props.isNew) {
         const result = await createGallery();
         if (result.data?.galleryCreate) {
-          props.onUpdate(result.data.galleryCreate);
           history.push(`/galleries/${result.data.galleryCreate.id}`);
           Toast.success({ content: "Created gallery" });
         }
       } else {
         const result = await updateGallery();
         if (result.data?.galleryUpdate) {
-          props.onUpdate(result.data.galleryUpdate);
           Toast.success({ content: "Updated gallery" });
         }
       }

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -21,14 +21,16 @@ interface IProps {
 interface INewProps {
   isNew: true;
   gallery: undefined;
-};
+}
 
 interface IExistingProps {
   isNew: false;
   gallery: GQL.GalleryDataFragment;
-};
+}
 
-export const GalleryEditPanel: React.FC<IProps & (INewProps|IExistingProps)> = (props) => {
+export const GalleryEditPanel: React.FC<
+  IProps & (INewProps | IExistingProps)
+> = (props) => {
   const Toast = useToast();
   const history = useHistory();
   const [title, setTitle] = useState<string>();

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
@@ -8,7 +8,7 @@ import { showWhenSelected } from "src/hooks/ListHook";
 import { useToast } from "src/hooks";
 
 interface IGalleryDetailsProps {
-  gallery: Partial<GQL.GalleryDataFragment>;
+  gallery: GQL.GalleryDataFragment;
 }
 
 export const GalleryImagesPanel: React.FC<IGalleryDetailsProps> = ({

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -8,7 +8,7 @@ import {
   useImageDecrementO,
   useImageResetO,
 } from "src/core/StashService";
-import { LoadingIndicator, Icon } from "src/components/Shared";
+import { ErrorMessage, LoadingIndicator, Icon } from "src/components/Shared";
 import { useToast } from "src/hooks";
 import { TextUtils } from "src/utils";
 import * as Mousetrap from "mousetrap";
@@ -196,11 +196,16 @@ export const Image: React.FC = () => {
     };
   });
 
-  if (loading || !image || !data?.findImage) {
+  if (loading) {
     return <LoadingIndicator />;
   }
 
-  if (error) return <div>{error.message}</div>;
+  if (error)
+    return <ErrorMessage error={error.message} />
+
+  if (!image || !data?.findImage) {
+    return <ErrorMessage error={<>No image found for id <i>{id}</i></>} />
+  }
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -188,15 +188,7 @@ export const Image: React.FC = () => {
   if (error) return <ErrorMessage error={error.message} />;
 
   if (!image) {
-    return (
-      <ErrorMessage
-        error={
-          <>
-            No image found for id <i>{id}</i>
-          </>
-        }
-      />
-    );
+    return <ErrorMessage error={`No image found with id ${id}.`} />;
   }
 
   return (

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -185,11 +185,18 @@ export const Image: React.FC = () => {
     return <LoadingIndicator />;
   }
 
-  if (error)
-    return <ErrorMessage error={error.message} />
+  if (error) return <ErrorMessage error={error.message} />;
 
   if (!image) {
-    return <ErrorMessage error={<>No image found for id <i>{id}</i></>} />
+    return (
+      <ErrorMessage
+        error={
+          <>
+            No image found for id <i>{id}</i>
+          </>
+        }
+      />
+    );
   }
 
   return (

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -1,7 +1,6 @@
 import { Tab, Nav, Dropdown } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { useParams, useHistory, Link } from "react-router-dom";
-import * as GQL from "src/core/generated-graphql";
 import {
   useFindImage,
   useImageIncrementO,
@@ -27,8 +26,8 @@ export const Image: React.FC = () => {
   const history = useHistory();
   const Toast = useToast();
 
-  const [image, setImage] = useState<GQL.ImageDataFragment | undefined>();
   const { data, error, loading } = useFindImage(id);
+  const image = data?.findImage;
   const [oLoading, setOLoading] = useState(false);
   const [incrementO] = useImageIncrementO(image?.id ?? "0");
   const [decrementO] = useImageDecrementO(image?.id ?? "0");
@@ -38,21 +37,10 @@ export const Image: React.FC = () => {
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
-  useEffect(() => {
-    if (data?.findImage) setImage(data.findImage);
-  }, [data]);
-
-  const updateOCounter = (newValue: number) => {
-    const modifiedImage = { ...image } as GQL.ImageDataFragment;
-    modifiedImage.o_counter = newValue;
-    setImage(modifiedImage);
-  };
-
   const onIncrementClick = async () => {
     try {
       setOLoading(true);
-      const result = await incrementO();
-      if (result.data) updateOCounter(result.data.imageIncrementO);
+      await incrementO();
     } catch (e) {
       Toast.error(e);
     } finally {
@@ -63,8 +51,7 @@ export const Image: React.FC = () => {
   const onDecrementClick = async () => {
     try {
       setOLoading(true);
-      const result = await decrementO();
-      if (result.data) updateOCounter(result.data.imageDecrementO);
+      await decrementO();
     } catch (e) {
       Toast.error(e);
     } finally {
@@ -75,8 +62,7 @@ export const Image: React.FC = () => {
   const onResetClick = async () => {
     try {
       setOLoading(true);
-      const result = await resetO();
-      if (result.data) updateOCounter(result.data.imageResetO);
+      await resetO();
     } catch (e) {
       Toast.error(e);
     } finally {
@@ -172,7 +158,6 @@ export const Image: React.FC = () => {
             <ImageEditPanel
               isVisible={activeTabKey === "image-edit-panel"}
               image={image}
-              onUpdate={(newImage) => setImage(newImage)}
               onDelete={() => setIsDeleteAlertOpen(true)}
             />
           </Tab.Pane>
@@ -203,7 +188,7 @@ export const Image: React.FC = () => {
   if (error)
     return <ErrorMessage error={error.message} />
 
-  if (!image || !data?.findImage) {
+  if (!image) {
     return <ErrorMessage error={<>No image found for id <i>{id}</i></>} />
   }
 

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -15,7 +15,6 @@ import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 interface IProps {
   image: GQL.ImageDataFragment;
   isVisible: boolean;
-  onUpdate: (image: GQL.ImageDataFragment) => void;
   onDelete: () => void;
 }
 
@@ -107,7 +106,6 @@ export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
     try {
       const result = await updateImage();
       if (result.data?.imageUpdate) {
-        props.onUpdate(result.data.imageUpdate);
         Toast.success({ content: "Updated image" });
       }
     } catch (e) {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -9,7 +9,12 @@ import {
   usePerformerCreate,
   usePerformerDestroy,
 } from "src/core/StashService";
-import { CountryFlag, ErrorMessage, Icon, LoadingIndicator } from "src/components/Shared";
+import {
+  CountryFlag,
+  ErrorMessage,
+  Icon,
+  LoadingIndicator,
+} from "src/components/Shared";
 import { useToast } from "src/hooks";
 import { TextUtils } from "src/utils";
 import FsLightbox from "fslightbox-react";
@@ -33,7 +38,7 @@ export const Performer: React.FC = () => {
   const [imageEncoding, setImageEncoding] = useState<boolean>(false);
   const [lightboxToggle, setLightboxToggle] = useState(false);
   const { data, loading: performerLoading, error } = useFindPerformer(id);
-  const performer = data?.findPerformer || {} as Partial<GQL.Performer>;
+  const performer = data?.findPerformer || ({} as Partial<GQL.Performer>);
 
   // if undefined then get the existing image
   // if null then get the default (no) image
@@ -85,7 +90,8 @@ export const Performer: React.FC = () => {
 
   if (isLoading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;
-  if (!performer.id && !isNew) return <ErrorMessage error={`No performer found with id ${id}.`} />
+  if (!performer.id && !isNew)
+    return <ErrorMessage error={`No performer found with id ${id}.`} />;
 
   async function onSave(
     performerInput:

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -309,7 +309,16 @@ export const Scene: React.FC = () => {
   if (loading || streamableLoading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;
   if (streamableError) return <ErrorMessage error={streamableError.message} />;
-  if (!scene) return <ErrorMessage error={<>No scene found with id <i>{id}</i></>} />
+  if (!scene)
+    return (
+      <ErrorMessage
+        error={
+          <>
+            No scene found with id <i>{id}</i>
+          </>
+        }
+      />
+    );
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -309,16 +309,7 @@ export const Scene: React.FC = () => {
   if (loading || streamableLoading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;
   if (streamableError) return <ErrorMessage error={streamableError.message} />;
-  if (!scene)
-    return (
-      <ErrorMessage
-        error={
-          <>
-            No scene found with id <i>{id}</i>
-          </>
-        }
-      />
-    );
+  if (!scene) return <ErrorMessage error={`No scene found with id ${id}.`} />;
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -36,7 +36,6 @@ import { SceneScrapeDialog } from "./SceneScrapeDialog";
 interface IProps {
   scene: GQL.SceneDataFragment;
   isVisible: boolean;
-  onUpdate: (scene: GQL.SceneDataFragment) => void;
   onDelete: () => void;
 }
 
@@ -226,7 +225,6 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     try {
       const result = await updateScene();
       if (result.data?.sceneUpdate) {
-        props.onUpdate(result.data.sceneUpdate);
         Toast.success({ content: "Updated scene" });
       }
     } catch (e) {

--- a/ui/v2.5/src/components/Shared/ErrorMessage.tsx
+++ b/ui/v2.5/src/components/Shared/ErrorMessage.tsx
@@ -1,0 +1,13 @@
+import React, { ReactNode } from "react";
+
+interface IProps {
+  error: string|ReactNode;
+}
+
+const ErrorMessage: React.FC<IProps> = ({ error }) => (
+  <div className="row ErrorMessage">
+    <h2 className="ErrorMessage-content">Error: {error}</h2>
+  </div>
+);
+
+export default ErrorMessage;

--- a/ui/v2.5/src/components/Shared/ErrorMessage.tsx
+++ b/ui/v2.5/src/components/Shared/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 
 interface IProps {
-  error: string|ReactNode;
+  error: string | ReactNode;
 }
 
 const ErrorMessage: React.FC<IProps> = ({ error }) => (

--- a/ui/v2.5/src/components/Shared/index.ts
+++ b/ui/v2.5/src/components/Shared/index.ts
@@ -19,3 +19,4 @@ export { default as LoadingIndicator } from "./LoadingIndicator";
 export { ImageInput } from "./ImageInput";
 export { SweatDrops } from "./SweatDrops";
 export { default as CountryFlag } from "./CountryFlag";
+export { default as ErrorMessage } from "./ErrorMessage";

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -133,3 +133,13 @@ button.collapse-button.btn-primary:not(:disabled):not(.disabled):active {
   max-width: 32rem;
   text-align: center;
 }
+
+.ErrorMessage {
+  align-items: center;
+  height: 20rem;
+  justify-content: center;
+
+  &-content {
+    display: inline-block;
+  }
+}

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -309,19 +309,44 @@ export const useBulkSceneUpdate = (input: GQL.BulkSceneUpdateInput) =>
 export const useScenesUpdate = (input: GQL.SceneUpdateInput[]) =>
   GQL.useScenesUpdateMutation({ variables: { input } });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const updateSceneO = (id: string, cache: ApolloCache<any>, updatedOCount?: number) => {
+  const scene = cache.readQuery<GQL.FindSceneQuery, GQL.FindSceneQueryVariables>({
+    query: GQL.FindSceneDocument,
+    variables: { id }
+  });
+  if (updatedOCount === undefined || !scene?.findScene)
+    return;
+
+  cache.writeQuery<GQL.FindSceneQuery, GQL.FindSceneQueryVariables>({
+    query: GQL.FindSceneDocument,
+    variables: { id },
+    data: {
+      ...scene,
+      findScene: {
+        ...scene.findScene,
+        o_counter: updatedOCount
+      }
+    }
+  });
+}
+
 export const useSceneIncrementO = (id: string) =>
   GQL.useSceneIncrementOMutation({
     variables: { id },
+    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneIncrementO)
   });
 
 export const useSceneDecrementO = (id: string) =>
   GQL.useSceneDecrementOMutation({
     variables: { id },
+    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneDecrementO)
   });
 
 export const useSceneResetO = (id: string) =>
   GQL.useSceneResetOMutation({
     variables: { id },
+    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneResetO)
   });
 
 export const useSceneDestroy = (input: GQL.SceneDestroyInput) =>
@@ -372,19 +397,43 @@ export const useImagesDestroy = (input: GQL.ImagesDestroyInput) =>
     update: deleteCache(imageMutationImpactedQueries),
   });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const updateImageO = (id: string, cache: ApolloCache<any>, updatedOCount?: number) => {
+  const image = cache.readQuery<GQL.FindImageQuery, GQL.FindImageQueryVariables>({
+    query: GQL.FindImageDocument,
+    variables: { id }
+  });
+  if (updatedOCount === undefined || !image?.findImage)
+    return;
+
+  cache.writeQuery<GQL.FindImageQuery, GQL.FindImageQueryVariables>({
+    query: GQL.FindImageDocument,
+    variables: { id },
+    data: {
+      findImage: {
+        ...image.findImage,
+        o_counter: updatedOCount
+      }
+    }
+  });
+}
+
 export const useImageIncrementO = (id: string) =>
   GQL.useImageIncrementOMutation({
     variables: { id },
+    update: (cache, data) => updateImageO(id, cache, data.data?.imageIncrementO)
   });
 
 export const useImageDecrementO = (id: string) =>
   GQL.useImageDecrementOMutation({
     variables: { id },
+    update: (cache, data) => updateImageO(id, cache, data.data?.imageDecrementO)
   });
 
 export const useImageResetO = (id: string) =>
   GQL.useImageResetOMutation({
     variables: { id },
+    update: (cache, data) => updateImageO(id, cache, data.data?.imageResetO)
   });
 
 const galleryMutationImpactedQueries = [

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -309,10 +309,13 @@ export const useBulkSceneUpdate = (input: GQL.BulkSceneUpdateInput) =>
 export const useScenesUpdate = (input: GQL.SceneUpdateInput[]) =>
   GQL.useScenesUpdateMutation({ variables: { input } });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SceneOMutation =
+  | GQL.SceneIncrementOMutation
+  | GQL.SceneDecrementOMutation
+  | GQL.SceneResetOMutation;
 const updateSceneO = (
   id: string,
-  cache: ApolloCache<any>,
+  cache: ApolloCache<SceneOMutation>,
   updatedOCount?: number
 ) => {
   const scene = cache.readQuery<
@@ -405,10 +408,13 @@ export const useImagesDestroy = (input: GQL.ImagesDestroyInput) =>
     update: deleteCache(imageMutationImpactedQueries),
   });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ImageOMutation =
+  | GQL.ImageIncrementOMutation
+  | GQL.ImageDecrementOMutation
+  | GQL.ImageResetOMutation;
 const updateImageO = (
   id: string,
-  cache: ApolloCache<any>,
+  cache: ApolloCache<ImageOMutation>,
   updatedOCount?: number
 ) => {
   const image = cache.readQuery<

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -310,13 +310,19 @@ export const useScenesUpdate = (input: GQL.SceneUpdateInput[]) =>
   GQL.useScenesUpdateMutation({ variables: { input } });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const updateSceneO = (id: string, cache: ApolloCache<any>, updatedOCount?: number) => {
-  const scene = cache.readQuery<GQL.FindSceneQuery, GQL.FindSceneQueryVariables>({
+const updateSceneO = (
+  id: string,
+  cache: ApolloCache<any>,
+  updatedOCount?: number
+) => {
+  const scene = cache.readQuery<
+    GQL.FindSceneQuery,
+    GQL.FindSceneQueryVariables
+  >({
     query: GQL.FindSceneDocument,
-    variables: { id }
+    variables: { id },
   });
-  if (updatedOCount === undefined || !scene?.findScene)
-    return;
+  if (updatedOCount === undefined || !scene?.findScene) return;
 
   cache.writeQuery<GQL.FindSceneQuery, GQL.FindSceneQueryVariables>({
     query: GQL.FindSceneDocument,
@@ -325,28 +331,30 @@ const updateSceneO = (id: string, cache: ApolloCache<any>, updatedOCount?: numbe
       ...scene,
       findScene: {
         ...scene.findScene,
-        o_counter: updatedOCount
-      }
-    }
+        o_counter: updatedOCount,
+      },
+    },
   });
-}
+};
 
 export const useSceneIncrementO = (id: string) =>
   GQL.useSceneIncrementOMutation({
     variables: { id },
-    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneIncrementO)
+    update: (cache, data) =>
+      updateSceneO(id, cache, data.data?.sceneIncrementO),
   });
 
 export const useSceneDecrementO = (id: string) =>
   GQL.useSceneDecrementOMutation({
     variables: { id },
-    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneDecrementO)
+    update: (cache, data) =>
+      updateSceneO(id, cache, data.data?.sceneDecrementO),
   });
 
 export const useSceneResetO = (id: string) =>
   GQL.useSceneResetOMutation({
     variables: { id },
-    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneResetO)
+    update: (cache, data) => updateSceneO(id, cache, data.data?.sceneResetO),
   });
 
 export const useSceneDestroy = (input: GQL.SceneDestroyInput) =>
@@ -398,13 +406,19 @@ export const useImagesDestroy = (input: GQL.ImagesDestroyInput) =>
   });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const updateImageO = (id: string, cache: ApolloCache<any>, updatedOCount?: number) => {
-  const image = cache.readQuery<GQL.FindImageQuery, GQL.FindImageQueryVariables>({
+const updateImageO = (
+  id: string,
+  cache: ApolloCache<any>,
+  updatedOCount?: number
+) => {
+  const image = cache.readQuery<
+    GQL.FindImageQuery,
+    GQL.FindImageQueryVariables
+  >({
     query: GQL.FindImageDocument,
-    variables: { id }
+    variables: { id },
   });
-  if (updatedOCount === undefined || !image?.findImage)
-    return;
+  if (updatedOCount === undefined || !image?.findImage) return;
 
   cache.writeQuery<GQL.FindImageQuery, GQL.FindImageQueryVariables>({
     query: GQL.FindImageDocument,
@@ -412,28 +426,30 @@ const updateImageO = (id: string, cache: ApolloCache<any>, updatedOCount?: numbe
     data: {
       findImage: {
         ...image.findImage,
-        o_counter: updatedOCount
-      }
-    }
+        o_counter: updatedOCount,
+      },
+    },
   });
-}
+};
 
 export const useImageIncrementO = (id: string) =>
   GQL.useImageIncrementOMutation({
     variables: { id },
-    update: (cache, data) => updateImageO(id, cache, data.data?.imageIncrementO)
+    update: (cache, data) =>
+      updateImageO(id, cache, data.data?.imageIncrementO),
   });
 
 export const useImageDecrementO = (id: string) =>
   GQL.useImageDecrementOMutation({
     variables: { id },
-    update: (cache, data) => updateImageO(id, cache, data.data?.imageDecrementO)
+    update: (cache, data) =>
+      updateImageO(id, cache, data.data?.imageDecrementO),
   });
 
 export const useImageResetO = (id: string) =>
   GQL.useImageResetOMutation({
     variables: { id },
-    update: (cache, data) => updateImageO(id, cache, data.data?.imageResetO)
+    update: (cache, data) => updateImageO(id, cache, data.data?.imageResetO),
   });
 
 const galleryMutationImpactedQueries = [


### PR DESCRIPTION
Added an `<ErrorMessage>` component. Also refactored the gallery loading to use discriminated prop types so we don't have to circumvent the type system. After the change setting isNew=false will guarantee gallery has a value, and vice versa. Using `Partial` and the non-null assertion operator (!) is risky and can frequently lead to bugs since it punches holes in the type system.