### PR TITLE
Fix scraper date parser failing when parsing time

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -368,10 +368,10 @@ func (p *postProcessParseDate) Apply(value string, q mappedQuery) string {
 
 	const internalDateFormat = "2006-01-02"
 
-	value = strings.ToLower(value)
-	if value == "today" || value == "yesterday" { // handle today, yesterday
+	valueLower := strings.ToLower(value)
+	if valueLower == "today" || valueLower == "yesterday" { // handle today, yesterday
 		dt := time.Now()
-		if value == "yesterday" { // subtract 1 day from now
+		if valueLower == "yesterday" { // subtract 1 day from now
 			dt = dt.AddDate(0, 0, -1)
 		}
 		return dt.Format(internalDateFormat)

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -12,5 +12,6 @@
 * Add button to remove studio stash ID. ([#1378](https://github.com/stashapp/stash/pull/1378))
 
 ### 🐛 Bug fixes
+* Fix scraper date parser failing when parsing time. ([#1431](https://github.com/stashapp/stash/pull/1431))
 * Fix quotes in filter labels causing UI errors. ([#1425](https://github.com/stashapp/stash/pull/1425))
 * Fix post-processing not running when scraping by performer fragment. ([#1387](https://github.com/stashapp/stash/pull/1387))


### PR DESCRIPTION
Don't mutate the original scraped date
`time.Parse` is case-sensitive for some values, `AM/pm` in particular

For example, original scraped date being `5/21/21 11:01AM` and `parseDate: 1/2/06 03:04PM`, the error:
`Error parsing date string '5/21/21 11:01am' using format '1/2/06 03:04PM': parsing time "5/21/21 11:01am" as "1/2/06 03:04PM": cannot parse "" as "PM"`