### PR TITLE
Check if gallery is already associated during scanning

### DIFF
--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -315,14 +315,22 @@ func (t *ScanTask) associateGallery(wg *sizedwaitgroup.SizedWaitGroup) {
 			scene, _ := sqb.FindByPath(scenePath)
 			// found related Scene
 			if scene != nil {
-				logger.Infof("associate: Gallery %s is related to scene: %d", t.FilePath, scene.ID)
-
-				if err := sqb.UpdateGalleries(scene.ID, []int{g.ID}); err != nil {
-					return err
+				sceneGalleries, _ := sqb.FindByGalleryID(g.ID) // check if gallery is already associated to the scene
+				isAssoc := false
+				for _, sg := range sceneGalleries {
+					if scene.ID == sg.ID {
+						isAssoc = true
+						break
+					}
+				}
+				if !isAssoc {
+					logger.Infof("associate: Gallery %s is related to scene: %d", t.FilePath, scene.ID)
+					if err := sqb.UpdateGalleries(scene.ID, []int{g.ID}); err != nil {
+						return err
+					}
 				}
 			}
 		}
-
 		return nil
 	}); err != nil {
 		logger.Error(err.Error())

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -8,6 +8,7 @@
 * Added Rescan button to scene, image, gallery details overflow button.
 
 ### 🐛 Bug fixes
+* Fix scan re-associating galleries to the same scene.
 * Fix SQL error when filtering galleries excluding performers or tags.
 * Fix version checking for armv7 and arm64.
 * Change "Is NULL" filter to include empty string values.


### PR DESCRIPTION
Fixes a regression for gallery association.
Before associating a gallery with a scene make sure that the gallery isnt already associated with the specific scene.