### PR TITLE
Fix scene editing of scenes with stash_ids

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -108,7 +108,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
     }),
     tag_ids: (scene.tags ?? []).map((t) => t.id),
     cover_image: undefined,
-    stash_ids: scene.stash_ids ?? undefined,
+    stash_ids: (scene.stash_ids ?? []).map(s => ({
+        stash_id: s.stash_id,
+        endpoint: s.endpoint,
+    })),
   };
 
   type InputValues = typeof initialValues;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -108,9 +108,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
     }),
     tag_ids: (scene.tags ?? []).map((t) => t.id),
     cover_image: undefined,
-    stash_ids: (scene.stash_ids ?? []).map(s => ({
-        stash_id: s.stash_id,
-        endpoint: s.endpoint,
+    stash_ids: (scene.stash_ids ?? []).map((s) => ({
+      stash_id: s.stash_id,
+      endpoint: s.endpoint,
     })),
   };
 


### PR DESCRIPTION
The stash_id objects have `__typename` fields which have to be stripped out, otherwise graphql input validation fails.