### PR TITLE
Add User Agent to image download requests

### DIFF
--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -111,6 +112,10 @@ func getImage(url string, globalConfig GlobalConfig) (*string, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("http error %d", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -79,6 +79,10 @@ func loadURL(url string, scraperConfig config, globalConfig GlobalConfig) (io.Re
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("http error %d", resp.StatusCode)
+	}
+
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/pkg/utils/user_agent.go
+++ b/pkg/utils/user_agent.go
@@ -1,0 +1,36 @@
+package utils
+
+import "runtime"
+
+// valid UA from https://user-agents.net
+const Safari = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15/iY0wnXbs-59"
+const FirefoxWindows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0"
+const FirefoxLinux = "Mozilla/5.0 (X11; Linux x86_64; rv:88.0) Gecko/20100101 Firefox/88.0"
+const FirefoxLinuxArm = "Mozilla/5.0 (X11; Linux armv7l; rv:86.0) Gecko/20100101 Firefox/86.0"
+const FirefoxLinuxArm64 = "Mozilla/5.0 (X11; Linux aarch64; rv:86.0) Gecko/20100101 Firefox/86.0"
+
+// GetUserAgent returns a valid User Agent string that matches the running os/arch
+func GetUserAgent() string {
+	arch := runtime.GOARCH
+	os := runtime.GOOS
+
+	switch os {
+	case "darwin":
+		return Safari
+	case "windows":
+		return FirefoxWindows
+	case "linux":
+		switch arch {
+		case "arm":
+			return FirefoxLinuxArm
+		case "arm64":
+			return FirefoxLinuxArm64
+		case "amd64":
+			return FirefoxLinux
+		default:
+			return FirefoxLinux
+		}
+	default:
+		return FirefoxLinux
+	}
+}


### PR DESCRIPTION
As mentioned in discord some sites require  a user agent to allow downloading eg `https://tour.pissinghd.com/volrac/yppsitetour/images/logo.png`

Disabled also the check for invalid certs and added a check for the http status response codes ( >= 400 should be treated as error)