### PR TITLE
Revert always show preview videos on small devices

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -30,6 +30,7 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Reverted video previews always playing on small devices.
 * Fixed error when auto-tagging for performers/studios/tags with regex characters in the name.
 * Fix scraped performer image not updating after clearing the current image when creating a new performer.
 * Fix error preventing adding a new library path when an existing library path is missing.

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -214,36 +214,17 @@ textarea.scene-description {
     }
   }
 
-  @media (pointer: fine) {
-    &:hover {
-      .scene-specs-overlay,
-      .rating-banner,
-      .scene-studio-overlay {
-        opacity: 0;
-        transition: opacity 0.5s;
-      }
-
-      .scene-studio-overlay:hover {
-        opacity: 0.75;
-        transition: opacity 0.5s;
-      }
-
-      .scene-card-check {
-        opacity: 0.75;
-        transition: opacity 0.5s;
-      }
-
-      .scene-card-preview-video {
-        top: 0;
-        transition-delay: 0.2s;
-      }
-    }
-  }
-
-  /* replicate hover for non-hoverable interfaces */
-  @media (hover: none), (pointer: coarse), (pointer: none) {
-    /* don't hide overlays */
+  &:hover,
+  &:active {
+    .scene-specs-overlay,
+    .rating-banner,
     .scene-studio-overlay {
+      opacity: 0;
+      transition: opacity 0.5s;
+    }
+
+    .scene-studio-overlay:hover,
+    .scene-studio-overlay:active {
       opacity: 0.75;
       transition: opacity 0.5s;
     }


### PR DESCRIPTION
Reverted change from #1104 which automatically showed preview videos on small devices. This had the unintended effect of playing everything on iPad devices.

I considered auto-previewing on very small width devices, but given that sounds of these videos _may_ also play depending on the settings, I think it's better to have this as a user-directed action. 

Note that with this fix, I still had issues when testing on iPad where preview videos would not show correctly if they were rendered off-screen (ie you had to scroll to show the card). I've been unable to fix this issue, but I don't think it was introduced by this change.

Fixes #1281 