### PR TITLE
Fix integration-testing in the build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,15 @@ jobs:
       if: ${{ github.event_name != 'pull_request' || steps.cache-ui.outputs.cache-hit != 'true' }}
       run: docker exec -t build /bin/bash -c "make validate-frontend"
 
-    # Backend validation happens in parallel to the build in the golangci-lint action
+    # Static validation happens in the linter workflow in parallel to this workflow
+    # Run Dynamic validation here, to make sure we pass all the projects integration tests
+    #
+    # create UI file so that the embed doesn't fail
+    - name: Test Backend
+      run: |
+        mkdir -p ui/v2.5/build
+        touch ui/v2.5/build/index.html
+        docker exec -t build /bin/bash -c "make it"
 
     - name: Build UI
       # skip UI build for pull requests if UI is unchanged (UI was cached)


### PR DESCRIPTION
When the golangci workflow action was added, we moved large parts of
validation to the parallel action. However, integration testing still
has to happen on the main build action, as it isn't covered by the
validation action.

Reenable the `it` target through docker container build.

This fixes backend test errors sneaking through the build action.