### PR TITLE
Fix fingerprint search when scene only has phash match

### DIFF
--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -290,7 +290,8 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       (s) =>
         s.stash_ids.length === 0 &&
         ((s.checksum && fingerprints[s.checksum]) ||
-          (s.oshash && fingerprints[s.oshash]))
+          (s.oshash && fingerprints[s.oshash]) ||
+          (s.phash && fingerprints[s.phash]))
     ).length;
   };
 
@@ -320,6 +321,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       const fingerprintMatch =
         fingerprints[scene.checksum ?? ""] ??
         fingerprints[scene.oshash ?? ""] ??
+        fingerprints[scene.phash ?? ""] ??
         null;
       const isTagged = taggedScenes[scene.id];
       const hasStashIDs = scene.stash_ids.length > 0;


### PR DESCRIPTION
When scene only had a phash match, and no oshash/md5 it would not be considered a match.