### PR TITLE
Various bugfixes for scene tagger

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 
 	"github.com/spf13/viper"
 
@@ -427,11 +428,18 @@ func ValidateCredentials(username string, password string) bool {
 func ValidateStashBoxes(boxes []*models.StashBoxInput) error {
 	isMulti := len(boxes) > 1
 
+	re, err := regexp.Compile("^http.*graphql$")
+	if err != nil {
+		return errors.New("Failure to generate regular expression")
+	}
+
 	for _, box := range boxes {
 		if box.APIKey == "" {
 			return errors.New("Stash-box API Key cannot be blank")
 		} else if box.Endpoint == "" {
 			return errors.New("Stash-box Endpoint cannot be blank")
+		} else if !re.Match([]byte(box.Endpoint)) {
+			return errors.New("Stash-box Endpoint is invalid")
 		} else if isMulti && box.Name == "" {
 			return errors.New("Stash-box Name cannot be blank")
 		}

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -20,3 +20,4 @@
 ### 🐛 Bug fixes
 * Corrected file sizes on 32bit platforms
 * Fixed login redirect to remember the current page.
+* Fixed scene tagger config saving

--- a/ui/v2.5/src/components/Settings/StashBoxConfiguration.tsx
+++ b/ui/v2.5/src/components/Settings/StashBoxConfiguration.tsx
@@ -41,7 +41,7 @@ const Instance: React.FC<IInstanceProps> = ({
           value={instance?.endpoint}
           isValid={(instance?.endpoint?.length ?? 0) > 0}
           onInput={(e: React.ChangeEvent<HTMLInputElement>) =>
-            handleInput("endpoint", e.currentTarget.value)
+            handleInput("endpoint", e.currentTarget.value.trim())
           }
         />
         <Form.Control
@@ -50,7 +50,7 @@ const Instance: React.FC<IInstanceProps> = ({
           value={instance?.api_key}
           isValid={(instance?.api_key?.length ?? 0) > 0}
           onInput={(e: React.ChangeEvent<HTMLInputElement>) =>
-            handleInput("api_key", e.currentTarget.value)
+            handleInput("api_key", e.currentTarget.value.trim())
           }
         />
         <InputGroup.Append>

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -16,7 +16,7 @@
   }
 
   &.inline {
-    display: inline-block;
+    display: inline;
     height: auto;
     margin-left: 0.5rem;
   }

--- a/ui/v2.5/src/components/Tagger/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/Config.tsx
@@ -10,7 +10,7 @@ import {
 import { Icon } from "src/components/Shared";
 import { useConfiguration } from "src/core/StashService";
 
-import { ITaggerConfig, ParseMode, ModeDesc } from './constants';
+import { ITaggerConfig, ParseMode, ModeDesc } from "./constants";
 
 interface IConfigProps {
   show: boolean;
@@ -41,15 +41,14 @@ const Config: React.FC<IConfigProps> = ({ show, config, setConfig }) => {
   };
 
   const handleBlacklistAddition = () => {
-    if (!blacklistRef.current)
-      return;
+    if (!blacklistRef.current) return;
 
     const input = blacklistRef.current.value;
     setConfig({
       ...config,
       blacklist: [...config.blacklist, input],
     });
-    blacklistRef.current.value = '';
+    blacklistRef.current.value = "";
   };
 
   const stashBoxes = stashConfig.data?.configuration.general.stashBoxes ?? [];
@@ -147,10 +146,7 @@ const Config: React.FC<IConfigProps> = ({ show, config, setConfig }) => {
           <div className="col-md-6">
             <h5>Blacklist</h5>
             <InputGroup>
-              <Form.Control
-                className="text-input"
-                ref={blacklistRef}
-              />
+              <Form.Control className="text-input" ref={blacklistRef} />
               <InputGroup.Append>
                 <Button onClick={handleBlacklistAddition}>Add</Button>
               </InputGroup.Append>

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -105,13 +105,15 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   const updateStudioStashID = useUpdateStudioStashID();
   const [updateScene] = GQL.useSceneUpdateMutation({
     onError: (e) => {
-      const message = e.message === "invalid JPEG format: short Huffman data" ?
-        "Failed to save scene due to corrupted cover image" : "Failed to save scene";
+      const message =
+        e.message === "invalid JPEG format: short Huffman data"
+          ? "Failed to save scene due to corrupted cover image"
+          : "Failed to save scene";
       setError({
         message,
         details: e.message,
       });
-    }
+    },
   });
 
   const { data: allTags } = GQL.useAllTagsForFilterQuery();

--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -104,8 +104,16 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   const updatePerformerStashID = useUpdatePerformerStashID();
   const updateStudioStashID = useUpdateStudioStashID();
   const [updateScene] = GQL.useSceneUpdateMutation({
-    onError: (errors) => errors,
+    onError: (e) => {
+      const message = e.message === "invalid JPEG format: short Huffman data" ?
+        "Failed to save scene due to corrupted cover image" : "Failed to save scene";
+      setError({
+        message,
+        details: e.message,
+      });
+    }
   });
+
   const { data: allTags } = GQL.useAllTagsForFilterQuery();
 
   const setPerformer = (
@@ -302,12 +310,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         },
       });
 
-      if (!sceneUpdateResult?.data?.sceneUpdate) {
-        setError({
-          message: "Failed to save scene",
-          details: sceneUpdateResult?.errors?.[0].message,
-        });
-      } else if (sceneUpdateResult.data?.sceneUpdate)
+      if (sceneUpdateResult?.data?.sceneUpdate)
         setScene(sceneUpdateResult.data.sceneUpdate);
 
       queueFingerprintSubmission(stashScene.id, endpoint);

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -24,13 +24,19 @@ import {
   sortScenesByDuration,
 } from "./utils";
 
-const dateRegex = /\.(\d\d)\.(\d\d)\.(\d\d)\./;
+const simpleDateRegex = /\.(\d\d)\.(\d\d)\.(\d\d)\./;
+const isoDateRegex = /\d{4}[-.]\d{2}[-.]\d{2}/;
 const parseDate = (input: string): string => {
-  const date = s.match(dateRegex);
-  if (date) {
-    s = s.replace(date[0], ` 20${date[1]}-${date[2]}-${date[3]} `);
+  let output = input;
+  const simpleDate = output.match(simpleDateRegex);
+  if (simpleDate) {
+    output = output.replace(simpleDate[0], ` 20${simpleDate[1]}-${simpleDate[2]}-${simpleDate[3]} `);
   }
-  return input;
+  const isoDate = output.match(isoDateRegex);
+  if (isoDate) {
+    output = output.replace(isoDate[0], ` 20${isoDate[1]}-${isoDate[2]}-${isoDate[3]} `);
+  }
+  return output;
 }
 
 function prepareQueryString(
@@ -66,7 +72,7 @@ function prepareQueryString(
     s = s.replace(new RegExp(b, "i"), "");
   });
   s = parseDate(s);
-  return s.replace(/[-\.]/g, " ");
+  return s.replace(/[-.]/g, " ");
 }
 
 interface ITaggerListProps {

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -1,0 +1,42 @@
+export const LOCAL_FORAGE_KEY = "tagger";
+export const DEFAULT_BLACKLIST = [
+  "\\sXXX\\s",
+  "1080p",
+  "720p",
+  "2160p",
+  "KTR",
+  "RARBG",
+  "\\scom\\s",
+  "\\[",
+  "\\]",
+];
+
+export const initialConfig: ITaggerConfig = {
+  blacklist: DEFAULT_BLACKLIST,
+  showMales: false,
+  mode: "auto",
+  setCoverImage: true,
+  setTags: false,
+  tagOperation: "merge",
+  fingerprintQueue: {},
+};
+
+export type ParseMode = "auto" | "filename" | "dir" | "path" | "metadata";
+export const ModeDesc = {
+  auto: "Uses metadata if present, or filename",
+  metadata: "Only uses metadata",
+  filename: "Only uses filename",
+  dir: "Only uses parent directory of video file",
+  path: "Uses entire file path",
+};
+
+export interface ITaggerConfig {
+  blacklist: string[];
+  showMales: boolean;
+  mode: ParseMode;
+  setCoverImage: boolean;
+  setTags: boolean;
+  tagOperation: string;
+  selectedEndpoint?: string;
+  fingerprintQueue: Record<string, string[]>;
+}

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -27,8 +27,9 @@ interface ILocalForage<T> {
 const Loading: Record<string, boolean> = {};
 const Cache: Record<string, {}> = {};
 
-function useLocalForage<T>(
-  key: string
+export function useLocalForage<T>(
+  key: string,
+  defaultValue: T = {} as T
 ): [ILocalForage<T>, Dispatch<SetStateAction<T>>] {
   const [error, setError] = React.useState(null);
   const [data, setData] = React.useState<T>(Cache[key] as T);
@@ -43,27 +44,32 @@ function useLocalForage<T>(
           setData(parsed);
           Cache[key] = parsed;
         } else {
-          setData({} as T);
-          Cache[key] = {};
+          setData(defaultValue);
+          Cache[key] = defaultValue;
         }
         setError(null);
       } catch (err) {
         setError(err);
+        Cache[key] = defaultValue;
       } finally {
         Loading[key] = false;
         setLoading(false);
       }
     }
+
     if (!loading && !Cache[key]) {
       Loading[key] = true;
       setLoading(true);
       runAsync();
     }
-  }, [loading, data, key]);
+  }, [loading, key, defaultValue]);
 
   useEffect(() => {
     if (!_.isEqual(Cache[key], data)) {
-      Cache[key] = _.merge(Cache[key], data);
+      Cache[key] = _.merge({
+        ...Cache[key],
+        ...data
+      });
       localForage.setItem(key, JSON.stringify(Cache[key]));
     }
   });

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -68,7 +68,7 @@ export function useLocalForage<T>(
     if (!_.isEqual(Cache[key], data)) {
       Cache[key] = _.merge({
         ...Cache[key],
-        ...data
+        ...data,
       });
       localForage.setItem(key, JSON.stringify(Cache[key]));
     }

--- a/ui/v2.5/src/hooks/index.ts
+++ b/ui/v2.5/src/hooks/index.ts
@@ -1,5 +1,9 @@
 export { default as useToast } from "./Toast";
-export { useInterfaceLocalForage, useChangelogStorage, useLocalForage } from "./LocalForage";
+export {
+  useInterfaceLocalForage,
+  useChangelogStorage,
+  useLocalForage,
+} from "./LocalForage";
 export {
   useScenesList,
   useSceneMarkersList,

--- a/ui/v2.5/src/hooks/index.ts
+++ b/ui/v2.5/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { default as useToast } from "./Toast";
-export { useInterfaceLocalForage, useChangelogStorage } from "./LocalForage";
+export { useInterfaceLocalForage, useChangelogStorage, useLocalForage } from "./LocalForage";
 export {
   useScenesList,
   useSceneMarkersList,


### PR DESCRIPTION
* Fixed tagger config saving. Switched to the LocalForage hook, with some minor changes to be able to set a default value, and make sure it merges saved state correctly.
* Added additional patterns for date parsing.
* Fixed scene error handling, and added message if scene update fails due to jpg corruption.
* Fixed issue where buttons get pushed off the side of the scene list. #1007 
* Add whitespace trimming and pattern validation of stash-box config.