### PR TITLE
Fix "Clear Image" button

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -10,5 +10,6 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix `Clear Image` button not updating image preview.
 * Fix processing some webp files.
 * Fix incorrect performer age calculation in UI.

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -47,7 +47,7 @@ export const Performer: React.FC = () => {
   const activeImage =
     imagePreview === undefined
       ? performer.image_path ?? ""
-      : imagePreview ?? `${performer.image_path}&default=true`;
+      : imagePreview ?? (isNew ? "" : `${performer.image_path}&default=true`);
   const lightboxImages = useMemo(
     () => [{ paths: { thumbnail: activeImage, image: activeImage } }],
     [activeImage]

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -47,7 +47,7 @@ export const Performer: React.FC = () => {
   const activeImage =
     imagePreview === undefined
       ? performer.image_path ?? ""
-      : imagePreview ?? `${performer.image_path}?default=true`;
+      : imagePreview ?? `${performer.image_path}&default=true`;
   const lightboxImages = useMemo(
     () => [{ paths: { thumbnail: activeImage, image: activeImage } }],
     [activeImage]

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -231,7 +231,7 @@ export const Studio: React.FC = () => {
   function onClearImage() {
     setImage(null);
     setImagePreview(
-      studio.image_path ? `${studio.image_path}?default=true` : undefined
+      studio.image_path ? `${studio.image_path}&default=true` : undefined
     );
   }
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -204,7 +204,7 @@ export const Tag: React.FC = () => {
   function onClearImage() {
     setImage(null);
     setImagePreview(
-      tag?.image_path ? `${tag.image_path}?default=true` : undefined
+      tag?.image_path ? `${tag.image_path}&default=true` : undefined
     );
   }
 


### PR DESCRIPTION
This PR fixes two scenarios:
1. **Editing a performer/studio/tag:**
   _Before:_ When clearing, the image remains visible (but when saving the performer/studio/tag, it is removed).
   _Now:_ The default performer/studio/tag image replaces the cleared image.
2. **New performer:**
   _Before:_ When clearing, the image source changes to `undefined?default=true` [making the `<img> alt` value appear](https://user-images.githubusercontent.com/66393006/113194337-b3299400-9269-11eb-9672-ad1ee2b0522b.png).
   _Now:_ The image is hidden.

The code in the second commit feels ugly, but this is all I could come up with (suggestions are welcome).
