### PR TITLE
Populate image/gallery title during scan

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -257,3 +257,10 @@ func GetTitle(s *models.Image) string {
 	_, fn := getFilePath(s.Path)
 	return filepath.Base(fn)
 }
+
+// GetFilename gets the base name of the image file
+// If stripExt is set the file extension is omitted from the name
+func GetFilename(s *models.Image, stripExt bool) string {
+	_, fn := getFilePath(s.Path)
+	return utils.GetNameFromPath(fn, stripExt)
+}

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -240,6 +240,10 @@ func (t *ScanTask) scanGallery() {
 						Timestamp: fileModTime,
 						Valid:     true,
 					},
+					Title: sql.NullString{
+						String: utils.GetNameFromPath(t.FilePath, t.StripFileExtension),
+						Valid:  true,
+					},
 					CreatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
 					UpdatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
 				}
@@ -853,6 +857,9 @@ func (t *ScanTask) scanImage() {
 				CreatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
 				UpdatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
 			}
+			newImage.Title.String = image.GetFilename(&newImage, t.StripFileExtension)
+			newImage.Title.Valid = true
+
 			if err := image.SetFileDetails(&newImage); err != nil {
 				logger.Error(err.Error())
 				return

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -973,6 +973,10 @@ func (t *ScanTask) associateImageWithFolderGallery(imageID int, qb models.Galler
 			},
 			CreatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
 			UpdatedAt: models.SQLiteTimestamp{Timestamp: currentTime},
+			Title: sql.NullString{
+				String: utils.GetNameFromPath(path, false),
+				Valid:  true,
+			},
 		}
 
 		logger.Infof("Creating gallery for folder %s", path)

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -283,3 +283,14 @@ func IsPathInDir(dir, pathToCheck string) bool {
 
 	return false
 }
+
+// GetNameFromPath returns the name of a file from its path
+// if stripExtension is true the extension is omitted from the name
+func GetNameFromPath(path string, stripExtension bool) string {
+	fn := filepath.Base(path)
+	if stripExtension {
+		ext := filepath.Ext(fn)
+		fn = strings.TrimSuffix(fn, ext)
+	}
+	return fn
+}

--- a/ui/v2.5/src/components/Changelog/versions/v070.md
+++ b/ui/v2.5/src/components/Changelog/versions/v070.md
@@ -31,6 +31,7 @@
 * Change performer text query to search by name and alias only.
 
 ### 🐛 Bug fixes
+* Fix image/gallery title not being set during scan.
 * Fix performer/studio being cleared when skipped in scene tagger.
 * Fixed error when auto-tagging for performers/studios/tags with regex characters in the name.
 * Fix scraped performer image not updating after clearing the current image when creating a new performer.


### PR DESCRIPTION
Adds titles to newly scanned images/galleries according to their filenames. 

Should partially solve #1354 ( for existing images a sql query from the user is probably better )

WithoutPants edit: fixes #1354 