### PR TITLE
Cache generated exclude regex

### DIFF
--- a/pkg/manager/exclude_files.go
+++ b/pkg/manager/exclude_files.go
@@ -38,15 +38,20 @@ func excludeFiles(files []string, patterns []string) ([]string, int) {
 	}
 }
 
+func matchFileRegex(file string, fileRegexps []*regexp.Regexp) bool {
+	for _, regPattern := range fileRegexps {
+		if regPattern.MatchString(strings.ToLower(file)) {
+			return true
+		}
+	}
+	return false
+}
+
 func matchFile(file string, patterns []string) bool {
 	if patterns != nil {
 		fileRegexps := generateRegexps(patterns)
 
-		for _, regPattern := range fileRegexps {
-			if regPattern.MatchString(strings.ToLower(file)) {
-				return true
-			}
-		}
+		return matchFileRegex(file, fileRegexps)
 	}
 
 	return false

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -651,8 +651,8 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 	vidExt := config.GetVideoExtensions()
 	imgExt := config.GetImageExtensions()
 	gExt := config.GetGalleryExtensions()
-	excludeVid := config.GetExcludes()
-	excludeImg := config.GetImageExcludes()
+	excludeVidRegex := generateRegexps(config.GetExcludes())
+	excludeImgRegex := generateRegexps(config.GetImageExcludes())
 
 	return utils.SymWalk(s.Path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -664,12 +664,12 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 			return nil
 		}
 
-		if !s.ExcludeVideo && matchExtension(path, vidExt) && !matchFile(path, excludeVid) {
+		if !s.ExcludeVideo && matchExtension(path, vidExt) && !matchFileRegex(path, excludeVidRegex) {
 			return f(path, info, err)
 		}
 
 		if !s.ExcludeImage {
-			if (matchExtension(path, imgExt) || matchExtension(path, gExt)) && !matchFile(path, excludeImg) {
+			if (matchExtension(path, imgExt) || matchExtension(path, gExt)) && !matchFileRegex(path, excludeImgRegex) {
 				return f(path, info, err)
 			}
 		}


### PR DESCRIPTION
Due to my abuse of the exclude regex to prevent scanning re scanning known duplicates (my config file contains 2580 excludes). I noticed the way the new code works re-compiles/generates the regex for each file scanned, rather than being cached.

This is a simple change to cache the generated exclude regex for each path scanned, rather than being recompiled for every file scanned.