### PR TITLE
Fix initial setup issue issues

### DIFF
--- a/graphql/documents/queries/settings/metadata.graphql
+++ b/graphql/documents/queries/settings/metadata.graphql
@@ -12,5 +12,6 @@ query SystemStatus {
     databasePath
     appSchema
     status
+    configPath
   }
 }

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -116,6 +116,7 @@ enum SystemStatusEnum {
 type SystemStatus {
   databaseSchema: Int
   databasePath: String
+  configPath: String
   appSchema: Int!
   status: SystemStatusEnum!
 }

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -141,7 +141,9 @@ func (e MissingConfigError) Error() string {
 	return fmt.Sprintf("missing the following mandatory settings: %s", strings.Join(e.missingFields, ", "))
 }
 
-type Instance struct{}
+type Instance struct {
+	isNewSystem bool
+}
 
 var instance *Instance
 
@@ -150,6 +152,10 @@ func GetInstance() *Instance {
 		instance = &Instance{}
 	}
 	return instance
+}
+
+func (i *Instance) IsNewSystem() bool {
+	return i.isNewSystem
 }
 
 func (i *Instance) SetConfigFile(fn string) {
@@ -687,29 +693,26 @@ func (i *Instance) Validate() error {
 	return nil
 }
 
-func (i *Instance) setDefaultValues() {
+func (i *Instance) setDefaultValues() error {
 	viper.SetDefault(ParallelTasks, parallelTasksDefault)
 	viper.SetDefault(PreviewSegmentDuration, previewSegmentDurationDefault)
 	viper.SetDefault(PreviewSegments, previewSegmentsDefault)
 	viper.SetDefault(PreviewExcludeStart, previewExcludeStartDefault)
 	viper.SetDefault(PreviewExcludeEnd, previewExcludeEndDefault)
 
-	// #1356 - only set these defaults once config file exists
-	if i.GetConfigFile() != "" {
-		viper.SetDefault(Database, i.GetDefaultDatabaseFilePath())
+	viper.SetDefault(Database, i.GetDefaultDatabaseFilePath())
 
-		// Set generated to the metadata path for backwards compat
-		viper.SetDefault(Generated, viper.GetString(Metadata))
+	// Set generated to the metadata path for backwards compat
+	viper.SetDefault(Generated, viper.GetString(Metadata))
 
-		// Set default scrapers and plugins paths
-		viper.SetDefault(ScrapersPath, i.GetDefaultScrapersPath())
-		viper.SetDefault(PluginsPath, i.GetDefaultPluginsPath())
-		viper.WriteConfig()
-	}
+	// Set default scrapers and plugins paths
+	viper.SetDefault(ScrapersPath, i.GetDefaultScrapersPath())
+	viper.SetDefault(PluginsPath, i.GetDefaultPluginsPath())
+	return viper.WriteConfig()
 }
 
 // SetInitialConfig fills in missing required config fields
-func (i *Instance) SetInitialConfig() {
+func (i *Instance) SetInitialConfig() error {
 	// generate some api keys
 	const apiKeyLength = 32
 
@@ -723,5 +726,9 @@ func (i *Instance) SetInitialConfig() {
 		i.Set(SessionStoreKey, sessionStoreKey)
 	}
 
-	i.setDefaultValues()
+	return i.setDefaultValues()
+}
+
+func (i *Instance) FinalizeSetup() {
+	i.isNewSystem = false
 }

--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"sync"
@@ -61,19 +62,22 @@ func initConfig(flags flagStruct) error {
 	}
 
 	if configFile != "" {
+		viper.SetConfigFile(configFile)
+
 		// if file does not exist, assume it is a new system
 		if exists, _ := utils.FileExists(configFile); !exists {
 			instance.isNewSystem = true
 
 			// ensure we can write to the file
 			if err := utils.Touch(configFile); err != nil {
-				return err
+				return fmt.Errorf(`could not write to provided config path "%s": %s`, configFile, err.Error())
+			} else {
+				// remove the file
+				os.Remove(configFile)
 			}
 
 			return nil
 		}
-
-		viper.SetConfigFile(envConfigFile)
 	}
 
 	err := viper.ReadInConfig() // Find and read the config file

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -79,7 +79,11 @@ func Initialize() *singleton {
 				}
 			}
 		} else {
-			logger.Warn("config file not found. Assuming new system...")
+			cfgFile := cfg.GetConfigFile()
+			if cfgFile != "" {
+				cfgFile = cfgFile + " "
+			}
+			logger.Warnf("config file %snot found. Assuming new system...", cfgFile)
 		}
 
 		initFFMPEG()

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Alert,
   Button,
@@ -26,6 +26,12 @@ export const Setup: React.FC = () => {
   const [showGeneratedDialog, setShowGeneratedDialog] = useState(false);
 
   const { data: systemStatus, loading: statusLoading } = useSystemStatus();
+
+  useEffect(() => {
+    if (systemStatus?.systemStatus.configPath) {
+      setConfigLocation(systemStatus.systemStatus.configPath);
+    }
+  }, [systemStatus])
 
   const discordLink = (
     <a href="https://discord.gg/2TsNFKt" target="_blank" rel="noreferrer">
@@ -57,6 +63,35 @@ export const Setup: React.FC = () => {
 
   function next() {
     setStep(step + 1);
+  }
+
+  function renderWelcomeSpecificConfig() {
+    return (
+      <>
+        <section>
+          <h2 className="mb-5">Welcome to Stash</h2>
+          <p className="lead text-center">
+            If you&apos;re reading this, then Stash couldn&apos;t find the
+            configuration file specified at the command line or the environment.
+            This wizard will guide you through the process of setting up a new configuration.
+          </p>
+          <p>
+            Stash will use the following configuration file path: <code>{configLocation}</code>
+          </p>
+          <p>
+            When you&apos;re ready to proceed with setting up a new system, click Next.
+          </p>
+        </section>
+
+        <section className="mt-5">
+          <div className="d-flex justify-content-center">
+            <Button variant="primary mx-2 p-5" onClick={() => next()}>
+              Next
+            </Button>
+          </div>
+        </section>
+      </>
+    );
   }
 
   function renderWelcome() {
@@ -433,8 +468,6 @@ export const Setup: React.FC = () => {
     return renderSuccess();
   }
 
-  const steps = [renderWelcome, renderSetPaths, renderConfirm, renderFinish];
-
   // only display setup wizard if system is not setup
   if (statusLoading) {
     return <LoadingIndicator />;
@@ -449,6 +482,9 @@ export const Setup: React.FC = () => {
     window.location.href = newURL.toString();
     return <LoadingIndicator />;
   }
+
+  const welcomeStep = systemStatus && systemStatus.systemStatus.configPath !== "" ? renderWelcomeSpecificConfig : renderWelcome;
+  const steps = [welcomeStep, renderSetPaths, renderConfirm, renderFinish];
 
   return (
     <Container>

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -31,7 +31,7 @@ export const Setup: React.FC = () => {
     if (systemStatus?.systemStatus.configPath) {
       setConfigLocation(systemStatus.systemStatus.configPath);
     }
-  }, [systemStatus])
+  }, [systemStatus]);
 
   const discordLink = (
     <a href="https://discord.gg/2TsNFKt" target="_blank" rel="noreferrer">
@@ -73,13 +73,16 @@ export const Setup: React.FC = () => {
           <p className="lead text-center">
             If you&apos;re reading this, then Stash couldn&apos;t find the
             configuration file specified at the command line or the environment.
-            This wizard will guide you through the process of setting up a new configuration.
+            This wizard will guide you through the process of setting up a new
+            configuration.
           </p>
           <p>
-            Stash will use the following configuration file path: <code>{configLocation}</code>
+            Stash will use the following configuration file path:{" "}
+            <code>{configLocation}</code>
           </p>
           <p>
-            When you&apos;re ready to proceed with setting up a new system, click Next.
+            When you&apos;re ready to proceed with setting up a new system,
+            click Next.
           </p>
         </section>
 
@@ -483,7 +486,10 @@ export const Setup: React.FC = () => {
     return <LoadingIndicator />;
   }
 
-  const welcomeStep = systemStatus && systemStatus.systemStatus.configPath !== "" ? renderWelcomeSpecificConfig : renderWelcome;
+  const welcomeStep =
+    systemStatus && systemStatus.systemStatus.configPath !== ""
+      ? renderWelcomeSpecificConfig
+      : renderWelcome;
   const steps = [welcomeStep, renderSetPaths, renderConfirm, renderFinish];
 
   return (


### PR DESCRIPTION
Fixes two bugs:

Set `STASH_CONFIG_FILE` environment variable to a non-existent file. Run stash. The following panic is caused:

```
INFO[2021-05-13 20:21:06] using config file: path_to/config.yml        
panic: error initializing configuration: missing the following mandatory settings: generated

goroutine 1 [running]:
github.com/stashapp/stash/pkg/manager.Initialize.func1()
        D:/dev/stash/pkg/manager/manager.go:71 +0x34c
sync.(*Once).doSlow(0x2e166c8, 0x23a5ae0)
        c:/go/src/sync/once.go:66 +0xf3
sync.(*Once).Do(...)
        c:/go/src/sync/once.go:57
github.com/stashapp/stash/pkg/manager.Initialize(0xc0000461d8)
        D:/dev/stash/pkg/manager/manager.go:49 +0x60
main.main()
        D:/dev/stash/main.go:13 +0x29
```

This manifests more specifically when using the docker image without setting the `STASH_` environment variables like what the `docker-compose.yml` file does.

Similarly, if stash is run with the `-c` flag, providing a non-existent file, then it uses the default behaviour of looking for the config file in the current working directory or `$HOME`. 

The config initialisation code has been further refactored to fix these issues. If the provided config file does not exists, then the system will behave as if it is a new system, but the wizard will show a different starting page:

![image](https://user-images.githubusercontent.com/53250216/118113511-c19eca00-b429-11eb-9374-56635a8c3b4c.png)
