### PR TITLE
Fixed rating filter on studios

### DIFF
--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -246,8 +246,6 @@ export class ListFilterModel {
         break;
       }
       case FilterMode.Studios:
-        this.sortBy = "name";
-        this.sortByOptions = ["name", "random", "rating", "scenes_count"];
         this.sortBy = defaultSort ?? "name";
         this.sortByOptions = [
           "name",
@@ -255,6 +253,7 @@ export class ListFilterModel {
           "images_count",
           "galleries_count",
           "random",
+          "rating",
         ];
         this.displayModeOptions = [DisplayMode.Grid];
         this.criterionOptions = [


### PR DESCRIPTION
GsMumbo noticed on #1308, there are not the filter rating on Studios. So I checked and it was because I think on bad merge. So now Rating filter exists and works on Studios page :)