### PR TITLE
Skip validation of existing paths when adding new paths

### DIFF
--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -25,11 +25,21 @@ func (r *mutationResolver) Migrate(ctx context.Context, input models.MigrateInpu
 
 func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.ConfigGeneralInput) (*models.ConfigGeneralResult, error) {
 	c := config.GetInstance()
+	existingPaths := c.GetStashPaths()
 	if len(input.Stashes) > 0 {
 		for _, s := range input.Stashes {
-			exists, err := utils.DirExists(s.Path)
-			if !exists {
-				return makeConfigGeneralResult(), err
+			// Only validate existence of new paths
+			isNew := true
+			for _, path := range existingPaths {
+				if path.Path == s.Path {
+					isNew = false
+				}
+			}
+			if isNew {
+				exists, err := utils.DirExists(s.Path)
+				if !exists {
+					return makeConfigGeneralResult(), err
+				}
 			}
 		}
 		c.Set(config.Stash, input.Stashes)

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -33,6 +33,7 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 			for _, path := range existingPaths {
 				if path.Path == s.Path {
 					isNew = false
+					break
 				}
 			}
 			if isNew {

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -18,6 +18,7 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix error preventing adding a new library path when an existing library path is missing.
 * Fix whitespace in query string returning all objects. 
 * Fix hang on Login page when not connected to internet.
 * Fix `Clear Image` button not updating image preview.


### PR DESCRIPTION
The current logic prevents users from adding new paths if one of the existing paths is missing. This makes it impossible to swap usb drives unless they have the same pathnames.

This change skips validation of existing paths so we avoid that. 