### PR TITLE
fix DirExists

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -39,10 +39,12 @@ func FileExists(path string) (bool, error) {
 
 // DirExists returns true if the given path exists and is a directory
 func DirExists(path string) (bool, error) {
-	exists, _ := FileExists(path)
-	fileInfo, _ := os.Stat(path)
-	if !exists || !fileInfo.IsDir() {
-		return false, fmt.Errorf("path either doesn't exist, or is not a directory <%s>", path)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("path doesn't exist <%s>", path)
+	}
+	if !fileInfo.IsDir() {
+		return false, fmt.Errorf("path is not a directory <%s>", path)
 	}
 	return true, nil
 }


### PR DESCRIPTION
Fixes a potential / rare issue with DirExists
In extreme conditions there can be a case where between two calls to os.stat for the same path one returns ok and the next returns an error.
Such an example could be when there is a lot of io wait or io over network (I couldnt actually force the issue but  a case mentioned in discord should be from this)
