### PR TITLE
Scraper log improvements

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -182,6 +182,11 @@ func Progressf(format string, args ...interface{}) {
 
 func Trace(args ...interface{}) {
 	logger.Trace(args...)
+	l := &LogItem{
+		Type:    "trace",
+		Message: fmt.Sprint(args...),
+	}
+	addLogItem(l)
 }
 
 func Tracef(format string, args ...interface{}) {

--- a/pkg/logger/plugin.go
+++ b/pkg/logger/plugin.go
@@ -146,19 +146,19 @@ func (log *PluginLogger) HandleStderrLine(line string) {
 
 	switch *level {
 	case TraceLevel:
-		logger.Trace(log.Prefix, ll)
+		Trace(log.Prefix, ll)
 	case DebugLevel:
-		logger.Debug(log.Prefix, ll)
+		Debug(log.Prefix, ll)
 	case InfoLevel:
-		logger.Info(log.Prefix, ll)
+		Info(log.Prefix, ll)
 	case WarningLevel:
-		logger.Warn(log.Prefix, ll)
+		Warn(log.Prefix, ll)
 	case ErrorLevel:
-		logger.Error(log.Prefix, ll)
+		Error(log.Prefix, ll)
 	case ProgressLevel:
 		p, err := strconv.ParseFloat(ll, 64)
 		if err != nil {
-			logger.Errorf("Error parsing progress value '%s': %s", ll, err.Error())
+			Errorf("Error parsing progress value '%s': %s", ll, err.Error())
 		} else {
 			// only pass progress through if channel present
 			if log.ProgressChan != nil {

--- a/pkg/plugin/log.go
+++ b/pkg/plugin/log.go
@@ -1,22 +1,23 @@
 package plugin
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/stashapp/stash/pkg/logger"
 )
 
-func (t *pluginTask) handlePluginStderr(pluginOutputReader io.ReadCloser) {
+func (t *pluginTask) handlePluginStderr(name string, pluginOutputReader io.ReadCloser) {
 	logLevel := logger.PluginLogLevelFromName(t.plugin.PluginErrLogLevel)
 	if logLevel == nil {
 		// default log level to error
 		logLevel = &logger.ErrorLevel
 	}
 
-	const pluginPrefix = "[Plugin] "
+	const pluginPrefix = "[Plugin / %s] "
 
 	lgr := logger.PluginLogger{
-		Prefix:          pluginPrefix,
+		Prefix:          fmt.Sprintf(pluginPrefix, name),
 		DefaultLogLevel: logLevel,
 		ProgressChan:    t.progress,
 	}

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -70,7 +70,7 @@ func (t *rawPluginTask) Start() error {
 		return fmt.Errorf("error running plugin: %s", err.Error())
 	}
 
-	go t.handlePluginStderr(stderr)
+	go t.handlePluginStderr(t.plugin.Name, stderr)
 	t.cmd = cmd
 
 	// send the stdout to the plugin output

--- a/pkg/plugin/rpc.go
+++ b/pkg/plugin/rpc.go
@@ -64,7 +64,7 @@ func (t *rpcPluginTask) Start() error {
 		return err
 	}
 
-	go t.handlePluginStderr(pluginErrReader)
+	go t.handlePluginStderr(t.plugin.Name, pluginErrReader)
 
 	iface := rpcPluginClient{
 		Client: t.client,

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -3,6 +3,7 @@ package scraper
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"path/filepath"
@@ -65,7 +66,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 		return errors.New("error running scraper script")
 	}
 
-	go handleScraperStderr(stderr)
+	go handleScraperStderr(s.config.Name, stderr)
 
 	logger.Debugf("Scraper script <%s> started", strings.Join(cmd.Args, " "))
 
@@ -248,11 +249,11 @@ func findPythonExecutable() (string, error) {
 	return "python3", nil
 }
 
-func handleScraperStderr(scraperOutputReader io.ReadCloser) {
-	const scraperPrefix = "[Scrape] "
+func handleScraperStderr(name string, scraperOutputReader io.ReadCloser) {
+	const scraperPrefix = "[Scrape / %s] "
 
 	lgr := logger.PluginLogger{
-		Prefix:          scraperPrefix,
+		Prefix:          fmt.Sprintf(scraperPrefix, name),
 		DefaultLogLevel: &logger.ErrorLevel,
 	}
 	lgr.HandlePluginStdErr(scraperOutputReader)


### PR DESCRIPTION
This makes two fixes / changes:
1. It fixes logs not being shown in the web UI as reported in #1648 (`logger` in the `logger` package is the logrus instance, not a reference to the package)
2. It prefixes the log lines not just with `[Scrape]` / `[Plugin]` but includes the name of the scraper / plugin as well so it's easier to distinguish them

@WithoutPants I might have found a third unrelated issue. `logger.Trace()` doesn't add the log to the list of "UI logs" so is never shown in the UI, while `Tracef` is, as seen here:
https://github.com/stashapp/stash/blob/66f92c5dccaed02ef0a6caa2669ad0e890dcf929/pkg/logger/logger.go#L183-L185
(Compare `Trace` with `Tracef`, `Debug` etc).
Do you want me to fix this as well, or is there some reason to not append unformatted trace messages to the log? (Possibly because of spamming a lot or whatever).