### PR TITLE
Make generate args optional

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -1,15 +1,15 @@
 scalar Upload
 
 input GenerateMetadataInput {
-  sprites: Boolean!
-  previews: Boolean!
-  imagePreviews: Boolean!
+  sprites: Boolean
+  previews: Boolean
+  imagePreviews: Boolean
   previewOptions: GeneratePreviewOptionsInput
-  markers: Boolean!
-  markerImagePreviews: Boolean!
-  markerScreenshots: Boolean!
-  transcodes: Boolean!
-  phashes: Boolean!
+  markers: Boolean
+  markerImagePreviews: Boolean
+  markerScreenshots: Boolean
+  transcodes: Boolean
+  phashes: Boolean
 
   """scene ids to generate for"""
   sceneIDs: [ID!]

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -1,15 +1,15 @@
 scalar Upload
 
 input GenerateMetadataInput {
-  sprites: Boolean
-  previews: Boolean
-  imagePreviews: Boolean
+  sprites: Boolean! = false
+  previews: Boolean! = false
+  imagePreviews: Boolean! = false
   previewOptions: GeneratePreviewOptionsInput
-  markers: Boolean
-  markerImagePreviews: Boolean
-  markerScreenshots: Boolean
-  transcodes: Boolean
-  phashes: Boolean
+  markers: Boolean! = false
+  markerImagePreviews: Boolean! = false
+  markerScreenshots: Boolean! = false
+  transcodes: Boolean! = false
+  phashes: Boolean! = false
 
   """scene ids to generate for"""
   sceneIDs: [ID!]
@@ -17,7 +17,7 @@ input GenerateMetadataInput {
   markerIDs: [ID!]
 
   """overwrite existing media"""
-  overwrite: Boolean
+  overwrite: Boolean! = false
 }
 
 input GeneratePreviewOptionsInput {

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -237,7 +237,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		fileNamingAlgo := config.GetVideoFileNamingAlgorithm()
 
-		overwrite := utils.IsTrue(input.Overwrite)
+		overwrite := input.Overwrite
 
 		generatePreviewOptions := input.PreviewOptions
 		if generatePreviewOptions == nil {
@@ -267,7 +267,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				continue
 			}
 
-			if utils.IsTrue(input.Sprites) {
+			if input.Sprites {
 				task := GenerateSpriteTask{
 					Scene:               *scene,
 					Overwrite:           overwrite,
@@ -280,10 +280,10 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if utils.IsTrue(input.Previews) {
+			if input.Previews {
 				task := GeneratePreviewTask{
 					Scene:               *scene,
-					ImagePreview:        utils.IsTrue(input.ImagePreviews),
+					ImagePreview:        input.ImagePreviews,
 					Options:             *generatePreviewOptions,
 					Overwrite:           overwrite,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -295,15 +295,15 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if utils.IsTrue(input.Markers) {
+			if input.Markers {
 				wg.Add()
 				task := GenerateMarkersTask{
 					TxnManager:          s.TxnManager,
 					Scene:               scene,
 					Overwrite:           overwrite,
 					fileNamingAlgorithm: fileNamingAlgo,
-					ImagePreview:        utils.IsTrue(input.MarkerImagePreviews),
-					Screenshot:          utils.IsTrue(input.MarkerScreenshots),
+					ImagePreview:        input.MarkerImagePreviews,
+					Screenshot:          input.MarkerScreenshots,
 				}
 				go progress.ExecuteTask(fmt.Sprintf("Generating markers for %s", scene.Path), func() {
 					task.Start()
@@ -311,7 +311,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if utils.IsTrue(input.Transcodes) {
+			if input.Transcodes {
 				wg.Add()
 				task := GenerateTranscodeTask{
 					Scene:               *scene,
@@ -324,7 +324,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if utils.IsTrue(input.Phashes) {
+			if input.Phashes {
 				task := GeneratePhashTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -644,12 +644,12 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 	}()
 
 	fileNamingAlgo := config.GetInstance().GetVideoFileNamingAlgorithm()
-	overwrite := utils.IsTrue(input.Overwrite)
+	overwrite := input.Overwrite
 
 	logger.Infof("Counting content to generate...")
 	for _, scene := range scenes {
 		if scene != nil {
-			if utils.IsTrue(input.Sprites) {
+			if input.Sprites {
 				task := GenerateSpriteTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -660,10 +660,10 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				}
 			}
 
-			if utils.IsTrue(input.Previews) {
+			if input.Previews {
 				task := GeneratePreviewTask{
 					Scene:               *scene,
-					ImagePreview:        utils.IsTrue(input.ImagePreviews),
+					ImagePreview:        input.ImagePreviews,
 					fileNamingAlgorithm: fileNamingAlgo,
 				}
 
@@ -672,12 +672,12 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 					totals.previews++
 				}
 
-				if utils.IsTrue(input.ImagePreviews) && (overwrite || !task.doesImagePreviewExist(sceneHash)) {
+				if input.ImagePreviews && (overwrite || !task.doesImagePreviewExist(sceneHash)) {
 					totals.imagePreviews++
 				}
 			}
 
-			if utils.IsTrue(input.Markers) {
+			if input.Markers {
 				task := GenerateMarkersTask{
 					TxnManager:          s.TxnManager,
 					Scene:               scene,
@@ -687,7 +687,7 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				totals.markers += int64(task.isMarkerNeeded())
 			}
 
-			if utils.IsTrue(input.Transcodes) {
+			if input.Transcodes {
 				task := GenerateTranscodeTask{
 					Scene:               *scene,
 					Overwrite:           overwrite,
@@ -698,7 +698,7 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				}
 			}
 
-			if utils.IsTrue(input.Phashes) {
+			if input.Phashes {
 				task := GeneratePhashTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,

--- a/pkg/manager/manager_tasks.go
+++ b/pkg/manager/manager_tasks.go
@@ -237,10 +237,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 
 		fileNamingAlgo := config.GetVideoFileNamingAlgorithm()
 
-		overwrite := false
-		if input.Overwrite != nil {
-			overwrite = *input.Overwrite
-		}
+		overwrite := utils.IsTrue(input.Overwrite)
 
 		generatePreviewOptions := input.PreviewOptions
 		if generatePreviewOptions == nil {
@@ -270,7 +267,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				continue
 			}
 
-			if input.Sprites {
+			if utils.IsTrue(input.Sprites) {
 				task := GenerateSpriteTask{
 					Scene:               *scene,
 					Overwrite:           overwrite,
@@ -283,10 +280,10 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if input.Previews {
+			if utils.IsTrue(input.Previews) {
 				task := GeneratePreviewTask{
 					Scene:               *scene,
-					ImagePreview:        input.ImagePreviews,
+					ImagePreview:        utils.IsTrue(input.ImagePreviews),
 					Options:             *generatePreviewOptions,
 					Overwrite:           overwrite,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -298,15 +295,15 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if input.Markers {
+			if utils.IsTrue(input.Markers) {
 				wg.Add()
 				task := GenerateMarkersTask{
 					TxnManager:          s.TxnManager,
 					Scene:               scene,
 					Overwrite:           overwrite,
 					fileNamingAlgorithm: fileNamingAlgo,
-					ImagePreview:        input.MarkerImagePreviews,
-					Screenshot:          input.MarkerScreenshots,
+					ImagePreview:        utils.IsTrue(input.MarkerImagePreviews),
+					Screenshot:          utils.IsTrue(input.MarkerScreenshots),
 				}
 				go progress.ExecuteTask(fmt.Sprintf("Generating markers for %s", scene.Path), func() {
 					task.Start()
@@ -314,7 +311,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if input.Transcodes {
+			if utils.IsTrue(input.Transcodes) {
 				wg.Add()
 				task := GenerateTranscodeTask{
 					Scene:               *scene,
@@ -327,7 +324,7 @@ func (s *singleton) Generate(ctx context.Context, input models.GenerateMetadataI
 				})
 			}
 
-			if input.Phashes {
+			if utils.IsTrue(input.Phashes) {
 				task := GeneratePhashTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -647,15 +644,12 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 	}()
 
 	fileNamingAlgo := config.GetInstance().GetVideoFileNamingAlgorithm()
-	overwrite := false
-	if input.Overwrite != nil {
-		overwrite = *input.Overwrite
-	}
+	overwrite := utils.IsTrue(input.Overwrite)
 
 	logger.Infof("Counting content to generate...")
 	for _, scene := range scenes {
 		if scene != nil {
-			if input.Sprites {
+			if utils.IsTrue(input.Sprites) {
 				task := GenerateSpriteTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,
@@ -666,10 +660,10 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				}
 			}
 
-			if input.Previews {
+			if utils.IsTrue(input.Previews) {
 				task := GeneratePreviewTask{
 					Scene:               *scene,
-					ImagePreview:        input.ImagePreviews,
+					ImagePreview:        utils.IsTrue(input.ImagePreviews),
 					fileNamingAlgorithm: fileNamingAlgo,
 				}
 
@@ -678,12 +672,12 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 					totals.previews++
 				}
 
-				if input.ImagePreviews && (overwrite || !task.doesImagePreviewExist(sceneHash)) {
+				if utils.IsTrue(input.ImagePreviews) && (overwrite || !task.doesImagePreviewExist(sceneHash)) {
 					totals.imagePreviews++
 				}
 			}
 
-			if input.Markers {
+			if utils.IsTrue(input.Markers) {
 				task := GenerateMarkersTask{
 					TxnManager:          s.TxnManager,
 					Scene:               scene,
@@ -693,7 +687,7 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				totals.markers += int64(task.isMarkerNeeded())
 			}
 
-			if input.Transcodes {
+			if utils.IsTrue(input.Transcodes) {
 				task := GenerateTranscodeTask{
 					Scene:               *scene,
 					Overwrite:           overwrite,
@@ -704,7 +698,7 @@ func (s *singleton) neededGenerate(scenes []*models.Scene, input models.Generate
 				}
 			}
 
-			if input.Phashes {
+			if utils.IsTrue(input.Phashes) {
 				task := GeneratePhashTask{
 					Scene:               *scene,
 					fileNamingAlgorithm: fileNamingAlgo,


### PR DESCRIPTION
This specifically makes `markerScreenshots` optional in `GenerateMetadataInput` to maintain backward compatibility with external clients. It also incidentally makes the other boolean options optional so that clients don't need to include irrelevant options.