### PR TITLE
fix check version

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -251,7 +251,6 @@ func getShaFromTags(shortHash bool, name string) string {
 					last = len(gitShort)
 					logger.Debugf("Short Hash:%s Length:%d differs from default %d\n", gitShort, last, defaultSHLength)
 				}
-				// default length of git short hash
 				return tag.Commit.Sha[0:last]
 			}
 

--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -18,6 +18,7 @@ const apiReleases string = "https://api.github.com/repos/stashapp/stash/releases
 const apiTags string = "https://api.github.com/repos/stashapp/stash/tags"
 const apiAcceptHeader string = "application/vnd.github.v3+json"
 const developmentTag string = "latest_develop"
+const defaultSHLength int = 7 // default length of SHA short hash returned by <git rev-parse --short HEAD>
 
 // ErrNoVersion indicates that no version information has been embedded in the
 // stash binary
@@ -191,14 +192,21 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 }
 
 func getReleaseHash(release githubReleasesResponse, shortHash bool, usePreRelease bool) string {
+	shaLength := len(release.Target_commitish)
 	// the /latest API call doesn't return the hash in target_commitish
 	// also add sanity check in case Target_commitish is not 40 characters
-	if !usePreRelease || len(release.Target_commitish) != 40 {
+	if !usePreRelease || shaLength != 40 {
 		return getShaFromTags(shortHash, release.Tag_name)
 	}
 
 	if shortHash {
-		return release.Target_commitish[0:7] //shorthash is first 7 digits of git commit hash
+		last := defaultSHLength                                 // default length of git short hash
+		_, gitShort, _ := GetVersion()                          // retrieve it to check actual length
+		if len(gitShort) != last && len(gitShort) < shaLength { // sometimes short hash is longer
+			last = len(gitShort)
+			logger.Debugf("Short Hash:%s Length:%d differs from default %d\n", gitShort, last, defaultSHLength)
+		}
+		return release.Target_commitish[0:last]
 	}
 
 	return release.Target_commitish
@@ -229,14 +237,22 @@ func getShaFromTags(shortHash bool, name string) string {
 		logger.Errorf("Github Tags Api %v", err)
 		return ""
 	}
+	_, gitShort, _ := GetVersion() // retrieve short hash to check actual length
 
 	for _, tag := range tags {
 		if tag.Name == name {
-			if len(tag.Commit.Sha) != 40 {
+			shaLength := len(tag.Commit.Sha)
+			if shaLength != 40 {
 				return ""
 			}
 			if shortHash {
-				return tag.Commit.Sha[0:7] //shorthash is first 7 digits of git commit hash
+				last := defaultSHLength                                 // default length of git short hash
+				if len(gitShort) != last && len(gitShort) < shaLength { // sometimes short hash is longer
+					last = len(gitShort)
+					logger.Debugf("Short Hash:%s Length:%d differs from default %d\n", gitShort, last, defaultSHLength)
+				}
+				// default length of git short hash
+				return tag.Commit.Sha[0:last]
 			}
 
 			return tag.Commit.Sha

--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -200,11 +200,10 @@ func getReleaseHash(release githubReleasesResponse, shortHash bool, usePreReleas
 	}
 
 	if shortHash {
-		last := defaultSHLength                                 // default length of git short hash
-		_, gitShort, _ := GetVersion()                          // retrieve it to check actual length
-		if len(gitShort) != last && len(gitShort) < shaLength { // sometimes short hash is longer
+		last := defaultSHLength                                // default length of git short hash
+		_, gitShort, _ := GetVersion()                         // retrieve it to check actual length
+		if len(gitShort) > last && len(gitShort) < shaLength { // sometimes short hash is longer
 			last = len(gitShort)
-			logger.Debugf("Short Hash:%s Length:%d differs from default %d\n", gitShort, last, defaultSHLength)
 		}
 		return release.Target_commitish[0:last]
 	}
@@ -246,10 +245,9 @@ func getShaFromTags(shortHash bool, name string) string {
 				return ""
 			}
 			if shortHash {
-				last := defaultSHLength                                 // default length of git short hash
-				if len(gitShort) != last && len(gitShort) < shaLength { // sometimes short hash is longer
+				last := defaultSHLength                                // default length of git short hash
+				if len(gitShort) > last && len(gitShort) < shaLength { // sometimes short hash is longer
 					last = len(gitShort)
-					logger.Debugf("Short Hash:%s Length:%d differs from default %d\n", gitShort, last, defaultSHLength)
 				}
 				return tag.Commit.Sha[0:last]
 			}

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -29,6 +29,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Fix version check sometimes giving incorrect results.
 * Fixed stash potentially deleting `downloads` directory when first run.
 * Fix sprite generation when generated path has special characters.
 * Prevent studio from being set as its own parent


### PR DESCRIPTION
On rare occasions `git rev-parse --short HEAD` generates a longer than the default 7 characters short hash
I adjusted the version check code to take that into account

I added also an extra `debug` print for  statistical reasons in case this occurs
eg
```bash
DEBU[0000] Short Hash:0dd2e269 Length:8 differs from default 7
INFO[0000] Version: (0dd2e269) is already the latest released.
```

to force the issue for testing you can either export the needed > 7 chars `GITHASH`  or just  do a `GITHASH=0dd2e269 make pre-ui && GITHASH=0dd2e269 make release`
`0dd2e269` is used to match the current (as of testing) dev build/commit hash