### PR TITLE
Login to docker before pulling/building

### DIFF
--- a/docker/ci/x86_64/docker_push.sh
+++ b/docker/ci/x86_64/docker_push.sh
@@ -3,7 +3,7 @@
 DOCKER_TAG=$1
 
 # must build the image from dist directory
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker build -t stashapp/stash:$DOCKER_TAG -f ./docker/ci/x86_64/Dockerfile ./dist
 
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker push stashapp/stash:$DOCKER_TAG


### PR DESCRIPTION
Fix issue where pulling docker images might hit a rate limit due to not logging in.

Edit: not logging in before performing the pull during the cross-compilation since the credentials are not available to pull requests. Changed the ordering of the push script so that it logs in before building the image. We may still run into issues with rate limits during builds. If this happens I'll add a conditional login in `after_success` to login if not in a pull request. Won't help PRs, but at least the branch builds will work.