### PR TITLE
Fix exception when scene preview is unavailable

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -35,7 +35,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
       entries.forEach((entry) => {
         if (entry.intersectionRatio > 0)
           // Catch is necessary due to DOMException if user hovers before clicking on page
-          videoEl.current?.play().catch(() => {});
+          videoEl.current?.play()?.catch(() => {});
         else videoEl.current?.pause();
       });
     });


### PR DESCRIPTION
## Summary

This PR fixes an exception that occurs when the scene preview is not available. The problematic code was missing a null nav operator that can cause `undefined` to be propagated when calling `catch`.