### PR TITLE
Add type policies for apollo cache

### DIFF
--- a/ui/v2.5/src/core/createClient.ts
+++ b/ui/v2.5/src/core/createClient.ts
@@ -4,11 +4,70 @@ import {
   split,
   from,
   ServerError,
+  TypePolicies,
 } from "@apollo/client";
 import { WebSocketLink } from "@apollo/client/link/ws";
 import { onError } from "@apollo/client/link/error";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { createUploadLink } from "apollo-upload-client";
+
+// Policies that tell apollo what the type of the returned object will be.
+// In many cases this allows it to return from cache immediately rather than fetching.
+const typePolicies: TypePolicies = {
+  Query: {
+    fields: {
+      findImage: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Image",
+            id: args?.id,
+          }),
+      },
+      findPerformer: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Performer",
+            id: args?.id,
+          }),
+      },
+      findStudio: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Studio",
+            id: args?.id,
+          }),
+      },
+      findMovie: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Movie",
+            id: args?.id,
+          }),
+      },
+      findGallery: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Gallery",
+            id: args?.id,
+          }),
+      },
+      findScene: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Scene",
+            id: args?.id,
+          }),
+      },
+      findTag: {
+        read: (_, { args, toReference }) =>
+          toReference({
+            __typename: "Tag",
+            id: args?.id,
+          }),
+      },
+    },
+  },
+};
 
 export const getPlatformURL = (ws?: boolean) => {
   const platformUrl = new URL(window.location.origin);
@@ -73,7 +132,7 @@ export const createClient = () => {
 
   const link = from([errorLink, splitLink]);
 
-  const cache = new InMemoryCache();
+  const cache = new InMemoryCache({ typePolicies });
   const client = new ApolloClient({
     link,
     cache,


### PR DESCRIPTION
When going from a list view to an item the data will usually be in the cache, but since apollo doesn't know what that they're the same it will always refetch it. By using Type Policies we can tell apollo what the type of the query will be so that it can check the cache before running the query.

It's most notable when going from the gallery grid view to an individual image, but it also gets rid of the flashing loading indicator when going  from the performer grid to a performer. It will of course have even more impact when accessing stash remotely.