### PR TITLE
Don't scan zero length files or directories

### DIFF
--- a/pkg/manager/task_scan.go
+++ b/pkg/manager/task_scan.go
@@ -83,6 +83,16 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 				return stoppingErr
 			}
 
+			// #1756 - skip zero length files and directories
+			if info.IsDir() {
+				return nil
+			}
+
+			if info.Size() == 0 {
+				logger.Infof("Skipping zero-length file: %s", path)
+				return nil
+			}
+
 			if isGallery(path) {
 				galleries = append(galleries, path)
 			}
@@ -401,11 +411,6 @@ func (t *ScanTask) scanGallery() {
 		// scan the zip files if the gallery has no images
 		scanImages = scanImages || images == 0
 	} else {
-		// Ignore directories.
-		if isDir, _ := utils.DirExists(t.FilePath); isDir {
-			return
-		}
-
 		checksum, err := t.calculateChecksum()
 		if err != nil {
 			logger.Error(err.Error())
@@ -726,11 +731,6 @@ func (t *ScanTask) scanScene() *models.Scene {
 			}
 		}
 
-		return nil
-	}
-
-	// Ignore directories.
-	if isDir, _ := utils.DirExists(t.FilePath); isDir {
 		return nil
 	}
 
@@ -1059,11 +1059,6 @@ func (t *ScanTask) scanImage() {
 		// check for thumbnails
 		t.generateThumbnail(i)
 	} else {
-		// Ignore directories.
-		if isDir, _ := utils.DirExists(t.FilePath); isDir {
-			return
-		}
-
 		var checksum string
 
 		logger.Infof("%s not found.  Calculating checksum...", t.FilePath)

--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -22,6 +22,7 @@
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
 
 ### 🐛 Bug fixes
+* Don't scan zero-length files. ([#1779](https://github.com/stashapp/stash/pull/1779))
 * Fix criteria being incorrectly applied when clicking back button. ([#1765](https://github.com/stashapp/stash/pull/1765))
 * Show first page and fix order direction not being maintained when clicking on card popover button. ([#1765](https://github.com/stashapp/stash/pull/1765))
 * Fix panic in autotagger when backslash character present in tag/performer/studio name. ([#1753](https://github.com/stashapp/stash/pull/1753))


### PR DESCRIPTION
Fixes #1756 

I've left zero-length checking out of the clean task since it would complicate the clean code more than I'd like.