### PR TITLE
Fix data race in progress_test

### DIFF
--- a/pkg/job/progress_test.go
+++ b/pkg/job/progress_test.go
@@ -132,14 +132,18 @@ func TestExecuteTask(t *testing.T) {
 
 	assert := assert.New(t)
 
+	m.mutex.Lock()
 	// ensure task is added to the job details
 	assert.Equal(taskDesciption, j.Details[0])
+	m.mutex.Unlock()
 
 	// allow task to finish
 	close(c)
 
 	time.Sleep(sleepTime)
 
+	m.mutex.Lock()
 	// ensure task is removed from the job details
 	assert.Len(j.Details, 0)
+	m.mutex.Unlock()
 }


### PR DESCRIPTION
The call to p.ExecuteTask happens in a separate go-routine. It writes,
under m.mutex, into the job's details. However, the test goroutine
itself reads j.Details which is a read race.

Protect the reads in the test by the lock.

This makes `package job` pass `go test -race`