### PR TITLE
Add format to performer field placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There is a [directory of themes](https://github.com/stashapp/stash/wiki/Themes) 
 ## CSS Customization
 You can make Stash interface fit your desired style with [Custom CSS snippets](https://github.com/stashapp/stash/wiki/Custom-CSS-snippets) and [CSS Tweaks](https://github.com/stashapp/stash/wiki/CSS-Tweaks).
 
-# Suppport
+# Support (FAQ)
 
 Answers to frequently asked questions can be found [on our Wiki](https://github.com/stashapp/stash/wiki/FAQ)
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -725,7 +725,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     );
   }
 
-function renderTextField(field: string, title: string, placeholder?: string) {
+  function renderTextField(field: string, title: string, placeholder?: string) {
     return (
       <Form.Group controlId={field} as={Row}>
         <Form.Label column xs={labelXS} xl={labelXL}>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -805,7 +805,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           </Col>
         </Form.Group>
 
-        {renderTextField("birthdate", "Birthdate")}
+        {renderTextField("birthdate", "YYYY-MM-DD")}
         {renderTextField("country", "Country")}
         {renderTextField("ethnicity", "Ethnicity")}
         {renderTextField("eye_color", "Eye Color")}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -725,7 +725,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     );
   }
 
-  function renderTextField(field: string, title: string) {
+function renderTextField(field: string, title: string, placeholder?: string) {
     return (
       <Form.Group controlId={field} as={Row}>
         <Form.Label column xs={labelXS} xl={labelXL}>
@@ -734,7 +734,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         <Col xs={fieldXS} xl={fieldXL}>
           <Form.Control
             className="text-input"
-            placeholder={title}
+            placeholder={placeholder ?? title}
             {...formik.getFieldProps(field)}
             isInvalid={!!formik.getFieldMeta(field).error}
           />
@@ -805,7 +805,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           </Col>
         </Form.Group>
 
-        {renderTextField("birthdate", "YYYY-MM-DD")}
+        {renderTextField("birthdate", "Birthdate", "YYYY-MM-DD")}
         {renderTextField("country", "Country")}
         {renderTextField("ethnicity", "Ethnicity")}
         {renderTextField("eye_color", "Eye Color")}


### PR DESCRIPTION
There are various birthday formats and unless you use YYYY-MM-DD format, the age calculation function don't work on performers page. 
It's not mentioned on Model Edit page text field.