### PR TITLE
Exclude media in generated directory

### DIFF
--- a/pkg/manager/task_clean.go
+++ b/pkg/manager/task_clean.go
@@ -41,7 +41,9 @@ func (t *CleanTask) shouldClean(path string) bool {
 	// use image.FileExists for zip file checking
 	fileExists := image.FileExists(path)
 
-	if !fileExists || getStashFromPath(path) == nil {
+	// #1102 - clean anything in generated path
+	generatedPath := config.GetGeneratedPath()
+	if !fileExists || getStashFromPath(path) == nil || utils.IsPathInDir(generatedPath, path) {
 		logger.Infof("File not found. Cleaning: \"%s\"", path)
 		return true
 	}

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -1044,6 +1044,8 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 	excludeVidRegex := generateRegexps(config.GetExcludes())
 	excludeImgRegex := generateRegexps(config.GetImageExcludes())
 
+	generatedPath := config.GetGeneratedPath()
+
 	return utils.SymWalk(s.Path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			logger.Warnf("error scanning %s: %s", path, err.Error())
@@ -1051,6 +1053,11 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 		}
 
 		if info.IsDir() {
+			// #1102 - ignore files in generated path
+			if utils.IsPathInDir(generatedPath, path) {
+				return filepath.SkipDir
+			}
+
 			return nil
 		}
 

--- a/ui/v2.5/src/components/Changelog/versions/v050.md
+++ b/ui/v2.5/src/components/Changelog/versions/v050.md
@@ -29,6 +29,7 @@
 * Support configurable number of threads for scanning and generation.
 
 ### 🐛 Bug fixes
+* Exclude media in `generated` directory from the library.
 * Prevent cover image from being incorrectly regenerated when a scene file's hash changes.
 * Fix version check sometimes giving incorrect results.
 * Fixed stash potentially deleting `downloads` directory when first run.


### PR DESCRIPTION
Resolves #1102 

Excludes any media within the configured `generated` directory from being added when scanning, and removes any such items during clean.