### PR TITLE
[WIP] ETA (time remaining for progress bar)

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -62,6 +62,7 @@ input AutoTagMetadataInput {
 
 type MetadataUpdateStatus {
   progress: Float!
+  started: Int!
   status: String!
   message: String!
 }

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -88,6 +88,7 @@ func (r *mutationResolver) JobStatus(ctx context.Context) (*models.MetadataUpdat
 	status := manager.GetInstance().Status
 	ret := models.MetadataUpdateStatus{
 		Progress: status.Progress,
+		Started:  status.Started,
 		Status:   status.Status.String(),
 		Message:  "",
 	}

--- a/pkg/api/resolver_query_metadata.go
+++ b/pkg/api/resolver_query_metadata.go
@@ -11,6 +11,7 @@ func (r *queryResolver) JobStatus(ctx context.Context) (*models.MetadataUpdateSt
 	status := manager.GetInstance().Status
 	ret := models.MetadataUpdateStatus{
 		Progress: status.Progress,
+		Started:  status.Started,
 		Status:   status.Status.String(),
 		Message:  "",
 	}

--- a/pkg/api/resolver_subscription_metadata.go
+++ b/pkg/api/resolver_subscription_metadata.go
@@ -22,6 +22,7 @@ func (r *subscriptionResolver) MetadataUpdate(ctx context.Context) (<-chan *mode
 				if thisStatus != lastStatus {
 					ret := models.MetadataUpdateStatus{
 						Progress: thisStatus.Progress,
+						Started: thisStatus.Started,
 						Status:   thisStatus.Status.String(),
 						Message:  "",
 					}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"net"
 	"sync"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -54,7 +55,7 @@ func Initialize() *singleton {
 		initLog()
 		initEnvs()
 		instance = &singleton{
-			Status: TaskStatus{Status: Idle, Progress: -1},
+			Status: TaskStatus{Status: Idle, Progress: -1, Started: int(time.Now().UTC().UnixNano() / 1e6)},
 			Paths:  paths.NewPaths(),
 
 			PluginCache: initPluginCache(),

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -35,6 +35,7 @@ func isImage(pathname string) bool {
 type TaskStatus struct {
 	Status     JobStatus
 	Progress   float64
+	Started    int
 	LastUpdate time.Time
 	stopping   bool
 	upTo       int

--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -34,6 +34,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",
+    "@types/ms": "^0.7.31",
     "@types/react-select": "^3.1.2",
     "apollo-upload-client": "^14.1.3",
     "axios": "0.21.1",


### PR DESCRIPTION
This should show a time remaining under the progress bar:

![image](https://user-images.githubusercontent.com/61285907/107127425-091e3300-68dc-11eb-9be4-84b493b41d64.png)

Work in progress! Doesn't work quite as expected...

The aim is to have a `started` variable (ideally in Go backend) that can be used to calculate the remaining time (based on current progress). 

This is my first time working in Go, but I've worked on React loads. 

So my first approach was to simply store a `started` variable within the React app itself. But obviously that wouldn't work when page is refreshed or something. It had to be in Go app. That's where I'm struggling a bit... 

Am I going in the right direction? I've tried to make the `started` variable in Go but..

1. Not sure if it's in all the right places
2. Can't get it through the GraphQL API call over to the frontend. 

Any help?