### PR TITLE
Find correct python executable

### DIFF
--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -193,12 +193,10 @@ func (s *scriptScraper) scrapeMovieByURL(url string) (*models.ScrapedMovie, erro
 }
 
 func findPythonExecutable() (string, error) {
-	cmd := exec.Command("python3", "--version")
-	_, err := cmd.Output()
+	_, err := exec.LookPath("python3")
 
 	if err != nil {
-		cmd := exec.Command("python", "--version")
-		_, err := cmd.Output()
+		_, err = exec.LookPath("python")
 
 		if err != nil {
 			return "", err

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -30,7 +30,7 @@ func newScriptScraper(scraper scraperTypeConfig, config config, globalConfig Glo
 func (s *scriptScraper) runScraperScript(inString string, out interface{}) error {
 	command := s.scraper.Script
 
-	if command[0] == "python" {
+	if command[0] == "python" || command[0] == "python3" {
 		executable, err := findPythonExecutable()
 		if err == nil {
 			command[0] = executable

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -30,6 +30,13 @@ func newScriptScraper(scraper scraperTypeConfig, config config, globalConfig Glo
 func (s *scriptScraper) runScraperScript(inString string, out interface{}) error {
 	command := s.scraper.Script
 
+	if command[0] == "python" {
+		executable, err := findPythonExecutable()
+		if err == nil {
+			command[0] = executable
+		}
+	}
+
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Dir = filepath.Dir(s.config.path)
 
@@ -183,4 +190,22 @@ func (s *scriptScraper) scrapeMovieByURL(url string) (*models.ScrapedMovie, erro
 	err := s.runScraperScript(string(inString), &ret)
 
 	return &ret, err
+}
+
+func findPythonExecutable() (string, error) {
+	cmd := exec.Command("python3", "--version")
+	_, err := cmd.Output()
+
+	if err != nil {
+		cmd := exec.Command("python", "--version")
+		_, err := cmd.Output()
+
+		if err != nil {
+			return "", err
+		}
+
+		return "python", nil
+	}
+
+	return "python3", nil
 }

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -1,4 +1,5 @@
 ### 🎨 Improvements
+* Resolve python executable to `python3` or `python` for python script scrapers.
 * Add `url` field to `URLReplace`, and make `queryURLReplace` available when scraping by URL.
 * Make logging format consistent across platforms and include full timestamp.
 * Remember gallery images view mode.

--- a/ui/v2.5/src/docs/en/Scraping.md
+++ b/ui/v2.5/src/docs/en/Scraping.md
@@ -85,7 +85,7 @@ script:
   - query
 ```
 
-This configuration would execute `python iafdScrape.py query`.
+Stash will find the correct python executable for your system, either `python` or `python3`. So for example. this configuration could execute `python iafdScrape.py query` or `python3 iafdScrape.py query`.
 
 Stash sends data to the script process's `stdin` stream and expects the output to be streamed to the `stdout` stream. Any errors and progress messages should be output to `stderr`.
 

--- a/ui/v2.5/src/docs/en/Scraping.md
+++ b/ui/v2.5/src/docs/en/Scraping.md
@@ -86,6 +86,7 @@ script:
 ```
 
 Stash will find the correct python executable for your system, either `python` or `python3`. So for example. this configuration could execute `python iafdScrape.py query` or `python3 iafdScrape.py query`.
+`python3` will be looked for first and if it's not found, we'll check for `python`. In the case neither are found, you will get an error.
 
 Stash sends data to the script process's `stdin` stream and expects the output to be streamed to the `stdout` stream. Any errors and progress messages should be output to `stderr`.
 


### PR DESCRIPTION
For script scrapers using python, both python and python3 are valid depending on the OS and running environment. To save users from having any issues, this change will find the correct executable for them.