### PR TITLE
Minor UI tweaks

### DIFF
--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -50,7 +50,6 @@ const Changelog: React.FC = () => {
         date="2020-11-24"
         openState={openState}
         setOpenState={setVersionOpenState}
-        defaultOpen
       >
         <MarkdownPage page={V040} />
       </Version>

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -19,7 +19,12 @@ export const Stats: React.FC = () => {
       <div className="col col-sm-8 m-sm-auto row stats">
         <div className="stats-element">
           <p className="title">
-            <FormattedNumber value={scenesSize.size} maximumFractionDigits={TextUtils.fileSizeFractionalDigits(scenesSize.unit)} />
+            <FormattedNumber
+              value={scenesSize.size}
+              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+                scenesSize.unit
+              )}
+            />
             {` ${TextUtils.formatFileSizeUnit(scenesSize.unit)}`}
           </p>
           <p className="heading">
@@ -36,7 +41,12 @@ export const Stats: React.FC = () => {
         </div>
         <div className="stats-element">
           <p className="title">
-            <FormattedNumber value={imagesSize.size} maximumFractionDigits={TextUtils.fileSizeFractionalDigits(imagesSize.unit)} />
+            <FormattedNumber
+              value={imagesSize.size}
+              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+                imagesSize.unit
+              )}
+            />
             {` ${TextUtils.formatFileSizeUnit(imagesSize.unit)}`}
           </p>
           <p className="heading">

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -19,7 +19,7 @@ export const Stats: React.FC = () => {
       <div className="col col-sm-8 m-sm-auto row stats">
         <div className="stats-element">
           <p className="title">
-            <FormattedNumber value={Math.floor(scenesSize.size)} />
+            <FormattedNumber value={scenesSize.size} maximumFractionDigits={TextUtils.fileSizeFractionalDigits(scenesSize.unit)} />
             {` ${TextUtils.formatFileSizeUnit(scenesSize.unit)}`}
           </p>
           <p className="heading">
@@ -36,7 +36,7 @@ export const Stats: React.FC = () => {
         </div>
         <div className="stats-element">
           <p className="title">
-            <FormattedNumber value={Math.floor(imagesSize.size)} />
+            <FormattedNumber value={imagesSize.size} maximumFractionDigits={TextUtils.fileSizeFractionalDigits(imagesSize.unit)} />
             {` ${TextUtils.formatFileSizeUnit(imagesSize.unit)}`}
           </p>
           <p className="heading">

--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -48,7 +48,7 @@ const fileSizeFractionalDigits = (unit: Unit) => {
   }
 
   return 0;
-}
+};
 
 const secondsToTimestamp = (seconds: number) => {
   let ret = new Date(seconds * 1000).toISOString().substr(11, 8);

--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -40,6 +40,16 @@ const formatFileSizeUnit = (u: Unit) => {
   return shortUnits[i];
 };
 
+// returns the number of fractional digits to use when displaying file sizes
+// returns 0 for MB and under, 1 for GB and over.
+const fileSizeFractionalDigits = (unit: Unit) => {
+  if (Units.indexOf(unit) >= 3) {
+    return 1;
+  }
+
+  return 0;
+}
+
 const secondsToTimestamp = (seconds: number) => {
   let ret = new Date(seconds * 1000).toISOString().substr(11, 8);
 
@@ -163,6 +173,7 @@ const formatDate = (intl: IntlShape, date?: string) => {
 const TextUtils = {
   fileSize,
   formatFileSizeUnit,
+  fileSizeFractionalDigits,
   secondsToTimestamp,
   fileNameFromPath,
   age: getAge,


### PR DESCRIPTION
Show one decimal point for stats sizes when showing GB or over.
Collapse 0.4 version section by default.