### PR TITLE
Github build action refinement and caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ develop, master, prs/1268 ]
+    branches: [ develop, master ]
   pull_request:
     branches: [ develop ]
   release:
@@ -60,9 +60,8 @@ jobs:
       run: docker exec -t build /bin/bash -c "make generate"
     
     - name: Validate UI
-      #github.event_name != 'pull_request' || 
       # skip UI validation for pull requests if UI is unchanged
-      if: ${{ steps.cache-ui.outputs.cache-hit != 'true' }}
+      if: ${{ github.event_name != 'pull_request' || steps.cache-ui.outputs.cache-hit != 'true' }}
       run: docker exec -t build /bin/bash -c "make ui-validate"
 
     # TODO: Replace with `make validate` once `revive` is bundled in COMPILER_IMAGE
@@ -73,8 +72,7 @@ jobs:
       # skip UI build for pull requests if UI is unchanged (UI was cached)
       # this means that the build version/time may be incorrect if the UI is
       # not changed in a pull request
-      #github.event_name != 'pull_request' || 
-      if: ${{ steps.cache-ui.outputs.cache-hit != 'true' }}
+      if: ${{ github.event_name != 'pull_request' || steps.cache-ui.outputs.cache-hit != 'true' }}
       run: docker exec -t build /bin/bash -c "make ui-only"
 
     - name: Compile for all supported platforms
@@ -99,7 +97,7 @@ jobs:
     
     - name: Upload Windows binary
       # only upload binaries for pull requests
-      #if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
+      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
       uses: actions/upload-artifact@v2
       with:
         name: stash-win.exe
@@ -115,7 +113,7 @@ jobs:
 
     - name: Upload Linux binary
       # only upload binaries for pull requests
-      #if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
+      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
       uses: actions/upload-artifact@v2
       with:
         name: stash-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, master, prs/1268 ]
   pull_request:
     branches: [ develop ]
   release:
@@ -31,8 +31,18 @@ jobs:
         path: ui/v2.5/node_modules
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock') }}
 
+    - name: Cache go build
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-go-cache
+      with:
+        path: .go-cache
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
+
     - name: Start build container
-      run: docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE tail -f /dev/null
+      run: |
+        mkdir -p .go-cache
+        docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated --mount type=bind,source="$(pwd)/.go-cache",target=/root/.cache/go-build,consistency=delegated -w /stash $COMPILER_IMAGE tail -f /dev/null
     
     - name: Pre-install
       run: docker exec -t build /bin/bash -c "make pre-ui"
@@ -45,10 +55,16 @@ jobs:
       run: docker exec -t build /bin/bash -c "make ui-validate fmt-check vet it"
 
     - name: Build UI
-      run: docker exec -t build /bin/bash -c "make ui-only"
+      run: docker exec -t build /bin/bash -c "make ui"
 
     - name: Compile for all supported platforms
-      run: ./scripts/cross-compile.sh
+      run: |
+        docker exec -t build /bin/bash -c "make cross-compile-windows"
+        docker exec -t build /bin/bash -c "make cross-compile-osx"
+        docker exec -t build /bin/bash -c "make cross-compile-linux"
+        docker exec -t build /bin/bash -c "make cross-compile-linux-arm64v8"
+        docker exec -t build /bin/bash -c "make cross-compile-linux-arm32v7"
+        docker exec -t build /bin/bash -c "make cross-compile-pi"
 
     - name: Cleanup build container
       run: docker rm -f -v build
@@ -62,7 +78,7 @@ jobs:
     
     - name: Upload Windows binary
       # only upload binaries for pull requests
-      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
+      #if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
       uses: actions/upload-artifact@v2
       with:
         name: stash-win.exe
@@ -78,7 +94,7 @@ jobs:
 
     - name: Upload Linux binary
       # only upload binaries for pull requests
-      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
+      #if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
       uses: actions/upload-artifact@v2
       with:
         name: stash-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         cache-name: cache-ui
       with:
         path: ui/v2.5/build
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock', 'ui/v2.5/public/**', 'ui/v2.5/src/**') }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock', 'ui/v2.5/public/**', 'ui/v2.5/src/**', 'graphql/**/*.graphql') }}
 
     - name: Cache go build
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,21 +31,27 @@ jobs:
         path: ui/v2.5/node_modules
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock') }}
 
+    - name: Start build container
+      run: docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE tail -f /dev/null
+    
     - name: Pre-install
-      run: docker run --rm --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE /bin/bash -c "make pre-ui"
+      run: docker exec -t build /bin/bash -c "make pre-ui"
 
     - name: Generate
-      run: docker run --rm --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE /bin/bash -c "make generate"
+      run: docker exec -t build /bin/bash -c "make generate"
     
     # TODO: Replace with `make validate` once `revive` is bundled in COMPILER_IMAGE
     - name: Validate
-      run: docker run --rm --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE /bin/bash -c "make ui-validate fmt-check vet it"
+      run: docker exec -t build /bin/bash -c "make ui-validate fmt-check vet it"
 
     - name: Build UI
-      run: docker run --rm --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated -w /stash $COMPILER_IMAGE /bin/bash -c "make ui-only"
+      run: docker exec -t build /bin/bash -c "make ui-only"
 
     - name: Compile for all supported platforms
       run: ./scripts/cross-compile.sh
+
+    - name: Cleanup build container
+      run: docker rm -f -v build
 
     - name: Generate checksums
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,15 @@ jobs:
         path: ui/v2.5/node_modules
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock') }}
 
+    - name: Cache UI build
+      uses: actions/cache@v2
+      id: cache-ui
+      env:
+        cache-name: cache-ui
+      with:
+        path: ui/v2.5/build
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ui/v2.5/yarn.lock', 'ui/v2.5/public/**', 'ui/v2.5/src/**') }}
+
     - name: Cache go build
       uses: actions/cache@v2
       env:
@@ -50,15 +59,27 @@ jobs:
     - name: Generate
       run: docker exec -t build /bin/bash -c "make generate"
     
+    - name: Validate UI
+      #github.event_name != 'pull_request' || 
+      # skip UI validation for pull requests if UI is unchanged
+      if: ${{ steps.cache-ui.outputs.cache-hit != 'true' }}
+      run: docker exec -t build /bin/bash -c "make ui-validate"
+
     # TODO: Replace with `make validate` once `revive` is bundled in COMPILER_IMAGE
     - name: Validate
-      run: docker exec -t build /bin/bash -c "make ui-validate fmt-check vet it"
+      run: docker exec -t build /bin/bash -c "make fmt-check vet it"
 
     - name: Build UI
-      run: docker exec -t build /bin/bash -c "make ui"
+      # skip UI build for pull requests if UI is unchanged (UI was cached)
+      # this means that the build version/time may be incorrect if the UI is
+      # not changed in a pull request
+      #github.event_name != 'pull_request' || 
+      if: ${{ steps.cache-ui.outputs.cache-hit != 'true' }}
+      run: docker exec -t build /bin/bash -c "make ui-only"
 
     - name: Compile for all supported platforms
       run: |
+        docker exec -t build /bin/bash -c "make packr"
         docker exec -t build /bin/bash -c "make cross-compile-windows"
         docker exec -t build /bin/bash -c "make cross-compile-osx"
         docker exec -t build /bin/bash -c "make cross-compile-linux"

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,46 @@ build-release: build
 build-release-static: EXTRA_LDFLAGS := -extldflags=-static -s -w
 build-release-static: build
 
+# cross-compile- targets should be run within the compiler docker container
+cross-compile-windows: GOOS := windows 
+cross-compile-windows: GOARCH := amd64 
+cross-compile-windows: CC := x86_64-w64-mingw32-gcc
+cross-compile-windows: CXX := x86_64-w64-mingw32-g++
+cross-compile-windows: OUTPUT := dist/stash-win.exe
+cross-compile-windows: build-release-static
+
+cross-compile-osx: GOOS := darwin 
+cross-compile-osx: GOARCH := amd64 
+cross-compile-osx: CC := o64-clang
+cross-compile-osx: CXX := o64-clang++
+cross-compile-osx: OUTPUT := dist/stash-osx
+cross-compile-osx: build-release-static
+
+cross-compile-linux: GOOS := linux 
+cross-compile-linux: GOARCH := amd64 
+cross-compile-linux: OUTPUT := dist/stash-linux
+cross-compile-linux: build-release-static
+
+cross-compile-linux-arm64v8: GOOS := linux 
+cross-compile-linux-arm64v8: GOARCH := arm64 
+cross-compile-linux-arm64v8: CC := aarch64-linux-gnu-gcc
+cross-compile-linux-arm64v8: OUTPUT := dist/stash-linux-arm64v8
+cross-compile-linux-arm64v8: build-release-static
+
+cross-compile-linux-arm32v7: GOOS := linux 
+cross-compile-linux-arm32v7: GOARCH := arm 
+cross-compile-linux-arm32v7: GOARM := 7 
+cross-compile-linux-arm32v7: CC := arm-linux-gnueabihf-gcc
+cross-compile-linux-arm32v7: OUTPUT := dist/stash-linux-arm32v7
+cross-compile-linux-arm32v7: build-release-static
+
+cross-compile-pi: GOOS := linux 
+cross-compile-pi: GOARCH := arm 
+cross-compile-pi: GOARM := 6
+cross-compile-pi: CC := arm-linux-gnueabi-gcc
+cross-compile-pi: OUTPUT := dist/stash-pi
+cross-compile-pi: build-release-static
+
 install:
 	packr2 install
 

--- a/scripts/cross-compile.sh
+++ b/scripts/cross-compile.sh
@@ -10,12 +10,12 @@ STASH_VERSION=`git describe --tags --exclude latest_develop`
 SETENV="BUILD_DATE=\"$BUILD_DATE\" GITHASH=$GITHASH STASH_VERSION=\"$STASH_VERSION\""
 SETUP="export GO111MODULE=on; export CGO_ENABLED=1; set -e; echo '=== Running packr ==='; make packr;"
 SETUP_FAST="export GO111MODULE=on; export CGO_ENABLED=1;"
-WINDOWS="echo '=== Building Windows binary ==='; $SETENV GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ LDFLAGS=\"-extldflags '-static' \" OUTPUT=\"dist/stash-win.exe\" make build-release;"
-DARWIN="echo '=== Building OSX binary ==='; $SETENV GOOS=darwin GOARCH=amd64 CC=o64-clang CXX=o64-clang++ OUTPUT=\"dist/stash-osx\" make build-release;"
-LINUX_AMD64="echo '=== Building Linux (amd64) binary ==='; $SETENV GOOS=linux GOARCH=amd64 OUTPUT=\"dist/stash-linux\" make build-release-static;"
-LINUX_ARM64v8="echo '=== Building Linux (armv8/arm64) binary ==='; $SETENV GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc OUTPUT=\"dist/stash-linux-arm64v8\" make build-release-static;"
-LINUX_ARM32v7="echo '=== Building Linux (armv7/armhf) binary ==='; $SETENV GOOS=linux GOARCH=arm GOARM=7 CC=arm-linux-gnueabihf-gcc OUTPUT=\"dist/stash-linux-arm32v7\" make build-release-static;"
-LINUX_ARM32v6="echo '=== Building Linux (armv6 | Raspberry Pi 1) binary ==='; $SETENV GOOS=linux GOARCH=arm GOARM=6 CC=arm-linux-gnueabi-gcc OUTPUT=\"dist/stash-pi\" make build-release-static;"
+WINDOWS="echo '=== Building Windows binary ==='; $SETENV make cross-compile-windows;"
+DARWIN="echo '=== Building OSX binary ==='; $SETENV make cross-compile-osx;"
+LINUX_AMD64="echo '=== Building Linux (amd64) binary ==='; $SETENV make cross-compile-linux;"
+LINUX_ARM64v8="echo '=== Building Linux (armv8/arm64) binary ==='; $SETENV make cross-compile-linux-arm64v8;"
+LINUX_ARM32v7="echo '=== Building Linux (armv7/armhf) binary ==='; $SETENV make cross-compile-linux-arm32v7;"
+LINUX_ARM32v6="echo '=== Building Linux (armv6 | Raspberry Pi 1) binary ==='; $SETENV make cross-compile-pi;"
 BUILD_COMPLETE="echo '=== Build complete ==='"
 
 # if build target ends with -fast then use prebuilt packr2. eg amd64-fast or all-fast


### PR DESCRIPTION
* Runs all build steps in the one container.
* Caches the go build cache and UI output, and skips rebuilding the UI in pull requests if the UI cache was successfully reloaded.
* Added cross compile make targets to the Makefile and used this in `build.yml` and `cross-compile.sh` (though `cross-compile.sh` is now mostly vestigial).

This saves around 5-6 minutes rebuilding the vendor dependencies, 4.5 minutes if the UI doesn't need to be validated and rebuilt, and 1 minute if node dependencies do not need to be resolved. Best-case scenario reduces build time to around 3 minutes (most of which is the docker container pull).

The one side-effect of this change is that the build tag and time of the UI will be incorrect for cached UI builds in pull requests. Builds on `develop` and `master` should always rebuild the UI.