### PR TITLE
Fix outstanding tagger issues

### DIFF
--- a/pkg/models/querybuilder_performer.go
+++ b/pkg/models/querybuilder_performer.go
@@ -175,6 +175,7 @@ func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, fin
 	query.body += `
 		left join performers_scenes as scenes_join on scenes_join.performer_id = performers.id
 		left join scenes on scenes_join.scene_id = scenes.id
+		left join performer_stash_ids on performer_stash_ids.performer_id = performers.id
 	`
 
 	if q := findFilter.Q; q != nil && *q != "" {
@@ -219,15 +220,14 @@ func (qb *PerformerQueryBuilder) Query(performerFilter *PerformerFilterType, fin
 			query.body += `left join performers_image on performers_image.performer_id = performers.id
 			`
 			query.addWhere("performers_image.performer_id IS NULL")
+		case "stash_id":
+			query.addWhere("performer_stash_ids.performer_id IS NULL")
 		default:
 			query.addWhere("performers." + *isMissingFilter + " IS NULL OR TRIM(performers." + *isMissingFilter + ") = ''")
 		}
 	}
 
 	if stashIDFilter := performerFilter.StashID; stashIDFilter != nil {
-		query.body += `
-			JOIN performer_stash_ids on performer_stash_ids.performer_id = performers.id
-		`
 		query.addWhere("performer_stash_ids.stash_id = ?")
 		query.addArg(stashIDFilter)
 	}

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -298,6 +298,7 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 		left join studios as studio on studio.id = scenes.studio_id
 		left join galleries as gallery on gallery.scene_id = scenes.id
 		left join scenes_tags as tags_join on tags_join.scene_id = scenes.id
+		left join scene_stash_ids on scene_stash_ids.scene_id = scenes.id
 	`
 
 	if q := findFilter.Q; q != nil && *q != "" {
@@ -356,6 +357,8 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 			query.addWhere("scenes.date IS \"\" OR scenes.date IS \"0001-01-01\"")
 		case "tags":
 			query.addWhere("tags_join.scene_id IS NULL")
+		case "stash_id":
+			query.addWhere("scene_stash_ids.scene_id IS NULL")
 		default:
 			query.addWhere("scenes." + *isMissingFilter + " IS NULL OR TRIM(scenes." + *isMissingFilter + ") = ''")
 		}
@@ -405,9 +408,6 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Fin
 	}
 
 	if stashIDFilter := sceneFilter.StashID; stashIDFilter != nil {
-		query.body += `
-			JOIN scene_stash_ids on scene_stash_ids.scene_id = scenes.id
-		`
 		query.addWhere("scene_stash_ids.stash_id = ?")
 		query.addArg(stashIDFilter)
 	}

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -158,6 +158,7 @@ func (qb *StudioQueryBuilder) Query(studioFilter *StudioFilterType, findFilter *
 	body := selectDistinctIDs("studios")
 	body += `
 		left join scenes on studios.id = scenes.studio_id		
+		left join studio_stash_ids on studio_stash_ids.studio_id = studios.id
 	`
 
 	if q := findFilter.Q; q != nil && *q != "" {
@@ -183,9 +184,6 @@ func (qb *StudioQueryBuilder) Query(studioFilter *StudioFilterType, findFilter *
 	}
 
 	if stashIDFilter := studioFilter.StashID; stashIDFilter != nil {
-		body += `
-			JOIN studio_stash_ids on studio_stash_ids.studio_id = studios.id
-		`
 		whereClauses = append(whereClauses, "studio_stash_ids.stash_id = ?")
 		args = append(args, stashIDFilter)
 	}
@@ -196,6 +194,8 @@ func (qb *StudioQueryBuilder) Query(studioFilter *StudioFilterType, findFilter *
 			body += `left join studios_image on studios_image.studio_id = studios.id
 			`
 			whereClauses = appendClause(whereClauses, "studios_image.studio_id IS NULL")
+		case "stash_id":
+			whereClauses = appendClause(whereClauses, "studio_stash_ids.studio_id IS NULL")
 		default:
 			whereClauses = appendClause(whereClauses, "studios."+*isMissingFilter+" IS NULL")
 		}

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -133,7 +133,7 @@ func (c Client) SubmitStashBoxFingerprints(sceneIDs []string, endpoint string) (
 		}
 
 		if scene == nil {
-			return false, fmt.Errorf("scene with id %d not found", idInt)
+			continue
 		}
 
 		stashIDs, err := jqb.GetSceneStashIDs(idInt)

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -93,21 +93,27 @@ func (c Client) FindStashBoxScenesByFingerprints(sceneIDs []string) ([]*models.S
 }
 
 func (c Client) findStashBoxScenesByFingerprints(fingerprints []string) ([]*models.ScrapedScene, error) {
-	scenes, err := c.client.FindScenesByFingerprints(context.TODO(), fingerprints)
-
-	if err != nil {
-		return nil, err
-	}
-
-	sceneFragments := scenes.FindScenesByFingerprints
-
 	var ret []*models.ScrapedScene
-	for _, s := range sceneFragments {
-		ss, err := sceneFragmentToScrapedScene(s)
+	for i := 0; i < len(fingerprints); i += 100 {
+		end := i + 100
+		if end > len(fingerprints) {
+			end = len(fingerprints)
+		}
+		scenes, err := c.client.FindScenesByFingerprints(context.TODO(), fingerprints[i:end])
+
 		if err != nil {
 			return nil, err
 		}
-		ret = append(ret, ss)
+
+		sceneFragments := scenes.FindScenesByFingerprints
+
+		for _, s := range sceneFragments {
+			ss, err := sceneFragmentToScrapedScene(s)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, ss)
+		}
 	}
 
 	return ret, nil

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -106,7 +106,10 @@ export const Performer: React.FC = () => {
     try {
       if (!isNew) {
         await updatePerformer({
-          variables: performerInput as GQL.PerformerUpdateInput,
+          variables: {
+            ...performerInput,
+            stash_ids: (performerInput?.stash_ids ?? []).map(s => ({ endpoint: s.endpoint, stash_id: s.stash_id })),
+          } as GQL.PerformerUpdateInput,
         });
         if (performerInput.image) {
           // Refetch image to bust browser cache

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -108,7 +108,10 @@ export const Performer: React.FC = () => {
         await updatePerformer({
           variables: {
             ...performerInput,
-            stash_ids: (performerInput?.stash_ids ?? []).map(s => ({ endpoint: s.endpoint, stash_id: s.stash_id })),
+            stash_ids: (performerInput?.stash_ids ?? []).map((s) => ({
+              endpoint: s.endpoint,
+              stash_id: s.stash_id,
+            })),
           } as GQL.PerformerUpdateInput,
         });
         if (performerInput.image) {

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -240,8 +240,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         if (img.status === 200) {
           const blob = await img.blob();
           // Sanity check on image size since bad images will fail
-          if (blob.size > 10000)
-            imgData = await blobToBase64(blob);
+          if (blob.size > 10000) imgData = await blobToBase64(blob);
         }
       }
 

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState, useReducer } from "react";
 import cx from "classnames";
 import { Button } from "react-bootstrap";
 import { uniq } from "lodash";
@@ -64,6 +64,16 @@ interface IStashSearchResultProps {
   queueFingerprintSubmission: (sceneId: string, endpoint: string) => void;
 }
 
+interface IPerformerReducerAction {
+  id: string;
+  data: PerformerOperation;
+}
+
+const performerReducer = (
+  state: Record<string, PerformerOperation>,
+  action: IPerformerReducerAction
+) => ({ ...state, [action.id]: action.data });
+
 const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   scene,
   stashScene,
@@ -78,9 +88,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   queueFingerprintSubmission,
 }) => {
   const [studio, setStudio] = useState<StudioOperation>();
-  const [performers, setPerformers] = useState<
-    Record<string, PerformerOperation>
-  >({});
+  const [performers, dispatch] = useReducer(performerReducer, {});
   const [saveState, setSaveState] = useState<string>("");
   const [error, setError] = useState<{ message?: string; details?: string }>(
     {}
@@ -96,11 +104,10 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   });
   const { data: allTags } = GQL.useAllTagsForFilterQuery();
 
-  const setPerformer = useCallback(
-    (performerData: PerformerOperation, performerID: string) =>
-      setPerformers({ ...performers, [performerID]: performerData }),
-    [performers]
-  );
+  const setPerformer = (
+    performerData: PerformerOperation,
+    performerID: string
+  ) => dispatch({ id: performerID, data: performerData });
 
   const handleSave = async () => {
     setError({});

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -239,7 +239,9 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         });
         if (img.status === 200) {
           const blob = await img.blob();
-          imgData = await blobToBase64(blob);
+          // Sanity check on image size since bad images will fail
+          if (blob.size > 10000)
+            imgData = await blobToBase64(blob);
         }
       }
 

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -132,6 +132,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
     { loading: submittingFingerprints },
   ] = GQL.useSubmitStashBoxFingerprintsMutation({
     onCompleted: (result) => {
+      setFingerprintError("");
       if (result.submitStashBoxFingerprints)
         clearSubmissionQueue(selectedEndpoint.endpoint);
     },

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -115,7 +115,8 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       })
       .catch(() => {
         setLoading(false);
-        const { [sceneID]: undefined, ...results } = searchResults;
+        // Destructure to remove existing result
+        const { [sceneID]: unassign, ...results } = searchResults;
         setSearchResults(results);
         setSearchErrors({
           ...searchErrors,

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -76,7 +76,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
   queueFingerprintSubmission,
   clearSubmissionQueue,
 }) => {
-  const [error, setError] = useState("");
+  const [fingerprintError, setFingerprintError] = useState("");
   const [loading, setLoading] = useState(false);
   const [queryString, setQueryString] = useState<Record<string, string>>({});
 
@@ -137,7 +137,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
         clearSubmissionQueue(selectedEndpoint.endpoint);
     },
     onError: () => {
-      setError("Network Error");
+      setFingerprintError("Network Error");
     },
   });
 
@@ -172,7 +172,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       selectedEndpoint.index
     ).catch(() => {
       setLoadingFingerprints(false);
-      setError("Network Error");
+      setFingerprintError("Network Error");
     });
     if (!results) return;
 
@@ -189,7 +189,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
 
     setFingerprints(newFingerprints);
     setLoadingFingerprints(false);
-    setError("");
+    setFingerprintError("");
   };
 
   const canFingerprintSearch = () =>
@@ -378,7 +378,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
         <div className="col-md-2">
           <b>Query</b>
         </div>
-        <b className="ml-auto mr-2 text-danger">{error}</b>
+        <b className="ml-auto mr-2 text-danger">{fingerprintError}</b>
         <div className="mr-2">
           {fingerprintQueue.length > 0 && (
             <Button

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -126,7 +126,6 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       });
 
     setLoading(true);
-    setError("");
   };
 
   const [
@@ -167,9 +166,6 @@ const TaggerList: React.FC<ITaggerListProps> = ({
     const sceneIDs = scenes
       .filter((s) => s.stash_ids.length === 0)
       .map((s) => s.id);
-
-    // clear search errors
-    setSearchErrors({});
 
     const results = await stashBoxBatchQuery(
       sceneIDs,

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -115,10 +115,6 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       })
       .catch(() => {
         setLoading(false);
-        setSearchResults({
-          ...searchResults,
-          [sceneID]: [],
-        });
         setSearchErrors({
           ...searchErrors,
           [sceneID]: "Network Error",
@@ -174,7 +170,11 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       setLoadingFingerprints(false);
       setFingerprintError("Network Error");
     });
+
     if (!results) return;
+
+    // clear search errors
+    setSearchErrors({});
 
     selectScenes(results.data?.queryStashBoxScene).forEach((scene) => {
       scene.fingerprints?.forEach((f) => {

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -115,6 +115,8 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       })
       .catch(() => {
         setLoading(false);
+        const { [sceneID]: undefined, ...results } = searchResults;
+        setSearchResults(results);
         setSearchErrors({
           ...searchErrors,
           [sceneID]: "Network Error",

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -159,9 +159,9 @@ export const sortScenesByDuration = (
 ) =>
   scenes.sort((a, b) => {
     const adur =
-      a?.duration ?? a?.fingerprints.map((f) => f.duration)?.[0] ?? null;
+      a?.duration || (a?.fingerprints.map((f) => f.duration)?.[0] ?? null);
     const bdur =
-      b?.duration ?? b?.fingerprints.map((f) => f.duration)?.[0] ?? null;
+      b?.duration || (b?.fingerprints.map((f) => f.duration)?.[0] ?? null);
     if (!adur && !bdur) return 0;
     if (adur && !bdur) return -1;
     if (!adur && bdur) return 1;

--- a/ui/v2.5/src/models/list-filter/criteria/is-missing.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/is-missing.ts
@@ -20,6 +20,7 @@ export class SceneIsMissingCriterion extends IsMissingCriterion {
     "movie",
     "performers",
     "tags",
+    "stash_id",
   ];
 }
 
@@ -103,7 +104,7 @@ export class TagIsMissingCriterionOption implements ICriterionOption {
 
 export class StudioIsMissingCriterion extends IsMissingCriterion {
   public type: CriterionType = "studioIsMissing";
-  public options: string[] = ["image"];
+  public options: string[] = ["image", "stash_id"];
 }
 
 export class StudioIsMissingCriterionOption implements ICriterionOption {


### PR DESCRIPTION
* Fixes issue where users could sometimes not save due to a state race-condition.
* Fixes duration sorting so closest match is sorted first.
* Adds is_missing stash_id filter for scene/performer/studio.
* Paginates fingerprint lookups so users can search for arbitrary amount of scenes.
* Disable `Match Fingerprint` button after search is performed, and show number of matches.

Resolves #903, #893, #915 