### PR TITLE
Abort PR upload if no server is available

### DIFF
--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -5,8 +5,19 @@ uploadFile()
 {
     FILE=$1
     BASENAME="$(basename "${FILE}")"
+    
     # get available server from gofile api
-    server=$(curl https://apiv2.gofile.io/getServer |cut -d "," -f 2  | cut -d "\"" -f 6)
+    serverApi=$(curl https://apiv2.gofile.io/getServer)
+    resp=$(echo "$serverApi" | cut -d "\"" -f 4)
+    
+    # if no server is available abort
+    if [ $resp != "ok" ] ; then
+	echo "Upload of $BASENAME failed! Server not available."
+	echo
+	return
+    fi
+    server=$(echo "$serverApi" | cut -d "," -f 2  | cut -d "\"" -f 6)
+
     # abort if it takes more than two minutes to upload
     uploadedTo=$(curl -m 120 -F "email=stash@stashapp.cc" -F "file=@$FILE" "https://$server.gofile.io/uploadFile")
     resp=$(echo "$uploadedTo" | cut -d "\"" -f 4)

--- a/scripts/upload-pull-request.sh
+++ b/scripts/upload-pull-request.sh
@@ -7,7 +7,7 @@ uploadFile()
     BASENAME="$(basename "${FILE}")"
     
     # get available server from gofile api
-    serverApi=$(curl https://apiv2.gofile.io/getServer)
+    serverApi=$(curl -m 15 https://apiv2.gofile.io/getServer)
     resp=$(echo "$serverApi" | cut -d "\"" -f 4)
     
     # if no server is available abort


### PR DESCRIPTION
Sometimes, not often, gofile is busy and the upload is not working.
The api returns `{"status":"error","data":{}}` in those cases so we should abort the upload with an error message when that happens.