### PR TITLE
Add target="_blank"  to links.

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -46,7 +46,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="path" />
         </span>
-        <a href={`file://${path}`} className="col-8">
+        <a href={`file://${path}`} className="col-8" target="_blank">
           <TruncatedText text={`file://${props.scene.path}`} />
         </a>{" "}
       </div>
@@ -59,7 +59,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="media_info.stream" />
         </span>
-        <a href={props.scene.paths.stream ?? ""} className="col-8">
+        <a href={props.scene.paths.stream ?? ""} className="col-8" target="_blank">
           <TruncatedText text={props.scene.paths.stream} />
         </a>{" "}
       </div>
@@ -203,7 +203,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="media_info.downloaded_from" />
         </span>
-        <a href={TextUtils.sanitiseURL(props.scene.url)} className="col-8">
+        <a href={TextUtils.sanitiseURL(props.scene.url)} className="col-8" target="_blank">
           <TruncatedText text={props.scene.url} />
         </a>
       </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -46,7 +46,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="path" />
         </span>
-        <a href={`file://${path}`} className="col-8" target="_blank">
+        <a href={`file://${path}`} className="col-8" target="_blank" rel="noreferrer">
           <TruncatedText text={`file://${props.scene.path}`} />
         </a>{" "}
       </div>
@@ -59,7 +59,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="media_info.stream" />
         </span>
-        <a href={props.scene.paths.stream ?? ""} className="col-8" target="_blank">
+        <a href={props.scene.paths.stream ?? ""} className="col-8" target="_blank" rel="noreferrer">
           <TruncatedText text={props.scene.paths.stream} />
         </a>{" "}
       </div>
@@ -203,7 +203,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         <span className="col-4">
           <FormattedMessage id="media_info.downloaded_from" />
         </span>
-        <a href={TextUtils.sanitiseURL(props.scene.url)} className="col-8" target="_blank">
+        <a href={TextUtils.sanitiseURL(props.scene.url)} className="col-8" target="_blank" rel="noreferrer">
           <TruncatedText text={props.scene.url} />
         </a>
       </div>


### PR DESCRIPTION
"Path", "Stream" and "Downloaded From" links in File Info screen will now open in new tab/window. 


![pull_request-LINKS](https://user-images.githubusercontent.com/66418211/128379801-092e46ed-d2b8-45fc-892d-d224be73df9c.png)


Links in the current version opens in the same tab/window which Stash runs.