### PR TITLE
Avoid wrapping strings.Replace in Contains

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -32,9 +32,7 @@ func (s mappedConfig) applyCommon(c commonMappedConfig, src string) string {
 
 	ret := src
 	for commonKey, commonVal := range c {
-		if strings.Contains(ret, commonKey) {
-			ret = strings.Replace(ret, commonKey, commonVal, -1)
-		}
+		ret = strings.Replace(ret, commonKey, commonVal, -1)
 	}
 
 	return ret


### PR DESCRIPTION
The strings.Replace function counts the number of replacements. If 0,
the original string is returned. Hence, there is no need to check if a
replacement will happen before doing the work.

This is a small patch, but it doesn't fit into any other topics I have lined up for PRs, and it's the last one of the odd-ones-out.

Applying this patch, and the unused-function one, will take us down to one missing linter to pass: error checking.