### PR TITLE
Update path field via SceneUpdate

### DIFF
--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -70,6 +70,7 @@ input SceneUpdateInput {
   rating: Int
   organized: Boolean
   studio_id: ID
+  path: String
   gallery_ids: [ID!]
   performer_ids: [ID!]
   movies: [SceneMovieInput!]
@@ -100,6 +101,7 @@ input BulkSceneUpdateInput {
   rating: Int
   organized: Boolean
   studio_id: ID
+  path: String
   gallery_ids: BulkUpdateIds
   performer_ids: BulkUpdateIds
   tag_ids: BulkUpdateIds

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -257,6 +257,10 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input models.Bul
 	updatedScene.StudioID = translator.nullInt64FromString(input.StudioID, "studio_id")
 	updatedScene.Organized = input.Organized
 
+	if input.Path != nil && *input.Path != "" {
+		updatedScene.Path = input.Path
+	}
+
 	ret := []*models.Scene{}
 
 	// Start the transaction and save the scene marker

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -108,6 +108,10 @@ func (r *mutationResolver) sceneUpdate(input models.SceneUpdateInput, translator
 	updatedScene.StudioID = translator.nullInt64FromString(input.StudioID, "studio_id")
 	updatedScene.Organized = input.Organized
 
+	if input.Path != nil && *input.Path != "" {
+		updatedScene.Path = input.Path
+	}
+
 	if input.CoverImage != nil && *input.CoverImage != "" {
 		var err error
 		coverImageData, err = utils.ProcessImageInput(*input.CoverImage)


### PR DESCRIPTION
Hi there, this is my first PR for this project, so please be kind! 😄 

This PR adds the `Path` field to the `sceneUpdate()` and `BulkSceneUpdate()` API functions as requested in #601.

Following @stg-annon advice, there is a check if the new path value is either null or empty, pretty much like the CoverImage field. However there is no check if the new path is valid or not due to the following reasons:

* We can't know if the third party tool moving the video file is moving it before or after the API call is made.
* Changing the path field of a scene is a rather important change, it should be on the third party tool responsibility to make sure the video file was correctly moved.

**Known issue (help needed)**

* In the API playground doc, all the functions' input argument tabs auto-close by themselves after a short second, making them unreadable. Needs to be fixed before merging this PR (help appreciated!).