### PR TITLE
Don't preload videos

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -22,6 +22,7 @@
 * Added sv-SE language option. ([#1691](https://github.com/stashapp/stash/pull/1691))
 
 ### 🐛 Bug fixes
+* Fix video transcoding process starting before video is played. ([#1780](https://github.com/stashapp/stash/pull/1780))
 * Fix criteria being incorrectly applied when clicking back button. ([#1765](https://github.com/stashapp/stash/pull/1765))
 * Show first page and fix order direction not being maintained when clicking on card popover button. ([#1765](https://github.com/stashapp/stash/pull/1765))
 * Fix panic in autotagger when backslash character present in tag/performer/studio name. ([#1753](https://github.com/stashapp/stash/pull/1753))

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -310,6 +310,7 @@ export class ScenePlayerImpl extends React.Component<
       height: "100%",
       cast: {},
       primary: "html5",
+      preload: "none",
       autostart:
         this.props.autoplay ||
         (this.props.config ? this.props.config.autostartVideo : false) ||


### PR DESCRIPTION
Fixes #1766 

Doesn't appear to have any real impact on transcoding files. May need testing on iOS devices to ensure no regressions are introduced.