### PR TITLE
Set NORMAL sync on sqlite3

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -91,7 +91,7 @@ func Initialize(databasePath string) error {
 
 func open(databasePath string, disableForeignKeys bool) *sqlx.DB {
 	// https://github.com/mattn/go-sqlite3
-	url := "file:" + databasePath + "?_journal=WAL"
+	url := "file:" + databasePath + "?_journal=WAL&_sync=NORMAL"
 	if !disableForeignKeys {
 		url += "&_fk=true"
 	}


### PR DESCRIPTION
NORMAL sync is safe when using WAL journaliing.

It cuts the amount of sync calls to the disk, resulting in faster write
operation. On power loss, the database will perhaps lose some ongoing
commits, but that is all.

The expectation is that if the database lives on the same disk as the
stash, this could help performance quite a bit under heavier operation.