### PR TITLE
Add sqlite filter builder. Add AND, OR, NOT filters to scene filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -75,6 +75,10 @@ input SceneMarkerFilterType {
 }
 
 input SceneFilterType {
+  AND: SceneFilterType
+  OR: SceneFilterType
+  NOT: SceneFilterType
+  
   """Filter by path"""
   path: StringCriterionInput
   """Filter by rating"""

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -48,6 +49,8 @@ func (t *AutoTagTask) getQueryFilter(regex string) *models.SceneFilterType {
 		Organized: &organized,
 	}
 
+	sep := string(filepath.Separator)
+
 	var or *models.SceneFilterType
 	for _, p := range t.paths {
 		newOr := &models.SceneFilterType{}
@@ -58,6 +61,10 @@ func (t *AutoTagTask) getQueryFilter(regex string) *models.SceneFilterType {
 		}
 
 		or = newOr
+
+		if !strings.HasSuffix(p, sep) {
+			p = p + sep
+		}
 
 		or.Path = &models.StringCriterionInput{
 			Modifier: models.CriterionModifierEquals,

--- a/pkg/manager/task_autotag.go
+++ b/pkg/manager/task_autotag.go
@@ -38,13 +38,50 @@ func (t *AutoTagTask) getQueryRegex(name string) string {
 	return ret
 }
 
+func (t *AutoTagTask) getQueryFilter(regex string) *models.SceneFilterType {
+	organized := false
+	ret := &models.SceneFilterType{
+		Path: &models.StringCriterionInput{
+			Modifier: models.CriterionModifierMatchesRegex,
+			Value:    "(?i)" + regex,
+		},
+		Organized: &organized,
+	}
+
+	var or *models.SceneFilterType
+	for _, p := range t.paths {
+		newOr := &models.SceneFilterType{}
+		if or == nil {
+			ret.And = newOr
+		} else {
+			or.Or = newOr
+		}
+
+		or = newOr
+
+		or.Path = &models.StringCriterionInput{
+			Modifier: models.CriterionModifierEquals,
+			Value:    p + "%",
+		}
+	}
+
+	return ret
+}
+
+func (t *AutoTagTask) getFindFilter() *models.FindFilterType {
+	perPage := 0
+	return &models.FindFilterType{
+		PerPage: &perPage,
+	}
+}
+
 func (t *AutoTagPerformerTask) autoTagPerformer() {
 	regex := t.getQueryRegex(t.performer.Name.String)
 
 	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
 		qb := r.Scene()
 
-		scenes, err := qb.QueryForAutoTag(regex, t.paths)
+		scenes, _, err := qb.Query(t.getQueryFilter(regex), t.getFindFilter())
 
 		if err != nil {
 			return fmt.Errorf("Error querying scenes with regex '%s': %s", regex, err.Error())
@@ -84,7 +121,7 @@ func (t *AutoTagStudioTask) autoTagStudio() {
 
 	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
 		qb := r.Scene()
-		scenes, err := qb.QueryForAutoTag(regex, t.paths)
+		scenes, _, err := qb.Query(t.getQueryFilter(regex), t.getFindFilter())
 
 		if err != nil {
 			return fmt.Errorf("Error querying scenes with regex '%s': %s", regex, err.Error())
@@ -133,7 +170,7 @@ func (t *AutoTagTagTask) autoTagTag() {
 
 	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
 		qb := r.Scene()
-		scenes, err := qb.QueryForAutoTag(regex, t.paths)
+		scenes, _, err := qb.Query(t.getQueryFilter(regex), t.getFindFilter())
 
 		if err != nil {
 			return fmt.Errorf("Error querying scenes with regex '%s': %s", regex, err.Error())

--- a/pkg/models/extension_resolution.go
+++ b/pkg/models/extension_resolution.go
@@ -1,0 +1,65 @@
+package models
+
+var resolutionMax = []int{
+	240,
+	360,
+	480,
+	540,
+	720,
+	1080,
+	1440,
+	1920,
+	2160,
+	2880,
+	3384,
+	4320,
+	0,
+}
+
+// GetMaxResolution returns the maximum width or height that media must be
+// to qualify as this resolution. A return value of 0 means that there is no
+// maximum.
+func (r *ResolutionEnum) GetMaxResolution() int {
+	if !r.IsValid() {
+		return 0
+	}
+
+	// sanity check - length of arrays must be the same
+	if len(resolutionMax) != len(AllResolutionEnum) {
+		panic("resolutionMax array length != AllResolutionEnum array length")
+	}
+
+	for i, rr := range AllResolutionEnum {
+		if rr == *r {
+			return resolutionMax[i]
+		}
+	}
+
+	return 0
+}
+
+// GetMinResolution returns the minimum width or height that media must be
+// to qualify as this resolution.
+func (r *ResolutionEnum) GetMinResolution() int {
+	if !r.IsValid() {
+		return 0
+	}
+
+	// sanity check - length of arrays must be the same
+	if len(resolutionMax) != len(AllResolutionEnum) {
+		panic("resolutionMax array length != AllResolutionEnum array length")
+	}
+
+	// use the previous resolution max as this resolution min
+	for i, rr := range AllResolutionEnum {
+		if rr == *r {
+			if i > 0 {
+				return resolutionMax[i-1]
+			}
+
+			return 0
+		}
+	}
+
+	return 0
+}

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -21,7 +21,6 @@ type SceneReader interface {
 	CountMissingOSHash() (int, error)
 	Wall(q *string) ([]*Scene, error)
 	All() ([]*Scene, error)
-	QueryForAutoTag(regex string, pathPrefixes []string) ([]*Scene, error)
 	Query(sceneFilter *SceneFilterType, findFilter *FindFilterType) ([]*Scene, int, error)
 	GetCover(sceneID int) ([]byte, error)
 	GetMovies(sceneID int) ([]MoviesScenes, error)

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -95,9 +95,9 @@ var errSubFilterAlreadySet error = errors.New(`sub-filter already set`)
 
 // sub-filter operator values
 var (
-	andOp string = "AND"
-	orOp  string = "OR"
-	notOp string = "AND NOT"
+	andOp = "AND"
+	orOp  = "OR"
+	notOp = "AND NOT"
 )
 
 // and sets the sub-filter that will be ANDed with this one.

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -169,6 +169,25 @@ func (f *filterBuilder) addHaving(sql string, args ...interface{}) {
 	f.havingClauses = append(f.havingClauses, makeClause(sql, args...))
 }
 
+func (f *filterBuilder) getSubFilterClause(clause, subFilterClause string) string {
+	ret := clause
+
+	if subFilterClause != "" {
+		var op string
+		if len(ret) > 0 {
+			op = " " + f.subFilterOp + " "
+		} else {
+			if f.subFilterOp == notOp {
+				op = "NOT "
+			}
+		}
+
+		ret += op + subFilterClause
+	}
+
+	return ret
+}
+
 // generateWhereClauses generates the SQL where clause for this filter.
 // All where clauses within the filter are ANDed together. This is combined
 // with the sub-filter, which will use the applicable operator (AND/OR/AND NOT).
@@ -178,7 +197,7 @@ func (f *filterBuilder) generateWhereClauses() (clause string, args []interface{
 	if f.subFilter != nil {
 		c, a := f.subFilter.generateWhereClauses()
 		if c != "" {
-			clause += " " + f.subFilterOp + " " + c
+			clause = f.getSubFilterClause(clause, c)
 			if len(a) > 0 {
 				args = append(args, a...)
 			}

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -1,0 +1,226 @@
+package sqlite
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type sqlClause struct {
+	sql  string
+	args []interface{}
+}
+
+func makeClause(sql string, args ...interface{}) sqlClause {
+	return sqlClause{
+		sql:  sql,
+		args: args,
+	}
+}
+
+type criterionHandler interface {
+	handle(f *filterBuilder)
+}
+
+type criterionHandlerFunc func(f *filterBuilder)
+
+type join struct {
+	table    string
+	as       string
+	onClause string
+}
+
+func (j join) getTable() string {
+	if j.as == "" {
+		return j.table
+	}
+
+	return j.as
+}
+
+func (j join) toSQL() string {
+	asStr := ""
+	if j.as != "" {
+		asStr = " AS " + j.as + " "
+	}
+
+	return fmt.Sprintf(" LEFT JOIN %s%s on %s ", j.table, asStr, j.onClause)
+}
+
+type filterBuilder struct {
+	joins         []join
+	whereClauses  []sqlClause
+	havingClauses []sqlClause
+
+	err error
+}
+
+func (f *filterBuilder) addJoin(table, as, onClause string) {
+	// only add if not already joined
+	name := as
+	if name == "" {
+		name = table
+	}
+
+	for _, j := range f.joins {
+		if j.getTable() == name {
+			return
+		}
+	}
+
+	f.joins = append(f.joins, join{
+		table:    table,
+		as:       as,
+		onClause: onClause,
+	})
+}
+
+func (f *filterBuilder) addWhere(sql string, args ...interface{}) {
+	if sql == "" {
+		return
+	}
+	f.whereClauses = append(f.whereClauses, makeClause(sql, args...))
+}
+
+func (f *filterBuilder) addHaving(sql string, args ...interface{}) {
+	if sql == "" {
+		return
+	}
+	f.havingClauses = append(f.havingClauses, makeClause(sql, args...))
+}
+
+func (f *filterBuilder) setError(e error) {
+	if f.err == nil {
+		f.err = e
+	}
+}
+
+func (f *filterBuilder) joinClauses(input []sqlClause) (string, []interface{}) {
+	var clauses []string
+	var args []interface{}
+	for _, w := range input {
+		clauses = append(clauses, w.sql)
+		args = append(args, w.args...)
+	}
+
+	if len(clauses) > 0 {
+		c := "(" + strings.Join(clauses, " AND ") + ")"
+		return c, args
+	}
+
+	return "", nil
+}
+
+func (f *filterBuilder) addToQueryBuilder(qb *queryBuilder) {
+	clauses, args := f.joinClauses(f.whereClauses)
+	if len(clauses) > 0 {
+		qb.addWhere(clauses)
+	}
+
+	if len(args) > 0 {
+		qb.addArg(args...)
+	}
+
+	clauses, args = f.joinClauses(f.havingClauses)
+	if len(clauses) > 0 {
+		qb.addHaving(clauses)
+	}
+
+	if len(args) > 0 {
+		qb.addArg(args...)
+	}
+
+	for _, j := range f.joins {
+		qb.body += j.toSQL()
+	}
+}
+
+func (f *filterBuilder) handleCriterion(handler criterionHandler) {
+	f.handleCriterionFunc(func(h *filterBuilder) {
+		handler.handle(h)
+	})
+}
+
+func (f *filterBuilder) handleCriterionFunc(handler criterionHandlerFunc) {
+	handler(f)
+}
+
+func stringCriterionHandler(c *models.StringCriterionInput, column string) criterionHandlerFunc {
+	return func(f *filterBuilder) {
+		if c != nil {
+			if modifier := c.Modifier; c.Modifier.IsValid() {
+				switch modifier {
+				case models.CriterionModifierIncludes:
+					clause, thisArgs := getSearchBinding([]string{column}, c.Value, false)
+					f.addWhere(clause, thisArgs...)
+				case models.CriterionModifierExcludes:
+					clause, thisArgs := getSearchBinding([]string{column}, c.Value, true)
+					f.addWhere(clause, thisArgs...)
+				case models.CriterionModifierEquals:
+					f.addWhere(column+" LIKE ?", c.Value)
+				case models.CriterionModifierNotEquals:
+					f.addWhere(column+" NOT LIKE ?", c.Value)
+				case models.CriterionModifierMatchesRegex:
+					if _, err := regexp.Compile(c.Value); err != nil {
+						f.setError(err)
+						return
+					}
+					f.addWhere(column+" regexp ?", c.Value)
+				case models.CriterionModifierNotMatchesRegex:
+					if _, err := regexp.Compile(c.Value); err != nil {
+						f.setError(err)
+						return
+					}
+					f.addWhere(column+" NOT regexp ?", c.Value)
+				default:
+					clause, count := getSimpleCriterionClause(modifier, "?")
+
+					if count == 1 {
+						f.addWhere(column+" "+clause, c.Value)
+					} else {
+						f.addWhere(column + " " + clause)
+					}
+				}
+			}
+		}
+	}
+}
+
+func intCriterionHandler(c *models.IntCriterionInput, column string) criterionHandlerFunc {
+	return func(f *filterBuilder) {
+		if c != nil {
+			clause, count := getIntCriterionWhereClause(column, *c)
+
+			if count == 1 {
+				f.addWhere(clause, c.Value)
+			} else {
+				f.addWhere(clause)
+			}
+		}
+	}
+}
+
+func boolCriterionHandler(c *bool, column string) criterionHandlerFunc {
+	return func(f *filterBuilder) {
+		if c != nil {
+			var v string
+			if *c {
+				v = "1"
+			} else {
+				v = "0"
+			}
+
+			f.addWhere(column + " = " + v)
+		}
+	}
+}
+
+func stringLiteralCriterionHandler(v *string, column string) criterionHandlerFunc {
+	return func(f *filterBuilder) {
+		if v != nil {
+			f.addWhere(column+" = ?", v)
+		}
+	}
+}

--- a/pkg/sqlite/filter_internal_test.go
+++ b/pkg/sqlite/filter_internal_test.go
@@ -1,0 +1,579 @@
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterBuilderAnd(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+	other := &filterBuilder{}
+	newBuilder := &filterBuilder{}
+
+	// and should set the subFilter
+	f.and(other)
+	assert.Equal(other, f.subFilter)
+	assert.Nil(f.getError())
+
+	// and should set error if and is set
+	f.and(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// and should set error if or is set
+	// and should not set subFilter if or is set
+	f = &filterBuilder{}
+	f.or(other)
+	f.and(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// and should set error if not is set
+	// and should not set subFilter if not is set
+	f = &filterBuilder{}
+	f.not(other)
+	f.and(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+}
+
+func TestFilterBuilderOr(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+	other := &filterBuilder{}
+	newBuilder := &filterBuilder{}
+
+	// or should set the orFilter
+	f.or(other)
+	assert.Equal(other, f.subFilter)
+	assert.Nil(f.getError())
+
+	// or should set error if or is set
+	f.or(newBuilder)
+	assert.Equal(newBuilder, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// or should set error if and is set
+	// or should not set subFilter if and is set
+	f = &filterBuilder{}
+	f.and(other)
+	f.or(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// or should set error if not is set
+	// or should not set subFilter if not is set
+	f = &filterBuilder{}
+	f.not(other)
+	f.or(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+}
+
+func TestFilterBuilderNot(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+	other := &filterBuilder{}
+	newBuilder := &filterBuilder{}
+
+	// not should set the subFilter
+	f.not(other)
+	// ensure and filter is set
+	assert.Equal(other, f.subFilter)
+	assert.Nil(f.getError())
+
+	// not should set error if not is set
+	f.not(newBuilder)
+	assert.Equal(newBuilder, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// not should set error if and is set
+	// not should not set subFilter if and is set
+	f = &filterBuilder{}
+	f.and(other)
+	f.not(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+
+	// not should set error if or is set
+	// not should not set subFilter if or is set
+	f = &filterBuilder{}
+	f.or(other)
+	f.not(newBuilder)
+	assert.Equal(other, f.subFilter)
+	assert.Equal(errSubFilterAlreadySet, f.getError())
+}
+
+func TestAddJoin(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+
+	const (
+		table1Name = "table1Name"
+		table2Name = "table2Name"
+
+		as1Name = "as1"
+		as2Name = "as2"
+
+		onClause = "onClause1"
+	)
+
+	f.addJoin(table1Name, as1Name, onClause)
+
+	// ensure join is added
+	assert.Len(f.joins, 1)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s AS %s ON %s", table1Name, as1Name, onClause), f.joins[0].toSQL())
+
+	// ensure join with same as is not added
+	f.addJoin(table2Name, as1Name, onClause)
+	assert.Len(f.joins, 1)
+
+	// ensure same table with different alias can be added
+	f.addJoin(table1Name, as2Name, onClause)
+	assert.Len(f.joins, 2)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s AS %s ON %s", table1Name, as2Name, onClause), f.joins[1].toSQL())
+
+	// ensure table without alias can be added if tableName != existing alias/tableName
+	f.addJoin(table1Name, "", onClause)
+	assert.Len(f.joins, 3)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s ON %s", table1Name, onClause), f.joins[2].toSQL())
+
+	// ensure table with alias == table name of a join without alias is not added
+	f.addJoin(table2Name, table1Name, onClause)
+	assert.Len(f.joins, 3)
+
+	// ensure table without alias cannot be added if tableName == existing alias
+	f.addJoin(as2Name, "", onClause)
+	assert.Len(f.joins, 3)
+
+	// ensure AS is not used if same as table name
+	f.addJoin(table2Name, table2Name, onClause)
+	assert.Len(f.joins, 4)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s ON %s", table2Name, onClause), f.joins[3].toSQL())
+}
+
+func TestAddWhere(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+
+	// ensure empty sql adds nothing
+	f.addWhere("")
+	assert.Len(f.whereClauses, 0)
+
+	const whereClause = "a = b"
+	var args = []interface{}{"1", "2"}
+
+	// ensure addWhere sets where clause and args
+	f.addWhere(whereClause, args...)
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(whereClause, f.whereClauses[0].sql)
+	assert.Equal(args, f.whereClauses[0].args)
+
+	// ensure addWhere without args sets where clause
+	f.addWhere(whereClause)
+	assert.Len(f.whereClauses, 2)
+	assert.Equal(whereClause, f.whereClauses[1].sql)
+	assert.Len(f.whereClauses[1].args, 0)
+}
+
+func TestAddHaving(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+
+	// ensure empty sql adds nothing
+	f.addHaving("")
+	assert.Len(f.havingClauses, 0)
+
+	const havingClause = "a = b"
+	var args = []interface{}{"1", "2"}
+
+	// ensure addWhere sets where clause and args
+	f.addHaving(havingClause, args...)
+	assert.Len(f.havingClauses, 1)
+	assert.Equal(havingClause, f.havingClauses[0].sql)
+	assert.Equal(args, f.havingClauses[0].args)
+
+	// ensure addWhere without args sets where clause
+	f.addHaving(havingClause)
+	assert.Len(f.havingClauses, 2)
+	assert.Equal(havingClause, f.havingClauses[1].sql)
+	assert.Len(f.havingClauses[1].args, 0)
+}
+
+func TestGenerateWhereClauses(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+
+	const clause1 = "a = 1"
+	const clause2 = "b = 2"
+	const clause3 = "c = 3"
+
+	const arg1 = "1"
+	const arg2 = "2"
+	const arg3 = "3"
+
+	// ensure single where clause is generated correctly
+	f.addWhere(clause1)
+	r, rArgs := f.generateWhereClauses()
+	assert.Equal("("+clause1+")", r)
+	assert.Len(rArgs, 0)
+
+	// ensure multiple where clauses are surrounded with parenthesis and
+	// ANDed together
+	f.addWhere(clause2, arg1, arg2)
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause1+" AND "+clause2+")", r)
+	assert.Len(rArgs, 2)
+
+	// ensure empty subfilter is not added to generated where clause
+	sf := &filterBuilder{}
+	f.and(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause1+" AND "+clause2+")", r)
+	assert.Len(rArgs, 2)
+
+	// ensure sub-filter is generated correctly
+	sf.addWhere(clause3, arg3)
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") AND ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+
+	// ensure OR sub-filter is generated correctly
+	f = &filterBuilder{}
+	f.addWhere(clause1)
+	f.addWhere(clause2, arg1, arg2)
+	f.or(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") OR ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+
+	// ensure NOT sub-filter is generated correctly
+	f = &filterBuilder{}
+	f.addWhere(clause1)
+	f.addWhere(clause2, arg1, arg2)
+	f.not(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") AND NOT ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+}
+
+func TestGenerateHavingClauses(t *testing.T) {
+	assert := assert.New(t)
+
+	f := &filterBuilder{}
+
+	const clause1 = "a = 1"
+	const clause2 = "b = 2"
+	const clause3 = "c = 3"
+
+	const arg1 = "1"
+	const arg2 = "2"
+	const arg3 = "3"
+
+	// ensure single Having clause is generated correctly
+	f.addHaving(clause1)
+	r, rArgs := f.generateHavingClauses()
+	assert.Equal("("+clause1+")", r)
+	assert.Len(rArgs, 0)
+
+	// ensure multiple Having clauses are surrounded with parenthesis and
+	// ANDed together
+	f.addHaving(clause2, arg1, arg2)
+	r, rArgs = f.generateHavingClauses()
+	assert.Equal("("+clause1+" AND "+clause2+")", r)
+	assert.Len(rArgs, 2)
+
+	// ensure empty subfilter is not added to generated Having clause
+	sf := &filterBuilder{}
+	f.and(sf)
+
+	r, rArgs = f.generateHavingClauses()
+	assert.Equal("("+clause1+" AND "+clause2+")", r)
+	assert.Len(rArgs, 2)
+
+	// ensure sub-filter is generated correctly
+	sf.addHaving(clause3, arg3)
+	r, rArgs = f.generateHavingClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") AND ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+
+	// ensure OR sub-filter is generated correctly
+	f = &filterBuilder{}
+	f.addHaving(clause1)
+	f.addHaving(clause2, arg1, arg2)
+	f.or(sf)
+
+	r, rArgs = f.generateHavingClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") OR ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+
+	// ensure NOT sub-filter is generated correctly
+	f = &filterBuilder{}
+	f.addHaving(clause1)
+	f.addHaving(clause2, arg1, arg2)
+	f.not(sf)
+
+	r, rArgs = f.generateHavingClauses()
+	assert.Equal("("+clause1+" AND "+clause2+") AND NOT ("+clause3+")", r)
+	assert.Len(rArgs, 3)
+}
+
+func TestGetAllJoins(t *testing.T) {
+	assert := assert.New(t)
+	f := &filterBuilder{}
+
+	const (
+		table1Name = "table1Name"
+		table2Name = "table2Name"
+
+		as1Name = "as1"
+		as2Name = "as2"
+
+		onClause = "onClause1"
+	)
+
+	f.addJoin(table1Name, as1Name, onClause)
+
+	// ensure join is returned
+	joins := f.getAllJoins()
+	assert.Len(joins, 1)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s AS %s ON %s", table1Name, as1Name, onClause), joins[0].toSQL())
+
+	// ensure joins in sub-filter are returned
+	subFilter := &filterBuilder{}
+	f.and(subFilter)
+	subFilter.addJoin(table2Name, as2Name, onClause)
+
+	joins = f.getAllJoins()
+	assert.Len(joins, 2)
+	assert.Equal(fmt.Sprintf("LEFT JOIN %s AS %s ON %s", table2Name, as2Name, onClause), joins[1].toSQL())
+
+	// ensure redundant joins are not returned
+	subFilter.addJoin(as1Name, "", onClause)
+	joins = f.getAllJoins()
+	assert.Len(joins, 2)
+}
+
+func TestGetError(t *testing.T) {
+	assert := assert.New(t)
+	f := &filterBuilder{}
+	subFilter := &filterBuilder{}
+
+	f.and(subFilter)
+
+	expectedErr := errors.New("test error")
+	expectedErr2 := errors.New("test error2")
+	f.err = expectedErr
+	subFilter.err = expectedErr2
+
+	// ensure getError returns the top-level error state
+	assert.Equal(expectedErr, f.getError())
+
+	// ensure getError returns sub-filter error state if top-level error
+	// is nil
+	f.err = nil
+	assert.Equal(expectedErr2, f.getError())
+
+	// ensure getError returns nil if all error states are nil
+	subFilter.err = nil
+	assert.Nil(f.getError())
+}
+
+func TestStringCriterionHandlerIncludes(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const value1 = "two words"
+	const quotedValue = `"two words"`
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierIncludes,
+		Value:    value1,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("(%[1]s LIKE ? OR %[1]s LIKE ?)", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 2)
+	assert.Equal("%two%", f.whereClauses[0].args[0])
+	assert.Equal("%words%", f.whereClauses[0].args[1])
+
+	f = &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierIncludes,
+		Value:    quotedValue,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("(%[1]s LIKE ?)", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal("%two words%", f.whereClauses[0].args[0])
+}
+
+func TestStringCriterionHandlerExcludes(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const value1 = "two words"
+	const quotedValue = `"two words"`
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierExcludes,
+		Value:    value1,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("(%[1]s NOT LIKE ? AND %[1]s NOT LIKE ?)", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 2)
+	assert.Equal("%two%", f.whereClauses[0].args[0])
+	assert.Equal("%words%", f.whereClauses[0].args[1])
+
+	f = &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierExcludes,
+		Value:    quotedValue,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("(%[1]s NOT LIKE ?)", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal("%two words%", f.whereClauses[0].args[0])
+}
+
+func TestStringCriterionHandlerEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const value1 = "two words"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierEquals,
+		Value:    value1,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s LIKE ?", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal(value1, f.whereClauses[0].args[0])
+}
+
+func TestStringCriterionHandlerNotEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const value1 = "two words"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierNotEquals,
+		Value:    value1,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s NOT LIKE ?", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal(value1, f.whereClauses[0].args[0])
+}
+
+func TestStringCriterionHandlerMatchesRegex(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const validValue = "two words"
+	const invalidValue = "*two words"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierMatchesRegex,
+		Value:    validValue,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s regexp ?", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal(validValue, f.whereClauses[0].args[0])
+
+	// ensure invalid regex sets error state
+	f = &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierMatchesRegex,
+		Value:    invalidValue,
+	}, column))
+
+	assert.NotNil(f.getError())
+}
+
+func TestStringCriterionHandlerNotMatchesRegex(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+	const validValue = "two words"
+	const invalidValue = "*two words"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierNotMatchesRegex,
+		Value:    validValue,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s NOT regexp ?", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 1)
+	assert.Equal(validValue, f.whereClauses[0].args[0])
+
+	// ensure invalid regex sets error state
+	f = &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierNotMatchesRegex,
+		Value:    invalidValue,
+	}, column))
+
+	assert.NotNil(f.getError())
+}
+
+func TestStringCriterionHandlerIsNull(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierIsNull,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s IS NULL", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 0)
+}
+
+func TestStringCriterionHandlerNotNull(t *testing.T) {
+	assert := assert.New(t)
+
+	const column = "column"
+
+	f := &filterBuilder{}
+	f.handleCriterionFunc(stringCriterionHandler(&models.StringCriterionInput{
+		Modifier: models.CriterionModifierNotNull,
+	}, column))
+
+	assert.Len(f.whereClauses, 1)
+	assert.Equal(fmt.Sprintf("%[1]s IS NOT NULL", column), f.whereClauses[0].sql)
+	assert.Len(f.whereClauses[0].args, 0)
+}

--- a/pkg/sqlite/filter_internal_test.go
+++ b/pkg/sqlite/filter_internal_test.go
@@ -270,6 +270,30 @@ func TestGenerateWhereClauses(t *testing.T) {
 	r, rArgs = f.generateWhereClauses()
 	assert.Equal("("+clause1+" AND "+clause2+") AND NOT ("+clause3+")", r)
 	assert.Len(rArgs, 3)
+
+	// ensure empty filter with ANDed sub-filter does not include AND
+	f = &filterBuilder{}
+	f.and(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause3+")", r)
+	assert.Len(rArgs, 1)
+
+	// ensure empty filter with ORed sub-filter does not include OR
+	f = &filterBuilder{}
+	f.or(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("("+clause3+")", r)
+	assert.Len(rArgs, 1)
+
+	// ensure empty filter with NOTed sub-filter does not include AND
+	f = &filterBuilder{}
+	f.not(sf)
+
+	r, rArgs = f.generateWhereClauses()
+	assert.Equal("NOT ("+clause3+")", r)
+	assert.Len(rArgs, 1)
 }
 
 func TestGenerateHavingClauses(t *testing.T) {

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -66,6 +66,34 @@ func (qb *queryBuilder) addJoins(joins ...join) {
 	qb.joins.add(joins...)
 }
 
+func (qb *queryBuilder) addFilter(f *filterBuilder) {
+	err := f.getError()
+	if err != nil {
+		qb.err = err
+		return
+	}
+
+	clause, args := f.generateWhereClauses()
+	if len(clause) > 0 {
+		qb.addWhere(clause)
+	}
+
+	if len(args) > 0 {
+		qb.addArg(args...)
+	}
+
+	clause, args = f.generateHavingClauses()
+	if len(clause) > 0 {
+		qb.addHaving(clause)
+	}
+
+	if len(args) > 0 {
+		qb.addArg(args...)
+	}
+
+	qb.addJoins(f.getAllJoins()...)
+}
+
 func (qb *queryBuilder) handleIntCriterionInput(c *models.IntCriterionInput, column string) {
 	if c != nil {
 		clause, count := getIntCriterionWhereClause(column, *c)

--- a/pkg/sqlite/repository.go
+++ b/pkg/sqlite/repository.go
@@ -273,6 +273,18 @@ func (r *repository) newQuery() queryBuilder {
 	}
 }
 
+func (r *repository) join(j joiner, as string, parentIDCol string) {
+	t := r.tableName
+	if as != "" {
+		t = as
+	}
+	j.addJoin(r.tableName, as, fmt.Sprintf("%s.%s = %s", t, r.idColumn, parentIDCol))
+}
+
+type joiner interface {
+	addJoin(table, as, onClause string)
+}
+
 type joinRepository struct {
 	repository
 	fkColumn string

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -342,13 +342,13 @@ func (qb *sceneQueryBuilder) makeFilter(sceneFilter *models.SceneFilterType) *fi
 	query := &filterBuilder{}
 
 	if sceneFilter.And != nil {
-		query.andFilter = qb.makeFilter(sceneFilter.And)
+		query.and(qb.makeFilter(sceneFilter.And))
 	}
 	if sceneFilter.Or != nil {
-		query.orFilter = qb.makeFilter(sceneFilter.Or)
+		query.or(qb.makeFilter(sceneFilter.Or))
 	}
 	if sceneFilter.Not != nil {
-		query.notFilter = qb.makeFilter(sceneFilter.Not)
+		query.not(qb.makeFilter(sceneFilter.Not))
 	}
 
 	query.handleCriterionFunc(stringCriterionHandler(sceneFilter.Path, "scenes.path"))
@@ -391,10 +391,7 @@ func (qb *sceneQueryBuilder) Query(sceneFilter *models.SceneFilterType, findFilt
 
 	filter := qb.makeFilter(sceneFilter)
 
-	err := filter.addToQueryBuilder(&query)
-	if err != nil {
-		return nil, 0, err
-	}
+	query.addFilter(filter)
 
 	query.sortAndPagination = qb.getSceneSort(findFilter) + getPagination(findFilter)
 
@@ -495,7 +492,6 @@ func hasMarkersCriterionHandler(hasMarkers *string) criterionHandlerFunc {
 func sceneIsMissingCriterionHandler(qb *sceneQueryBuilder, isMissing *string) criterionHandlerFunc {
 	return func(f *filterBuilder) {
 		if isMissing != nil && *isMissing != "" {
-			// TODO - add joins
 			switch *isMissing {
 			case "galleries":
 				qb.galleriesRepository().join(f, "galleries_join", "scenes.id")

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -341,6 +341,16 @@ func (qb *sceneQueryBuilder) QueryForAutoTag(regex string, pathPrefixes []string
 func (qb *sceneQueryBuilder) makeFilter(sceneFilter *models.SceneFilterType) *filterBuilder {
 	query := &filterBuilder{}
 
+	if sceneFilter.And != nil {
+		query.andFilter = qb.makeFilter(sceneFilter.And)
+	}
+	if sceneFilter.Or != nil {
+		query.orFilter = qb.makeFilter(sceneFilter.Or)
+	}
+	if sceneFilter.Not != nil {
+		query.notFilter = qb.makeFilter(sceneFilter.Not)
+	}
+
 	query.handleCriterionFunc(stringCriterionHandler(sceneFilter.Path, "scenes.path"))
 	query.handleCriterionFunc(intCriterionHandler(sceneFilter.Rating, "scenes.rating"))
 	query.handleCriterionFunc(intCriterionHandler(sceneFilter.OCounter, "scenes.o_counter"))
@@ -381,7 +391,10 @@ func (qb *sceneQueryBuilder) Query(sceneFilter *models.SceneFilterType, findFilt
 
 	filter := qb.makeFilter(sceneFilter)
 
-	filter.addToQueryBuilder(&query)
+	err := filter.addToQueryBuilder(&query)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	query.sortAndPagination = qb.getSceneSort(findFilter) + getPagination(findFilter)
 

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -139,6 +139,7 @@ func TestSceneQueryQ(t *testing.T) {
 }
 
 func queryScene(t *testing.T, sqb models.SceneReader, sceneFilter *models.SceneFilterType, findFilter *models.FindFilterType) []*models.Scene {
+	t.Helper()
 	scenes, _, err := sqb.Query(sceneFilter, findFilter)
 	if err != nil {
 		t.Errorf("Error querying scene: %s", err.Error())

--- a/pkg/sqlite/sql.go
+++ b/pkg/sqlite/sql.go
@@ -103,7 +103,7 @@ func getSearchBinding(columns []string, q string, not bool) (string, []interface
 	notStr := ""
 	binaryType := " OR "
 	if not {
-		notStr = " NOT "
+		notStr = " NOT"
 		binaryType = " AND "
 	}
 


### PR DESCRIPTION
Further iteration of the data layer refactoring. Adds a `filterBuilder` type. This is used to generate where and having filter clauses from graphql criteria. 

Added `AND`, `OR` and `NOT` to the `SceneFilterType` graphql input. These accept an optional `SceneFilterType` and will be combined with the parent with the applicable operator. Only a single one of these may be specified per filter, but they can be chained.

For example (rough, not usable):
```
// path == "a" OR path == "b" OR path == "c"
findScenes(scene_filter: {
 path: a
 OR: {
  path: b
  OR: {
   path: c
  }
 }
})

// path == "a" AND NOT (rating == 1 AND o_counter == 1)
findScenes(scene_filter: {
 path: a
 NOT: {
  rating: 1
  o_counter: 1
 }
})

// invalid
findScenes(scene_filter: {
 OR: {
  path: a
 }
 AND: {
  rating: 1
 }
})
```

I've changed the autotag task to use `Query` once again, and removed the `QueryForAutoTag` function from the interface.
The scene `Query` function is refactored and now uses the filter builder.

The resolution filtering code has been changed to use an extension to the resolution enum type.

TODO: I think OR/AND/NOT without anything else in the top-level filter will result in a bad SQL query.