### PR TITLE
Fix hierarchical criteria performance issue

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v090.md
+++ b/ui/v2.5/src/components/Changelog/versions/v090.md
@@ -19,6 +19,7 @@
 * Added de-DE language option. ([#1578](https://github.com/stashapp/stash/pull/1578))
 
 ### 🐛 Bug fixes
+* Fix performance issue on Studios page getting studio image count. ([#1643](https://github.com/stashapp/stash/pull/1643))
 * Regenerate scene phash if overwrite flag is set. ([#1633](https://github.com/stashapp/stash/pull/1633))
 * Create .stash directory in $HOME only if required. ([#1623](https://github.com/stashapp/stash/pull/1623))
 * Include stash id when scraping performer from stash-box. ([#1608](https://github.com/stashapp/stash/pull/1608))


### PR DESCRIPTION
Don't apply recursive clause to hierarchical criteria when the depth is set to 0 (i.e.: no recursion is needed).

This undoes the current performance penalty on for example the studios page. This as reported in #1519, using a database of 4M images, 30K scenes and 500 studios. Without this fix loading the studios overview, with the default of 40 items per page, takes 6 to 7 seconds. With this fix it only takes 0,07 seconds reverting the performance back to the pre-hierarchical filtering performance (tested against 508f7b84 which was the last commit before #1397 was merged).