### PR TITLE
Tag stable versions with the version number on Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,4 +182,4 @@ jobs:
         docker buildx create --name builder --use
         docker buildx inspect --bootstrap
         docker buildx ls
-        bash ./docker/ci/x86_64/docker_push.sh latest
+        bash ./docker/ci/x86_64/docker_push.sh latest "${{ github.event.release.tag_name }}"

--- a/docker/ci/x86_64/docker_push.sh
+++ b/docker/ci/x86_64/docker_push.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-DOCKER_TAG=$1
+DOCKER_TAGS=""
+
+for TAG in "$@"
+do
+	DOCKER_TAGS="$DOCKER_TAGS -t stashapp/stash:$TAG"
+done
+
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 # must build the image from dist directory
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --output type=image,name=stashapp/stash:$DOCKER_TAG,push=true -f docker/ci/x86_64/Dockerfile dist/
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push $DOCKER_TAGS -f docker/ci/x86_64/Dockerfile dist/
 


### PR DESCRIPTION
Fixes #1546

Obviously only partially tested as I can't push tags nor execute the GitHub Actions workflow. But executing docker script using `--load` instead of `--push`, in combination with multiple args, builds the image builds just fine and imports it under both tags into my local docker daemon.