### PR TITLE
Include server host in plugin input

### DIFF
--- a/pkg/plugin/common/msg.go
+++ b/pkg/plugin/common/msg.go
@@ -11,8 +11,8 @@ const (
 type StashServerConnection struct {
 	// http or https
 	Scheme string
-
-	Port int
+	Host   string
+	Port   int
 
 	// Cookie for authentication purposes
 	SessionCookie *http.Cookie

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -127,6 +127,7 @@ func (c Cache) makeServerConnection(ctx context.Context) common.StashServerConne
 
 	serverConnection := common.StashServerConnection{
 		Scheme:        "http",
+		Host:          c.config.GetHost(),
 		Port:          c.config.GetPort(),
 		SessionCookie: cookie,
 		Dir:           c.config.GetConfigPath(),

--- a/pkg/plugin/util/client.go
+++ b/pkg/plugin/util/client.go
@@ -19,7 +19,7 @@ import (
 func NewClient(provider common.StashServerConnection) *graphql.Client {
 	portStr := strconv.Itoa(provider.Port)
 
-	u, _ := url.Parse("http://localhost:" + portStr + "/graphql")
+	u, _ := url.Parse("http://" + provider.Host + ":" + portStr + "/graphql")
 	u.Scheme = provider.Scheme
 
 	cookieJar, _ := cookiejar.New(nil)

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -11,6 +11,7 @@
 * Added [DLNA server](/settings?tab=dlna). ([#1364](https://github.com/stashapp/stash/pull/1364))
 
 ### 🎨 Improvements
+* Include `Host` in input to plugins. ([#1514](https://github.com/stashapp/stash/pull/1514))
 * Added internationalisation for all UI pages and added zh-TW language option. ([#1471](https://github.com/stashapp/stash/pull/1471))
 * Add option to disable audio for generated previews. ([#1454](https://github.com/stashapp/stash/pull/1454))
 * Prompt when leaving scene edit page with unsaved changes. ([#1429](https://github.com/stashapp/stash/pull/1429))


### PR DESCRIPTION
Resolves #1155 

Adds `Host` to the `StashServerConnection` structure provided to plugins.