### PR TITLE
Remove new-from-rev from the linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,23 @@ run:
   timeout: 3m
   modules-download-mode: vendor
 
-issues:
-  # Rev at which the linter was introduced. Older bugs are still
-  # present, but should not be considered validation errors for now
-  new-from-rev: b14d5c56504dfcea2f5a7b86706b0ecdafd0b68c
+linters:
+  disable-all: true
+  enable:
+    # Default set of linters from golangci-lint
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    # Linters added by the stash project
+    - gofmt
+    - revive
 
 linters-settings:
   gofmt:
@@ -51,22 +64,4 @@ linters-settings:
         disabled: true
       - name: unreachable-code
       - name: redefines-builtin-id
-
-linters:
-  disable-all: true
-  enable:
-    # Default set of linters from golangci-lint
-    - deadcode
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
-    # Linters added by the stash project
-    - gofmt
-    - revive
 

--- a/pkg/api/routes_image.go
+++ b/pkg/api/routes_image.go
@@ -59,7 +59,9 @@ func (rs imageRoutes) Thumbnail(w http.ResponseWriter, r *http.Request) {
 				logger.Errorf("error writing thumbnail for image %s: %s", img.Path, err)
 			}
 		}
-		w.Write(data)
+		if n, err := w.Write(data); err != nil {
+			logger.Errorf("error writing thumbnail response. Wrote %v bytes: %v", n, err)
+		}
 	}
 }
 

--- a/pkg/gallery/export_test.go
+++ b/pkg/gallery/export_test.go
@@ -39,8 +39,10 @@ const (
 	studioName = "studioName"
 )
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullGallery(id int) models.Gallery {
 	return models.Gallery{

--- a/pkg/gallery/import_test.go
+++ b/pkg/gallery/import_test.go
@@ -39,8 +39,10 @@ const (
 	errChecksum     = "errChecksum"
 )
 
-var createdAt time.Time = time.Date(2001, time.January, 2, 1, 2, 3, 4, time.Local)
-var updatedAt time.Time = time.Date(2002, time.January, 2, 1, 2, 3, 4, time.Local)
+var (
+	createdAt = time.Date(2001, time.January, 2, 1, 2, 3, 4, time.Local)
+	updatedAt = time.Date(2002, time.January, 2, 1, 2, 3, 4, time.Local)
+)
 
 func TestImporterName(t *testing.T) {
 	i := Importer{

--- a/pkg/image/export_test.go
+++ b/pkg/image/export_test.go
@@ -53,8 +53,10 @@ const (
 	//galleryChecksum = "galleryChecksum"
 )
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullImage(id int) models.Image {
 	return models.Image{

--- a/pkg/image/thumbnail.go
+++ b/pkg/image/thumbnail.go
@@ -46,7 +46,9 @@ func (e *ThumbnailEncoder) GetThumbnail(img *models.Image, maxSize int) ([]byte,
 	}
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(reader)
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, err
+	}
 
 	_, format, err := DecodeSourceImage(img)
 	if err != nil {

--- a/pkg/movie/export_test.go
+++ b/pkg/movie/export_test.go
@@ -44,18 +44,24 @@ const url = "url"
 
 const studioName = "studio"
 
-const frontImage = "ZnJvbnRJbWFnZUJ5dGVz"
-const backImage = "YmFja0ltYWdlQnl0ZXM="
+const (
+	frontImage = "ZnJvbnRJbWFnZUJ5dGVz"
+	backImage  = "YmFja0ltYWdlQnl0ZXM="
+)
 
-var frontImageBytes = []byte("frontImageBytes")
-var backImageBytes = []byte("backImageBytes")
+var (
+	frontImageBytes = []byte("frontImageBytes")
+	backImageBytes  = []byte("backImageBytes")
+)
 
 var studio models.Studio = models.Studio{
 	Name: models.NullString(studioName),
 }
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullMovie(id int, studioID int) models.Movie {
 	return models.Movie{

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -54,8 +54,11 @@ var deathDate = models.SQLiteDate{
 	String: "2021-02-02",
 	Valid:  true,
 }
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.Local)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.Local)
+
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullPerformer(id int, name string) *models.Performer {
 	return &models.Performer{

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -56,8 +56,8 @@ var deathDate = models.SQLiteDate{
 }
 
 var (
-	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.Local)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.Local)
 )
 
 func createFullPerformer(id int, name string) *models.Performer {

--- a/pkg/scene/export_test.go
+++ b/pkg/scene/export_test.go
@@ -87,8 +87,10 @@ var imageBytes = []byte("imageBytes")
 
 const image = "aW1hZ2VCeXRlcw=="
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullScene(id int) models.Scene {
 	return models.Scene{

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -105,7 +105,7 @@ type filterBuilder struct {
 	err error
 }
 
-var errSubFilterAlreadySet error = errors.New(`sub-filter already set`)
+var errSubFilterAlreadySet = errors.New(`sub-filter already set`)
 
 // sub-filter operator values
 var (

--- a/pkg/studio/export_test.go
+++ b/pkg/studio/export_test.go
@@ -42,8 +42,8 @@ var imageBytes = []byte("imageBytes")
 const image = "aW1hZ2VCeXRlcw=="
 
 var (
-	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.Local)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.Local)
 )
 
 func createFullStudio(id int, parentID int) models.Studio {

--- a/pkg/studio/export_test.go
+++ b/pkg/studio/export_test.go
@@ -41,8 +41,10 @@ var imageBytes = []byte("imageBytes")
 
 const image = "aW1hZ2VCeXRlcw=="
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.Local)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.Local)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createFullStudio(id int, parentID int) models.Studio {
 	ret := models.Studio{

--- a/pkg/tag/export_test.go
+++ b/pkg/tag/export_test.go
@@ -23,8 +23,10 @@ const (
 
 const tagName = "testTag"
 
-var createTime time.Time = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
-var updateTime time.Time = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+var (
+	createTime = time.Date(2001, 01, 01, 0, 0, 0, 0, time.UTC)
+	updateTime = time.Date(2002, 01, 01, 0, 0, 0, 0, time.UTC)
+)
 
 func createTag(id int) models.Tag {
 	return models.Tag{


### PR DESCRIPTION
With the linter in place, we can now "backflush" the project for the older errors we didn't fix before enabling the linter. This small patch stack does that, and cleans up the remaining revive and errcheck warnings in the project.

Once done, the `new-from-rev` setting is removed.