### PR TITLE
Fix image thumbnail display

### DIFF
--- a/ui/v2.5/src/components/Images/styles.scss
+++ b/ui/v2.5/src/components/Images/styles.scss
@@ -46,7 +46,7 @@
 
     &-image {
       height: 100%;
-      object-fit: cover;
+      object-fit: contain;
       width: 100%;
     }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -138,9 +138,12 @@ textarea.text-input {
     }
 
     .gallery-card-image,
-    .tag-card-image,
-    .image-card-preview {
+    .tag-card-image {
       max-height: 240px;
+    }
+
+    .image-card-preview {
+      height: 240px;
     }
   }
 
@@ -156,9 +159,12 @@ textarea.text-input {
     }
 
     .gallery-card-image,
-    .tag-card-image,
-    .image-card-preview {
+    .tag-card-image {
       max-height: 360px;
+    }
+
+    .image-card-preview {
+      height: 360px;
     }
   }
 
@@ -174,9 +180,12 @@ textarea.text-input {
     }
 
     .tag-card-image,
-    .gallery-card-image,
-    .image-card-preview {
+    .gallery-card-image {
       max-height: 480px;
+    }
+
+    .image-card-preview {
+      height: 480px;
     }
   }
 }


### PR DESCRIPTION
Fixes the presentation of image thumbnails. Fixes issue where images with a certain aspect ratio would overlap the card title. Example image that caused this issue was 443x424.