### PR TITLE
Overwrite new performer image after clearing current image

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -23,6 +23,7 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix scraped performer image not updating after clearing the current image when creating a new performer.
 * Fix error preventing adding a new library path when an existing library path is missing.
 * Fix whitespace in query string returning all objects. 
 * Fix hang on Login page when not connected to internet.

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -311,9 +311,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     // image is a base64 string
     // #404: don't overwrite image if it has been modified by the user
     // overwrite if not new since it came from a dialog
-    // otherwise follow existing behaviour
+    // overwrite if image was cleared (`null`)
+    // otherwise follow existing behaviour (`undefined`)
     if (
-      (!isNew || formik.values.image === undefined) &&
+      (!isNew || [null, undefined].includes(formik.values.image)) &&
       state.image !== undefined
     ) {
       const imageStr = state.image;


### PR DESCRIPTION
Following a discussion on #bugs, this expands on #449 (the fix to #404), while keeping that functionality:

When creating a new performer, after either selecting an image via file/URL or scraping a performer with an image,
you could not overwrite the current image using a scraper, even after clearing the image.

With this change, if you **intentionally** clear the current image, the next scrape will update the image to the scraped one. All other functionality remains the same - the image will only be replaced if you manually select a different image via file/URL.

N.B.
This could be expanded even more to keep note of the source of the image (scraped or manually selected) and clear based on that as well, but I feel like this is actually good enough to satisfy most cases, without complicating things too much more.