### PR TITLE
Fix studio parent getting wiped in edit mode

### DIFF
--- a/pkg/models/querybuilder_studio.go
+++ b/pkg/models/querybuilder_studio.go
@@ -141,7 +141,7 @@ func (qb *StudioQueryBuilder) All() ([]*Studio, error) {
 }
 
 func (qb *StudioQueryBuilder) AllSlim() ([]*Studio, error) {
-	return qb.queryStudios("SELECT studios.id, studios.name FROM studios "+qb.getStudioSort(nil), nil, nil)
+	return qb.queryStudios("SELECT studios.id, studios.name, studios.parent_id FROM studios "+qb.getStudioSort(nil), nil, nil)
 }
 
 func (qb *StudioQueryBuilder) Query(studioFilter *StudioFilterType, findFilter *FindFilterType) ([]*Studio, int) {


### PR DESCRIPTION
The AllSlim endpoint only returns name/id, and since the frontend queries parent id as well it returns null, which then gets merged into the existing state when the edit tab is opened and the selector is opened. Resolved by populating the parent id field on the slim object.

In general I don't think the slim endpoints make that much sense anymore after we removed the images. If the selectors are changed to query on input rather than fetching all entities, the performance should be just as fast if they query the full objects. 