### PR TITLE
build arm and x86_64 docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,24 @@ env:
   global:
   - GO111MODULE=on
 before_install:
+  - set -e
+  # Configure environment so changes are picked up when the Docker daemon is restarted after upgrading
+  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+  - export DOCKER_CLI_EXPERIMENTAL=enabled
+  # Upgrade to Docker CE 19.03 for BuildKit support
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  # install binfmt docker container, this container uses qemu to run arm programs transparently allowng docker to build arm 6,7,8 containers.
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  # Show info to simplify debugging and create a builder that can build the platforms we need
+  - docker info
+  - docker buildx create --name builder --use
+  - docker buildx inspect --bootstrap
+  - docker buildx ls
+
+install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 - nvm install 12
 - travis_retry make pre-ui
@@ -58,7 +76,7 @@ deploy:
   # docker image build for develop release
   - provider: script
     skip_cleanup: true
-    script: bash ./docker/ci/x86_64/docker_push.sh development-x86_64
+    script: bash ./docker/ci/x86_64/docker_push.sh development
     on:
       repo: stashapp/stash
       branch: develop

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -1,25 +1,17 @@
-
-# must be built from /dist directory
-
-FROM ubuntu:20.04 as prep
-LABEL MAINTAINER="https://discord.gg/Uz29ny"
-
-RUN apt-get update && \
-    apt-get -y install curl xz-utils && \
-    apt-get autoclean -y && \
-    rm -rf /var/lib/apt/lists/*
+FROM --platform=$BUILDPLATFORM ubuntu:20.04  AS prep
+ARG TARGETPLATFORM
 WORKDIR /
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN curl --http1.1 -o /ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
-    tar xf /ffmpeg.tar.xz && \
-    rm ffmpeg.tar.xz && \
-    mv /ffmpeg*/ /ffmpeg/
-
+COPY stash-*  /
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-pi; \
+    elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then BIN=stash-linux-arm32v7; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ];  then BIN=stash-linux-arm64v8; \
+    elif [ "$TARGETPLATFORM" = "linux/amd64" ];  then BIN=stash-linux; \
+    fi; \
+    mv $BIN /stash
 FROM ubuntu:20.04 as app
-RUN apt-get update && apt-get -y install ca-certificates
-COPY --from=prep /ffmpeg/ffmpeg /ffmpeg/ffprobe /usr/bin/
-COPY /stash-linux /usr/bin/stash
+run apt update && apt install -y python3 python3 python-is-python3 python3-requests && rm -rf /var/lib/apt/lists/*
+COPY --from=prep /stash /usr/bin/
 
 EXPOSE 9999
 CMD ["stash"]
+

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -9,7 +9,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-pi; \
     fi; \
     mv $BIN /stash
 FROM ubuntu:20.04 as app
-run apt update && apt install -y python3 python3 python-is-python3 python3-requests && rm -rf /var/lib/apt/lists/*
+run apt update && apt install -y python3 python3 python-is-python3 python3-requests ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY --from=prep /stash /usr/bin/
 
 EXPOSE 9999

--- a/docker/ci/x86_64/docker_push.sh
+++ b/docker/ci/x86_64/docker_push.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 DOCKER_TAG=$1
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 # must build the image from dist directory
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build -t stashapp/stash:$DOCKER_TAG -f ./docker/ci/x86_64/Dockerfile ./dist
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --output type=image,name=stashapp/stash:$DOCKER_TAG,push=true -f docker/ci/x86_64/Dockerfile dist/
 
-docker push stashapp/stash:$DOCKER_TAG


### PR DESCRIPTION
This changes travisci to use docker buildx to build arm and x86_64 containers.

Buildx is a alternate builder for docker that allows you to build many containers at once.
This uses binfmt and qemu to allow linux to run arm programs allowing you to build containers for arm on an x86 machine.

This will build containers for x86_64, arm 8 (arm 64), and arm 7 containers and push this to docker hub.
The user can then pull stash for thair cpu as needed.
This uses ubuntu and includes ffmpeg and python needed for some scrapers and plugins.