### PR TITLE
Fix IsPathInDir

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -276,7 +276,7 @@ func IsPathInDir(dir, pathToCheck string) bool {
 	rel, err := filepath.Rel(dir, pathToCheck)
 
 	if err == nil {
-		if !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if !strings.HasPrefix(rel, "..") {
 			return true
 		}
 	}

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPathInDir(t *testing.T) {
+	type test struct {
+		dir         string
+		pathToCheck string
+		expected    bool
+	}
+
+	const parentDirName = "parentDir"
+	const subDirName = "subDir"
+	const filename = "filename"
+	subDir := filepath.Join(parentDirName, subDirName)
+	fileInSubDir := filepath.Join(subDir, filename)
+	fileInParentDir := filepath.Join(parentDirName, filename)
+	subSubSubDir := filepath.Join(parentDirName, subDirName, subDirName, subDirName)
+
+	tests := []test{
+		{dir: parentDirName, pathToCheck: subDir, expected: true},
+		{dir: subDir, pathToCheck: subDir, expected: true},
+		{dir: subDir, pathToCheck: parentDirName, expected: false},
+		{dir: subDir, pathToCheck: fileInSubDir, expected: true},
+		{dir: parentDirName, pathToCheck: fileInSubDir, expected: true},
+		{dir: subDir, pathToCheck: fileInParentDir, expected: false},
+		{dir: parentDirName, pathToCheck: fileInParentDir, expected: true},
+		{dir: parentDirName, pathToCheck: filename, expected: false},
+		{dir: parentDirName, pathToCheck: subSubSubDir, expected: true},
+		{dir: subSubSubDir, pathToCheck: parentDirName, expected: false},
+	}
+
+	assert := assert.New(t)
+	for i, tc := range tests {
+		result := IsPathInDir(tc.dir, tc.pathToCheck)
+		assert.Equal(tc.expected, result, "[%d] expected: %t for dir: %s; pathToCheck: %s", i, tc.expected, tc.dir, tc.pathToCheck)
+	}
+}

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -18,6 +18,7 @@
 * Added Rescan button to scene, image, gallery details overflow button.
 
 ### 🐛 Bug fixes
+* Fix incorrect folders being excluded during scanning.
 * Filter out streaming resolution options that are over the maximum streaming resolution.
 * Fix `cover.jpg` not being detected as cover image when in sub-directory.
 * Fix scan re-associating galleries to the same scene.


### PR DESCRIPTION
Fixes #1188 

Also adds unit tests to prove the functionality of `IsPathInDir`.