### PR TITLE
Disable vips in Windows

### DIFF
--- a/pkg/image/thumbnail.go
+++ b/pkg/image/thumbnail.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -56,7 +57,8 @@ func (e *ThumbnailEncoder) GetThumbnail(img *models.Image, maxSize int) ([]byte,
 		return buf.Bytes(), nil
 	}
 
-	if e.VipsPath != "" {
+	// vips has issues loading files from stdin on Windows
+	if e.VipsPath != "" && runtime.GOOS != "windows" {
 		return e.getVipsThumbnail(buf, maxSize)
 	} else {
 		return e.getFFMPEGThumbnail(buf, format, maxSize, img.Path)


### PR DESCRIPTION
Vips seems to have a bug causing loading files from stdin to fail when running Windows. The equivalent method works fine for ffmpeg.

We could probably work around this when not loading from zips by loading the file directly rather than from stdin, but I'd prefer to not have multiple paths. This will likely not affect a lot of people either way.