### PR TITLE
Handle auto-tagging where filename has no whitespace in name

### DIFF
--- a/pkg/autotag/tagger.go
+++ b/pkg/autotag/tagger.go
@@ -87,7 +87,13 @@ func getPathWords(path string) []string {
 	var ret []string
 	for _, w := range words {
 		if len(w) > 1 {
-			ret = append(ret, w)
+			// #1450 - we need to open up the criteria for matching so that we
+			// can match where path has no space between subject names -
+			// ie name = "foo bar" - path = "foobar"
+			// we post-match afterwards, so we can afford to be a little loose
+			// with the query
+			// just use the first two characters
+			ret = append(ret, w[0:2])
 		}
 	}
 

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -185,9 +185,9 @@ func (qb *performerQueryBuilder) QueryForAutoTag(words []string) ([]*models.Perf
 
 	for _, w := range words {
 		whereClauses = append(whereClauses, "name like ?")
-		args = append(args, "%"+w+"%")
+		args = append(args, w+"%")
 		whereClauses = append(whereClauses, "aliases like ?")
-		args = append(args, "%"+w+"%")
+		args = append(args, w+"%")
 	}
 
 	where := strings.Join(whereClauses, " OR ")

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -132,7 +132,7 @@ func (qb *studioQueryBuilder) QueryForAutoTag(words []string) ([]*models.Studio,
 
 	for _, w := range words {
 		whereClauses = append(whereClauses, "name like ?")
-		args = append(args, "%"+w+"%")
+		args = append(args, w+"%")
 	}
 
 	where := strings.Join(whereClauses, " OR ")

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -214,7 +214,7 @@ func (qb *tagQueryBuilder) QueryForAutoTag(words []string) ([]*models.Tag, error
 	var args []interface{}
 
 	for _, w := range words {
-		ww := "%" + w + "%"
+		ww := w + "%"
 		whereClauses = append(whereClauses, "tags.name like ?")
 		args = append(args, ww)
 

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -18,6 +18,7 @@
 * Add button to remove studio stash ID. ([#1378](https://github.com/stashapp/stash/pull/1378))
 
 ### 🐛 Bug fixes
+* Fix auto-tagger not tagging scenes with no whitespace in name. ([#1488](https://github.com/stashapp/stash/pull/1488))
 * Fix click/drag to select scenes. ([#1476](https://github.com/stashapp/stash/pull/1476))
 * Fix clearing Performer and Movie ratings not working. ([#1429](https://github.com/stashapp/stash/pull/1429))
 * Fix scraper date parser failing when parsing time. ([#1431](https://github.com/stashapp/stash/pull/1431))


### PR DESCRIPTION
Fixes #1450 

Loosens the auto-tag performer/studio/tag database query so that it queries by the first to characters of each path word, rather than the entire path word.

For example, take the following scene path name: `dir/scene.foobar.mp4` and the performer name `foo bar`.

The existing query would search for performers where name like `%dir%`, `%scene%`, and `%foobar%`. This will not match performer `foo bar`.

The new query will search where name like `di%`, `sc%` and `fo%`. This will return false positives, but we perform a more expensive regex match on the names returned anyway. 

One alternative method that I used was to get all of the performer names and perform the regex. Even when caching the performer names and regex patterns, it was still prohibitively slow. I am hoping this will be a decent compromise.