### PR TITLE
Fix image memory issue

### DIFF
--- a/graphql/documents/mutations/image.graphql
+++ b/graphql/documents/mutations/image.graphql
@@ -16,7 +16,7 @@ mutation ImageUpdate(
                         performer_ids: $performer_ids,
                         tag_ids: $tag_ids
                       }) {
-      ...ImageData
+      ...SlimImageData
   }
 }
 
@@ -38,13 +38,13 @@ mutation BulkImageUpdate(
                         performer_ids: $performer_ids,
                         tag_ids: $tag_ids
                       }) {
-      ...ImageData
+      ...SlimImageData
   }
 }
 
 mutation ImagesUpdate($input : [ImageUpdateInput!]!) {
   imagesUpdate(input: $input) {
-    ...ImageData
+    ...SlimImageData
   }
 }
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -90,11 +90,15 @@ func openSourceImage(path string) (io.ReadCloser, error) {
 			return nil, err
 		}
 
+		// defer closing of zip to the calling function, unless an error
+		// is returned, in which case it should be closed immediately
+
 		// find the file matching the filename
 		for _, f := range r.File {
 			if f.Name == filename {
 				src, err := f.Open()
 				if err != nil {
+					r.Close()
 					return nil, err
 				}
 				return &imageReadCloser{
@@ -104,6 +108,7 @@ func openSourceImage(path string) (io.ReadCloser, error) {
 			}
 		}
 
+		r.Close()
 		return nil, fmt.Errorf("file with name '%s' not found in zip file '%s'", filename, zipFilename)
 	}
 

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -67,6 +67,7 @@ func walkGalleryZip(path string, walkFunc func(file *zip.File) error) error {
 	if err != nil {
 		return err
 	}
+	defer readCloser.Close()
 
 	for _, file := range readCloser.File {
 		if file.FileInfo().IsDir() {


### PR DESCRIPTION
The (bulk) Image update client mutations were returning the full image data. The full image data includes the full gallery data, which in turn includes _slim_ image data. When performing a bulk image update with a large number of images within galleries, the memory use would explode while trying to marshal all of the data. 

Changed the return values to be slim image data instead.

To reproduce the original issue, need to have a zip with a large amount of images (I had one with just under 1000 images). Query for images in this zip, setting page size to 1000. Select all, edit to add a performer and click apply.

Also included plugs for some potential unrelated memory leaks when opening zip files.