### PR TITLE
Prevent studio parent id and scene rating from being unset when tagged

### DIFF
--- a/graphql/documents/data/studio-slim.graphql
+++ b/graphql/documents/data/studio-slim.graphql
@@ -6,4 +6,7 @@ fragment SlimStudioData on Studio {
     endpoint
     stash_id
   }
+  parent_studio {
+    id
+  }
 }

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -143,7 +143,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
       studioID = studioCreateResult.data.studioCreate.id;
     } else if (studio.type === "update") {
       setSaveState("Saving studio stashID");
-      const res = await updateStudioStashID(studio.data.id, [
+      const res = await updateStudioStashID(studio.data, [
         ...studio.data.stash_ids,
         { stash_id: scene.studio.stash_id, endpoint },
       ]);
@@ -284,6 +284,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
           cover_image: imgData,
           url: scene.url,
           tag_ids: updatedTags,
+          rating: stashScene.rating,
           stash_ids: [
             ...(stashScene?.stash_ids ?? []),
             {

--- a/ui/v2.5/src/components/Tagger/queries.ts
+++ b/ui/v2.5/src/components/Tagger/queries.ts
@@ -111,7 +111,10 @@ export const useUpdateStudioStashID = () => {
     onError: (errors) => errors,
   });
 
-  const handleUpdate = (studio: GQL.SlimStudioDataFragment, stashIDs: GQL.StashIdInput[]) =>
+  const handleUpdate = (
+    studio: GQL.SlimStudioDataFragment,
+    stashIDs: GQL.StashIdInput[]
+  ) =>
     updateStudio({
       variables: {
         id: studio.id,

--- a/ui/v2.5/src/components/Tagger/queries.ts
+++ b/ui/v2.5/src/components/Tagger/queries.ts
@@ -111,10 +111,11 @@ export const useUpdateStudioStashID = () => {
     onError: (errors) => errors,
   });
 
-  const handleUpdate = (studioID: string, stashIDs: GQL.StashIdInput[]) =>
+  const handleUpdate = (studio: GQL.SlimStudioDataFragment, stashIDs: GQL.StashIdInput[]) =>
     updateStudio({
       variables: {
-        id: studioID,
+        id: studio.id,
+        parent_id: studio.parent_studio?.id,
         stash_ids: stashIDs.map((s) => ({
           stash_id: s.stash_id,
           endpoint: s.endpoint,


### PR DESCRIPTION
Studio parentid and scene rating get nulled if not provided when updating, so the tagger needs to set them.