### PR TITLE
Fix scene file name parser update

### DIFF
--- a/pkg/api/changeset_translator.go
+++ b/pkg/api/changeset_translator.go
@@ -39,7 +39,14 @@ func getUpdateInputMaps(ctx context.Context) []map[string]interface{} {
 	input, _ := args[updateInputField]
 	var ret []map[string]interface{}
 	if input != nil {
-		ret, _ = input.([]map[string]interface{})
+		// convert []interface{} into []map[string]interface{}
+		iSlice, _ := input.([]interface{})
+		for _, i := range iSlice {
+			m, _ := i.(map[string]interface{})
+			if m != nil {
+				ret = append(ret, m)
+			}
+		}
 	}
 
 	return ret

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
@@ -85,12 +85,8 @@ export class SceneParserResult {
       title: this.title.isSet ? this.title.value : undefined,
       date: this.date.isSet ? this.date.value : undefined,
       studio_id: this.studio.isSet ? this.studio.value : undefined,
-      performer_ids: this.performers.isSet
-        ? this.performers.value
-        : undefined,
-      tag_ids: this.tags.isSet
-        ? this.tags.value
-        : undefined,
+      performer_ids: this.performers.isSet ? this.performers.value : undefined,
+      tag_ids: this.tags.isSet ? this.tags.value : undefined,
     };
   }
 }

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
@@ -81,19 +81,16 @@ export class SceneParserResult {
   public toSceneUpdateInput() {
     return {
       id: this.id,
-      details: this.scene.details,
-      url: this.scene.url,
-      rating: this.rating.isSet ? this.rating.value : this.scene.rating,
-      gallery_id: this.scene.gallery?.id,
-      title: this.title.isSet ? this.title.value : this.scene.title,
-      date: this.date.isSet ? this.date.value : this.scene.date,
-      studio_id: this.studio.isSet ? this.studio.value : this.scene.studio?.id,
+      rating: this.rating.isSet ? this.rating.value : undefined,
+      title: this.title.isSet ? this.title.value : undefined,
+      date: this.date.isSet ? this.date.value : undefined,
+      studio_id: this.studio.isSet ? this.studio.value : undefined,
       performer_ids: this.performers.isSet
         ? this.performers.value
-        : this.scene.performers.map((performer) => performer.id),
+        : undefined,
       tag_ids: this.tags.isSet
         ? this.tags.value
-        : this.scene.tags.map((tag) => tag.id),
+        : undefined,
     };
   }
 }


### PR DESCRIPTION
Fixes error when applying changes in the scene filename parser. Related to bug in `ScenesUpdate` interface.

Also changes the UI side so that it only sends the changed data.