### PR TITLE
Fix scene gallery selection

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -598,7 +598,7 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
             <Col xs={9}>
               <SceneGallerySelect
                 sceneId={props.scene.id}
-                initialId={galleryId}
+                gallery={props.scene.gallery ?? undefined}
                 onSelect={(item) => setGalleryId(item ? item.id : undefined)}
               />
             </Col>

--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -72,7 +72,7 @@ interface IFilterSelectProps
   extends Omit<ISelectProps, "onChange" | "items" | "onCreateOption"> {}
 
 interface ISceneGallerySelect {
-  initialId?: string;
+  gallery?: Pick<GQL.Gallery, "title" | "path" | "id">;
   sceneId: string;
   onSelect: (
     item:
@@ -225,8 +225,9 @@ const FilterSelectComponent: React.FC<
 };
 
 export const SceneGallerySelect: React.FC<ISceneGallerySelect> = (props) => {
-  const [query, setQuery] = React.useState<string>("");
+  const [query, setQuery] = useState<string>("");
   const { data, loading } = useFindGalleries(getFilter());
+  const [selectedOption, setSelectedOption] = useState<Option>();
 
   const galleries = data?.findGalleries.galleries ?? [];
   const items = galleries.map((g) => ({
@@ -246,14 +247,22 @@ export const SceneGallerySelect: React.FC<ISceneGallerySelect> = (props) => {
 
   const onChange = (selectedItems: ValueType<Option>) => {
     const selectedItem = getSelectedValues(selectedItems)[0];
+    setSelectedOption(
+      Array.isArray(selectedItems) ? selectedItems[0] : selectedItems
+    );
     props.onSelect(
       selectedItem ? galleries.find((g) => g.id === selectedItem) : undefined
     );
   };
 
-  const selectedOptions: Option[] = props.initialId
-    ? items.filter((item) => props.initialId?.indexOf(item.value) !== -1)
-    : [];
+  const selectedOptions: Option[] = [];
+  if (selectedOption !== undefined) selectedOptions.push(selectedOption);
+  else if (props.gallery) {
+    selectedOptions.push({
+      value: props.gallery.id,
+      label: props.gallery.title ?? props.gallery.path ?? "Unknown",
+    });
+  }
 
   return (
     <SelectComponent
@@ -274,7 +283,7 @@ interface IScrapePerformerSuggestProps {
 export const ScrapePerformerSuggest: React.FC<IScrapePerformerSuggestProps> = (
   props
 ) => {
-  const [query, setQuery] = React.useState<string>("");
+  const [query, setQuery] = useState<string>("");
   const { data, loading } = useScrapePerformerList(props.scraperId, query);
 
   const performers = data?.scrapePerformerList ?? [];


### PR DESCRIPTION
When the user selects a gallery that is not in the initial 20 galleries loaded, the name will get corrupted immediately after selecting. The reason is that the select uses the query data to get the name, and as soon as the gallery is selected the query is reset and no longer contains the selected gallery.

I've resolved this by explicitly saving the entire selected gallery and always showing that rather than using the queried data. The same applies to saved galleries that are not in the initial query, so I've changed it to pass in the entire gallery and use that rather than the queried data.