### PR TITLE
Cache fixes

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -6,6 +6,7 @@
 * Allow configuration of visible navbar items.
 
 ### 🎨 Improvements
+* Reset cache after scan/clean to ensure scenes are updated.
 * Add more video/image resolution tags.
 * Add option to strip file extension from scene title when populating from scanning task.
 * Pagination support and general improvements for image lightbox.
@@ -20,6 +21,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Fix tag/studio images not being changed after update.
 * Fixed resolution tags and querying for portrait videos and images.
 * Corrected file sizes on 32bit platforms
 * Fixed login redirect to remember the current page.

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -134,6 +134,10 @@ export const Studio: React.FC = () => {
             input: getStudioInput() as GQL.StudioUpdateInput,
           },
         });
+        if (result.data?.studioUpdate?.image_path)
+          await fetch(result.data?.studioUpdate?.image_path, {
+            cache: "reload",
+          });
         if (result.data?.studioUpdate) {
           updateStudioData(result.data.studioUpdate);
           setIsEditing(false);

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -133,6 +133,8 @@ export const Tag: React.FC = () => {
           },
         });
         if (result.data?.tagUpdate) {
+          if (result.data.tagUpdate.image_path)
+            await fetch(result.data.tagUpdate.image_path, { cache: "reload" });
           updateTagData(result.data.tagUpdate);
           setIsEditing(false);
         }


### PR DESCRIPTION
* Adds a subscription for metadata tasks that resets the cache whenever a scan or clean has been completed. This ensures all tabs will refresh their data and be in sync with the backend. One caveat is that the task needs to run for at least ~5s otherwise it's unlikely to be reported by the websocket.
* Adds image cache busting for tags/studios. Should mostly ensure that the images are swapped whenever they are updated. One exception are the studio labels in the studio scene list, but that resolves itself as soon as the user navigates.