### PR TITLE
Movie UI refresh

### DIFF
--- a/pkg/api/resolver_model_movie.go
+++ b/pkg/api/resolver_model_movie.go
@@ -89,6 +89,24 @@ func (r *movieResolver) FrontImagePath(ctx context.Context, obj *models.Movie) (
 }
 
 func (r *movieResolver) BackImagePath(ctx context.Context, obj *models.Movie) (*string, error) {
+	// don't return any thing if there is no back image
+	var img []byte
+	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
+		var err error
+		img, err = repo.Movie().GetBackImage(obj.ID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if img == nil {
+		return nil, nil
+	}
+
 	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
 	backimagePath := urlbuilders.NewMovieURLBuilder(baseURL, obj).GetMovieBackImageURL()
 	return &backimagePath, nil

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -2,6 +2,7 @@
 * Added scene queue.
 
 ### 🎨 Improvements
+* Improve Movie UI.
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -30,6 +30,8 @@ import {
 import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { MovieScenesPanel } from "./MovieScenesPanel";
 import { MovieScrapeDialog } from "./MovieScrapeDialog";
+import { MovieDetailsPanel } from "./MovieDetailsPanel";
+import { MovieEditPanel } from "./MovieEditPanel";
 
 interface IMovieParams {
   id?: string;
@@ -45,6 +47,7 @@ export const Movie: React.FC = () => {
   const [isEditing, setIsEditing] = useState<boolean>(isNew);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
   const [isImageAlertOpen, setIsImageAlertOpen] = useState<boolean>(false);
+  const [movieEditState, setMovieEditState] = useState<Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>>();
 
   // Editing movie state
   const [frontImage, setFrontImage] = useState<string | undefined | null>(
@@ -53,18 +56,8 @@ export const Movie: React.FC = () => {
   const [backImage, setBackImage] = useState<string | undefined | null>(
     undefined
   );
-  const [name, setName] = useState<string | undefined>(undefined);
-  const [aliases, setAliases] = useState<string | undefined>(undefined);
-  const [duration, setDuration] = useState<number | undefined>(undefined);
-  const [date, setDate] = useState<string | undefined>(undefined);
-  const [rating, setRating] = useState<number | undefined>(undefined);
-  const [studioId, setStudioId] = useState<string>();
-  const [director, setDirector] = useState<string | undefined>(undefined);
-  const [synopsis, setSynopsis] = useState<string | undefined>(undefined);
-  const [url, setUrl] = useState<string | undefined>(undefined);
 
   // Movie state
-  const [movie, setMovie] = useState<Partial<GQL.MovieDataFragment>>({});
   const [imagePreview, setImagePreview] = useState<string | undefined>(
     undefined
   );
@@ -78,85 +71,23 @@ export const Movie: React.FC = () => {
 
   // Network state
   const { data, error, loading } = useFindMovie(id);
+  const movie = data?.findMovie;
+
   const [isLoading, setIsLoading] = useState(false);
   const [updateMovie] = useMovieUpdate();
-  const [createMovie] = useMovieCreate(getMovieInput() as GQL.MovieCreateInput);
-  const [deleteMovie] = useMovieDestroy(
-    getMovieInput() as GQL.MovieDestroyInput
-  );
-
-  const Scrapers = useListMovieScrapers();
-  const [scrapedMovie, setScrapedMovie] = useState<
-    GQL.ScrapedMovie | undefined
-  >();
-
-  const intl = useIntl();
+  const [createMovie] = useMovieCreate();
+  const [deleteMovie] = useMovieDestroy({id});
 
   // set up hotkeys
   useEffect(() => {
-    if (isEditing) {
-      Mousetrap.bind("r 0", () => setRating(NaN));
-      Mousetrap.bind("r 1", () => setRating(1));
-      Mousetrap.bind("r 2", () => setRating(2));
-      Mousetrap.bind("r 3", () => setRating(3));
-      Mousetrap.bind("r 4", () => setRating(4));
-      Mousetrap.bind("r 5", () => setRating(5));
-      // Mousetrap.bind("u", (e) => {
-      //   setStudioFocus()
-      //   e.preventDefault();
-      // });
-      Mousetrap.bind("s s", () => onSave());
-    }
-
     Mousetrap.bind("e", () => setIsEditing(true));
     Mousetrap.bind("d d", () => onDelete());
 
     return () => {
-      if (isEditing) {
-        Mousetrap.unbind("r 0");
-        Mousetrap.unbind("r 1");
-        Mousetrap.unbind("r 2");
-        Mousetrap.unbind("r 3");
-        Mousetrap.unbind("r 4");
-        Mousetrap.unbind("r 5");
-        // Mousetrap.unbind("u");
-        Mousetrap.unbind("s s");
-      }
-
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
     };
   });
-
-  function updateMovieEditState(state: Partial<GQL.MovieDataFragment>) {
-    setName(state.name ?? undefined);
-    setAliases(state.aliases ?? undefined);
-    setDuration(state.duration ?? undefined);
-    setDate(state.date ?? undefined);
-    setRating(state.rating ?? undefined);
-    setStudioId(state?.studio?.id ?? undefined);
-    setDirector(state.director ?? undefined);
-    setSynopsis(state.synopsis ?? undefined);
-    setUrl(state.url ?? undefined);
-  }
-
-  const updateMovieData = useCallback(
-    (movieData: Partial<GQL.MovieDataFragment>) => {
-      setFrontImage(undefined);
-      setBackImage(undefined);
-      updateMovieEditState(movieData);
-      setImagePreview(movieData.front_image_path ?? undefined);
-      setBackImagePreview(movieData.back_image_path ?? undefined);
-      setMovie(movieData);
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (data && data.findMovie) {
-      updateMovieData(data.findMovie);
-    }
-  }, [data, updateMovieData]);
 
   function showImageAlert(imageData: string) {
     setImageClipboard(imageData);
@@ -195,41 +126,35 @@ export const Movie: React.FC = () => {
     }
   }
 
-  function getMovieInput() {
-    const input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
-      name,
-      aliases,
-      duration,
-      date,
-      rating: rating ?? null,
-      studio_id: studioId ?? null,
-      director,
-      synopsis,
-      url,
+  function getMovieInput(input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) {
+    const ret: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
+      ...input,
       front_image: frontImage,
       back_image: backImage,
     };
 
     if (!isNew) {
-      (input as GQL.MovieUpdateInput).id = id;
+      (ret as GQL.MovieUpdateInput).id = id;
     }
-    return input;
+    return ret;
   }
 
-  async function onSave() {
+  async function onSave(input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) {
     try {
       if (!isNew) {
         const result = await updateMovie({
           variables: {
-            input: getMovieInput() as GQL.MovieUpdateInput,
+            input: getMovieInput(input) as GQL.MovieUpdateInput,
           },
         });
         if (result.data?.movieUpdate) {
-          updateMovieData(result.data.movieUpdate);
           setIsEditing(false);
+          history.push(`/movies/${result.data.movieUpdate.id}`);
         }
       } else {
-        const result = await createMovie();
+        const result = await createMovie({
+          variables: getMovieInput(input) as GQL.MovieCreateInput,
+        });
         if (result.data?.movieCreate?.id) {
           history.push(`/movies/${result.data.movieCreate.id}`);
           setIsEditing(false);
@@ -261,7 +186,8 @@ export const Movie: React.FC = () => {
 
   function onToggleEdit() {
     setIsEditing(!isEditing);
-    updateMovieData(movie);
+    setFrontImage(undefined);
+    setBackImage(undefined);
   }
 
   function renderDeleteAlert() {
@@ -272,7 +198,7 @@ export const Movie: React.FC = () => {
         accept={{ text: "Delete", variant: "danger", onClick: onDelete }}
         cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
       >
-        <p>Are you sure you want to delete {name ?? "movie"}?</p>
+        <p>Are you sure you want to delete {movie?.name ?? "movie"}?</p>
       </Modal>
     );
   }
@@ -314,153 +240,19 @@ export const Movie: React.FC = () => {
     );
   }
 
-  function updateMovieEditStateFromScraper(
-    state: Partial<GQL.ScrapedMovieDataFragment>
-  ) {
-    if (state.name) {
-      setName(state.name);
-    }
-
-    if (state.aliases) {
-      setAliases(state.aliases ?? undefined);
-    }
-
-    if (state.duration) {
-      setDuration(DurationUtils.stringToSeconds(state.duration) ?? undefined);
-    }
-
-    if (state.date) {
-      setDate(state.date ?? undefined);
-    }
-
-    if (state.studio && state.studio.id) {
-      setStudioId(state.studio.id ?? undefined);
-    }
-
-    if (state.director) {
-      setDirector(state.director ?? undefined);
-    }
-    if (state.synopsis) {
-      setSynopsis(state.synopsis ?? undefined);
-    }
-    if (state.url) {
-      setUrl(state.url ?? undefined);
-    }
-
-    // image is a base64 string
-    // #404: don't overwrite image if it has been modified by the user
-    // overwrite if not new since it came from a dialog
-    // otherwise follow existing behaviour
-    if (
-      (!isNew || frontImage === undefined) &&
-      (state as GQL.ScrapedMovieDataFragment).front_image !== undefined
-    ) {
-      const imageStr = (state as GQL.ScrapedMovieDataFragment).front_image;
-      setFrontImage(imageStr ?? undefined);
-      setImagePreview(imageStr ?? undefined);
-    }
-
-    if (
-      (!isNew || backImage === undefined) &&
-      (state as GQL.ScrapedMovieDataFragment).back_image !== undefined
-    ) {
-      const imageStr = (state as GQL.ScrapedMovieDataFragment).back_image;
-      setBackImage(imageStr ?? undefined);
-      setBackImagePreview(imageStr ?? undefined);
-    }
-  }
-
-  async function onScrapeMovieURL() {
-    if (!url) return;
-    setIsLoading(true);
-
-    try {
-      const result = await queryScrapeMovieURL(url);
-      if (!result.data || !result.data.scrapeMovieURL) {
-        return;
+  function renderImage(originalImage: string | undefined | null, editedImage: string | undefined | null, altText: string) {
+    let image = originalImage;
+    if (isEditing) {
+      if (editedImage === null) {
+        image = `${image}&default=true`;
+      } else if (editedImage) {
+        image = editedImage;
       }
-
-      // if this is a new movie, just dump the data
-      if (isNew) {
-        updateMovieEditStateFromScraper(result.data.scrapeMovieURL);
-      } else {
-        setScrapedMovie(result.data.scrapeMovieURL);
-      }
-    } catch (e) {
-      Toast.error(e);
-    } finally {
-      setIsLoading(false);
-    }
-  }
-
-  function urlScrapable(scrapedUrl: string) {
-    return (
-      !!scrapedUrl &&
-      (Scrapers?.data?.listMovieScrapers ?? []).some((s) =>
-        (s?.movie?.urls ?? []).some((u) => scrapedUrl.includes(u))
-      )
-    );
-  }
-
-  function maybeRenderScrapeButton() {
-    if (!url || !isEditing || !urlScrapable(url)) {
-      return undefined;
-    }
-    return (
-      <Button
-        className="minimal scrape-url-button"
-        onClick={() => onScrapeMovieURL()}
-      >
-        <Icon icon="file-upload" />
-      </Button>
-    );
-  }
-
-  function maybeRenderScrapeDialog() {
-    if (!scrapedMovie) {
-      return;
     }
 
-    const currentMovie = getMovieInput();
-
-    // Get image paths for scrape gui
-    currentMovie.front_image = movie.front_image_path;
-    currentMovie.back_image = movie.back_image_path;
-
-    return (
-      <MovieScrapeDialog
-        movie={currentMovie}
-        scraped={scrapedMovie}
-        onClose={(m) => {
-          onScrapeDialogClosed(m);
-        }}
-      />
-    );
-  }
-
-  function onScrapeDialogClosed(p?: GQL.ScrapedMovieDataFragment) {
-    if (p) {
-      updateMovieEditStateFromScraper(p);
+    if (image) {
+      return <img alt={altText} className="logo w-50" src={image} />
     }
-    setScrapedMovie(undefined);
-  }
-
-  function onClearFrontImage() {
-    setFrontImage(null);
-    setImagePreview(
-      movie.front_image_path
-        ? `${movie.front_image_path}?default=true`
-        : undefined
-    );
-  }
-
-  function onClearBackImage() {
-    setBackImage(null);
-    setBackImagePreview(
-      movie.back_image_path
-        ? `${movie.back_image_path}?default=true`
-        : undefined
-    );
   }
 
   if (isLoading) return <LoadingIndicator />;
@@ -469,124 +261,52 @@ export const Movie: React.FC = () => {
   return (
     <div className="row">
       <div className="movie-details col">
-        {isNew && <h2>Add Movie</h2>}
         <div className="logo w-100">
           {encodingImage ? (
             <LoadingIndicator message="Encoding image..." />
           ) : (
             <>
-              <img alt={name} className="logo w-50" src={imagePreview} />
-              <img alt={name} className="logo w-50" src={backimagePreview} />
+              {renderImage(movie?.front_image_path, frontImage, "Front cover")}
+              {renderImage(movie?.back_image_path, backImage, "Back cover")}
             </>
           )}
         </div>
 
-        <Table>
-          <tbody>
-            {TableUtils.renderInputGroup({
-              title: "Name",
-              value: name ?? "",
-              isEditing: !!isEditing,
-              onChange: setName,
-            })}
-            {TableUtils.renderInputGroup({
-              title: "Aliases",
-              value: aliases,
-              isEditing,
-              onChange: setAliases,
-            })}
-            {TableUtils.renderDurationInput({
-              title: "Duration",
-              value: duration ? duration.toString() : "",
-              isEditing,
-              onChange: (value: string | undefined) =>
-                setDuration(value ? Number.parseInt(value, 10) : undefined),
-            })}
-            {TableUtils.renderInputGroup({
-              title: `Date ${isEditing ? "(YYYY-MM-DD)" : ""}`,
-              value: isEditing ? date : TextUtils.formatDate(intl, date),
-              isEditing,
-              onChange: setDate,
-            })}
-            <tr>
-              <td>Studio</td>
-              <td>
-                <StudioSelect
-                  isDisabled={!isEditing}
-                  onSelect={(items) =>
-                    setStudioId(items.length > 0 ? items[0]?.id : undefined)
-                  }
-                  ids={studioId ? [studioId] : []}
-                />
-              </td>
-            </tr>
-            {TableUtils.renderInputGroup({
-              title: "Director",
-              value: director,
-              isEditing,
-              onChange: setDirector,
-            })}
-            <tr>
-              <td>Rating</td>
-              <td>
-                <RatingStars
-                  value={rating}
-                  disabled={!isEditing}
-                  onSetRating={(value) => setRating(value)}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </Table>
-
-        <Form.Group controlId="url">
-          <Form.Label>URL {maybeRenderScrapeButton()}</Form.Label>
-          <div>
-            {EditableTextUtils.renderInputGroup({
-              isEditing,
-              onChange: setUrl,
-              value: url,
-              url: TextUtils.sanitiseURL(url),
-            })}
-          </div>
-        </Form.Group>
-
-        <Form.Group controlId="synopsis">
-          <Form.Label>Synopsis</Form.Label>
-          <Form.Control
-            as="textarea"
-            readOnly={!isEditing}
-            className="movie-synopsis text-input"
-            onChange={(newValue: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setSynopsis(newValue.currentTarget.value)
-            }
-            value={synopsis}
+        {!isEditing && movie ? (
+          <>
+            <MovieDetailsPanel
+              movie={movie}
+            />
+            {/* HACK - this is also rendered in the MovieEditPanel */}
+            <DetailsEditNavbar
+              objectName={movie?.name ?? "movie"}
+              isNew={isNew}
+              isEditing={isEditing}
+              onToggleEdit={onToggleEdit}
+              onSave={() => {}}
+              onImageChange={() => {}}
+              onDelete={onDelete}
+            />
+          </>
+        ) : (
+          <MovieEditPanel
+            movie={movie ?? undefined}
+            onSubmit={onSave}
+            onCancel={onToggleEdit}
+            onDelete={onDelete}
+            setFrontImage={setFrontImage}
+            setBackImage={setBackImage}
           />
-        </Form.Group>
-
-        <DetailsEditNavbar
-          objectName={name ?? "movie"}
-          isNew={isNew}
-          isEditing={isEditing}
-          onToggleEdit={onToggleEdit}
-          onSave={onSave}
-          onImageChange={onFrontImageChange}
-          onImageChangeURL={onFrontImageLoad}
-          onClearImage={onClearFrontImage}
-          onBackImageChange={onBackImageChange}
-          onBackImageChangeURL={onBackImageLoad}
-          onClearBackImage={onClearBackImage}
-          onDelete={onDelete}
-        />
+        )}
       </div>
-      {!isNew && (
+
+      {!isNew && movie && (
         <div className="col-lg-8 col-md-7">
           <MovieScenesPanel movie={movie} />
         </div>
       )}
       {renderDeleteAlert()}
       {renderImageAlert()}
-      {maybeRenderScrapeDialog()}
     </div>
   );
 };

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState } from "react";
 import cx from "classnames";
-import { useIntl } from "react-intl";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import {
@@ -8,29 +7,17 @@ import {
   useMovieUpdate,
   useMovieCreate,
   useMovieDestroy,
-  queryScrapeMovieURL,
-  useListMovieScrapers,
 } from "src/core/StashService";
 import { useParams, useHistory } from "react-router-dom";
 import {
   DetailsEditNavbar,
   LoadingIndicator,
   Modal,
-  StudioSelect,
-  Icon,
 } from "src/components/Shared";
 import { useToast } from "src/hooks";
-import { Table, Form, Modal as BSModal, Button } from "react-bootstrap";
-import {
-  TableUtils,
-  ImageUtils,
-  EditableTextUtils,
-  TextUtils,
-  DurationUtils,
-} from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
+import { Modal as BSModal, Button } from "react-bootstrap";
+import { ImageUtils } from "src/utils";
 import { MovieScenesPanel } from "./MovieScenesPanel";
-import { MovieScrapeDialog } from "./MovieScrapeDialog";
 import { MovieDetailsPanel } from "./MovieDetailsPanel";
 import { MovieEditPanel } from "./MovieEditPanel";
 
@@ -69,7 +56,7 @@ export const Movie: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [updateMovie] = useMovieUpdate();
   const [createMovie] = useMovieCreate();
-  const [deleteMovie] = useMovieDestroy({id});
+  const [deleteMovie] = useMovieDestroy({ id });
 
   // set up hotkeys
   useEffect(() => {
@@ -107,7 +94,9 @@ export const Movie: React.FC = () => {
     }
   }
 
-  function getMovieInput(input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) {
+  function getMovieInput(
+    input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>
+  ) {
     const ret: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
       ...input,
       front_image: frontImage,
@@ -120,7 +109,9 @@ export const Movie: React.FC = () => {
     return ret;
   }
 
-  async function onSave(input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) {
+  async function onSave(
+    input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>
+  ) {
     try {
       setIsLoading(true);
 
@@ -263,7 +254,11 @@ export const Movie: React.FC = () => {
   // TODO: CSS class
   return (
     <div className="row">
-      <div className={cx("movie-details mb-3 col", {"col-xl-4 col-lg-6": !isNew})}>
+      <div
+        className={cx("movie-details mb-3 col", {
+          "col-xl-4 col-lg-6": !isNew,
+        })}
+      >
         <div className="logo w-100">
           {encodingImage ? (
             <LoadingIndicator message="Encoding image..." />
@@ -277,9 +272,7 @@ export const Movie: React.FC = () => {
 
         {!isEditing && movie ? (
           <>
-            <MovieDetailsPanel
-              movie={movie}
-            />
+            <MovieDetailsPanel movie={movie} />
             {/* HACK - this is also rendered in the MovieEditPanel */}
             <DetailsEditNavbar
               objectName={movie?.name ?? "movie"}

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from "react";
+import cx from "classnames";
 import { useIntl } from "react-intl";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
@@ -47,7 +48,6 @@ export const Movie: React.FC = () => {
   const [isEditing, setIsEditing] = useState<boolean>(isNew);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
   const [isImageAlertOpen, setIsImageAlertOpen] = useState<boolean>(false);
-  const [movieEditState, setMovieEditState] = useState<Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>>();
 
   // Editing movie state
   const [frontImage, setFrontImage] = useState<string | undefined | null>(
@@ -263,7 +263,7 @@ export const Movie: React.FC = () => {
   // TODO: CSS class
   return (
     <div className="row">
-      <div className="movie-details col-xl-4 col-lg-6 mb-3">
+      <div className={cx("movie-details mb-3 col", {"col-xl-4 col-lg-6": !isNew})}>
         <div className="logo w-100">
           {encodingImage ? (
             <LoadingIndicator message="Encoding image..." />

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
-import {
-  DurationUtils,
-  TextUtils,
-} from "src/utils";
+import { DurationUtils, TextUtils } from "src/utils";
 import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { TextField, URLField } from "src/utils/field";
 
@@ -12,7 +9,7 @@ interface IMovieDetailsPanel {
   movie: Partial<GQL.MovieDataFragment>;
 }
 
-export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
+export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({ movie }) => {
   // Network state
   const intl = useIntl();
 
@@ -36,10 +33,7 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
       <dl className="row">
         <dt className="col-3 col-xl-2">Rating</dt>
         <dd className="col-9 col-xl-10">
-          <RatingStars
-            value={movie.rating}
-            disabled={true}
-          />
+          <RatingStars value={movie.rating} disabled />
         </dd>
       </dl>
     );
@@ -57,7 +51,9 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
       <div>
         <TextField
           name="Duration"
-          value={movie.duration ? DurationUtils.secondsToString(movie.duration) : ""}
+          value={
+            movie.duration ? DurationUtils.secondsToString(movie.duration) : ""
+          }
         />
         <TextField
           name="Date"
@@ -68,10 +64,7 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
           value={movie.studio?.name}
           url={`/studios/${movie.studio?.id}`}
         />
-        <TextField
-          name="Director"
-          value={movie.director}
-        />
+        <TextField name="Director" value={movie.director} />
 
         {renderRatingField()}
 
@@ -81,10 +74,7 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
           url={TextUtils.sanitiseURL(movie.url ?? "")}
         />
 
-        <TextField
-          name="Synopsis"
-          value={movie.synopsis}
-        />
+        <TextField name="Synopsis" value={movie.synopsis} />
       </div>
     </div>
   );

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import * as GQL from "src/core/generated-graphql";
+import {
+  DurationUtils,
+  TextUtils,
+} from "src/utils";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
+import { TextField, URLField } from "src/utils/field";
+
+interface IMovieDetailsPanel {
+  movie: Partial<GQL.MovieDataFragment>;
+}
+
+export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({movie}) => {
+  // Network state
+  const intl = useIntl();
+
+  function maybeRenderAliases() {
+    if (movie.aliases) {
+      return (
+        <div>
+          <span className="alias-head">Also known as </span>
+          <span className="alias">{movie.aliases}</span>
+        </div>
+      );
+    }
+  }
+
+  function renderRatingField() {
+    if (!movie.rating) {
+      return;
+    }
+
+    return (
+      <dl className="row">
+        <dt className="col-3 col-xl-2">Rating</dt>
+        <dd className="col-9 col-xl-10">
+          <RatingStars
+            value={movie.rating}
+            disabled={true}
+          />
+        </dd>
+      </dl>
+    );
+  }
+
+  // TODO: CSS class
+  return (
+    <div className="movie-details">
+      <div>
+        <h2>{movie.name}</h2>
+      </div>
+
+      {maybeRenderAliases()}
+
+      <div>
+        <TextField
+          name="Duration"
+          value={movie.duration ? DurationUtils.secondsToString(movie.duration) : ""}
+        />
+        <TextField
+          name="Date"
+          value={movie.date ? TextUtils.formatDate(intl, movie.date) : ""}
+        />
+        <URLField
+          name="Studio"
+          value={movie.studio?.name}
+          url={`/studios/${movie.studio?.id}`}
+        />
+        <TextField
+          name="Director"
+          value={movie.director}
+        />
+
+        {renderRatingField()}
+
+        <URLField
+          name="URL"
+          value={movie.url}
+          url={TextUtils.sanitiseURL(movie.url ?? "")}
+        />
+
+        <TextField
+          name="Synopsis"
+          value={movie.synopsis}
+        />
+      </div>
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -60,6 +60,11 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     name: yup.string().required(),
     aliases: yup.string().optional().nullable(),
     duration: yup.string().optional().nullable(),
+    date: yup
+      .string()
+      .optional()
+      .nullable()
+      .matches(/^\d{4}-\d{2}-\d{2}$/),
     rating: yup.number().optional().nullable(),
     studio_id: yup.string().optional().nullable(),
     director: yup.string().optional().nullable(),
@@ -71,6 +76,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     name: movie?.name,
     aliases: movie?.aliases,
     duration: movie?.duration,
+    date: movie?.date,
     rating: movie?.rating,
     studio_id: movie?.studio?.id,
     director: movie?.director,

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -1,0 +1,362 @@
+import React, { useEffect, useState, useCallback } from "react";
+import * as GQL from "src/core/generated-graphql";
+import Mousetrap from "mousetrap";
+import {
+  queryScrapeMovieURL,
+  useListMovieScrapers,
+} from "src/core/StashService";
+import {
+  LoadingIndicator,
+  StudioSelect,
+  Icon,
+  DetailsEditNavbar,
+} from "src/components/Shared";
+import { useToast } from "src/hooks";
+import { Table, Form, Modal as BSModal, Button } from "react-bootstrap";
+import {
+  TableUtils,
+  EditableTextUtils,
+  TextUtils,
+  DurationUtils,
+  ImageUtils,
+} from "src/utils";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
+import { MovieScrapeDialog } from "./MovieScrapeDialog";
+
+interface IMovieEditPanel {
+  movie?: Partial<GQL.MovieDataFragment>;
+  onSubmit: (movie: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) => void;
+  onCancel: () => void;
+  onDelete: () => void;
+  setFrontImage: (image?: string | null) => void;
+  setBackImage: (image?: string | null) => void;
+}
+
+export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCancel, onDelete, setFrontImage, setBackImage}) => {
+  const Toast = useToast();
+
+  const isNew = movie === undefined;
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Editing movie state
+  const [name, setName] = useState<string | undefined>(undefined);
+  const [aliases, setAliases] = useState<string | undefined>(undefined);
+  const [duration, setDuration] = useState<number | undefined>(undefined);
+  const [date, setDate] = useState<string | undefined>(undefined);
+  const [rating, setRating] = useState<number | undefined>(undefined);
+  const [studioId, setStudioId] = useState<string>();
+  const [director, setDirector] = useState<string | undefined>(undefined);
+  const [synopsis, setSynopsis] = useState<string | undefined>(undefined);
+  const [url, setUrl] = useState<string | undefined>(undefined);
+
+  const Scrapers = useListMovieScrapers();
+  const [scrapedMovie, setScrapedMovie] = useState<
+    GQL.ScrapedMovie | undefined
+  >();
+
+  // set up hotkeys
+  useEffect(() => {
+    Mousetrap.bind("r 0", () => setRating(NaN));
+    Mousetrap.bind("r 1", () => setRating(1));
+    Mousetrap.bind("r 2", () => setRating(2));
+    Mousetrap.bind("r 3", () => setRating(3));
+    Mousetrap.bind("r 4", () => setRating(4));
+    Mousetrap.bind("r 5", () => setRating(5));
+    // Mousetrap.bind("u", (e) => {
+    //   setStudioFocus()
+    //   e.preventDefault();
+    // });
+    Mousetrap.bind("s s", () => onSubmit(getMovieInput()));
+
+    return () => {
+      Mousetrap.unbind("r 0");
+      Mousetrap.unbind("r 1");
+      Mousetrap.unbind("r 2");
+      Mousetrap.unbind("r 3");
+      Mousetrap.unbind("r 4");
+      Mousetrap.unbind("r 5");
+      // Mousetrap.unbind("u");
+      Mousetrap.unbind("s s");
+    };
+  });
+
+  function updateMovieEditState(state: Partial<GQL.MovieDataFragment>) {
+    setName(state.name ?? undefined);
+    setAliases(state.aliases ?? undefined);
+    setDuration(state.duration ?? undefined);
+    setDate(state.date ?? undefined);
+    setRating(state.rating ?? undefined);
+    setStudioId(state?.studio?.id ?? undefined);
+    setDirector(state.director ?? undefined);
+    setSynopsis(state.synopsis ?? undefined);
+    setUrl(state.url ?? undefined);
+  }
+
+  const updateMovieData = useCallback(
+    (movieData: Partial<GQL.MovieDataFragment>) => {
+      setFrontImage(undefined);
+      setBackImage(undefined);
+      updateMovieEditState(movieData);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (movie) {
+      updateMovieData(movie);
+    }
+  }, [movie]);
+
+  function getMovieInput() {
+    const input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
+      name,
+      aliases,
+      duration,
+      date,
+      rating: rating ?? null,
+      studio_id: studioId ?? null,
+      director,
+      synopsis,
+      url,
+    };
+
+    if (movie && movie.id) {
+      (input as GQL.MovieUpdateInput).id = movie.id;
+    }
+    return input;
+  }
+
+  function updateMovieEditStateFromScraper(
+    state: Partial<GQL.ScrapedMovieDataFragment>
+  ) {
+    if (state.name) {
+      setName(state.name);
+    }
+
+    if (state.aliases) {
+      setAliases(state.aliases ?? undefined);
+    }
+
+    if (state.duration) {
+      setDuration(DurationUtils.stringToSeconds(state.duration) ?? undefined);
+    }
+
+    if (state.date) {
+      setDate(state.date ?? undefined);
+    }
+
+    if (state.studio && state.studio.id) {
+      setStudioId(state.studio.id ?? undefined);
+    }
+
+    if (state.director) {
+      setDirector(state.director ?? undefined);
+    }
+    if (state.synopsis) {
+      setSynopsis(state.synopsis ?? undefined);
+    }
+    if (state.url) {
+      setUrl(state.url ?? undefined);
+    }
+
+    const imageStr = (state as GQL.ScrapedMovieDataFragment).front_image;
+    setFrontImage(imageStr ?? undefined);
+
+    const backImageStr = (state as GQL.ScrapedMovieDataFragment).back_image;
+    setBackImage(backImageStr ?? undefined);
+  }
+
+  async function onScrapeMovieURL() {
+    if (!url) return;
+    setIsLoading(true);
+
+    try {
+      const result = await queryScrapeMovieURL(url);
+      if (!result.data || !result.data.scrapeMovieURL) {
+        return;
+      }
+
+      // if this is a new movie, just dump the data
+      if (isNew) {
+        updateMovieEditStateFromScraper(result.data.scrapeMovieURL);
+      } else {
+        setScrapedMovie(result.data.scrapeMovieURL);
+      }
+    } catch (e) {
+      Toast.error(e);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function urlScrapable(scrapedUrl: string) {
+    return (
+      !!scrapedUrl &&
+      (Scrapers?.data?.listMovieScrapers ?? []).some((s) =>
+        (s?.movie?.urls ?? []).some((u) => scrapedUrl.includes(u))
+      )
+    );
+  }
+
+  function maybeRenderScrapeButton() {
+    if (!url || !urlScrapable(url)) {
+      return undefined;
+    }
+    return (
+      <Button
+        className="minimal scrape-url-button"
+        onClick={() => onScrapeMovieURL()}
+      >
+        <Icon icon="file-upload" />
+      </Button>
+    );
+  }
+
+  function maybeRenderScrapeDialog() {
+    if (!scrapedMovie) {
+      return;
+    }
+
+    const currentMovie = getMovieInput();
+
+    // Get image paths for scrape gui
+    currentMovie.front_image = movie?.front_image_path;
+    currentMovie.back_image = movie?.back_image_path;
+
+    return (
+      <MovieScrapeDialog
+        movie={currentMovie}
+        scraped={scrapedMovie}
+        onClose={(m) => {
+          onScrapeDialogClosed(m);
+        }}
+      />
+    );
+  }
+
+  function onScrapeDialogClosed(p?: GQL.ScrapedMovieDataFragment) {
+    if (p) {
+      updateMovieEditStateFromScraper(p);
+    }
+    setScrapedMovie(undefined);
+  }
+
+  function onFrontImageChange(event: React.FormEvent<HTMLInputElement>) {
+    ImageUtils.onImageChange(event, setFrontImage);
+  }
+
+  function onBackImageChange(event: React.FormEvent<HTMLInputElement>) {
+    ImageUtils.onImageChange(event, setBackImage);
+  }
+
+  if (isLoading) return <LoadingIndicator />;
+
+  const isEditing = true;
+
+  // TODO: CSS class
+  return (
+    <div className="row">
+      <div className="movie-details col">
+        {isNew && <h2>Add Movie</h2>}
+
+        <Table>
+          <tbody>
+            {TableUtils.renderInputGroup({
+              title: "Name",
+              value: name ?? "",
+              isEditing,
+              onChange: setName,
+            })}
+            {TableUtils.renderInputGroup({
+              title: "Aliases",
+              value: aliases,
+              isEditing,
+              onChange: setAliases,
+            })}
+            {TableUtils.renderDurationInput({
+              title: "Duration",
+              value: duration ? duration.toString() : "",
+              isEditing,
+              onChange: (value: string | undefined) =>
+                setDuration(value ? Number.parseInt(value, 10) : undefined),
+            })}
+            {TableUtils.renderInputGroup({
+              title: "Date (YYYY-MM-DD)",
+              value: date,
+              isEditing,
+              onChange: setDate,
+            })}
+            <tr>
+              <td>Studio</td>
+              <td>
+                <StudioSelect
+                  onSelect={(items) =>
+                    setStudioId(items.length > 0 ? items[0]?.id : undefined)
+                  }
+                  ids={studioId ? [studioId] : []}
+                />
+              </td>
+            </tr>
+            {TableUtils.renderInputGroup({
+              title: "Director",
+              value: director,
+              isEditing,
+              onChange: setDirector,
+            })}
+            <tr>
+              <td>Rating</td>
+              <td>
+                <RatingStars
+                  value={rating}
+                  onSetRating={(value) => setRating(value)}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+
+        <Form.Group controlId="url">
+          <Form.Label>URL {maybeRenderScrapeButton()}</Form.Label>
+          <div>
+            {EditableTextUtils.renderInputGroup({
+              isEditing,
+              onChange: setUrl,
+              value: url,
+              url: TextUtils.sanitiseURL(url),
+            })}
+          </div>
+        </Form.Group>
+
+        <Form.Group controlId="synopsis">
+          <Form.Label>Synopsis</Form.Label>
+          <Form.Control
+            as="textarea"
+            className="movie-synopsis text-input"
+            onChange={(newValue: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setSynopsis(newValue.currentTarget.value)
+            }
+            value={synopsis}
+          />
+        </Form.Group>
+
+        <DetailsEditNavbar
+          objectName={movie?.name ?? "movie"}
+          isNew={isNew}
+          isEditing={isEditing}
+          onToggleEdit={onCancel}
+          onSave={() => onSubmit(getMovieInput())}
+          onImageChange={onFrontImageChange}
+          onImageChangeURL={setFrontImage}
+          onClearImage={() => { setFrontImage(null)}}
+          onBackImageChange={onBackImageChange}
+          onBackImageChangeURL={setBackImage}
+          onClearBackImage={() => { setBackImage(null)}}
+          onDelete={onDelete}
+        />
+      </div>
+
+      {maybeRenderScrapeDialog()}
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
 import Mousetrap from "mousetrap";
@@ -15,25 +15,31 @@ import {
 } from "src/components/Shared";
 import { useToast } from "src/hooks";
 import { Form, Button, Col, Row, InputGroup } from "react-bootstrap";
-import {
-  DurationUtils,
-  ImageUtils,
-} from "src/utils";
+import { DurationUtils, ImageUtils } from "src/utils";
 import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
-import { MovieScrapeDialog } from "./MovieScrapeDialog";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
+import { MovieScrapeDialog } from "./MovieScrapeDialog";
 
 interface IMovieEditPanel {
   movie?: Partial<GQL.MovieDataFragment>;
-  onSubmit: (movie: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>) => void;
+  onSubmit: (
+    movie: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput>
+  ) => void;
   onCancel: () => void;
   onDelete: () => void;
   setFrontImage: (image?: string | null) => void;
   setBackImage: (image?: string | null) => void;
 }
 
-export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCancel, onDelete, setFrontImage, setBackImage}) => {
+export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
+  movie,
+  onSubmit,
+  onCancel,
+  onDelete,
+  setFrontImage,
+  setBackImage,
+}) => {
   const Toast = useToast();
 
   const isNew = movie === undefined;
@@ -110,33 +116,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
     };
   });
 
-  function updateMovieEditState(state: Partial<GQL.MovieDataFragment>) {
-    formik.setFieldValue("name", state.name ?? undefined);
-    formik.setFieldValue("aliases", state.aliases ?? undefined);
-    formik.setFieldValue("duration", state.duration ?? undefined);
-    formik.setFieldValue("date", state.date ?? undefined);
-    formik.setFieldValue("rating", state.rating ?? undefined);
-    formik.setFieldValue("studio_id", state?.studio?.id ?? undefined);
-    formik.setFieldValue("director", state.director ?? undefined);
-    formik.setFieldValue("synopsis", state.synopsis ?? undefined);
-    formik.setFieldValue("url", state.url ?? undefined);
-  }
-
-  const updateMovieData = useCallback(
-    (movieData: Partial<GQL.MovieDataFragment>) => {
-      setFrontImage(undefined);
-      setBackImage(undefined);
-      updateMovieEditState(movieData);
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (movie) {
-      updateMovieData(movie);
-    }
-  }, [movie]);
-
   function getMovieInput(values: InputValues) {
     const input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
       ...values,
@@ -162,7 +141,10 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
     }
 
     if (state.duration) {
-      formik.setFieldValue("duration", DurationUtils.stringToSeconds(state.duration) ?? undefined);
+      formik.setFieldValue(
+        "duration",
+        DurationUtils.stringToSeconds(state.duration) ?? undefined
+      );
     }
 
     if (state.date) {
@@ -191,7 +173,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
   }
 
   async function onScrapeMovieURL() {
-    const url = formik.values.url;
+    const { url } = formik.values;
     if (!url) return;
     setIsLoading(true);
 
@@ -224,7 +206,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
   }
 
   function maybeRenderScrapeButton() {
-    const url = formik.values.url;
+    const { url } = formik.values;
     if (!url || !urlScrapable(url)) {
       return undefined;
     }
@@ -350,7 +332,10 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
           <Col sm={fieldXS} xl={fieldXL}>
             <StudioSelect
               onSelect={(items) =>
-                formik.setFieldValue("studio_id", items.length > 0 ? items[0]?.id : undefined)
+                formik.setFieldValue(
+                  "studio_id",
+                  items.length > 0 ? items[0]?.id : undefined
+                )
               }
               ids={formik.values.studio_id ? [formik.values.studio_id] : []}
             />
@@ -364,10 +349,10 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
             Rating
           </Form.Label>
           <Col sm={fieldXS} xl={fieldXL}>
-              <RatingStars
-                value={formik.values.rating ?? undefined}
-                onSetRating={(value) => formik.setFieldValue("rating", value)}
-              />
+            <RatingStars
+              value={formik.values.rating ?? undefined}
+              onSetRating={(value) => formik.setFieldValue("rating", value)}
+            />
           </Col>
         </Form.Group>
 
@@ -401,7 +386,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
           </Col>
         </Form.Group>
       </Form>
-      
+
       <DetailsEditNavbar
         objectName={movie?.name ?? "movie"}
         isNew={isNew}
@@ -410,10 +395,14 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({movie, onSubmit, onCa
         onSave={() => formik.handleSubmit()}
         onImageChange={onFrontImageChange}
         onImageChangeURL={setFrontImage}
-        onClearImage={() => { setFrontImage(null)}}
+        onClearImage={() => {
+          setFrontImage(null);
+        }}
         onBackImageChange={onBackImageChange}
         onBackImageChangeURL={setBackImage}
-        onClearBackImage={() => { setBackImage(null)}}
+        onClearBackImage={() => {
+          setBackImage(null);
+        }}
         onDelete={onDelete}
       />
 

--- a/ui/v2.5/src/components/Movies/styles.scss
+++ b/ui/v2.5/src/components/Movies/styles.scss
@@ -18,3 +18,21 @@
     width: 100%;
   }
 }
+
+.movie-images {
+  margin: 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+  max-width: 100%;
+
+  .movie-image-container {
+    margin: 1rem;
+  }
+
+  img {
+    max-width: 100%;
+    object-fit: contain;
+  }
+}

--- a/ui/v2.5/src/components/Movies/styles.scss
+++ b/ui/v2.5/src/components/Movies/styles.scss
@@ -20,11 +20,11 @@
 }
 
 .movie-images {
-  margin: 1rem;
+  align-items: center;
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
-  align-items: center;
+  margin: 1rem;
   max-width: 100%;
 
   .movie-image-container {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
@@ -317,7 +317,7 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = (
 
   const [createStudio] = useStudioCreate({ name: "" });
   const [createPerformer] = usePerformerCreate();
-  const [createMovie] = useMovieCreate({ name: "" });
+  const [createMovie] = useMovieCreate();
   const [createTag] = useTagCreate({ name: "" });
 
   const Toast = useToast();

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -594,9 +594,8 @@ export const movieMutationImpactedQueries = [
   GQL.AllMoviesForFilterDocument,
 ];
 
-export const useMovieCreate = (input: GQL.MovieCreateInput) =>
+export const useMovieCreate = () =>
   GQL.useMovieCreateMutation({
-    variables: input,
     update: deleteCache([
       GQL.FindMoviesDocument,
       GQL.AllMoviesForFilterDocument,

--- a/ui/v2.5/src/utils/field.tsx
+++ b/ui/v2.5/src/utils/field.tsx
@@ -29,7 +29,7 @@ export const URLField: React.FC<IURLField> = ({ name, value, url }) => {
     return null;
   }
   return (
-    <dl className="row">
+    <dl className="row mb-0">
       <dt className="col-3 col-xl-2">{name}:</dt>
       <dd className="col-9 col-xl-10">
         {url ? (


### PR DESCRIPTION
Cleans up and improves the Movie page.

Details and Edit panels have been separated. Details are now shown in the same style as performers:

![image](https://user-images.githubusercontent.com/53250216/112259208-fb6e1280-8cbb-11eb-8306-c8db45cafe38.png)

If no back cover image is set, then it is now omitted from display: 

![image](https://user-images.githubusercontent.com/53250216/112259067-bc3fc180-8cbb-11eb-8429-168146e40e3f.png)

Edit page now uses formik and prompts if navigating away after changing data:

![image](https://user-images.githubusercontent.com/53250216/112259307-2ce6de00-8cbc-11eb-99e1-d24c37f9b5c6.png)
