### PR TITLE
Add configFilePath and scrapersPath to configuration query

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -94,6 +94,10 @@ type ConfigGeneralResult {
   databasePath: String!
   """Path to generated files"""
   generatedPath: String!
+  """Path to the config file used"""
+  configFilePath: String!
+  """Path to scrapers"""
+  scrapersPath: String!
   """Path to cache"""
   cachePath: String!
   """Whether to calculate MD5 checksums for scene video files"""

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -46,6 +46,8 @@ func makeConfigGeneralResult() *models.ConfigGeneralResult {
 		Stashes:                    config.GetStashPaths(),
 		DatabasePath:               config.GetDatabasePath(),
 		GeneratedPath:              config.GetGeneratedPath(),
+		ConfigFilePath:             config.GetConfigFilePath(),
+		ScrapersPath:               config.GetScrapersPath(),
 		CachePath:                  config.GetCachePath(),
 		CalculateMd5:               config.IsCalculateMD5(),
 		VideoFileNamingAlgorithm:   config.GetVideoFileNamingAlgorithm(),

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -146,6 +146,10 @@ func GetConfigPath() string {
 	return filepath.Dir(configFileUsed)
 }
 
+func GetConfigFilePath() string {
+	return viper.ConfigFileUsed()
+}
+
 func GetStashPaths() []*models.StashConfig {
 	var ret []*models.StashConfig
 	if err := viper.UnmarshalKey(Stash, &ret); err != nil || len(ret) == 0 {


### PR DESCRIPTION
Adds the config.yml file path and the scrapers directory used to the configuration query.
This helps script developers to get the paths from a graphql query.
eg
```bash
curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ configuration { general { scrapersPath } }}" }' localhost:9999/graphql
curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ configuration { general { configFilePath } }}" }' localhost:9999/graphql
```