### PR TITLE
Add id to hierarchy filter checkbox input

### DIFF
--- a/ui/v2.5/src/components/List/Filters/HierarchicalLabelValueFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/HierarchicalLabelValueFilter.tsx
@@ -52,11 +52,13 @@ export const HierarchicalLabelValueFilter: React.FC<IHierarchicalLabelValueFilte
   }
 
   function criterionOptionTypeToIncludeID(): string {
-    return criterion.criterionOption.type === "studios"
-        ? "include-sub-studios"
-        : criterion.criterionOption.type === "childTags"
-        ? "include-parent-tags"
-        : "include-sub-tags";
+    if (criterion.criterionOption.type === "studios") {
+      return "include-sub-studios";
+    }
+    if (criterion.criterionOption.type === "childTags") {
+      return "include-parent-tags";
+    }
+    return "include-sub-tags";
   }
 
   function criterionOptionTypeToIncludeUIString(): MessageDescriptor {


### PR DESCRIPTION
This adds an ID to the checkbox for the studio/tags filter so that you can click the checkbox label instead of only being able to click the box.