### PR TITLE
Fix Performer Studio filtering

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -86,7 +86,7 @@ input PerformerFilterType {
   """Filter by death year"""
   death_year: IntCriterionInput
   """Filter by studios where performer appears in scene/image/gallery"""
-  studios: MultiCriterionInput
+  studios: HierarchicalMultiCriterionInput
 }
 
 input SceneMarkerFilterType {

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -746,7 +746,7 @@ func TestPerformerQueryStudio(t *testing.T) {
 		sqb := r.Performer()
 
 		for _, tc := range testCases {
-			studioCriterion := models.MultiCriterionInput{
+			studioCriterion := models.HierarchicalMultiCriterionInput{
 				Value: []string{
 					strconv.Itoa(studioIDs[tc.studioIndex]),
 				},
@@ -764,7 +764,7 @@ func TestPerformerQueryStudio(t *testing.T) {
 			// ensure id is correct
 			assert.Equal(t, performerIDs[tc.performerIndex], performers[0].ID)
 
-			studioCriterion = models.MultiCriterionInput{
+			studioCriterion = models.HierarchicalMultiCriterionInput{
 				Value: []string{
 					strconv.Itoa(studioIDs[tc.studioIndex]),
 				},

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -14,4 +16,19 @@ func RandomSequence(n int) string {
 		b[i] = characters[rand.Intn(len(characters))]
 	}
 	return string(b)
+}
+
+type StrFormatMap map[string]interface{}
+
+func StrFormat(format string, m StrFormatMap) string {
+	args := make([]string, len(m)*2)
+	i := 0
+
+	for k, v := range m {
+		args[i] = fmt.Sprintf("{%s}", k)
+		args[i+1] = fmt.Sprint(v)
+		i += 2
+	}
+
+	return strings.NewReplacer(args...).Replace(format)
 }

--- a/ui/v2.5/src/core/studios.ts
+++ b/ui/v2.5/src/core/studios.ts
@@ -15,16 +15,14 @@ export const studioFilterHook = (studio: Partial<GQL.StudioDataFragment>) => {
       (studioCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
         studioCriterion.modifier === GQL.CriterionModifier.Includes)
     ) {
-      // add the studio if not present
-      if (
-        !studioCriterion.value.items.find((p) => {
-          return p.id === studio.id;
-        })
-      ) {
+      // we should be showing studio only. Remove other values
+      studioCriterion.value.items = studioCriterion.value.items.filter(
+        (v) => v.id === studio.id
+      );
+
+      if (studioCriterion.value.items.length === 0) {
         studioCriterion.value.items.push(studioValue);
       }
-
-      studioCriterion.modifier = GQL.CriterionModifier.IncludesAll;
     } else {
       // overwrite
       studioCriterion = new StudiosCriterion();


### PR DESCRIPTION
Fixes #1482 

Applied the new hierarchical studio filtering for performer query. I've left the existing implementation in there for `depth = 0` since it seems more performant. I haven't spent a long time trying to improve performance. @gitgiggety if you get the chance could you take a look at the changes? I'll merge this in now so that at least the query should work correctly.

Also fixed issue with the UI studio hook that caused the wrong criterion modifier to be used.