### PR TITLE
Only set stash from env if not set

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -131,10 +131,14 @@ func initEnvs() {
 	viper.BindEnv("host")          // STASH_HOST
 	viper.BindEnv("port")          // STASH_PORT
 	viper.BindEnv("external_host") // STASH_EXTERNAL_HOST
-	viper.BindEnv("stash")         // STASH_STASH
 	viper.BindEnv("generated")     // STASH_GENERATED
 	viper.BindEnv("metadata")      // STASH_METADATA
 	viper.BindEnv("cache")         // STASH_CACHE
+
+	// only set stash config flag if not already set
+	if config.GetStashPaths() == nil {
+		viper.BindEnv("stash") // STASH_STASH
+	}
 }
 
 func initFFMPEG() {


### PR DESCRIPTION
Fixes #936 

Changes the startup so that it only sets the stash libraries from the `STASH_STASH` environment variable if there is not already a stash library set in the config. Means that `STASH_STASH` will be used when the app is started for the first time, and afterwards will be ignored unless all stash library paths are removed from the config.