### PR TITLE
Allow setting metadata directory from UI

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -6,6 +6,7 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   }
   databasePath
   generatedPath
+  metadataPath
   cachePath
   calculateMD5
   videoFileNamingAlgorithm

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -39,6 +39,8 @@ input ConfigGeneralInput {
   databasePath: String
   """Path to generated files"""
   generatedPath: String
+  """Path to import/export files"""
+  metadataPath: String
   """Path to cache"""
   cachePath: String
   """Whether to calculate MD5 checksums for scene video files"""
@@ -110,6 +112,8 @@ type ConfigGeneralResult {
   databasePath: String!
   """Path to generated files"""
   generatedPath: String!
+  """Path to import/export files"""
+  metadataPath: String!
   """Path to the config file used"""
   configFilePath: String!
   """Path to scrapers"""

--- a/pkg/api/resolver_mutation_configure.go
+++ b/pkg/api/resolver_mutation_configure.go
@@ -61,6 +61,15 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input models.Co
 		c.Set(config.Generated, input.GeneratedPath)
 	}
 
+	if input.MetadataPath != nil {
+		if *input.MetadataPath != "" {
+			if err := utils.EnsureDir(*input.MetadataPath); err != nil {
+				return makeConfigGeneralResult(), err
+			}
+		}
+		c.Set(config.Metadata, input.MetadataPath)
+	}
+
 	if input.CachePath != nil {
 		if *input.CachePath != "" {
 			if err := utils.EnsureDir(*input.CachePath); err != nil {

--- a/pkg/api/resolver_query_configuration.go
+++ b/pkg/api/resolver_query_configuration.go
@@ -59,6 +59,7 @@ func makeConfigGeneralResult() *models.ConfigGeneralResult {
 		Stashes:                      config.GetStashPaths(),
 		DatabasePath:                 config.GetDatabasePath(),
 		GeneratedPath:                config.GetGeneratedPath(),
+		MetadataPath:                 config.GetMetadataPath(),
 		ConfigFilePath:               config.GetConfigFilePath(),
 		ScrapersPath:                 config.GetScrapersPath(),
 		CachePath:                    config.GetCachePath(),

--- a/ui/v2.5/src/components/Changelog/versions/v0100.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0100.md
@@ -13,6 +13,7 @@
 * Support filtering Movies by Performers. ([#1675](https://github.com/stashapp/stash/pull/1675))
 
 ### 🎨 Improvements
+* Support setting metadata import/export directory from UI. ([#1782](https://github.com/stashapp/stash/pull/1782))
 * Added movie count to performer and studio cards. ([#1760](https://github.com/stashapp/stash/pull/1760))
 * Added date and details to Movie card, and move scene count to icon. ([#1758](https://github.com/stashapp/stash/pull/1758))
 * Added date and details to Gallery card, and move image count to icon. ([#1763](https://github.com/stashapp/stash/pull/1763))

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -80,6 +80,9 @@ export const SettingsConfigurationPanel: React.FC = () => {
   const [generatedPath, setGeneratedPath] = useState<string | undefined>(
     undefined
   );
+  const [metadataPath, setMetadataPath] = useState<string | undefined>(
+    undefined
+  );
   const [cachePath, setCachePath] = useState<string | undefined>(undefined);
   const [calculateMD5, setCalculateMD5] = useState<boolean>(false);
   const [videoFileNamingAlgorithm, setVideoFileNamingAlgorithm] = useState<
@@ -145,6 +148,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
     })),
     databasePath,
     generatedPath,
+    metadataPath,
     cachePath,
     calculateMD5,
     videoFileNamingAlgorithm:
@@ -191,6 +195,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
       setStashes(conf.general.stashes ?? []);
       setDatabasePath(conf.general.databasePath);
       setGeneratedPath(conf.general.generatedPath);
+      setMetadataPath(conf.general.metadataPath);
       setCachePath(conf.general.cachePath);
       setVideoFileNamingAlgorithm(conf.general.videoFileNamingAlgorithm);
       setCalculateMD5(conf.general.calculateMD5);
@@ -419,6 +424,24 @@ export const SettingsConfigurationPanel: React.FC = () => {
           <Form.Text className="text-muted">
             {intl.formatMessage({
               id: "config.general.generated_files_location",
+            })}
+          </Form.Text>
+        </Form.Group>
+
+        <Form.Group id="metadata-path">
+          <h6>
+            <FormattedMessage id="config.general.metadata_path.heading" />
+          </h6>
+          <Form.Control
+            className="col col-sm-6 text-input"
+            defaultValue={metadataPath}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setMetadataPath(e.currentTarget.value)
+            }
+          />
+          <Form.Text className="text-muted">
+            {intl.formatMessage({
+              id: "config.general.metadata_path.description",
             })}
           </Form.Text>
         </Form.Group>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -227,6 +227,10 @@
       "maximum_streaming_transcode_size_head": "Maximum streaming transcode size",
       "maximum_transcode_size_desc": "Maximum size for generated transcodes",
       "maximum_transcode_size_head": "Maximum transcode size",
+      "metadata_path": {
+        "heading": "Metadata Path",
+        "description": "Directory location used when performing a full export or import"
+      },
       "number_of_parallel_task_for_scan_generation_desc": "Set to 0 for auto-detection. Warning running more tasks than is required to achieve 100% cpu utilisation will decrease performance and potentially cause other issues.",
       "number_of_parallel_task_for_scan_generation_head": "Number of parallel task for scan/generation",
       "parallel_scan_head": "Parallel Scan/Generation",


### PR DESCRIPTION
Currently not able to set the `metadata` directory config setting from the UI, which means the user needs to manually edit `config.yml` before they can perform a full import/export. Added the ability to set `metadata` directory in the UI.