### PR TITLE
Fix: login form label references

### DIFF
--- a/ui/login/login.html
+++ b/ui/login/login.html
@@ -15,12 +15,12 @@
             <form action="/login" method="POST">
                 <div class="form-group">
                     <label for="username"><h6>Username</h6></label>
-                    <input class="text-input form-control" name="username" type="text" placeholder="Username" />
+                    <input class="text-input form-control" id="username" name="username" type="text" placeholder="Username" />
                 </div>
                 <div>
                 <div class="form-group">
                     <label for="password"><h6>Password</h6></label>
-                    <input class="text-input form-control" name="password" type="password" placeholder="Password" />
+                    <input class="text-input form-control" id="password" name="password" type="password" placeholder="Password" />
                 </div>
                 <div class="login-error">
                     {{.Error}}


### PR DESCRIPTION
Fixes the login form label references for Username and Password by adding
the missing id attributes to each of the input fields respectively
to which the labels where referring to.