### PR TITLE
Clamp page to max pages

### DIFF
--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -175,6 +175,14 @@ const RenderList = <
   const result = useData(filter);
   const totalCount = getCount(result);
   const items = getData(result);
+  const pages = Math.ceil(totalCount / filter.itemsPerPage);
+
+  // handle case where page is more than there are pages
+  useEffect(() => {
+    if (pages > 0 && filter.currentPage > pages) {
+      onChangePage(pages);
+    }
+  }, [pages, filter.currentPage, onChangePage]);
 
   useEffect(() => {
     Mousetrap.bind("right", () => {
@@ -363,8 +371,6 @@ const RenderList = <
     if (result.loading || result.error) {
       return;
     }
-
-    const pages = Math.ceil(totalCount / filter.itemsPerPage);
 
     return (
       <>


### PR DESCRIPTION
Fixes edge case where is page is set past the maximum (ie from the URL `p` query param), then page will be automatically set to the maximum pages for the query.