### PR TITLE
Fix image clean

### DIFF
--- a/pkg/manager/task_clean.go
+++ b/pkg/manager/task_clean.go
@@ -41,9 +41,7 @@ func (t *CleanTask) shouldClean(path string) bool {
 	// use image.FileExists for zip file checking
 	fileExists := image.FileExists(path)
 
-	if fileExists && t.getStashFromPath(path) != nil {
-		logger.Debugf("File Found: %s", path)
-	} else {
+	if !fileExists || t.getStashFromPath(path) == nil {
 		logger.Infof("File not found. Cleaning: \"%s\"", path)
 		return true
 	}
@@ -56,11 +54,6 @@ func (t *CleanTask) shouldCleanScene(s *models.Scene) bool {
 		return true
 	}
 
-	if matchFile(s.Path, config.GetExcludes()) {
-		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
-		return true
-	}
-
 	stash := t.getStashFromPath(s.Path)
 	if stash.ExcludeVideo {
 		logger.Infof("File in stash library that excludes video. Cleaning: \"%s\"", s.Path)
@@ -69,6 +62,11 @@ func (t *CleanTask) shouldCleanScene(s *models.Scene) bool {
 
 	if !matchExtension(s.Path, config.GetVideoExtensions()) {
 		logger.Infof("File extension does not match video extensions. Cleaning: \"%s\"", s.Path)
+		return true
+	}
+
+	if matchFile(s.Path, config.GetExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
 		return true
 	}
 
@@ -86,11 +84,6 @@ func (t *CleanTask) shouldCleanGallery(g *models.Gallery) bool {
 		return true
 	}
 
-	if matchFile(path, config.GetImageExcludes()) {
-		logger.Infof("File matched regex. Cleaning: \"%s\"", path)
-		return true
-	}
-
 	stash := t.getStashFromPath(path)
 	if stash.ExcludeImage {
 		logger.Infof("File in stash library that excludes images. Cleaning: \"%s\"", path)
@@ -99,6 +92,11 @@ func (t *CleanTask) shouldCleanGallery(g *models.Gallery) bool {
 
 	if !matchExtension(path, config.GetGalleryExtensions()) {
 		logger.Infof("File extension does not match gallery extensions. Cleaning: \"%s\"", path)
+		return true
+	}
+
+	if matchFile(path, config.GetImageExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", path)
 		return true
 	}
 
@@ -115,11 +113,6 @@ func (t *CleanTask) shouldCleanImage(s *models.Image) bool {
 		return true
 	}
 
-	if matchFile(s.Path, config.GetImageExcludes()) {
-		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
-		return true
-	}
-
 	stash := t.getStashFromPath(s.Path)
 	if stash.ExcludeImage {
 		logger.Infof("File in stash library that excludes images. Cleaning: \"%s\"", s.Path)
@@ -128,6 +121,11 @@ func (t *CleanTask) shouldCleanImage(s *models.Image) bool {
 
 	if !matchExtension(s.Path, config.GetImageExtensions()) {
 		logger.Infof("File extension does not match image extensions. Cleaning: \"%s\"", s.Path)
+		return true
+	}
+
+	if matchFile(s.Path, config.GetImageExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
 		return true
 	}
 

--- a/pkg/manager/task_clean.go
+++ b/pkg/manager/task_clean.go
@@ -43,10 +43,6 @@ func (t *CleanTask) shouldClean(path string) bool {
 
 	if fileExists && t.getStashFromPath(path) != nil {
 		logger.Debugf("File Found: %s", path)
-		if matchFile(path, config.GetExcludes()) {
-			logger.Infof("File matched regex. Cleaning: \"%s\"", path)
-			return true
-		}
 	} else {
 		logger.Infof("File not found. Cleaning: \"%s\"", path)
 		return true
@@ -57,6 +53,11 @@ func (t *CleanTask) shouldClean(path string) bool {
 
 func (t *CleanTask) shouldCleanScene(s *models.Scene) bool {
 	if t.shouldClean(s.Path) {
+		return true
+	}
+
+	if matchFile(s.Path, config.GetExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
 		return true
 	}
 
@@ -85,6 +86,11 @@ func (t *CleanTask) shouldCleanGallery(g *models.Gallery) bool {
 		return true
 	}
 
+	if matchFile(path, config.GetImageExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", path)
+		return true
+	}
+
 	stash := t.getStashFromPath(path)
 	if stash.ExcludeImage {
 		logger.Infof("File in stash library that excludes images. Cleaning: \"%s\"", path)
@@ -106,6 +112,11 @@ func (t *CleanTask) shouldCleanGallery(g *models.Gallery) bool {
 
 func (t *CleanTask) shouldCleanImage(s *models.Image) bool {
 	if t.shouldClean(s.Path) {
+		return true
+	}
+
+	if matchFile(s.Path, config.GetImageExcludes()) {
+		logger.Infof("File matched regex. Cleaning: \"%s\"", s.Path)
 		return true
 	}
 

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -423,7 +423,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
         </Form.Group>
 
         <Form.Group>
-          <h6>Excluded Patterns</h6>
+          <h6>Excluded Video Patterns</h6>
           <ExclusionPatterns excludes={excludes} setExcludes={setExcludes} />
           <Form.Text className="text-muted">
             Regexps of video files/paths to exclude from Scan and add to Clean


### PR DESCRIPTION
The clean task was using the video exclusion patterns when checking images and galleries. This meant that images and galleries could be scanned into the system, then subsequently cleaned out. Changed so that clean task checks the correct exclusion patterns for the file type.