### PR TITLE
Fix styling for scene duration on empty system

### DIFF
--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -14,6 +14,11 @@ export const Stats: React.FC = () => {
   const scenesSize = TextUtils.fileSize(data.stats.scenes_size);
   const imagesSize = TextUtils.fileSize(data.stats.images_size);
 
+  const scenesDuration = TextUtils.secondsAsTimeString(
+    data.stats.scenes_duration,
+    3
+  );
+
   return (
     <div className="mt-5">
       <div className="col col-sm-8 m-sm-auto row stats">
@@ -48,9 +53,7 @@ export const Stats: React.FC = () => {
           </p>
         </div>
         <div className="stats-element">
-          <p className="title">
-            {` ${TextUtils.secondsAsTimeString(data.stats.scenes_duration, 3)}`}
-          </p>
+          <p className="title">{scenesDuration || "-"}</p>
           <p className="heading">
             <FormattedMessage id="stats.scenes_duration" />
           </p>


### PR DESCRIPTION
Shows `-` character for scenes duration on system with no scenes:

![image](https://user-images.githubusercontent.com/53250216/134858077-c295b0e4-8e26-49a7-b36b-99133832ab40.png)

Existing code made the stats wonky:

![image](https://user-images.githubusercontent.com/53250216/134858136-fe3ae574-3271-49ba-8370-7c8875beadff.png)
