### PR TITLE
Update various GQL `image` fields' comments

### DIFF
--- a/graphql/schema/types/movie.graphql
+++ b/graphql/schema/types/movie.graphql
@@ -28,8 +28,9 @@ input MovieCreateInput {
   director: String
   synopsis: String
   url: String
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   front_image: String
+  """This should be a URL or a base64 encoded data URL"""
   back_image: String
 }
 
@@ -44,8 +45,9 @@ input MovieUpdateInput {
   director: String
   synopsis: String
   url: String
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   front_image: String
+  """This should be a URL or a base64 encoded data URL"""
   back_image: String
 }
 

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -54,7 +54,7 @@ input PerformerCreateInput {
   instagram: String
   favorite: Boolean
   tag_ids: [ID!]
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
 }
@@ -79,7 +79,7 @@ input PerformerUpdateInput {
   instagram: String
   favorite: Boolean
   tag_ids: [ID!]
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
 }

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -67,7 +67,7 @@ input SceneUpdateInput {
   performer_ids: [ID!]
   movies: [SceneMovieInput!]
   tag_ids: [ID!]
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   cover_image: String
   stash_ids: [StashIDInput!]
 }

--- a/graphql/schema/types/scraped-movie.graphql
+++ b/graphql/schema/types/scraped-movie.graphql
@@ -17,8 +17,9 @@ type ScrapedMovie {
   synopsis: String
   studio: ScrapedMovieStudio
 
-  """This should be base64 encoded"""
+  """This should be a base64 encoded data URL"""
   front_image: String
+  """This should be a base64 encoded data URL"""
   back_image: String
 }
 

--- a/graphql/schema/types/scraped-performer.graphql
+++ b/graphql/schema/types/scraped-performer.graphql
@@ -19,7 +19,7 @@ type ScrapedPerformer {
   # Should be ScrapedPerformerTag - but would be identical types
   tags: [ScrapedSceneTag!]
 
-  """This should be base64 encoded"""
+  """This should be a base64 encoded data URL"""
   image: String
 }
 

--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -85,7 +85,7 @@ type ScrapedScene {
   url: String
   date: String
 
-  """This should be base64 encoded"""
+  """This should be a base64 encoded data URL"""
   image: String
 
   file: SceneFileType # Resolver

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -15,7 +15,7 @@ input StudioCreateInput {
   name: String!
   url: String
   parent_id: ID
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
 }
@@ -25,7 +25,7 @@ input StudioUpdateInput {
   name: String
   url: String
   parent_id: ID,
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
   stash_ids: [StashIDInput!]
 }

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -11,7 +11,7 @@ type Tag {
 input TagCreateInput {
   name: String!
 
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
 }
 
@@ -19,7 +19,7 @@ input TagUpdateInput {
   id: ID!
   name: String!
 
-  """This should be base64 encoded"""
+  """This should be a URL or a base64 encoded data URL"""
   image: String
 }
 


### PR DESCRIPTION
As discussed on Discord, updated the comments for the various `image` GraphQL fields.

- The base types' image fields are all processed using [`ProcessImageInput`](https://github.com/stashapp/stash/blob/76714653342887f249159cd14b5554882455807f/pkg/utils/image.go#L21-L32) which allows for either a direct image URL or a base64 encoded [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
- The `Scraped*` types all expect Data URLs.