### PR TITLE
Fix initial plugins/scrapers paths when initialising in home directory

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -687,12 +687,25 @@ func (i *Instance) Validate() error {
 	return nil
 }
 
-func setDefaultValues() {
+func (i *Instance) setDefaultValues() {
 	viper.SetDefault(ParallelTasks, parallelTasksDefault)
 	viper.SetDefault(PreviewSegmentDuration, previewSegmentDurationDefault)
 	viper.SetDefault(PreviewSegments, previewSegmentsDefault)
 	viper.SetDefault(PreviewExcludeStart, previewExcludeStartDefault)
 	viper.SetDefault(PreviewExcludeEnd, previewExcludeEndDefault)
+
+	// #1356 - only set these defaults once config file exists
+	if i.GetConfigFile() != "" {
+		viper.SetDefault(Database, i.GetDefaultDatabaseFilePath())
+
+		// Set generated to the metadata path for backwards compat
+		viper.SetDefault(Generated, viper.GetString(Metadata))
+
+		// Set default scrapers and plugins paths
+		viper.SetDefault(ScrapersPath, i.GetDefaultScrapersPath())
+		viper.SetDefault(PluginsPath, i.GetDefaultPluginsPath())
+		viper.WriteConfig()
+	}
 }
 
 // SetInitialConfig fills in missing required config fields
@@ -710,5 +723,5 @@ func (i *Instance) SetInitialConfig() {
 		i.Set(SessionStoreKey, sessionStoreKey)
 	}
 
-	setDefaultValues()
+	i.setDefaultValues()
 }

--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -51,26 +51,9 @@ func initConfig(flags flagStruct) error {
 	err := viper.ReadInConfig() // Find and read the config file
 	// continue, but set an error to be handled by caller
 
-	postInitConfig()
 	instance.SetInitialConfig()
 
 	return err
-}
-
-func postInitConfig() {
-	c := instance
-	if c.GetConfigFile() != "" {
-		viper.SetDefault(Database, c.GetDefaultDatabaseFilePath())
-	}
-
-	// Set generated to the metadata path for backwards compat
-	viper.SetDefault(Generated, viper.GetString(Metadata))
-
-	// Set default scrapers and plugins paths
-	viper.SetDefault(ScrapersPath, c.GetDefaultScrapersPath())
-	viper.SetDefault(PluginsPath, c.GetDefaultPluginsPath())
-
-	viper.WriteConfig()
 }
 
 func initFlags() flagStruct {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -40,12 +40,6 @@ type singleton struct {
 var instance *singleton
 var once sync.Once
 
-type flagStruct struct {
-	configFilePath string
-}
-
-var flags = flagStruct{}
-
 func GetInstance() *singleton {
 	Initialize()
 	return instance
@@ -134,6 +128,8 @@ func initPluginCache() *plugin.Cache {
 // configuration has been set. Should only be called if the configuration
 // is valid.
 func (s *singleton) PostInit() error {
+	s.Config.SetInitialConfig()
+
 	s.Paths = paths.NewPaths(s.Config.GetGeneratedPath())
 	s.PluginCache = initPluginCache()
 	s.ScraperCache = instance.initScraperCache()

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -225,6 +225,10 @@ export const Setup: React.FC = () => {
       return <code>&lt;current working directory&gt;/config.yml</code>;
     }
 
+    if (configLocation === "") {
+      return <code>$HOME/.stash/config.yml</code>;
+    }
+
     return <code>{configLocation}</code>;
   }
 


### PR DESCRIPTION
Changes config initialisation code so that it only sets the default directories once the config file has been initialised.

Also fixes minor issue where the configuration file location would not be shown in the setup wizard if using the home directory.

Fixes #1356 