### PR TITLE
Separate UI

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -234,9 +234,21 @@ func Start() {
 		})
 	}
 
+	customUILocation := c.GetCustomUILocation()
+
 	// Serve the web app
 	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
 		ext := path.Ext(r.URL.Path)
+
+		if customUILocation != "" {
+			if r.URL.Path == "index.html" || ext == "" {
+				r.URL.Path = "/"
+			}
+
+			http.FileServer(http.Dir(customUILocation)).ServeHTTP(w, r)
+			return
+		}
+
 		if ext == ".html" || ext == "" {
 			data, _ := uiBox.Find("index.html")
 			_, _ = w.Write(data)

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -106,6 +106,10 @@ const Language = "language"
 // this should be manually configured only
 const CustomServedFolders = "custom_served_folders"
 
+// UI directory. Overrides to serve the UI from a specific location
+// rather than use the embedded UI.
+const CustomUILocation = "custom_ui_location"
+
 // Interface options
 const MenuItems = "menu_items"
 
@@ -521,6 +525,10 @@ func (i *Instance) GetMaxSessionAge() int {
 // filesystem locations
 func (i *Instance) GetCustomServedFolders() URLMap {
 	return viper.GetStringMapString(CustomServedFolders)
+}
+
+func (i *Instance) GetCustomUILocation() string {
+	return viper.GetString(CustomUILocation)
 }
 
 // Interface options

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -1,4 +1,5 @@
 ### ✨ New Features
+* Support serving UI from specific directory location.
 * Added details, death date, hair color, and weight to Performers.
 * Added details to Studios.
 * Added [perceptual dupe checker](/settings?tab=duplicates).

--- a/ui/v2.5/src/docs/en/Configuration.md
+++ b/ui/v2.5/src/docs/en/Configuration.md
@@ -115,4 +115,20 @@ These options are typically not exposed in the UI and must be changed manually i
 
 | Field | Remarks |
 |-------|---------|
+| `custom_served_folders` | A map of URLs to file system folders. See below. |
+| `custom_ui_location` | The file system folder where the UI files will be served from, instead of using the embedded UI. Empty to disable. Stash must be restarted to take effect. |
 | `max_upload_size` | Maximum file upload size for import files. Defaults to 1GB. |
+
+### Custom served folders
+
+Custom served folders are served when the server handles a request with the `/custom` URL prefix. The following is an example configuration:
+
+```
+custom_served_folders:
+  /: D:\stash\static
+  /foo: D:\bar
+```
+
+With the above configuration, a request for `/custom/foo/bar.png` would serve `D:\bar\bar.png`. 
+
+The `/` entry matches anything that is not otherwise mapped by the other entries. For example, `/custom/baz/xyz.png` would serve `D:\stash\static\baz\xyz.png`.


### PR DESCRIPTION
Adds a new configuration field `custom_ui_location`. When not empty, it will serve the UI from the configured location, rather than using the UI embedded in the binary. This will allow (advanced) users to customise their UI to their liking, and potentially allow testing of UI changes (we could zip up the UI as an artifact in PR builds for example).

Requires a restart of stash when changed.

Resolves #752 