### PR TITLE
Add write mutex and max connection lifetime

### DIFF
--- a/pkg/sqlite/transaction.go
+++ b/pkg/sqlite/transaction.go
@@ -176,17 +176,15 @@ func (t *ReadTransaction) Tag() models.TagReader {
 }
 
 type TransactionManager struct {
-	// only allow one write transaction at a time
-	c chan struct{}
 }
 
 func NewTransactionManager() *TransactionManager {
-	return &TransactionManager{
-		c: make(chan struct{}, 1),
-	}
+	return &TransactionManager{}
 }
 
 func (t *TransactionManager) WithTxn(ctx context.Context, fn func(r models.Repository) error) error {
+	database.WriteMu.Lock()
+	defer database.WriteMu.Unlock()
 	return models.WithTxn(&transaction{Ctx: ctx}, fn)
 }
 


### PR DESCRIPTION
Adds a database write mutex so that only one write operation may occur at once. This should eliminate any database locked issues.

Adds a connection timeout of 30 seconds for the database connection. This will mean that after 30 seconds of inactivity, the `-wal` and `-shm` files will be deleted, hopefully mitigating some of the risk if users try to restore a database file without removing these files.