### PR TITLE
Fix studio logo getting nulled when editing a studio

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -116,8 +116,8 @@ export const Studio: React.FC = () => {
     const input: Partial<GQL.StudioCreateInput | GQL.StudioUpdateInput> = {
       name,
       url,
+      image,
       parent_id: parentStudioId ?? null,
-      image: image ?? null,
     };
 
     if (!isNew) {


### PR DESCRIPTION
When you edit a studio with an existing logo and hit save (without changing the logo) then the logo disappears.
