### PR TITLE
Add option to filename parser to skip organized scenes

### DIFF
--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -125,7 +125,8 @@ type FindScenesResultType {
 input SceneParserInput {
   ignoreWords: [String!],
   whitespaceCharacters: String,
-  capitalizeTitle: Boolean
+  capitalizeTitle: Boolean,
+  ignoreOrganized: Boolean
 }
 
 type SceneMovieID {

--- a/pkg/manager/filename_parser.go
+++ b/pkg/manager/filename_parser.go
@@ -484,6 +484,11 @@ func (p *SceneFilenameParser) Parse(repo models.ReaderRepository) ([]*models.Sce
 		},
 	}
 
+	if p.ParserInput.IgnoreOrganized != nil && *p.ParserInput.IgnoreOrganized {
+		organized := false
+		sceneFilter.Organized = &organized
+	}
+
 	p.Filter.Q = nil
 
 	scenes, total, err := repo.Scene().Query(sceneFilter, p.Filter)

--- a/ui/v2.5/src/components/SceneFilenameParser/ParserInput.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/ParserInput.tsx
@@ -63,6 +63,7 @@ export interface IParserInput {
   page: number;
   pageSize: number;
   findClicked: boolean;
+  ignoreOrganized: boolean;
 }
 
 interface IParserRecipe {
@@ -95,6 +96,9 @@ export const ParserInput: React.FC<IParserInputProps> = (
   const [capitalizeTitle, setCapitalizeTitle] = useState<boolean>(
     props.input.capitalizeTitle
   );
+  const [ignoreOrganized, setIgnoreOrganized] = useState<boolean>(
+    props.input.ignoreOrganized
+  );
 
   function onFind() {
     props.onFind({
@@ -105,6 +109,7 @@ export const ParserInput: React.FC<IParserInputProps> = (
       page: 1,
       pageSize: props.input.pageSize,
       findClicked: props.input.findClicked,
+      ignoreOrganized,
     });
   }
 
@@ -223,6 +228,20 @@ export const ParserInput: React.FC<IParserInputProps> = (
         <Form.Label htmlFor="capitalize-title">
           {intl.formatMessage({
             id: "config.tools.scene_filename_parser.capitalize_title",
+          })}
+        </Form.Label>
+      </Form.Group>
+      <Form.Group>
+        <Form.Check
+          inline
+          className="m-0"
+          id="ignore-organized"
+          checked={ignoreOrganized}
+          onChange={() => setIgnoreOrganized(!ignoreOrganized)}
+        />
+        <Form.Label htmlFor="ignore-organized">
+          {intl.formatMessage({
+            id: "config.tools.scene_filename_parser.ignore_organized",
           })}
         </Form.Label>
       </Form.Group>

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneFilenameParser.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneFilenameParser.tsx
@@ -24,6 +24,7 @@ const initialParserInput = {
   page: 1,
   pageSize: 20,
   findClicked: false,
+  ignoreOrganized: true,
 };
 
 const initialShowFieldsState = new Map<string, boolean>([
@@ -127,6 +128,7 @@ export const SceneFilenameParser: React.FC = () => {
       ignoreWords: parserInput.ignoreWords,
       whitespaceCharacters: parserInput.whitespaceCharacters,
       capitalizeTitle: parserInput.capitalizeTitle,
+      ignoreOrganized: parserInput.ignoreOrganized,
     };
 
     queryParseSceneFilenames(parserFilter, parserInputData)

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -295,6 +295,7 @@
         "escape_chars": "Use \\ to escape literal characters",
         "filename": "Filename",
         "filename_pattern": "Filename Pattern",
+        "ignore_organized": "Ignore organised scenes",
         "ignored_words": "Ignored words",
         "matches_with": "Matches with {i}",
         "select_parser_recipe": "Select Parser Recipe",

--- a/ui/v2.5/src/locales/en-US.json
+++ b/ui/v2.5/src/locales/en-US.json
@@ -2,5 +2,10 @@
   "eye_color": "Eye Color",
   "favourite": "Favorite",
   "hair_color": "Hair Color",
-  "organized": "Organized"
+  "organized": "Organized",
+  "tools": {
+    "scene_filename_parser": {
+      "ignore_organized": "Ignore organized scenes"
+    }
+  }
 }


### PR DESCRIPTION
Opted to set the setting in the UI to "on" by default, while it's optional in the API and defaults to "false". This to be backwards compatible to API clients, while making this the new default in the UI. If desired this can obviously be changed easily.

Fixes #1219