### PR TITLE
Fix interface state storage

### DIFF
--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -22,10 +22,7 @@ import {
   FindImagesQueryResult,
   SlimImageDataFragment,
 } from "src/core/generated-graphql";
-import {
-  useInterfaceLocalForage,
-  IInterfaceConfig,
-} from "src/hooks/LocalForage";
+import { useInterfaceLocalForage } from "src/hooks/LocalForage";
 import { LoadingIndicator } from "src/components/Shared";
 import { ListFilter } from "src/components/List/ListFilter";
 import { Pagination, PaginationIndex } from "src/components/List/Pagination";
@@ -431,16 +428,12 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
 
   const updateInterfaceConfig = useCallback(
     (updatedFilter: ListFilterModel) => {
-      setInterfaceState((config) => {
-        const data = { ...config } as IInterfaceConfig;
-        data.queries = {
-          [options.filterMode]: {
-            filter: updatedFilter.makeQueryParameters(),
-            itemsPerPage: updatedFilter.itemsPerPage,
-            currentPage: updatedFilter.currentPage,
-          },
-        };
-        return data;
+      setInterfaceState({
+        [options.filterMode]: {
+          filter: updatedFilter.makeQueryParameters(),
+          itemsPerPage: updatedFilter.itemsPerPage,
+          currentPage: updatedFilter.currentPage,
+        },
       });
     },
     [options.filterMode, setInterfaceState]
@@ -458,7 +451,7 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
 
     if (!options.persistState) return;
 
-    const storedQuery = interfaceState.data?.queries?.[options.filterMode];
+    const storedQuery = interfaceState.data?.[options.filterMode];
     if (!storedQuery) return;
 
     const queryFilter = queryString.parse(history.location.search);

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -2,17 +2,13 @@ import localForage from "localforage";
 import _ from "lodash";
 import React, { Dispatch, SetStateAction, useEffect } from "react";
 
-interface IInterfaceWallConfig {}
 interface IInterfaceQueryConfig {
   filter: string;
   itemsPerPage: number;
   currentPage: number;
 }
 
-export interface IInterfaceConfig {
-  wall?: IInterfaceWallConfig;
-  queries?: Record<string, IInterfaceQueryConfig>;
-}
+type IInterfaceConfig = Record<string, IInterfaceQueryConfig>;
 
 export interface IChangelogConfig {
   versions: Record<string, boolean>;
@@ -66,10 +62,10 @@ export function useLocalForage<T>(
 
   useEffect(() => {
     if (!_.isEqual(Cache[key], data)) {
-      Cache[key] = _.merge({
+      Cache[key] = {
         ...Cache[key],
         ...data,
-      });
+      };
       localForage.setItem(key, JSON.stringify(Cache[key]));
     }
   });


### PR DESCRIPTION
When fixing the tagger state storage I inadvertantly broke the interface state by using a shallow merge rather than a recursive merge of the state. I've resolved this by removing some of the cruft from the interface state so that a shallow merge is sufficient.