### PR TITLE
Show studio as text in scene cards where studio image isn't set

### DIFF
--- a/pkg/api/resolver_model_studio.go
+++ b/pkg/api/resolver_model_studio.go
@@ -24,6 +24,19 @@ func (r *studioResolver) URL(ctx context.Context, obj *models.Studio) (*string, 
 func (r *studioResolver) ImagePath(ctx context.Context, obj *models.Studio) (*string, error) {
 	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 	imagePath := urlbuilders.NewStudioURLBuilder(baseURL, obj.ID).GetStudioImageURL()
+
+	qb := models.NewStudioQueryBuilder()
+	hasImage, err := qb.HasStudioImage(obj.ID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// indicate that image is missing by setting default query param to true
+	if !hasImage {
+		imagePath = imagePath + "?default=true"
+	}
+
 	return &imagePath, nil
 }
 

--- a/pkg/api/routes_studio.go
+++ b/pkg/api/routes_studio.go
@@ -26,10 +26,14 @@ func (rs studioRoutes) Routes() chi.Router {
 func (rs studioRoutes) Image(w http.ResponseWriter, r *http.Request) {
 	studio := r.Context().Value(studioKey).(*models.Studio)
 	qb := models.NewStudioQueryBuilder()
-	image, _ := qb.GetStudioImage(studio.ID, nil)
-
+	var image []byte
 	defaultParam := r.URL.Query().Get("default")
-	if len(image) == 0 || defaultParam == "true" {
+
+	if defaultParam != "true" {
+		image, _ = qb.GetStudioImage(studio.ID, nil)
+	}
+
+	if len(image) == 0 {
 		_, image, _ = utils.ProcessBase64Image(models.DefaultStudioImage)
 	}
 

--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -296,3 +296,12 @@ func (qb *StudioQueryBuilder) GetStudioImage(studioID int, tx *sqlx.Tx) ([]byte,
 	query := `SELECT image from studios_image WHERE studio_id = ?`
 	return getImage(tx, query, studioID)
 }
+
+func (qb *StudioQueryBuilder) HasStudioImage(studioID int) (bool, error) {
+	ret, err := runCountQuery(buildCountQuery("SELECT studio_id from studios_image WHERE studio_id = ?"), []interface{}{studioID})
+	if err != nil {
+		return false, err
+	}
+
+	return ret == 1, nil
+}

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -1,4 +1,5 @@
 ### 🎨 Improvements
+* Show scene studio as text where image is missing.
 * Use natural sort for titles and movie names.
 * Support optional preview and sprite generation during scanning.
 * Support configurable number of threads for scanning and generation.

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -69,8 +69,14 @@ export const SceneCard: React.FC<ISceneCardProps> = (
   props: ISceneCardProps
 ) => {
   const config = useConfiguration();
+
+  // studio image is missing if it uses the default
+  const missingStudioImage = props.scene.studio?.image_path?.endsWith(
+    "?default=true"
+  );
   const showStudioAsText =
-    config?.data?.configuration.interface.showStudioAsText ?? false;
+    missingStudioImage ||
+    (config?.data?.configuration.interface.showStudioAsText ?? false);
 
   function maybeRenderRatingBanner() {
     if (!props.scene.rating) {


### PR DESCRIPTION
Currently, studios are shown as the default image on scene cards if there is no studio image set. This PR changes that behaviour to show the studio title instead, in the same way as if "Show Studio as text" is checked in the settings.