### PR TITLE
Fix performer age timezone issues

### DIFF
--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -72,11 +72,14 @@ const fileNameFromPath = (path: string) => {
 const getAge = (dateString?: string | null, fromDateString?: string) => {
   if (!dateString) return 0;
 
+  const birthdate = new Date(dateString);
+  const fromDate = fromDateString ? new Date(fromDateString) : new Date();
+
   // Set time to midnight to force system timezone instead of UTC
-  const birthdate = new Date(`${dateString} 00:00:00`);
-  const fromDate = fromDateString
-    ? new Date(`${fromDateString} 00:00:00`)
-    : new Date();
+  birthdate.setHours(0, 0, 0, 0);
+  if (fromDateString) {
+    fromDate.setHours(0, 0, 0, 0);
+  }
 
   let age = fromDate.getFullYear() - birthdate.getFullYear();
   if (

--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -69,17 +69,27 @@ const fileNameFromPath = (path: string) => {
   return path.replace(/^.*[\\/]/, "");
 };
 
+const stringToDate = (dateString: string) => {
+  if (!dateString) return null;
+
+  const parts = dateString.split("-");
+  // Invalid date string
+  if (parts.length !== 3) return null;
+
+  const year = Number(parts[0]);
+  const monthIndex = Math.max(0, Number(parts[1]) - 1);
+  const day = Number(parts[2]);
+
+  return new Date(year, monthIndex, day, 0, 0, 0, 0);
+};
+
 const getAge = (dateString?: string | null, fromDateString?: string) => {
   if (!dateString) return 0;
 
-  const birthdate = new Date(dateString);
-  const fromDate = fromDateString ? new Date(fromDateString) : new Date();
+  const birthdate = stringToDate(dateString);
+  const fromDate = fromDateString ? stringToDate(fromDateString) : new Date();
 
-  // Set time to midnight to force system timezone instead of UTC
-  birthdate.setHours(0, 0, 0, 0);
-  if (fromDateString) {
-    fromDate.setHours(0, 0, 0, 0);
-  }
+  if (!birthdate || !fromDate) return 0;
 
   let age = fromDate.getFullYear() - birthdate.getFullYear();
   if (
@@ -182,6 +192,7 @@ const TextUtils = {
   fileSizeFractionalDigits,
   secondsToTimestamp,
   fileNameFromPath,
+  stringToDate,
   age: getAge,
   bitRate,
   resolution,

--- a/ui/v2.5/src/utils/text.ts
+++ b/ui/v2.5/src/utils/text.ts
@@ -72,8 +72,11 @@ const fileNameFromPath = (path: string) => {
 const getAge = (dateString?: string | null, fromDateString?: string) => {
   if (!dateString) return 0;
 
-  const birthdate = new Date(dateString);
-  const fromDate = fromDateString ? new Date(fromDateString) : new Date();
+  // Set time to midnight to force system timezone instead of UTC
+  const birthdate = new Date(`${dateString} 00:00:00`);
+  const fromDate = fromDateString
+    ? new Date(`${fromDateString} 00:00:00`)
+    : new Date();
 
   let age = fromDate.getFullYear() - birthdate.getFullYear();
   if (


### PR DESCRIPTION
Continuing #1237, and as discussed on Discord:
The scene date / birthdate were both being created as UTC, which meant they are not at the user's midnight (as it should have been), causing the age to be incorrect, at times.

This could lead to issues if at any point later on a full date-time string is passed to this function,
because obviously the time part will be reset.
But this is function is specific for calculating the age, and I believe the comment makes it clear.