### PR TITLE
Fix scene edit state resetting when scene is updated

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -29,10 +29,11 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Fix edit data being lost when clicking the O-Counter, Organized or Favorite buttons.
 * Exclude media in `generated` directory from the library.
 * Prevent cover image from being incorrectly regenerated when a scene file's hash changes.
 * Fix version check sometimes giving incorrect results.
-* Fixed stash potentially deleting `downloads` directory when first run.
+* Fix stash potentially deleting `downloads` directory when first run.
 * Fix sprite generation when generated path has special characters.
 * Prevent studio from being set as its own parent
 * Fixed performer scraper select overlapping search results

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -19,26 +19,32 @@ interface IProps {
   onDelete: () => void;
 }
 
-export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
+export const ImageEditPanel: React.FC<IProps> = ({
+  image,
+  isVisible,
+  onDelete,
+}) => {
   const Toast = useToast();
-  const [title, setTitle] = useState<string>();
-  const [rating, setRating] = useState<number>();
-  const [studioId, setStudioId] = useState<string>();
-  const [performerIds, setPerformerIds] = useState<string[]>();
-  const [tagIds, setTagIds] = useState<string[]>();
+  const [title, setTitle] = useState<string>(image?.title ?? "");
+  const [rating, setRating] = useState<number>(image.rating ?? NaN);
+  const [studioId, setStudioId] = useState<string>(image.studio?.id ?? "");
+  const [performerIds, setPerformerIds] = useState<string[]>(
+    image.performers.map((p) => p.id)
+  );
+  const [tagIds, setTagIds] = useState<string[]>(image.tags.map((t) => t.id));
 
   // Network state
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   const [updateImage] = useImageUpdate();
 
   useEffect(() => {
-    if (props.isVisible) {
+    if (isVisible) {
       Mousetrap.bind("s s", () => {
         onSave();
       });
       Mousetrap.bind("d d", () => {
-        props.onDelete();
+        onDelete();
       });
 
       // numeric keypresses get caught by jwplayer, so blur the element
@@ -74,26 +80,9 @@ export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
     }
   });
 
-  function updateImageEditState(state: Partial<GQL.ImageDataFragment>) {
-    const perfIds = state.performers?.map((performer) => performer.id);
-    const tIds = state.tags ? state.tags.map((tag) => tag.id) : undefined;
-
-    setTitle(state.title ?? undefined);
-    setRating(state.rating === null ? NaN : state.rating);
-    // setGalleryId(state?.gallery?.id ?? undefined);
-    setStudioId(state?.studio?.id ?? undefined);
-    setPerformerIds(perfIds);
-    setTagIds(tIds);
-  }
-
-  useEffect(() => {
-    updateImageEditState(props.image);
-    setIsLoading(false);
-  }, [props.image]);
-
   function getImageInput(): GQL.ImageUpdateInput {
     return {
-      id: props.image.id,
+      id: image.id,
       title,
       rating: rating ?? null,
       studio_id: studioId ?? null,
@@ -131,7 +120,7 @@ export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
           <Button
             className="edit-button"
             variant="danger"
-            onClick={() => props.onDelete()}
+            onClick={() => onDelete()}
           >
             Delete
           </Button>
@@ -152,7 +141,7 @@ export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
             <Col xs={9}>
               <RatingStars
                 value={rating}
-                onSetRating={(value) => setRating(value)}
+                onSetRating={(value) => setRating(value ?? NaN)}
               />
             </Col>
           </Form.Group>
@@ -164,7 +153,7 @@ export const ImageEditPanel: React.FC<IProps> = (props: IProps) => {
             <Col xs={9}>
               <StudioSelect
                 onSelect={(items) =>
-                  setStudioId(items.length > 0 ? items[0]?.id : undefined)
+                  setStudioId(items.length > 0 ? items[0]?.id : "")
                 }
                 ids={studioId ? [studioId] : []}
               />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -223,10 +223,16 @@ export const Performer: React.FC = () => {
   }
 
   function setFavorite(v: boolean) {
-    onSave({
-      id: performer.id,
-      favorite: v,
-    });
+    if (performer.id) {
+      updatePerformer({
+        variables: {
+          input: {
+            id: performer.id,
+            favorite: v,
+          },
+        },
+      });
+    }
   }
 
   const renderIcons = () => (

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -68,24 +68,32 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
 
   // Editing performer state
   const [image, setImage] = useState<string | null>();
-  const [name, setName] = useState<string>();
-  const [aliases, setAliases] = useState<string>();
-  const [favorite, setFavorite] = useState<boolean>();
-  const [birthdate, setBirthdate] = useState<string>();
-  const [ethnicity, setEthnicity] = useState<string>();
-  const [country, setCountry] = useState<string>();
-  const [eyeColor, setEyeColor] = useState<string>();
-  const [height, setHeight] = useState<string>();
-  const [measurements, setMeasurements] = useState<string>();
-  const [fakeTits, setFakeTits] = useState<string>();
-  const [careerLength, setCareerLength] = useState<string>();
-  const [tattoos, setTattoos] = useState<string>();
-  const [piercings, setPiercings] = useState<string>();
-  const [url, setUrl] = useState<string>();
-  const [twitter, setTwitter] = useState<string>();
-  const [instagram, setInstagram] = useState<string>();
-  const [gender, setGender] = useState<string | undefined>(undefined);
-  const [stashIDs, setStashIDs] = useState<GQL.StashIdInput[]>([]);
+  const [name, setName] = useState<string>(performer?.name ?? "");
+  const [aliases, setAliases] = useState<string>(performer.aliases ?? "");
+  const [birthdate, setBirthdate] = useState<string>(performer.birthdate ?? "");
+  const [ethnicity, setEthnicity] = useState<string>(performer.ethnicity ?? "");
+  const [country, setCountry] = useState<string>(performer.country ?? "");
+  const [eyeColor, setEyeColor] = useState<string>(performer.eye_color ?? "");
+  const [height, setHeight] = useState<string>(performer.height ?? "");
+  const [measurements, setMeasurements] = useState<string>(
+    performer.measurements ?? ""
+  );
+  const [fakeTits, setFakeTits] = useState<string>(performer.fake_tits ?? "");
+  const [careerLength, setCareerLength] = useState<string>(
+    performer.career_length ?? ""
+  );
+  const [tattoos, setTattoos] = useState<string>(performer.tattoos ?? "");
+  const [piercings, setPiercings] = useState<string>(performer.piercings ?? "");
+  const [url, setUrl] = useState<string>(performer.url ?? "");
+  const [twitter, setTwitter] = useState<string>(performer.twitter ?? "");
+  const [instagram, setInstagram] = useState<string>(performer.instagram ?? "");
+  const [gender, setGender] = useState<string | undefined>(
+    performer.gender ?? undefined
+  );
+  const [stashIDs, setStashIDs] = useState<GQL.StashIdInput[]>(
+    performer.stash_ids ?? []
+  );
+  const favorite = performer.favorite ?? false;
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
@@ -100,35 +108,6 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
   >();
 
   const imageEncoding = ImageUtils.usePasteImage(onImageLoad, isEditing);
-
-  function updatePerformerEditState(
-    state: Partial<GQL.PerformerDataFragment | GQL.ScrapedPerformerDataFragment>
-  ) {
-    if ((state as GQL.PerformerDataFragment).favorite !== undefined) {
-      setFavorite((state as GQL.PerformerDataFragment).favorite);
-    }
-    setName(state.name ?? undefined);
-    setAliases(state.aliases ?? undefined);
-    setBirthdate(state.birthdate ?? undefined);
-    setEthnicity(state.ethnicity ?? undefined);
-    setCountry(state.country ?? undefined);
-    setEyeColor(state.eye_color ?? undefined);
-    setHeight(state.height ?? undefined);
-    setMeasurements(state.measurements ?? undefined);
-    setFakeTits(state.fake_tits ?? undefined);
-    setCareerLength(state.career_length ?? undefined);
-    setTattoos(state.tattoos ?? undefined);
-    setPiercings(state.piercings ?? undefined);
-    setUrl(state.url ?? undefined);
-    setTwitter(state.twitter ?? undefined);
-    setInstagram(state.instagram ?? undefined);
-    setGender(
-      genderToString((state as GQL.PerformerDataFragment).gender ?? undefined)
-    );
-    if ((state as GQL.PerformerDataFragment).stash_ids !== undefined) {
-      setStashIDs((state as GQL.PerformerDataFragment).stash_ids);
-    }
-  }
 
   function translateScrapedGender(scrapedGender?: string) {
     if (!scrapedGender) {
@@ -244,10 +223,6 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
       };
     }
   });
-
-  useEffect(() => {
-    if (!isNew) updatePerformerEditState(performer);
-  }, [isNew, performer]);
 
   useEffect(() => {
     if (onImageChange) {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -40,26 +40,43 @@ interface IProps {
   onDelete: () => void;
 }
 
-export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
+export const SceneEditPanel: React.FC<IProps> = ({
+  scene,
+  isVisible,
+  onDelete,
+}) => {
   const Toast = useToast();
-  const [title, setTitle] = useState<string>();
-  const [details, setDetails] = useState<string>();
-  const [url, setUrl] = useState<string>();
-  const [date, setDate] = useState<string>();
-  const [rating, setRating] = useState<number>();
-  const [galleries, setGalleries] = useState<{ id: string; title: string }[]>(
-    []
+  const [title, setTitle] = useState<string>(scene.title ?? "");
+  const [details, setDetails] = useState<string>(scene.details ?? "");
+  const [url, setUrl] = useState<string>(scene.url ?? "");
+  const [date, setDate] = useState<string>(scene.date ?? "");
+  const [rating, setRating] = useState<number | undefined>(
+    scene.rating ?? undefined
   );
-  const [studioId, setStudioId] = useState<string>();
-  const [performerIds, setPerformerIds] = useState<string[]>();
-  const [movieIds, setMovieIds] = useState<string[] | undefined>(undefined);
+  const [galleries, setGalleries] = useState<{ id: string; title: string }[]>(
+    scene.galleries.map((g) => ({
+      id: g.id,
+      title: g.title ?? TextUtils.fileNameFromPath(g.path ?? ""),
+    }))
+  );
+  const [studioId, setStudioId] = useState<string | undefined>(
+    scene.studio?.id
+  );
+  const [performerIds, setPerformerIds] = useState<string[]>(
+    scene.performers.map((p) => p.id)
+  );
+  const [movieIds, setMovieIds] = useState<string[]>(
+    scene.movies.map((m) => m.movie.id)
+  );
   const [
     movieSceneIndexes,
     setMovieSceneIndexes,
-  ] = useState<MovieSceneIndexMap>(new Map());
-  const [tagIds, setTagIds] = useState<string[]>();
+  ] = useState<MovieSceneIndexMap>(
+    new Map(scene.movies.map((m) => [m.movie.id, m.scene_index ?? undefined]))
+  );
+  const [tagIds, setTagIds] = useState<string[]>(scene.tags.map((t) => t.id));
   const [coverImage, setCoverImage] = useState<string>();
-  const [stashIDs, setStashIDs] = useState<GQL.StashIdInput[]>([]);
+  const [stashIDs, setStashIDs] = useState<GQL.StashIdInput[]>(scene.stash_ids);
 
   const Scrapers = useListSceneScrapers();
   const [queryableScrapers, setQueryableScrapers] = useState<GQL.Scraper[]>([]);
@@ -71,17 +88,17 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
   const stashConfig = useConfiguration();
 
   // Network state
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   const [updateScene] = useSceneUpdate();
 
   useEffect(() => {
-    if (props.isVisible) {
+    if (isVisible) {
       Mousetrap.bind("s s", () => {
         onSave();
       });
       Mousetrap.bind("d d", () => {
-        props.onDelete();
+        onDelete();
       });
 
       // numeric keypresses get caught by jwplayer, so blur the element
@@ -141,7 +158,7 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
       });
 
       if (!changed) {
-        movieSceneIndexes.forEach((v, id) => {
+        movieSceneIndexes.forEach((_v, id) => {
           if (!newMap.has(id)) {
             // id was removed
             changed = true;
@@ -155,49 +172,11 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     }
   }, [movieIds, movieSceneIndexes]);
 
-  function updateSceneEditState(state: Partial<GQL.SceneDataFragment>) {
-    const perfIds = state.performers?.map((performer) => performer.id);
-    const tIds = state.tags ? state.tags.map((tag) => tag.id) : undefined;
-    const moviIds = state.movies
-      ? state.movies.map((sceneMovie) => sceneMovie.movie.id)
-      : undefined;
-    const movieSceneIdx: MovieSceneIndexMap = new Map();
-    if (state.movies) {
-      state.movies.forEach((m) => {
-        movieSceneIdx.set(m.movie.id, m.scene_index ?? undefined);
-      });
-    }
-
-    setTitle(state.title ?? undefined);
-    setDetails(state.details ?? undefined);
-    setUrl(state.url ?? undefined);
-    setDate(state.date ?? undefined);
-    setRating(state.rating === null ? NaN : state.rating);
-    setGalleries(
-      (state?.galleries ?? []).map((g) => ({
-        id: g.id,
-        title: g.title ?? TextUtils.fileNameFromPath(g.path ?? ""),
-      }))
-    );
-    setStudioId(state?.studio?.id ?? undefined);
-    setMovieIds(moviIds);
-    setMovieSceneIndexes(movieSceneIdx);
-    setPerformerIds(perfIds);
-    setTagIds(tIds);
-    setStashIDs(state?.stash_ids ?? []);
-  }
-
-  useEffect(() => {
-    updateSceneEditState(props.scene);
-    setCoverImagePreview(props.scene?.paths?.screenshot ?? undefined);
-    setIsLoading(false);
-  }, [props.scene]);
-
   const imageEncoding = ImageUtils.usePasteImage(onImageLoad, true);
 
   function getSceneInput(): GQL.SceneUpdateInput {
     return {
-      id: props.scene.id,
+      id: scene.id,
       title,
       details,
       url,
@@ -284,7 +263,7 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
   async function onScrapeStashBoxClicked(stashBoxIndex: number) {
     setIsLoading(true);
     try {
-      const result = await queryStashBoxScene(stashBoxIndex, props.scene.id);
+      const result = await queryStashBoxScene(stashBoxIndex, scene.id);
       if (!result.data || !result.data.queryStashBoxScene) {
         return;
       }
@@ -339,9 +318,9 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     }
   }
 
-  function onScrapeDialogClosed(scene?: GQL.ScrapedSceneDataFragment) {
-    if (scene) {
-      updateSceneFromScrapedScene(scene);
+  function onScrapeDialogClosed(sceneData?: GQL.ScrapedSceneDataFragment) {
+    if (sceneData) {
+      updateSceneFromScrapedScene(sceneData);
     }
     setScrapedScene(undefined);
   }
@@ -353,16 +332,14 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
 
     const currentScene = getSceneInput();
     if (!currentScene.cover_image) {
-      currentScene.cover_image = props.scene.paths.screenshot;
+      currentScene.cover_image = scene.paths.screenshot;
     }
 
     return (
       <SceneScrapeDialog
         scene={currentScene}
         scraped={scrapedScene}
-        onClose={(scene) => {
-          onScrapeDialogClosed(scene);
-        }}
+        onClose={(s) => onScrapeDialogClosed(s)}
       />
     );
   }
@@ -444,29 +421,31 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
     );
   }
 
-  function updateSceneFromScrapedScene(scene: GQL.ScrapedSceneDataFragment) {
-    if (scene.title) {
-      setTitle(scene.title);
+  function updateSceneFromScrapedScene(
+    updatedScene: GQL.ScrapedSceneDataFragment
+  ) {
+    if (updatedScene.title) {
+      setTitle(updatedScene.title);
     }
 
-    if (scene.details) {
-      setDetails(scene.details);
+    if (updatedScene.details) {
+      setDetails(updatedScene.details);
     }
 
-    if (scene.date) {
-      setDate(scene.date);
+    if (updatedScene.date) {
+      setDate(updatedScene.date);
     }
 
-    if (scene.url) {
-      setUrl(scene.url);
+    if (updatedScene.url) {
+      setUrl(updatedScene.url);
     }
 
-    if (scene.studio && scene.studio.stored_id) {
-      setStudioId(scene.studio.stored_id);
+    if (updatedScene.studio && updatedScene.studio.stored_id) {
+      setStudioId(updatedScene.studio.stored_id);
     }
 
-    if (scene.performers && scene.performers.length > 0) {
-      const idPerfs = scene.performers.filter((p) => {
+    if (updatedScene.performers && updatedScene.performers.length > 0) {
+      const idPerfs = updatedScene.performers.filter((p) => {
         return p.stored_id !== undefined && p.stored_id !== null;
       });
 
@@ -476,8 +455,8 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
       }
     }
 
-    if (scene.movies && scene.movies.length > 0) {
-      const idMovis = scene.movies.filter((p) => {
+    if (updatedScene.movies && updatedScene.movies.length > 0) {
+      const idMovis = updatedScene.movies.filter((p) => {
         return p.stored_id !== undefined && p.stored_id !== null;
       });
 
@@ -487,8 +466,8 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
       }
     }
 
-    if (scene?.tags?.length) {
-      const idTags = scene.tags.filter((p) => {
+    if (updatedScene?.tags?.length) {
+      const idTags = updatedScene.tags.filter((p) => {
         return p.stored_id !== undefined && p.stored_id !== null;
       });
 
@@ -498,10 +477,10 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
       }
     }
 
-    if (scene.image) {
+    if (updatedScene.image) {
       // image is a base64 string
-      setCoverImage(scene.image);
-      setCoverImagePreview(scene.image);
+      setCoverImage(updatedScene.image);
+      setCoverImagePreview(updatedScene.image);
     }
   }
 
@@ -551,7 +530,7 @@ export const SceneEditPanel: React.FC<IProps> = (props: IProps) => {
           <Button
             className="edit-button"
             variant="danger"
-            onClick={() => props.onDelete()}
+            onClick={() => onDelete()}
           >
             Delete
           </Button>


### PR DESCRIPTION
Replaces useEffect form initialization with initialization directly in the state variables, so state is only ever initialized once. This avoids the issue where updating organized/ocounter state would reinitialize the form.

Resolves #1110.