### PR TITLE
Remove streaming resolutions over max configured

### DIFF
--- a/pkg/api/resolver_query_scene.go
+++ b/pkg/api/resolver_query_scene.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stashapp/stash/pkg/api/urlbuilders"
 	"github.com/stashapp/stash/pkg/manager"
+	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 )
 
@@ -29,5 +30,5 @@ func (r *queryResolver) SceneStreams(ctx context.Context, id *string) ([]*models
 	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 	builder := urlbuilders.NewSceneURLBuilder(baseURL, scene.ID)
 
-	return manager.GetSceneStreamPaths(scene, builder.GetStreamURL())
+	return manager.GetSceneStreamPaths(scene, builder.GetStreamURL(), config.GetMaxStreamingTranscodeSize())
 }

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -84,6 +84,14 @@ func (s Scene) GetHash(hashAlgorithm HashAlgorithm) string {
 	panic("unknown hash algorithm")
 }
 
+func (s Scene) GetMinResolution() int64 {
+	if s.Width.Int64 < s.Height.Int64 {
+		return s.Width.Int64
+	}
+
+	return s.Height.Int64
+}
+
 // SceneFileType represents the file metadata for a scene.
 type SceneFileType struct {
 	Size       *string  `graphql:"size" json:"size"`

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -11,6 +11,7 @@
 * Added Rescan button to scene, image, gallery details overflow button.
 
 ### 🐛 Bug fixes
+* Filter out streaming resolution options that are over the maximum streaming resolution.
 * Fix `cover.jpg` not being detected as cover image when in sub-directory.
 * Fix scan re-associating galleries to the same scene.
 * Fix SQL error when filtering galleries excluding performers or tags.


### PR DESCRIPTION
Fixes #1160 

Changed `sceneStreams` to only return streams up to the maximum configured streaming transcode quality. This means that scenes will be streamed at the maximum allowed resolution when transcoding, and higher options will not be available.