### PR TITLE
Order sceneDuplicateChecker results by size

### DIFF
--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -68,13 +68,15 @@ SELECT GROUP_CONCAT(id) as ids
 FROM scenes
 WHERE phash IS NOT NULL
 GROUP BY phash
-HAVING COUNT(*) > 1;
+HAVING COUNT(phash) > 1
+ORDER BY SUM(size) DESC;
 `
 
 var findAllPhashesQuery = `
 SELECT id, phash
 FROM scenes
 WHERE phash IS NOT NULL
+ORDER BY size DESC
 `
 
 type sceneQueryBuilder struct {

--- a/ui/v2.5/src/components/Changelog/versions/v090.md
+++ b/ui/v2.5/src/components/Changelog/versions/v090.md
@@ -9,6 +9,7 @@
 * Added not equals/greater than/less than modifiers for resolution criteria. ([#1568](https://github.com/stashapp/stash/pull/1568))
 
 ### 🎨 Improvements
+* Show largest duplicates first in scene duplicate checker. ([#1639](https://github.com/stashapp/stash/pull/1639))
 * Added checkboxes to scene list view. ([#1642](https://github.com/stashapp/stash/pull/1642))
 * Added keyboard shortcuts for scene queue navigation. ([#1635](https://github.com/stashapp/stash/pull/1635))
 * Made performer scrape menu scrollable. ([#1634](https://github.com/stashapp/stash/pull/1634))


### PR DESCRIPTION
Right now, the scene duplicate checker results are ordered randomly / by insert order. As the duplicate checker is primarily a space saver tool, this increases its usefulness by ordering results by potential size savings.

Before, small files up front:
![Screenshot_20210815-225825_1_1](https://user-images.githubusercontent.com/84814418/129518066-b1a63faf-6d33-4f0b-96e3-11f3cc391747.jpg)


After, large files up front:
![Screenshot_20210815-224758_1](https://user-images.githubusercontent.com/84814418/129517892-d279974b-5016-4af0-83fc-fbf17e085a44.jpg)

Related https://github.com/stashapp/stash/issues/1220