### PR TITLE
Fix Query for Scene Markers

### DIFF
--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -149,7 +149,7 @@ func (qb *sceneMarkerQueryBuilder) Query(sceneMarkerFilter *models.SceneMarkerFi
 	query.body = selectDistinctIDs("scene_markers")
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		searchColumns := []string{"scene_markers.title", "scene.title"}
+		searchColumns := []string{"scene_markers.title", "scenes.title"}
 		clause, thisArgs := getSearchBinding(searchColumns, *q, false)
 		query.addWhere(clause)
 		query.addArg(thisArgs...)


### PR DESCRIPTION
Fixes bug reported in discord channel
```
error executing count query with SQL: SELECT COUNT(*) as count FROM (SELECT DISTINCT scene_markers.id FROM scene_markers LEFT JOIN scenes ON scenes.id = scene_markers.scene_id WHERE (scene_markers.title LIKE ? OR scene.title LIKE ?) GROUP BY scene_markers.id ) as temp, args: [%cow% %cow%], error: no such column: scene.title
```
when doing a search in the markers page