### PR TITLE
fix json unmarshal error return

### DIFF
--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -61,6 +61,10 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 
 	// TODO - add a timeout here
 	decodeErr := json.NewDecoder(stdout).Decode(out)
+	if decodeErr != nil {
+		logger.Error("could not unmarshal json: " + decodeErr.Error())
+		return errors.New("could not unmarshal json: " + decodeErr.Error())
+	}
 
 	stderrData, _ := ioutil.ReadAll(stderr)
 	stderrString := string(stderrData)
@@ -71,11 +75,6 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 		// error message should be in the stderr stream
 		logger.Errorf("scraper error when running command <%s>: %s", strings.Join(cmd.Args, " "), stderrString)
 		return errors.New("Error running scraper script")
-	}
-
-	if decodeErr != nil {
-		logger.Errorf("error decoding performer from scraper data: %s", err.Error())
-		return errors.New("Error decoding performer from scraper script")
 	}
 
 	return nil


### PR DESCRIPTION
Script scrapers would have an unhandled error return if the JSON the script sent back could not be unmarshalled. This happened for both performers and tags to my knowledge but possibly other fields too.

The error handling was there but it just needed to be moved up.