### PR TITLE
Handle /healthz for liveness checks.

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -124,6 +124,7 @@ func Start() {
 
 	r := chi.NewRouter()
 
+	r.Use(middleware.Heartbeat("/healthz"))
 	r.Use(authenticateHandler())
 	r.Use(middleware.Recoverer)
 

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -3,6 +3,7 @@
 * Added scene queue.
 
 ### 🎨 Improvements
+* Add HTTP endpoint for health checking at /healthz.
 * Disable sounds on scene/marker wall previews by default.
 * Improve Movie UI.
 * Change performer text query to search by name and alias only.


### PR DESCRIPTION
This is pre-authentication as it exposes no info and is far cheaper than
e.g. transmitting the login page.