### PR TITLE
Update zh-tw Localization & Fix i18n Grammar Issue

### DIFF
--- a/ui/v2.5/src/locales/zh-TW.json
+++ b/ui/v2.5/src/locales/zh-TW.json
@@ -192,7 +192,9 @@
         "password_desc": "使用 Stash 時所需的密碼，留空以關閉身份驗證",
         "stash-box_integration": "整合 Stash-box",
         "username": "用戶名",
-        "username_desc": "使用 Stash 時所需的用戶名，留空以關閉身份驗證"
+        "username_desc": "使用 Stash 時所需的用戶名，留空以關閉身份驗證",
+        "trusted_proxies": "已信任代理伺服器",
+        "trusted_proxies_desc": "允許代理 stash 流量的代理伺服器列表。留空以允許內網。"
       },
       "cache_location": "快取的檔案位置",
       "cache_path_head": "快取路徑",
@@ -238,7 +240,11 @@
       "video_ext_head": "影片副檔名",
       "video_head": "影片設定",
       "include_audio_desc": "產生預覽檔案時，順便產生音訊預覽。",
-      "include_audio_head": "包含音訊"
+      "include_audio_head": "包含音訊",
+      "metadata_path": {
+        "heading": "Metadata 路徑",
+        "description": "進行完整匯出或匯入時所使用的檔案位置"
+      }
     },
     "logs": {
       "log_level": "日誌級別"
@@ -287,7 +293,8 @@
       "only_dry_run": "僅模擬作業，不要刪除任何東西",
       "plugin_tasks": "插件排程",
       "scan_for_content_desc": "掃描新內容，並將其新增到資料庫中。",
-      "set_name_date_details_from_metadata_if_present": "使用多媒體檔案中內建的標題、日期、詳細資訊（如果適用的話）"
+      "set_name_date_details_from_metadata_if_present": "使用多媒體檔案中內建的標題、日期、詳細資訊（如果適用的話）",
+      "generate_thumbnails_during_scan": "掃描圖片時，順便產生縮圖。"
     },
     "tools": {
       "scene_duplicate_checker": "短片相近性檢查工具",
@@ -369,6 +376,18 @@
             "heading": "自訂演員圖像路徑"
           }
         }
+      },
+      "funscript_offset": {
+        "description": "互動式腳本的時間偏移量 (毫秒)。",
+        "heading": "Funscript 偏移量 (毫秒)"
+      },
+      "images": {
+        "options": {
+          "write_image_thumbnails": {
+            "heading": "建立圖片縮圖",
+            "description": "建立縮圖時，將檔案寫至磁碟中"
+          }
+        }
       }
     },
     "plugins": {
@@ -440,7 +459,9 @@
       "preview_seg_duration_head": "預覽片段長度",
       "sprites": "時間軸預覽（用於短片中時間軸的預覽圖）",
       "transcodes": "轉碼（將不支援的影片格式轉換成 MP4）",
-      "video_previews": "影片預覽（當滑鼠移至任一短片上時所播放的預覽短片）"
+      "video_previews": "影片預覽（當滑鼠移至任一短片上時所播放的預覽短片）",
+      "marker_image_previews": "章節預覽（動態 WebP 預覽，僅當預覽類型設置為『動圖』時才需要）",
+      "marker_screenshots": "章節截圖（靜態 JPG 預覽，僅當預覽類型設置為『靜態』時才需要）"
     },
     "scrape_entity_title": "{entity_type}爬取結果",
     "scrape_results_existing": "現有資訊",
@@ -453,7 +474,28 @@
     },
     "overwrite_filter_confirm": "您確定要覆蓋現有的條件 {entityName} 嗎？",
     "scenes_found": "已找到 {count} 個短片",
-    "scrape_entity_query": "{entity_type}爬蟲搜尋"
+    "scrape_entity_query": "{entity_type}爬蟲搜尋",
+    "lightbox": {
+      "delay": "延遲 (秒)",
+      "display_mode": {
+        "fit_horizontally": "橫向置放",
+        "label": "顯示模式",
+        "fit_to_screen": "適應螢幕大小",
+        "original": "原始"
+      },
+      "options": "選項",
+      "reset_zoom_on_nav": "當更換圖片時，重置縮放大小",
+      "scale_up": {
+        "label": "縮放適應",
+        "description": "將較小的圖片放大，以填滿整個畫面"
+      },
+      "scroll_mode": {
+        "description": "按住 Shift 以暫時使用其他模式。",
+        "pan_y": "Y 軸滑動",
+        "label": "滑動模式",
+        "zoom": "放大"
+      }
+    }
   },
   "dimensions": "解析度",
   "director": "導演",
@@ -636,5 +678,8 @@
   "include_sub_studios": "包含子工作室",
   "include_sub_tags": "包含子標籤",
   "parent_tags": "母標籤",
-  "sub_tags": "子標籤"
+  "sub_tags": "子標籤",
+  "include_parent_tags": "包含母標籤",
+  "parent_tag_count": "母標籤數量",
+  "sub_tag_count": "子標籤數量"
 }


### PR DESCRIPTION
## Summary

This PR is your usual periodic zh-tw localization update. 

## Issues Before Merging

Before this can be merged, however, one issue needs to be addressed. `Parent of`/`Sub-tag of` was added in one of the merges recently. As previously mentioned in one of the localization updates before, this type of string can be problematic for some languages. The current approach in the implementation of these string is as follows,

```tsx

  function maybeRenderChildren() {
    if (tag.children.length > 1) {
      return (
        <div className="tag-sub-tags">
          <FormattedMessage id="parent_of" />
          &nbsp;
          <Link to={NavUtils.makeChildTagsUrl(tag)}>
            {tag.children.length}&nbsp;
            <FormattedMessage
              id="countables.tags"
              values={{ count: tag.children.length }}
            />
          </Link>
        </div>
      );
    }
```

Ideally, this needs to be re-written as something that would allow the translator to move the tag name around in the localization string, e.g., `Parent of <x>`/`<x> 的母標籤`.