### PR TITLE
Update findGalleries to only fetch imageCount instead of all images

### DIFF
--- a/graphql/documents/data/gallery-slim.graphql
+++ b/graphql/documents/data/gallery-slim.graphql
@@ -1,0 +1,28 @@
+fragment GallerySlimData on Gallery {
+  id
+  checksum
+  path
+  title
+  date
+  url
+  details
+  rating
+  image_count
+  cover {
+    ...SlimImageData
+  }
+  studio {
+    ...StudioData
+  }
+  tags {
+    ...TagData
+  }
+  performers {
+    ...PerformerData
+  }
+  scene {
+    id
+    title
+    path
+  }
+}

--- a/graphql/documents/queries/gallery.graphql
+++ b/graphql/documents/queries/gallery.graphql
@@ -2,7 +2,7 @@ query FindGalleries($filter: FindFilterType, $gallery_filter: GalleryFilterType)
   findGalleries(gallery_filter: $gallery_filter, filter: $filter) {
     count
     galleries {
-      ...GalleryData
+      ...GallerySlimData
     }
   }
 }

--- a/graphql/schema/types/gallery.graphql
+++ b/graphql/schema/types/gallery.graphql
@@ -10,6 +10,7 @@ type Gallery {
   rating: Int
   scene: Scene
   studio: Studio
+  image_count: Int!
   tags: [Tag!]!
   performers: [Performer!]!
 

--- a/pkg/api/resolver_model_gallery.go
+++ b/pkg/api/resolver_model_gallery.go
@@ -108,3 +108,8 @@ func (r *galleryResolver) Performers(ctx context.Context, obj *models.Gallery) (
 	qb := models.NewPerformerQueryBuilder()
 	return qb.FindByGalleryID(obj.ID, nil)
 }
+
+func (r *galleryResolver) ImageCount(ctx context.Context, obj *models.Gallery) (int, error) {
+	qb := models.NewImageQueryBuilder()
+	return qb.CountByGalleryID(obj.ID)
+}

--- a/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
@@ -10,7 +10,7 @@ import MultiSet from "../Shared/MultiSet";
 import { RatingStars } from "../Scenes/SceneDetails/RatingStars";
 
 interface IListOperationProps {
-  selected: GQL.GalleryDataFragment[];
+  selected: GQL.GallerySlimDataFragment[];
   onClose: (applied: boolean) => void;
 }
 
@@ -134,11 +134,11 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     setIsUpdating(false);
   }
 
-  function getRating(state: GQL.GalleryDataFragment[]) {
+  function getRating(state: GQL.GallerySlimDataFragment[]) {
     let ret: number | undefined;
     let first = true;
 
-    state.forEach((gallery: GQL.GalleryDataFragment) => {
+    state.forEach((gallery) => {
       if (first) {
         ret = gallery.rating ?? undefined;
         first = false;
@@ -150,11 +150,11 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getStudioId(state: GQL.GalleryDataFragment[]) {
+  function getStudioId(state: GQL.GallerySlimDataFragment[]) {
     let ret: string | undefined;
     let first = true;
 
-    state.forEach((gallery: GQL.GalleryDataFragment) => {
+    state.forEach((gallery) => {
       if (first) {
         ret = gallery?.studio?.id;
         first = false;
@@ -169,11 +169,11 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getPerformerIds(state: GQL.GalleryDataFragment[]) {
+  function getPerformerIds(state: GQL.GallerySlimDataFragment[]) {
     let ret: string[] = [];
     let first = true;
 
-    state.forEach((gallery: GQL.GalleryDataFragment) => {
+    state.forEach((gallery) => {
       if (first) {
         ret = gallery.performers
           ? gallery.performers.map((p) => p.id).sort()
@@ -193,11 +193,11 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getTagIds(state: GQL.GalleryDataFragment[]) {
+  function getTagIds(state: GQL.GallerySlimDataFragment[]) {
     let ret: string[] = [];
     let first = true;
 
-    state.forEach((gallery: GQL.GalleryDataFragment) => {
+    state.forEach((gallery) => {
       if (first) {
         ret = gallery.tags ? gallery.tags.map((t) => t.id).sort() : [];
         first = false;
@@ -221,7 +221,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     let updateTagIds: string[] = [];
     let first = true;
 
-    state.forEach((gallery: GQL.GalleryDataFragment) => {
+    state.forEach((gallery: GQL.GallerySlimDataFragment) => {
       const galleryRating = gallery.rating;
       const GalleriestudioID = gallery?.studio?.id;
       const galleryPerformerIDs = (gallery.performers ?? [])

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -8,7 +8,7 @@ import { HoverPopover, Icon, TagLink } from "../Shared";
 import { BasicCard } from "../Shared/BasicCard";
 
 interface IProps {
-  gallery: GQL.GalleryDataFragment;
+  gallery: GQL.GallerySlimDataFragment;
   selecting?: boolean;
   selected: boolean | undefined;
   zoomIndex: number;
@@ -164,9 +164,9 @@ export const GalleryCard: React.FC<IProps> = (props) => {
             </h5>
           </Link>
           <span>
-            {props.gallery.images.length}&nbsp;
+            {props.gallery.image_count}&nbsp;
             <FormattedPlural
-              value={props.gallery.images.length ?? 0}
+              value={props.gallery.image_count}
               one="image"
               other="images"
             />

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -4,7 +4,7 @@ import { Table } from "react-bootstrap";
 import { Link, useHistory } from "react-router-dom";
 import {
   FindGalleriesQueryResult,
-  GalleryDataFragment,
+  GallerySlimDataFragment,
 } from "src/core/generated-graphql";
 import { useGalleriesList } from "src/hooks";
 import { showWhenSelected } from "src/hooks/ListHook";
@@ -127,7 +127,7 @@ export const GalleryList: React.FC<IGalleryList> = ({
   }
 
   function renderEditGalleriesDialog(
-    selectedImages: GalleryDataFragment[],
+    selectedImages: GallerySlimDataFragment[],
     onClose: (applied: boolean) => void
   ) {
     return (
@@ -138,7 +138,7 @@ export const GalleryList: React.FC<IGalleryList> = ({
   }
 
   function renderDeleteGalleriesDialog(
-    selectedImages: GalleryDataFragment[],
+    selectedImages: GallerySlimDataFragment[],
     onClose: (confirmed: boolean) => void
   ) {
     return (
@@ -200,8 +200,8 @@ export const GalleryList: React.FC<IGalleryList> = ({
                 </td>
                 <td className="d-none d-sm-block">
                   <Link to={`/galleries/${gallery.id}`}>
-                    {gallery.title ?? gallery.path} ({gallery.images.length}{" "}
-                    {gallery.images.length === 1 ? "image" : "images"})
+                    {gallery.title ?? gallery.path} ({gallery.image_count}{" "}
+                    {gallery.image_count === 1 ? "image" : "images"})
                   </Link>
                 </td>
               </tr>

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -6,7 +6,7 @@ import { useHistory, useLocation } from "react-router-dom";
 import {
   SlimSceneDataFragment,
   SceneMarkerDataFragment,
-  GalleryDataFragment,
+  GallerySlimDataFragment,
   StudioDataFragment,
   PerformerDataFragment,
   FindScenesQueryResult,
@@ -567,9 +567,9 @@ export const useImagesList = (
   });
 
 export const useGalleriesList = (
-  props: IListHookOptions<FindGalleriesQueryResult, GalleryDataFragment>
+  props: IListHookOptions<FindGalleriesQueryResult, GallerySlimDataFragment>
 ) =>
-  useList<FindGalleriesQueryResult, GalleryDataFragment>({
+  useList<FindGalleriesQueryResult, GallerySlimDataFragment>({
     ...props,
     filterMode: FilterMode.Galleries,
     useData: useFindGalleries,


### PR DESCRIPTION
Massively speeds up findGalleries for galleries that have a lot of images. Kudos to @bnkai for catching that.