### PR TITLE
Fix invalid scene queue generated link

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -5,11 +5,12 @@
 * Added [DLNA server](/settings?tab=dlna). ([#1364](https://github.com/stashapp/stash/pull/1364))
 
 ### 🎨 Improvements
-* Add `CreatedAt` and `UpdatedAt` (and `FileModTime` where applicable) to API objects.
+* Add `CreatedAt` and `UpdatedAt` (and `FileModTime` where applicable) to API objects. ([#1421](https://github.com/stashapp/stash/pull/1421))
 * Add Studios Performer filter criterion. ([#1405](https://github.com/stashapp/stash/pull/1405))
 * Add `subtractDays` post-process scraper action. ([#1399](https://github.com/stashapp/stash/pull/1399))
 * Skip scanning directories if path matches image and video exclude patterns. ([#1382](https://github.com/stashapp/stash/pull/1382))
 * Add button to remove studio stash ID. ([#1378](https://github.com/stashapp/stash/pull/1378))
 
 ### 🐛 Bug fixes
+* Fix quotes in filter labels causing UI errors. ([#1425](https://github.com/stashapp/stash/pull/1425))
 * Fix post-processing not running when scraping by performer fragment. ([#1387](https://github.com/stashapp/stash/pull/1387))

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -425,13 +425,18 @@ export class ListFilterModel {
       }
 
       jsonParameters.forEach((jsonString) => {
-        const encodedCriterion = JSON.parse(jsonString);
-        const criterion = makeCriteria(encodedCriterion.type);
-        // it's possible that we have unsupported criteria. Just skip if so.
-        if (criterion) {
-          criterion.value = encodedCriterion.value;
-          criterion.modifier = encodedCriterion.modifier;
-          this.criteria.push(criterion);
+        try {
+          const encodedCriterion = JSON.parse(jsonString);
+          const criterion = makeCriteria(encodedCriterion.type);
+          // it's possible that we have unsupported criteria. Just skip if so.
+          if (criterion) {
+            criterion.value = encodedCriterion.value;
+            criterion.modifier = encodedCriterion.modifier;
+            this.criteria.push(criterion);
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("Failed to parse encoded criterion:", err);
         }
       });
     }

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -29,8 +29,8 @@ export interface ILabeledValue {
 }
 
 export function encodeILabeledId(o: ILabeledId) {
-  // escape \ to \\ so that it encodes to JSON correctly
-  const adjustedLabel = o.label.replaceAll("\\", "\\\\");
+  // escape " and \ and by encoding to JSON so that it encodes to JSON correctly down the line
+  const adjustedLabel = JSON.stringify(o.label).slice(1, -1);
   return { ...o, label: encodeURIComponent(adjustedLabel) };
 }
 


### PR DESCRIPTION
Fixes (reported on Discord):
> `SyntaxError: JSON.parse: expected ',' or '}' after property value in object at line 1 column 49 of the JSON data`
> Trying to get to this page (Access this scene from the movie page): `http://localhost:9999/scenes/2645?qfc=%7B%22type%22:%22movies%22,%22value%22:[%7B%22id%22:%22950%22,%22label%22:%22%22Hey%2C%20I%27ve%20Already%20Cum%22%22%7D],%22modifier%22:%22INCLUDES%22%7D&qfp=1&qsort=movie_scene_number`
> I think i know why, the title is "Hey, I've Already Cum" maybe the quote broke it

The above decodes to: `http://localhost:9999/scenes/2645?qfc={"type":"movies","value":[{"id":"950","label":""Hey, I've Already Cum""}],"modifier":"INCLUDES"}&qfp=1&qsort=movie_scene_number`

Escaping quotes in criterion label by JSON encoding and slicing off the encompassing <sub>*(if that is even the right word)*</sub> JSON-string quotes seems like a safer option to escape all possible issues.
I'm not sure what to write in the change log..