### PR TITLE
Make hierarchical criterion depth input optional

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -361,7 +361,7 @@ input GenderCriterionInput {
 input HierarchicalMultiCriterionInput {
   value: [ID!]
   modifier: CriterionModifier!
-  depth: Int!
+  depth: Int
 }
 
 enum FilterMode {

--- a/pkg/dlna/cds.go
+++ b/pkg/dlna/cds.go
@@ -533,7 +533,6 @@ func (me *contentDirectoryService) getStudioScenes(paths []string, host string) 
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Modifier: models.CriterionModifierIncludes,
 			Value:    []string{paths[0]},
-			Depth:    0,
 		},
 	}
 
@@ -573,7 +572,6 @@ func (me *contentDirectoryService) getTagScenes(paths []string, host string) []i
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Modifier: models.CriterionModifierIncludes,
 			Value:    []string{paths[0]},
-			Depth:    0,
 		},
 	}
 

--- a/pkg/gallery/query.go
+++ b/pkg/gallery/query.go
@@ -22,7 +22,6 @@ func CountByStudioID(r models.GalleryReader, id int) (int, error) {
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		},
 	}
 
@@ -34,7 +33,6 @@ func CountByTagID(r models.GalleryReader, id int) (int, error) {
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		},
 	}
 

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -22,7 +22,6 @@ func CountByStudioID(r models.ImageReader, id int) (int, error) {
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		},
 	}
 
@@ -34,7 +33,6 @@ func CountByTagID(r models.ImageReader, id int) (int, error) {
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		},
 	}
 

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -627,7 +627,6 @@ func TestGalleryQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithGallery]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		galleryFilter := models.GalleryFilterType{
@@ -648,7 +647,6 @@ func TestGalleryQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithGallery]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		galleries = queryGallery(t, sqb, &galleryFilter, nil)
@@ -661,7 +659,6 @@ func TestGalleryQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithGallery]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getGalleryStringValue(galleryIdxWithTwoTags, titleField)
@@ -684,7 +681,6 @@ func TestGalleryQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithGallery]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		galleryFilter := models.GalleryFilterType{
@@ -703,7 +699,6 @@ func TestGalleryQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithGallery]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getGalleryStringValue(galleryIdxWithStudio, titleField)
@@ -721,12 +716,13 @@ func TestGalleryQueryStudio(t *testing.T) {
 func TestGalleryQueryStudioDepth(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Gallery()
+		depth := 2
 		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		galleryFilter := models.GalleryFilterType{
@@ -736,7 +732,7 @@ func TestGalleryQueryStudioDepth(t *testing.T) {
 		galleries := queryGallery(t, sqb, &galleryFilter, nil)
 		assert.Len(t, galleries, 1)
 
-		studioCriterion.Depth = 1
+		depth = 1
 
 		galleries = queryGallery(t, sqb, &galleryFilter, nil)
 		assert.Len(t, galleries, 0)
@@ -748,12 +744,14 @@ func TestGalleryQueryStudioDepth(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, galleryIDs[galleryIdxWithGrandChildStudio], galleries[0].ID)
 
+		depth = 2
+
 		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		q := getGalleryStringValue(galleryIdxWithGrandChildStudio, pathField)
@@ -764,7 +762,7 @@ func TestGalleryQueryStudioDepth(t *testing.T) {
 		galleries = queryGallery(t, sqb, &galleryFilter, &findFilter)
 		assert.Len(t, galleries, 0)
 
-		studioCriterion.Depth = 1
+		depth = 1
 		galleries = queryGallery(t, sqb, &galleryFilter, &findFilter)
 		assert.Len(t, galleries, 1)
 
@@ -785,7 +783,6 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		galleryFilter := models.GalleryFilterType{
@@ -806,7 +803,6 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		galleries = queryGallery(t, sqb, &galleryFilter, nil)
@@ -819,7 +815,6 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getGalleryStringValue(galleryIdxWithPerformerTwoTags, titleField)

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -728,7 +728,6 @@ func TestImageQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithImage]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		imageFilter := models.ImageFilterType{
@@ -753,7 +752,6 @@ func TestImageQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithImage]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		images, _, err = sqb.Query(&imageFilter, nil)
@@ -769,7 +767,6 @@ func TestImageQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithImage]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getImageStringValue(imageIdxWithTwoTags, titleField)
@@ -795,7 +792,6 @@ func TestImageQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithImage]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		imageFilter := models.ImageFilterType{
@@ -817,7 +813,6 @@ func TestImageQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithImage]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getImageStringValue(imageIdxWithStudio, titleField)
@@ -838,12 +833,13 @@ func TestImageQueryStudio(t *testing.T) {
 func TestImageQueryStudioDepth(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Image()
+		depth := 2
 		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		imageFilter := models.ImageFilterType{
@@ -853,7 +849,7 @@ func TestImageQueryStudioDepth(t *testing.T) {
 		images := queryImages(t, sqb, &imageFilter, nil)
 		assert.Len(t, images, 1)
 
-		studioCriterion.Depth = 1
+		depth = 1
 
 		images = queryImages(t, sqb, &imageFilter, nil)
 		assert.Len(t, images, 0)
@@ -865,12 +861,14 @@ func TestImageQueryStudioDepth(t *testing.T) {
 		// ensure id is correct
 		assert.Equal(t, imageIDs[imageIdxWithGrandChildStudio], images[0].ID)
 
+		depth = 2
+
 		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		q := getImageStringValue(imageIdxWithGrandChildStudio, titleField)
@@ -881,7 +879,7 @@ func TestImageQueryStudioDepth(t *testing.T) {
 		images = queryImages(t, sqb, &imageFilter, &findFilter)
 		assert.Len(t, images, 0)
 
-		studioCriterion.Depth = 1
+		depth = 1
 		images = queryImages(t, sqb, &imageFilter, &findFilter)
 		assert.Len(t, images, 1)
 
@@ -911,7 +909,6 @@ func TestImageQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		imageFilter := models.ImageFilterType{
@@ -932,7 +929,6 @@ func TestImageQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		images = queryImages(t, sqb, &imageFilter, nil)
@@ -945,7 +941,6 @@ func TestImageQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getImageStringValue(imageIdxWithPerformerTwoTags, titleField)

--- a/pkg/sqlite/movies_test.go
+++ b/pkg/sqlite/movies_test.go
@@ -82,7 +82,6 @@ func TestMovieQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithMovie]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		movieFilter := models.MovieFilterType{
@@ -104,7 +103,6 @@ func TestMovieQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithMovie]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getMovieStringValue(movieIdxWithStudio, titleField)

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -506,7 +506,6 @@ func TestPerformerQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		performerFilter := models.PerformerFilterType{
@@ -526,7 +525,6 @@ func TestPerformerQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		performers = queryPerformers(t, sqb, &performerFilter, nil)
@@ -539,7 +537,6 @@ func TestPerformerQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getSceneStringValue(performerIdxWithTwoTags, titleField)

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -1040,7 +1040,6 @@ func TestSceneQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithScene]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		sceneFilter := models.SceneFilterType{
@@ -1061,7 +1060,6 @@ func TestSceneQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithScene]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		scenes = queryScene(t, sqb, &sceneFilter, nil)
@@ -1074,7 +1072,6 @@ func TestSceneQueryTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithScene]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getSceneStringValue(sceneIdxWithTwoTags, titleField)
@@ -1098,7 +1095,6 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		sceneFilter := models.SceneFilterType{
@@ -1119,7 +1115,6 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
 			},
 			Modifier: models.CriterionModifierIncludesAll,
-			Depth:    0,
 		}
 
 		scenes = queryScene(t, sqb, &sceneFilter, nil)
@@ -1132,7 +1127,6 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 				strconv.Itoa(tagIDs[tagIdx1WithPerformer]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getSceneStringValue(sceneIdxWithPerformerTwoTags, titleField)
@@ -1155,7 +1149,6 @@ func TestSceneQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithScene]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    0,
 		}
 
 		sceneFilter := models.SceneFilterType{
@@ -1174,7 +1167,6 @@ func TestSceneQueryStudio(t *testing.T) {
 				strconv.Itoa(studioIDs[studioIdxWithScene]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    0,
 		}
 
 		q := getSceneStringValue(sceneIdxWithStudio, titleField)
@@ -1192,12 +1184,13 @@ func TestSceneQueryStudio(t *testing.T) {
 func TestSceneQueryStudioDepth(t *testing.T) {
 	withTxn(func(r models.Repository) error {
 		sqb := r.Scene()
+		depth := 2
 		studioCriterion := models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		sceneFilter := models.SceneFilterType{
@@ -1207,7 +1200,7 @@ func TestSceneQueryStudioDepth(t *testing.T) {
 		scenes := queryScene(t, sqb, &sceneFilter, nil)
 		assert.Len(t, scenes, 1)
 
-		studioCriterion.Depth = 1
+		depth = 1
 
 		scenes = queryScene(t, sqb, &sceneFilter, nil)
 		assert.Len(t, scenes, 0)
@@ -1218,13 +1211,14 @@ func TestSceneQueryStudioDepth(t *testing.T) {
 
 		// ensure id is correct
 		assert.Equal(t, sceneIDs[sceneIdxWithGrandChildStudio], scenes[0].ID)
+		depth = 2
 
 		studioCriterion = models.HierarchicalMultiCriterionInput{
 			Value: []string{
 				strconv.Itoa(studioIDs[studioIdxWithGrandChild]),
 			},
 			Modifier: models.CriterionModifierExcludes,
-			Depth:    2,
+			Depth:    &depth,
 		}
 
 		q := getSceneStringValue(sceneIdxWithGrandChildStudio, titleField)
@@ -1235,7 +1229,7 @@ func TestSceneQueryStudioDepth(t *testing.T) {
 		scenes = queryScene(t, sqb, &sceneFilter, &findFilter)
 		assert.Len(t, scenes, 0)
 
-		studioCriterion.Depth = 1
+		depth = 1
 		scenes = queryScene(t, sqb, &sceneFilter, &findFilter)
 		assert.Len(t, scenes, 1)
 

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -374,7 +374,6 @@ func verifyStudiosImageCount(t *testing.T, imageCountCriterion models.IntCriteri
 				Studios: &models.HierarchicalMultiCriterionInput{
 					Value:    []string{strconv.Itoa(studio.ID)},
 					Modifier: models.CriterionModifierIncludes,
-					Depth:    0,
 				},
 			}, &models.FindFilterType{
 				PerPage: &pp,
@@ -425,7 +424,6 @@ func verifyStudiosGalleryCount(t *testing.T, galleryCountCriterion models.IntCri
 				Studios: &models.HierarchicalMultiCriterionInput{
 					Value:    []string{strconv.Itoa(studio.ID)},
 					Modifier: models.CriterionModifierIncludes,
-					Depth:    0,
 				},
 			}, &models.FindFilterType{
 				PerPage: &pp,


### PR DESCRIPTION
Fixes backward compatibility with clients (now) using hierarchical multi criterion inputs. Makes depth optional, defaulting to 0.