### PR TITLE
CPU profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,15 @@ where the app can be cross-compiled.  This process is kicked off by CI via the `
 command to open a bash shell to the container to poke around:
 
 `docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash -i -t stashappdev/compiler:latest /bin/bash`
+
+## Profiling
+
+Stash can be profiled using the `--cpuprofile <output profile filename>` command line flag.
+
+The resulting file can then be used with pprof as follows: 
+
+`go tool pprof <path to binary> <path to profile filename>`
+
+With `graphviz` installed and in the path, a call graph can be generated with:
+
+`go tool pprof -svg <path to binary> <path to profile filename> > <output svg file>`

--- a/main.go
+++ b/main.go
@@ -2,6 +2,11 @@
 package main
 
 import (
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"syscall"
+
 	"github.com/stashapp/stash/pkg/api"
 	"github.com/stashapp/stash/pkg/manager"
 
@@ -12,9 +17,16 @@ import (
 func main() {
 	manager.Initialize()
 	api.Start()
+
+	// stop any profiling at exit
+	defer pprof.StopCPUProfile()
 	blockForever()
 }
 
 func blockForever() {
-	select {}
+	// handle signals
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	<-signals
 }

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -141,7 +141,9 @@ func (e MissingConfigError) Error() string {
 	return fmt.Sprintf("missing the following mandatory settings: %s", strings.Join(e.missingFields, ", "))
 }
 
-type Instance struct{}
+type Instance struct {
+	cpuProfilePath string
+}
 
 var instance *Instance
 
@@ -154,6 +156,13 @@ func GetInstance() *Instance {
 
 func (i *Instance) SetConfigFile(fn string) {
 	viper.SetConfigFile(fn)
+}
+
+// GetCPUProfilePath returns the path to the CPU profile file to output
+// profiling info to. This is set only via a commandline flag. Returns an
+// empty string if not set.
+func (i *Instance) GetCPUProfilePath() string {
+	return i.cpuProfilePath
 }
 
 func (i *Instance) Set(key string, value interface{}) {

--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -16,14 +16,17 @@ var once sync.Once
 
 type flagStruct struct {
 	configFilePath string
+	cpuProfilePath string
 }
 
 func Initialize() (*Instance, error) {
 	var err error
 	once.Do(func() {
-		instance = &Instance{}
-
 		flags := initFlags()
+		instance = &Instance{
+			cpuProfilePath: flags.cpuProfilePath,
+		}
+
 		err = initConfig(flags)
 		initEnvs()
 	})
@@ -31,6 +34,7 @@ func Initialize() (*Instance, error) {
 }
 
 func initConfig(flags flagStruct) error {
+
 	// The config file is called config.  Leave off the file extension.
 	viper.SetConfigName("config")
 
@@ -62,6 +66,7 @@ func initFlags() flagStruct {
 	pflag.IP("host", net.IPv4(0, 0, 0, 0), "ip address for the host")
 	pflag.Int("port", 9999, "port to serve from")
 	pflag.StringVarP(&flags.configFilePath, "config", "c", "", "config file to use")
+	pflag.StringVar(&flags.cpuProfilePath, "cpuprofile", "", "write cpu profile to file")
 
 	pflag.Parse()
 	if err := viper.BindPFlags(pflag.CommandLine); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ func Initialize() *singleton {
 		_ = utils.EnsureDir(paths.GetStashHomeDirectory())
 		cfg, err := config.Initialize()
 		initLog()
+		initProfiling(cfg.GetCPUProfilePath())
 
 		instance = &singleton{
 			Config:        cfg,
@@ -82,6 +84,22 @@ func Initialize() *singleton {
 	})
 
 	return instance
+}
+
+func initProfiling(cpuProfilePath string) {
+	if cpuProfilePath == "" {
+		return
+	}
+
+	f, err := os.Create(cpuProfilePath)
+	if err != nil {
+		logger.Fatalf("unable to create cpu profile file: %s", err.Error())
+	}
+
+	logger.Infof("profiling to %s", cpuProfilePath)
+
+	// StopCPUProfile is defer called in main
+	pprof.StartCPUProfile(f)
 }
 
 func initFFMPEG() {


### PR DESCRIPTION
Adds a commandline flag `-cpuprofile <filename>`. When provided, the executable will be profiled, outputting to the provided filename. This can then be parsed using `go tool pprof`. 

Includes a signal handler in the main loop to handle terminate and interrupt signals (the lack of which results in a profile file not being flushed before exiting).

Adds documentation to the readme file.

Known issue: the flag is setting a config field in the config file