### PR TITLE
Fix SQL error in 8K resolution filter

### DIFF
--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -297,7 +297,7 @@ func (qb *imageQueryBuilder) Query(imageFilter *models.ImageFilterType, findFilt
 			case "SIX_K":
 				query.addWhere("(MIN(images.height, images.width) >= 3384 AND MIN(images.height, images.width) < 4320)")
 			case "EIGHT_K":
-				query.addWhere("(MIN(images.height, images.width) >= 4320")
+				query.addWhere("MIN(images.height, images.width) >= 4320")
 			}
 		}
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -413,7 +413,7 @@ func (qb *sceneQueryBuilder) Query(sceneFilter *models.SceneFilterType, findFilt
 			case "SIX_K":
 				query.addWhere("(MIN(scenes.height, scenes.width) >= 3384 AND MIN(scenes.height, scenes.width) < 4320)")
 			case "EIGHT_K":
-				query.addWhere("(MIN(scenes.height, scenes.width) >= 4320")
+				query.addWhere("MIN(scenes.height, scenes.width) >= 4320")
 			}
 		}
 	}


### PR DESCRIPTION
The 8K resolution filter is currently broken both for scenes and images. This fixes the SQL error by removing the redundant open parentheses (same as the `VERY_LOW` resolution doesn't use parentheses).