### PR TITLE
Use temp redirects for setup

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -400,7 +400,7 @@ func ConfigCheckMiddleware(next http.Handler) http.Handler {
 		if !config.IsValid() && shouldRedirect {
 			// #539 - don't redirect if loading login page
 			if !strings.HasPrefix(r.URL.Path, setupEndPoint) && !strings.HasPrefix(r.URL.Path, loginEndPoint) {
-				http.Redirect(w, r, setupEndPoint, 301)
+				http.Redirect(w, r, setupEndPoint, http.StatusFound)
 				return
 			}
 		}
@@ -416,7 +416,7 @@ func DatabaseCheckMiddleware(next http.Handler) http.Handler {
 			// #451 - don't redirect if loading login page
 			// #539 - or setup page
 			if !strings.HasPrefix(r.URL.Path, migrateEndPoint) && !strings.HasPrefix(r.URL.Path, loginEndPoint) && !strings.HasPrefix(r.URL.Path, setupEndPoint) {
-				http.Redirect(w, r, migrateEndPoint, 301)
+				http.Redirect(w, r, migrateEndPoint, http.StatusFound)
 				return
 			}
 		}


### PR DESCRIPTION
Currently if browser needs to redirect to the setup page, it uses a permanent redirect. This means that if you return to the URL that redirected to setup, and the setup redirect is no longer necessary, it gets redirected anyway. Changed the redirection code to use `StatusFound` instead, which doesn't redirect permanently.