### PR TITLE
Add container_name to docker compose

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -6,7 +6,11 @@ services:
     image: stashapp/stash:latest
     container_name: stash
     restart: unless-stopped
-    network_mode: host
+    ## the container's port must be the same with the STASH_PORT in the environment section
+    ports:
+      - "9999:9999"
+    ## If you intend to use stash's DLNA functionality uncomment the below network mode and comment out the above ports section
+    # network_mode: host
     logging:
       driver: "json-file"
       options:

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -4,9 +4,9 @@ version: '3.4'
 services:
   stash:
     image: stashapp/stash:latest
+    container_name: stash
     restart: unless-stopped
-    ports:
-      - "9999:9999"
+    network_mode: host
     logging:
       driver: "json-file"
       options:

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - STASH_GENERATED=/generated/
       - STASH_METADATA=/metadata/
       - STASH_CACHE=/cache/
+      ## Adjust below to change default port (9999)
+      - STASH_PORT=9999
     volumes:
       - /etc/localtime:/etc/localtime:ro
       ## Adjust below paths (the left part) to your liking.


### PR DESCRIPTION
Setting container_name will set the container name to "stash" instead of the stack and container name ie "stash-stash-1".
For DLNA support we need to change from port mapping to host networking for this to work with docker.