### PR TITLE
This adds extra libraries required by scrapers

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -8,9 +8,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-pi; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];  then BIN=stash-linux; \
     fi; \
     mv $BIN /stash
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y python3 python-is-python3 python3-requests python3-requests-toolbelt python3-lxml python3-pip && pip3 install cloudscraper
 FROM ubuntu:20.04 as app
-run apt update && apt install -y python3 python3 python-is-python3 python3-requests ffmpeg && rm -rf /var/lib/apt/lists/*
+run apt update && apt install -y python3 python-is-python3 python3-requests python3-requests-toolbelt python3-lxml ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY --from=prep /stash /usr/bin/
+COPY --from=prep /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
 
 EXPOSE 9999
 CMD ["stash"]


### PR DESCRIPTION
This adds extra libraries required by the IAFD scraper: requests-toolbelt lxml cloudscraper
This installs pip in the prep environment, uses this to install cloudscraper then copies this to the final application container.
Pip installs this by copying files to /usr/local/lib/python3.8/dist-packages and this directory is copied to the new container.

cloudscraper is pure python so an alternate method would be to just use wget and extract this to that directory but if there are other libraries that are needed it might be useful to have pip available.