### PR TITLE
Add backup database functionality

### DIFF
--- a/graphql/documents/mutations/metadata.graphql
+++ b/graphql/documents/mutations/metadata.graphql
@@ -37,3 +37,7 @@ mutation MigrateHashNaming {
 mutation StopJob {
   stopJob
 }
+
+mutation BackupDatabase($input: BackupDatabaseInput!) {
+  backupDatabase(input: $input)
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -226,8 +226,11 @@ type Mutation {
 
   stopJob: Boolean!
 
-  """ Submit fingerprints to stash-box instance """
+  """Submit fingerprints to stash-box instance"""
   submitStashBoxFingerprints(input: StashBoxFingerprintSubmissionInput!): Boolean!
+
+  """Backup the database. Optionally returns a link to download the database file"""
+  backupDatabase(input: BackupDatabaseInput!): String
 }
 
 type Subscription {

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -92,3 +92,7 @@ input ImportObjectsInput {
   duplicateBehaviour: ImportDuplicateEnum!
   missingRefBehaviour: ImportMissingRefEnum!
 }
+
+input BackupDatabaseInput {
+  download: Boolean
+}

--- a/pkg/api/migrate.go
+++ b/pkg/api/migrate.go
@@ -60,7 +60,7 @@ func doMigrateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// perform database backup
-	if err = database.Backup(backupPath); err != nil {
+	if err = database.Backup(database.DB, backupPath); err != nil {
 		http.Error(w, fmt.Sprintf("error backing up database: %s", err), 500)
 		return
 	}

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -125,7 +125,9 @@ func (r *mutationResolver) BackupDatabase(ctx context.Context, input models.Back
 
 		ret := baseURL + "/downloads/" + downloadHash + "/" + database.DatabaseBackupPath()
 		return &ret, nil
+	} else {
+		logger.Infof("Successfully backed up database to: %s", backupPath)
 	}
-	
+
 	return nil, nil
 }

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"io/ioutil"
+	"path"
 	"time"
 
 	"github.com/stashapp/stash/pkg/database"
@@ -123,7 +124,8 @@ func (r *mutationResolver) BackupDatabase(ctx context.Context, input models.Back
 
 		baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 
-		ret := baseURL + "/downloads/" + downloadHash + "/" + database.DatabaseBackupPath()
+		fn := path.Base(database.DatabaseBackupPath())
+		ret := baseURL + "/downloads/" + downloadHash + "/" + fn
 		return &ret, nil
 	} else {
 		logger.Infof("Successfully backed up database to: %s", backupPath)

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/stashapp/stash/pkg/database"
@@ -124,7 +124,7 @@ func (r *mutationResolver) BackupDatabase(ctx context.Context, input models.Back
 
 		baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 
-		fn := path.Base(database.DatabaseBackupPath())
+		fn := filepath.Base(database.DatabaseBackupPath())
 		ret := baseURL + "/downloads/" + downloadHash + "/" + fn
 		return &ret, nil
 	} else {

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -2,11 +2,15 @@ package api
 
 import (
 	"context"
+	"io/ioutil"
 	"time"
 
+	"github.com/stashapp/stash/pkg/database"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 func (r *mutationResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
@@ -88,4 +92,40 @@ func (r *mutationResolver) JobStatus(ctx context.Context) (*models.MetadataUpdat
 
 func (r *mutationResolver) StopJob(ctx context.Context) (bool, error) {
 	return manager.GetInstance().Status.Stop(), nil
+}
+
+func (r *mutationResolver) BackupDatabase(ctx context.Context, input models.BackupDatabaseInput) (*string, error) {
+	// if download is true, then backup to temporary file and return a link
+	download := input.Download != nil && *input.Download
+	mgr := manager.GetInstance()
+	var backupPath string
+	if download {
+		utils.EnsureDir(mgr.Paths.Generated.Downloads)
+		f, err := ioutil.TempFile(mgr.Paths.Generated.Downloads, "backup*.sqlite")
+		if err != nil {
+			return nil, err
+		}
+
+		backupPath = f.Name()
+		f.Close()
+	} else {
+		backupPath = database.DatabaseBackupPath()
+	}
+
+	err := database.Backup(database.DB, backupPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if download {
+		downloadHash := mgr.DownloadStore.RegisterFile(backupPath, "", false)
+		logger.Debugf("Generated backup file %s with hash %s", backupPath, downloadHash)
+
+		baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
+
+		ret := baseURL + "/downloads/" + downloadHash + "/" + database.DatabaseBackupPath()
+		return &ret, nil
+	}
+	
+	return nil, nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -99,16 +99,20 @@ func Reset(databasePath string) error {
 	return nil
 }
 
-// Backup the database
-func Backup(backupPath string) error {
-	db, err := sqlx.Connect(sqlite3Driver, "file:"+dbPath+"?_fk=true")
-	if err != nil {
-		return fmt.Errorf("Open database %s failed:%s", dbPath, err)
+// Backup the database. If db is nil, then uses the existing database 
+// connection.
+func Backup(db *sqlx.DB, backupPath string) error {
+	if db == nil {
+		var err error
+		db, err = sqlx.Connect(sqlite3Driver, "file:"+dbPath+"?_fk=true")
+		if err != nil {
+			return fmt.Errorf("Open database %s failed:%s", dbPath, err)
+		}
+		defer db.Close()
 	}
-	defer db.Close()
 
 	logger.Infof("Backing up database into: %s", backupPath)
-	_, err = db.Exec(`VACUUM INTO "` + backupPath + `"`)
+	_, err := db.Exec(`VACUUM INTO "` + backupPath + `"`)
 	if err != nil {
 		return fmt.Errorf("Vacuum failed: %s", err)
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -99,7 +99,7 @@ func Reset(databasePath string) error {
 	return nil
 }
 
-// Backup the database. If db is nil, then uses the existing database 
+// Backup the database. If db is nil, then uses the existing database
 // connection.
 func Backup(db *sqlx.DB, backupPath string) error {
 	if db == nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -102,6 +102,6 @@ func (s *Scenes) Append(o interface{}) {
 	*s = append(*s, o.(*Scene))
 }
 
-func (m *Scenes) New() interface{} {
+func (s *Scenes) New() interface{} {
 	return &Scene{}
 }

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -1,6 +1,7 @@
 #### 💥 Note: After upgrading, all scene file sizes will be 0B until a new [scan](/settings?tab=tasks) is run.
 
 ### ✨ New Features
+* Add backup database functionality to Settings/Tasks.
 * Add gallery wall view.
 * Add organized flag for scenes, galleries and images.
 * Allow configuration of visible navbar items.

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -858,6 +858,12 @@ export const mutateImportObjects = (input: GQL.ImportObjectsInput) =>
     variables: { input },
   });
 
+export const mutateBackupDatabase = (input: GQL.BackupDatabaseInput) =>
+  client.mutate<GQL.BackupDatabaseMutation>({
+    mutation: GQL.BackupDatabaseDocument,
+    variables: { input },
+  });
+
 export const querySceneByPathRegex = (filter: GQL.FindFilterType) =>
   client.query<GQL.FindScenesByPathRegexQuery>({
     query: GQL.FindScenesByPathRegexDocument,


### PR DESCRIPTION
Adds two buttons to the tasks settings page. The first backs up to a file in the same directory as the sqlite file, using the same file naming format as for migrations. The second button backs up the database and downloads the resulting file.

![image](https://user-images.githubusercontent.com/53250216/105135743-a5a6ae00-5b44-11eb-86c9-e74722eb3869.png)
