### PR TITLE
Prevent movie link from being wiped when tagging scene

### DIFF
--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -285,6 +285,10 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
           url: scene.url,
           tag_ids: updatedTags,
           rating: stashScene.rating,
+          movies: stashScene.movies.map((m) => ({
+            movie_id: m.movie.id,
+            scene_index: m.scene_index,
+          })),
           stash_ids: [
             ...(stashScene?.stash_ids ?? []),
             {


### PR DESCRIPTION
Should be the last property that was unhandled.