### PR TITLE
Add includes/excludes modifiers to path filter

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -281,6 +281,8 @@ export class MandatoryStringCriterion extends StringCriterion {
   public modifierOptions = [
     StringCriterion.getModifierOption(CriterionModifier.Equals),
     StringCriterion.getModifierOption(CriterionModifier.NotEquals),
+    StringCriterion.getModifierOption(CriterionModifier.Includes),
+    StringCriterion.getModifierOption(CriterionModifier.Excludes),
   ];
 }
 


### PR DESCRIPTION
MandatoryStringCriterion is only used by the path filter. Allows for including/excluding partial paths.