### PR TITLE
Migrate generated files when a scene is rescanned

### DIFF
--- a/pkg/manager/migrate_hash.go
+++ b/pkg/manager/migrate_hash.go
@@ -1,0 +1,59 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/utils"
+)
+
+func MigrateHash(oldHash string, newHash string) {
+	oldPath := filepath.Join(instance.Paths.Generated.Markers, oldHash)
+	newPath := filepath.Join(instance.Paths.Generated.Markers, newHash)
+	migrate(oldPath, newPath)
+
+	scenePaths := GetInstance().Paths.Scene
+	oldPath = scenePaths.GetThumbnailScreenshotPath(oldHash)
+	newPath = scenePaths.GetThumbnailScreenshotPath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetScreenshotPath(oldHash)
+	newPath = scenePaths.GetScreenshotPath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetStreamPreviewPath(oldHash)
+	newPath = scenePaths.GetStreamPreviewPath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetStreamPreviewImagePath(oldHash)
+	newPath = scenePaths.GetStreamPreviewImagePath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetTranscodePath(oldHash)
+	newPath = scenePaths.GetTranscodePath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetSpriteVttFilePath(oldHash)
+	newPath = scenePaths.GetSpriteVttFilePath(newHash)
+	migrate(oldPath, newPath)
+
+	oldPath = scenePaths.GetSpriteImageFilePath(oldHash)
+	newPath = scenePaths.GetSpriteImageFilePath(newHash)
+	migrate(oldPath, newPath)
+}
+
+func migrate(oldName, newName string) {
+	oldExists, err := utils.FileExists(oldName)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Errorf("Error checking existence of %s: %s", oldName, err.Error())
+		return
+	}
+
+	if oldExists {
+		logger.Infof("renaming %s to %s", oldName, newName)
+		if err := os.Rename(oldName, newName); err != nil {
+			logger.Errorf("error renaming %s to %s: %s", oldName, newName, err.Error())
+		}
+	}
+}

--- a/pkg/manager/task_migrate_hash.go
+++ b/pkg/manager/task_migrate_hash.go
@@ -1,13 +1,9 @@
 package manager
 
 import (
-	"os"
-	"path/filepath"
 	"sync"
 
-	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
-	"github.com/stashapp/stash/pkg/utils"
 )
 
 // MigrateHashTask renames generated files between oshash and MD5 based on the
@@ -36,51 +32,5 @@ func (t *MigrateHashTask) Start(wg *sync.WaitGroup) {
 		newHash = oshash
 	}
 
-	oldPath := filepath.Join(instance.Paths.Generated.Markers, oldHash)
-	newPath := filepath.Join(instance.Paths.Generated.Markers, newHash)
-	t.migrate(oldPath, newPath)
-
-	scenePaths := GetInstance().Paths.Scene
-	oldPath = scenePaths.GetThumbnailScreenshotPath(oldHash)
-	newPath = scenePaths.GetThumbnailScreenshotPath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetScreenshotPath(oldHash)
-	newPath = scenePaths.GetScreenshotPath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetStreamPreviewPath(oldHash)
-	newPath = scenePaths.GetStreamPreviewPath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetStreamPreviewImagePath(oldHash)
-	newPath = scenePaths.GetStreamPreviewImagePath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetTranscodePath(oldHash)
-	newPath = scenePaths.GetTranscodePath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetSpriteVttFilePath(oldHash)
-	newPath = scenePaths.GetSpriteVttFilePath(newHash)
-	t.migrate(oldPath, newPath)
-
-	oldPath = scenePaths.GetSpriteImageFilePath(oldHash)
-	newPath = scenePaths.GetSpriteImageFilePath(newHash)
-	t.migrate(oldPath, newPath)
-}
-
-func (t *MigrateHashTask) migrate(oldName, newName string) {
-	oldExists, err := utils.FileExists(oldName)
-	if err != nil && !os.IsNotExist(err) {
-		logger.Errorf("Error checking existence of %s: %s", oldName, err.Error())
-		return
-	}
-
-	if oldExists {
-		logger.Infof("renaming %s to %s", oldName, newName)
-		if err := os.Rename(oldName, newName); err != nil {
-			logger.Errorf("error renaming %s to %s: %s", oldName, newName, err.Error())
-		}
-	}
+	MigrateHash(oldHash, newHash)
 }

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -380,9 +380,16 @@ func (t *ScanTask) scanScene() *models.Scene {
 		// scene, then recalculate the checksum and regenerate the thumbnail
 		modified := t.isFileModified(fileModTime, s.FileModTime)
 		if modified || !s.Size.Valid {
+			oldHash := s.GetHash(config.GetVideoFileNamingAlgorithm())
 			s, err = t.rescanScene(s, fileModTime)
 			if err != nil {
 				return logError(err)
+			}
+
+			// Migrate any generated files if the hash has changed
+			newHash := s.GetHash(config.GetVideoFileNamingAlgorithm())
+			if newHash != oldHash {
+				MigrateHash(oldHash, newHash)
 			}
 		}
 
@@ -578,6 +585,7 @@ func (t *ScanTask) rescanScene(s *models.Scene, fileModTime time.Time) (*models.
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(oshash)
 
 	var checksum *sql.NullString
 	if t.calculateMD5 {

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -585,7 +585,6 @@ func (t *ScanTask) rescanScene(s *models.Scene, fileModTime time.Time) (*models.
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(oshash)
 
 	var checksum *sql.NullString
 	if t.calculateMD5 {

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -29,6 +29,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Prevent cover image from being incorrectly regenerated when a scene file's hash changes.
 * Fix version check sometimes giving incorrect results.
 * Fixed stash potentially deleting `downloads` directory when first run.
 * Fix sprite generation when generated path has special characters.


### PR DESCRIPTION
Refactors the migrate task so the generated files migrations can be reused when a scene is rescanned. While migrating previews and transcodes might not be desirable when going from e.g 480p->4k I figure it's better to migrate everything so that we don't leave orphan files in the generated folder. It's also easy to regenerate previews if desired.

Resolves #1101 