### PR TITLE
Skip insecure certificates check when scraping

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -31,6 +31,7 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   excludes
   imageExcludes
   scraperUserAgent
+  scraperCertCheck
   scraperCDPPath
   stashBoxes {
     name

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -81,6 +81,8 @@ input ConfigGeneralInput {
   scraperUserAgent: String
   """Scraper CDP path. Path to chrome executable or remote address"""
   scraperCDPPath: String
+  """Whether the scraper should check for invalid certificates"""
+  scraperCertCheck: Boolean!
   """Stash-box instances used for tagging"""
   stashBoxes: [StashBoxInput!]!
 }
@@ -144,6 +146,8 @@ type ConfigGeneralResult {
   scraperUserAgent: String
   """Scraper CDP path. Path to chrome executable or remote address"""
   scraperCDPPath: String
+  """Whether the scraper should check for invalid certificates"""
+  scraperCertCheck: Boolean!
   """Stash-box instances used for tagging"""
   stashBoxes: [StashBox!]!
 }

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -151,6 +151,8 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 		refreshScraperCache = true
 	}
 
+	config.Set(config.ScraperCertCheck, input.ScraperCertCheck)
+
 	if input.StashBoxes != nil {
 		if err := config.ValidateStashBoxes(input.StashBoxes); err != nil {
 			return nil, err

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -71,6 +71,7 @@ func makeConfigGeneralResult() *models.ConfigGeneralResult {
 		Excludes:                   config.GetExcludes(),
 		ImageExcludes:              config.GetImageExcludes(),
 		ScraperUserAgent:           &scraperUserAgent,
+		ScraperCertCheck:           config.GetScraperCertCheck(),
 		ScraperCDPPath:             &scraperCDPPath,
 		StashBoxes:                 config.GetStashBoxes(),
 	}

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -86,6 +86,7 @@ const SessionStoreKey = "session_store_key"
 // scraping options
 const ScrapersPath = "scrapers_path"
 const ScraperUserAgent = "scraper_user_agent"
+const ScraperCertCheck = "scraper_cert_check"
 const ScraperCDPPath = "scraper_cdp_path"
 
 // stash-box options
@@ -272,6 +273,17 @@ func GetScraperUserAgent() string {
 // to an instance of Chrome.
 func GetScraperCDPPath() string {
 	return viper.GetString(ScraperCDPPath)
+}
+
+// GetScraperCertCheck returns true if the scraper should check for insecure
+// certificates when fetching an image or a page.
+func GetScraperCertCheck() bool {
+	ret := true
+	if viper.IsSet(ScraperCertCheck) {
+		ret = viper.GetBool(ScraperCertCheck)
+	}
+
+	return ret
 }
 
 func GetStashBoxes() []*models.StashBox {

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	stashConfig "github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
 )
@@ -85,7 +86,7 @@ func setMovieBackImage(m *models.ScrapedMovie, globalConfig GlobalConfig) error 
 func getImage(url string, globalConfig GlobalConfig) (*string, error) {
 	client := &http.Client{
 		Transport: &http.Transport{ // ignore insecure certificates
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !stashConfig.GetScraperCertCheck()}},
 		Timeout: imageGetTimeout,
 	}
 

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -83,6 +84,8 @@ func setMovieBackImage(m *models.ScrapedMovie, globalConfig GlobalConfig) error 
 
 func getImage(url string, globalConfig GlobalConfig) (*string, error) {
 	client := &http.Client{
+		Transport: &http.Transport{ // ignore insecure certificates
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 		Timeout: imageGetTimeout,
 	}
 

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/stashapp/stash/pkg/logger"
+	stashConfig "github.com/stashapp/stash/pkg/manager/config"
 )
 
 // Timeout for the scrape http request. Includes transfer time. May want to make this
@@ -51,7 +52,7 @@ func loadURL(url string, scraperConfig config, globalConfig GlobalConfig) (io.Re
 
 	client := &http.Client{
 		Transport: &http.Transport{ // ignore insecure certificates
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !stashConfig.GetScraperCertCheck()},
 		},
 		Timeout: scrapeGetTimeout,
 		// defaultCheckRedirect code with max changed from 10 to 20

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -3,6 +3,7 @@ package scraper
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -49,6 +50,9 @@ func loadURL(url string, scraperConfig config, globalConfig GlobalConfig) (io.Re
 	printCookies(jar, scraperConfig, "Jar cookies set from scraper")
 
 	client := &http.Client{
+		Transport: &http.Transport{ // ignore insecure certificates
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
 		Timeout: scrapeGetTimeout,
 		// defaultCheckRedirect code with max changed from 10 to 20
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -1,3 +1,4 @@
 ### 🎨 Improvements
+* Add option to skip checking of insecure SSL certificates when scraping.
 * Support random strings for scraper cookie values.
 * Added Rescan button to scene, image, gallery details overflow button.

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -125,6 +125,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
   const [scraperCDPPath, setScraperCDPPath] = useState<string | undefined>(
     undefined
   );
+  const [scraperCertCheck, setScraperCertCheck] = useState<boolean>(true);
   const [stashBoxes, setStashBoxes] = useState<IStashBoxInstance[]>([]);
 
   const { data, error, loading } = useConfiguration();
@@ -164,6 +165,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
     imageExcludes,
     scraperUserAgent,
     scraperCDPPath,
+    scraperCertCheck,
     stashBoxes: stashBoxes.map(
       (b) =>
         ({
@@ -212,6 +214,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
       setImageExcludes(conf.general.imageExcludes);
       setScraperUserAgent(conf.general.scraperUserAgent ?? undefined);
       setScraperCDPPath(conf.general.scraperCDPPath ?? undefined);
+      setScraperCertCheck(conf.general.scraperCertCheck);
       setStashBoxes(
         conf.general.stashBoxes.map((box, i) => ({
           name: box?.name ?? undefined,
@@ -715,6 +718,20 @@ export const SettingsConfigurationPanel: React.FC = () => {
             File path to the Chrome executable, or a remote address (starting
             with http:// or https://, for example
             http://localhost:9222/json/version) to a Chrome instance.
+          </Form.Text>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Check
+            id="scaper-cert-check"
+            checked={scraperCertCheck}
+            label="Check for insecure certificates"
+            onChange={() => setScraperCertCheck(!scraperCertCheck)}
+          />
+          <Form.Text className="text-muted">
+            Some sites use insecure ssl certificates. When unticked the scraper
+            skips the insecure certificates check and allows scraping of those
+            sites. If you get a certificate error when scraping untick this.
           </Form.Text>
         </Form.Group>
       </Form.Group>


### PR DESCRIPTION
The http client we use to do the scraping and download images is a little picky with certificates. That causes an error when trying to scrape from sites that have certificate issues.
example  `https://www.sslshopper.com/ssl-checker.html#hostname=https://dreamtranny.com`

If needed i can add this as an option to the scraper config section instead of hardcoding it.