### PR TITLE
Force reload of custom css if it's updated

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -7,6 +7,7 @@
 * Allow configuration of visible navbar items.
 
 ### 🎨 Improvements
+* Refresh UI when changing custom CSS options.
 * Add batch deleting of performers, tags, studios, and movies.
 * Reset cache after scan/clean to ensure scenes are updated.
 * Add more video/image resolution tags.

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -60,10 +60,18 @@ export const SettingsInterfacePanel: React.FC = () => {
   }, [config]);
 
   async function onSave() {
+    const prevCSS = config?.configuration.interface.css;
     try {
       const result = await updateInterfaceConfig();
       // eslint-disable-next-line no-console
       console.log(result);
+
+      // Force refetch of custom css if it was changed
+      if (prevCSS !== result.data?.configureInterface.css) {
+        await fetch("/css", { cache: "reload" });
+        window.location.reload();
+      }
+
       Toast.success({ content: "Updated config" });
     } catch (e) {
       Toast.error(e);

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -61,13 +61,17 @@ export const SettingsInterfacePanel: React.FC = () => {
 
   async function onSave() {
     const prevCSS = config?.configuration.interface.css;
+    const prevCSSenabled = config?.configuration.interface.cssEnabled;
     try {
       const result = await updateInterfaceConfig();
       // eslint-disable-next-line no-console
       console.log(result);
 
       // Force refetch of custom css if it was changed
-      if (prevCSS !== result.data?.configureInterface.css) {
+      if (
+        prevCSS !== result.data?.configureInterface.css ||
+        prevCSSenabled !== result.data?.configureInterface.cssEnabled
+      ) {
         await fetch("/css", { cache: "reload" });
         window.location.reload();
       }


### PR DESCRIPTION
Seems like the only way to get the browser to reload the css is to bust the cache and then reload the page. Not a big fan of reloading like that, but I figure since it's a setting that isn't modified frequently it shouldn't be a huge issue.