### PR TITLE
Added Auto scroll user back to the top when page navigation is clicked

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -3,6 +3,7 @@
 * Added scene queue.
 
 ### 🎨 Improvements
+* Scroll to top when changing page number.
 * Add URL filter criteria for scenes, galleries, movies, performers and studios.
 * Add HTTP endpoint for health checking at `/healthz`.
 * Support `today` and `yesterday` for `parseDate` in scrapers.

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -534,6 +534,7 @@ const useList = <QueryResult extends IQueryResult, QueryData extends IDataItem>(
     const newFilter = _.cloneDeep(filter);
     newFilter.currentPage = page;
     updateQueryParams(newFilter);
+    window.scrollTo(0, 0);
   };
 
   const renderFilter = !options.filterHook


### PR DESCRIPTION
When clicking on any of the following (First, Previous, , Next or Last) auto scroll the user back to the top of the page.
 Resolves #1267