### PR TITLE
Fix sort by movies_scene_number

### DIFF
--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -673,7 +673,7 @@ func (qb *sceneQueryBuilder) setSceneSort(query *queryBuilder, findFilter *model
 	direction := findFilter.GetDirection()
 	switch sort {
 	case "movie_scene_number":
-		query.join(moviesScenesTable, "movies_join", "scenes.id")
+		query.join(moviesScenesTable, "movies_join", "scenes.id = movies_join.scene_id")
 		query.sortAndPagination += fmt.Sprintf(" ORDER BY movies_join.scene_index %s", getSortDirection(direction))
 	case "tag_count":
 		query.sortAndPagination += getCountSort(sceneTable, scenesTagsTable, sceneIDColumn, direction)


### PR DESCRIPTION
Fixes the sort by `movies_scene_number` in the scenes page.
The existing one did a complete join that took seconds and seemed to work because of the distinct in the select.