### PR TITLE
Fix dropdown menus z-index issue

### DIFF
--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -133,7 +133,7 @@ textarea.scene-description {
   position: absolute;
   right: 0.7rem;
   top: 0.7rem;
-  z-index: 9;
+  z-index: 8;
 
   .image-thumbnail {
     height: auto;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -229,7 +229,7 @@ div.react-select__menu,
 div.dropdown-menu {
   background-color: $secondary;
   color: $text-color;
-  z-index: 3;
+  z-index: 16;
 
   .react-select__option,
   .dropdown-item {


### PR DESCRIPTION
CSS change only: Fixes the z-index problem introduced a week ago, pictured below.

![Screenshot from 2021-08-10 03-06-39](https://user-images.githubusercontent.com/84814418/128849929-db304f09-dc09-43ff-a1f0-e7dbcc22c4ae.png)
