### PR TITLE
Add support for merging tags

### DIFF
--- a/graphql/documents/mutations/tag.graphql
+++ b/graphql/documents/mutations/tag.graphql
@@ -17,3 +17,9 @@ mutation TagUpdate($input: TagUpdateInput!) {
     ...TagData
   }
 }
+
+mutation TagsMerge($source: [ID!]!, $destination: ID!) {
+  tagsMerge(input: { source: $source, destination: $destination }) {
+    ...TagData
+  }
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -197,6 +197,7 @@ type Mutation {
   tagUpdate(input: TagUpdateInput!): Tag
   tagDestroy(input: TagDestroyInput!): Boolean!
   tagsDestroy(ids: [ID!]!): Boolean!
+  tagsMerge(input: TagsMergeInput!): Tag
 
   """Change general configuration options"""
   configureGeneral(input: ConfigGeneralInput!): ConfigGeneralResult!

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -38,3 +38,8 @@ type FindTagsResultType {
   count: Int!
   tags: [Tag!]!
 }
+
+input TagsMergeInput {
+  source: [ID!]!
+  destination: ID!
+}

--- a/pkg/models/mocks/TagReaderWriter.go
+++ b/pkg/models/mocks/TagReaderWriter.go
@@ -360,6 +360,20 @@ func (_m *TagReaderWriter) GetImage(tagID int) ([]byte, error) {
 	return r0, r1
 }
 
+// MergeTags provides a mock function with given fields: source, destination
+func (_m *TagReaderWriter) MergeTags(source []int, destination int) error {
+	ret := _m.Called(source, destination)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]int, int) error); ok {
+		r0 = rf(source, destination)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Query provides a mock function with given fields: tagFilter, findFilter
 func (_m *TagReaderWriter) Query(tagFilter *models.TagFilterType, findFilter *models.FindFilterType) ([]*models.Tag, int, error) {
 	ret := _m.Called(tagFilter, findFilter)

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -28,6 +28,7 @@ type TagWriter interface {
 	UpdateImage(tagID int, image []byte) error
 	DestroyImage(tagID int) error
 	UpdateAliases(tagID int, aliases []string) error
+	MergeTags(source []int, destination int) error
 }
 
 type TagReaderWriter interface {

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -536,3 +536,63 @@ func (qb *tagQueryBuilder) GetAliases(tagID int) ([]string, error) {
 func (qb *tagQueryBuilder) UpdateAliases(tagID int, aliases []string) error {
 	return qb.aliasRepository().replace(tagID, aliases)
 }
+
+func (qb *tagQueryBuilder) MergeTags(source []int, destination int) error {
+	inBinding := getInBinding(len(source))
+
+	args := []interface{}{destination}
+	for _, id := range source {
+		if id != destination {
+			args = append(args, id)
+		}
+	}
+
+	if len(args) == 1 {
+		return nil
+	}
+
+	tagTables := map[string]string{
+		scenesTagsTable:      sceneIDColumn,
+		"scene_markers_tags": "scene_marker_id",
+		galleriesTagsTable:   galleryIDColumn,
+		imagesTagsTable:      imageIDColumn,
+		"performers_tags":    "performer_id",
+	}
+
+	tagArgs := append(args, destination)
+	for table, idColumn := range tagTables {
+		_, err := qb.tx.Exec(`UPDATE `+table+`
+SET tag_id = ?
+WHERE tag_id IN `+inBinding+`
+AND NOT EXISTS(SELECT 1 FROM `+table+` o WHERE o.`+idColumn+` = `+table+`.`+idColumn+` AND o.tag_id = ?)`,
+			tagArgs...,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := qb.tx.Exec("UPDATE "+sceneMarkerTable+" SET primary_tag_id = ? WHERE primary_tag_id IN "+inBinding, args...)
+	if err != nil {
+		return err
+	}
+
+	_, err = qb.tx.Exec("INSERT INTO "+tagAliasesTable+" (tag_id, alias) SELECT ?, name FROM "+tagTable+" WHERE id IN "+inBinding, args...)
+	if err != nil {
+		return err
+	}
+
+	_, err = qb.tx.Exec("UPDATE "+tagAliasesTable+" SET tag_id = ? WHERE tag_id IN "+inBinding, args...)
+	if err != nil {
+		return err
+	}
+
+	for _, id := range source {
+		err = qb.Destroy(id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -474,14 +474,20 @@ export const MovieSelect: React.FC<IFilterProps> = (props) => {
   );
 };
 
-export const TagSelect: React.FC<IFilterProps> = (props) => {
+export const TagSelect: React.FC<IFilterProps & { excludeIds?: string[] }> = (
+  props
+) => {
   const [tagAliases, setTagAliases] = useState<Record<string, string[]>>({});
   const [allAliases, setAllAliases] = useState<string[]>([]);
   const { data, loading } = useAllTagsForFilter();
   const [createTag] = useTagCreate();
   const placeholder = props.noSelectionString ?? "Select tags...";
 
-  const tags = useMemo(() => data?.allTags ?? [], [data?.allTags]);
+  const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
+  const tags = useMemo(
+    () => (data?.allTags ?? []).filter((tag) => !exclude.includes(tag.id)),
+    [data?.allTags, exclude]
+  );
 
   useEffect(() => {
     // build the tag aliases map

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -10,7 +10,6 @@ import {
   useTagUpdate,
   useTagCreate,
   useTagDestroy,
-  mutateMetadataAutoTag,
 } from "src/core/StashService";
 import { ImageUtils } from "src/utils";
 import {
@@ -26,6 +25,7 @@ import { TagPerformersPanel } from "./TagPerformersPanel";
 import { TagGalleriesPanel } from "./TagGalleriesPanel";
 import { TagDetailsPanel } from "./TagDetailsPanel";
 import { TagEditPanel } from "./TagEditPanel";
+import { TagOperationsPanel } from "./TagOperationsPanel";
 
 interface ITabParams {
   id?: string;
@@ -57,7 +57,8 @@ export const Tag: React.FC = () => {
     tab === "markers" ||
     tab === "images" ||
     tab === "performers" ||
-    tab === "galleries"
+    tab === "galleries" ||
+    tab === "operations"
       ? tab
       : "scenes";
   const setActiveTabKey = (newTab: string | null) => {
@@ -144,16 +145,6 @@ export const Tag: React.FC = () => {
     }
   }
 
-  async function onAutoTag() {
-    if (!tag?.id) return;
-    try {
-      await mutateMetadataAutoTag({ tags: [tag.id] });
-      Toast.success({ content: "Started auto tagging" });
-    } catch (e) {
-      Toast.error(e);
-    }
-  }
-
   async function onDelete() {
     try {
       await deleteTag();
@@ -226,7 +217,6 @@ export const Tag: React.FC = () => {
               onSave={() => {}}
               onImageChange={() => {}}
               onClearImage={() => {}}
-              onAutoTag={onAutoTag}
               onDelete={onDelete}
             />
           </>
@@ -262,6 +252,9 @@ export const Tag: React.FC = () => {
             </Tab>
             <Tab eventKey="performers" title="Performers">
               <TagPerformersPanel tag={tag} />
+            </Tab>
+            <Tab eventKey="operations" title="Operations">
+              <TagOperationsPanel tag={tag} />
             </Tab>
           </Tabs>
         </div>

--- a/ui/v2.5/src/components/Tags/TagDetails/TagOperationsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagOperationsPanel.tsx
@@ -1,0 +1,35 @@
+import { Button, Form } from "react-bootstrap";
+import React from "react";
+import * as GQL from "src/core/generated-graphql";
+import { mutateMetadataAutoTag } from "src/core/StashService";
+import { useToast } from "src/hooks";
+
+interface ITagOperationsProps {
+  tag: Partial<GQL.TagDataFragment>;
+}
+
+export const TagOperationsPanel: React.FC<ITagOperationsProps> = ({ tag }) => {
+  const Toast = useToast();
+
+  async function onAutoTag() {
+    if (!tag?.id) return;
+    try {
+      await mutateMetadataAutoTag({ tags: [tag.id] });
+      Toast.success({ content: "Started auto tagging" });
+    } catch (e) {
+      Toast.error(e);
+    }
+  }
+
+  return (
+    <>
+      <h5>Auto Tagging</h5>
+      <Form.Group>
+        <Button onClick={onAutoTag}>Auto Tag</Button>
+        <Form.Text className="text-muted">
+          Auto-tag content based on filenames.
+        </Form.Text>
+      </Form.Group>
+    </>
+  );
+};

--- a/ui/v2.5/src/components/Tags/TagDetails/TagOperationsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagOperationsPanel.tsx
@@ -1,8 +1,11 @@
-import { Button, Form } from "react-bootstrap";
-import React from "react";
+import { Button, Form, Col, Row } from "react-bootstrap";
+import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
-import { mutateMetadataAutoTag } from "src/core/StashService";
+import { mutateMetadataAutoTag, useTagsMerge } from "src/core/StashService";
+import { Modal, TagSelect } from "src/components/Shared";
 import { useToast } from "src/hooks";
+import { FormUtils } from "src/utils";
 
 interface ITagOperationsProps {
   tag: Partial<GQL.TagDataFragment>;
@@ -10,6 +13,15 @@ interface ITagOperationsProps {
 
 export const TagOperationsPanel: React.FC<ITagOperationsProps> = ({ tag }) => {
   const Toast = useToast();
+  const history = useHistory();
+
+  const [mergeTags] = useTagsMerge();
+
+  const [mergeModalOpen, setMergeModalOpen] = useState<string | null>(null);
+  const [mergeSourceIds, setMergeSourceIds] = useState<string[]>([]);
+  const [mergeDestinationId, setMergeDestinationId] = useState<string | null>(
+    null
+  );
 
   async function onAutoTag() {
     if (!tag?.id) return;
@@ -21,6 +33,90 @@ export const TagOperationsPanel: React.FC<ITagOperationsProps> = ({ tag }) => {
     }
   }
 
+  async function onMerge() {
+    try {
+      const result = await mergeTags({
+        variables: {
+          source: mergeSourceIds,
+          destination: mergeDestinationId ?? "",
+        },
+      });
+      if (result.data?.tagsMerge) {
+        Toast.success({ content: "Merged tags" });
+        setMergeModalOpen(null);
+        history.push(`/tags/${mergeDestinationId}`);
+      }
+    } catch (e) {
+      Toast.error(e);
+    }
+  }
+
+  function renderMergeModal() {
+    return (
+      <>
+        <Modal
+          show={mergeModalOpen !== null}
+          icon={mergeModalOpen === "from" ? "sign-in-alt" : "sign-out-alt"}
+          accept={{ text: "Merge", onClick: onMerge }}
+          cancel={{
+            variant: "secondary",
+            onClick: () => setMergeModalOpen(null),
+          }}
+        >
+          <div className="form-container row px-3">
+            <div className="col-12 col-lg-6 col-xl-12">
+              {mergeModalOpen === "from" && (
+                <Form.Group controlId="source" as={Row}>
+                  {FormUtils.renderLabel({
+                    title: "Source",
+                    labelProps: {
+                      column: true,
+                      sm: 3,
+                      xl: 12,
+                    },
+                  })}
+                  <Col sm={9} xl={12}>
+                    <TagSelect
+                      isMulti
+                      creatable={false}
+                      onSelect={(items) =>
+                        setMergeSourceIds(items.map((item) => item.id))
+                      }
+                      ids={mergeSourceIds}
+                      excludeIds={tag?.id ? [tag.id] : []}
+                    />
+                  </Col>
+                </Form.Group>
+              )}
+              {mergeModalOpen === "into" && (
+                <Form.Group controlId="destination" as={Row}>
+                  {FormUtils.renderLabel({
+                    title: "Destination",
+                    labelProps: {
+                      column: true,
+                      sm: 3,
+                      xl: 12,
+                    },
+                  })}
+                  <Col sm={9} xl={12}>
+                    <TagSelect
+                      creatable={false}
+                      onSelect={(items) => setMergeDestinationId(items[0]?.id)}
+                      ids={
+                        mergeDestinationId ? [mergeDestinationId] : undefined
+                      }
+                      excludeIds={tag?.id ? [tag.id] : []}
+                    />
+                  </Col>
+                </Form.Group>
+              )}
+            </div>
+          </div>
+        </Modal>
+      </>
+    );
+  }
+
   return (
     <>
       <h5>Auto Tagging</h5>
@@ -30,6 +126,40 @@ export const TagOperationsPanel: React.FC<ITagOperationsProps> = ({ tag }) => {
           Auto-tag content based on filenames.
         </Form.Text>
       </Form.Group>
+
+      <hr />
+      <h5>Merging</h5>
+
+      <Form.Group>
+        <Button
+          onClick={() => {
+            setMergeSourceIds([]);
+            setMergeDestinationId(tag?.id ?? null);
+            setMergeModalOpen("from");
+          }}
+        >
+          Merge From
+        </Button>
+        <Form.Text className="text-muted">
+          Merge other tags into this tag.
+        </Form.Text>
+      </Form.Group>
+
+      <Form.Group>
+        <Button
+          onClick={() => {
+            setMergeSourceIds([tag.id as string]);
+            setMergeDestinationId(null);
+            setMergeModalOpen("into");
+          }}
+        >
+          Merge Into
+        </Button>
+        <Form.Text className="text-muted">
+          Merge this tag into another tag.
+        </Form.Text>
+      </Form.Group>
+      {renderMergeModal()}
     </>
   );
 };

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -680,6 +680,11 @@ export const useTagsDestroy = (input: GQL.TagsDestroyMutationVariables) =>
     update: deleteCache(tagMutationImpactedQueries),
   });
 
+export const useTagsMerge = () =>
+  GQL.useTagsMergeMutation({
+    update: deleteCache(tagMutationImpactedQueries),
+  });
+
 export const useConfigureGeneral = (input: GQL.ConfigGeneralInput) =>
   GQL.useConfigureGeneralMutation({
     variables: { input },


### PR DESCRIPTION
Add support for merging tags. Merging tags means that all usages of the source tag(s) will be updated to use the defined destination tag. Aliases set on the source tag(s) will be added to the destination as well and finally the name of the source(s) will also be added as alias to the destination. Afterwards the source tag(s) will be removed.

Fixes #918 