### PR TITLE
Fix sorting of tagger fingerprint matches

### DIFF
--- a/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/StashSearchResult.tsx
@@ -46,7 +46,10 @@ const getDurationStatus = (
       </div>
     );
 
-  const minDiff = Math.min(scene.duration, ...durations);
+  const minDiff = Math.min(
+    Math.abs(scene.duration - stashDuration),
+    ...durations
+  );
   return <div>Duration off by at least {Math.floor(minDiff)}s</div>;
 };
 

--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Button, Card, Form, InputGroup } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { HashLink } from "react-router-hash-link";
+import { uniqBy } from "lodash";
 import { ScenePreview } from "src/components/Scenes/SceneCard";
 import { useLocalForage } from "src/hooks";
 
@@ -333,11 +334,17 @@ const TaggerList: React.FC<ITaggerListProps> = ({
         config.mode,
         config.blacklist
       );
-      const fingerprintMatch =
-        fingerprints[scene.checksum ?? ""] ??
-        fingerprints[scene.oshash ?? ""] ??
-        fingerprints[scene.phash ?? ""] ??
-        null;
+
+      // Get all scenes matching one of the fingerprints, and return array of unique scenes
+      const fingerprintMatches = uniqBy(
+        [
+          ...(fingerprints[scene.checksum ?? ""] ?? []),
+          ...(fingerprints[scene.oshash ?? ""] ?? []),
+          ...(fingerprints[scene.phash ?? ""] ?? []),
+        ].flat(),
+        (f) => f.stash_id
+      );
+
       const isTagged = taggedScenes[scene.id];
       const hasStashIDs = scene.stash_ids.length > 0;
       const width = scene.file.width ? scene.file.width : 0;
@@ -432,9 +439,9 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       }
 
       let searchResult;
-      if (fingerprintMatch && !isTagged && !hasStashIDs) {
+      if (fingerprintMatches.length > 0 && !isTagged && !hasStashIDs) {
         searchResult = sortScenesByDuration(
-          fingerprintMatch,
+          fingerprintMatches,
           scene.file.duration ?? 0
         ).map((match, i) => (
           <StashSearchResult
@@ -460,7 +467,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
       } else if (
         searchResults[scene.id]?.length > 0 &&
         !isTagged &&
-        !fingerprintMatch
+        fingerprintMatches.length === 0
       ) {
         searchResult = (
           <ul className="pl-0 mt-3 mb-0">
@@ -495,7 +502,7 @@ const TaggerList: React.FC<ITaggerListProps> = ({
         );
       }
 
-      return hideUnmatched && !fingerprintMatch ? null : (
+      return hideUnmatched && fingerprintMatches.length === 0 ? null : (
         <div key={scene.id} className="mt-3 search-item">
           <div className="row">
             <div className="col col-lg-6 overflow-hidden align-items-center d-flex flex-column flex-sm-row">

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -179,6 +179,15 @@ export const sortScenesByDuration = (
     if (aDur.length > 0 && bDur.length === 0) return -1;
     if (aDur.length === 0 && bDur.length > 0) return 1;
 
+    const aMatches = aDur.filter((match) => match <= 5);
+    const bMatches = bDur.filter((match) => match <= 5);
+
+    if (aMatches.length > 0 || bMatches.length > 0) {
+      if (aMatches.length > bMatches.length) return -1;
+      if (aMatches.length < bMatches.length) return 1;
+      return 0;
+    }
+
     const aDiff = Math.min(...aDur);
     const bDiff = Math.min(...bDur);
 


### PR DESCRIPTION
Changes scene ordering to take number of fingerprints with duration matches into account, so a 13/14 match is sorted over a 2/20.

Also fixes an edge case if where scenes with only a phash match wouldn't show up if another scene only had md5/oshash match, and a regression where the duration status would always show `off by at least 0s` if there wasn't a full match.