### PR TITLE
Support today,yesterday when using parseDate in scrapers

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -362,6 +362,17 @@ type postProcessParseDate string
 func (p *postProcessParseDate) Apply(value string, q mappedQuery) string {
 	parseDate := string(*p)
 
+	const internalDateFormat = "2006-01-02"
+
+	value = strings.ToLower(value)
+	if value == "today" || value == "yesterday" { // handle today, yesterday
+		dt := time.Now()
+		if value == "yesterday" { // subtract 1 day from now
+			dt = dt.AddDate(0, 0, -1)
+		}
+		return dt.Format(internalDateFormat)
+	}
+
 	if parseDate == "" {
 		return value
 	}
@@ -375,7 +386,6 @@ func (p *postProcessParseDate) Apply(value string, q mappedQuery) string {
 	}
 
 	// convert it into our date format
-	const internalDateFormat = "2006-01-02"
 	return parsedValue.Format(internalDateFormat)
 }
 

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -3,6 +3,7 @@
 * Added scene queue.
 
 ### 🎨 Improvements
+* Support `today` and `yesterday` for `parseDate` in scrapers.
 * Add random sorting option for galleries, studios, movies and tags.
 * Disable sounds on scene/marker wall previews by default.
 * Improve Movie UI.

--- a/ui/v2.5/src/docs/en/Scraping.md
+++ b/ui/v2.5/src/docs/en/Scraping.md
@@ -360,7 +360,7 @@ performer:
 ```
 Gets the contents of the selected div element, and sets the returned value to `Female` if the scraped value is `F`; `Male` if the scraped value is `M`.
 
-* `parseDate`: if present, the value is the date format using go's reference date (2006-01-02). For example, if an example date was `14-Mar-2003`, then the date format would be `02-Jan-2006`. See the [time.Parse documentation](https://golang.org/pkg/time/#Parse) for details. When present, the scraper will convert the input string into a date, then convert it to the string format used by stash (`YYYY-MM-DD`).
+* `parseDate`: if present, the value is the date format using go's reference date (2006-01-02). For example, if an example date was `14-Mar-2003`, then the date format would be `02-Jan-2006`. See the [time.Parse documentation](https://golang.org/pkg/time/#Parse) for details. When present, the scraper will convert the input string into a date, then convert it to the string format used by stash (`YYYY-MM-DD`). Strings "Today", "Yesterday" are matched (case insensitive) and converted by the scraper so you don't need to edit/replace them.
 
 * `replace`: contains an array of sub-objects. Each sub-object must have a `regex` and `with` field. The `regex` field is the regex pattern to replace, and `with` is the string to replace it with. `$` is used to reference capture groups - `$1` is the first capture group, `$2` the second and so on. Replacements are performed in order of the array.
 


### PR DESCRIPTION
Matches and converts the strings `today` and `yesterday` when using the parseDate pp in scrapers.
The string matching is case insensitive
The conversion is transparent to the scraper developers, all they need to do is  have a `parseDate` and make sure that the strings are cleaned up.
example scraper from here <https://github.com/stashapp/CommunityScrapers/pull/459>