### PR TITLE
Apply scene queuing for all scene listviews

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -12,6 +12,7 @@ import {
   TruncatedText,
 } from "src/components/Shared";
 import { TextUtils } from "src/utils";
+import { SceneQueue } from "src/models/sceneQueue";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
 
 interface IScenePreviewProps {
@@ -65,12 +66,13 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
+  index?: number;
+  queue?: SceneQueue;
   compact?: boolean;
   selecting?: boolean;
   selected?: boolean | undefined;
   zoomIndex?: number;
   onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
-  onSceneClicked?: () => void;
 }
 
 export const SceneCard: React.FC<ISceneCardProps> = (
@@ -300,9 +302,6 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     if (props.selecting && props.onSelectedChanged) {
       props.onSelectedChanged(!props.selected, shiftKey);
       event.preventDefault();
-    } else if (props.onSceneClicked) {
-      props.onSceneClicked();
-      event.preventDefault();
     }
   }
 
@@ -340,6 +339,10 @@ export const SceneCard: React.FC<ISceneCardProps> = (
 
   let shiftKey = false;
 
+  const sceneLink = props.queue
+    ? props.queue.makeLink(props.scene.id, { sceneIndex: props.index })
+    : `/scenes/${props.scene.id}`;
+
   return (
     <Card className={`scene-card ${zoomIndex()}`}>
       <Form.Control
@@ -356,7 +359,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
 
       <div className="video-section">
         <Link
-          to={`/scenes/${props.scene.id}`}
+          to={sceneLink}
           className="scene-card-link"
           onClick={handleSceneClick}
           onDragStart={handleDrag}

--- a/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
@@ -1,41 +1,37 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
+import { SceneQueue } from "src/models/sceneQueue";
 import { SceneCard } from "./SceneCard";
 
 interface ISceneCardsGrid {
   scenes: GQL.SlimSceneDataFragment[];
+  queue?: SceneQueue;
   selectedIds: Set<string>;
   zoomIndex: number;
   onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
-  onSceneClick?: (id: string, index: number) => void;
 }
 
 export const SceneCardsGrid: React.FC<ISceneCardsGrid> = ({
   scenes,
+  queue,
   selectedIds,
   zoomIndex,
   onSelectChange,
-  onSceneClick,
 }) => {
-  function sceneClicked(sceneID: string, index: number) {
-    if (onSceneClick) {
-      onSceneClick(sceneID, index);
-    }
-  }
-
   return (
     <div className="row justify-content-center">
       {scenes.map((scene, index) => (
         <SceneCard
           key={scene.id}
           scene={scene}
+          queue={queue}
+          index={index}
           zoomIndex={zoomIndex}
           selecting={selectedIds.size > 0}
           selected={selectedIds.has(scene.id)}
           onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
             onSelectChange(scene.id, selected, shiftKey)
           }
-          onSceneClicked={() => sceneClicked(scene.id, index)}
         />
       ))}
     </div>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -120,8 +120,8 @@ export const SceneList: React.FC<ISceneList> = ({
       if (queryResults.data.findScenes.scenes.length > index) {
         const { id } = queryResults!.data!.findScenes!.scenes[index];
         // navigate to the image player page
-        const queue = SceneQueue.fromListFilterModel(filterCopy, index);
-        queue.playScene(history, id, { autoPlay: true });
+        const queue = SceneQueue.fromListFilterModel(filterCopy);
+        queue.playScene(history, id, { sceneIndex: index, autoPlay: true });
       }
     }
   }
@@ -138,15 +138,6 @@ export const SceneList: React.FC<ISceneList> = ({
   async function onExportAll() {
     setIsExportAll(true);
     setIsExportDialogOpen(true);
-  }
-
-  async function sceneClicked(
-    sceneId: string,
-    sceneIndex: number,
-    filter: ListFilterModel
-  ) {
-    const queue = SceneQueue.fromListFilterModel(filter, sceneIndex);
-    queue.playScene(history, sceneId);
   }
 
   function maybeRenderSceneGenerateDialog(selectedIds: Set<string>) {
@@ -204,24 +195,31 @@ export const SceneList: React.FC<ISceneList> = ({
     if (!result.data || !result.data.findScenes) {
       return;
     }
+
+    const queue = SceneQueue.fromListFilterModel(filter);
+
     if (filter.displayMode === DisplayMode.Grid) {
       return (
         <SceneCardsGrid
           scenes={result.data.findScenes.scenes}
+          queue={queue}
           zoomIndex={zoomIndex}
           selectedIds={selectedIds}
           onSelectChange={(id, selected, shiftKey) =>
             listData.onSelectChange(id, selected, shiftKey)
           }
-          onSceneClick={(id, index) => sceneClicked(id, index, filter)}
         />
       );
     }
     if (filter.displayMode === DisplayMode.List) {
-      return <SceneListTable scenes={result.data.findScenes.scenes} />;
+      return (
+        <SceneListTable scenes={result.data.findScenes.scenes} queue={queue} />
+      );
     }
     if (filter.displayMode === DisplayMode.Wall) {
-      return <WallPanel scenes={result.data.findScenes.scenes} />;
+      return (
+        <WallPanel scenes={result.data.findScenes.scenes} sceneQueue={queue} />
+      );
     }
     if (filter.displayMode === DisplayMode.Tagger) {
       return <Tagger scenes={result.data.findScenes.scenes} />;

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -222,7 +222,7 @@ export const SceneList: React.FC<ISceneList> = ({
       );
     }
     if (filter.displayMode === DisplayMode.Tagger) {
-      return <Tagger scenes={result.data.findScenes.scenes} />;
+      return <Tagger scenes={result.data.findScenes.scenes} queue={queue} />;
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -9,6 +9,7 @@ import { Icon, TruncatedText } from "src/components/Shared";
 
 interface ISceneListTableProps {
   scenes: GQL.SlimSceneDataFragment[];
+  queue?: SceneQueue;
 }
 
 export const SceneListTable: React.FC<ISceneListTableProps> = (
@@ -37,52 +38,58 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
       )
     );
 
-  const renderSceneRow = (scene: GQL.SlimSceneDataFragment) => (
-    <tr key={scene.id}>
-      <td>
-        <Link to={`/scenes/${scene.id}`}>
-          <img
-            className="image-thumbnail"
-            alt={scene.title ?? ""}
-            src={scene.paths.screenshot ?? ""}
-          />
-        </Link>
-      </td>
-      <td className="text-left">
-        <Link to={`/scenes/${scene.id}`}>
-          <h5>
-            <TruncatedText
-              text={scene.title ?? TextUtils.fileNameFromPath(scene.path)}
+  const renderSceneRow = (scene: GQL.SlimSceneDataFragment, index: number) => {
+    const sceneLink = props.queue
+      ? props.queue.makeLink(scene.id, { sceneIndex: index })
+      : `/scenes/${scene.id}`;
+
+    return (
+      <tr key={scene.id}>
+        <td>
+          <Link to={sceneLink}>
+            <img
+              className="image-thumbnail"
+              alt={scene.title ?? ""}
+              src={scene.paths.screenshot ?? ""}
             />
-          </h5>
-        </Link>
-      </td>
-      <td>{scene.rating ? scene.rating : ""}</td>
-      <td>
-        {scene.file.duration &&
-          TextUtils.secondsToTimestamp(scene.file.duration)}
-      </td>
-      <td>{renderTags(scene.tags)}</td>
-      <td>{renderPerformers(scene.performers)}</td>
-      <td>
-        {scene.studio && (
-          <Link to={NavUtils.makeStudioScenesUrl(scene.studio)}>
-            <h6>{scene.studio.name}</h6>
           </Link>
-        )}
-      </td>
-      <td>{renderMovies(scene)}</td>
-      <td>
-        {scene.gallery && (
-          <Button className="minimal">
-            <Link to={`/galleries/${scene.gallery.id}`}>
-              <Icon icon="image" />
+        </td>
+        <td className="text-left">
+          <Link to={sceneLink}>
+            <h5>
+              <TruncatedText
+                text={scene.title ?? TextUtils.fileNameFromPath(scene.path)}
+              />
+            </h5>
+          </Link>
+        </td>
+        <td>{scene.rating ? scene.rating : ""}</td>
+        <td>
+          {scene.file.duration &&
+            TextUtils.secondsToTimestamp(scene.file.duration)}
+        </td>
+        <td>{renderTags(scene.tags)}</td>
+        <td>{renderPerformers(scene.performers)}</td>
+        <td>
+          {scene.studio && (
+            <Link to={NavUtils.makeStudioScenesUrl(scene.studio)}>
+              <h6>{scene.studio.name}</h6>
             </Link>
-          </Button>
-        )}
-      </td>
-    </tr>
-  );
+          )}
+        </td>
+        <td>{renderMovies(scene)}</td>
+        <td>
+          {scene.gallery && (
+            <Button className="minimal">
+              <Link to={`/galleries/${scene.gallery.id}`}>
+                <Icon icon="image" />
+              </Link>
+            </Button>
+          )}
+        </td>
+      </tr>
+    );
+  };
 
   return (
     <div className="row table-list justify-content-center">

--- a/ui/v2.5/src/components/Wall/WallItem.tsx
+++ b/ui/v2.5/src/components/Wall/WallItem.tsx
@@ -4,9 +4,12 @@ import * as GQL from "src/core/generated-graphql";
 import { useConfiguration } from "src/core/StashService";
 import { TextUtils, NavUtils } from "src/utils";
 import cx from "classnames";
+import { SceneQueue } from "src/models/sceneQueue";
 
 interface IWallItemProps {
+  index?: number;
   scene?: GQL.SlimSceneDataFragment;
+  sceneQueue?: SceneQueue;
   sceneMarker?: GQL.SceneMarkerDataFragment;
   image?: GQL.SlimImageDataFragment;
   clickHandler?: (
@@ -161,7 +164,9 @@ export const WallItem: React.FC<IWallItemProps> = (props: IWallItemProps) => {
   let linkSrc: string = "#";
   if (!props.clickHandler) {
     if (props.scene) {
-      linkSrc = `/scenes/${props.scene.id}`;
+      linkSrc = props.sceneQueue
+        ? props.sceneQueue.makeLink(props.scene.id, { sceneIndex: props.index })
+        : `/scenes/${props.scene.id}`;
     } else if (props.sceneMarker) {
       linkSrc = NavUtils.makeSceneMarkerUrl(props.sceneMarker);
     } else if (props.image) {

--- a/ui/v2.5/src/components/Wall/WallPanel.tsx
+++ b/ui/v2.5/src/components/Wall/WallPanel.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
+import { SceneQueue } from "src/models/sceneQueue";
 import { WallItem } from "./WallItem";
 
 interface IWallPanelProps {
   scenes?: GQL.SlimSceneDataFragment[];
+  sceneQueue?: SceneQueue;
   sceneMarkers?: GQL.SceneMarkerDataFragment[];
   images?: GQL.SlimImageDataFragment[];
   clickHandler?: (
@@ -43,7 +45,9 @@ export const WallPanel: React.FC<IWallPanelProps> = (
   const scenes = (props.scenes ?? []).map((scene, index, sceneArray) => (
     <WallItem
       key={scene.id}
+      index={index}
       scene={scene}
+      sceneQueue={props.sceneQueue}
       clickHandler={props.clickHandler}
       className={calculateClass(index, sceneArray.length)}
     />

--- a/ui/v2.5/src/locale/en-GB.json
+++ b/ui/v2.5/src/locale/en-GB.json
@@ -1,6 +1,7 @@
 {
   "developmentVersion": "Development Version",
   "images": "Images",
+  "images-size": "Images size",
   "galleries": "Galleries",
   "library-size": "Library size",
   "markers": "Markers",
@@ -9,6 +10,7 @@
   "organized": "Organised",
   "performers": "Performers",
   "scenes": "Scenes",
+  "scenes-size": "Scenes size",
   "studios": "Studios",
   "tags": "Tags",
   "up-dir": "Up a directory",

--- a/ui/v2.5/src/locale/en-US.json
+++ b/ui/v2.5/src/locale/en-US.json
@@ -1,6 +1,7 @@
 {
   "developmentVersion": "Development Version",
   "images": "Images",
+  "images-size": "Images size",
   "galleries": "Galleries",
   "library-size": "Library size",
   "markers": "Markers",
@@ -9,6 +10,7 @@
   "organized": "Organized",
   "performers": "Performers",
   "scenes": "Scenes",
+  "scenes-size": "Scenes size",
   "studios": "Studios",
   "tags": "Tags",
   "up-dir": "Up a directory",


### PR DESCRIPTION
Refactors the scene queue code to apply it to all scene list views. Links are now generated at render, rather than using a click handler.