### PR TITLE
Add short names for Iran and Moldova

### DIFF
--- a/ui/v2.5/src/utils/country.ts
+++ b/ui/v2.5/src/utils/country.ts
@@ -13,6 +13,8 @@ const fuzzyDict: Record<string, string> = {
   "United Kingdom": "GB",
   Russia: "RU",
   "Slovak Republic": "SK",
+  Iran: "IR",
+  Moldova: "MD",
 };
 
 const getISOCountry = (country: string | null | undefined) => {


### PR DESCRIPTION
Iran and Moldova are officially named `Iran, Islamic Republic of` and `Moldova, Republic of`, neither of which most people use.