### PR TITLE
update docs to match current functionality

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -6,7 +6,7 @@ enum SortDirectionEnum {
 input FindFilterType {
   q: String
   page: Int
-  """use per_page = 0 to indicate all results. Defaults to 25."""
+  """use per_page = -1 to indicate all results. Defaults to 25."""
   per_page: Int
   sort: String
   direction: SortDirectionEnum


### PR DESCRIPTION
was wondering why `per_page:0` was not working it seems to have been updated to `per_page:-1` to return all results