### PR TITLE
Disable sounds on scene/marker wall previews by default

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -488,7 +488,7 @@ func GetMenuItems() []string {
 }
 
 func GetSoundOnPreview() bool {
-	viper.SetDefault(SoundOnPreview, true)
+	viper.SetDefault(SoundOnPreview, false)
 	return viper.GetBool(SoundOnPreview)
 }
 

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -3,9 +3,9 @@
 * Added scene queue.
 
 ### 🎨 Improvements
+* Disable sounds on scene/marker wall previews by default.
 * Improve Movie UI.
 * Change performer text query to search by name and alias only.
-* Disable sounds on scene/marker wall previews by default.
 
 ### 🐛 Bug fixes
 * Fix incorrect performer age calculation in UI.

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -1,3 +1,4 @@
 ### 🎨 Improvements
 * Fix incorrect performer age calculation in UI.
 * Change performer text query to search by name and alias only.
+* Disable sounds on scene/marker wall previews by default.


### PR DESCRIPTION
Really should be disabled by default. 😄
([For clarity, this option](https://user-images.githubusercontent.com/66393006/113021503-51dfc300-918c-11eb-83a0-8be3cca091cb.png))