### PR TITLE
Fix z-index of performer scrape selector and correct no options message

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -20,6 +20,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Fixed performer scraper select overlapping search results
 * Fixed resolution tags and querying for portrait videos and images.
 * Corrected file sizes on 32bit platforms
 * Fixed login redirect to remember the current page.

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -397,9 +397,9 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     }
 
     const popover = (
-      <Popover id="scraper-popover">
+      <Popover id="performer-scraper-popover">
         <Popover.Content>
-          <div>
+          <>
             {queryableScrapers
               ? queryableScrapers.map((s) => (
                   <div key={s.name}>
@@ -421,7 +421,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
                 <span>Reload scrapers</span>
               </Button>
             </div>
-          </div>
+          </>
         </Popover.Content>
       </Popover>
     );

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -88,3 +88,7 @@
   margin-top: 10px;
   max-width: 100%;
 }
+
+#performer-scraper-popover {
+  z-index: 1;
+}

--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -63,6 +63,7 @@ interface ISelectProps {
   showDropdown?: boolean;
   groupHeader?: string;
   closeMenuOnSelect?: boolean;
+  noOptionsMessage?: string | null;
 }
 interface IFilterComponentProps extends IFilterProps {
   items: Array<ValidTypes>;
@@ -106,6 +107,7 @@ const SelectComponent: React.FC<ISelectProps & ITypeProps> = ({
   showDropdown = true,
   groupHeader,
   closeMenuOnSelect = true,
+  noOptionsMessage = type !== "tags" ? "None" : null,
 }) => {
   const defaultValue =
     items.filter((item) => initialIds?.indexOf(item.value) !== -1) ?? null;
@@ -143,7 +145,7 @@ const SelectComponent: React.FC<ISelectProps & ITypeProps> = ({
     isMulti,
     isClearable,
     defaultValue,
-    noOptionsMessage: () => (type !== "tags" ? "None" : null),
+    noOptionsMessage: () => noOptionsMessage,
     placeholder: isDisabled ? "" : placeholder,
     onInputChange,
     isDisabled,
@@ -312,6 +314,7 @@ export const ScrapePerformerSuggest: React.FC<IScrapePerformerSuggestProps> = (
       placeholder={props.placeholder}
       className="select-suggest"
       showDropdown={false}
+      noOptionsMessage={query === "" ? null : "No performers found."}
     />
   );
 };


### PR DESCRIPTION
* Fix z-index so the scraper selector doesn't cover the search modal.
* Adds noOptionsMessage prop so we can hide the None when no query has been entered, and show a proper message if no search results are returned.

Resolves #1049 