### PR TITLE
Clear scene tagger results on new search

### DIFF
--- a/ui/v2.5/src/components/Tagger/Tagger.tsx
+++ b/ui/v2.5/src/components/Tagger/Tagger.tsx
@@ -195,7 +195,17 @@ const TaggerList: React.FC<ITaggerListProps> = ({
     inputForm?.current?.reset();
   }, [config.mode, config.blacklist]);
 
+  function clearSceneSearchResult(sceneID: string) {
+    // remove sceneID results from the results object
+    const { [sceneID]: _removedResult, ...newSearchResults } = searchResults;
+    const { [sceneID]: _removedError, ...newSearchErrors } = searchErrors;
+    setSearchResults(newSearchResults);
+    setSearchErrors(newSearchErrors);
+  }
+
   const doBoxSearch = (sceneID: string, searchVal: string) => {
+    clearSceneSearchResult(sceneID);
+
     stashBoxSceneQuery(searchVal, selectedEndpoint.index)
       .then((queryData) => {
         const s = selectScenes(queryData.data?.queryStashBoxScene);

--- a/ui/v2.5/src/models/list-filter/criteria/factory.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/factory.ts
@@ -49,7 +49,7 @@ export function makeCriteria(type: CriterionType = "none") {
     case "checksum":
     case "oshash":
       return new StringCriterion(
-        new MandatoryStringCriterionOption(type, type)
+        new MandatoryStringCriterionOption("media_info.hash", type, type)
       );
     case "rating":
       return new NumberCriterion(RatingCriterionOption);


### PR DESCRIPTION
Clears tagger results for a scene when beginning a new search.
Fixes #1494 

Also fixes a minor oshash message ID problem.