### PR TITLE
Disable float-on-scroll behavior for jwplayer

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -296,9 +296,10 @@ export class ScenePlayerImpl extends React.Component<
       image: scene.paths.screenshot,
       width: "100%",
       height: "100%",
-      floating: {
-        dismissible: true,
-      },
+      // FIXME: Enabling this in jwplayer 8.11.5 causes full screen in mobile to default to picture-in-picture
+      // floating: {
+      //   dismissible: true,
+      // },
       cast: {},
       primary: "html5",
       autostart:


### PR DESCRIPTION
Fixes #1440

Narrowed down a possible solution to the bug causing mobile full screen in ScenePlayer to default to a floating window. I have built and tested that this fixes the fullscreen issue, but I'm not sure what this feature was originally enabled for. 

Before (notice the blurred background of floating window behavior):
![121628884-f99c2b80-ca2e-11eb-8a13-40043d7f3b71 (1)](https://user-images.githubusercontent.com/59550864/121629431-f9e8f680-ca2f-11eb-8c6e-166658b56912.png)

After:
![image](https://user-images.githubusercontent.com/59550864/121629262-a8406c00-ca2f-11eb-82c3-9b41ad85587a.png)


[Float On Scroll](https://developer.jwplayer.com/jwplayer/docs/jw8-player-configuration-reference#float-on-scroll) configuration reference.
