### PR TITLE
Errcheck phase 1

### DIFF
--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -289,8 +289,7 @@ func (r *mutationResolver) ConfigureDlna(ctx context.Context, input models.Confi
 		if !*input.Enabled && dlnaService.IsRunning() {
 			dlnaService.Stop(nil)
 		} else if *input.Enabled && !dlnaService.IsRunning() {
-			err := dlnaService.Start(nil)
-			if err != nil {
+			if err := dlnaService.Start(nil); err != nil {
 				logger.Warnf("error starting DLNA service: %v", err)
 			}
 		}

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -289,7 +289,10 @@ func (r *mutationResolver) ConfigureDlna(ctx context.Context, input models.Confi
 		if !*input.Enabled && dlnaService.IsRunning() {
 			dlnaService.Stop(nil)
 		} else if *input.Enabled && !dlnaService.IsRunning() {
-			dlnaService.Start(nil)
+			err := dlnaService.Start(nil)
+			if err != nil {
+				logger.Warnf("error starting DLNA service: %v", err)
+			}
 		}
 	}
 

--- a/pkg/api/resolver_mutation_plugin.go
+++ b/pkg/api/resolver_mutation_plugin.go
@@ -17,7 +17,7 @@ func (r *mutationResolver) RunPluginTask(ctx context.Context, pluginID string, t
 func (r *mutationResolver) ReloadPlugins(ctx context.Context) (bool, error) {
 	err := manager.GetInstance().PluginCache.LoadPlugins()
 	if err != nil {
-		logger.Errorf("Error reading plugin configs: %s", err.Error())
+		logger.Errorf("Error reading plugin configs: %v", err)
 	}
 
 	return true, nil

--- a/pkg/api/routes_image.go
+++ b/pkg/api/routes_image.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/stashapp/stash/pkg/image"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
@@ -59,7 +60,7 @@ func ImageCtx(next http.Handler) http.Handler {
 		imageID, _ := strconv.Atoi(imageIdentifierQueryParam)
 
 		var image *models.Image
-		manager.GetInstance().TxnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
+		readTxnErr := manager.GetInstance().TxnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
 			qb := repo.Image()
 			if imageID == 0 {
 				image, _ = qb.FindByChecksum(imageIdentifierQueryParam)
@@ -69,6 +70,9 @@ func ImageCtx(next http.Handler) http.Handler {
 
 			return nil
 		})
+		if readTxnErr != nil {
+			logger.Warnf("read transaction failure while trying to read image by id: %v", readTxnErr)
+		}
 
 		if image == nil {
 			http.Error(w, http.StatusText(404), 404)

--- a/pkg/api/routes_movie.go
+++ b/pkg/api/routes_movie.go
@@ -46,8 +46,7 @@ func (rs movieRoutes) FrontImage(w http.ResponseWriter, r *http.Request) {
 		_, image, _ = utils.ProcessBase64Image(models.DefaultMovieImage)
 	}
 
-	err := utils.ServeImage(image, w, r)
-	if err != nil {
+	if err := utils.ServeImage(image, w, r); err != nil {
 		logger.Warnf("error serving front image: %v", err)
 	}
 }
@@ -70,8 +69,7 @@ func (rs movieRoutes) BackImage(w http.ResponseWriter, r *http.Request) {
 		_, image, _ = utils.ProcessBase64Image(models.DefaultMovieImage)
 	}
 
-	err := utils.ServeImage(image, w, r)
-	if err != nil {
+	if err := utils.ServeImage(image, w, r); err != nil {
 		logger.Warnf("error while serving image: %v", err)
 	}
 }

--- a/pkg/api/routes_performer.go
+++ b/pkg/api/routes_performer.go
@@ -47,8 +47,7 @@ func (rs performerRoutes) Image(w http.ResponseWriter, r *http.Request) {
 		image, _ = getRandomPerformerImageUsingName(performer.Name.String, performer.Gender.String, config.GetInstance().GetCustomPerformerImageLocation())
 	}
 
-	err := utils.ServeImage(image, w, r)
-	if err != nil {
+	if err := utils.ServeImage(image, w, r); err != nil {
 		logger.Warnf("error serving image: %v", err)
 	}
 }

--- a/pkg/api/routes_scene.go
+++ b/pkg/api/routes_scene.go
@@ -84,8 +84,7 @@ func (rs sceneRoutes) StreamMKV(w http.ResponseWriter, r *http.Request) {
 	container := getSceneFileContainer(scene)
 	if container != ffmpeg.Matroska {
 		w.WriteHeader(http.StatusBadRequest)
-		_, err := w.Write([]byte("not an mkv file"))
-		if err != nil {
+		if _, err := w.Write([]byte("not an mkv file")); err != nil {
 			logger.Warnf("[stream] error writing to stream: %v", err)
 		}
 		return
@@ -128,8 +127,7 @@ func (rs sceneRoutes) StreamHLS(w http.ResponseWriter, r *http.Request) {
 	rangeStr := requestByteRange.ToHeaderValue(int64(str.Len()))
 	w.Header().Set("Content-Range", rangeStr)
 
-	n, err := w.Write(ret)
-	if err != nil {
+	if n, err := w.Write(ret); err != nil {
 		logger.Warnf("[stream] error writing stream (wrote %v bytes): %v", n, err)
 	}
 }
@@ -151,8 +149,7 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 	}
 
 	// start stream based on query param, if provided
-	err = r.ParseForm()
-	if err != nil {
+	if err = r.ParseForm(); err != nil {
 		logger.Warnf("[stream] error parsing query form: %v", err)
 	}
 
@@ -179,8 +176,7 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 	if err != nil {
 		logger.Errorf("[stream] error transcoding video file: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		_, err := w.Write([]byte(err.Error()))
-		if err != nil {
+		if _, err := w.Write([]byte(err.Error())); err != nil {
 			logger.Warnf("[stream] error writing response: %v", err)
 		}
 		return

--- a/pkg/api/routes_scene.go
+++ b/pkg/api/routes_scene.go
@@ -58,7 +58,7 @@ func getSceneFileContainer(scene *models.Scene) ffmpeg.Container {
 		// shouldn't happen, fallback to ffprobe
 		tmpVideoFile, err := ffmpeg.NewVideoFile(manager.GetInstance().FFProbePath, scene.Path, false)
 		if err != nil {
-			logger.Errorf("[transcode] error reading video file: %s", err.Error())
+			logger.Errorf("[transcode] error reading video file: %v", err)
 			return ffmpeg.Container("")
 		}
 
@@ -104,7 +104,7 @@ func (rs sceneRoutes) StreamHLS(w http.ResponseWriter, r *http.Request) {
 
 	videoFile, err := ffmpeg.NewVideoFile(manager.GetInstance().FFProbePath, scene.Path, false)
 	if err != nil {
-		logger.Errorf("[stream] error reading video file: %s", err.Error())
+		logger.Errorf("[stream] error reading video file: %v", err)
 		return
 	}
 
@@ -140,7 +140,7 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 
 	videoFile, err := ffmpeg.NewVideoFile(manager.GetInstance().FFProbePath, scene.Path, false)
 	if err != nil {
-		logger.Errorf("[stream] error reading video file: %s", err.Error())
+		logger.Errorf("[stream] error reading video file: %v", err)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 	stream, err = encoder.GetTranscodeStream(options)
 
 	if err != nil {
-		logger.Errorf("[stream] error transcoding video file: %s", err.Error())
+		logger.Errorf("[stream] error transcoding video file: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return

--- a/pkg/api/routes_scene.go
+++ b/pkg/api/routes_scene.go
@@ -84,7 +84,10 @@ func (rs sceneRoutes) StreamMKV(w http.ResponseWriter, r *http.Request) {
 	container := getSceneFileContainer(scene)
 	if container != ffmpeg.Matroska {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("not an mkv file"))
+		_, err := w.Write([]byte("not an mkv file"))
+		if err != nil {
+			logger.Warnf("[stream] error writing to stream: %v", err)
+		}
 		return
 	}
 
@@ -125,7 +128,10 @@ func (rs sceneRoutes) StreamHLS(w http.ResponseWriter, r *http.Request) {
 	rangeStr := requestByteRange.ToHeaderValue(int64(str.Len()))
 	w.Header().Set("Content-Range", rangeStr)
 
-	w.Write(ret)
+	n, err := w.Write(ret)
+	if err != nil {
+		logger.Warnf("[stream] error writing stream (wrote %v bytes): %v", n, err)
+	}
 }
 
 func (rs sceneRoutes) StreamTS(w http.ResponseWriter, r *http.Request) {
@@ -145,7 +151,11 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 	}
 
 	// start stream based on query param, if provided
-	r.ParseForm()
+	err = r.ParseForm()
+	if err != nil {
+		logger.Warnf("[stream] error parsing query form: %v", err)
+	}
+
 	startTime := r.Form.Get("start")
 	requestedSize := r.Form.Get("resolution")
 
@@ -169,7 +179,10 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, vi
 	if err != nil {
 		logger.Errorf("[stream] error transcoding video file: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
+		_, err := w.Write([]byte(err.Error()))
+		if err != nil {
+			logger.Warnf("[stream] error writing response: %v", err)
+		}
 		return
 	}
 
@@ -327,7 +340,7 @@ func SceneCtx(next http.Handler) http.Handler {
 		sceneID, _ := strconv.Atoi(sceneIdentifierQueryParam)
 
 		var scene *models.Scene
-		manager.GetInstance().TxnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
+		readTxnErr := manager.GetInstance().TxnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
 			qb := repo.Scene()
 			if sceneID == 0 {
 				// determine checksum/os by the length of the query param
@@ -342,6 +355,9 @@ func SceneCtx(next http.Handler) http.Handler {
 
 			return nil
 		})
+		if readTxnErr != nil {
+			logger.Warnf("error executing SceneCtx transaction: %v", readTxnErr)
+		}
 
 		if scene == nil {
 			http.Error(w, http.StatusText(404), 404)

--- a/pkg/api/routes_studio.go
+++ b/pkg/api/routes_studio.go
@@ -46,8 +46,7 @@ func (rs studioRoutes) Image(w http.ResponseWriter, r *http.Request) {
 		_, image, _ = utils.ProcessBase64Image(models.DefaultStudioImage)
 	}
 
-	err := utils.ServeImage(image, w, r)
-	if err != nil {
+	if err := utils.ServeImage(image, w, r); err != nil {
 		logger.Warnf("error serving studio image: %v", err)
 	}
 }

--- a/pkg/api/routes_studio.go
+++ b/pkg/api/routes_studio.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
@@ -32,17 +33,23 @@ func (rs studioRoutes) Image(w http.ResponseWriter, r *http.Request) {
 
 	var image []byte
 	if defaultParam != "true" {
-		rs.txnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
+		err := rs.txnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
 			image, _ = repo.Studio().GetImage(studio.ID)
 			return nil
 		})
+		if err != nil {
+			logger.Warnf("read transaction error while fetching studio image: %v", err)
+		}
 	}
 
 	if len(image) == 0 {
 		_, image, _ = utils.ProcessBase64Image(models.DefaultStudioImage)
 	}
 
-	utils.ServeImage(image, w, r)
+	err := utils.ServeImage(image, w, r)
+	if err != nil {
+		logger.Warnf("error serving studio image: %v", err)
+	}
 }
 
 func StudioCtx(next http.Handler) http.Handler {

--- a/pkg/api/routes_tag.go
+++ b/pkg/api/routes_tag.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
@@ -32,17 +33,23 @@ func (rs tagRoutes) Image(w http.ResponseWriter, r *http.Request) {
 
 	var image []byte
 	if defaultParam != "true" {
-		rs.txnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
+		err := rs.txnManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
 			image, _ = repo.Tag().GetImage(tag.ID)
 			return nil
 		})
+		if err != nil {
+			logger.Warnf("read transaction error while getting tag image: %v", err)
+		}
 	}
 
 	if len(image) == 0 {
 		image = models.DefaultTagImage
 	}
 
-	utils.ServeImage(image, w, r)
+	err := utils.ServeImage(image, w, r)
+	if err != nil {
+		logger.Warnf("error serving tag image: %v", err)
+	}
 }
 
 func TagCtx(next http.Handler) http.Handler {

--- a/pkg/api/routes_tag.go
+++ b/pkg/api/routes_tag.go
@@ -46,8 +46,7 @@ func (rs tagRoutes) Image(w http.ResponseWriter, r *http.Request) {
 		image = models.DefaultTagImage
 	}
 
-	err := utils.ServeImage(image, w, r)
-	if err != nil {
+	if err := utils.ServeImage(image, w, r); err != nil {
 		logger.Warnf("error serving tag image: %v", err)
 	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -232,6 +232,7 @@ func RunMigrations() error {
 	if err != nil {
 		panic(err.Error())
 	}
+	defer m.Close()
 
 	databaseSchemaVersion, _, _ = m.Version()
 	stepNumber := appSchemaVersion - databaseSchemaVersion
@@ -240,13 +241,9 @@ func RunMigrations() error {
 		err = m.Steps(int(stepNumber))
 		if err != nil {
 			// migration failed
-			logger.Errorf("Error migrating database: %s", err.Error())
-			m.Close()
 			return err
 		}
 	}
-
-	m.Close()
 
 	// re-initialise the database
 	Initialize(dbPath)
@@ -255,7 +252,7 @@ func RunMigrations() error {
 	logger.Info("Performing vacuum on database")
 	_, err = DB.Exec("VACUUM")
 	if err != nil {
-		logger.Warnf("error while performing post-migration vacuum: %s", err.Error())
+		logger.Warnf("error while performing post-migration vacuum: %v", err)
 	}
 
 	return nil

--- a/pkg/dlna/service.go
+++ b/pkg/dlna/service.go
@@ -251,8 +251,7 @@ func (s *Service) Stop(duration *time.Duration) {
 
 		if s.startTimer == nil {
 			s.startTimer = time.AfterFunc(*duration, func() {
-				err := s.Start(nil)
-				if err != nil {
+				if err := s.Start(nil); err != nil {
 					logger.Warnf("error restarting DLNA server: %v", err)
 				}
 			})

--- a/pkg/dlna/service.go
+++ b/pkg/dlna/service.go
@@ -251,7 +251,10 @@ func (s *Service) Stop(duration *time.Duration) {
 
 		if s.startTimer == nil {
 			s.startTimer = time.AfterFunc(*duration, func() {
-				s.Start(nil)
+				err := s.Start(nil)
+				if err != nil {
+					logger.Warnf("error restarting DLNA server: %v", err)
+				}
 			})
 			t := time.Now().Add(*duration)
 			s.startTime = &t

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -273,8 +273,9 @@ func parse(filePath string, probeJSON *FFProbeJSON, stripExt bool) (*VideoFile, 
 	result.Duration = math.Round(duration*100) / 100
 	fileStat, err := os.Stat(filePath)
 	if err != nil {
-		logger.Errorf("Error statting file <%s>: %s", filePath, err.Error())
-		return nil, err
+		statErr := fmt.Errorf("error statting file <%s>: %w", filePath, err)
+		logger.Errorf("%v", statErr)
+		return nil, statErr
 	}
 	result.Size = fileStat.Size()
 	result.StartTime, _ = strconv.ParseFloat(probeJSON.Format.StartTime, 64)

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -225,8 +225,7 @@ func (e *Encoder) stream(probeResult VideoFile, options TranscodeStreamOptions) 
 
 	registerRunningEncoder(probeResult.Path, cmd.Process)
 	go func() {
-		err := waitAndDeregister(probeResult.Path, cmd)
-		if err != nil {
+		if err := waitAndDeregister(probeResult.Path, cmd); err != nil {
 			logger.Warnf("Error while deregistering ffmpeg stream: %v", err)
 		}
 	}()

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -224,7 +224,12 @@ func (e *Encoder) stream(probeResult VideoFile, options TranscodeStreamOptions) 
 	}
 
 	registerRunningEncoder(probeResult.Path, cmd.Process)
-	go waitAndDeregister(probeResult.Path, cmd)
+	go func() {
+		err := waitAndDeregister(probeResult.Path, cmd)
+		if err != nil {
+			logger.Warnf("Error while deregistering ffmpeg stream: %v", err)
+		}
+	}()
 
 	// stderr must be consumed or the process deadlocks
 	go func() {

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager/paths"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/utils"
@@ -453,7 +454,11 @@ func (i *Instance) GetStashBoxes() []*models.StashBox {
 	i.RLock()
 	defer i.RUnlock()
 	var boxes []*models.StashBox
-	viper.UnmarshalKey(StashBoxes, &boxes)
+	err := viper.UnmarshalKey(StashBoxes, &boxes)
+	if err != nil {
+		logger.Warnf("error in unmarshalkey: %v", err)
+	}
+
 	return boxes
 }
 
@@ -801,7 +806,10 @@ func (i *Instance) SetCSS(css string) {
 
 	buf := []byte(css)
 
-	ioutil.WriteFile(fn, buf, 0777)
+	err := ioutil.WriteFile(fn, buf, 0777)
+	if err != nil {
+		logger.Warnf("error while writing %v bytes to %v: %v", len(buf), fn, err)
+	}
 }
 
 func (i *Instance) GetCSSEnabled() bool {

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -454,8 +454,7 @@ func (i *Instance) GetStashBoxes() []*models.StashBox {
 	i.RLock()
 	defer i.RUnlock()
 	var boxes []*models.StashBox
-	err := viper.UnmarshalKey(StashBoxes, &boxes)
-	if err != nil {
+	if err := viper.UnmarshalKey(StashBoxes, &boxes); err != nil {
 		logger.Warnf("error in unmarshalkey: %v", err)
 	}
 
@@ -806,8 +805,7 @@ func (i *Instance) SetCSS(css string) {
 
 	buf := []byte(css)
 
-	err := ioutil.WriteFile(fn, buf, 0777)
-	if err != nil {
+	if err := ioutil.WriteFile(fn, buf, 0777); err != nil {
 		logger.Warnf("error while writing %v bytes to %v: %v", len(buf), fn, err)
 	}
 }

--- a/pkg/manager/config/config_concurrency_test.go
+++ b/pkg/manager/config/config_concurrency_test.go
@@ -13,11 +13,14 @@ func TestConcurrentConfigAccess(t *testing.T) {
 	//const loops = 1000
 	const loops = 200
 	var wg sync.WaitGroup
-	for t := 0; t < workers; t++ {
+	for k := 0; k < workers; k++ {
 		wg.Add(1)
-		go func() {
+		go func(wk int) {
 			for l := 0; l < loops; l++ {
-				i.SetInitialConfig()
+				err := i.SetInitialConfig()
+				if err != nil {
+					t.Errorf("Failure setting initial config in worker %v loop %v: %v", wk, l, err)
+				}
 
 				i.HasCredentials()
 				i.GetCPUProfilePath()
@@ -93,7 +96,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.Set(MaxUploadSize, i.GetMaxUploadSize())
 			}
 			wg.Done()
-		}()
+		}(k)
 	}
 
 	wg.Wait()

--- a/pkg/manager/config/config_concurrency_test.go
+++ b/pkg/manager/config/config_concurrency_test.go
@@ -17,10 +17,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 		wg.Add(1)
 		go func(wk int) {
 			for l := 0; l < loops; l++ {
-				err := i.SetInitialConfig()
-				if err != nil {
-					t.Errorf("Failure setting initial config in worker %v loop %v: %v", wk, l, err)
-				}
+				i.SetInitialConfig()
 
 				i.HasCredentials()
 				i.GetCPUProfilePath()

--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -127,8 +127,7 @@ func initEnvs() {
 }
 
 func bindEnv(key string) {
-	err := viper.BindEnv(key)
-	if err != nil {
+	if err := viper.BindEnv(key); err != nil {
 		panic(fmt.Sprintf("unable to set environment key (%v): %v", key, err))
 	}
 }

--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -112,16 +112,23 @@ func initFlags() flagStruct {
 }
 
 func initEnvs() {
-	viper.SetEnvPrefix("stash")    // will be uppercased automatically
-	viper.BindEnv("host")          // STASH_HOST
-	viper.BindEnv("port")          // STASH_PORT
-	viper.BindEnv("external_host") // STASH_EXTERNAL_HOST
-	viper.BindEnv("generated")     // STASH_GENERATED
-	viper.BindEnv("metadata")      // STASH_METADATA
-	viper.BindEnv("cache")         // STASH_CACHE
+	viper.SetEnvPrefix("stash") // will be uppercased automatically
+	bindEnv("host")             // STASH_HOST
+	bindEnv("port")             // STASH_PORT
+	bindEnv("external_host")    // STASH_EXTERNAL_HOST
+	bindEnv("generated")        // STASH_GENERATED
+	bindEnv("metadata")         // STASH_METADATA
+	bindEnv("cache")            // STASH_CACHE
 
 	// only set stash config flag if not already set
 	if instance.GetStashPaths() == nil {
-		viper.BindEnv("stash") // STASH_STASH
+		bindEnv("stash") // STASH_STASH
+	}
+}
+
+func bindEnv(key string) {
+	err := viper.BindEnv(key)
+	if err != nil {
+		panic(fmt.Sprintf("unable to set environment key (%v): %v", key, err))
 	}
 }

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -61,10 +61,13 @@ func walkGalleryZip(path string, walkFunc func(file *zip.File) error) error {
 
 func countImagesInZip(path string) int {
 	ret := 0
-	walkGalleryZip(path, func(file *zip.File) error {
+	err := walkGalleryZip(path, func(file *zip.File) error {
 		ret++
 		return nil
 	})
+	if err != nil {
+		logger.Warnf("Error while walking gallery zip: %v", err)
+	}
 
 	return ret
 }

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -163,7 +163,10 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 	if err := s.validateFFMPEG(); err != nil {
 		return 0, err
 	}
-	instance.Paths.Generated.EnsureTmpDir()
+	err := instance.Paths.Generated.EnsureTmpDir()
+	if err != nil {
+		logger.Warnf("could not generate temporary directory: %v", err)
+	}
 
 	sceneIDs, err := utils.StringSliceToIntSlice(input.SceneIDs)
 	if err != nil {
@@ -250,14 +253,20 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		// Start measuring how long the generate has taken. (consider moving this up)
 		start := time.Now()
-		instance.Paths.Generated.EnsureTmpDir()
+		err = instance.Paths.Generated.EnsureTmpDir()
+		if err != nil {
+			logger.Warnf("could not create temprary directory: %v", err)
+		}
 
 		for _, scene := range scenes {
 			progress.Increment()
 			if job.IsCancelled(ctx) {
 				logger.Info("Stopping due to user request")
 				wg.Wait()
-				instance.Paths.Generated.EmptyTmpDir()
+				err := instance.Paths.Generated.EmptyTmpDir()
+				if err != nil {
+					logger.Warnf("failure emptying temporary directory: %v", err)
+				}
 				return
 			}
 
@@ -338,7 +347,10 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 			if job.IsCancelled(ctx) {
 				logger.Info("Stopping due to user request")
 				wg.Wait()
-				instance.Paths.Generated.EmptyTmpDir()
+				err := instance.Paths.Generated.EmptyTmpDir()
+				if err != nil {
+					logger.Warnf("failure emptying temporary directory: %v", err)
+				}
 				elapsed := time.Since(start)
 				logger.Info(fmt.Sprintf("Generate finished (%s)", elapsed))
 				return
@@ -363,7 +375,10 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		wg.Wait()
 
-		instance.Paths.Generated.EmptyTmpDir()
+		err = instance.Paths.Generated.EmptyTmpDir()
+		if err != nil {
+			logger.Warnf("failure emptying temporary directory: %v", err)
+		}
 		elapsed := time.Since(start)
 		logger.Info(fmt.Sprintf("Generate finished (%s)", elapsed))
 	})
@@ -381,7 +396,10 @@ func (s *singleton) GenerateScreenshot(ctx context.Context, sceneId string, at f
 
 // generate default screenshot if at is nil
 func (s *singleton) generateScreenshot(ctx context.Context, sceneId string, at *float64) int {
-	instance.Paths.Generated.EnsureTmpDir()
+	err := instance.Paths.Generated.EnsureTmpDir()
+	if err != nil {
+		logger.Warnf("failure generating screenshot: %v", err)
+	}
 
 	j := job.MakeJobExec(func(ctx context.Context, progress *job.Progress) {
 		sceneIdInt, err := strconv.Atoi(sceneId)

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -163,8 +163,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 	if err := s.validateFFMPEG(); err != nil {
 		return 0, err
 	}
-	err := instance.Paths.Generated.EnsureTmpDir()
-	if err != nil {
+	if err := instance.Paths.Generated.EnsureTmpDir(); err != nil {
 		logger.Warnf("could not generate temporary directory: %v", err)
 	}
 
@@ -253,8 +252,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		// Start measuring how long the generate has taken. (consider moving this up)
 		start := time.Now()
-		err = instance.Paths.Generated.EnsureTmpDir()
-		if err != nil {
+		if err = instance.Paths.Generated.EnsureTmpDir(); err != nil {
 			logger.Warnf("could not create temprary directory: %v", err)
 		}
 
@@ -263,8 +261,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 			if job.IsCancelled(ctx) {
 				logger.Info("Stopping due to user request")
 				wg.Wait()
-				err := instance.Paths.Generated.EmptyTmpDir()
-				if err != nil {
+				if err := instance.Paths.Generated.EmptyTmpDir(); err != nil {
 					logger.Warnf("failure emptying temporary directory: %v", err)
 				}
 				return
@@ -347,8 +344,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 			if job.IsCancelled(ctx) {
 				logger.Info("Stopping due to user request")
 				wg.Wait()
-				err := instance.Paths.Generated.EmptyTmpDir()
-				if err != nil {
+				if err := instance.Paths.Generated.EmptyTmpDir(); err != nil {
 					logger.Warnf("failure emptying temporary directory: %v", err)
 				}
 				elapsed := time.Since(start)
@@ -375,8 +371,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		wg.Wait()
 
-		err = instance.Paths.Generated.EmptyTmpDir()
-		if err != nil {
+		if err = instance.Paths.Generated.EmptyTmpDir(); err != nil {
 			logger.Warnf("failure emptying temporary directory: %v", err)
 		}
 		elapsed := time.Since(start)
@@ -396,8 +391,7 @@ func (s *singleton) GenerateScreenshot(ctx context.Context, sceneId string, at f
 
 // generate default screenshot if at is nil
 func (s *singleton) generateScreenshot(ctx context.Context, sceneId string, at *float64) int {
-	err := instance.Paths.Generated.EnsureTmpDir()
-	if err != nil {
+	if err := instance.Paths.Generated.EnsureTmpDir(); err != nil {
 		logger.Warnf("failure generating screenshot: %v", err)
 	}
 

--- a/pkg/manager/paths/paths_generated.go
+++ b/pkg/manager/paths/paths_generated.go
@@ -51,7 +51,10 @@ func (gp *generatedPaths) RemoveTmpDir() error {
 }
 
 func (gp *generatedPaths) TempDir(pattern string) (string, error) {
-	gp.EnsureTmpDir()
+	err := gp.EnsureTmpDir()
+	if err != nil {
+		logger.Warnf("Could not ensure existence of a temporary directory: %v", err)
+	}
 	ret, err := ioutil.TempDir(gp.Tmp, pattern)
 	if err != nil {
 		return "", err

--- a/pkg/manager/paths/paths_generated.go
+++ b/pkg/manager/paths/paths_generated.go
@@ -51,8 +51,7 @@ func (gp *generatedPaths) RemoveTmpDir() error {
 }
 
 func (gp *generatedPaths) TempDir(pattern string) (string, error) {
-	err := gp.EnsureTmpDir()
-	if err != nil {
+	if err := gp.EnsureTmpDir(); err != nil {
 		logger.Warnf("Could not ensure existence of a temporary directory: %v", err)
 	}
 	ret, err := ioutil.TempDir(gp.Tmp, pattern)
@@ -60,8 +59,7 @@ func (gp *generatedPaths) TempDir(pattern string) (string, error) {
 		return "", err
 	}
 
-	err = utils.EmptyDir(ret)
-	if err != nil {
+	if err = utils.EmptyDir(ret); err != nil {
 		logger.Warnf("could not recursively empty dir: %v", err)
 	}
 

--- a/pkg/manager/paths/paths_generated.go
+++ b/pkg/manager/paths/paths_generated.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -37,16 +38,16 @@ func (gp *generatedPaths) GetTmpPath(fileName string) string {
 	return filepath.Join(gp.Tmp, fileName)
 }
 
-func (gp *generatedPaths) EnsureTmpDir() {
-	utils.EnsureDir(gp.Tmp)
+func (gp *generatedPaths) EnsureTmpDir() error {
+	return utils.EnsureDir(gp.Tmp)
 }
 
-func (gp *generatedPaths) EmptyTmpDir() {
-	utils.EmptyDir(gp.Tmp)
+func (gp *generatedPaths) EmptyTmpDir() error {
+	return utils.EmptyDir(gp.Tmp)
 }
 
-func (gp *generatedPaths) RemoveTmpDir() {
-	utils.RemoveDir(gp.Tmp)
+func (gp *generatedPaths) RemoveTmpDir() error {
+	return utils.RemoveDir(gp.Tmp)
 }
 
 func (gp *generatedPaths) TempDir(pattern string) (string, error) {
@@ -56,7 +57,10 @@ func (gp *generatedPaths) TempDir(pattern string) (string, error) {
 		return "", err
 	}
 
-	utils.EmptyDir(ret)
+	err = utils.EmptyDir(ret)
+	if err != nil {
+		logger.Warnf("could not recursively empty dir: %v", err)
+	}
 
 	return ret, nil
 }

--- a/pkg/manager/paths/paths_json.go
+++ b/pkg/manager/paths/paths_json.go
@@ -3,6 +3,7 @@ package paths
 import (
 	"path/filepath"
 
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -43,14 +44,38 @@ func GetJSONPaths(baseDir string) *JSONPaths {
 
 func EnsureJSONDirs(baseDir string) {
 	jsonPaths := GetJSONPaths(baseDir)
-	utils.EnsureDir(jsonPaths.Metadata)
-	utils.EnsureDir(jsonPaths.Scenes)
-	utils.EnsureDir(jsonPaths.Images)
-	utils.EnsureDir(jsonPaths.Galleries)
-	utils.EnsureDir(jsonPaths.Performers)
-	utils.EnsureDir(jsonPaths.Studios)
-	utils.EnsureDir(jsonPaths.Movies)
-	utils.EnsureDir(jsonPaths.Tags)
+	err := utils.EnsureDir(jsonPaths.Metadata)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Metadata: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Scenes)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Scenes: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Images)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Images: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Galleries)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Galleries: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Performers)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Performers: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Studios)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Studios: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Movies)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Movies: %v", err)
+	}
+	err = utils.EnsureDir(jsonPaths.Tags)
+	if err != nil {
+		logger.Warnf("couldn't create directories for Tags: %v", err)
+	}
 }
 
 func (jp *JSONPaths) PerformerJSONPath(checksum string) string {

--- a/pkg/manager/paths/paths_json.go
+++ b/pkg/manager/paths/paths_json.go
@@ -44,36 +44,28 @@ func GetJSONPaths(baseDir string) *JSONPaths {
 
 func EnsureJSONDirs(baseDir string) {
 	jsonPaths := GetJSONPaths(baseDir)
-	err := utils.EnsureDir(jsonPaths.Metadata)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Metadata); err != nil {
 		logger.Warnf("couldn't create directories for Metadata: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Scenes)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Scenes); err != nil {
 		logger.Warnf("couldn't create directories for Scenes: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Images)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Images); err != nil {
 		logger.Warnf("couldn't create directories for Images: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Galleries)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Galleries); err != nil {
 		logger.Warnf("couldn't create directories for Galleries: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Performers)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Performers); err != nil {
 		logger.Warnf("couldn't create directories for Performers: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Studios)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Studios); err != nil {
 		logger.Warnf("couldn't create directories for Studios: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Movies)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Movies); err != nil {
 		logger.Warnf("couldn't create directories for Movies: %v", err)
 	}
-	err = utils.EnsureDir(jsonPaths.Tags)
-	if err != nil {
+	if err := utils.EnsureDir(jsonPaths.Tags); err != nil {
 		logger.Warnf("couldn't create directories for Tags: %v", err)
 	}
 }

--- a/pkg/manager/running_streams.go
+++ b/pkg/manager/running_streams.go
@@ -98,6 +98,9 @@ func (s *SceneServer) ServeScreenshot(scene *models.Scene, w http.ResponseWriter
 		if err != nil {
 			logger.Warnf("read transaction failed while serving screenshot: %v", err)
 		}
-		utils.ServeImage(cover, w, r)
+		err = utils.ServeImage(cover, w, r)
+		if err != nil {
+			logger.Warnf("unable to serve screenshot image: %v", err)
+		}
 	}
 }

--- a/pkg/manager/running_streams.go
+++ b/pkg/manager/running_streams.go
@@ -91,10 +91,13 @@ func (s *SceneServer) ServeScreenshot(scene *models.Scene, w http.ResponseWriter
 		http.ServeFile(w, r, filepath)
 	} else {
 		var cover []byte
-		s.TXNManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
+		err := s.TXNManager.WithReadTxn(r.Context(), func(repo models.ReaderRepository) error {
 			cover, _ = repo.Scene().GetCover(scene.ID)
 			return nil
 		})
+		if err != nil {
+			logger.Warnf("read transaction failed while serving screenshot: %v", err)
+		}
 		utils.ServeImage(cover, w, r)
 	}
 }

--- a/pkg/manager/running_streams.go
+++ b/pkg/manager/running_streams.go
@@ -98,8 +98,8 @@ func (s *SceneServer) ServeScreenshot(scene *models.Scene, w http.ResponseWriter
 		if err != nil {
 			logger.Warnf("read transaction failed while serving screenshot: %v", err)
 		}
-		err = utils.ServeImage(cover, w, r)
-		if err != nil {
+
+		if err = utils.ServeImage(cover, w, r); err != nil {
 			logger.Warnf("unable to serve screenshot image: %v", err)
 		}
 	}

--- a/pkg/manager/screenshot.go
+++ b/pkg/manager/screenshot.go
@@ -13,8 +13,8 @@ func makeScreenshot(probeResult ffmpeg.VideoFile, outputPath string, quality int
 		Time:       time,
 		Width:      width,
 	}
-	err := encoder.Screenshot(probeResult, options)
-	if err != nil {
+
+	if err := encoder.Screenshot(probeResult, options); err != nil {
 		logger.Warnf("[encoder] failure to generate screenshot: %v", err)
 	}
 }

--- a/pkg/manager/screenshot.go
+++ b/pkg/manager/screenshot.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
 )
 
 func makeScreenshot(probeResult ffmpeg.VideoFile, outputPath string, quality int, width int, time float64) {
@@ -12,5 +13,8 @@ func makeScreenshot(probeResult ffmpeg.VideoFile, outputPath string, quality int
 		Time:       time,
 		Width:      width,
 	}
-	encoder.Screenshot(probeResult, options)
+	err := encoder.Screenshot(probeResult, options)
+	if err != nil {
+		logger.Warnf("[encoder] failure to generate screenshot: %v", err)
+	}
 }

--- a/pkg/manager/task_export.go
+++ b/pkg/manager/task_export.go
@@ -218,8 +218,7 @@ func (t *ExportTask) zipFiles(w io.Writer) error {
 
 // like filepath.Walk but issue a warning on error
 func walkWarn(root string, fn filepath.WalkFunc) {
-	err := filepath.Walk(root, fn)
-	if err != nil {
+	if err := filepath.Walk(root, fn); err != nil {
 		logger.Warnf("error walking structure %v: %v", root, err)
 	}
 }

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -160,7 +160,10 @@ func (t *ImportTask) unzipFile() error {
 		fn := filepath.Join(t.BaseDir, f.Name)
 
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(fn, os.ModePerm)
+			err := os.MkdirAll(fn, os.ModePerm)
+			if err != nil {
+				logger.Warnf("couldn't create directory %v while unzipping import file: %v", fn, err)
+			}
 			continue
 		}
 

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -160,8 +160,7 @@ func (t *ImportTask) unzipFile() error {
 		fn := filepath.Join(t.BaseDir, f.Name)
 
 		if f.FileInfo().IsDir() {
-			err := os.MkdirAll(fn, os.ModePerm)
-			if err != nil {
+			if err := os.MkdirAll(fn, os.ModePerm); err != nil {
 				logger.Warnf("couldn't create directory %v while unzipping import file: %v", fn, err)
 			}
 			continue

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -87,8 +87,7 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 				galleries = append(galleries, path)
 			}
 
-			tmpDirErr := instance.Paths.Generated.EnsureTmpDir()
-			if tmpDirErr != nil {
+			if err := instance.Paths.Generated.EnsureTmpDir(); err != nil {
 				logger.Warnf("couldn't create temporary directory: %v", err)
 			}
 
@@ -129,10 +128,11 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 	}
 
 	wg.Wait()
-	tmpDirErr := instance.Paths.Generated.EmptyTmpDir()
-	if tmpDirErr != nil {
-		logger.Warnf("couldn't empty temporary directory: %v", tmpDirErr)
+
+	if err := instance.Paths.Generated.EmptyTmpDir(); err != nil {
+		logger.Warnf("couldn't empty temporary directory: %v", err)
 	}
+
 	elapsed := time.Since(start)
 	logger.Info(fmt.Sprintf("Scan finished (%s)", elapsed))
 

--- a/pkg/manager/task_stash_box_tag.go
+++ b/pkg/manager/task_stash_box_tag.go
@@ -47,7 +47,7 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag() {
 
 	if t.refresh {
 		var performerID string
-		t.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		txnErr := t.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
 			stashids, _ := r.Performer().GetStashIDs(t.performer.ID)
 			for _, id := range stashids {
 				if id.Endpoint == t.box.Endpoint {
@@ -56,6 +56,9 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag() {
 			}
 			return nil
 		})
+		if txnErr != nil {
+			logger.Warnf("error while executing read transaction: %v", err)
+		}
 		if performerID != "" {
 			performer, err = client.FindStashBoxPerformerByID(performerID)
 		}

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -86,7 +86,11 @@ func (t *jsPluginTask) Start() error {
 	if err != nil {
 		return fmt.Errorf("error adding util API: %w", err)
 	}
-	js.AddGQLAPI(t.vm, t.input.ServerConnection.SessionCookie, t.gqlHandler)
+
+	err = js.AddGQLAPI(t.vm, t.input.ServerConnection.SessionCookie, t.gqlHandler)
+	if err != nil {
+		return fmt.Errorf("error adding GraphQL API: %w", err)
+	}
 
 	t.vm.Interrupt = make(chan func(), 1)
 

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -77,7 +77,11 @@ func (t *jsPluginTask) Start() error {
 		return fmt.Errorf("error setting input: %w", err)
 	}
 
-	js.AddLogAPI(t.vm, t.progress)
+	err = js.AddLogAPI(t.vm, t.progress)
+	if err != nil {
+		return fmt.Errorf("error adding log API: %w", err)
+	}
+
 	err = js.AddUtilAPI(t.vm)
 	if err != nil {
 		return fmt.Errorf("error adding util API: %w", err)

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -72,7 +72,11 @@ func (t *jsPluginTask) Start() error {
 		return err
 	}
 
-	t.vm.Set("input", t.input)
+	err = t.vm.Set("input", t.input)
+	if err != nil {
+		return fmt.Errorf("error setting input: %w", err)
+	}
+
 	js.AddLogAPI(t.vm, t.progress)
 	err = js.AddUtilAPI(t.vm)
 	if err != nil {

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -72,23 +72,19 @@ func (t *jsPluginTask) Start() error {
 		return err
 	}
 
-	err = t.vm.Set("input", t.input)
-	if err != nil {
+	if err := t.vm.Set("input", t.input); err != nil {
 		return fmt.Errorf("error setting input: %w", err)
 	}
 
-	err = js.AddLogAPI(t.vm, t.progress)
-	if err != nil {
+	if err := js.AddLogAPI(t.vm, t.progress); err != nil {
 		return fmt.Errorf("error adding log API: %w", err)
 	}
 
-	err = js.AddUtilAPI(t.vm)
-	if err != nil {
+	if err := js.AddUtilAPI(t.vm); err != nil {
 		return fmt.Errorf("error adding util API: %w", err)
 	}
 
-	err = js.AddGQLAPI(t.vm, t.input.ServerConnection.SessionCookie, t.gqlHandler)
-	if err != nil {
+	if err := js.AddGQLAPI(t.vm, t.input.ServerConnection.SessionCookie, t.gqlHandler); err != nil {
 		return fmt.Errorf("error adding GraphQL API: %w", err)
 	}
 

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -73,7 +74,10 @@ func (t *jsPluginTask) Start() error {
 
 	t.vm.Set("input", t.input)
 	js.AddLogAPI(t.vm, t.progress)
-	js.AddUtilAPI(t.vm)
+	err = js.AddUtilAPI(t.vm)
+	if err != nil {
+		return fmt.Errorf("error adding util API: %w", err)
+	}
 	js.AddGQLAPI(t.vm, t.input.ServerConnection.SessionCookie, t.gqlHandler)
 
 	t.vm.Interrupt = make(chan func(), 1)

--- a/pkg/plugin/js/gql.go
+++ b/pkg/plugin/js/gql.go
@@ -105,13 +105,11 @@ func gqlRequestFunc(vm *otto.Otto, cookie *http.Cookie, gqlHandler http.Handler)
 
 func AddGQLAPI(vm *otto.Otto, cookie *http.Cookie, gqlHandler http.Handler) error {
 	gql, _ := vm.Object("({})")
-	err := gql.Set("Do", gqlRequestFunc(vm, cookie, gqlHandler))
-	if err != nil {
+	if err := gql.Set("Do", gqlRequestFunc(vm, cookie, gqlHandler)); err != nil {
 		return fmt.Errorf("unable to set GraphQL Do function: %w", err)
 	}
 
-	err = vm.Set("gql", gql)
-	if err != nil {
+	if err := vm.Set("gql", gql); err != nil {
 		return fmt.Errorf("unable to set gql: %w", err)
 	}
 

--- a/pkg/plugin/js/gql.go
+++ b/pkg/plugin/js/gql.go
@@ -103,9 +103,17 @@ func gqlRequestFunc(vm *otto.Otto, cookie *http.Cookie, gqlHandler http.Handler)
 	}
 }
 
-func AddGQLAPI(vm *otto.Otto, cookie *http.Cookie, gqlHandler http.Handler) {
+func AddGQLAPI(vm *otto.Otto, cookie *http.Cookie, gqlHandler http.Handler) error {
 	gql, _ := vm.Object("({})")
-	gql.Set("Do", gqlRequestFunc(vm, cookie, gqlHandler))
+	err := gql.Set("Do", gqlRequestFunc(vm, cookie, gqlHandler))
+	if err != nil {
+		return fmt.Errorf("unable to set GraphQL Do function: %w", err)
+	}
 
-	vm.Set("gql", gql)
+	err = vm.Set("gql", gql)
+	if err != nil {
+		return fmt.Errorf("unable to set gql: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugin/js/log.go
+++ b/pkg/plugin/js/log.go
@@ -2,6 +2,7 @@ package js
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 
 	"github.com/robertkrimen/otto"
@@ -64,14 +65,37 @@ func logProgressFunc(c chan float64) func(call otto.FunctionCall) otto.Value {
 	}
 }
 
-func AddLogAPI(vm *otto.Otto, progress chan float64) {
+func AddLogAPI(vm *otto.Otto, progress chan float64) error {
 	log, _ := vm.Object("({})")
-	log.Set("Trace", logTrace)
-	log.Set("Debug", logDebug)
-	log.Set("Info", logInfo)
-	log.Set("Warn", logWarn)
-	log.Set("Error", logError)
-	log.Set("Progress", logProgressFunc(progress))
+	err := log.Set("Trace", logTrace)
+	if err != nil {
+		return fmt.Errorf("error setting Trace: %v", err)
+	}
+	err = log.Set("Debug", logDebug)
+	if err != nil {
+		return fmt.Errorf("error setting Debug: %v", err)
+	}
+	err = log.Set("Info", logInfo)
+	if err != nil {
+		return fmt.Errorf("error setting Info: %v", err)
+	}
+	err = log.Set("Warn", logWarn)
+	if err != nil {
+		return fmt.Errorf("error setting Warn: %v", err)
+	}
+	err = log.Set("Error", logError)
+	if err != nil {
+		return fmt.Errorf("error setting Error: %v", err)
+	}
+	err = log.Set("Progress", logProgressFunc(progress))
+	if err != nil {
+		return fmt.Errorf("error setting Progress: %v", err)
+	}
 
-	vm.Set("log", log)
+	err = vm.Set("log", log)
+	if err != nil {
+		return fmt.Errorf("unable to set log: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/plugin/js/log.go
+++ b/pkg/plugin/js/log.go
@@ -67,33 +67,25 @@ func logProgressFunc(c chan float64) func(call otto.FunctionCall) otto.Value {
 
 func AddLogAPI(vm *otto.Otto, progress chan float64) error {
 	log, _ := vm.Object("({})")
-	err := log.Set("Trace", logTrace)
-	if err != nil {
+	if err := log.Set("Trace", logTrace); err != nil {
 		return fmt.Errorf("error setting Trace: %w", err)
 	}
-	err = log.Set("Debug", logDebug)
-	if err != nil {
+	if err := log.Set("Debug", logDebug); err != nil {
 		return fmt.Errorf("error setting Debug: %w", err)
 	}
-	err = log.Set("Info", logInfo)
-	if err != nil {
+	if err := log.Set("Info", logInfo); err != nil {
 		return fmt.Errorf("error setting Info: %w", err)
 	}
-	err = log.Set("Warn", logWarn)
-	if err != nil {
+	if err := log.Set("Warn", logWarn); err != nil {
 		return fmt.Errorf("error setting Warn: %w", err)
 	}
-	err = log.Set("Error", logError)
-	if err != nil {
+	if err := log.Set("Error", logError); err != nil {
 		return fmt.Errorf("error setting Error: %w", err)
 	}
-	err = log.Set("Progress", logProgressFunc(progress))
-	if err != nil {
+	if err := log.Set("Progress", logProgressFunc(progress)); err != nil {
 		return fmt.Errorf("error setting Progress: %v", err)
 	}
-
-	err = vm.Set("log", log)
-	if err != nil {
+	if err := vm.Set("log", log); err != nil {
 		return fmt.Errorf("unable to set log: %w", err)
 	}
 

--- a/pkg/plugin/js/log.go
+++ b/pkg/plugin/js/log.go
@@ -69,23 +69,23 @@ func AddLogAPI(vm *otto.Otto, progress chan float64) error {
 	log, _ := vm.Object("({})")
 	err := log.Set("Trace", logTrace)
 	if err != nil {
-		return fmt.Errorf("error setting Trace: %v", err)
+		return fmt.Errorf("error setting Trace: %w", err)
 	}
 	err = log.Set("Debug", logDebug)
 	if err != nil {
-		return fmt.Errorf("error setting Debug: %v", err)
+		return fmt.Errorf("error setting Debug: %w", err)
 	}
 	err = log.Set("Info", logInfo)
 	if err != nil {
-		return fmt.Errorf("error setting Info: %v", err)
+		return fmt.Errorf("error setting Info: %w", err)
 	}
 	err = log.Set("Warn", logWarn)
 	if err != nil {
-		return fmt.Errorf("error setting Warn: %v", err)
+		return fmt.Errorf("error setting Warn: %w", err)
 	}
 	err = log.Set("Error", logError)
 	if err != nil {
-		return fmt.Errorf("error setting Error: %v", err)
+		return fmt.Errorf("error setting Error: %w", err)
 	}
 	err = log.Set("Progress", logProgressFunc(progress))
 	if err != nil {
@@ -94,7 +94,7 @@ func AddLogAPI(vm *otto.Otto, progress chan float64) error {
 
 	err = vm.Set("log", log)
 	if err != nil {
-		return fmt.Errorf("unable to set log: %v", err)
+		return fmt.Errorf("unable to set log: %w", err)
 	}
 
 	return nil

--- a/pkg/plugin/js/util.go
+++ b/pkg/plugin/js/util.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -14,9 +15,17 @@ func sleepFunc(call otto.FunctionCall) otto.Value {
 	return otto.UndefinedValue()
 }
 
-func AddUtilAPI(vm *otto.Otto) {
+func AddUtilAPI(vm *otto.Otto) error {
 	util, _ := vm.Object("({})")
-	util.Set("Sleep", sleepFunc)
+	err := util.Set("Sleep", sleepFunc)
+	if err != nil {
+		return fmt.Errorf("unable to set sleep func: %w", err)
+	}
 
-	vm.Set("util", util)
+	err = vm.Set("util", util)
+	if err != nil {
+		return fmt.Errorf("unable to set util: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugin/js/util.go
+++ b/pkg/plugin/js/util.go
@@ -17,13 +17,11 @@ func sleepFunc(call otto.FunctionCall) otto.Value {
 
 func AddUtilAPI(vm *otto.Otto) error {
 	util, _ := vm.Object("({})")
-	err := util.Set("Sleep", sleepFunc)
-	if err != nil {
+	if err := util.Set("Sleep", sleepFunc); err != nil {
 		return fmt.Errorf("unable to set sleep func: %w", err)
 	}
 
-	err = vm.Set("util", util)
-	if err != nil {
+	if err := vm.Set("util", util); err != nil {
 		return fmt.Errorf("unable to set util: %w", err)
 	}
 

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -219,8 +219,7 @@ func (c Cache) executePostHooks(ctx context.Context, hookType HookTriggerEnum, h
 
 			select {
 			case <-ctx.Done():
-				err := task.Stop()
-				if err != nil {
+				if err := task.Stop(); err != nil {
 					logger.Warnf("could not stop task: %v", err)
 				}
 				return fmt.Errorf("operation cancelled")

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -219,7 +219,10 @@ func (c Cache) executePostHooks(ctx context.Context, hookType HookTriggerEnum, h
 
 			select {
 			case <-ctx.Done():
-				task.Stop()
+				err := task.Stop()
+				if err != nil {
+					logger.Warnf("could not stop task: %v", err)
+				}
 				return fmt.Errorf("operation cancelled")
 			case <-c:
 				// task finished normally

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -51,7 +51,10 @@ func (t *rawPluginTask) Start() error {
 		defer stdin.Close()
 
 		inBytes, _ := json.Marshal(t.input)
-		io.WriteString(stdin, string(inBytes))
+		k, err := io.WriteString(stdin, string(inBytes))
+		if err != nil {
+			logger.Warnf("error writing input to plugins stdin (wrote %v bytes out of %v): %v", k, len(string(inBytes)), err)
+		}
 	}()
 
 	stderr, err := cmd.StderrPipe()

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -51,8 +51,7 @@ func (t *rawPluginTask) Start() error {
 		defer stdin.Close()
 
 		inBytes, _ := json.Marshal(t.input)
-		k, err := io.WriteString(stdin, string(inBytes))
-		if err != nil {
+		if k, err := io.WriteString(stdin, string(inBytes)); err != nil {
 			logger.Warnf("error writing input to plugins stdin (wrote %v bytes out of %v): %v", k, len(string(inBytes)), err)
 		}
 	}()

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -7,6 +7,8 @@ import (
 	"hash/fnv"
 	"io"
 	"os"
+
+	"github.com/stashapp/stash/pkg/logger"
 )
 
 func MD5FromBytes(data []byte) string {
@@ -40,7 +42,10 @@ func MD5FromReader(src io.Reader) (string, error) {
 
 func GenerateRandomKey(l int) string {
 	b := make([]byte, l)
-	rand.Read(b)
+	n, err := rand.Read(b)
+	if err != nil {
+		logger.Warnf("failure generating random key: %v (only read %v bytes)", err, n)
+	}
 	return fmt.Sprintf("%x", b)
 }
 

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -42,8 +42,7 @@ func MD5FromReader(src io.Reader) (string, error) {
 
 func GenerateRandomKey(l int) string {
 	b := make([]byte, l)
-	n, err := rand.Read(b)
-	if err != nil {
+	if n, err := rand.Read(b); err != nil {
 		logger.Warnf("failure generating random key: %v (only read %v bytes)", err, n)
 	}
 	return fmt.Sprintf("%x", b)

--- a/scripts/test_db_generator/makeTestDB.go
+++ b/scripts/test_db_generator/makeTestDB.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"strconv"
@@ -43,12 +44,15 @@ func main() {
 	var err error
 	c, err = loadConfig()
 	if err != nil {
-		panic(err)
+		log.Fatalf("couldn't load configuration: %v", err)
 	}
 
 	initNaming(*c)
 
-	database.Initialize(c.Database)
+	err = database.Initialize(c.Database)
+	if err != nil {
+		log.Fatalf("couldn't initialize database: %v", err)
+	}
 	populateDB()
 }
 

--- a/scripts/test_db_generator/makeTestDB.go
+++ b/scripts/test_db_generator/makeTestDB.go
@@ -49,8 +49,7 @@ func main() {
 
 	initNaming(*c)
 
-	err = database.Initialize(c.Database)
-	if err != nil {
+	if err = database.Initialize(c.Database); err != nil {
 		log.Fatalf("couldn't initialize database: %v", err)
 	}
 	populateDB()


### PR DESCRIPTION
This stack of patches goes through unhandled errors in stash, and does the following:

* If there's an obvious error-return already in place, the error is returned.
* If not, a `logger.Warnf(..)` is issued with the error. My rationale is that the program has worked well up until this point, so it's not an error that will suddenly make the program fail.
* Wrap errors if there is more contextual data to the error in a few places.
* If we already have logging higher up the call stack, propagate the error.

in `func RunMigrations`, just defer the close of the migration data to the function epilogue through a `defer`.

in `config_concurrency_test.go`: prepare to check errors. Rename `t` to `k` so `t *testing.T` is available, pass the worker explicitly.

Unhandled errors tend to hide faults in programs. By logging these, we get a heads-up on those faults. It can also improve support on a program because the errors are fed back to the user in the log, so many users can fix their own problems.

There's a `phase 2` errcheck handling coming up as well. So this isn't all the unchecked errors in the software. But by now, this stack is large enough I'd like to get that in first if possible.