### PR TITLE
Fix inaccurate age calculation

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -29,3 +29,4 @@
 * Fix version checking for armv7 and arm64.
 * Change "Is NULL" filter to include empty string values.
 * Prevent scene card previews playing in full-screen on iOS devices.
+* Fix inaccurate performer age calculation.

--- a/ui/v2.5/src/components/Changelog/versions/v060.md
+++ b/ui/v2.5/src/components/Changelog/versions/v060.md
@@ -29,4 +29,3 @@
 * Fix version checking for armv7 and arm64.
 * Change "Is NULL" filter to include empty string values.
 * Prevent scene card previews playing in full-screen on iOS devices.
-* Fix inaccurate performer age calculation.

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -1,2 +1,3 @@
 ### 🎨 Improvements
+* Fix incorrect performer age calculation in UI.
 * Change performer text query to search by name and alias only.

--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -79,7 +79,7 @@ const getAge = (dateString?: string | null, fromDateString?: string) => {
   if (
     birthdate.getMonth() > fromDate.getMonth() ||
     (birthdate.getMonth() >= fromDate.getMonth() &&
-      birthdate.getDay() > fromDate.getDay())
+      birthdate.getDate() > fromDate.getDate())
   ) {
     age -= 1;
   }


### PR DESCRIPTION
As reported on Discord by **AdultSun**:
> I've been loading info into my performer pages and noticed a bug with how stash calculates ages. It seems to only look at month and year, not day.
For example, Casey Calvert's birthday is 17 March 1990. On the performer page she's listed as 30 years old, but it should be 31.
If I change it to February 17 it updates to 31 years old, so it doesn't seem to realize that the current date is after March 17, just that it's the same month.

The bug:
```js
// getDay = day of WEEK (0-6)
> new Date('1990-03-27').getDay()
2
// getDate = day of MONTH
> new Date('1990-03-27').getDate()
27
```

- [x] Change log entry needs to be moved to next version.