### PR TITLE
Add avif to the compatible Image Formats

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -37,7 +37,7 @@ var defaultVideoExtensions = []string{"m4v", "mp4", "mov", "wmv", "avi", "mpg", 
 
 const ImageExtensions = "image_extensions"
 
-var defaultImageExtensions = []string{"png", "jpg", "jpeg", "gif", "webp"}
+var defaultImageExtensions = []string{"png", "jpg", "jpeg", "gif", "webp", "avif"}
 
 const GalleryExtensions = "gallery_extensions"
 


### PR DESCRIPTION
Avif is a new open image format which is very likely to be the next big format. It is supported by Chrome (and Chromium-derivates) as well as Firefox, although there is a config variable you have to set (should be gone any time now, it was announced to be standard at the end of February).