### PR TITLE
Load settings panels on demand

### DIFF
--- a/ui/v2.5/src/components/Settings/Settings.tsx
+++ b/ui/v2.5/src/components/Settings/Settings.tsx
@@ -66,19 +66,19 @@ export const Settings: React.FC = () => {
               <Tab.Pane eventKey="tasks">
                 <SettingsTasksPanel />
               </Tab.Pane>
-              <Tab.Pane eventKey="scrapers">
+              <Tab.Pane eventKey="scrapers" unmountOnExit>
                 <SettingsScrapersPanel />
               </Tab.Pane>
-              <Tab.Pane eventKey="plugins">
+              <Tab.Pane eventKey="plugins" unmountOnExit>
                 <SettingsPluginsPanel />
               </Tab.Pane>
-              <Tab.Pane eventKey="logs">
+              <Tab.Pane eventKey="logs" unmountOnExit>
                 <SettingsLogsPanel />
               </Tab.Pane>
-              <Tab.Pane eventKey="duplicates">
+              <Tab.Pane eventKey="duplicates" unmountOnExit>
                 <SettingsDuplicatePanel />
               </Tab.Pane>
-              <Tab.Pane eventKey="about">
+              <Tab.Pane eventKey="about" unmountOnExit>
                 <SettingsAboutPanel />
               </Tab.Pane>
             </Tab.Content>


### PR DESCRIPTION
When `unmountOnExit` isn't set the panels will be rendered immediately when the settings page is loaded, which causes it to fire off a bunch of queries that may never be used. The remaining panels have settings so it's better to leave them alone so they don't get reset when you navigate between panes.