### PR TITLE
Make IHierarchicalLabeledIdCriterion backwards compatible

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -99,6 +99,10 @@ export abstract class Criterion<V extends CriterionValue> {
     return this.value;
   }
 
+  public decodeValue(value: V) {
+    this.value = value;
+  }
+
   public toJSON() {
     const encodedCriterion = {
       type: this.criterionOption.type,
@@ -409,6 +413,15 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
       }),
       depth: this.value.depth,
     };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public decodeValue(value: any) {
+    if (Array.isArray(value)) {
+      this.value.items = value;
+    } else {
+      this.value = value;
+    }
   }
 
   protected toCriterionInput(): HierarchicalMultiCriterionInput {

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -116,7 +116,7 @@ export class ListFilterModel {
           const criterion = makeCriteria(encodedCriterion.type);
           // it's possible that we have unsupported criteria. Just skip if so.
           if (criterion) {
-            criterion.value = encodedCriterion.value;
+            criterion.decodeValue(encodedCriterion.value);
             criterion.modifier = encodedCriterion.modifier;
             this.criteria.push(criterion);
           }


### PR DESCRIPTION
Add some form of backwards compatibility in the UI for
`IHierarchicalLabeledIdCriterion`. With this backwards compatibility
it's possible to recall saved filters which use the tags filter.
Otherwise stuff would blow up because the saved filter has a different
structure than what the `IHierarchicalLabeledIdCriterion` expects.