### PR TITLE
Add script offset / delay to Handy support.

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -55,6 +55,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   language
   slideshowDelay
   handyKey
+  scriptOffset
 }
 
 fragment ConfigDLNAData on ConfigDLNAResult {

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -196,6 +196,8 @@ input ConfigInterfaceInput {
   slideshowDelay: Int
   """Handy Connection Key"""
   handyKey: String
+  """Funscript Time Offset"""
+  scriptOffset: Int
 }
 
 type ConfigInterfaceResult {
@@ -222,6 +224,8 @@ type ConfigInterfaceResult {
   slideshowDelay: Int
   """Handy Connection Key"""
   handyKey: String
+  """Funscript Time Offset"""
+  scriptOffset: Int
 }
 
 input ConfigDLNAInput {

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -253,6 +253,10 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input models.
 		c.Set(config.HandyKey, *input.HandyKey)
 	}
 
+	if input.ScriptOffset != nil {
+		c.Set(config.ScriptOffset, *input.ScriptOffset)
+	}
+
 	if err := c.Write(); err != nil {
 		return makeConfigInterfaceResult(), err
 	}

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -105,6 +105,7 @@ func makeConfigInterfaceResult() *models.ConfigInterfaceResult {
 	language := config.GetLanguage()
 	slideshowDelay := config.GetSlideshowDelay()
 	handyKey := config.GetHandyKey()
+	scriptOffset := config.GetScriptOffset()
 
 	return &models.ConfigInterfaceResult{
 		MenuItems:           menuItems,
@@ -119,6 +120,7 @@ func makeConfigInterfaceResult() *models.ConfigInterfaceResult {
 		Language:            &language,
 		SlideshowDelay:      &slideshowDelay,
 		HandyKey:            &handyKey,
+		ScriptOffset:        &scriptOffset,
 	}
 }
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -127,6 +127,7 @@ const CSSEnabled = "cssEnabled"
 const WallPlayback = "wall_playback"
 const SlideshowDelay = "slideshow_delay"
 const HandyKey = "handy_key"
+const ScriptOffset = "script_offset"
 
 // DLNA options
 const DLNAServerName = "dlna.server_name"
@@ -651,6 +652,11 @@ func (i *Instance) GetCSSEnabled() bool {
 
 func (i *Instance) GetHandyKey() string {
 	return viper.GetString(HandyKey)
+}
+
+func (i *Instance) GetScriptOffset() int {
+	viper.SetDefault(ScriptOffset, 0)
+	return viper.GetInt(ScriptOffset)
 }
 
 // GetDLNAServerName returns the visible name of the DLNA server. If empty,

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -54,7 +54,9 @@ export class ScenePlayerImpl extends React.Component<
     this.state = {
       scrubberPosition: 0,
       config: this.makeJWPlayerConfig(props.scene),
-      interactiveClient: new Interactive(this.props.config?.handyKey || ""),
+      interactiveClient: new Interactive(
+        this.props.config?.handyKey || "",
+        this.props.config?.scriptOffset || 0),
     };
 
     // Default back to Direct Streaming

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -37,6 +37,7 @@ export const SettingsInterfacePanel: React.FC = () => {
   const [cssEnabled, setCSSEnabled] = useState<boolean>(false);
   const [language, setLanguage] = useState<string>("en");
   const [handyKey, setHandyKey] = useState<string>();
+  const [scriptOffset, setScriptOffset] = useState<number>(0);
 
   const [updateInterfaceConfig] = useConfigureInterface({
     menuItems: menuItemIds,
@@ -51,6 +52,7 @@ export const SettingsInterfacePanel: React.FC = () => {
     language,
     slideshowDelay,
     handyKey,
+    scriptOffset,
   });
 
   useEffect(() => {
@@ -67,6 +69,7 @@ export const SettingsInterfacePanel: React.FC = () => {
     setLanguage(iCfg?.language ?? "en-US");
     setSlideshowDelay(iCfg?.slideshowDelay ?? 5000);
     setHandyKey(iCfg?.handyKey ?? "");
+    setScriptOffset(iCfg?.scriptOffset ?? 0);
   }, [config]);
 
   async function onSave() {
@@ -277,7 +280,7 @@ export const SettingsInterfacePanel: React.FC = () => {
       </Form.Group>
 
       <Form.Group>
-        <h5>{intl.formatMessage({ id: "config.ui.handy_connection_key" })}</h5>
+        <h5>{intl.formatMessage({ id: "config.ui.handy_connection_key.heading" })}</h5>
         <Form.Control
           className="col col-sm-6 text-input"
           value={handyKey}
@@ -286,7 +289,25 @@ export const SettingsInterfacePanel: React.FC = () => {
           }}
         />
         <Form.Text className="text-muted">
-          {intl.formatMessage({ id: "config.ui.handy_connection_key_desc" })}
+          {intl.formatMessage({ id: "config.ui.handy_connection_key.description" })}
+        </Form.Text>
+      </Form.Group>
+      <Form.Group>
+        <h5>
+          {intl.formatMessage({ id: "config.ui.script_offset.heading" })}
+        </h5>
+        <Form.Control
+          className="col col-sm-6 text-input"
+          type="number"
+          value={scriptOffset}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setScriptOffset(
+              Number.parseInt(e.currentTarget.value, 10)
+            );
+          }}
+        />
+        <Form.Text className="text-muted">
+          {intl.formatMessage({ id: "config.ui.script_offset.description" })}
         </Form.Text>
       </Form.Group>
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -307,8 +307,14 @@
         "heading": "Custom CSS",
         "option_label": "Custom CSS enabled"
       },
-      "handy_connection_key": "Handy Connection Key",
-      "handy_connection_key_desc": "Handy connection key to use for interactive scenes.",
+      "handy_connection_key": {
+        "description": "Handy connection key to use for interactive scenes.",
+        "heading": "Handy Connection Key"
+      },
+      "script_offset": {
+        "description": "Time offset in milliseconds for interactive scripts playback.",
+        "heading": "Funscript Offset (ms)"
+      },
       "language": {
         "heading": "Language"
       },

--- a/ui/v2.5/src/locales/zh-TW.json
+++ b/ui/v2.5/src/locales/zh-TW.json
@@ -296,8 +296,10 @@
         "heading": "自定義 CSS",
         "option_label": "啟用自定義 CSS"
       },
-      "handy_connection_key": "Handy 連線金鑰",
-      "handy_connection_key_desc": "播放支援互動性的短片時所用的 Handy 連線金鑰。",
+      "handy_connection_key": {
+        "description": "播放支援互動性的短片時所用的 Handy 連線金鑰。",
+        "heading": "Handy 連線金鑰"
+      },
       "language": {
         "heading": "語言"
       },

--- a/ui/v2.5/src/utils/interactive.ts
+++ b/ui/v2.5/src/utils/interactive.ts
@@ -26,11 +26,13 @@ function convertFunscriptToCSV(funscript: IFunscript) {
 export class Interactive {
   private _connected: boolean;
   private _playing: boolean;
+  private _scriptOffset: number;
   private _handy: Handy;
 
-  constructor(handyKey: string) {
+  constructor(handyKey: string, scriptOffset: number) {
     this._handy = new Handy();
     this._handy.connectionKey = handyKey;
+    this._scriptOffset = scriptOffset;
     this._connected = false;
     this._playing = false;
   }
@@ -76,7 +78,7 @@ export class Interactive {
       return;
     }
     this._playing = await this._handy
-      .syncPlay(true, Math.round(position * 1000))
+      .syncPlay(true, Math.round(position * 1000 + this._scriptOffset))
       .then(() => true);
   }
 


### PR DESCRIPTION
Further work on  #1376.

Offsets are added to the current video position, so a positive value leads to earlier motion.  (The most common setting.)

This is needed because most script times have a consistent delay when compared to the video. (Delay from the API calls to the server should be handled by the server offset calculation.)