### PR TITLE
Error strings noncapitalized

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -117,10 +117,12 @@ func makeGithubRequest(url string, output interface{}) error {
 	response, err := client.Do(req)
 
 	if err != nil {
+		//lint:ignore ST1005 Github is a proper capitalized noun
 		return fmt.Errorf("Github API request failed: %s", err)
 	}
 
 	if response.StatusCode != http.StatusOK {
+		//lint:ignore ST1005 Github is a proper capitalized noun
 		return fmt.Errorf("Github API request failed: %s", response.Status)
 	}
 
@@ -128,12 +130,13 @@ func makeGithubRequest(url string, output interface{}) error {
 
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
+		//lint:ignore ST1005 Github is a proper capitalized noun
 		return fmt.Errorf("Github API read response failed: %s", err)
 	}
 
 	err = json.Unmarshal(data, output)
 	if err != nil {
-		return fmt.Errorf("Unmarshalling Github API response failed: %s", err)
+		return fmt.Errorf("unmarshalling Github API response failed: %s", err)
 	}
 
 	return nil
@@ -196,7 +199,7 @@ func GetLatestVersion(shortHash bool) (latestVersion string, latestRelease strin
 	}
 
 	if latestVersion == "" {
-		return "", "", fmt.Errorf("No version found for \"%s\"", version)
+		return "", "", fmt.Errorf("no version found for \"%s\"", version)
 	}
 	return latestVersion, latestRelease, nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -156,7 +156,7 @@ func Backup(db *sqlx.DB, backupPath string) error {
 	logger.Infof("Backing up database into: %s", backupPath)
 	_, err := db.Exec(`VACUUM INTO "` + backupPath + `"`)
 	if err != nil {
-		return fmt.Errorf("Vacuum failed: %s", err)
+		return fmt.Errorf("vacuum failed: %s", err)
 	}
 
 	return nil
@@ -272,7 +272,7 @@ func registerCustomDriver() {
 
 				for name, fn := range funcs {
 					if err := conn.RegisterFunc(name, fn, true); err != nil {
-						return fmt.Errorf("Error registering function %s: %s", name, err.Error())
+						return fmt.Errorf("error registering function %s: %s", name, err.Error())
 					}
 				}
 
@@ -286,7 +286,7 @@ func registerCustomDriver() {
 				})
 
 				if err != nil {
-					return fmt.Errorf("Error registering natural sort collation: %s", err.Error())
+					return fmt.Errorf("error registering natural sort collation: %s", err.Error())
 				}
 
 				return nil

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -236,7 +236,7 @@ func NewVideoFile(ffprobePath string, videoPath string, stripExt bool) (*VideoFi
 
 	probeJSON := &FFProbeJSON{}
 	if err := json.Unmarshal(out, probeJSON); err != nil {
-		return nil, fmt.Errorf("Error unmarshalling video data for <%s>: %s", videoPath, err.Error())
+		return nil, fmt.Errorf("error unmarshalling video data for <%s>: %s", videoPath, err.Error())
 	}
 
 	return parse(videoPath, probeJSON, stripExt)

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -656,17 +656,21 @@ func (i *Instance) ValidateStashBoxes(boxes []*models.StashBoxInput) error {
 
 	re, err := regexp.Compile("^http.*graphql$")
 	if err != nil {
-		return errors.New("Failure to generate regular expression")
+		return errors.New("failure to generate regular expression")
 	}
 
 	for _, box := range boxes {
 		if box.APIKey == "" {
+			//lint:ignore ST1005 Stash-box is a name
 			return errors.New("Stash-box API Key cannot be blank")
 		} else if box.Endpoint == "" {
+			//lint:ignore ST1005 Stash-box is a name
 			return errors.New("Stash-box Endpoint cannot be blank")
 		} else if !re.Match([]byte(box.Endpoint)) {
+			//lint:ignore ST1005 Stash-box is a name
 			return errors.New("Stash-box Endpoint is invalid")
 		} else if isMulti && box.Name == "" {
+			//lint:ignore ST1005 Stash-box is a name
 			return errors.New("Stash-box Name cannot be blank")
 		}
 	}

--- a/pkg/manager/task_generate_screenshot.go
+++ b/pkg/manager/task_generate_screenshot.go
@@ -70,18 +70,18 @@ func (t *GenerateScreenshotTask) Start(wg *sync.WaitGroup) {
 		}
 
 		if err := SetSceneScreenshot(checksum, coverImageData); err != nil {
-			return fmt.Errorf("Error writing screenshot: %s", err.Error())
+			return fmt.Errorf("error writing screenshot: %v", err)
 		}
 
 		// update the scene cover table
 		if err := qb.UpdateCover(t.Scene.ID, coverImageData); err != nil {
-			return fmt.Errorf("Error setting screenshot: %s", err.Error())
+			return fmt.Errorf("error setting screenshot: %v", err)
 		}
 
 		// update the scene with the update date
 		_, err = qb.Update(updatedScene)
 		if err != nil {
-			return fmt.Errorf("Error updating scene: %s", err.Error())
+			return fmt.Errorf("error updating scene: %v", err)
 		}
 
 		return nil

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -56,18 +56,18 @@ func (t *rawPluginTask) Start() error {
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		logger.Error("Plugin stderr not available: " + err.Error())
+		logger.Error("plugin stderr not available: " + err.Error())
 	}
 
 	stdout, err := cmd.StdoutPipe()
 	if nil != err {
-		logger.Error("Plugin stdout not available: " + err.Error())
+		logger.Error("plugin stdout not available: " + err.Error())
 	}
 
 	t.waitGroup.Add(1)
 	t.done = make(chan bool, 1)
 	if err = cmd.Start(); err != nil {
-		return fmt.Errorf("Error running plugin: %s", err.Error())
+		return fmt.Errorf("error running plugin: %s", err.Error())
 	}
 
 	go t.handlePluginStderr(stderr)

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -109,7 +109,7 @@ func loadURL(url string, scraperConfig config, globalConfig GlobalConfig) (io.Re
 func urlFromCDP(url string, driverOptions scraperDriverOptions, globalConfig GlobalConfig) (io.Reader, error) {
 
 	if !driverOptions.UseCDP {
-		return nil, fmt.Errorf("Url shouldn't be feetched through CDP")
+		return nil, fmt.Errorf("URL shouldn't be fetched through CDP")
 	}
 
 	sleepDuration := scrapeDefaultSleep

--- a/pkg/sqlite/repository.go
+++ b/pkg/sqlite/repository.go
@@ -269,10 +269,10 @@ func (r *repository) executeFindQuery(body string, args []interface{}, sortAndPa
 	idsResult, idsErr = r.runIdsQuery(idsQuery, args)
 
 	if countErr != nil {
-		return nil, 0, fmt.Errorf("Error executing count query with SQL: %s, args: %v, error: %s", countQuery, args, countErr.Error())
+		return nil, 0, fmt.Errorf("error executing count query with SQL: %s, args: %v, error: %s", countQuery, args, countErr.Error())
 	}
 	if idsErr != nil {
-		return nil, 0, fmt.Errorf("Error executing find query with SQL: %s, args: %v, error: %s", idsQuery, args, idsErr.Error())
+		return nil, 0, fmt.Errorf("error executing find query with SQL: %s, args: %v, error: %s", idsQuery, args, idsErr.Error())
 	}
 
 	return idsResult, countResult, nil

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -78,7 +78,7 @@ func (qb *tagQueryBuilder) Destroy(id int) error {
 	}
 
 	if primaryMarkers > 0 {
-		return errors.New("Cannot delete tag used as a primary tag in scene markers")
+		return errors.New("cannot delete tag used as a primary tag in scene markers")
 	}
 
 	return qb.destroyExisting([]int{id})

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -193,12 +193,12 @@ func IsZipFileUncompressed(path string) (bool, error) {
 func WriteFile(path string, file []byte) error {
 	pathErr := EnsureDirAll(filepath.Dir(path))
 	if pathErr != nil {
-		return fmt.Errorf("Cannot ensure path %s", pathErr)
+		return fmt.Errorf("cannot ensure path %s", pathErr)
 	}
 
 	err := ioutil.WriteFile(path, file, 0755)
 	if err != nil {
-		return fmt.Errorf("Write error for thumbnail %s: %s ", path, err)
+		return fmt.Errorf("write error for thumbnail %s: %s ", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Nitpick commit: uncapitalize error strings.

These often follow a colon in an wrapping error string, or sits after a beginning logger header in the line. Hence, capitalization is often grammatically incorrect.

These are not all the error strings, but it's what `golangci` complains about up front.