### PR TITLE
Tune image referrer path

### DIFF
--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -100,7 +100,7 @@ func getImage(url string, globalConfig GlobalConfig) (*string, error) {
 
 	// set the host of the URL as the referer
 	if req.URL.Scheme != "" {
-		req.Header.Set("Referer", req.URL.Scheme+"://"+req.Host)
+		req.Header.Set("Referer", req.URL.Scheme+"://"+req.Host+"/")
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
Very minor change needed for a specific site , mentioned in discord

```yaml
name: "Minnano-AV (JAV)"
performerByName:
  action: scrapeXPath
  queryURL: http://www.minnano-av.com/search_result.php?search_scope=actress&search_word={}
  scraper: performerSearch
performerByURL:
  - action: scrapeXPath
    url: 
      - http://www.minnano-av.com/
    scraper: performerScraper

xPathScrapers:
  performerSearch:
    performer:
      Name: //tbody/tr/td/p[@class="furi"]|//div[@class="act-profile"]/table/tbody/tr[1]/td/h2/text()
      URL: 
        selector: //tbody/tr/td/h2[@class="ttl"]/a/@href|//form[@class="add_favorite"]/@action
        postProcess:
          - replace:
            - regex: (actress)(\d+)(.+)
              with: $2
            - regex: (.+=)(.+)
              with: $2
            - regex: ^
              with: "http://www.minnano-av.com/actress"
            - regex: $
              with: ".html"
  performerScraper:
    performer:
      #Name: 
      #  selector: //div[@class="act-profile"]/table/tbody/tr[1]/td/h2/text()
        # $1 Name in Jap | $3 Aliases name in Jap? | $5 Name in Latin script
      #  postProcess:
      #    - replace:
      #      - regex: (.+)(\s（)(.+)(\s\/\s)(.+)(）)
      #        with: $5
      Aliases: 
        selector: //div[@class="act-profile"]/table/tbody/tr[1]/td/h2/text()
        postProcess:
          - replace:
            - regex: (.+)(\s（)(.+)(\s\/\s)(.+)(）)
              with: $1,$3
      URL: 
        selector: //form[@class="add_favorite"]/@action
        postProcess:
          - replace:
            - regex: (.+=)(.+)
              with: http://www.minnano-av.com/actress$2
            - regex: $
              with: ".html"
      Twitter: //span[text()='ブログ']/../p/a[contains(@href,'twitter.com')]/@href
      Instagram: //span[text()='ブログ']/../p/a[contains(@href,'instagram.com')]/@href
      Birthdate:
        selector: //span[text()='生年月日']/../p/a/@href
        postProcess:
            - replace:
                - regex: (.+=)(.+)
                  with: $2
      Height: 
        selector: //span[text()='サイズ']/../p/text()[1]
        postProcess:
          - replace:
            - regex: (T)(\d+)(.+)
              with: $2
      Measurements: 
        selector: //span[text()='サイズ']/../p/a/@href|//span[text()='サイズ']/../p/text()
        concat: "|"
        postProcess:
          - replace:
            - regex: (.+=)(\w*)(.+B)(\d*)(.+W)(\d*)(.+H)(\d*)(.+)
              with: $4$2-$6-$8
      CareerLength: 
        selector: //span[text()='AV出演期間']/../p/text()
        postProcess:
          - replace:
            - regex: "～"
              with: "-"
            - regex: "[\\p{Han}\\p{Hiragana}\\p{Katakana}ー]+"
              with: 
      Image:
        selector: //div[@class='act-area']/div[@class="thumb"]/img/@src
        postProcess:
          - replace:
            - regex: ^
              with: http://www.minnano-av.com
      Ethnicity: 
        fixed: "asian"
      Country: 
        fixed: "Japan"
      Gender: 
        fixed: "Female"
        
#Last Updated September 09, 2020
```
sample url `http://www.minnano-av.com/actress493582.html`

This site is more picky and needed the `/` and that doesn't hurt othercases anyway.
Tested against the scraper mentioned in #661 and seems to work ok