### PR TITLE
Upgrade x/image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.0.1
 	github.com/vektra/mockery/v2 v2.2.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	golang.org/x/tools v0.0.0-20200915031644-64986481280e // indirect

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,6 @@ github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.13.0 h1:LnJI81JidiW9r7pS/hXe6cFeO5EXNq7KbfvoJLRI69c=
-github.com/mattn/go-sqlite3 v1.13.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -804,6 +802,8 @@ golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86h
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb h1:fqpd0EBDzlHRCjiphRR5Zo/RSWWQlWv34418dnEixWk=
+golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -8,4 +8,5 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix processing some webp files.
 * Fix incorrect performer age calculation in UI.

--- a/vendor/golang.org/x/image/bmp/reader.go
+++ b/vendor/golang.org/x/image/bmp/reader.go
@@ -144,6 +144,9 @@ func decodeConfig(r io.Reader) (config image.Config, bitsPerPixel int, topDown b
 	)
 	var b [1024]byte
 	if _, err := io.ReadFull(r, b[:fileHeaderLen+4]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return image.Config{}, 0, false, err
 	}
 	if string(b[:2]) != "BM" {
@@ -155,6 +158,9 @@ func decodeConfig(r io.Reader) (config image.Config, bitsPerPixel int, topDown b
 		return image.Config{}, 0, false, ErrUnsupported
 	}
 	if _, err := io.ReadFull(r, b[fileHeaderLen+4:fileHeaderLen+infoLen]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return image.Config{}, 0, false, err
 	}
 	width := int(int32(readUint32(b[18:22])))

--- a/vendor/golang.org/x/image/ccitt/table.go
+++ b/vendor/golang.org/x/image/ccitt/table.go
@@ -31,17 +31,7 @@ package ccitt
 
 // modeDecodeTable represents Table 1 and the End-of-Line code.
 //
-//                              +=XXXXX
-// b015                       +-+
-//                            | +=v0010
-// b014                     +-+
-//                          | +=XXXXX
-// b013                   +-+
-//                        | +=XXXXX
-// b012                 +-+
-//                      | +=XXXXX
-// b011               +-+
-//                    | +=XXXXX
+//                    +=XXXXX
 // b009             +-+
 //                  | +=v0009
 // b007           +-+
@@ -72,13 +62,8 @@ var modeDecodeTable = [...][2]int16{
 	6:  {7, 8},
 	7:  {9, 10},
 	8:  {^7, ^4},
-	9:  {11, ^9},
+	9:  {0, ^9},
 	10: {^8, ^5},
-	11: {12, 0},
-	12: {13, 0},
-	13: {14, 0},
-	14: {15, 0},
-	15: {0, ^10},
 }
 
 // whiteDecodeTable represents Tables 2 and 3 for a white run.
@@ -733,17 +718,16 @@ type bitString struct {
 
 // modeEncodeTable represents Table 1 and the End-of-Line code.
 var modeEncodeTable = [...]bitString{
-	0:  {0x0001, 4},  // "0001"
-	1:  {0x0001, 3},  // "001"
-	2:  {0x0001, 1},  // "1"
-	3:  {0x0003, 3},  // "011"
-	4:  {0x0003, 6},  // "000011"
-	5:  {0x0003, 7},  // "0000011"
-	6:  {0x0002, 3},  // "010"
-	7:  {0x0002, 6},  // "000010"
-	8:  {0x0002, 7},  // "0000010"
-	9:  {0x0001, 7},  // "0000001"
-	10: {0x0001, 12}, // "000000000001"
+	0: {0x0001, 4}, // "0001"
+	1: {0x0001, 3}, // "001"
+	2: {0x0001, 1}, // "1"
+	3: {0x0003, 3}, // "011"
+	4: {0x0003, 6}, // "000011"
+	5: {0x0003, 7}, // "0000011"
+	6: {0x0002, 3}, // "010"
+	7: {0x0002, 6}, // "000010"
+	8: {0x0002, 7}, // "0000010"
+	9: {0x0001, 7}, // "0000001"
 }
 
 // whiteEncodeTable2 represents Table 2 for a white run.
@@ -983,7 +967,6 @@ const (
 	modeVL2         // Vertical-Left-2
 	modeVL3         // Vertical-Left-3
 	modeExt         // Extension
-	modeEOL         // End-of-Line
 )
 
 // COPY PASTE table.go END

--- a/vendor/golang.org/x/image/tiff/fuzz.go
+++ b/vendor/golang.org/x/image/tiff/fuzz.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build gofuzz
 // +build gofuzz
 
 package tiff

--- a/vendor/golang.org/x/image/tiff/lzw/reader.go
+++ b/vendor/golang.org/x/image/tiff/lzw/reader.go
@@ -178,7 +178,7 @@ loop:
 			break loop
 		case code <= d.hi:
 			c, i := code, len(d.output)-1
-			if code == d.hi {
+			if code == d.hi && d.last != decoderInvalidCode {
 				// code == hi is a special case which expands to the last expansion
 				// followed by the head of the last expansion. To find the head, we walk
 				// the prefix chain until we find a literal code.

--- a/vendor/golang.org/x/image/tiff/reader.go
+++ b/vendor/golang.org/x/image/tiff/reader.go
@@ -404,6 +404,9 @@ func newDecoder(r io.Reader) (*decoder, error) {
 
 	p := make([]byte, 8)
 	if _, err := d.r.ReadAt(p, 0); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return nil, err
 	}
 	switch string(p[0:4]) {

--- a/vendor/golang.org/x/image/webp/decode.go
+++ b/vendor/golang.org/x/image/webp/decode.go
@@ -126,22 +126,23 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 				alphaBit        = 1 << 4
 				iccProfileBit   = 1 << 5
 			)
-			if buf[0] != alphaBit {
-				return nil, image.Config{}, errors.New("webp: non-Alpha VP8X is not implemented")
-			}
+			wantAlpha = (buf[0] & alphaBit) != 0
 			widthMinusOne = uint32(buf[4]) | uint32(buf[5])<<8 | uint32(buf[6])<<16
 			heightMinusOne = uint32(buf[7]) | uint32(buf[8])<<8 | uint32(buf[9])<<16
 			if configOnly {
+				if wantAlpha {
+					return nil, image.Config{
+						ColorModel: color.NYCbCrAModel,
+						Width:      int(widthMinusOne) + 1,
+						Height:     int(heightMinusOne) + 1,
+					}, nil
+				}
 				return nil, image.Config{
-					ColorModel: color.NYCbCrAModel,
+					ColorModel: color.YCbCrModel,
 					Width:      int(widthMinusOne) + 1,
 					Height:     int(heightMinusOne) + 1,
 				}, nil
 			}
-			wantAlpha = true
-
-		default:
-			return nil, image.Config{}, errInvalidFormat
 		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -305,7 +305,7 @@ github.com/vektra/mockery/v2/pkg/logging
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/image v0.0.0-20190802002840-cff245a6509b
+# golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
 golang.org/x/image/bmp
 golang.org/x/image/ccitt
 golang.org/x/image/riff


### PR DESCRIPTION
upgrades the golang.org/x/image to latest
The library has various improvementss/fixes including the <https://github.com/golang/image/commit/3a743ba83854117dc10e2af4c7213cd946169367> for the case below

When adding some webp files we get a `webp: non-Alpha VP8X is not implemented` error when trrying to save an image
eg NSFW `https://images1.naughtycdn.com/cms/nacmscontent/v1/scenes/mfst/ivylucas/scene/horizontal/1279x719c.webp`
Scraping the scene or trying to save the image from the url results in error
![scrape-error](https://user-images.githubusercontent.com/48220860/113053056-8ebdb100-91b0-11eb-92a2-2050117027f9.png)
