### PR TITLE
Migrate PR build storage from transfer.sh to Gofile.io

### DIFF
--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -8,7 +8,7 @@ uploadFile()
     # get available server from gofile api
     server=$(curl https://apiv2.gofile.io/getServer |cut -d "," -f 2  | cut -d "\"" -f 6)
     # abort if it takes more than two minutes to upload
-    uploadedTo=$(curl -m 120 -F "email=stash@example.com" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
+    uploadedTo=$(curl -m 120 -F "email=stash@stashapp.cc" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
     resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)
     if [ $resp = "ok" ] ; then
 	URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -6,11 +6,16 @@ uploadFile()
     FILE=$1
     BASENAME="$(basename "${FILE}")"
     # abort if it takes more than two minutes to upload
-    uploadedTo=`curl -m 120 --upload-file $FILE "https://oshi.at/$BASENAME/20160"`
-    CDN=`echo "$uploadedTo"|grep CDN`
-    echo "$BASENAME uploaded to url: $CDN"
+    server=$(curl https://apiv2.gofile.io/getServer |cut -d "," -f 2  | cut -d "\"" -f 6)
+    uploadedTo=$(curl -m 120 -F "email=stash@example.com" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
+    resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)
+    URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)
+    if [ $resp = "ok" ] ; then
+	    echo -e "$BASENAME uploaded to url: \"https://gofile.io/d/$URL\"\n\n"
+    fi
 }
 
 uploadFile "dist/stash-osx"
 uploadFile "dist/stash-win.exe"
 uploadFile "dist/stash-linux"
+

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -12,11 +12,12 @@ uploadFile()
     resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)
     URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)
     if [ $resp = "ok" ] ; then
-	    echo -e "$BASENAME uploaded to url: \"https://gofile.io/d/$URL\"\n\n"
+	    echo "$BASENAME uploaded to url: \"https://gofile.io/d/$URL\""
+	    # print an extra newline
+	    echo
     fi
 }
 
 uploadFile "dist/stash-osx"
 uploadFile "dist/stash-win.exe"
 uploadFile "dist/stash-linux"
-

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -6,7 +6,7 @@ uploadFile()
     FILE=$1
     BASENAME="$(basename "${FILE}")"
     # abort if it takes more than two minutes to upload
-    uploadedTo=`curl -m 120 --upload-file $FILE "https://oshi.at/$BASENAME/10000"`
+    uploadedTo=`curl -m 120 --upload-file $FILE "https://oshi.at/$BASENAME/20160"`
     CDN=`echo "$uploadedTo"|grep CDN`
     echo "$BASENAME uploaded to url: $CDN"
 }

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -10,12 +10,13 @@ uploadFile()
     # abort if it takes more than two minutes to upload
     uploadedTo=$(curl -m 120 -F "email=stash@example.com" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
     resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)
-    URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)
     if [ $resp = "ok" ] ; then
-	    echo "$BASENAME uploaded to url: \"https://gofile.io/d/$URL\""
-	    # print an extra newline
-	    echo
+	URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)
+	echo "$BASENAME uploaded to url: \"https://gofile.io/d/$URL\""
     fi
+    # print an extra newline
+    echo
+
 }
 
 uploadFile "dist/stash-osx"

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -6,8 +6,9 @@ uploadFile()
     FILE=$1
     BASENAME="$(basename "${FILE}")"
     # abort if it takes more than two minutes to upload
-    uploadedTo=`curl -m 120 --upload-file $FILE "https://transfer.sh/$BASENAME"`
-    echo "$BASENAME uploaded to url: $uploadedTo"
+    uploadedTo=`curl -m 120 --upload-file $FILE "https://oshi.at/$BASENAME/10000"`
+    CDN=`echo "$uploadedTo"|grep CDN`
+    echo "$BASENAME uploaded to url: $CDN"
 }
 
 uploadFile "dist/stash-osx"

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -5,8 +5,9 @@ uploadFile()
 {
     FILE=$1
     BASENAME="$(basename "${FILE}")"
-    # abort if it takes more than two minutes to upload
+    # get available server from gofile api
     server=$(curl https://apiv2.gofile.io/getServer |cut -d "," -f 2  | cut -d "\"" -f 6)
+    # abort if it takes more than two minutes to upload
     uploadedTo=$(curl -m 120 -F "email=stash@example.com" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
     resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)
     URL=$(echo "$uploadedTo"|cut -d "," -f 2 | cut -d "\"" -f 6)


### PR DESCRIPTION
Since transfer.sh is EOL oshi.at was the most compatible i could find to store the PR builds.