### PR TITLE
Set DeleteFile to default = true

### DIFF
--- a/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
@@ -29,7 +29,7 @@ export const DeleteScenesDialog: React.FC<IDeleteSceneDialogProps> = (
   const messageId = plural ? pluralMessageId : singleMessageId;
   const message = plural ? pluralMessage : singleMessage;
 
-  const [deleteFile, setDeleteFile] = useState<boolean>(false);
+  const [deleteFile, setDeleteFile] = useState<boolean>(true);
   const [deleteGenerated, setDeleteGenerated] = useState<boolean>(true);
 
   const Toast = useToast();


### PR DESCRIPTION
It just sucks to have to tick it EVERY single time you want to use duplicate checker to delete the duplicates.