### PR TITLE
Fix Scene Player CLS issue

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -17,3 +17,4 @@
 * Fix tag aliases not being matched when autotagging from the tasks page. ([#1713](https://github.com/stashapp/stash/pull/1713))
 * Disabled float-on-scroll player on mobile devices. ([#1721](https://github.com/stashapp/stash/pull/1721))
 * Fix Create Marker form on small devices. ([#1718](https://github.com/stashapp/stash/pull/1718))
+* Fix Scene Player CLS issue ([#1739](https://github.com/stashapp/stash/pull/1739))

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -349,6 +349,7 @@ export class ScenePlayerImpl extends React.Component<
           onSeeked={this.onSeeked}
           onTime={this.onTime}
           onOneHundredPercent={() => this.onComplete()}
+          className="video-wrapper"
         />
         <ScenePlayerScrubber
           scene={this.props.scene}

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -1,43 +1,31 @@
 $scrubberHeight: 120px;
+$menuHeight: 4rem;
+$sceneTabWidth: 450px;
 
 #jwplayer-container {
-  /* full height minus the top navbar */
-  height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - #{$menuHeight});
   padding-bottom: 0.25rem;
 
-  @media (max-width: 1200px) {
-    height: inherit;
-
-    .jw-aspect {
-      display: block;
-      height: 56.25vw;
-      max-height: calc(100vh - #{$scrubberHeight} - 4.25rem - 15px);
-    }
-
-    &.portrait .jw-aspect {
-      height: 177.78vw;
-    }
-  }
-  @media (max-height: 449px), (max-width: 575px) {
-    .jw-aspect {
-      max-height: calc(100vh - 4.25rem);
-    }
+  @media (min-width: 1200px) {
+    height: 100vh;
   }
 
   & video:focus {
     outline: 0;
   }
 
-  > div:first-child {
-    /* minus the scrubber height and margin */
-    height: calc(100% - #{$scrubberHeight} - 15px);
-  }
-}
+  .video-wrapper {
+    height: 56.25vw;
 
-/* scrubber is hidden when height < 450px or width < 576, so use entire height for scene player */
-@media (max-height: 449px), (max-width: 575px) {
-  #jwplayer-container > div:first-child {
-    height: 100%;
+    @media (min-width: 1200px) {
+      height: 100%;
+    }
+  }
+
+  &.portrait .video-wrapper {
+    height: 177.78vw;
   }
 }
 
@@ -57,9 +45,6 @@ $scrubberHeight: 120px;
     padding-right: 15px;
   }
 }
-
-$sceneTabWidth: 450px;
-
 @media (min-width: 1200px) {
   .scene-tabs {
     flex: 0 0 $sceneTabWidth;
@@ -117,6 +102,7 @@ $sceneTabWidth: 450px;
 }
 
 .scrubber-wrapper {
+  flex-shrink: 0;
   margin: 5px 0;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
# Scope

Because JWPlayer script is loaded asynchronously by `ReactJWPlayer`, the browser has no elements to apply styles to on first paint. Hence, the layout shift. This PR reworks the styles to reserve space for the player and eliminates CLS completely.

# How to test

1. Make sure the backend is running
2. Launch the UI dev server: `make ui-start`
3. Navigate to a scene and make sure no layout shift happens on load
   - Alternatively, you can use [Web Vitals](https://chrome.google.com/webstore/detail/web-vitals/ahfhijdlegdabablpippeagghigmibma) Chrome extension to see the numbers
4. Check player visual regressions manually on all breakpoints and screen orientations for both:
    - Landscape video
    - Portrait video

## CLS screenshots

| Before | After |
| --- | --- |
|![cls_before](https://user-images.githubusercontent.com/90413137/133884807-f3e683a2-6c64-4319-99fb-fae0fea7c4d1.png)|![cls_after](https://user-images.githubusercontent.com/90413137/133884812-55c4dda9-8d5d-4ff6-b644-a499f248b86b.png)|

## Video recordings

| Before | After |
| --- | --- |
|https://www.awesomescreenshot.com/video/5279696?key=5e9471de2e1f9698b059a7c05eee908d|https://www.awesomescreenshot.com/video/5279687?key=a77d91b1e932beb2cdaa1976e7ba6120|