### PR TITLE
Add scene queue keyboard shortcuts

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v090.md
+++ b/ui/v2.5/src/components/Changelog/versions/v090.md
@@ -7,6 +7,7 @@
 * Added not equals/greater than/less than modifiers for resolution criteria. ([#1568](https://github.com/stashapp/stash/pull/1568))
 
 ### 🎨 Improvements
+* Added keyboard shortcuts for scene queue navigation. ([#1635](https://github.com/stashapp/stash/pull/1635))
 * Improve Studio UI. ([#1629](https://github.com/stashapp/stash/pull/1629))
 * Improve link styling and ensure links open in a new tab. ([#1622](https://github.com/stashapp/stash/pull/1622))
 * Added zh-CN language option. ([#1620](https://github.com/stashapp/stash/pull/1620))

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -291,7 +291,9 @@ export const Scene: React.FC = () => {
       const { query } = sceneQueue;
       const pages = Math.ceil(queueTotal / query.itemsPerPage);
       const page = Math.floor(Math.random() * pages) + 1;
-      const index = Math.floor(Math.random() * query.itemsPerPage);
+      const index = Math.floor(
+        Math.random() * Math.min(query.itemsPerPage, queueTotal)
+      );
       const filterCopy = sceneQueue.query.clone();
       filterCopy.currentPage = page;
       const queryResults = await queryFindScenes(filterCopy);
@@ -554,17 +556,25 @@ export const Scene: React.FC = () => {
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("a", () => setActiveTabKey("scene-details-panel"));
+    Mousetrap.bind("q", () => setActiveTabKey("scene-queue-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("scene-edit-panel"));
     Mousetrap.bind("k", () => setActiveTabKey("scene-markers-panel"));
     Mousetrap.bind("f", () => setActiveTabKey("scene-file-info-panel"));
     Mousetrap.bind("o", () => onIncrementClick());
+    Mousetrap.bind("p n", () => onQueueNext());
+    Mousetrap.bind("p p", () => onQueuePrevious());
+    Mousetrap.bind("p r", () => onQueueRandom());
 
     return () => {
       Mousetrap.unbind("a");
+      Mousetrap.unbind("q");
       Mousetrap.unbind("e");
       Mousetrap.unbind("k");
       Mousetrap.unbind("f");
       Mousetrap.unbind("o");
+      Mousetrap.unbind("p n");
+      Mousetrap.unbind("p p");
+      Mousetrap.unbind("p r");
     };
   });
 

--- a/ui/v2.5/src/docs/en/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/KeyboardShortcuts.md
@@ -54,10 +54,14 @@
 | Keyboard sequence | Action |
 |-------------------|--------|
 | `a` | Details tab |
+| `q` | Queue tab |
 | `k` | Markers tab |
 | `f` | File info tab |
 | `e` | Edit tab |
 | `o` | Increment O-Counter |
+| `p n` | Play next scene in queue |
+| `p p` | Play previous scene in queue |
+| `p r` | Play random scene in queue |
 
 ### Scene Markers tab shortcuts
 


### PR DESCRIPTION
Resolves #1423 

Adds shortcut to queue tab (`q`), play next scene in queue (`p n`), previous scene (`p p`), and play random scene in queue (`p r`).