### PR TITLE
Small UI filter fixes

### DIFF
--- a/ui/v2.5/src/components/List/AddFilter.tsx
+++ b/ui/v2.5/src/components/List/AddFilter.tsx
@@ -227,6 +227,22 @@ export const AddFilter: React.FC<IAddFilterProps> = (
     );
   };
 
+  function maybeRenderFilterCriterion() {
+    if (!props.editingCriterion) {
+      return;
+    }
+
+    return (
+      <Form.Group>
+        <strong>
+          {intl.formatMessage({
+            id: props.editingCriterion.criterionOption.messageID,
+          })}
+        </strong>
+      </Form.Group>
+    );
+  }
+
   function maybeRenderFilterSelect() {
     if (props.editingCriterion) {
       return;
@@ -281,6 +297,7 @@ export const AddFilter: React.FC<IAddFilterProps> = (
         <Modal.Body>
           <div className="dialog-content">
             {maybeRenderFilterSelect()}
+            {maybeRenderFilterCriterion()}
             {maybeRenderFilterPopoverContents()}
           </div>
         </Modal.Body>

--- a/ui/v2.5/src/components/List/AddFilter.tsx
+++ b/ui/v2.5/src/components/List/AddFilter.tsx
@@ -239,7 +239,11 @@ export const AddFilter: React.FC<IAddFilterProps> = (
           text: intl.formatMessage({ id: c.messageID }),
         };
       })
-      .sort((a, b) => a.text.localeCompare(b.text));
+      .sort((a, b) => {
+        if (a.value === "none") return -1;
+        if (b.value === "none") return 1;
+        return a.text.localeCompare(b.text);
+      });
 
     return (
       <Form.Group controlId="filter">
@@ -251,7 +255,7 @@ export const AddFilter: React.FC<IAddFilterProps> = (
           className="btn-secondary"
         >
           {options.map((c) => (
-            <option key={c.value} value={c.value}>
+            <option key={c.value} value={c.value} disabled={c.value === "none"}>
               {c.text}
             </option>
           ))}

--- a/ui/v2.5/src/models/list-filter/criteria/interactive.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/interactive.ts
@@ -1,8 +1,8 @@
 import { BooleanCriterion, CriterionOption } from "./criterion";
 
 export const InteractiveCriterionOption = new CriterionOption(
-  "organized",
-  "organized"
+  "interactive",
+  "interactive"
 );
 
 export class InteractiveCriterion extends BooleanCriterion {


### PR DESCRIPTION
* Fix interactive filter name/value
* Place the `None` filter option above all other options and disable it, to make it clear that this is a placeholder and not an actual option that can be selected.
	[Image (SFW)](https://user-images.githubusercontent.com/66393006/120202945-dc49af00-c22f-11eb-97aa-c57c7974aaa6.png)
* Display current criterion when editing filter.
	[Image (SFW)](https://user-images.githubusercontent.com/66393006/120203010-f08dac00-c22f-11eb-9fc7-6e4c970e6c76.png)