### PR TITLE
Add equals/not equals string criteria

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -250,6 +250,8 @@ export class StringCriterion extends Criterion {
   public modifierOptions = [
     StringCriterion.getModifierOption(CriterionModifier.Equals),
     StringCriterion.getModifierOption(CriterionModifier.NotEquals),
+    StringCriterion.getModifierOption(CriterionModifier.Includes),
+    StringCriterion.getModifierOption(CriterionModifier.Excludes),
     StringCriterion.getModifierOption(CriterionModifier.IsNull),
     StringCriterion.getModifierOption(CriterionModifier.NotNull),
   ];
@@ -272,36 +274,6 @@ export class StringCriterion extends Criterion {
     } else {
       this.parameterName = type;
     }
-  }
-
-  public static getModifierOption(
-    modifier: CriterionModifier = CriterionModifier.Equals
-  ): ILabeledValue {
-    switch (modifier) {
-      case CriterionModifier.Equals:
-        return { value: CriterionModifier.Equals, label: "Includes" };
-      case CriterionModifier.NotEquals:
-        return { value: CriterionModifier.NotEquals, label: "Excludes" };
-      default:
-        return super.getModifierOption(modifier);
-    }
-  }
-
-  public getLabel(): string {
-    let modifierString: string;
-    switch (this.modifier) {
-      case CriterionModifier.Equals:
-        modifierString = "includes";
-        break;
-      case CriterionModifier.NotEquals:
-        modifierString = "excludes";
-        break;
-      default:
-        return super.getLabel();
-    }
-
-    const valueString = this.getLabelValue();
-    return `${Criterion.getLabel(this.type)} ${modifierString} ${valueString}`;
   }
 }
 

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -329,10 +329,7 @@ export class ListFilterModel {
       }
 
       jsonParameters.forEach((jsonString) => {
-        // make sure we escape \
-        const escaped = jsonString.replaceAll("\\", "\\\\");
-
-        const encodedCriterion = JSON.parse(escaped);
+        const encodedCriterion = JSON.parse(jsonString);
         const criterion = makeCriteria(encodedCriterion.type);
         // it's possible that we have unsupported criteria. Just skip if so.
         if (criterion) {

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -29,7 +29,9 @@ export interface ILabeledValue {
 }
 
 export function encodeILabeledId(o: ILabeledId) {
-  return { ...o, label: encodeURIComponent(o.label) };
+  // escape \ to \\ so that it encodes to JSON correctly
+  const adjustedLabel = o.label.replaceAll("\\", "\\\\");
+  return { ...o, label: encodeURIComponent(adjustedLabel) };
 }
 
 export interface IOptionType {

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -29,7 +29,7 @@ const makePerformersCountryUrl = (
   if (!performer.id) return "#";
   const filter = new ListFilterModel(FilterMode.Performers);
   const criterion = new CountryCriterion();
-  criterion.value = `${performer.country}`;
+  criterion.value = `"${performer.country}"`;
   filter.criteria.push(criterion);
   return `/performers?${filter.makeQueryParameters()}`;
 };

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -29,7 +29,7 @@ const makePerformersCountryUrl = (
   if (!performer.id) return "#";
   const filter = new ListFilterModel(FilterMode.Performers);
   const criterion = new CountryCriterion();
-  criterion.value = `"${performer.country}"`;
+  criterion.value = `${performer.country}`;
   filter.criteria.push(criterion);
   return `/performers?${filter.makeQueryParameters()}`;
 };


### PR DESCRIPTION
The existing behaviour of string criteria was to treat `EQUALS`/`NOT EQUALS` as a wildcard search. I have moved this behaviour into `INCLUDES`/`EXCLUDES` and changed `EQUALS`/`NOT EQUALS` to be a direct comparison.

Fixed criteria encoding so that quotes are correctly encoded.

Fixes #910 