### PR TITLE
Fix PluginCache initialisation

### DIFF
--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -192,6 +192,7 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 	if refreshScraperCache {
 		manager.GetInstance().RefreshScraperCache()
 	}
+	manager.GetInstance().PluginCache.ReloadPlugins()
 
 	return makeConfigGeneralResult(), nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -79,6 +79,7 @@ func Initialize() *singleton {
 			TXNManager: instance.TxnManager,
 		}
 		instance.DLNAService = dlna.NewService(instance.TxnManager, instance.Config, &sceneServer)
+		instance.PluginCache = initPluginCache()
 
 		if !cfg.IsNewSystem() {
 			logger.Infof("using config file: %s", cfg.GetConfigFile())


### PR DESCRIPTION
More of a hack/quickfix probably than a proper fix for #1469 
Feel free to edit/close if needed
The plugin reload in the config was added so that after the initial setup the plugins folder gets loaded properly (otherwise you would need to do a reload plugins or restart stash)