### PR TITLE
Remove unnecessary graphql fields

### DIFF
--- a/graphql/documents/data/gallery-slim.graphql
+++ b/graphql/documents/data/gallery-slim.graphql
@@ -1,4 +1,4 @@
-fragment GallerySlimData on Gallery {
+fragment SlimGalleryData on Gallery {
   id
   checksum
   path
@@ -10,16 +10,31 @@ fragment GallerySlimData on Gallery {
   organized
   image_count
   cover {
-    ...SlimImageData
+    file {
+      size
+      width
+      height
+    }
+    
+    paths {
+      thumbnail
+    }
   }
   studio {
-    ...StudioData
+    id
+    name
+    image_path
   }
   tags {
-    ...TagData
+    id
+    name
   }
   performers {
-    ...PerformerData
+    id
+    name
+    gender
+    favorite
+    image_path
   }
   scenes {
     id

--- a/graphql/documents/data/gallery.graphql
+++ b/graphql/documents/data/gallery.graphql
@@ -15,16 +15,16 @@ fragment GalleryData on Gallery {
     ...SlimImageData
   }
   studio {
-    ...StudioData
+    ...SlimStudioData
   }
   tags {
-    ...TagData
+    ...SlimTagData
   }
 
   performers {
     ...PerformerData
   }
   scenes {
-    ...SceneData
+    ...SlimSceneData
   }
 }

--- a/graphql/documents/data/image.graphql
+++ b/graphql/documents/data/image.graphql
@@ -23,11 +23,11 @@ fragment ImageData on Image {
   }
 
   studio {
-    ...StudioData
+    ...SlimStudioData
   }
   
   tags {
-    ...TagData
+    ...SlimTagData
   }
 
   performers {

--- a/graphql/documents/data/movie.graphql
+++ b/graphql/documents/data/movie.graphql
@@ -9,7 +9,7 @@ fragment MovieData on Movie {
   director
 
   studio {
-    ...StudioData
+    ...SlimStudioData
   }
   
   synopsis

--- a/graphql/documents/data/performer.graphql
+++ b/graphql/documents/data/performer.graphql
@@ -24,7 +24,7 @@ fragment PerformerData on Performer {
   gallery_count
 
   tags {
-    ...TagData
+    ...SlimTagData
   }
 
   stash_ids {

--- a/graphql/documents/data/scene.graphql
+++ b/graphql/documents/data/scene.graphql
@@ -37,11 +37,11 @@ fragment SceneData on Scene {
   }
 
   galleries {
-    ...GallerySlimData
+    ...SlimGalleryData
   }
 
   studio {
-    ...StudioData
+    ...SlimStudioData
   }
   
   movies {
@@ -52,7 +52,7 @@ fragment SceneData on Scene {
   }
 
   tags {
-    ...TagData
+    ...SlimTagData
   }
 
   performers {

--- a/graphql/documents/data/tag-slim.graphql
+++ b/graphql/documents/data/tag-slim.graphql
@@ -1,0 +1,5 @@
+fragment SlimTagData on Tag {
+  id
+  name
+  image_path
+}

--- a/graphql/documents/queries/gallery.graphql
+++ b/graphql/documents/queries/gallery.graphql
@@ -2,7 +2,7 @@ query FindGalleries($filter: FindFilterType, $gallery_filter: GalleryFilterType)
   findGalleries(gallery_filter: $gallery_filter, filter: $filter) {
     count
     galleries {
-      ...GallerySlimData
+      ...SlimGalleryData
     }
   }
 }

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -341,11 +341,17 @@ func galleryTagCountCriterionHandler(qb *galleryQueryBuilder, tagCount *models.I
 }
 
 func galleryPerformersCriterionHandler(qb *galleryQueryBuilder, performers *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		qb.performersRepository().join(f, "performers_join", "galleries.id")
-		f.addJoin(performerTable, "", "performers_join.performer_id = performers.id")
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: galleryTable,
+		joinTable:    performersGalleriesTable,
+		joinAs:       "performers_join",
+		primaryFK:    galleryIDColumn,
+		foreignFK:    performerIDColumn,
+
+		addJoinTable: func(f *filterBuilder) {
+			qb.performersRepository().join(f, "performers_join", "galleries.id")
+		},
 	}
-	h := qb.getMultiCriterionHandlerBuilder(performerTable, performersGalleriesTable, performerIDColumn, addJoinsFunc)
 
 	return h.handler(performers)
 }

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -321,11 +321,17 @@ func (qb *galleryQueryBuilder) getMultiCriterionHandlerBuilder(foreignTable, joi
 }
 
 func galleryTagsCriterionHandler(qb *galleryQueryBuilder, tags *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		qb.tagsRepository().join(f, "tags_join", "galleries.id")
-		f.addJoin(tagTable, "", "tags_join.tag_id = tags.id")
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: galleryTable,
+		joinTable:    galleriesTagsTable,
+		joinAs:       "tags_join",
+		primaryFK:    galleryIDColumn,
+		foreignFK:    tagIDColumn,
+
+		addJoinTable: func(f *filterBuilder) {
+			qb.tagsRepository().join(f, "tags_join", "galleries.id")
+		},
 	}
-	h := qb.getMultiCriterionHandlerBuilder(tagTable, galleriesTagsTable, tagIDColumn, addJoinsFunc)
 
 	return h.handler(tags)
 }

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -377,11 +377,17 @@ func imageGalleriesCriterionHandler(qb *imageQueryBuilder, galleries *models.Mul
 }
 
 func imagePerformersCriterionHandler(qb *imageQueryBuilder, performers *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		qb.performersRepository().join(f, "performers_join", "images.id")
-		f.addJoin(performerTable, "", "performers_join.performer_id = performers.id")
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: imageTable,
+		joinTable:    performersImagesTable,
+		joinAs:       "performers_join",
+		primaryFK:    imageIDColumn,
+		foreignFK:    performerIDColumn,
+
+		addJoinTable: func(f *filterBuilder) {
+			qb.performersRepository().join(f, "performers_join", "images.id")
+		},
 	}
-	h := qb.getMultiCriterionHandlerBuilder(performerTable, performersImagesTable, performerIDColumn, addJoinsFunc)
 
 	return h.handler(performers)
 }

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -347,11 +347,17 @@ func (qb *imageQueryBuilder) getMultiCriterionHandlerBuilder(foreignTable, joinT
 }
 
 func imageTagsCriterionHandler(qb *imageQueryBuilder, tags *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		qb.tagsRepository().join(f, "tags_join", "images.id")
-		f.addJoin(tagTable, "", "tags_join.tag_id = tags.id")
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: imageTable,
+		joinTable:    imagesTagsTable,
+		joinAs:       "tags_join",
+		primaryFK:    imageIDColumn,
+		foreignFK:    tagIDColumn,
+
+		addJoinTable: func(f *filterBuilder) {
+			qb.tagsRepository().join(f, "tags_join", "images.id")
+		},
 	}
-	h := qb.getMultiCriterionHandlerBuilder(tagTable, imagesTagsTable, tagIDColumn, addJoinsFunc)
 
 	return h.handler(tags)
 }

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -562,11 +562,17 @@ func sceneTagCountCriterionHandler(qb *sceneQueryBuilder, tagCount *models.IntCr
 }
 
 func scenePerformersCriterionHandler(qb *sceneQueryBuilder, performers *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		qb.performersRepository().join(f, "performers_join", "scenes.id")
-		f.addJoin("performers", "", "performers_join.performer_id = performers.id")
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: sceneTable,
+		joinTable:    performersScenesTable,
+		joinAs:       "performers_join",
+		primaryFK:    sceneIDColumn,
+		foreignFK:    performerIDColumn,
+
+		addJoinTable: func(f *filterBuilder) {
+			qb.performersRepository().join(f, "performers_join", "scenes.id")
+		},
 	}
-	h := qb.getMultiCriterionHandlerBuilder(performerTable, performersScenesTable, performerIDColumn, addJoinsFunc)
 
 	return h.handler(performers)
 }

--- a/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
@@ -10,7 +10,7 @@ import MultiSet from "../Shared/MultiSet";
 import { RatingStars } from "../Scenes/SceneDetails/RatingStars";
 
 interface IListOperationProps {
-  selected: GQL.GallerySlimDataFragment[];
+  selected: GQL.SlimGalleryDataFragment[];
   onClose: (applied: boolean) => void;
 }
 
@@ -146,7 +146,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     setIsUpdating(false);
   }
 
-  function getRating(state: GQL.GallerySlimDataFragment[]) {
+  function getRating(state: GQL.SlimGalleryDataFragment[]) {
     let ret: number | undefined;
     let first = true;
 
@@ -162,7 +162,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getStudioId(state: GQL.GallerySlimDataFragment[]) {
+  function getStudioId(state: GQL.SlimGalleryDataFragment[]) {
     let ret: string | undefined;
     let first = true;
 
@@ -181,7 +181,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getPerformerIds(state: GQL.GallerySlimDataFragment[]) {
+  function getPerformerIds(state: GQL.SlimGalleryDataFragment[]) {
     let ret: string[] = [];
     let first = true;
 
@@ -205,7 +205,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     return ret;
   }
 
-  function getTagIds(state: GQL.GallerySlimDataFragment[]) {
+  function getTagIds(state: GQL.SlimGalleryDataFragment[]) {
     let ret: string[] = [];
     let first = true;
 
@@ -234,7 +234,7 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
     let updateOrganized: boolean | undefined;
     let first = true;
 
-    state.forEach((gallery: GQL.GallerySlimDataFragment) => {
+    state.forEach((gallery: GQL.SlimGalleryDataFragment) => {
       const galleryRating = gallery.rating;
       const GalleriestudioID = gallery?.studio?.id;
       const galleryPerformerIDs = (gallery.performers ?? [])

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -15,7 +15,7 @@ import { TextUtils } from "src/utils";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
 
 interface IProps {
-  gallery: GQL.GallerySlimDataFragment;
+  gallery: GQL.SlimGalleryDataFragment;
   selecting?: boolean;
   selected?: boolean | undefined;
   zoomIndex?: number;

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScenesPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScenesPanel.tsx
@@ -3,7 +3,7 @@ import * as GQL from "src/core/generated-graphql";
 import { SceneCard } from "src/components/Scenes/SceneCard";
 
 interface IGalleryScenesPanelProps {
-  scenes: GQL.SceneDataFragment[];
+  scenes: GQL.SlimSceneDataFragment[];
 }
 
 export const GalleryScenesPanel: React.FC<IGalleryScenesPanelProps> = ({

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -5,7 +5,7 @@ import { Link, useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import {
   FindGalleriesQueryResult,
-  GallerySlimDataFragment,
+  SlimGalleryDataFragment,
 } from "src/core/generated-graphql";
 import { useGalleriesList } from "src/hooks";
 import { TextUtils } from "src/utils";
@@ -130,7 +130,7 @@ export const GalleryList: React.FC<IGalleryList> = ({
   }
 
   function renderEditGalleriesDialog(
-    selectedImages: GallerySlimDataFragment[],
+    selectedImages: SlimGalleryDataFragment[],
     onClose: (applied: boolean) => void
   ) {
     return (
@@ -141,7 +141,7 @@ export const GalleryList: React.FC<IGalleryList> = ({
   }
 
   function renderDeleteGalleriesDialog(
-    selectedImages: GallerySlimDataFragment[],
+    selectedImages: SlimGalleryDataFragment[],
     onClose: (confirmed: boolean) => void
   ) {
     return (

--- a/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
@@ -12,7 +12,7 @@ const CLASSNAME_IMG = `${CLASSNAME}-img`;
 const CLASSNAME_TITLE = `${CLASSNAME}-title`;
 
 interface IProps {
-  gallery: GQL.GallerySlimDataFragment;
+  gallery: GQL.SlimGalleryDataFragment;
 }
 
 const GalleryWallCard: React.FC<IProps> = ({ gallery }) => {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
@@ -3,7 +3,7 @@ import * as GQL from "src/core/generated-graphql";
 import { GalleryCard } from "src/components/Galleries/GalleryCard";
 
 interface ISceneGalleriesPanelProps {
-  galleries: GQL.GallerySlimDataFragment[];
+  galleries: GQL.SlimGalleryDataFragment[];
 }
 
 export const SceneGalleriesPanel: React.FC<ISceneGalleriesPanelProps> = ({

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -13,7 +13,7 @@ import Mousetrap from "mousetrap";
 import {
   SlimSceneDataFragment,
   SceneMarkerDataFragment,
-  GallerySlimDataFragment,
+  SlimGalleryDataFragment,
   StudioDataFragment,
   PerformerDataFragment,
   FindScenesQueryResult,
@@ -621,9 +621,9 @@ export const useImagesList = (
   });
 
 export const useGalleriesList = (
-  props: IListHookOptions<FindGalleriesQueryResult, GallerySlimDataFragment>
+  props: IListHookOptions<FindGalleriesQueryResult, SlimGalleryDataFragment>
 ) =>
-  useList<FindGalleriesQueryResult, GallerySlimDataFragment>({
+  useList<FindGalleriesQueryResult, SlimGalleryDataFragment>({
     ...props,
     filterMode: FilterMode.Galleries,
     useData: useFindGalleries,


### PR DESCRIPTION
Fixes #1368 

Removes fields from graphql queries that are unnecessary. 

Should result in improvements for queries in the following pages:
* galleries
* gallery detail
* image detail
* movie detail
* performers
* performer detail
* scene detail

Also renames `GallerySlimData` to `SlimGalleryData` for consistency.