### PR TITLE
Add shim for String.prototype.replaceAll

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -60,6 +60,7 @@
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.2.0",
     "react-select": "^3.1.0",
+    "string.prototype.replaceall": "^1.0.3",
     "subscriptions-transport-ws": "^0.9.18",
     "universal-cookie": "^4.0.3"
   },

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -7,6 +7,7 @@ import { fas } from "@fortawesome/free-solid-svg-icons";
 import "@formatjs/intl-numberformat/polyfill";
 import "@formatjs/intl-numberformat/locale-data/en";
 import "@formatjs/intl-numberformat/locale-data/en-GB";
+import replaceAll from "string.prototype.replaceall";
 
 import locales from "src/locale";
 import { useConfiguration } from "src/core/StashService";
@@ -24,6 +25,9 @@ import { SceneFilenameParser } from "./components/SceneFilenameParser/SceneFilen
 import Movies from "./components/Movies/Movies";
 import Tags from "./components/Tags/Tags";
 import Images from "./components/Images/Images";
+
+// Required for browsers older than August 2020ish. Can be removed at some point.
+replaceAll.shim();
 
 // Set fontawesome/free-solid-svg as default fontawesome icons
 library.add(fas);

--- a/ui/v2.5/src/globals.d.ts
+++ b/ui/v2.5/src/globals.d.ts
@@ -1,2 +1,2 @@
 declare module "*.md";
-declare module 'string.prototype.replaceall';
+declare module "string.prototype.replaceall";

--- a/ui/v2.5/src/globals.d.ts
+++ b/ui/v2.5/src/globals.d.ts
@@ -1,1 +1,2 @@
 declare module "*.md";
+declare module 'string.prototype.replaceall';

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -14344,6 +14344,17 @@ string.prototype.matchall@^4.0.2:
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
 
+string.prototype.replaceall@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.replaceall/-/string.prototype.replaceall-1.0.3.tgz#f7839a016a290b60769138f4d4938238cbb5a809"
+  integrity sha512-GF8JS9jtHSDkIsVMsYBPR4dItwaU6xOSPsMcRGTAbBr12ZDfyKMtgxdC2HDFbsMogGel29pmwxioJoXeu9ztIg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.1"
+    is-regex "^1.0.4"
+
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"


### PR DESCRIPTION
replaceAll is still pretty fresh so we should shim it for now. It's a no-op in any new browsers so no risk of breaking things.