### PR TITLE
Add studio `*_count` filters and sort options

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -143,6 +143,12 @@ input StudioFilterType {
   stash_id: String
   """Filter to only include studios missing this property"""
   is_missing: String
+  """Filter by scene count"""
+  scene_count: IntCriterionInput
+  """Filter by image count"""
+  image_count: IntCriterionInput
+  """Filter by gallery count"""
+  gallery_count: IntCriterionInput
   """Filter by url"""
   url: StringCriterionInput
 }

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -126,7 +126,7 @@ func TestImageQueryPath(t *testing.T) {
 	verifyImagePath(t, pathCriterion, totalImages-1)
 
 	pathCriterion.Modifier = models.CriterionModifierMatchesRegex
-	pathCriterion.Value = "image_.*1_Path"
+	pathCriterion.Value = "image_.*01_Path"
 	verifyImagePath(t, pathCriterion, 1) // TODO - 2 if zip path is included
 
 	pathCriterion.Modifier = models.CriterionModifierNotMatchesRegex

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1021,7 +1021,7 @@ func linkImagePerformers(qb models.ImageReaderWriter) error {
 
 func linkGalleryPerformers(qb models.GalleryReaderWriter) error {
 	return doLinks(galleryPerformerLinks, func(galleryIndex, performerIndex int) error {
-		galleryID := imageIDs[galleryIndex]
+		galleryID := galleryIDs[galleryIndex]
 		performers, err := qb.GetPerformerIDs(galleryID)
 		if err != nil {
 			return err
@@ -1045,17 +1045,17 @@ func linkGalleryStudios(qb models.GalleryReaderWriter) error {
 	})
 }
 
-func linkGalleryTags(iqb models.GalleryReaderWriter) error {
+func linkGalleryTags(qb models.GalleryReaderWriter) error {
 	return doLinks(galleryTagLinks, func(galleryIndex, tagIndex int) error {
-		galleryID := imageIDs[galleryIndex]
-		tags, err := iqb.GetTagIDs(galleryID)
+		galleryID := galleryIDs[galleryIndex]
+		tags, err := qb.GetTagIDs(galleryID)
 		if err != nil {
 			return err
 		}
 
 		tags = append(tags, tagIDs[tagIndex])
 
-		return iqb.UpdateTags(galleryID, tags)
+		return qb.UpdateTags(galleryID, tags)
 	})
 }
 

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -213,7 +213,15 @@ func (qb *studioQueryBuilder) getStudioSort(findFilter *models.FindFilterType) s
 		sort = findFilter.GetSort("name")
 		direction = findFilter.GetDirection()
 	}
-	return getSort(sort, direction, "studios")
+
+	switch sort {
+	case "images_count":
+		return getCountSort(studioTable, imageTable, studioIDColumn, direction)
+	case "galleries_count":
+		return getCountSort(studioTable, galleryTable, studioIDColumn, direction)
+	default:
+		return getSort(sort, direction, "studios")
+	}
 }
 
 func (qb *studioQueryBuilder) queryStudio(query string, args []interface{}) (*models.Studio, error) {

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -133,7 +133,7 @@ func (qb *studioQueryBuilder) Query(studioFilter *models.StudioFilterType, findF
 
 	query.body = selectDistinctIDs("studios")
 	query.body += `
-		left join scenes on studios.id = scenes.studio_id		
+		left join scenes on studios.id = scenes.studio_id
 		left join studio_stash_ids on studio_stash_ids.studio_id = studios.id
 	`
 
@@ -164,6 +164,10 @@ func (qb *studioQueryBuilder) Query(studioFilter *models.StudioFilterType, findF
 		query.addWhere("studio_stash_ids.stash_id = ?")
 		query.addArg(stashIDFilter)
 	}
+
+	query.handleCountCriterion(studioFilter.SceneCount, studioTable, sceneTable, studioIDColumn)
+	query.handleCountCriterion(studioFilter.ImageCount, studioTable, imageTable, studioIDColumn)
+	query.handleCountCriterion(studioFilter.GalleryCount, studioTable, galleryTable, studioIDColumn)
 
 	query.handleStringCriterionInput(studioFilter.URL, "studios.url")
 

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -265,6 +265,147 @@ func TestStudioDestroyStudioImage(t *testing.T) {
 	}
 }
 
+func TestStudioQuerySceneCount(t *testing.T) {
+	const sceneCount = 1
+	sceneCountCriterion := models.IntCriterionInput{
+		Value:    sceneCount,
+		Modifier: models.CriterionModifierEquals,
+	}
+
+	verifyStudiosSceneCount(t, sceneCountCriterion)
+
+	sceneCountCriterion.Modifier = models.CriterionModifierNotEquals
+	verifyStudiosSceneCount(t, sceneCountCriterion)
+
+	sceneCountCriterion.Modifier = models.CriterionModifierGreaterThan
+	verifyStudiosSceneCount(t, sceneCountCriterion)
+
+	sceneCountCriterion.Modifier = models.CriterionModifierLessThan
+	verifyStudiosSceneCount(t, sceneCountCriterion)
+}
+
+func verifyStudiosSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionInput) {
+	withTxn(func(r models.Repository) error {
+		sqb := r.Studio()
+		studioFilter := models.StudioFilterType{
+			SceneCount: &sceneCountCriterion,
+		}
+
+		studios := queryStudio(t, sqb, &studioFilter, nil)
+		assert.Greater(t, len(studios), 0)
+
+		for _, studio := range studios {
+			sceneCount, err := r.Scene().CountByStudioID(studio.ID)
+			if err != nil {
+				return err
+			}
+			verifyInt(t, sceneCount, sceneCountCriterion)
+		}
+
+		return nil
+	})
+}
+
+func TestStudioQueryImageCount(t *testing.T) {
+	const imageCount = 1
+	imageCountCriterion := models.IntCriterionInput{
+		Value:    imageCount,
+		Modifier: models.CriterionModifierEquals,
+	}
+
+	verifyStudiosImageCount(t, imageCountCriterion)
+
+	imageCountCriterion.Modifier = models.CriterionModifierNotEquals
+	verifyStudiosImageCount(t, imageCountCriterion)
+
+	imageCountCriterion.Modifier = models.CriterionModifierGreaterThan
+	verifyStudiosImageCount(t, imageCountCriterion)
+
+	imageCountCriterion.Modifier = models.CriterionModifierLessThan
+	verifyStudiosImageCount(t, imageCountCriterion)
+}
+
+func verifyStudiosImageCount(t *testing.T, imageCountCriterion models.IntCriterionInput) {
+	withTxn(func(r models.Repository) error {
+		sqb := r.Studio()
+		studioFilter := models.StudioFilterType{
+			ImageCount: &imageCountCriterion,
+		}
+
+		studios := queryStudio(t, sqb, &studioFilter, nil)
+		assert.Greater(t, len(studios), 0)
+
+		for _, studio := range studios {
+			pp := 0
+
+			_, count, err := r.Image().Query(&models.ImageFilterType{
+				Studios: &models.MultiCriterionInput{
+					Value:    []string{strconv.Itoa(studio.ID)},
+					Modifier: models.CriterionModifierIncludes,
+				},
+			}, &models.FindFilterType{
+				PerPage: &pp,
+			})
+			if err != nil {
+				return err
+			}
+			verifyInt(t, count, imageCountCriterion)
+		}
+
+		return nil
+	})
+}
+
+func TestStudioQueryGalleryCount(t *testing.T) {
+	const galleryCount = 1
+	galleryCountCriterion := models.IntCriterionInput{
+		Value:    galleryCount,
+		Modifier: models.CriterionModifierEquals,
+	}
+
+	verifyStudiosGalleryCount(t, galleryCountCriterion)
+
+	galleryCountCriterion.Modifier = models.CriterionModifierNotEquals
+	verifyStudiosGalleryCount(t, galleryCountCriterion)
+
+	galleryCountCriterion.Modifier = models.CriterionModifierGreaterThan
+	verifyStudiosGalleryCount(t, galleryCountCriterion)
+
+	galleryCountCriterion.Modifier = models.CriterionModifierLessThan
+	verifyStudiosGalleryCount(t, galleryCountCriterion)
+}
+
+func verifyStudiosGalleryCount(t *testing.T, galleryCountCriterion models.IntCriterionInput) {
+	withTxn(func(r models.Repository) error {
+		sqb := r.Studio()
+		studioFilter := models.StudioFilterType{
+			GalleryCount: &galleryCountCriterion,
+		}
+
+		studios := queryStudio(t, sqb, &studioFilter, nil)
+		assert.Greater(t, len(studios), 0)
+
+		for _, studio := range studios {
+			pp := 0
+
+			_, count, err := r.Gallery().Query(&models.GalleryFilterType{
+				Studios: &models.MultiCriterionInput{
+					Value:    []string{strconv.Itoa(studio.ID)},
+					Modifier: models.CriterionModifierIncludes,
+				},
+			}, &models.FindFilterType{
+				PerPage: &pp,
+			})
+			if err != nil {
+				return err
+			}
+			verifyInt(t, count, galleryCountCriterion)
+		}
+
+		return nil
+	})
+}
+
 func TestStudioStashIDs(t *testing.T) {
 	if err := withTxn(func(r models.Repository) error {
 		qb := r.Studio()

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -240,6 +240,9 @@ export class ListFilterModel {
           new NoneCriterionOption(),
           new ParentStudiosCriterionOption(),
           new StudioIsMissingCriterionOption(),
+          ListFilterModel.createCriterionOption("scene_count"),
+          ListFilterModel.createCriterionOption("image_count"),
+          ListFilterModel.createCriterionOption("gallery_count"),
           ListFilterModel.createCriterionOption("url"),
         ];
         break;
@@ -1007,8 +1010,34 @@ export class ListFilterModel {
           };
           break;
         }
-        case "studioIsMissing":
+        case "studioIsMissing": {
           result.is_missing = (criterion as IsMissingCriterion).value;
+          break;
+        }
+        case "scene_count": {
+          const countCrit = criterion as NumberCriterion;
+          result.scene_count = {
+            value: countCrit.value,
+            modifier: countCrit.modifier,
+          };
+          break;
+        }
+        case "image_count": {
+          const countCrit = criterion as NumberCriterion;
+          result.image_count = {
+            value: countCrit.value,
+            modifier: countCrit.modifier,
+          };
+          break;
+        }
+        case "gallery_count": {
+          const countCrit = criterion as NumberCriterion;
+          result.gallery_count = {
+            value: countCrit.value,
+            modifier: countCrit.modifier,
+          };
+          break;
+        }
         // no default
       }
     });

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -234,7 +234,13 @@ export class ListFilterModel {
       }
       case FilterMode.Studios:
         this.sortBy = "name";
-        this.sortByOptions = ["name", "scenes_count", "random"];
+        this.sortByOptions = [
+          "name",
+          "scenes_count",
+          "images_count",
+          "galleries_count",
+          "random"
+        ];
         this.displayModeOptions = [DisplayMode.Grid];
         this.criterionOptions = [
           new NoneCriterionOption(),

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -239,7 +239,7 @@ export class ListFilterModel {
           "scenes_count",
           "images_count",
           "galleries_count",
-          "random"
+          "random",
         ];
         this.displayModeOptions = [DisplayMode.Grid];
         this.criterionOptions = [


### PR DESCRIPTION
This was mostly copy-paste for me (I don't really know Go), with a few adjustments for the tests.
I know the filters work. ~I believe the sort does too but I don't remember (wrote this 5 days ago).~
_Edit:_ Sort works too.

Still falls under the v0.7.0 change log entry, if merged:
> Add various `count` filter criteria and sort options.