### PR TITLE
Fix import file copying

### DIFF
--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -25,8 +25,12 @@ func (r *mutationResolver) MetadataImport(ctx context.Context) (string, error) {
 }
 
 func (r *mutationResolver) ImportObjects(ctx context.Context, input models.ImportObjectsInput) (string, error) {
-	t := manager.CreateImportTask(config.GetVideoFileNamingAlgorithm(), input)
-	_, err := manager.GetInstance().RunSingleTask(t)
+	t, err := manager.CreateImportTask(config.GetVideoFileNamingAlgorithm(), input)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = manager.GetInstance().RunSingleTask(t)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -57,8 +57,9 @@ func CreateImportTask(a models.HashAlgorithm, input models.ImportObjectsInput) (
 			return nil, err
 		}
 
-		if _, err := io.Copy(out, input.File.File); err != nil {
-			out.Close()
+		_, err = io.Copy(out, input.File.File)
+		out.Close()
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -48,8 +48,10 @@ func CreateImportTask(a models.HashAlgorithm, input models.ImportObjectsInput) (
 		logger.Errorf("error creating temporary directory for import: %s", err.Error())
 		return nil, err
 	}
-	tmpZip := filepath.Join(baseDir, "import.zip")
+
+	tmpZip := ""
 	if input.File.File != nil {
+		tmpZip := filepath.Join(baseDir, "import.zip")
 		out, err := os.Create(tmpZip)
 		if err != nil {
 			return nil, err
@@ -86,9 +88,11 @@ func (t *ImportTask) Start(wg *sync.WaitGroup) {
 		}
 	}()
 
-	if err := t.unzipFile(); err != nil {
-		logger.Errorf("error unzipping provided file for import: %s", err.Error())
-		return
+	if t.TmpZip != "" {
+		if err := t.unzipFile(); err != nil {
+			logger.Errorf("error unzipping provided file for import: %s", err.Error())
+			return
+		}
 	}
 
 	t.json = jsonUtils{

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -81,14 +81,14 @@ func (t *ImportTask) GetStatus() JobStatus {
 func (t *ImportTask) Start(wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	defer func() {
-		err := utils.RemoveDir(t.BaseDir)
-		if err != nil {
-			logger.Errorf("error removing directory %s: %s", t.BaseDir, err.Error())
-		}
-	}()
-
 	if t.TmpZip != "" {
+		defer func() {
+			err := utils.RemoveDir(t.BaseDir)
+			if err != nil {
+				logger.Errorf("error removing directory %s: %s", t.BaseDir, err.Error())
+			}
+		}()
+
 		if err := t.unzipFile(); err != nil {
 			logger.Errorf("error unzipping provided file for import: %s", err.Error())
 			return

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -51,7 +51,7 @@ func CreateImportTask(a models.HashAlgorithm, input models.ImportObjectsInput) (
 
 	tmpZip := ""
 	if input.File.File != nil {
-		tmpZip := filepath.Join(baseDir, "import.zip")
+		tmpZip = filepath.Join(baseDir, "import.zip")
 		out, err := os.Create(tmpZip)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Copying the zip inside the import task goroutine creates a race condition where the zip might be closed before the task is done copying.