### PR TITLE
Performer edit UI further updates

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -806,7 +806,19 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           </Col>
         </Form.Group>
 
-        {renderTextField("aliases", "Alias")}
+        <Form.Group controlId="aliases" as={Row}>
+          <Form.Label column sm={labelXS} xl={labelXL}>
+            Alias
+          </Form.Label>
+          <Col sm={fieldXS} xl={fieldXL}>
+            <Form.Control
+              as="textarea"
+              className="text-input"
+              placeholder="Alias"
+              {...formik.getFieldProps("aliases")}
+            />
+          </Col>
+        </Form.Group>
 
         <Form.Group as={Row}>
           <Form.Label column xs={labelXS} xl={labelXL}>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -677,9 +677,11 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   function renderTagsField() {
     return (
-      <Form.Row>
-        <Form.Group as={Col} sm="6">
-          <Form.Label>Tags</Form.Label>
+      <Form.Group controlId={"tags"} as={Row}>
+        <Form.Label column sm={labelXS} xl={labelXL}>
+          Tags
+        </Form.Label>
+        <Col xs={fieldXS} xl={fieldXL}>
           <TagSelect
             menuPortalTarget={document.body}
             isMulti
@@ -692,8 +694,8 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
             ids={formik.values.tag_ids}
           />
           {renderNewTags()}
-        </Form.Group>
-      </Form.Row>
+        </Col>
+      </Form.Group>
     );
   }
 
@@ -714,8 +716,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
     return (
       <Row>
-        <Col sm="auto">
-          <div>StashIDs</div>
+        <Form.Label column sm={labelXS} xl={labelXL}>
+          StashIDs
+        </Form.Label>
+        <Col sm={fieldXS} xl={fieldXL}>
           <ul className="pl-0">
             {formik.values.stash_ids.map((stashID) => {
               const base = stashID.endpoint.match(/https?:\/\/.*?\//)?.[0];
@@ -750,6 +754,29 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     );
   }
 
+  const labelXS = 3;
+  const labelXL = 2;
+  const fieldXS = 9;
+  const fieldXL = 7;
+
+  function renderTextField(field: string, title: string) {
+    return (
+      <Form.Group controlId={field} as={Row}>
+        <Form.Label column xs={labelXS} xl={labelXL}>
+          {title}
+        </Form.Label>
+        <Col xs={fieldXS} xl={fieldXL}>
+          <Form.Control
+            className="text-input"
+            placeholder={title}
+            {...formik.getFieldProps(field)}
+            isInvalid={!!formik.getFieldMeta(field).error}
+          />
+        </Col>
+      </Form.Group>
+    );
+  }
+
   return (
     <>
       {renderDeleteAlert()}
@@ -762,9 +789,11 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       />
 
       <Form noValidate onSubmit={formik.handleSubmit} id="performer-edit">
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Name</Form.Label>
+        <Form.Group controlId="name" as={Row}>
+          <Form.Label column xs={labelXS} xl={labelXL}>
+            Name
+          </Form.Label>
+          <Col xs={fieldXS} xl={fieldXL}>
             <Form.Control
               className="text-input"
               placeholder="Name"
@@ -774,20 +803,16 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
             <Form.Control.Feedback type="invalid">
               {formik.errors.name}
             </Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group as={Col} sm="8">
-            <Form.Label>Aliases</Form.Label>
-            <Form.Control
-              className="text-input"
-              placeholder="Aliases"
-              {...formik.getFieldProps("aliases")}
-            />
-          </Form.Group>
-        </Form.Row>
+          </Col>
+        </Form.Group>
 
-        <Form.Row>
-          <Form.Group as={Col} md="auto">
-            <Form.Label>Gender</Form.Label>
+        {renderTextField("aliases", "Alias")}
+
+        <Form.Group as={Row}>
+          <Form.Label column xs={labelXS} xl={labelXL}>
+            Gender
+          </Form.Label>
+          <Col xs="auto">
             <Form.Control
               as="select"
               className="input-control"
@@ -799,139 +824,66 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
                 </option>
               ))}
             </Form.Control>
-          </Form.Group>
-        </Form.Row>
+          </Col>
+        </Form.Group>
 
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Birthdate</Form.Label>
-            <Form.Control
-              className="text-input"
-              placeholder="Birthdate"
-              {...formik.getFieldProps("birthdate")}
-            />
-          </Form.Group>
-        </Form.Row>
+        {renderTextField("birthdate", "Birthdate")}
+        {renderTextField("country", "Country")}
+        {renderTextField("ethnicity", "Ethnicity")}
+        {renderTextField("eye_color", "Eye Color")}
+        {renderTextField("height", "Height (cm)")}
+        {renderTextField("measurements", "Measurements")}
+        {renderTextField("fake_tits", "Fake Tits")}
 
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Country</Form.Label>
+        <Form.Group controlId="tattoos" as={Row}>
+          <Form.Label column sm={labelXS} xl={labelXL}>
+            Tattoos
+          </Form.Label>
+          <Col sm={fieldXS} xl={fieldXL}>
             <Form.Control
+              as="textarea"
               className="text-input"
-              {...formik.getFieldProps("country")}
-              placeholder="Country"
-            />
-          </Form.Group>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Ethnicity</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("ethnicity")}
-              placeholder="Ethnicity"
-            />
-          </Form.Group>
-        </Form.Row>
-
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Eye Color</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("eye_color")}
-              placeholder="Eye Color"
-            />
-          </Form.Group>
-        </Form.Row>
-
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Height (cm)</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("height")}
-              placeholder="Height (cm)"
-            />
-          </Form.Group>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Measurements</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("measurements")}
-              placeholder="Measurements"
-            />
-          </Form.Group>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Fake Tits</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("fake_tits")}
-              placeholder="Fake Tits"
-            />
-          </Form.Group>
-        </Form.Row>
-
-        <Form.Row>
-          <Form.Group as={Col} lg="6">
-            <Form.Label>Tattoos</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("tattoos")}
               placeholder="Tattoos"
+              {...formik.getFieldProps("tattoos")}
             />
-          </Form.Group>
-          <Form.Group as={Col} lg="6">
-            <Form.Label>Piercings</Form.Label>
+          </Col>
+        </Form.Group>
+
+        <Form.Group controlId="piercings" as={Row}>
+          <Form.Label column sm={labelXS} xl={labelXL}>
+            Piercings
+          </Form.Label>
+          <Col sm={fieldXS} xl={fieldXL}>
             <Form.Control
+              as="textarea"
               className="text-input"
-              {...formik.getFieldProps("piercings")}
               placeholder="Piercings"
+              {...formik.getFieldProps("piercings")}
             />
-          </Form.Group>
-        </Form.Row>
+          </Col>
+        </Form.Group>
 
-        <Form.Row>
-          <Form.Group as={Col} sm="4">
-            <Form.Label>Career Length</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("career_length")}
-              placeholder="Career Length"
-            />
-          </Form.Group>
-        </Form.Row>
+        {renderTextField("career_length", "Career Length")}
 
-        <Form.Row>
-          <Form.Group as={Col} sm="6">
-            <Form.Label>URL</Form.Label>
+        <Form.Group controlId="name" as={Row}>
+          <Form.Label column xs={labelXS} xl={labelXL}>
+            URL
+          </Form.Label>
+          <Col xs={fieldXS} xl={fieldXL}>
             <InputGroup>
               <Form.Control
                 className="text-input"
-                {...formik.getFieldProps("url")}
                 placeholder="URL"
+                {...formik.getFieldProps("url")}
               />
               <InputGroup.Append>{maybeRenderScrapeButton()}</InputGroup.Append>
             </InputGroup>
-          </Form.Group>
-        </Form.Row>
+          </Col>
+        </Form.Group>
 
-        <Form.Row>
-          <Form.Group as={Col} lg="6">
-            <Form.Label>Twitter</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("twitter")}
-              placeholder="Twitter"
-            />
-          </Form.Group>
-          <Form.Group as={Col} lg="6">
-            <Form.Label>Instagram</Form.Label>
-            <Form.Control
-              className="text-input"
-              {...formik.getFieldProps("instagram")}
-              placeholder="Instagram"
-            />
-          </Form.Group>
-        </Form.Row>
+        {renderTextField("twitter", "Twitter")}
+        {renderTextField("instagram", "Instagram")}
+
         {renderTagsField()}
         {renderStashIDs()}
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -91,6 +91,11 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   const genderOptions = [""].concat(getGenderStrings());
 
+  const labelXS = 3;
+  const labelXL = 2;
+  const fieldXS = 9;
+  const fieldXL = 7;
+
   const schema = yup.object({
     name: yup.string().required(),
     aliases: yup.string().optional(),
@@ -677,7 +682,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   function renderTagsField() {
     return (
-      <Form.Group controlId={"tags"} as={Row}>
+      <Form.Group controlId="tags" as={Row}>
         <Form.Label column sm={labelXS} xl={labelXL}>
           Tags
         </Form.Label>
@@ -753,11 +758,6 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       </Row>
     );
   }
-
-  const labelXS = 3;
-  const labelXL = 2;
-  const fieldXS = 9;
-  const fieldXL = 7;
 
   function renderTextField(field: string, title: string) {
     return (

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -6,6 +6,7 @@ import {
   ScrapedInputGroupRow,
   ScrapedImageRow,
   ScrapeDialogRow,
+  ScrapedTextAreaRow,
 } from "src/components/Shared/ScrapeDialog";
 import {
   getGenderStrings,
@@ -358,7 +359,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
           result={name}
           onChange={(value) => setName(value)}
         />
-        <ScrapedInputGroupRow
+        <ScrapedTextAreaRow
           title="Aliases"
           result={aliases}
           onChange={(value) => setAliases(value)}
@@ -404,12 +405,12 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
           result={careerLength}
           onChange={(value) => setCareerLength(value)}
         />
-        <ScrapedInputGroupRow
+        <ScrapedTextAreaRow
           title="Tattoos"
           result={tattoos}
           onChange={(value) => setTattoos(value)}
         />
-        <ScrapedInputGroupRow
+        <ScrapedTextAreaRow
           title="Piercings"
           result={piercings}
           onChange={(value) => setPiercings(value)}

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -44,6 +44,10 @@ code,
     monospace;
 }
 
+dd {
+  white-space: pre-line;
+}
+
 .input-control,
 .text-input {
   border: 0;


### PR DESCRIPTION
Reverted Performer edit UI page to be single column again. Changed to textarea for Alias, Tattoos and Piercings. 

![image](https://user-images.githubusercontent.com/53250216/111219860-961b8100-862c-11eb-8720-6352d470926b.png)

Changed details field value styling to maintain line breaks:

![image](https://user-images.githubusercontent.com/53250216/111220028-c6fbb600-862c-11eb-993d-f544c8d882cc.png)

(corresponding value):
![image](https://user-images.githubusercontent.com/53250216/111220245-0de9ab80-862d-11eb-952d-99861eb8c00a.png)

Made Alias, Tattoos and Piercings textareas in scraper dialog.

![image](https://user-images.githubusercontent.com/53250216/111220135-e8f53880-862c-11eb-9876-b757a2005376.png)
