### PR TITLE
Correct error propagation

### DIFF
--- a/pkg/manager/task_stash_box_tag.go
+++ b/pkg/manager/task_stash_box_tag.go
@@ -229,9 +229,9 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag() {
 				}
 
 				if len(performer.Images) > 0 {
-					image, err := utils.ReadImageFromURL(performer.Images[0])
-					if err != nil {
-						return err
+					image, imageErr := utils.ReadImageFromURL(performer.Images[0])
+					if imageErr != nil {
+						return imageErr
 					}
 					err = r.Performer().UpdateImage(createdPerformer.ID, image)
 				}


### PR DESCRIPTION
Rename an inner error to imageErr. This avoids a shadowing of an error
in the following lines which aren't returned otherwise.