### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"runtime"
@@ -129,7 +129,7 @@ func makeGithubRequest(url string, output interface{}) error {
 
 	defer response.Body.Close()
 
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		//lint:ignore ST1005 Github is a proper capitalized noun
 		return fmt.Errorf("Github API read response failed: %s", err)

--- a/pkg/api/images.go
+++ b/pkg/api/images.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -92,5 +92,5 @@ func getRandomPerformerImageUsingName(name, gender, customPath string) ([]byte, 
 	}
 	defer img.Close()
 
-	return ioutil.ReadAll(img)
+	return io.ReadAll(img)
 }

--- a/pkg/api/resolver_mutation_metadata.go
+++ b/pkg/api/resolver_mutation_metadata.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -109,7 +109,7 @@ func (r *mutationResolver) BackupDatabase(ctx context.Context, input models.Back
 		if err := utils.EnsureDir(mgr.Paths.Generated.Downloads); err != nil {
 			return nil, fmt.Errorf("could not create backup directory %v: %w", mgr.Paths.Generated.Downloads, err)
 		}
-		f, err := ioutil.TempFile(mgr.Paths.Generated.Downloads, "backup*.sqlite")
+		f, err := os.CreateTemp(mgr.Paths.Generated.Downloads, "backup*.sqlite")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"runtime/debug"
 	"strconv"
@@ -344,12 +344,12 @@ func makeTLSConfig(c *config.Instance) (*tls.Config, error) {
 		return nil, errors.New("SSL key file must be present if certificate file is present")
 	}
 
-	cert, err := ioutil.ReadFile(certFile)
+	cert, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading SSL certificate file %s: %s", certFile, err.Error())
 	}
 
-	key, err := ioutil.ReadFile(keyFile)
+	key, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading SSL key file %s: %s", keyFile, err.Error())
 	}

--- a/pkg/autotag/integration_test.go
+++ b/pkg/autotag/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func testTeardown(databaseFile string) {
 
 func runTests(m *testing.M) int {
 	// create the database file
-	f, err := ioutil.TempFile("", "*.sqlite")
+	f, err := os.CreateTemp("", "*.sqlite")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create temporary file: %s", err.Error()))
 	}

--- a/pkg/dlna/dms.go
+++ b/pkg/dlna/dms.go
@@ -33,7 +33,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -483,7 +482,7 @@ func (me *Server) contentDirectoryInitialEvent(urls []*url.URL, sid string) {
 			logger.Errorf("Could not notify %s: %s", _url.String(), err)
 			continue
 		}
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		if len(b) > 0 {
 			logger.Debug(string(b))
 		}

--- a/pkg/ffmpeg/encoder.go
+++ b/pkg/ffmpeg/encoder.go
@@ -2,7 +2,7 @@ package ffmpeg
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -126,7 +126,7 @@ func (e *Encoder) runTranscode(probeResult VideoFile, args []string) (string, er
 		}
 	}
 
-	stdoutData, _ := ioutil.ReadAll(stdout)
+	stdoutData, _ := io.ReadAll(stdout)
 	stdoutString := string(stdoutData)
 
 	registerRunningEncoder(probeResult.Path, cmd.Process)

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -2,7 +2,6 @@ package ffmpeg
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -234,7 +233,7 @@ func (e *Encoder) stream(probeResult VideoFile, options TranscodeStreamOptions) 
 
 	// stderr must be consumed or the process deadlocks
 	go func() {
-		stderrData, _ := ioutil.ReadAll(stderr)
+		stderrData, _ := io.ReadAll(stderr)
 		stderrString := string(stderrData)
 		if len(stderrString) > 0 {
 			logger.Debugf("[stream] ffmpeg stderr: %s", stderrString)

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -247,7 +246,7 @@ func Serve(w http.ResponseWriter, r *http.Request, path string) {
 		}
 		defer rc.Close()
 
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -800,7 +800,7 @@ func (i *Instance) GetCSS() string {
 		return ""
 	}
 
-	buf, err := ioutil.ReadFile(fn)
+	buf, err := os.ReadFile(fn)
 
 	if err != nil {
 		return ""
@@ -816,7 +816,7 @@ func (i *Instance) SetCSS(css string) {
 
 	buf := []byte(css)
 
-	if err := ioutil.WriteFile(fn, buf, 0777); err != nil {
+	if err := os.WriteFile(fn, buf, 0777); err != nil {
 		logger.Warnf("error while writing %v bytes to %v: %v", len(buf), fn, err)
 	}
 }

--- a/pkg/manager/generator_sprite.go
+++ b/pkg/manager/generator_sprite.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -141,7 +140,7 @@ func (g *SpriteGenerator) generateSpriteVTT(encoder *ffmpeg.Encoder) error {
 	}
 	vtt := strings.Join(vttLines, "\n")
 
-	return ioutil.WriteFile(g.VTTOutputPath, []byte(vtt), 0644)
+	return os.WriteFile(g.VTTOutputPath, []byte(vtt), 0644)
 }
 
 func (g *SpriteGenerator) imageExists() bool {

--- a/pkg/manager/jsonschema/utils.go
+++ b/pkg/manager/jsonschema/utils.go
@@ -2,8 +2,7 @@ package jsonschema
 
 import (
 	"bytes"
-
-	"io/ioutil"
+	"os"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -19,7 +18,7 @@ func marshalToFile(filePath string, j interface{}) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filePath, data, 0644)
+	return os.WriteFile(filePath, data, 0644)
 }
 
 func encode(j interface{}) ([]byte, error) {

--- a/pkg/manager/paths/paths_generated.go
+++ b/pkg/manager/paths/paths_generated.go
@@ -2,7 +2,7 @@ package paths
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/stashapp/stash/pkg/logger"
@@ -54,7 +54,7 @@ func (gp *generatedPaths) TempDir(pattern string) (string, error) {
 	if err := gp.EnsureTmpDir(); err != nil {
 		logger.Warnf("Could not ensure existence of a temporary directory: %v", err)
 	}
-	ret, err := ioutil.TempDir(gp.Tmp, pattern)
+	ret, err := os.MkdirTemp(gp.Tmp, pattern)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/manager/task_export.go
+++ b/pkg/manager/task_export.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -177,7 +176,7 @@ func (t *ExportTask) generateDownload() error {
 	if err := utils.EnsureDir(instance.Paths.Generated.Downloads); err != nil {
 		return err
 	}
-	z, err := ioutil.TempFile(instance.Paths.Generated.Downloads, "export*.zip")
+	z, err := os.CreateTemp(instance.Paths.Generated.Downloads, "export*.zip")
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/task_generate_screenshot.go
+++ b/pkg/manager/task_generate_screenshot.go
@@ -3,7 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -52,7 +52,7 @@ func (t *GenerateScreenshotTask) Start() {
 	}
 	defer f.Close()
 
-	coverImageData, err := ioutil.ReadAll(f)
+	coverImageData, err := io.ReadAll(f)
 	if err != nil {
 		logger.Errorf("Error reading screenshot: %s", err.Error())
 		return

--- a/pkg/plugin/examples/goraw/main.go
+++ b/pkg/plugin/examples/goraw/main.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -23,7 +23,7 @@ func main() {
 	input := common.PluginInput{}
 
 	if len(os.Args) < 2 {
-		inData, _ := ioutil.ReadAll(os.Stdin)
+		inData, _ := io.ReadAll(os.Stdin)
 		log.Debugf("Raw input: %s", string(inData))
 		decodeErr := json.Unmarshal(inData, &input)
 

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"sync"
 
@@ -79,7 +78,7 @@ func (t *rawPluginTask) Start() error {
 	go func() {
 		defer t.waitGroup.Done()
 		defer close(t.done)
-		stdoutData, _ := ioutil.ReadAll(stdout)
+		stdoutData, _ := io.ReadAll(stdout)
 		stdoutString := string(stdoutData)
 
 		output := t.getOutput(stdoutString)

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -3,7 +3,7 @@ package scraper
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -121,7 +121,7 @@ func getImage(url string, globalConfig GlobalConfig) (*string, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scraper/json.go
+++ b/pkg/scraper/json.go
@@ -2,7 +2,7 @@ package scraper
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 
@@ -53,7 +53,7 @@ func (s *jsonScraper) loadURL(url string) (string, error) {
 		return "", err
 	}
 	logger.Infof("loadURL (%s)\n", url)
-	doc, err := ioutil.ReadAll(r)
+	doc, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -3,7 +3,7 @@ package stashbox
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -522,7 +522,7 @@ func fetchImage(url string) (*string, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
@@ -92,7 +91,7 @@ func loadURL(url string, scraperConfig config, globalConfig GlobalConfig) (io.Re
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +139,7 @@ func urlFromCDP(url string, driverOptions scraperDriverOptions, globalConfig Glo
 			act, cancelAct = chromedp.NewRemoteAllocator(context.Background(), remote)
 		} else {
 			// use a temporary user directory for chrome
-			dir, err := ioutil.TempDir("", "stash-chromedp")
+			dir, err := os.MkdirTemp("", "stash-chromedp")
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -381,7 +380,7 @@ func testTeardown(databaseFile string) {
 
 func runTests(m *testing.M) int {
 	// create the database file
-	f, err := ioutil.TempFile("", "*.sqlite")
+	f, err := os.CreateTemp("", "*.sqlite")
 	if err != nil {
 		panic(fmt.Sprintf("Could not create temporary file: %s", err.Error()))
 	}

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -108,10 +107,10 @@ func EmptyDir(path string) error {
 // ListDir will return the contents of a given directory path as a string slice
 func ListDir(path string) ([]string, error) {
 	var dirPaths []string
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		path = filepath.Dir(path)
-		files, err = ioutil.ReadDir(path)
+		files, err = os.ReadDir(path)
 		if err != nil {
 			return dirPaths, err
 		}
@@ -196,7 +195,7 @@ func WriteFile(path string, file []byte) error {
 		return fmt.Errorf("cannot ensure path %s", pathErr)
 	}
 
-	err := ioutil.WriteFile(path, file, 0755)
+	err := os.WriteFile(path, file, 0755)
 	if err != nil {
 		return fmt.Errorf("write error for thumbnail %s: %s ", path, err)
 	}

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,11 +52,11 @@ func TestDirExists(t *testing.T) {
 	const st = "stash_tmp"
 
 	tmp := os.TempDir()
-	tmpDir, err := ioutil.TempDir(tmp, st) // create a tmp dir in the system's tmp folder
+	tmpDir, err := os.MkdirTemp(tmp, st) // create a tmp dir in the system's tmp folder
 	if err == nil {
 		defer os.RemoveAll(tmpDir)
 
-		tmpFile, err := ioutil.TempFile(tmpDir, st)
+		tmpFile, err := os.CreateTemp(tmpDir, st)
 		if err != nil {
 			return
 		}

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -66,7 +66,7 @@ func ReadImageFromURL(url string) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Special notes for reviewers
No breaking changes.