### PR TITLE
Add sprite to SceneData fragment

### DIFF
--- a/graphql/documents/data/scene.graphql
+++ b/graphql/documents/data/scene.graphql
@@ -31,6 +31,7 @@ fragment SceneData on Scene {
     webp
     vtt
     chapters_vtt
+    sprite
     funscript
   }
 

--- a/ui/v2.5/src/components/Changelog/versions/v080.md
+++ b/ui/v2.5/src/components/Changelog/versions/v080.md
@@ -27,6 +27,7 @@
 * Add button to remove studio stash ID. ([#1378](https://github.com/stashapp/stash/pull/1378))
 
 ### 🐛 Bug fixes
+* Fix scene query not being cached correctly when navigating using back. ([#1533](https://github.com/stashapp/stash/pull/1533))
 * Fix query with multiple table joins causing invalid query SQL. ([#1510](https://github.com/stashapp/stash/pull/1510))
 * Fix file move detection when case of filename is changed on case-insensitive file systems. ([#1426](https://github.com/stashapp/stash/issues/1426))
 * Fix auto-tagger not tagging scenes with no whitespace in name. ([#1488](https://github.com/stashapp/stash/pull/1488))


### PR DESCRIPTION
Necessary so that TypePolicies object is populated correctly.

Fixes #1442 