### PR TITLE
Fix scene edit panel layout

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -14,8 +14,8 @@
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
 
 ### 🐛 Bug fixes
+* Fix Scene Edit Panel form layout for mobile and desktop. ([#1737](https://github.com/stashapp/stash/pull/1737))
 * Fix Gallery create plugin hook not being invoked when creating Gallery from folder. ([#1731](https://github.com/stashapp/stash/pull/1731)) 
 * Fix tag aliases not being matched when autotagging from the tasks page. ([#1713](https://github.com/stashapp/stash/pull/1713))
 * Disabled float-on-scroll player on mobile devices. ([#1721](https://github.com/stashapp/stash/pull/1721))
 * Fix Create Marker form on small devices. ([#1718](https://github.com/stashapp/stash/pull/1718))
-* Fix Scene Edit Panel form layout for mobile and desktop. ([#1737](https://github.com/stashapp/stash/pull/1737))

--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -15,3 +15,4 @@
 ### 🐛 Bug fixes
 * Disabled float-on-scroll player on mobile devices. ([#1721](https://github.com/stashapp/stash/pull/1721))
 * Fix Create Marker form on small devices. ([#1718](https://github.com/stashapp/stash/pull/1718))
+* Fix Scene Edit Panel form layout for mobile and desktop. ([#1737](https://github.com/stashapp/stash/pull/1737))

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -644,7 +644,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
           </div>
         </div>
         <div className="form-container row px-3">
-          <div className="col-12 col-lg-6 col-xl-12">
+          <div className="col-12 col-lg-7 col-xl-12">
             {renderTextField("title", intl.formatMessage({ id: "title" }))}
             <Form.Group controlId="url" as={Row}>
               <Col xs={3} className="pr-0 url-label">
@@ -685,8 +685,12 @@ export const SceneEditPanel: React.FC<IProps> = ({
             <Form.Group controlId="galleries" as={Row}>
               {FormUtils.renderLabel({
                 title: intl.formatMessage({ id: "galleries" }),
+                labelProps: {
+                  column: true,
+                  sm: 3,
+                },
               })}
-              <Col xs={9}>
+              <Col sm={9}>
                 <GallerySelect
                   galleries={galleries}
                   onSelect={(items) => onSetGalleries(items)}
@@ -697,8 +701,12 @@ export const SceneEditPanel: React.FC<IProps> = ({
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
                 title: intl.formatMessage({ id: "studios" }),
+                labelProps: {
+                  column: true,
+                  sm: 3,
+                },
               })}
-              <Col xs={9}>
+              <Col sm={9}>
                 <StudioSelect
                   onSelect={(items) =>
                     formik.setFieldValue(
@@ -815,7 +823,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
               </ul>
             </Form.Group>
           </div>
-          <div className="col-12 col-lg-6 col-xl-12">
+          <div className="col-12 col-lg-5 col-xl-12">
             <Form.Group controlId="details">
               <Form.Label>
                 <FormattedMessage id="details" />


### PR DESCRIPTION
# Scope

UI: SceneEditPanel

This PR fixes the layout on 320 and 1024 viewports (labels for Galleries, Studios, Movies/Scenes)

# How to test

1. Run the UI
2. Navigate to any scene, click the `Edit` tab
3. Check that the layout is consistent on the following breakpoints: 320, 576, 768, 1024, 1200

# Screenshots

## 320px

| Before | After |
|---|---|
|![before-320](https://user-images.githubusercontent.com/90413137/133731699-1490ac8d-87a3-4927-a3b3-837f2448121f.png)|![after-320](https://user-images.githubusercontent.com/90413137/133731720-0271d19b-437a-4fa5-a883-cc4788cadfd0.png)|

## 1024px
| Before | After |
|---|---|
|![before-1024](https://user-images.githubusercontent.com/90413137/133731768-efb9885b-8cf8-4541-b7ae-cffac5539b90.png)|![after-1024](https://user-images.githubusercontent.com/90413137/133731817-2879e91f-8a27-4794-9518-45159f2dcea8.png)|