### PR TITLE
Random strings for cookie values

### DIFF
--- a/pkg/scraper/config.go
+++ b/pkg/scraper/config.go
@@ -158,10 +158,11 @@ type scraperDebugOptions struct {
 }
 
 type scraperCookies struct {
-	Name   string `yaml:"Name"`
-	Value  string `yaml:"Value"`
-	Domain string `yaml:"Domain"`
-	Path   string `yaml:"Path"`
+	Name        string `yaml:"Name"`
+	Value       string `yaml:"Value"`
+	ValueRandom int    `yaml:"ValueRandom"`
+	Domain      string `yaml:"Domain"`
+	Path        string `yaml:"Path"`
 }
 
 type cookieOptions struct {

--- a/pkg/scraper/cookies.go
+++ b/pkg/scraper/cookies.go
@@ -33,13 +33,9 @@ func setCookies(jar *cookiejar.Jar, scraperConfig config) {
 				for _, cookie := range ckURL.Cookies {
 					httpCookie = &http.Cookie{
 						Name:   cookie.Name,
-						Value:  cookie.Value,
+						Value:  getCookieValue(cookie),
 						Path:   cookie.Path,
 						Domain: cookie.Domain,
-					}
-
-					if httpCookie.Value == "random" {
-						httpCookie.Value = utils.RandomSequence(20)
 					}
 
 					httpCookies = append(httpCookies, httpCookie)
@@ -56,6 +52,13 @@ func setCookies(jar *cookiejar.Jar, scraperConfig config) {
 
 		}
 	}
+}
+
+func getCookieValue(cookie *scraperCookies) string {
+	if cookie.ValueRandom != 0 {
+		return utils.RandomSequence(cookie.ValueRandom)
+	}
+	return cookie.Value
 }
 
 // print all cookies from the jar of the native http client
@@ -97,7 +100,7 @@ func setCDPCookies(driverOptions scraperDriverOptions) chromedp.Tasks {
 
 			for _, ckURL := range driverOptions.Cookies {
 				for _, cookie := range ckURL.Cookies {
-					success, err := network.SetCookie(cookie.Name, cookie.Value).
+					success, err := network.SetCookie(cookie.Name, getCookieValue(cookie)).
 						WithExpires(&expr).
 						WithDomain(cookie.Domain).
 						WithPath(cookie.Path).

--- a/pkg/scraper/cookies.go
+++ b/pkg/scraper/cookies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chromedp/chromedp"
 
 	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 // set cookies for the native http client
@@ -35,6 +36,10 @@ func setCookies(jar *cookiejar.Jar, scraperConfig config) {
 						Value:  cookie.Value,
 						Path:   cookie.Path,
 						Domain: cookie.Domain,
+					}
+
+					if httpCookie.Value == "random" {
+						httpCookie.Value = utils.RandomSequence(20)
 					}
 
 					httpCookies = append(httpCookies, httpCookie)

--- a/pkg/scraper/cookies.go
+++ b/pkg/scraper/cookies.go
@@ -55,7 +55,7 @@ func setCookies(jar *cookiejar.Jar, scraperConfig config) {
 }
 
 func getCookieValue(cookie *scraperCookies) string {
-	if cookie.ValueRandom != 0 {
+	if cookie.ValueRandom > 0 {
 		return utils.RandomSequence(cookie.ValueRandom)
 	}
 	return cookie.Value

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,11 +1,15 @@
 package utils
 
-import "math/rand"
+import (
+	"math/rand"
+	"time"
+)
 
 var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
 
 func RandomSequence(n int) string {
 	b := make([]rune, n)
+	rand.Seed(time.Now().UnixNano())
 	for i := range b {
 		b[i] = characters[rand.Intn(len(characters))]
 	}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,0 +1,13 @@
+package utils
+
+import "math/rand"
+
+var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+
+func RandomSequence(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = characters[rand.Intn(len(characters))]
+	}
+	return string(b)
+}

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -1,2 +1,3 @@
 ### 🎨 Improvements
+* Support random strings for scraper cookie values.
 * Added Rescan button to scene, image, gallery details overflow button.

--- a/ui/v2.5/src/docs/en/Scraping.md
+++ b/ui/v2.5/src/docs/en/Scraping.md
@@ -489,6 +489,33 @@ driver:
           Domain: ".somewhere.com"
 ```
 
+For some sites, the value of the cookie itself doesn't actually matter. In these cases, we can use the `ValueRandom`
+property instead of `Value`. Unlike `Value`, `ValueRandom` requires an integer value greater than `0` where the value
+indicates how long the cookie string should be.
+
+In the following example, we will adapt the previous cookies to use `ValueRandom` instead. We set the `_test2` cookie
+to randomly generate a value with a length of 6 characters and the `_warn` cookie to a length of 3.
+
+```yaml
+driver:
+  cookies:
+    - CookieURL: "https://www.example.com"
+      Cookies:
+        - Name: "_warning"
+          Domain: ".example.com"
+          Value: "true"
+          Path: "/"
+        - Name: "_test2"
+          ValueRandom: 6
+          Domain: ".example.com"
+          Path: "/"
+    - CookieURL: "https://api.somewhere.com"
+      Cookies:
+        - Name: "_warn"
+          ValueRandom: 3
+          Domain: ".somewhere.com"
+```
+
 When developing a scraper you can have a look at the cookies set by a site by adding
 
 * a `CookieURL` if you use the direct xpath scraper


### PR DESCRIPTION
If a scraper requires cookies and any random value can be used, we can now set the value to `"random"` for a random string to be generated and used.