### PR TITLE
Fix oversized movie images on scrape dialog

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
@@ -180,13 +180,13 @@ export const MovieScrapeDialog: React.FC<IMovieScrapeDialogProps> = (
         />
         <ScrapedImageRow
           title="Front Image"
-          className="front-image"
+          className="movie-image"
           result={frontImage}
           onChange={(value) => setFrontImage(value)}
         />
         <ScrapedImageRow
           title="Back Image"
-          className="front-image"
+          className="movie-image"
           result={backImage}
           onChange={(value) => setBackImage(value)}
         />

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -252,6 +252,10 @@ textarea.scene-description {
   max-width: 100%;
 }
 
+.movie-image {
+  max-width: 100%;
+}
+
 .movie-table {
   width: 100%;
 


### PR DESCRIPTION
Images are censored:
[Before](https://user-images.githubusercontent.com/66393006/100120366-8d861b80-2e80-11eb-9a98-6df336ae57e7.jpg)
[After](https://user-images.githubusercontent.com/66393006/100120373-8eb74880-2e80-11eb-9d8d-3378ceb7b83b.jpg)
