### PR TITLE
Add scene sorting by tag count

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -47,7 +47,7 @@ input PerformerFilterType {
   measurements: StringCriterionInput
   """Filter by fake tits value"""
   fake_tits: StringCriterionInput
-  """Filter by career length"""  
+  """Filter by career length"""
   career_length: StringCriterionInput
   """Filter by tattoos"""
   tattoos: StringCriterionInput
@@ -80,7 +80,7 @@ input SceneFilterType {
   AND: SceneFilterType
   OR: SceneFilterType
   NOT: SceneFilterType
-  
+
   """Filter by path"""
   path: StringCriterionInput
   """Filter by rating"""
@@ -103,6 +103,8 @@ input SceneFilterType {
   movies: MultiCriterionInput
   """Filter to only include scenes with these tags"""
   tags: MultiCriterionInput
+  """Filter by tag count"""
+  tag_count: IntCriterionInput
   """Filter to only include scenes with performers with these tags"""
   performer_tags: MultiCriterionInput
   """Filter to only include scenes with these performers"""

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/models"
@@ -286,7 +287,7 @@ func (qb *sceneQueryBuilder) Wall(q *string) ([]*models.Scene, error) {
 }
 
 func (qb *sceneQueryBuilder) All() ([]*models.Scene, error) {
-	return qb.queryScenes(selectAll(sceneTable)+qb.getSceneSort(nil), nil)
+	return qb.queryScenes(selectAll(sceneTable)+qb.getDefaultSceneSort(), nil)
 }
 
 func illegalFilterCombination(type1, type2 string) error {
@@ -383,7 +384,8 @@ func (qb *sceneQueryBuilder) Query(sceneFilter *models.SceneFilterType, findFilt
 
 	query.addFilter(filter)
 
-	query.sortAndPagination = qb.getSceneSort(findFilter) + getPagination(findFilter)
+	qb.setSceneSort(&query, findFilter)
+	query.sortAndPagination += getPagination(findFilter)
 
 	idsResult, countResult, err := query.executeFind()
 	if err != nil {
@@ -585,8 +587,8 @@ func scenePerformerTagsCriterionHandler(qb *sceneQueryBuilder, performerTagsFilt
 				f.addWhere("performer_tags_join.tag_id IN "+getInBinding(len(performerTagsFilter.Value)), args...)
 				f.addHaving(fmt.Sprintf("count(distinct performer_tags_join.tag_id) IS %d", len(performerTagsFilter.Value)))
 			} else if performerTagsFilter.Modifier == models.CriterionModifierExcludes {
-				f.addWhere(fmt.Sprintf(`not exists 
-					(select performers_scenes.performer_id from performers_scenes 
+				f.addWhere(fmt.Sprintf(`not exists
+					(select performers_scenes.performer_id from performers_scenes
 						left join performers_tags on performers_tags.performer_id = performers_scenes.performer_id where
 						performers_scenes.scene_id = scenes.id AND
 						performers_tags.tag_id in %s)`, getInBinding(len(performerTagsFilter.Value))), args...)
@@ -611,8 +613,8 @@ func handleScenePerformerTagsCriterion(query *queryBuilder, performerTagsFilter 
 			query.addWhere("performer_tags_join.tag_id IN " + getInBinding(len(performerTagsFilter.Value)))
 			query.addHaving(fmt.Sprintf("count(distinct performer_tags_join.tag_id) IS %d", len(performerTagsFilter.Value)))
 		} else if performerTagsFilter.Modifier == models.CriterionModifierExcludes {
-			query.addWhere(fmt.Sprintf(`not exists 
-				(select performers_scenes.performer_id from performers_scenes 
+			query.addWhere(fmt.Sprintf(`not exists
+				(select performers_scenes.performer_id from performers_scenes
 					left join performers_tags on performers_tags.performer_id = performers_scenes.performer_id where
 					performers_scenes.scene_id = scenes.id AND
 					performers_tags.tag_id in %s)`, getInBinding(len(performerTagsFilter.Value))))
@@ -620,13 +622,24 @@ func handleScenePerformerTagsCriterion(query *queryBuilder, performerTagsFilter 
 	}
 }
 
-func (qb *sceneQueryBuilder) getSceneSort(findFilter *models.FindFilterType) string {
+func (qb *sceneQueryBuilder) getDefaultSceneSort() string {
+	return " ORDER BY scenes.path, scenes.date ASC "
+}
+
+func (qb *sceneQueryBuilder) setSceneSort(query *queryBuilder, findFilter *models.FindFilterType) {
 	if findFilter == nil {
-		return " ORDER BY scenes.path, scenes.date ASC "
+		query.sortAndPagination += qb.getDefaultSceneSort()
+		return
 	}
 	sort := findFilter.GetSort("title")
 	direction := findFilter.GetDirection()
-	return getSort(sort, direction, "scenes")
+	if strings.Compare(sort, "tag_count") == 0 {
+		query.sortAndPagination +=
+			" ORDER BY (SELECT COUNT(*) FROM scenes_tags WHERE scene_id = scenes.id) " +
+				getSortDirection(direction)
+	} else {
+		query.sortAndPagination += getSort(sort, direction, "scenes")
+	}
 }
 
 func (qb *sceneQueryBuilder) queryScene(query string, args []interface{}) (*models.Scene, error) {

--- a/pkg/sqlite/sql.go
+++ b/pkg/sqlite/sql.go
@@ -44,10 +44,15 @@ func getPaginationSQL(page int, perPage int) string {
 	return " LIMIT " + strconv.Itoa(perPage) + " OFFSET " + strconv.Itoa(page) + " "
 }
 
-func getSort(sort string, direction string, tableName string) string {
+func getSortDirection(direction string) string {
 	if direction != "ASC" && direction != "DESC" {
-		direction = "ASC"
+		return "ASC"
+	} else {
+		return direction
 	}
+}
+func getSort(sort string, direction string, tableName string) string {
+	direction = getSortDirection(direction)
 
 	const randomSeedPrefix = "random_"
 

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -25,6 +25,7 @@ export type CriterionType =
   | "tags"
   | "sceneTags"
   | "performerTags"
+  | "tag_count"
   | "performers"
   | "studios"
   | "movies"
@@ -89,6 +90,8 @@ export abstract class Criterion {
         return "Scene Tags";
       case "performerTags":
         return "Performer Tags";
+      case "tag_count":
+        return "Tag Count";
       case "performers":
         return "Performers";
       case "studios":

--- a/ui/v2.5/src/models/list-filter/criteria/utils.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/utils.ts
@@ -46,6 +46,7 @@ export function makeCriteria(type: CriterionType = "none") {
     case "image_count":
     case "gallery_count":
     case "performer_count":
+    case "tag_count":
       return new NumberCriterion(type, type);
     case "resolution":
       return new ResolutionCriterion();

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -148,6 +148,7 @@ export class ListFilterModel {
           new HasMarkersCriterionOption(),
           new SceneIsMissingCriterionOption(),
           new TagsCriterionOption(),
+          ListFilterModel.createCriterionOption("tag_count"),
           new PerformerTagsCriterionOption(),
           new PerformersCriterionOption(),
           new StudiosCriterionOption(),
@@ -545,6 +546,14 @@ export class ListFilterModel {
           result.performer_tags = {
             value: performerTagsCrit.value.map((tag) => tag.id),
             modifier: performerTagsCrit.modifier,
+          };
+          break;
+        }
+        case "tag_count": {
+          const tagCountCrit = criterion as NumberCriterion;
+          result.tag_count = {
+            value: tagCountCrit.value,
+            modifier: tagCountCrit.modifier,
           };
           break;
         }

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -128,6 +128,7 @@ export class ListFilterModel {
           "duration",
           "framerate",
           "bitrate",
+          "tag_count",
           "random",
         ];
         this.displayModeOptions = [


### PR DESCRIPTION
Hey,

I added scene sorting and filtering by tag count. Especially useful when organizing newly imported files. I had to do a few minor changes to the code to make it possible.
As it's my first time writing Go, please check that I am not violating some code style laws or something like that :)
Due to my editor (Atom) trimming trailing spaces, there were a few extra lines or so that were changed just because of the trailing spaces being removed. If it's a big deal I can fix that up (or you can at merge if u want). One of those was a multiline sql string so you might want to check if that trailing space was needed, although I don't think so as newline counts just as well.

PS: I can also confirm that stash builds fine on Apple M1 arm64.

Cheers!