### PR TITLE
Filter studio hierarchy

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -122,7 +122,7 @@ input SceneFilterType {
   """Filter to only include scenes missing this property"""
   is_missing: String
   """Filter to only include scenes with this studio"""
-  studios: MultiCriterionInput
+  studios: HierarchicalMultiCriterionInput
   """Filter to only include scenes with this movie"""
   movies: MultiCriterionInput
   """Filter to only include scenes with these tags"""
@@ -145,7 +145,7 @@ input SceneFilterType {
 
 input MovieFilterType {
   """Filter to only include movies with this studio"""
-  studios: MultiCriterionInput
+  studios: HierarchicalMultiCriterionInput
   """Filter to only include movies missing this property"""
   is_missing: String
   """Filter by url"""
@@ -189,7 +189,7 @@ input GalleryFilterType {
   """Filter by average image resolution"""
   average_resolution: ResolutionEnum
   """Filter to only include galleries with this studio"""
-  studios: MultiCriterionInput
+  studios: HierarchicalMultiCriterionInput
   """Filter to only include galleries with these tags"""
   tags: MultiCriterionInput
   """Filter by tag count"""
@@ -254,7 +254,7 @@ input ImageFilterType {
   """Filter to only include images missing this property"""
   is_missing: String
   """Filter to only include images with this studio"""
-  studios: MultiCriterionInput
+  studios: HierarchicalMultiCriterionInput
   """Filter to only include images with these tags"""
   tags: MultiCriterionInput
   """Filter by tag count"""

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -311,3 +311,9 @@ input GenderCriterionInput {
   value: GenderEnum
   modifier: CriterionModifier!
 }
+
+input HierarchicalMultiCriterionInput {
+  value: [ID!]
+  modifier: CriterionModifier!
+  depth: Int!
+}

--- a/pkg/dlna/cds.go
+++ b/pkg/dlna/cds.go
@@ -505,9 +505,10 @@ func (me *contentDirectoryService) getStudios() []interface{} {
 
 func (me *contentDirectoryService) getStudioScenes(paths []string, host string) []interface{} {
 	sceneFilter := &models.SceneFilterType{
-		Studios: &models.MultiCriterionInput{
+		Studios: &models.HierarchicalMultiCriterionInput{
 			Modifier: models.CriterionModifierIncludes,
 			Value:    []string{paths[0]},
+			Depth:    0,
 		},
 	}
 

--- a/pkg/gallery/query.go
+++ b/pkg/gallery/query.go
@@ -19,9 +19,10 @@ func CountByPerformerID(r models.GalleryReader, id int) (int, error) {
 
 func CountByStudioID(r models.GalleryReader, id int) (int, error) {
 	filter := &models.GalleryFilterType{
-		Studios: &models.MultiCriterionInput{
+		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		},
 	}
 

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -19,9 +19,10 @@ func CountByPerformerID(r models.ImageReader, id int) (int, error) {
 
 func CountByStudioID(r models.ImageReader, id int) (int, error) {
 	filter := &models.ImageFilterType{
-		Studios: &models.MultiCriterionInput{
+		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		},
 	}
 

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -87,6 +87,7 @@ type filterBuilder struct {
 	joins         joins
 	whereClauses  []sqlClause
 	havingClauses []sqlClause
+	withClauses   []sqlClause
 
 	err error
 }
@@ -169,6 +170,15 @@ func (f *filterBuilder) addHaving(sql string, args ...interface{}) {
 	f.havingClauses = append(f.havingClauses, makeClause(sql, args...))
 }
 
+// addWith adds a with clause and arguments to the filter
+func (f *filterBuilder) addWith(sql string, args ...interface{}) {
+	if sql == "" {
+		return
+	}
+
+	f.withClauses = append(f.withClauses, makeClause(sql, args...))
+}
+
 func (f *filterBuilder) getSubFilterClause(clause, subFilterClause string) string {
 	ret := clause
 
@@ -224,6 +234,21 @@ func (f *filterBuilder) generateHavingClauses() (string, []interface{}) {
 	}
 
 	return clause, args
+}
+
+func (f *filterBuilder) generateWithClauses() (string, []interface{}) {
+	var clauses []string
+	var args []interface{}
+	for _, w := range f.withClauses {
+		clauses = append(clauses, w.sql)
+		args = append(args, w.args...)
+	}
+
+	if len(clauses) > 0 {
+		return strings.Join(clauses, ", "), args
+	}
+
+	return "", nil
 }
 
 // getAllJoins returns all of the joins in this filter and any sub-filter(s).
@@ -501,6 +526,58 @@ func (m *stringListCriterionHandlerBuilder) handler(criterion *models.StringCrit
 			m.addJoinTable(f)
 
 			stringCriterionHandler(criterion, m.joinTable+"."+m.stringColumn)(f)
+
+		}
+	}
+}
+
+type hierarchicalMultiCriterionHandlerBuilder struct {
+	primaryTable string
+	foreignTable string
+	foreignFK    string
+
+	derivedTable string
+	parentFK     string
+}
+
+func (m *hierarchicalMultiCriterionHandlerBuilder) handler(criterion *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	return func(f *filterBuilder) {
+		if criterion != nil && len(criterion.Value) > 0 {
+			var args []interface{}
+			for _, value := range criterion.Value {
+				args = append(args, value)
+			}
+			inCount := len(args)
+
+			f.addJoin(m.derivedTable, "", fmt.Sprintf("%s.child_id = %s.%s", m.derivedTable, m.primaryTable, m.foreignFK))
+
+			depthCondition := "1"
+			if criterion.Depth != -1 {
+				depthCondition = "depth < ?"
+				args = append(args, criterion.Depth)
+			}
+
+			withClause := fmt.Sprintf(
+				"RECURSIVE %s AS (SELECT id as id, id as child_id, 0 as depth FROM %s WHERE id in %s UNION SELECT p.id, c.id, depth + 1 FROM %s as c INNER JOIN %s as p ON c.%s = p.child_id WHERE %s)",
+				m.derivedTable,
+				m.foreignTable,
+				getInBinding(inCount),
+				m.foreignTable,
+				m.derivedTable,
+				m.parentFK,
+				depthCondition,
+			)
+
+			f.addWith(withClause, args...)
+
+			if criterion.Modifier == models.CriterionModifierIncludes {
+				f.addWhere(fmt.Sprintf("%s.id IS NOT NULL", m.derivedTable))
+			} else if criterion.Modifier == models.CriterionModifierIncludesAll {
+				f.addWhere(fmt.Sprintf("%s.id IS NOT NULL", m.derivedTable))
+				f.addHaving(fmt.Sprintf("count(distinct %s.id) IS %d", m.derivedTable, inCount))
+			} else if criterion.Modifier == models.CriterionModifierExcludes {
+				f.addWhere(fmt.Sprintf("%s.id IS NULL", m.derivedTable))
+			}
 		}
 	}
 }

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -551,14 +551,14 @@ func (m *hierarchicalMultiCriterionHandlerBuilder) handler(criterion *models.Hie
 
 			f.addJoin(m.derivedTable, "", fmt.Sprintf("%s.child_id = %s.%s", m.derivedTable, m.primaryTable, m.foreignFK))
 
-			depthCondition := "1"
+			var depthCondition string
 			if criterion.Depth != -1 {
-				depthCondition = "depth < ?"
+				depthCondition = "WHERE depth < ?"
 				args = append(args, criterion.Depth)
 			}
 
 			withClause := fmt.Sprintf(
-				"RECURSIVE %s AS (SELECT id as id, id as child_id, 0 as depth FROM %s WHERE id in %s UNION SELECT p.id, c.id, depth + 1 FROM %s as c INNER JOIN %s as p ON c.%s = p.child_id WHERE %s)",
+				"RECURSIVE %s AS (SELECT id as id, id as child_id, 0 as depth FROM %s WHERE id in %s UNION SELECT p.id, c.id, depth + 1 FROM %s as c INNER JOIN %s as p ON c.%s = p.child_id %s)",
 				m.derivedTable,
 				m.foreignTable,
 				getInBinding(inCount),

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -382,11 +382,14 @@ func galleryImageCountCriterionHandler(qb *galleryQueryBuilder, imageCount *mode
 	return h.handler(imageCount)
 }
 
-func galleryStudioCriterionHandler(qb *galleryQueryBuilder, studios *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		f.addJoin(studioTable, "studio", "studio.id = galleries.studio_id")
+func galleryStudioCriterionHandler(qb *galleryQueryBuilder, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	h := hierarchicalMultiCriterionHandlerBuilder{
+		primaryTable: galleryTable,
+		foreignTable: studioTable,
+		foreignFK:    studioIDColumn,
+		derivedTable: "studio",
+		parentFK:     "parent_id",
 	}
-	h := qb.getMultiCriterionHandlerBuilder("studio", "", studioIDColumn, addJoinsFunc)
 
 	return h.handler(studios)
 }

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -675,11 +675,12 @@ func TestGalleryQueryTags(t *testing.T) {
 func TestGalleryQueryStudio(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Gallery()
-		studioCriterion := models.MultiCriterionInput{
+		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGallery]),
 			},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		}
 
 		galleryFilter := models.GalleryFilterType{
@@ -693,11 +694,12 @@ func TestGalleryQueryStudio(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, galleryIDs[galleryIdxWithStudio], galleries[0].ID)
 
-		studioCriterion = models.MultiCriterionInput{
+		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGallery]),
 			},
 			Modifier: models.CriterionModifierExcludes,
+			Depth:    0,
 		}
 
 		q := getGalleryStringValue(galleryIdxWithStudio, titleField)

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -408,11 +408,14 @@ func imagePerformerCountCriterionHandler(qb *imageQueryBuilder, performerCount *
 	return h.handler(performerCount)
 }
 
-func imageStudioCriterionHandler(qb *imageQueryBuilder, studios *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		f.addJoin(studioTable, "studio", "studio.id = images.studio_id")
+func imageStudioCriterionHandler(qb *imageQueryBuilder, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	h := hierarchicalMultiCriterionHandlerBuilder{
+		primaryTable: imageTable,
+		foreignTable: studioTable,
+		foreignFK:    studioIDColumn,
+		derivedTable: "studio",
+		parentFK:     "parent_id",
 	}
-	h := qb.getMultiCriterionHandlerBuilder("studio", "", studioIDColumn, addJoinsFunc)
 
 	return h.handler(studios)
 }

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -783,11 +783,12 @@ func TestImageQueryTags(t *testing.T) {
 func TestImageQueryStudio(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Image()
-		studioCriterion := models.MultiCriterionInput{
+		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithImage]),
 			},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		}
 
 		imageFilter := models.ImageFilterType{
@@ -804,11 +805,12 @@ func TestImageQueryStudio(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, imageIDs[imageIdxWithStudio], images[0].ID)
 
-		studioCriterion = models.MultiCriterionInput{
+		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithImage]),
 			},
 			Modifier: models.CriterionModifierExcludes,
+			Depth:    0,
 		}
 
 		q := getImageStringValue(imageIdxWithStudio, titleField)

--- a/pkg/sqlite/movies.go
+++ b/pkg/sqlite/movies.go
@@ -187,17 +187,13 @@ func movieIsMissingCriterionHandler(qb *movieQueryBuilder, isMissing *string) cr
 	}
 }
 
-func movieStudioCriterionHandler(qb *movieQueryBuilder, studios *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		f.addJoin(studioTable, "studio", "studio.id = movies.studio_id")
-	}
-	h := multiCriterionHandlerBuilder{
+func movieStudioCriterionHandler(qb *movieQueryBuilder, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	h := hierarchicalMultiCriterionHandlerBuilder{
 		primaryTable: movieTable,
-		foreignTable: "studio",
-		joinTable:    "",
-		primaryFK:    movieIDColumn,
+		foreignTable: studioTable,
 		foreignFK:    studioIDColumn,
-		addJoinsFunc: addJoinsFunc,
+		derivedTable: "studio",
+		parentFK:     "parent_id",
 	}
 
 	return h.handler(studios)

--- a/pkg/sqlite/movies_test.go
+++ b/pkg/sqlite/movies_test.go
@@ -76,11 +76,12 @@ func TestMovieFindByNames(t *testing.T) {
 func TestMovieQueryStudio(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		mqb := r.Movie()
-		studioCriterion := models.MultiCriterionInput{
+		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithMovie]),
 			},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		}
 
 		movieFilter := models.MovieFilterType{
@@ -97,11 +98,12 @@ func TestMovieQueryStudio(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, movieIDs[movieIdxWithStudio], movies[0].ID)
 
-		studioCriterion = models.MultiCriterionInput{
+		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithMovie]),
 			},
 			Modifier: models.CriterionModifierExcludes,
+			Depth:    0,
 		}
 
 		q := getMovieStringValue(movieIdxWithStudio, titleField)

--- a/pkg/sqlite/repository.go
+++ b/pkg/sqlite/repository.go
@@ -246,11 +246,16 @@ func (r *repository) buildQueryBody(body string, whereClauses []string, havingCl
 	return body
 }
 
-func (r *repository) executeFindQuery(body string, args []interface{}, sortAndPagination string, whereClauses []string, havingClauses []string) ([]int, int, error) {
+func (r *repository) executeFindQuery(body string, args []interface{}, sortAndPagination string, whereClauses []string, havingClauses []string, withClauses []string) ([]int, int, error) {
 	body = r.buildQueryBody(body, whereClauses, havingClauses)
 
-	countQuery := r.buildCountQuery(body)
-	idsQuery := body + sortAndPagination
+	withClause := ""
+	if len(withClauses) > 0 {
+		withClause = "WITH " + strings.Join(withClauses, ", ") + " "
+	}
+
+	countQuery := withClause + r.buildCountQuery(body)
+	idsQuery := withClause + body + sortAndPagination
 
 	// Perform query and fetch result
 	logger.Tracef("SQL: %s, args: %v", idsQuery, args)

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -588,11 +588,14 @@ func scenePerformerCountCriterionHandler(qb *sceneQueryBuilder, performerCount *
 	return h.handler(performerCount)
 }
 
-func sceneStudioCriterionHandler(qb *sceneQueryBuilder, studios *models.MultiCriterionInput) criterionHandlerFunc {
-	addJoinsFunc := func(f *filterBuilder) {
-		f.addJoin("studios", "studio", "studio.id = scenes.studio_id")
+func sceneStudioCriterionHandler(qb *sceneQueryBuilder, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	h := hierarchicalMultiCriterionHandlerBuilder{
+		primaryTable: sceneTable,
+		foreignTable: studioTable,
+		foreignFK:    studioIDColumn,
+		derivedTable: "studio",
+		parentFK:     "parent_id",
 	}
-	h := qb.getMultiCriterionHandlerBuilder("studio", "", studioIDColumn, addJoinsFunc)
 
 	return h.handler(studios)
 }

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -249,7 +249,7 @@ func (qb *sceneMarkerQueryBuilder) Query(sceneMarkerFilter *models.SceneMarkerFi
 	}
 
 	sortAndPagination := qb.getSceneMarkerSort(findFilter) + getPagination(findFilter)
-	idsResult, countResult, err := qb.executeFindQuery(body, args, sortAndPagination, whereClauses, havingClauses)
+	idsResult, countResult, err := qb.executeFindQuery(body, args, sortAndPagination, whereClauses, havingClauses, []string{})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -1070,11 +1070,12 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 func TestSceneQueryStudio(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Scene()
-		studioCriterion := models.MultiCriterionInput{
+		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithScene]),
 			},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    0,
 		}
 
 		sceneFilter := models.SceneFilterType{
@@ -1088,11 +1089,12 @@ func TestSceneQueryStudio(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, sceneIDs[sceneIdxWithStudio], scenes[0].ID)
 
-		studioCriterion = models.MultiCriterionInput{
+		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithScene]),
 			},
 			Modifier: models.CriterionModifierExcludes,
+			Depth:    0,
 		}
 
 		q := getSceneStringValue(sceneIdxWithStudio, titleField)

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -41,6 +41,7 @@ const (
 	sceneIdxWithPerformerTwoTags
 	sceneIdxWithSpacedName
 	sceneIdxWithStudioPerformer
+	sceneIdxWithGrandChildStudio
 	// new indexes above
 	lastSceneIdx
 
@@ -65,6 +66,7 @@ const (
 	imageIdxInZip // TODO - not implemented
 	imageIdxWithPerformerTag
 	imageIdxWithPerformerTwoTags
+	imageIdxWithGrandChildStudio
 	// new indexes above
 	totalImages
 )
@@ -125,6 +127,7 @@ const (
 	galleryIdxWithPerformerTag
 	galleryIdxWithPerformerTwoTags
 	galleryIdxWithStudioPerformer
+	galleryIdxWithGrandChildStudio
 	// new indexes above
 	lastGalleryIdx
 
@@ -169,6 +172,9 @@ const (
 	studioIdxWithScenePerformer
 	studioIdxWithImagePerformer
 	studioIdxWithGalleryPerformer
+	studioIdxWithGrandChild
+	studioIdxWithParentAndChild
+	studioIdxWithGrandParent
 	// new indexes above
 	// studios with dup names start from the end
 	studioIdxWithDupName
@@ -241,6 +247,7 @@ var (
 		{sceneIdx1WithStudio, studioIdxWithTwoScenes},
 		{sceneIdx2WithStudio, studioIdxWithTwoScenes},
 		{sceneIdxWithStudioPerformer, studioIdxWithScenePerformer},
+		{sceneIdxWithGrandChildStudio, studioIdxWithGrandParent},
 	}
 )
 
@@ -257,6 +264,7 @@ var (
 		{imageIdx1WithStudio, studioIdxWithTwoImages},
 		{imageIdx2WithStudio, studioIdxWithTwoImages},
 		{imageIdxWithStudioPerformer, studioIdxWithImagePerformer},
+		{imageIdxWithGrandChildStudio, studioIdxWithGrandParent},
 	}
 	imageTagLinks = [][2]int{
 		{imageIdxWithTag, tagIdxWithImage},
@@ -292,6 +300,7 @@ var (
 		{galleryIdx1WithStudio, studioIdxWithTwoGalleries},
 		{galleryIdx2WithStudio, studioIdxWithTwoGalleries},
 		{galleryIdxWithStudioPerformer, studioIdxWithGalleryPerformer},
+		{galleryIdxWithGrandChildStudio, studioIdxWithGrandParent},
 	}
 
 	galleryTagLinks = [][2]int{
@@ -310,6 +319,8 @@ var (
 var (
 	studioParentLinks = [][2]int{
 		{studioIdxWithChildStudio, studioIdxWithParentStudio},
+		{studioIdxWithGrandChild, studioIdxWithParentAndChild},
+		{studioIdxWithParentAndChild, studioIdxWithGrandParent},
 	}
 )
 

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -359,9 +359,10 @@ func verifyStudiosImageCount(t *testing.T, imageCountCriterion models.IntCriteri
 			pp := 0
 
 			_, count, err := r.Image().Query(&models.ImageFilterType{
-				Studios: &models.MultiCriterionInput{
+				Studios: &models.HierarchicalMultiCriterionInput{
 					Value:    []string{strconv.Itoa(studio.ID)},
 					Modifier: models.CriterionModifierIncludes,
+					Depth:    0,
 				},
 			}, &models.FindFilterType{
 				PerPage: &pp,
@@ -409,9 +410,10 @@ func verifyStudiosGalleryCount(t *testing.T, galleryCountCriterion models.IntCri
 			pp := 0
 
 			_, count, err := r.Gallery().Query(&models.GalleryFilterType{
-				Studios: &models.MultiCriterionInput{
+				Studios: &models.HierarchicalMultiCriterionInput{
 					Value:    []string{strconv.Itoa(studio.ID)},
 					Modifier: models.CriterionModifierIncludes,
+					Depth:    0,
 				},
 			}, &models.FindFilterType{
 				PerPage: &pp,

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -1,4 +1,5 @@
 ### ✨ New Features
+* Support Studio filter including child studios. ([#1397](https://github.com/stashapp/stash/pull/1397))
 * Added support for tag aliases. ([#1412](https://github.com/stashapp/stash/pull/1412))
 * Support embedded Javascript plugins. ([#1393](https://github.com/stashapp/stash/pull/1393))
 * Revamped job management: tasks can now be queued. ([#1379](https://github.com/stashapp/stash/pull/1379))

--- a/ui/v2.5/src/components/List/AddFilter.tsx
+++ b/ui/v2.5/src/components/List/AddFilter.tsx
@@ -13,7 +13,7 @@ import {
 import { NoneCriterion } from "src/models/list-filter/criteria/none";
 import { makeCriteria } from "src/models/list-filter/criteria/factory";
 import { ListFilterOptions } from "src/models/list-filter/filter-options";
-import { useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
 import {
   criterionIsHierarchicalLabelValue,
   CriterionType,
@@ -42,6 +42,13 @@ export const AddFilter: React.FC<IAddFilterProps> = (
   const valueStage = useRef<CriterionValue>(criterion.value);
 
   const intl = useIntl();
+
+  const messages = defineMessages({
+    studio_depth: {
+      id: "studio_depth",
+      defaultMessage: "Levels (empty for all)",
+    },
+  });
 
   // configure keyboard shortcuts
   useEffect(() => {
@@ -266,6 +273,7 @@ export const AddFilter: React.FC<IAddFilterProps> = (
                 <Form.Control
                   className="btn-secondary"
                   type="number"
+                  placeholder={intl.formatMessage(messages.studio_depth)}
                   onChange={(e) => {
                     const newCriterion = _.cloneDeep(criterion);
                     newCriterion.value.depth = e.target.value

--- a/ui/v2.5/src/components/List/AddFilter.tsx
+++ b/ui/v2.5/src/components/List/AddFilter.tsx
@@ -8,12 +8,16 @@ import {
   DurationCriterion,
   CriterionValue,
   Criterion,
+  IHierarchicalLabeledIdCriterion,
 } from "src/models/list-filter/criteria/criterion";
 import { NoneCriterion } from "src/models/list-filter/criteria/none";
 import { makeCriteria } from "src/models/list-filter/criteria/factory";
 import { ListFilterOptions } from "src/models/list-filter/filter-options";
 import { useIntl } from "react-intl";
-import { CriterionType } from "src/models/list-filter/types";
+import {
+  criterionIsHierarchicalLabelValue,
+  CriterionType,
+} from "src/models/list-filter/types";
 
 interface IAddFilterProps {
   onAddCriterion: (
@@ -183,7 +187,29 @@ export const AddFilter: React.FC<IAddFilterProps> = (
           />
         );
       }
-      if (criterion.options) {
+      if (criterion instanceof IHierarchicalLabeledIdCriterion) {
+        if (criterion.criterionOption.value !== "studios") return;
+
+        return (
+          <FilterSelect
+            type={criterion.criterionOption.value}
+            isMulti
+            onSelect={(items) => {
+              const newCriterion = _.cloneDeep(criterion);
+              newCriterion.value.items = items.map((i) => ({
+                id: i.id,
+                label: i.name!,
+              }));
+              setCriterion(newCriterion);
+            }}
+            ids={criterion.value.items.map((labeled) => labeled.id)}
+          />
+        );
+      }
+      if (
+        criterion.options &&
+        !criterionIsHierarchicalLabelValue(criterion.value)
+      ) {
         defaultValue.current = criterion.value;
         return (
           <Form.Control
@@ -219,10 +245,52 @@ export const AddFilter: React.FC<IAddFilterProps> = (
         />
       );
     }
+    function renderAdditional() {
+      if (criterion instanceof IHierarchicalLabeledIdCriterion) {
+        return (
+          <>
+            <Form.Group>
+              <Form.Check
+                checked={criterion.value.depth !== 0}
+                label="Include child studios"
+                onChange={() => {
+                  const newCriterion = _.cloneDeep(criterion);
+                  newCriterion.value.depth =
+                    newCriterion.value.depth !== 0 ? 0 : -1;
+                  setCriterion(newCriterion);
+                }}
+              />
+            </Form.Group>
+            {criterion.value.depth !== 0 && (
+              <Form.Group>
+                <Form.Control
+                  className="btn-secondary"
+                  type="number"
+                  onChange={(e) => {
+                    const newCriterion = _.cloneDeep(criterion);
+                    newCriterion.value.depth = e.target.value
+                      ? parseInt(e.target.value, 10)
+                      : -1;
+                    setCriterion(newCriterion);
+                  }}
+                  defaultValue={
+                    criterion.value && criterion.value.depth !== -1
+                      ? criterion.value.depth
+                      : ""
+                  }
+                  min="1"
+                />
+              </Form.Group>
+            )}
+          </>
+        );
+      }
+    }
     return (
       <>
         <Form.Group>{renderModifier()}</Form.Group>
         <Form.Group>{renderSelect()}</Form.Group>
+        {renderAdditional()}
       </>
     );
   };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
@@ -12,9 +12,10 @@ export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
   studio,
 }) => {
   const studioCriterion = new StudiosCriterion();
-  studioCriterion.value = [
-    { id: studio.id!, label: studio.name || `Studio ${studio.id}` },
-  ];
+  studioCriterion.value = {
+    items: [{ id: studio.id!, label: studio.name || `Studio ${studio.id}` }],
+    depth: 0,
+  };
 
   const extraCriteria = {
     scenes: [studioCriterion],

--- a/ui/v2.5/src/core/studios.ts
+++ b/ui/v2.5/src/core/studios.ts
@@ -17,18 +17,21 @@ export const studioFilterHook = (studio: Partial<GQL.StudioDataFragment>) => {
     ) {
       // add the studio if not present
       if (
-        !studioCriterion.value.find((p) => {
+        !studioCriterion.value.items.find((p) => {
           return p.id === studio.id;
         })
       ) {
-        studioCriterion.value.push(studioValue);
+        studioCriterion.value.items.push(studioValue);
       }
 
       studioCriterion.modifier = GQL.CriterionModifier.IncludesAll;
     } else {
       // overwrite
       studioCriterion = new StudiosCriterion();
-      studioCriterion.value = [studioValue];
+      studioCriterion.value = {
+        items: [studioValue],
+        depth: 0,
+      };
       filter.criteria.push(studioCriterion);
     }
 

--- a/ui/v2.5/src/locale/en-GB.json
+++ b/ui/v2.5/src/locale/en-GB.json
@@ -73,6 +73,7 @@
   "scenes_updated_at": "Scene Updated At",
   "seconds": "Seconds",
   "stash_id": "Stash ID",
+  "studio_depth": "Levels (empty for all)",
   "studios": "Studios",
   "tag_count": "Tag Count",
   "tags": "Tags",

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -312,10 +312,28 @@ export abstract class ILabeledIdCriterion extends Criterion<ILabeledId[]> {
 }
 
 export abstract class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabelValue> {
+  public modifier = CriterionModifier.IncludesAll;
+  public modifierOptions = [
+    Criterion.getModifierOption(CriterionModifier.IncludesAll),
+    Criterion.getModifierOption(CriterionModifier.Includes),
+    Criterion.getModifierOption(CriterionModifier.Excludes),
+  ];
+
+  public options: IOptionType[] = [];
   public value: IHierarchicalLabelValue = {
     items: [],
     depth: 0,
   };
+
+  public encodeValue() {
+    return {
+      items: this.value.items.map((o) => {
+        return encodeILabeledId(o);
+      }),
+      depth: this.value.depth,
+    };
+  }
+
   protected toCriterionInput(): HierarchicalMultiCriterionInput {
     return {
       value: this.value.items.map((v) => v.id),
@@ -341,6 +359,18 @@ export abstract class IHierarchicalLabeledIdCriterion extends Criterion<IHierarc
       modifier: this.modifier,
     };
     return JSON.stringify(encodedCriterion);
+  }
+
+  constructor(type: CriterionOption, includeAll: boolean) {
+    super(type);
+
+    if (!includeAll) {
+      this.modifier = CriterionModifier.Includes;
+      this.modifierOptions = [
+        Criterion.getModifierOption(CriterionModifier.Includes),
+        Criterion.getModifierOption(CriterionModifier.Excludes),
+      ];
+    }
   }
 }
 

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -3,6 +3,7 @@
 import { IntlShape } from "react-intl";
 import {
   CriterionModifier,
+  HierarchicalMultiCriterionInput,
   MultiCriterionInput,
 } from "src/core/generated-graphql";
 import DurationUtils from "src/utils/duration";
@@ -12,10 +13,15 @@ import {
   ILabeledId,
   ILabeledValue,
   IOptionType,
+  IHierarchicalLabelValue,
 } from "../types";
 
 type Option = string | number | IOptionType;
-export type CriterionValue = string | number | ILabeledId[];
+export type CriterionValue =
+  | string
+  | number
+  | ILabeledId[]
+  | IHierarchicalLabelValue;
 
 // V = criterion value type
 export abstract class Criterion<V extends CriterionValue> {
@@ -302,6 +308,39 @@ export abstract class ILabeledIdCriterion extends Criterion<ILabeledId[]> {
         Criterion.getModifierOption(CriterionModifier.Excludes),
       ];
     }
+  }
+}
+
+export abstract class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabelValue> {
+  public value: IHierarchicalLabelValue = {
+    items: [],
+    depth: 0,
+  };
+  protected toCriterionInput(): HierarchicalMultiCriterionInput {
+    return {
+      value: this.value.items.map((v) => v.id),
+      modifier: this.modifier,
+      depth: this.value.depth,
+    };
+  }
+
+  public getLabelValue(): string {
+    const labels = this.value.items.map((v) => v.label).join(", ");
+
+    if (this.value.depth === 0) {
+      return labels;
+    }
+
+    return `${labels} (+${this.value.depth > 0 ? this.value.depth : "all"})`;
+  }
+
+  public toJSON() {
+    const encodedCriterion = {
+      type: this.criterionOption.value,
+      value: this.encodeValue(),
+      modifier: this.modifier,
+    };
+    return JSON.stringify(encodedCriterion);
   }
 }
 

--- a/ui/v2.5/src/models/list-filter/criteria/studios.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/studios.ts
@@ -1,15 +1,13 @@
-import { CriterionOption, ILabeledIdCriterion } from "./criterion";
-
-abstract class AbstractStudiosCriterion extends ILabeledIdCriterion {
-  constructor(type: CriterionOption) {
-    super(type, false);
-  }
-}
+import {
+  CriterionOption,
+  IHierarchicalLabeledIdCriterion,
+  ILabeledIdCriterion,
+} from "./criterion";
 
 export const StudiosCriterionOption = new CriterionOption("studios", "studios");
-export class StudiosCriterion extends AbstractStudiosCriterion {
+export class StudiosCriterion extends IHierarchicalLabeledIdCriterion {
   constructor() {
-    super(StudiosCriterionOption);
+    super(StudiosCriterionOption, false);
   }
 }
 
@@ -18,8 +16,8 @@ export const ParentStudiosCriterionOption = new CriterionOption(
   "parent_studios",
   "parents"
 );
-export class ParentStudiosCriterion extends AbstractStudiosCriterion {
+export class ParentStudiosCriterion extends ILabeledIdCriterion {
   constructor() {
-    super(ParentStudiosCriterionOption);
+    super(ParentStudiosCriterionOption, false);
   }
 }

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -29,6 +29,18 @@ export interface ILabeledValue {
   value: string;
 }
 
+export interface IHierarchicalLabelValue {
+  items: ILabeledId[];
+  depth: number;
+}
+
+export function criterionIsHierarchicalLabelValue(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any
+): value is IHierarchicalLabelValue {
+  return typeof value === "object" && "items" in value && "depth" in value;
+}
+
 export function encodeILabeledId(o: ILabeledId) {
   // escape " and \ and by encoding to JSON so that it encodes to JSON correctly down the line
   const adjustedLabel = JSON.stringify(o.label).slice(1, -1);

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -85,9 +85,10 @@ const makeStudioScenesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   if (!studio.id) return "#";
   const filter = new ListFilterModel();
   const criterion = new StudiosCriterion();
-  criterion.value = [
-    { id: studio.id, label: studio.name || `Studio ${studio.id}` },
-  ];
+  criterion.value = {
+    items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
+    depth: 0,
+  };
   filter.criteria.push(criterion);
   return `/scenes?${filter.makeQueryParameters()}`;
 };
@@ -96,9 +97,10 @@ const makeStudioImagesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   if (!studio.id) return "#";
   const filter = new ListFilterModel();
   const criterion = new StudiosCriterion();
-  criterion.value = [
-    { id: studio.id, label: studio.name || `Studio ${studio.id}` },
-  ];
+  criterion.value = {
+    items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
+    depth: 0,
+  };
   filter.criteria.push(criterion);
   return `/images?${filter.makeQueryParameters()}`;
 };
@@ -107,9 +109,10 @@ const makeStudioGalleriesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   if (!studio.id) return "#";
   const filter = new ListFilterModel();
   const criterion = new StudiosCriterion();
-  criterion.value = [
-    { id: studio.id, label: studio.name || `Studio ${studio.id}` },
-  ];
+  criterion.value = {
+    items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
+    depth: 0,
+  };
   filter.criteria.push(criterion);
   return `/galleries?${filter.makeQueryParameters()}`;
 };


### PR DESCRIPTION
I've been working on adding support for filtering on studios including their children. This so you can set a filter on a parent studio and for example the scenes for all child studios will be shown as well.

This is a work in progress and I'm currently creating this PR to get feedback. I probably won't be working on this till next weekend so this gives you some time to provide input which I will be able to incorperate then.

The TODOs are:
- [x] Redesign filter. Currently only a numeric input is shown, might be better to add a checkbox and an optional number input (no number specified is infinite depth, checkbox not checked is depth of 0)
- [x] Use new filter as well for:
  - [x] Images
  - [x] Galleries
- [x] Add depth setting to Studio tabs(? not sure if needed or works automatically)
  - [x] Scenes
  - [x] Images
  - [x] Galleries
- [x] Testing