### PR TITLE
Fix scene form layout bugs

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -666,8 +666,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
               />
             </Col>
           </Form.Group>
-        </div>
-        <div className="col-12 col-lg-6 col-xl-12">
           <Form.Group controlId="details">
             <Form.Label>StashIDs</Form.Label>
             <ul className="pl-0">

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -417,7 +417,6 @@ div.dropdown-menu {
   [type="file"] {
     display: block;
     filter: alpha(opacity=0);
-    font-size: 999px;
     min-height: 100%;
     min-width: 100%;
     opacity: 0;


### PR DESCRIPTION
* Remove font-size from image input so it isn't unnecessarily tall.
* Put stash ids in same column as rest of main metadata so the form is just two columns on medium sized screens.