### PR TITLE
Enable safe linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,24 @@ linters:
     - unused
     - varcheck
     # Linters added by the stash project
+    # - bodyclose
+    - dogsled
+    # - errorlint
+    # - exhaustive
+    # - exportloopref
+    # - goconst
+    # - gocritic
+    # - goerr113
     - gofmt
+    # - gosec
+    # - ifshort
+    - misspell
+    # - nakedret
+    # - noctx
+    # - paralleltest
     - revive
+    - rowserrcheck
+    - sqlclosecheck
 
 linters-settings:
   gofmt:
@@ -64,4 +80,3 @@ linters-settings:
         disabled: true
       - name: unreachable-code
       - name: redefines-builtin-id
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters:
     - dogsled
     # - errorlint
     # - exhaustive
-    # - exportloopref
+    - exportloopref
     # - goconst
     # - gocritic
     # - goerr113

--- a/pkg/autotag/gallery_test.go
+++ b/pkg/autotag/gallery_test.go
@@ -12,6 +12,8 @@ import (
 const galleryExt = "zip"
 
 func TestGalleryPerformers(t *testing.T) {
+	t.Parallel()
+
 	const galleryID = 1
 	const performerName = "performer name"
 	const performerID = 2
@@ -55,6 +57,8 @@ func TestGalleryPerformers(t *testing.T) {
 }
 
 func TestGalleryStudios(t *testing.T) {
+	t.Parallel()
+
 	const galleryID = 1
 	const studioName = "studio name"
 	const studioID = 2
@@ -124,6 +128,8 @@ func TestGalleryStudios(t *testing.T) {
 }
 
 func TestGalleryTags(t *testing.T) {
+	t.Parallel()
+
 	const galleryID = 1
 	const tagName = "tag name"
 	const tagID = 2

--- a/pkg/autotag/image_test.go
+++ b/pkg/autotag/image_test.go
@@ -12,6 +12,8 @@ import (
 const imageExt = "jpg"
 
 func TestImagePerformers(t *testing.T) {
+	t.Parallel()
+
 	const imageID = 1
 	const performerName = "performer name"
 	const performerID = 2
@@ -55,6 +57,8 @@ func TestImagePerformers(t *testing.T) {
 }
 
 func TestImageStudios(t *testing.T) {
+	t.Parallel()
+
 	const imageID = 1
 	const studioName = "studio name"
 	const studioID = 2
@@ -124,6 +128,8 @@ func TestImageStudios(t *testing.T) {
 }
 
 func TestImageTags(t *testing.T) {
+	t.Parallel()
+
 	const imageID = 1
 	const tagName = "tag name"
 	const tagID = 2

--- a/pkg/autotag/performer_test.go
+++ b/pkg/autotag/performer_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestPerformerScenes(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		performerName string
 		expectedRegex string
@@ -85,6 +87,8 @@ func testPerformerScenes(t *testing.T, performerName, expectedRegex string) {
 }
 
 func TestPerformerImages(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		performerName string
 		expectedRegex string
@@ -157,6 +161,8 @@ func testPerformerImages(t *testing.T, performerName, expectedRegex string) {
 }
 
 func TestPerformerGalleries(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		performerName string
 		expectedRegex string

--- a/pkg/autotag/scene_test.go
+++ b/pkg/autotag/scene_test.go
@@ -145,6 +145,8 @@ func generateTestTable(testName, ext string) []pathTestTable {
 }
 
 func TestScenePerformers(t *testing.T) {
+	t.Parallel()
+
 	const sceneID = 1
 	const performerName = "performer name"
 	const performerID = 2
@@ -188,6 +190,8 @@ func TestScenePerformers(t *testing.T) {
 }
 
 func TestSceneStudios(t *testing.T) {
+	t.Parallel()
+
 	const sceneID = 1
 	const studioName = "studio name"
 	const studioID = 2
@@ -257,6 +261,8 @@ func TestSceneStudios(t *testing.T) {
 }
 
 func TestSceneTags(t *testing.T) {
+	t.Parallel()
+
 	const sceneID = 1
 	const tagName = "tag name"
 	const tagID = 2

--- a/pkg/autotag/studio_test.go
+++ b/pkg/autotag/studio_test.go
@@ -55,6 +55,8 @@ var testStudioCases = []testStudioCase{
 }
 
 func TestStudioScenes(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testStudioCases {
 		testStudioScenes(t, p)
 	}
@@ -145,6 +147,8 @@ func testStudioScenes(t *testing.T, tc testStudioCase) {
 }
 
 func TestStudioImages(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testStudioCases {
 		testStudioImages(t, p)
 	}
@@ -234,6 +238,8 @@ func testStudioImages(t *testing.T, tc testStudioCase) {
 }
 
 func TestStudioGalleries(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testStudioCases {
 		testStudioGalleries(t, p)
 	}

--- a/pkg/autotag/tag_test.go
+++ b/pkg/autotag/tag_test.go
@@ -55,6 +55,8 @@ var testTagCases = []testTagCase{
 }
 
 func TestTagScenes(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testTagCases {
 		testTagScenes(t, p)
 	}
@@ -141,6 +143,8 @@ func testTagScenes(t *testing.T, tc testTagCase) {
 }
 
 func TestTagImages(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testTagCases {
 		testTagImages(t, p)
 	}
@@ -226,6 +230,8 @@ func testTagImages(t *testing.T, tc testTagCase) {
 }
 
 func TestTagGalleries(t *testing.T) {
+	t.Parallel()
+
 	for _, p := range testTagCases {
 		testTagGalleries(t, p)
 	}

--- a/pkg/logger/plugin.go
+++ b/pkg/logger/plugin.go
@@ -112,6 +112,7 @@ func DetectLogLevel(line string) (*PluginLogLevel, string) {
 	var level *PluginLogLevel
 	for _, l := range validLevels {
 		if l.char == char {
+			l := l // Make a copy of the loop variable
 			level = &l
 			break
 		}

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -251,7 +251,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 		// Start measuring how long the generate has taken. (consider moving this up)
 		start := time.Now()
 		if err = instance.Paths.Generated.EnsureTmpDir(); err != nil {
-			logger.Warnf("could not create temprary directory: %v", err)
+			logger.Warnf("could not create temporary directory: %v", err)
 		}
 
 		for _, scene := range scenes {

--- a/pkg/movie/export_test.go
+++ b/pkg/movie/export_test.go
@@ -148,32 +148,32 @@ var scenarios []testScenario
 
 func initTestTable() {
 	scenarios = []testScenario{
-		testScenario{
+		{
 			createFullMovie(movieID, studioID),
 			createFullJSONMovie(studioName, frontImage, backImage),
 			false,
 		},
-		testScenario{
+		{
 			createEmptyMovie(emptyID),
 			createEmptyJSONMovie(),
 			false,
 		},
-		testScenario{
+		{
 			createFullMovie(errFrontImageID, studioID),
 			nil,
 			true,
 		},
-		testScenario{
+		{
 			createFullMovie(errBackImageID, studioID),
 			nil,
 			true,
 		},
-		testScenario{
+		{
 			createFullMovie(errStudioMovieID, errStudioID),
 			nil,
 			true,
 		},
-		testScenario{
+		{
 			createFullMovie(missingStudioMovieID, missingStudioID),
 			createFullJSONMovie("", frontImage, backImage),
 			false,

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -168,17 +168,17 @@ var scenarios []testScenario
 
 func initTestTable() {
 	scenarios = []testScenario{
-		testScenario{
+		{
 			*createFullPerformer(performerID, performerName),
 			createFullJSONPerformer(performerName, image),
 			false,
 		},
-		testScenario{
+		{
 			createEmptyPerformer(noImageID),
 			createEmptyJSONPerformer(),
 			false,
 		},
-		testScenario{
+		{
 			*createFullPerformer(errImageID, performerName),
 			nil,
 			true,

--- a/pkg/plugin/args.go
+++ b/pkg/plugin/args.go
@@ -17,6 +17,7 @@ func findArg(args []*models.PluginArgInput, name string) *models.PluginArgInput 
 func applyDefaultArgs(args []*models.PluginArgInput, defaultArgs map[string]string) []*models.PluginArgInput {
 	for k, v := range defaultArgs {
 		if arg := findArg(args, k); arg == nil {
+			v := v // Copy v, because it's being exported out of the loop
 			args = append(args, &models.PluginArgInput{
 				Key: k,
 				Value: &models.PluginValueInput{

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -223,6 +223,7 @@ func getRemoteCDPWSAddress(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	var result map[string]interface{}
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/pkg/scraper/xpath_test.go
+++ b/pkg/scraper/xpath_test.go
@@ -53,9 +53,9 @@ const htmlDoc1 = `
 								<b>Country of Origin:</b>
 							</td>
 							<td class="paramvalue">
-								
+
 								<span class="country-us">
-								
+
 									United States
 								<span>
 							</span></span></td>
@@ -661,7 +661,7 @@ func verifyPerformers(t *testing.T, expectedNames []string, expectedURLs []strin
 			t.Errorf("Expected performer name %s, got %s", expectedName, actualName)
 		}
 		if expectedURL != actualURL {
-			t.Errorf("Expected perfromer URL %s, got %s", expectedName, actualName)
+			t.Errorf("Expected performer URL %s, got %s", expectedName, actualName)
 		}
 		i++
 	}
@@ -741,7 +741,7 @@ func TestLoadXPathScraperFromYAML(t *testing.T) {
 	const yamlStr = `name: Test
 performerByURL:
   - action: scrapeXPath
-    url: 
+    url:
       - test.com
     scraper: performerScraper
 xPathScrapers:
@@ -755,11 +755,11 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Tags:
-        Name: //tags  
+        Name: //tags
       Movies:
-        Name: //movies  
+        Name: //movies
       Performers:
-        Name: //performers  
+        Name: //performers
       Studio:
         Name: //studio
 `
@@ -848,13 +848,13 @@ func TestSubScrape(t *testing.T) {
 	yamlStr := `name: Test
 performerByURL:
   - action: scrapeXPath
-    url: 
+    url:
       - ` + ts.URL + `
     scraper: performerScraper
 xPathScrapers:
   performerScraper:
     performer:
-      Name: 
+      Name:
         selector: //div/a/@href
         postProcess:
           - replace:

--- a/pkg/studio/export_test.go
+++ b/pkg/studio/export_test.go
@@ -119,32 +119,32 @@ var scenarios []testScenario
 
 func initTestTable() {
 	scenarios = []testScenario{
-		testScenario{
+		{
 			createFullStudio(studioID, parentStudioID),
 			createFullJSONStudio(parentStudioName, image, []string{"alias"}),
 			false,
 		},
-		testScenario{
+		{
 			createEmptyStudio(noImageID),
 			createEmptyJSONStudio(),
 			false,
 		},
-		testScenario{
+		{
 			createFullStudio(errImageID, parentStudioID),
 			nil,
 			true,
 		},
-		testScenario{
+		{
 			createFullStudio(missingParentStudioID, missingStudioID),
 			createFullJSONStudio("", image, nil),
 			false,
 		},
-		testScenario{
+		{
 			createFullStudio(errStudioID, errParentStudioID),
 			nil,
 			true,
 		},
-		testScenario{
+		{
 			createFullStudio(errAliasID, parentStudioID),
 			nil,
 			true,


### PR DESCRIPTION
This patch stack enables some linters which are very low in false-positive rate, and where the code base passes through more-or-less unscathed. It also fixes some minor points in the code base while we're at it. The enabled linters are:

* `dogsled` - Complains on more than two blank identifers as in `x, _, _, _ := f()`.
* `exportloopref` - Finds loop variables which are exported by reference. There were a couple of warnings in the code base which have been fixed.
* `misspell` - Spelling fixes in code. A couple of warnings have been fixed as well.
* `rowserrcheck` - Warn if processing a sql `Rows` object and no error checks are being made. I'm not sure if it extends into `sqlx` though, but there are no errors in the code base.
* `sqlclosecheck` - Check for closing of sql objects. Again, `sqlx` might pose false negatives, but enabled it as there are no warnings in the code base currently.

I've taken a look on all the other linters in the stack, but they all have either a very large error count, or they have false positives, which I don't think should be enabled by default. However:

* Fix an unclosed response body
* Remove some redundant type specifications in tests

Finally, mark the `autotag` test suite as parallel. Unscientific benchmark on an 8-core laptop:

Before:

```
go test -mod=vendor -count=5 .
ok  	github.com/stashapp/stash/pkg/autotag	71.261s
```

After:

```
go test -mod=vendor -count=5 .
ok  	github.com/stashapp/stash/pkg/autotag	34.898s
```

Or indexed

* Before - `1.0`
* After - `0.49`

Roughly cuts test time in half.
