### PR TITLE
Don't show studio error message while loading

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -49,7 +49,7 @@ export const Studio: React.FC = () => {
   // Studio state
   const [image, setImage] = useState<string | null>();
 
-  const { data, error } = useFindStudio(id);
+  const { data, loading: studioLoading, error } = useFindStudio(id);
   const studio = data?.findStudio;
 
   const [isLoading, setIsLoading] = useState(false);
@@ -198,7 +198,7 @@ export const Studio: React.FC = () => {
     }
   };
 
-  if (isLoading) return <LoadingIndicator />;
+  if (isLoading || studioLoading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;
   if (!studio?.id && !isNew)
     return <ErrorMessage error={`No studio found with id ${id}.`} />;


### PR DESCRIPTION
Fixes issue where `No studio found with id ${id}.` would be shown briefly while loading the studio page.