### PR TITLE
Remove external resource from Login page

### DIFF
--- a/ui/login/login.css
+++ b/ui/login/login.css
@@ -9,7 +9,7 @@ html {
 body {
     background-color: #202b33;
     color: #f5f8fa;
-    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;

--- a/ui/login/login.html
+++ b/ui/login/login.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Login</title>
 
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
     <link rel="stylesheet" href="/login/login.css">
     <link rel="stylesheet" href="/css">
 </head>
@@ -26,9 +25,9 @@
                 <div class="login-error">
                     {{.Error}}
                 </div>
-    
+
                 <input type="hidden" name="returnURL" value="{{.URL}}" />
-    
+
                 <div>
                     <input class="btn btn-primary" type="submit" value="Login">
                 </div>

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -13,6 +13,7 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix hang on Login page when not connected to internet.
 * Fix `Clear Image` button not updating image preview.
 * Fix processing some webp files.
 * Fix incorrect performer age calculation in UI.


### PR DESCRIPTION
Fetching external resources via HTML may cause the entire page to not load if the internet connection is spotty or down.

**This applies to the Setup and Migrate pages as well,**
however, #1190 integrates them into the `v2.5` codebase and removes their HTML files.

It doesn't look like the Roboto font is imported/used in Stash (other than in the pages mentioned above).

To locally import fonts, [Fontsource](https://fontsource.org/#roboto) should probably be used.
```scss
/* yarn add @fontsource/roboto */
@import "@fontsource/roboto/300.css";
@import "@fontsource/roboto/300-italic.css";
@import "@fontsource/roboto/700.css";
@import "@fontsource/roboto/700-italic.css";
```