### PR TITLE
Don't set default studio image

### DIFF
--- a/pkg/api/resolver_mutation_studio.go
+++ b/pkg/api/resolver_mutation_studio.go
@@ -19,14 +19,12 @@ func (r *mutationResolver) StudioCreate(ctx context.Context, input models.Studio
 	var imageData []byte
 	var err error
 
-	if input.Image == nil {
-		input.Image = &models.DefaultStudioImage
-	}
-
 	// Process the base 64 encoded image string
-	_, imageData, err = utils.ProcessBase64Image(*input.Image)
-	if err != nil {
-		return nil, err
+	if input.Image != nil {
+		_, imageData, err = utils.ProcessBase64Image(*input.Image)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Populate a new studio from the input

--- a/ui/v2.5/src/components/Changelog/versions/v040.md
+++ b/ui/v2.5/src/components/Changelog/versions/v040.md
@@ -22,6 +22,7 @@
 * Re-show preview thumbnail when mousing away from scene card.
 
 ### 🐛 Bug fixes
+* Don't set default studio image during studio creation.
 * Fix invalid date tag preventing video file from being scanned.
 * Fix error when creating movie from scene scrape dialog.
 * Fix incorrect date timezone.


### PR DESCRIPTION
When creating studio, it currently sets the default image if one is not provided. This causes incorrect behaviour for the Is Missing Image filter. Changed so that the default image is no longer set if it is not provided. Placeholder image is used for studios without images when viewing them, but they will correctly be filtered for is missing image.

Resolves #866 