### PR TITLE
Fix: file close even if file was not opened

### DIFF
--- a/pkg/manager/jsonschema/gallery.go
+++ b/pkg/manager/jsonschema/gallery.go
@@ -29,10 +29,10 @@ type Gallery struct {
 func LoadGalleryFile(filePath string) (*Gallery, error) {
 	var gallery Gallery
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&gallery)

--- a/pkg/manager/jsonschema/image.go
+++ b/pkg/manager/jsonschema/image.go
@@ -33,10 +33,10 @@ type Image struct {
 func LoadImageFile(filePath string) (*Image, error) {
 	var image Image
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&image)

--- a/pkg/manager/jsonschema/mappings.go
+++ b/pkg/manager/jsonschema/mappings.go
@@ -26,10 +26,10 @@ type Mappings struct {
 func LoadMappingsFile(filePath string) (*Mappings, error) {
 	var mappings Mappings
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&mappings)

--- a/pkg/manager/jsonschema/movie.go
+++ b/pkg/manager/jsonschema/movie.go
@@ -27,10 +27,10 @@ type Movie struct {
 func LoadMovieFile(filePath string) (*Movie, error) {
 	var movie Movie
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&movie)

--- a/pkg/manager/jsonschema/performer.go
+++ b/pkg/manager/jsonschema/performer.go
@@ -40,10 +40,10 @@ type Performer struct {
 func LoadPerformerFile(filePath string) (*Performer, error) {
 	var performer Performer
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&performer)

--- a/pkg/manager/jsonschema/scene.go
+++ b/pkg/manager/jsonschema/scene.go
@@ -61,10 +61,10 @@ type Scene struct {
 func LoadSceneFile(filePath string) (*Scene, error) {
 	var scene Scene
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&scene)

--- a/pkg/manager/jsonschema/scraped.go
+++ b/pkg/manager/jsonschema/scraped.go
@@ -27,10 +27,10 @@ type ScrapedItem struct {
 func LoadScrapedFile(filePath string) ([]ScrapedItem, error) {
 	var scraped []ScrapedItem
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&scraped)

--- a/pkg/manager/jsonschema/studio.go
+++ b/pkg/manager/jsonschema/studio.go
@@ -22,10 +22,10 @@ type Studio struct {
 func LoadStudioFile(filePath string) (*Studio, error) {
 	var studio Studio
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&studio)

--- a/pkg/manager/jsonschema/tag.go
+++ b/pkg/manager/jsonschema/tag.go
@@ -18,10 +18,10 @@ type Tag struct {
 func LoadTagFile(filePath string) (*Tag, error) {
 	var tag Tag
 	file, err := os.Open(filePath)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonParser := json.NewDecoder(file)
 	err = jsonParser.Decode(&tag)

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -211,10 +211,10 @@ func loadPluginFromYAML(reader io.Reader) (*Config, error) {
 
 func loadPluginFromYAMLFile(path string) (*Config, error) {
 	file, err := os.Open(path)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	ret, err := loadPluginFromYAML(file)
 	if err != nil {

--- a/pkg/scraper/config.go
+++ b/pkg/scraper/config.go
@@ -209,10 +209,10 @@ func loadScraperFromYAML(id string, reader io.Reader) (*config, error) {
 
 func loadScraperFromYAMLFile(path string) (*config, error) {
 	file, err := os.Open(path)
-	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
 	// set id to the filename
 	id := filepath.Base(path)


### PR DESCRIPTION
Fixed a bug where in many implementations of load-file functions the file-close was still
executed even if the file-open resulted in an error.