### PR TITLE
Change gallery icon to images

### DIFF
--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -95,7 +95,7 @@ const allMenuItems: IMenuItem[] = [
     name: "galleries",
     message: messages.galleries,
     href: "/galleries",
-    icon: "image",
+    icon: "images",
   },
   {
     name: "performers",

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -265,7 +265,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     return (
       <HoverPopover placement="bottom" content={popoverContent}>
         <Button className="minimal">
-          <Icon icon="image" />
+          <Icon icon="images" />
           <span>{props.scene.galleries.length}</span>
         </Button>
       </HoverPopover>


### PR DESCRIPTION
Changes the gallery icon in the top navbar and card icons to be the multiple `images` to distinguish it from images.

![image](https://user-images.githubusercontent.com/53250216/109575427-dfa4a000-7b45-11eb-9fee-7bde7ddb1776.png)
