### PR TITLE
Don't delete downloads directory at startup if generated not set

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -67,8 +67,11 @@ func Initialize() *singleton {
 		instance.RefreshConfig()
 
 		// clear the downloads and tmp directories
-		utils.EmptyDir(instance.Paths.Generated.Downloads)
-		utils.EmptyDir(instance.Paths.Generated.Tmp)
+		// #1021 - only clear these directories if the generated folder is non-empty
+		if config.GetGeneratedPath() != "" {
+			utils.EmptyDir(instance.Paths.Generated.Downloads)
+			utils.EmptyDir(instance.Paths.Generated.Tmp)
+		}
 
 		initFFMPEG()
 	})

--- a/pkg/manager/paths/paths_generated.go
+++ b/pkg/manager/paths/paths_generated.go
@@ -29,7 +29,7 @@ func newGeneratedPaths() *generatedPaths {
 	gp.Vtt = filepath.Join(config.GetGeneratedPath(), "vtt")
 	gp.Markers = filepath.Join(config.GetGeneratedPath(), "markers")
 	gp.Transcodes = filepath.Join(config.GetGeneratedPath(), "transcodes")
-	gp.Downloads = filepath.Join(config.GetGeneratedPath(), "downloads")
+	gp.Downloads = filepath.Join(config.GetGeneratedPath(), "download_stage")
 	gp.Tmp = filepath.Join(config.GetGeneratedPath(), "tmp")
 	return &gp
 }

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -29,6 +29,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Fixed stash potentially deleting `downloads` directory when first run.
 * Fix sprite generation when generated path has special characters.
 * Prevent studio from being set as its own parent
 * Fixed performer scraper select overlapping search results


### PR DESCRIPTION
Fixes #1021 

Also renamed `generated/downloads` to `generated/download_stage` to further reduce the possibilty of accidental deletion.