### PR TITLE
Shortcut scan walk for excluded folders

### DIFF
--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -1098,6 +1098,13 @@ func walkFilesToScan(s *models.StashConfig, f filepath.WalkFunc) error {
 				return filepath.SkipDir
 			}
 
+			// shortcut: skip the directory entirely if it matches both exclusion patterns
+			// add a trailing separator so that it correctly matches against patterns like path/.*
+			pathExcludeTest := path + string(filepath.Separator)
+			if (s.ExcludeVideo || matchFileRegex(pathExcludeTest, excludeVidRegex)) && (s.ExcludeImage || matchFileRegex(pathExcludeTest, excludeImgRegex)) {
+				return filepath.SkipDir
+			}
+
 			return nil
 		}
 

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -1,2 +1,3 @@
 ### 🎨 Improvements
+* Skip scanning directories if path matches image and video exclude patterns. ([#1382](https://github.com/stashapp/stash/pull/1382))
 * Add button to remove studio stash ID. ([#1378](https://github.com/stashapp/stash/pull/1378))

--- a/ui/v2.5/src/docs/en/Configuration.md
+++ b/ui/v2.5/src/docs/en/Configuration.md
@@ -32,6 +32,8 @@ exclude:
 * the fourth the directory `/stash/videos/exclude/`
 * and the last a windows network path `\\stash\network\share\excl\`
 
+**Note:** if a directory is excluded for images and videos, then the directory will be excluded from scans completely.
+
 _a useful [link](https://regex101.com/) to experiment with regexps_
 
 ## Hashing algorithms


### PR DESCRIPTION
Skips walking a directory if it matches both exclusion patterns.