### PR TITLE
Make ffmpeg download location more portable

### DIFF
--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -15,7 +15,9 @@ import (
 )
 
 func (r *mutationResolver) MetadataScan(ctx context.Context, input models.ScanMetadataInput) (string, error) {
-	manager.GetInstance().Scan(input)
+	if err := manager.GetInstance().Scan(input); err != nil {
+		return "", err
+	}
 	return "todo", nil
 }
 
@@ -71,7 +73,9 @@ func (r *mutationResolver) ExportObjects(ctx context.Context, input models.Expor
 }
 
 func (r *mutationResolver) MetadataGenerate(ctx context.Context, input models.GenerateMetadataInput) (string, error) {
-	manager.GetInstance().Generate(input)
+	if err := manager.GetInstance().Generate(input); err != nil {
+		return "", err
+	}
 	return "todo", nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -262,6 +262,14 @@ func (s *singleton) Setup(input models.SetupInput) error {
 	return nil
 }
 
+func (s *singleton) validateFFMPEG() error {
+	if s.FFMPEGPath == "" || s.FFProbePath == "" {
+		return errors.New("missing ffmpeg and/or ffprobe")
+	}
+
+	return nil
+}
+
 func (s *singleton) Migrate(input models.MigrateInput) error {
 	// always backup so that we can roll back to the previous version if
 	// migration fails

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -155,9 +155,13 @@ func (s *singleton) neededScan(paths []*models.StashConfig) (total *int, newFile
 	return &t, &n
 }
 
-func (s *singleton) Scan(input models.ScanMetadataInput) {
+func (s *singleton) Scan(input models.ScanMetadataInput) error {
+	if err := s.validateFFMPEG(); err != nil {
+		return err
+	}
+
 	if s.Status.Status != Idle {
-		return
+		return nil
 	}
 	s.Status.SetStatus(Scan)
 	s.Status.indefiniteProgress()
@@ -264,6 +268,8 @@ func (s *singleton) Scan(input models.ScanMetadataInput) {
 		}
 		logger.Info("Finished gallery association")
 	}()
+
+	return nil
 }
 
 func (s *singleton) Import() error {
@@ -378,9 +384,13 @@ func setGeneratePreviewOptionsInput(optionsInput *models.GeneratePreviewOptionsI
 	}
 }
 
-func (s *singleton) Generate(input models.GenerateMetadataInput) {
+func (s *singleton) Generate(input models.GenerateMetadataInput) error {
+	if err := s.validateFFMPEG(); err != nil {
+		return err
+	}
+
 	if s.Status.Status != Idle {
-		return
+		return nil
 	}
 	s.Status.SetStatus(Generate)
 	s.Status.indefiniteProgress()
@@ -571,6 +581,8 @@ func (s *singleton) Generate(input models.GenerateMetadataInput) {
 		elapsed := time.Since(start)
 		logger.Info(fmt.Sprintf("Generate finished (%s)", elapsed))
 	}()
+
+	return nil
 }
 
 func (s *singleton) GenerateDefaultScreenshot(sceneId string) {

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -492,15 +492,24 @@ export const Setup: React.FC = () => {
       : renderWelcome;
   const steps = [welcomeStep, renderSetPaths, renderConfirm, renderFinish];
 
+  function renderCreating() {
+    return (
+      <Card>
+        <LoadingIndicator message="Creating your system" />
+        <Alert variant="info text-center">
+          If <code>ffmpeg</code> is not yet in your paths, please be patient
+          while stash downloads it. View the console output to see download
+          progress.
+        </Alert>
+      </Card>
+    );
+  }
+
   return (
     <Container>
       {maybeRenderGeneratedSelectDialog()}
       <h1 className="text-center">Stash Setup Wizard</h1>
-      {loading ? (
-        <LoadingIndicator message="Creating your system" />
-      ) : (
-        <Card>{steps[step]()}</Card>
-      )}
+      {loading ? renderCreating() : <Card>{steps[step]()}</Card>}
     </Container>
   );
 };


### PR DESCRIPTION
* No longer errors out if ffmpeg cannot be downloaded. Scan and generate tasks will give an appropriate error if ffmpeg is not present.
* The downloader now outputs progress in 5% increments.
* stash now checks the config file directory for ffmpeg, in addition to the user's home directory (and the path environment)
* Similarly, ffmpeg is now downloaded to the same directory as the config file, instead of to the user's home directory. This should make stash more portable.
* ffmpeg will be downloaded as part of the system setup process if no config file was provided at startup. The wizard has been updated indicating that this may take a while.