### PR TITLE
Reorder waitgroup completion

### DIFF
--- a/pkg/manager/task.go
+++ b/pkg/manager/task.go
@@ -1,8 +1,6 @@
 package manager
 
-import "sync"
-
 type Task interface {
-	Start(wg *sync.WaitGroup)
+	Start()
 	GetDescription() string
 }

--- a/pkg/manager/task_generate_markers.go
+++ b/pkg/manager/task_generate_markers.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/remeh/sizedwaitgroup"
-
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
@@ -24,9 +22,7 @@ type GenerateMarkersTask struct {
 	Screenshot   bool
 }
 
-func (t *GenerateMarkersTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *GenerateMarkersTask) Start() {
 	if t.Scene != nil {
 		t.generateSceneMarkers()
 	}

--- a/pkg/manager/task_generate_phash.go
+++ b/pkg/manager/task_generate_phash.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"github.com/remeh/sizedwaitgroup"
-
 	"context"
 	"database/sql"
 
@@ -18,9 +16,7 @@ type GeneratePhashTask struct {
 	txnManager          models.TransactionManager
 }
 
-func (t *GeneratePhashTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *GeneratePhashTask) Start() {
 	if !t.shouldGenerate() {
 		return
 	}

--- a/pkg/manager/task_generate_preview.go
+++ b/pkg/manager/task_generate_preview.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"github.com/remeh/sizedwaitgroup"
-
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager/config"
@@ -20,9 +18,7 @@ type GeneratePreviewTask struct {
 	fileNamingAlgorithm models.HashAlgorithm
 }
 
-func (t *GeneratePreviewTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *GeneratePreviewTask) Start() {
 	videoFilename := t.videoFilename()
 	videoChecksum := t.Scene.GetHash(t.fileNamingAlgorithm)
 	imageFilename := t.imageFilename()

--- a/pkg/manager/task_generate_screenshot.go
+++ b/pkg/manager/task_generate_screenshot.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/stashapp/stash/pkg/ffmpeg"
@@ -20,9 +19,7 @@ type GenerateScreenshotTask struct {
 	txnManager          models.TransactionManager
 }
 
-func (t *GenerateScreenshotTask) Start(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (t *GenerateScreenshotTask) Start() {
 	scenePath := t.Scene.Path
 	probeResult, err := ffmpeg.NewVideoFile(instance.FFProbePath, scenePath, false)
 

--- a/pkg/manager/task_generate_sprite.go
+++ b/pkg/manager/task_generate_sprite.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"github.com/remeh/sizedwaitgroup"
-
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
@@ -15,9 +13,7 @@ type GenerateSpriteTask struct {
 	fileNamingAlgorithm models.HashAlgorithm
 }
 
-func (t *GenerateSpriteTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *GenerateSpriteTask) Start() {
 	if !t.Overwrite && !t.required() {
 		return
 	}

--- a/pkg/manager/task_import.go
+++ b/pkg/manager/task_import.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/stashapp/stash/pkg/database"
@@ -79,9 +78,7 @@ func (t *ImportTask) GetDescription() string {
 	return "Importing..."
 }
 
-func (t *ImportTask) Start(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (t *ImportTask) Start() {
 	if t.TmpZip != "" {
 		defer func() {
 			err := utils.RemoveDir(t.BaseDir)

--- a/pkg/manager/task_migrate_hash.go
+++ b/pkg/manager/task_migrate_hash.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"sync"
-
 	"github.com/stashapp/stash/pkg/models"
 )
 
@@ -14,9 +12,7 @@ type MigrateHashTask struct {
 }
 
 // Start starts the task.
-func (t *MigrateHashTask) Start(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (t *MigrateHashTask) Start() {
 	if !t.Scene.OSHash.Valid || !t.Scene.Checksum.Valid {
 		// nothing to do
 		return

--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -109,7 +109,8 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 			}
 
 			go func() {
-				task.Start(&wg)
+				task.Start()
+				wg.Done()
 				progress.Increment()
 			}()
 
@@ -225,9 +226,7 @@ type ScanTask struct {
 	CaseSensitiveFs      bool
 }
 
-func (t *ScanTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *ScanTask) Start() {
 	var s *models.Scene
 
 	t.progress.ExecuteTask("Scanning "+t.FilePath, func() {
@@ -252,7 +251,8 @@ func (t *ScanTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
 					Overwrite:           false,
 					fileNamingAlgorithm: t.fileNamingAlgorithm,
 				}
-				taskSprite.Start(&iwg)
+				taskSprite.Start()
+				iwg.Done()
 			})
 		}
 
@@ -265,7 +265,8 @@ func (t *ScanTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
 					fileNamingAlgorithm: t.fileNamingAlgorithm,
 					txnManager:          t.TxnManager,
 				}
-				taskPhash.Start(&iwg)
+				taskPhash.Start()
+				iwg.Done()
 			})
 		}
 
@@ -296,7 +297,8 @@ func (t *ScanTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
 					Overwrite:           false,
 					fileNamingAlgorithm: t.fileNamingAlgorithm,
 				}
-				taskPreview.Start(wg)
+				taskPreview.Start()
+				iwg.Done()
 			})
 		}
 
@@ -972,9 +974,7 @@ func (t *ScanTask) scanZipImages(zipGallery *models.Gallery) {
 		subTask.zipGallery = zipGallery
 
 		// run the subtask and wait for it to complete
-		iwg := sizedwaitgroup.New(1)
-		iwg.Add()
-		subTask.Start(&iwg)
+		subTask.Start()
 		return nil
 	})
 	if err != nil {

--- a/pkg/manager/task_stash_box_tag.go
+++ b/pkg/manager/task_stash_box_tag.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/stashapp/stash/pkg/logger"
@@ -22,9 +21,7 @@ type StashBoxPerformerTagTask struct {
 	excluded_fields []string
 }
 
-func (t *StashBoxPerformerTagTask) Start(wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (t *StashBoxPerformerTagTask) Start() {
 	t.stashBoxPerformerTag()
 }
 

--- a/pkg/manager/task_transcode.go
+++ b/pkg/manager/task_transcode.go
@@ -1,8 +1,6 @@
 package manager
 
 import (
-	"github.com/remeh/sizedwaitgroup"
-
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/manager/config"
@@ -16,9 +14,7 @@ type GenerateTranscodeTask struct {
 	fileNamingAlgorithm models.HashAlgorithm
 }
 
-func (t *GenerateTranscodeTask) Start(wg *sizedwaitgroup.SizedWaitGroup) {
-	defer wg.Done()
-
+func (t *GenerateTranscodeTask) Start() {
 	hasTranscode := HasTranscode(&t.Scene, t.fileNamingAlgorithm)
 	if !t.Overwrite && hasTranscode {
 		return


### PR DESCRIPTION
Rather than passing a pointer to a waitgroup into task.Start(..)
functions, handle the waitgroup.Done() at the callsite.

This makes waitgroup handling local to its definition rather than it
being spread out over multiple files. Tasks now simply execute, and
the policy of waiting on them is handled by the caller.

The deeper rationale for doing this is that none of the tasks are currently using the Waitgroup for anything, but to mark completion. If the tasks added more work to the waitgroups, passing it on is necessary. When you read the code, you immediately think "what are the tasks adding to the waitgroup?" With this change, there's no such pondering, since it is clear it isn't being used.