### PR TITLE
Fix list state navigation

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -19,6 +19,8 @@
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
 
 ### 🐛 Bug fixes
+* Fix criteria being incorrectly applied when clicking back button. ([#1765](https://github.com/stashapp/stash/pull/1765))
+* Show first page and fix order direction not being maintained when clicking on card popover button. ([#1765](https://github.com/stashapp/stash/pull/1765))
 * Fix panic in autotagger when backslash character present in tag/performer/studio name. ([#1753](https://github.com/stashapp/stash/pull/1753))
 * Fix Scene Player CLS issue ([#1739](https://github.com/stashapp/stash/pull/1739))
 * Fix Scene Edit Panel form layout for mobile and desktop. ([#1737](https://github.com/stashapp/stash/pull/1737))

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -91,9 +91,7 @@ export class ListFilterModel {
     if (params.q) {
       this.searchTerm = params.q.trim();
     }
-    if (params.p) {
-      this.currentPage = Number.parseInt(params.p, 10);
-    }
+    this.currentPage = params.p ? Number.parseInt(params.p, 10) : 1;
     if (params.perPage) this.itemsPerPage = Number.parseInt(params.perPage, 10);
     if (params.z !== undefined) {
       const zoomIndex = Number.parseInt(params.z, 10);

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -79,10 +79,12 @@ export class ListFilterModel {
         }
       }
     }
-    this.sortDirection =
-      params.sortdir === "desc"
-        ? SortDirectionEnum.Desc
-        : SortDirectionEnum.Asc;
+    if (params.sortdir !== undefined) {
+      this.sortDirection =
+        params.sortdir === "desc"
+          ? SortDirectionEnum.Desc
+          : SortDirectionEnum.Asc;
+    }
     if (params.disp !== undefined) {
       this.displayMode = Number.parseInt(params.disp, 10);
     }

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -102,9 +102,8 @@ export class ListFilterModel {
       }
     }
 
+    this.criteria = [];
     if (params.c !== undefined) {
-      this.criteria = [];
-
       let jsonParameters: string[];
       if (params.c instanceof Array) {
         jsonParameters = params.c;


### PR DESCRIPTION
This fixes two bugs with lists:
* When order is set to DESC and clicking a tag or performer in the popover the sort column is maintained, but the sort order is lost
* When using the back button to a URL where no criterion is applied the criterion(s) aren't removed, in other words the criterion(s) are still applied
* Show the first page when clicking on tag / performer / ... while on a different page

Fixes #1762 