### PR TITLE
Fix hacky CSS for scene card video preview

### DIFF
--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -196,6 +196,9 @@ textarea.scene-description {
 
     &-video {
       position: absolute;
+      top: -9999px;
+      transition: top 0s;
+      transition-delay: 0s;
       visibility: hidden;
     }
 
@@ -226,6 +229,8 @@ textarea.scene-description {
     }
 
     .scene-card-preview-video {
+      top: 0;
+      transition-delay: 0.2s;
       visibility: visible;
     }
   }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -196,9 +196,7 @@ textarea.scene-description {
 
     &-video {
       position: absolute;
-      top: -9999px;
-      transition: top 0s;
-      transition-delay: 0s;
+      visibility: hidden;
     }
 
     &.portrait {
@@ -228,8 +226,7 @@ textarea.scene-description {
     }
 
     .scene-card-preview-video {
-      top: 0;
-      transition-delay: 0.2s;
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
The positioning for previews was rather bad and extremely hacky. Using CSS visibility is a more appropriate solution that won't cause issues.