### PR TITLE
Fix galleryCreate mutation

### DIFF
--- a/graphql/documents/mutations/gallery.graphql
+++ b/graphql/documents/mutations/gallery.graphql
@@ -1,26 +1,7 @@
 mutation GalleryCreate(
-  $title: String!,
-  $details: String,
-  $url: String,
-  $date: String,
-  $rating: Int,
-  $organized: Boolean,
-  $scene_id: ID,
-  $studio_id: ID,
-  $performer_ids: [ID!] = [],
-  $tag_ids: [ID!] = []) {
+  $input: GalleryCreateInput!) {
 
-  galleryCreate(input: {
-    title: $title,
-    details: $details,
-    url: $url,
-    date: $date,
-    rating: $rating,
-    scene_id: $scene_id,
-    studio_id: $studio_id,
-    tag_ids: $tag_ids,
-    performer_ids: $performer_ids
-    }) {
+  galleryCreate(input: $input) {
       ...GalleryData
   }
 }

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -60,9 +60,7 @@ export const GalleryEditPanel: React.FC<
   // Network state
   const [isLoading, setIsLoading] = useState(true);
 
-  const [createGallery] = useGalleryCreate(
-    getGalleryInput() as GQL.GalleryCreateInput
-  );
+  const [createGallery] = useGalleryCreate();
   const [updateGallery] = useGalleryUpdate();
 
   useEffect(() => {
@@ -129,7 +127,7 @@ export const GalleryEditPanel: React.FC<
   function getGalleryInput() {
     return {
       id: props.isNew ? undefined : props.gallery.id,
-      title,
+      title: title ?? "",
       details,
       url,
       date,
@@ -144,7 +142,11 @@ export const GalleryEditPanel: React.FC<
     setIsLoading(true);
     try {
       if (props.isNew) {
-        const result = await createGallery();
+        const result = await createGallery({
+          variables: {
+            input: getGalleryInput(),
+          },
+        });
         if (result.data?.galleryCreate) {
           history.push(`/galleries/${result.data.galleryCreate.id}`);
           Toast.success({ content: "Created gallery" });

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -499,9 +499,8 @@ const galleryMutationImpactedQueries = [
   GQL.FindGalleriesDocument,
 ];
 
-export const useGalleryCreate = (input: GQL.GalleryCreateInput) =>
+export const useGalleryCreate = () =>
   GQL.useGalleryCreateMutation({
-    variables: input,
     update: deleteCache(galleryMutationImpactedQueries),
   });
 


### PR DESCRIPTION
Organized flag was specified but not passed through. Not sure why the object was enumerated rather than just using the entire input type, but it seems to work fine. 