### PR TITLE
Execute Gallery.Create.Post plugin hook during scan

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -14,6 +14,7 @@
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
 
 ### 🐛 Bug fixes
+* Fix Gallery create plugin hook not being invoked when creating Gallery from folder. ([#1731](https://github.com/stashapp/stash/pull/1731)) 
 * Fix tag aliases not being matched when autotagging from the tasks page. ([#1713](https://github.com/stashapp/stash/pull/1713))
 * Disabled float-on-scroll player on mobile devices. ([#1721](https://github.com/stashapp/stash/pull/1721))
 * Fix Create Marker form on small devices. ([#1718](https://github.com/stashapp/stash/pull/1718))


### PR DESCRIPTION
Fix issue where Gallery.Create.Post hook is not executed when a new
gallery is created during scan, when the gallery is created based on the
folder.