### PR TITLE
Add new zh-tw localizations & move non-legacy localization keys

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -735,11 +735,15 @@ export const SettingsConfigurationPanel: React.FC = () => {
           <Form.Check
             id="preview-include-audio"
             checked={previewAudio}
-            label="Include audio"
+            label={intl.formatMessage({
+              id: "config.general.include_audio_head",
+            })}
             onChange={() => setPreviewAudio(!previewAudio)}
           />
           <Form.Text className="text-muted">
-            Includes audio stream when generating previews.
+            {intl.formatMessage({
+              id: "config.general.include_audio_desc",
+            })}
           </Form.Text>
         </Form.Group>
 

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -28,7 +28,7 @@ export const Stats: React.FC = () => {
             {` ${TextUtils.formatFileSizeUnit(scenesSize.unit)}`}
           </p>
           <p className="heading">
-            <FormattedMessage id="scenes-size" defaultMessage="Scenes size" />
+            <FormattedMessage id="stats.scenes_size" />
           </p>
         </div>
         <div className="stats-element">
@@ -36,7 +36,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.scene_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="scenes" defaultMessage="Scenes" />
+            <FormattedMessage id="scenes" />
           </p>
         </div>
         <div className="stats-element">
@@ -52,10 +52,7 @@ export const Stats: React.FC = () => {
             {` ${TextUtils.secondsAsTimeString(data.stats.scenes_duration, 3)}`}
           </p>
           <p className="heading">
-            <FormattedMessage
-              id="scenes-duration"
-              defaultMessage="Scenes duration"
-            />
+            <FormattedMessage id="stats.scenes_duration" />
           </p>
         </div>
         <div className="stats-element">
@@ -79,7 +76,7 @@ export const Stats: React.FC = () => {
             {` ${TextUtils.formatFileSizeUnit(imagesSize.unit)}`}
           </p>
           <p className="heading">
-            <FormattedMessage id="images-size" defaultMessage="Images size" />
+            <FormattedMessage id="stats.image_size" />
           </p>
         </div>
         <div className="stats-element">

--- a/ui/v2.5/src/locales/de-DE.json
+++ b/ui/v2.5/src/locales/de-DE.json
@@ -500,7 +500,7 @@
   "image": "Bild",
   "image_count": "Bilderanzahl",
   "images": "Bilder",
-  "images-size": "Bildgröße",
+  "include_sub_studios": "Tochterstudios einbeziehen",
   "instagram": "Instagram",
   "interactive": "Interaktiv",
   "isMissing": "Wird vermisst",
@@ -556,7 +556,6 @@
   "scene_count": "Szenenanzahl",
   "scene_id": "Szenen-ID",
   "scenes": "Szenen",
-  "scenes-size": "Szenengröße",
   "scenes_updated_at": "Szene aktualisiert am",
   "sceneTagger": "Szenen-Tagger",
   "sceneTags": "Szenen-Tags",
@@ -599,5 +598,9 @@
   "updated_at": "Aktualisiert am",
   "url": "URL",
   "weight": "Gewicht",
-  "years_old": "Jahre alt"
+  "years_old": "Jahre alt",
+  "stats": {
+    "image_size": "Bildgröße",
+    "scenes_size": "Szenengröße"
+  }
 }

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -237,7 +237,9 @@
       "sqlite_location": "File location for the SQLite database (requires restart)",
       "video_ext_desc": "Comma-delimited list of file extensions that will be identified as videos.",
       "video_ext_head": "Video Extensions",
-      "video_head": "Video"
+      "video_head": "Video",
+      "include_audio_head": "Include audio",
+      "include_audio_desc": "Includes audio stream when generating previews."
     },
     "logs": {
       "log_level": "Log Level"
@@ -532,7 +534,6 @@
   "image": "Image",
   "image_count": "Image Count",
   "images": "Images",
-  "images-size": "Images size",
   "include_sub_studios": "Include subsidiary studios",
   "include_sub_tags": "Include sub-tags",
   "instagram": "Instagram",
@@ -592,8 +593,6 @@
   "scene_count": "Scene Count",
   "scene_id": "Scene ID",
   "scenes": "Scenes",
-  "scenes-duration": "Scenes duration",
-  "scenes-size": "Scenes size",
   "scenes_updated_at": "Scene Updated At",
   "sceneTagger": "Scene Tagger",
   "sceneTags": "Scene Tags",
@@ -636,5 +635,10 @@
   "updated_at": "Updated At",
   "url": "URL",
   "weight": "Weight",
-  "years_old": "years old"
+  "years_old": "years old",
+  "stats": {
+    "image_size": "Images size",
+    "scenes_size": "Scenes size",
+    "scenes_duration": "Scenes duration"
+  }
 }

--- a/ui/v2.5/src/locales/pt-BR.json
+++ b/ui/v2.5/src/locales/pt-BR.json
@@ -500,7 +500,7 @@
   "image": "Imagem",
   "image_count": "Contagem de imagem",
   "images": "Imagens",
-  "images-size": "Tamanho das imagens",
+  "include_sub_studios": "Incluem estúdios filho",
   "instagram": "Instagram",
   "interactive": "Interativo",
   "isMissing": "Está faltando",
@@ -556,7 +556,6 @@
   "scene_count": "Contagem de cena",
   "scene_id": "Cena ID",
   "scenes": "Cenas",
-  "scenes-size": "Tamanho de cenas",
   "scenes_updated_at": "Cena atualizada em",
   "sceneTagger": "Tagger de cena",
   "sceneTags": "Tags de cena",
@@ -599,5 +598,9 @@
   "updated_at": "Atualizado em",
   "url": "URL",
   "weight": "Peso",
-  "years_old": "anos"
+  "years_old": "anos",
+  "stats": {
+    "image_size": "Tamanho das imagens",
+    "scenes_size": "Tamanho de cenas"
+  }
 }

--- a/ui/v2.5/src/locales/sv-SE.json
+++ b/ui/v2.5/src/locales/sv-SE.json
@@ -155,7 +155,8 @@
       "logs": "Loggar",
       "plugins": "Tillägg",
       "tasks": "Uppgifter",
-      "tools": "Verktyg"
+      "tools": "Verktyg",
+      "scraping": "Skrapare"
     },
     "dlna": {
       "allow_temp_ip": "Tillåt {tempIP}",
@@ -625,7 +626,7 @@
   "updated_at": "Uppdaterad vid",
   "url": "URL",
   "weight": "Vikt",
-  "years_old": "år gammal"
+  "years_old": "år gammal",
   "stats": {
     "image_size": "Bildstorlek",
     "scenes_duration": "Total speltid",

--- a/ui/v2.5/src/locales/sv-SE.json
+++ b/ui/v2.5/src/locales/sv-SE.json
@@ -95,7 +95,6 @@
   "birthdate": "Födelsedatum",
   "bitrate": "Bithastighet",
   "career_length": "Karriärlängd",
-  "child_studios": "Underordnade studior",
   "component_tagger": {
     "config": {
       "active_instance": "Aktiv stash-box instans:",
@@ -155,7 +154,6 @@
       "interface": "Gränssnitt",
       "logs": "Loggar",
       "plugins": "Tillägg",
-      "scrapers": "Skrapare",
       "tasks": "Uppgifter",
       "tools": "Verktyg"
     },
@@ -528,8 +526,7 @@
   "image": "Bild",
   "image_count": "Antal bilder",
   "images": "Bilder",
-  "images-size": "Bildstorlek",
-  "include_child_studios": "Inkludera underordnade studior",
+  "include_sub_studios": "Inkludera underordnade studior",
   "instagram": "Instagram",
   "interactive": "Interaktiv",
   "isMissing": "Saknas",
@@ -586,8 +583,6 @@
   "scene_count": "Antal scener",
   "scene_id": "Scenens ID",
   "scenes": "Scener",
-  "scenes-duration": "Total speltid",
-  "scenes-size": "Scenens storlek",
   "scenes_updated_at": "Scen uppdaterad vid",
   "sceneTagger": "Scentaggaren",
   "sceneTags": "Scentaggar",

--- a/ui/v2.5/src/locales/sv-SE.json
+++ b/ui/v2.5/src/locales/sv-SE.json
@@ -626,4 +626,9 @@
   "url": "URL",
   "weight": "Vikt",
   "years_old": "år gammal"
+  "stats": {
+    "image_size": "Bildstorlek",
+    "scenes_duration": "Total speltid",
+    "scenes_size": "Scenens storlek"
+  }
 }

--- a/ui/v2.5/src/locales/zh-CN.json
+++ b/ui/v2.5/src/locales/zh-CN.json
@@ -528,7 +528,7 @@
   "image": "图片",
   "image_count": "图片数量",
   "images": "图片",
-  "images-size": "图片大小",
+  "include_sub_studios": "包含子工作室",
   "instagram": "Instagram",
   "interactive": "互动",
   "isMissing": "缺失",
@@ -585,8 +585,6 @@
   "scene_count": "短片数量",
   "scene_id": "短片ID",
   "scenes": "短片",
-  "scenes-duration": "短片时长",
-  "scenes-size": "短片大小",
   "scenes_updated_at": "短片更新时间",
   "sceneTagger": "短片标记器",
   "sceneTags": "短片标记",
@@ -629,5 +627,9 @@
   "updated_at": "更新时间",
   "url": "链接",
   "weight": "体重",
-  "years_old": "岁"
+  "years_old": "岁",
+  "stats": {
+    "image_size": "图片大小",
+    "scenes_size": "短片大小"
+  }
 }

--- a/ui/v2.5/src/locales/zh-TW.json
+++ b/ui/v2.5/src/locales/zh-TW.json
@@ -627,11 +627,6 @@
   "custom": "自訂",
   "frames_per_second": "{value} 幀/秒",
   "megabits_per_second": "{value} megabits/秒",
-  "tools": {
-    "scene_filename_parser": {
-      "ignore_organized": "忽略已整理的短片"
-    }
-  },
   "stats": {
     "image_size": "圖片大小",
     "scenes_size": "短片大小",

--- a/ui/v2.5/src/locales/zh-TW.json
+++ b/ui/v2.5/src/locales/zh-TW.json
@@ -83,7 +83,8 @@
     "confirm": "確認",
     "select_folders": "選擇資料夾",
     "browse_for_image": "選擇圖像…",
-    "open_random": "隨機開啟"
+    "open_random": "隨機開啟",
+    "scrape_query": "爬蟲搜尋關鍵字"
   },
   "actions_name": "動作",
   "age": "年齡",
@@ -116,7 +117,8 @@
       "set_tag_desc": "選擇套用標籤時，該如何處理現有標籤。",
       "set_tag_label": "標籤設定",
       "show_male_desc": "選擇搜尋時，是否要取得男優資訊。",
-      "show_male_label": "顯示男優"
+      "show_male_label": "顯示男優",
+      "query_mode_metadata": "Metadata"
     },
     "noun_query": "關鍵字",
     "results": {
@@ -234,7 +236,9 @@
       "sqlite_location": "SQLite 資料庫的位置（需重新啟動）",
       "video_ext_desc": "以逗號為區隔的副檔名名稱，這些檔案將被視為影片",
       "video_ext_head": "影片副檔名",
-      "video_head": "影片設定"
+      "video_head": "影片設定",
+      "include_audio_desc": "產生預覽檔案時，順便產生音訊預覽。",
+      "include_audio_head": "包含音訊"
     },
     "logs": {
       "log_level": "日誌級別"
@@ -368,7 +372,8 @@
       }
     },
     "plugins": {
-      "triggers_on": "觸發於"
+      "triggers_on": "觸發於",
+      "hooks": "Hooks"
     }
   },
   "configuration": "設定",
@@ -446,7 +451,9 @@
       "source": "來源",
       "destination": "目的地"
     },
-    "overwrite_filter_confirm": "您確定要覆蓋現有的條件 {entityName} 嗎？"
+    "overwrite_filter_confirm": "您確定要覆蓋現有的條件 {entityName} 嗎？",
+    "scenes_found": "已找到 {count} 個短片",
+    "scrape_entity_query": "{entity_type}爬蟲搜尋"
   },
   "dimensions": "解析度",
   "director": "導演",
@@ -511,7 +518,6 @@
   "image": "圖片",
   "image_count": "圖片數量",
   "images": "圖片",
-  "images-size": "圖片大小",
   "interactive": "互動性支援",
   "isMissing": "缺失",
   "library": "收藏庫",
@@ -565,7 +571,6 @@
   "scene_count": "短片數量",
   "scene_id": "短片 ID",
   "scenes": "短片",
-  "scenes-size": "短片大小",
   "scenes_updated_at": "短片更新時間",
   "sceneTagger": "短片標籤器",
   "sceneTags": "短片標籤",
@@ -626,5 +631,15 @@
     "scene_filename_parser": {
       "ignore_organized": "忽略已整理的短片"
     }
-  }
+  },
+  "stats": {
+    "image_size": "圖片大小",
+    "scenes_size": "短片大小",
+    "scenes_duration": "短片長度"
+  },
+  "metadata": "Metadata",
+  "include_sub_studios": "包含子工作室",
+  "include_sub_tags": "包含子標籤",
+  "parent_tags": "母標籤",
+  "sub_tags": "子標籤"
 }


### PR DESCRIPTION
# Summary

This PR updates the localization table for zh-tw, as well as fixing inconsistencies in the existing tables. Most notably, moving stats exclusive keys under the stats category, as opposed to leaving them in the root. Other similar entries are kept in the root as they are considered strings that are shared across the entire UI (e.g., "Scenes" may be used on the stats screen, on the navbar, etc.) Additionally, key naming inconsistencies are also corrected, where some key names used the kebab-case naming conventions instead of the snake-case one used by the rest of the table.