### PR TITLE
Tweak scraper script error printing

### DIFF
--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -62,7 +62,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 	scanner := bufio.NewScanner(stderr)
 	go func() { // log errors from stderr pipe
 		for scanner.Scan() {
-			logger.Errorf("Scraper error: %s", scanner.Text())
+			logger.Errorf("Scraper: %s", scanner.Text())
 		}
 	}()
 

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -1,10 +1,10 @@
 package scraper
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -59,17 +59,22 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 		return errors.New("Error running scraper script")
 	}
 
+	scanner := bufio.NewScanner(stderr)
+	go func() { // log errors from stderr pipe
+		for scanner.Scan() {
+			logger.Errorf("Scraper error: %s", scanner.Text())
+		}
+	}()
+
+	logger.Debugf("Scraper script <%s> started", strings.Join(cmd.Args, " "))
+
 	// TODO - add a timeout here
 	decodeErr := json.NewDecoder(stdout).Decode(out)
 
-	stderrData, _ := ioutil.ReadAll(stderr)
-	stderrString := string(stderrData)
-
 	err = cmd.Wait()
+	logger.Debugf("Scraper script finished")
 
 	if err != nil {
-		// error message should be in the stderr stream
-		logger.Errorf("scraper error when running command <%s>: %s", strings.Join(cmd.Args, " "), stderrString)
 		return errors.New("Error running scraper script")
 	}
 

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -62,7 +62,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 	scanner := bufio.NewScanner(stderr)
 	go func() { // log errors from stderr pipe
 		for scanner.Scan() {
-			logger.Errorf("Scraper: %s", scanner.Text())
+			logger.Errorf("scraper: %s", scanner.Text())
 		}
 	}()
 


### PR DESCRIPTION
I moved the error printing in a separate thread using a buffered reader
This allows script scraper developers to `misuse` the stderr for debugging and us catch the error even if the script doesnt exit.
The debug prints are useful to devs so that they know if the script started/ended ok