### PR TITLE
[Bug Fix] Fix scene markers editor mobile UI

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -10,3 +10,6 @@
 
 ### 🎨 Improvements
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
+
+### 🐛 Bug fixes
+* Fix Create Marker form on small devices. ([#1718](https://github.com/stashapp/stash/pull/1718))

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
@@ -68,30 +68,26 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
       .catch((err) => Toast.error(err));
   };
   const renderTitleField = (fieldProps: FieldProps<string>) => (
-    <div className="col-10 col-xl-12">
-      <MarkerTitleSuggest
-        initialMarkerTitle={fieldProps.field.value}
-        onChange={(query: string) =>
-          fieldProps.form.setFieldValue("title", query)
-        }
-      />
-    </div>
+    <MarkerTitleSuggest
+      initialMarkerTitle={fieldProps.field.value}
+      onChange={(query: string) =>
+        fieldProps.form.setFieldValue("title", query)
+      }
+    />
   );
 
   const renderSecondsField = (fieldProps: FieldProps<string>) => (
-    <div className="col-3 col-xl-12">
-      <DurationInput
-        onValueChange={(s) => fieldProps.form.setFieldValue("seconds", s)}
-        onReset={() =>
-          fieldProps.form.setFieldValue(
-            "seconds",
-            Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
-          )
-        }
-        numericValue={Number.parseInt(fieldProps.field.value ?? "0", 10)}
-        mandatory
-      />
-    </div>
+    <DurationInput
+      onValueChange={(s) => fieldProps.form.setFieldValue("seconds", s)}
+      onReset={() =>
+        fieldProps.form.setFieldValue(
+          "seconds",
+          Math.round(JWUtils.getPlayer()?.getPosition() ?? 0)
+        )
+      }
+      numericValue={Number.parseInt(fieldProps.field.value ?? "0", 10)}
+      mandatory
+    />
   );
 
   const renderPrimaryTagField = (fieldProps: FieldProps<string>) => (
@@ -100,7 +96,7 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
         fieldProps.form.setFieldValue("primaryTagId", tags[0]?.id)
       }
       ids={fieldProps.field.value ? [fieldProps.field.value] : []}
-      noSelectionString="Select or create tag..."
+      noSelectionString="Select/create tag..."
     />
   );
 
@@ -114,7 +110,7 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
         )
       }
       ids={fieldProps.field.value}
-      noSelectionString="Select or create tags..."
+      noSelectionString="Select/create tags..."
     />
   );
 
@@ -133,28 +129,48 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
       <FormikForm>
         <div>
           <Form.Group className="row">
-            <Form.Label htmlFor="title" className="col-2 col-xl-12">
-              Scene Marker Title
+            <Form.Label
+              htmlFor="title"
+              className="col-sm-3 col-md-2 col-xl-12 col-form-label"
+            >
+              Marker Title
             </Form.Label>
-            <Field name="title">{renderTitleField}</Field>
+            <div className="col-sm-9 col-md-10 col-xl-12">
+              <Field name="title">{renderTitleField}</Field>
+            </div>
           </Form.Group>
           <Form.Group className="row">
-            <Form.Label htmlFor="primaryTagId" className="col-2 col-xl-12">
+            <Form.Label
+              htmlFor="primaryTagId"
+              className="col-sm-3 col-md-2 col-xl-12 col-form-label"
+            >
               Primary Tag
             </Form.Label>
-            <div className="col-6 col-xl-12">
+            <div className="col-sm-4 col-md-6 col-xl-12 mb-3 mb-sm-0 mb-xl-3">
               <Field name="primaryTagId">{renderPrimaryTagField}</Field>
             </div>
-            <Form.Label htmlFor="seconds" className="col-1 col-xl-12 mt-2">
-              Time
-            </Form.Label>
-            <Field name="seconds">{renderSecondsField}</Field>
+            <div className="col-sm-5 col-md-4 col-xl-12">
+              <div className="row">
+                <Form.Label
+                  htmlFor="seconds"
+                  className="col-sm-4 col-md-4 col-xl-12 col-form-label text-sm-right text-xl-left"
+                >
+                  Time
+                </Form.Label>
+                <div className="col-sm-8 col-xl-12">
+                  <Field name="seconds">{renderSecondsField}</Field>
+                </div>
+              </div>
+            </div>
           </Form.Group>
           <Form.Group className="row">
-            <Form.Label htmlFor="tagIds" className="col-2 col-xl-12">
+            <Form.Label
+              htmlFor="tagIds"
+              className="col-sm-3 col-md-2 col-xl-12 col-form-label"
+            >
               Tags
             </Form.Label>
-            <div className="col-10 col-xl-12">
+            <div className="col-sm-9 col-md-10 col-xl-12">
               <Field name="tagIds">{renderTagsField}</Field>
             </div>
           </Form.Group>

--- a/ui/v2.5/src/components/Shared/DurationInput.tsx
+++ b/ui/v2.5/src/components/Shared/DurationInput.tsx
@@ -93,7 +93,7 @@ export const DurationInput: React.FC<IProps> = (props: IProps) => {
   }
 
   return (
-    <Form.Group className={`duration-input ${props.className}`}>
+    <div className={`duration-input ${props.className}`}>
       <InputGroup>
         <Form.Control
           className="duration-control text-input"
@@ -122,6 +122,6 @@ export const DurationInput: React.FC<IProps> = (props: IProps) => {
           {renderButtons()}
         </InputGroup.Append>
       </InputGroup>
-    </Form.Group>
+    </div>
   );
 };

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -217,6 +217,7 @@ div.react-select__control {
   border-color: $secondary;
   color: $text-color;
   cursor: pointer;
+  white-space: nowrap;
 
   .react-select__single-value,
   .react-select__input {

--- a/ui/v2.5/src/styles/_theme.scss
+++ b/ui/v2.5/src/styles/_theme.scss
@@ -78,7 +78,7 @@ hr {
 .nav-tabs {
   border: none;
   margin: auto;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
 
   .nav-link {
     border: none;


### PR DESCRIPTION
# Scope

Scene -> Markers

This PR fixes the mobile view of the scene markers editor on 320px and 576px breakpoints. It also includes some minor refactoring and UI improvements for the components in scope.

## Testing

1. Launch the server: `./stash`
2. Launch UI dev server: `make ui-start`
3. Navigate to any scene
4. Select `Markers` tab
5. Check the layout on the following breakpoints: 320px, 575px, 576px, 767px, 768px, 1023px, 1024px, 1199px, 1200px

## Screenshots

### 320px
| Before | After |
| --- | --- |
|![before-320](https://user-images.githubusercontent.com/90413137/132941990-3d5804d7-d27d-4e66-8071-413d0077c821.png)|![after-320](https://user-images.githubusercontent.com/90413137/132941996-5ee1d789-ad54-481d-9605-7e3ad91046da.png)|

### 576px
| Before | After |
| --- | --- |
|![before-576](https://user-images.githubusercontent.com/90413137/132942000-eb5a903e-7bb3-439d-b7f0-872b7e674d99.png)|![after-576](https://user-images.githubusercontent.com/90413137/132942022-8cd9f1f1-1944-440a-9d20-ecc533202bf3.png)|

### 768px
| Before | After |
| --- | --- |
|![before-768](https://user-images.githubusercontent.com/90413137/132942017-b4a4d907-6c63-447d-a002-3f48cf0f3474.png)|![after-768](https://user-images.githubusercontent.com/90413137/132942031-2a4f861a-160c-482f-909e-4c33947419e6.png)|

### 1024
| Before | After |
| --- | --- |
|![before-1024](https://user-images.githubusercontent.com/90413137/132942046-cc4369b3-b698-41ce-8bdc-0081c28f7e93.png)|![after-1024](https://user-images.githubusercontent.com/90413137/132942052-f5d41b9d-f05c-46df-a674-07498e8fa511.png)|

### 1200px
| Before | After |
| --- | --- |
|![before-1200](https://user-images.githubusercontent.com/90413137/132942056-4374d4a6-d0a8-4099-ba7f-605d1acfb464.png)|![after-1200](https://user-images.githubusercontent.com/90413137/132942060-57cf592d-00ae-4b9e-87e8-73304ea82324.png)|