### PR TITLE
Fix performer page lightbox

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Button, Tabs, Tab } from "react-bootstrap";
 import { useParams, useHistory } from "react-router-dom";
 import cx from "classnames";
@@ -48,9 +48,13 @@ export const Performer: React.FC = () => {
     imagePreview === undefined
       ? performer.image_path ?? ""
       : imagePreview ?? `${performer.image_path}?default=true`;
+  const lightboxImages = useMemo(
+    () => [{ paths: { thumbnail: activeImage, image: activeImage } }],
+    [activeImage]
+  );
 
   const showLightbox = useLightbox({
-    images: [{ paths: { thumbnail: activeImage, image: activeImage } }],
+    images: lightboxImages,
   });
 
   // Network state


### PR DESCRIPTION
The lightbox depends on referential equality of inputs to determine when to update the state. For graphql objects this isn't an issue since they only update when there's actually new data, but in the case of the performer page the image input was a constructed object which has a new value every render, thus causing a render loop.

Fixed by wrapping it in useMemo which ensures the variable is only changed when the actual image changes.