### PR TITLE
Move rating stars out of details and edit tabs

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -12,6 +12,7 @@ import { TextUtils } from "src/utils";
 import * as Mousetrap from "mousetrap";
 import { useToast } from "src/hooks";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { GalleryEditPanel } from "./GalleryEditPanel";
 import { GalleryDetailPanel } from "./GalleryDetailPanel";
 import { DeleteGalleriesDialog } from "../DeleteGalleriesDialog";
@@ -92,6 +93,19 @@ export const Gallery: React.FC = () => {
     setIsDeleteAlertOpen(false);
     if (deleted) {
       history.push("/galleries");
+    }
+  }
+
+  function setRating(v: number | null) {
+    if (gallery?.id) {
+      updateGallery({
+        variables: {
+          input: {
+            id: gallery?.id,
+            rating: v,
+          },
+        },
+      });
     }
   }
 
@@ -179,6 +193,12 @@ export const Gallery: React.FC = () => {
               </Nav.Link>
             </Nav.Item>
             <Nav.Item className="ml-auto">
+              <RatingStars
+                value={gallery?.rating ?? undefined}
+                onSetRating={(value) => setRating(value ?? null)}
+              />
+            </Nav.Item>
+            <Nav.Item>
               <OrganizedButton
                 loading={organizedLoading}
                 organized={gallery.organized}
@@ -261,10 +281,36 @@ export const Gallery: React.FC = () => {
     Mousetrap.bind("e", () => setActiveTabKey("gallery-edit-panel"));
     Mousetrap.bind("f", () => setActiveTabKey("gallery-file-info-panel"));
 
+    // numeric keypresses get caught by jwplayer, so blur the element
+    // if the rating sequence is started
+    Mousetrap.bind("r", () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      Mousetrap.bind("0", () => setRating(NaN));
+      Mousetrap.bind("1", () => setRating(1));
+      Mousetrap.bind("2", () => setRating(2));
+      Mousetrap.bind("3", () => setRating(3));
+      Mousetrap.bind("4", () => setRating(4));
+      Mousetrap.bind("5", () => setRating(5));
+
+      setTimeout(() => {
+        Mousetrap.unbind("0");
+        Mousetrap.unbind("1");
+        Mousetrap.unbind("2");
+        Mousetrap.unbind("3");
+        Mousetrap.unbind("4");
+        Mousetrap.unbind("5");
+      }, 1000);
+    });
+
     return () => {
       Mousetrap.unbind("a");
       Mousetrap.unbind("e");
       Mousetrap.unbind("f");
+
+      Mousetrap.unbind("r");
     };
   });
 

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
@@ -5,7 +5,6 @@ import * as GQL from "src/core/generated-graphql";
 import { TextUtils } from "src/utils";
 import { TagLink, TruncatedText } from "src/components/Shared";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { sortPerformers } from "src/core/performers";
 
 interface IGalleryDetailProps {
@@ -79,13 +78,6 @@ export const GalleryDetailPanel: React.FC<IGalleryDetailProps> = (props) => {
               />
             </h5>
           ) : undefined}
-          {props.gallery.rating ? (
-            <h6>
-              Rating: <RatingStars value={props.gallery.rating} />
-            </h6>
-          ) : (
-            ""
-          )}
         </div>
         {props.gallery.studio && (
           <div className="col-3 d-xl-none">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -32,7 +32,6 @@ import { useToast } from "src/hooks";
 import { useFormik } from "formik";
 import { Prompt } from "react-router";
 import { FormUtils, TextUtils } from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { GalleryScrapeDialog } from "./GalleryScrapeDialog";
 
 interface IProps {
@@ -82,7 +81,6 @@ export const GalleryEditPanel: React.FC<
     details: yup.string().optional().nullable(),
     url: yup.string().optional().nullable(),
     date: yup.string().optional().nullable(),
-    rating: yup.number().optional().nullable(),
     studio_id: yup.string().optional().nullable(),
     performer_ids: yup.array(yup.string().required()).optional().nullable(),
     tag_ids: yup.array(yup.string().required()).optional().nullable(),
@@ -94,7 +92,6 @@ export const GalleryEditPanel: React.FC<
     details: gallery?.details ?? "",
     url: gallery?.url ?? "",
     date: gallery?.date ?? "",
-    rating: gallery?.rating ?? null,
     studio_id: gallery?.studio?.id,
     performer_ids: (gallery?.performers ?? []).map((p) => p.id),
     tag_ids: (gallery?.tags ?? []).map((t) => t.id),
@@ -108,10 +105,6 @@ export const GalleryEditPanel: React.FC<
     validationSchema: schema,
     onSubmit: (values) => onSave(getGalleryInput(values)),
   });
-
-  function setRating(v: number) {
-    formik.setFieldValue("rating", v);
-  }
 
   interface ISceneSelectValue {
     id: string;
@@ -135,35 +128,9 @@ export const GalleryEditPanel: React.FC<
         onDelete();
       });
 
-      // numeric keypresses get caught by jwplayer, so blur the element
-      // if the rating sequence is started
-      Mousetrap.bind("r", () => {
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-
-        Mousetrap.bind("0", () => setRating(NaN));
-        Mousetrap.bind("1", () => setRating(1));
-        Mousetrap.bind("2", () => setRating(2));
-        Mousetrap.bind("3", () => setRating(3));
-        Mousetrap.bind("4", () => setRating(4));
-        Mousetrap.bind("5", () => setRating(5));
-
-        setTimeout(() => {
-          Mousetrap.unbind("0");
-          Mousetrap.unbind("1");
-          Mousetrap.unbind("2");
-          Mousetrap.unbind("3");
-          Mousetrap.unbind("4");
-          Mousetrap.unbind("5");
-        }, 1000);
-      });
-
       return () => {
         Mousetrap.unbind("s s");
         Mousetrap.unbind("d d");
-
-        Mousetrap.unbind("r");
       };
     }
   });
@@ -480,20 +447,6 @@ export const GalleryEditPanel: React.FC<
               intl.formatMessage({ id: "date" }),
               "YYYY-MM-DD"
             )}
-            <Form.Group controlId="rating" as={Row}>
-              {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "rating" }),
-              })}
-              <Col xs={9}>
-                <RatingStars
-                  value={formik.values.rating ?? undefined}
-                  onSetRating={(value) =>
-                    formik.setFieldValue("rating", value ?? null)
-                  }
-                />
-              </Col>
-            </Form.Group>
-
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
                 title: intl.formatMessage({ id: "studio" }),

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -16,6 +16,7 @@ import { TextUtils } from "src/utils";
 import * as Mousetrap from "mousetrap";
 import { OCounterButton } from "src/components/Scenes/SceneDetails/OCounterButton";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { ImageFileInfoPanel } from "./ImageFileInfoPanel";
 import { ImageEditPanel } from "./ImageEditPanel";
 import { ImageDetailPanel } from "./ImageDetailPanel";
@@ -124,6 +125,19 @@ export const Image: React.FC = () => {
     }
   }
 
+  function setRating(v: number | null) {
+    if (image?.id) {
+      updateImage({
+        variables: {
+          input: {
+            id: image?.id,
+            rating: v,
+          },
+        },
+      });
+    }
+  }
+
   function maybeRenderDeleteDialog() {
     if (isDeleteAlertOpen && image) {
       return (
@@ -194,6 +208,12 @@ export const Image: React.FC = () => {
               </Nav.Link>
             </Nav.Item>
             <Nav.Item className="ml-auto">
+              <RatingStars
+                value={image?.rating ?? undefined}
+                onSetRating={(value) => setRating(value ?? null)}
+              />
+            </Nav.Item>
+            <Nav.Item>
               <OCounterButton
                 loading={oLoading}
                 value={image.o_counter || 0}
@@ -242,11 +262,37 @@ export const Image: React.FC = () => {
     Mousetrap.bind("f", () => setActiveTabKey("image-file-info-panel"));
     Mousetrap.bind("o", () => onIncrementClick());
 
+    // numeric keypresses get caught by jwplayer, so blur the element
+    // if the rating sequence is started
+    Mousetrap.bind("r", () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      Mousetrap.bind("0", () => setRating(NaN));
+      Mousetrap.bind("1", () => setRating(1));
+      Mousetrap.bind("2", () => setRating(2));
+      Mousetrap.bind("3", () => setRating(3));
+      Mousetrap.bind("4", () => setRating(4));
+      Mousetrap.bind("5", () => setRating(5));
+
+      setTimeout(() => {
+        Mousetrap.unbind("0");
+        Mousetrap.unbind("1");
+        Mousetrap.unbind("2");
+        Mousetrap.unbind("3");
+        Mousetrap.unbind("4");
+        Mousetrap.unbind("5");
+      }, 1000);
+    });
+
     return () => {
       Mousetrap.unbind("a");
       Mousetrap.unbind("e");
       Mousetrap.unbind("f");
       Mousetrap.unbind("o");
+
+      Mousetrap.unbind("r");
     };
   });
 

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
@@ -4,7 +4,6 @@ import * as GQL from "src/core/generated-graphql";
 import { TextUtils } from "src/utils";
 import { TagLink, TruncatedText } from "src/components/Shared";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { sortPerformers } from "src/core/performers";
 
 interface IImageDetailProps {
@@ -72,13 +71,6 @@ export const ImageDetailPanel: React.FC<IImageDetailProps> = (props) => {
               />
             </h3>
           </div>
-          {props.image.rating ? (
-            <h6>
-              Rating: <RatingStars value={props.image.rating} />
-            </h6>
-          ) : (
-            ""
-          )}
           {renderGalleries()}
           {props.image.file.width && props.image.file.height ? (
             <h6>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -15,7 +15,6 @@ import { useToast } from "src/hooks";
 import { FormUtils } from "src/utils";
 import { useFormik } from "formik";
 import { Prompt } from "react-router";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 
 interface IProps {
   image: GQL.ImageDataFragment;
@@ -38,7 +37,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
   const schema = yup.object({
     title: yup.string().optional().nullable(),
-    rating: yup.number().optional().nullable(),
     studio_id: yup.string().optional().nullable(),
     performer_ids: yup.array(yup.string().required()).optional().nullable(),
     tag_ids: yup.array(yup.string().required()).optional().nullable(),
@@ -46,7 +44,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
   const initialValues = {
     title: image.title ?? "",
-    rating: image.rating ?? null,
     studio_id: image.studio?.id,
     performer_ids: (image.performers ?? []).map((p) => p.id),
     tag_ids: (image.tags ?? []).map((t) => t.id),
@@ -60,10 +57,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
     onSubmit: (values) => onSave(getImageInput(values)),
   });
 
-  function setRating(v: number) {
-    formik.setFieldValue("rating", v);
-  }
-
   useEffect(() => {
     if (isVisible) {
       Mousetrap.bind("s s", () => {
@@ -73,35 +66,9 @@ export const ImageEditPanel: React.FC<IProps> = ({
         onDelete();
       });
 
-      // numeric keypresses get caught by jwplayer, so blur the element
-      // if the rating sequence is started
-      Mousetrap.bind("r", () => {
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-
-        Mousetrap.bind("0", () => setRating(NaN));
-        Mousetrap.bind("1", () => setRating(1));
-        Mousetrap.bind("2", () => setRating(2));
-        Mousetrap.bind("3", () => setRating(3));
-        Mousetrap.bind("4", () => setRating(4));
-        Mousetrap.bind("5", () => setRating(5));
-
-        setTimeout(() => {
-          Mousetrap.unbind("0");
-          Mousetrap.unbind("1");
-          Mousetrap.unbind("2");
-          Mousetrap.unbind("3");
-          Mousetrap.unbind("4");
-          Mousetrap.unbind("5");
-        }, 1000);
-      });
-
       return () => {
         Mousetrap.unbind("s s");
         Mousetrap.unbind("d d");
-
-        Mousetrap.unbind("r");
       };
     }
   });
@@ -189,20 +156,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
         <div className="form-container row px-3">
           <div className="col-12 col-lg-6 col-xl-12">
             {renderTextField("title", intl.formatMessage({ id: "title" }))}
-            <Form.Group controlId="rating" as={Row}>
-              {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "rating" }),
-              })}
-              <Col xs={9}>
-                <RatingStars
-                  value={formik.values.rating ?? undefined}
-                  onSetRating={(value) =>
-                    formik.setFieldValue("rating", value ?? null)
-                  }
-                />
-              </Col>
-            </Form.Group>
-
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
                 title: intl.formatMessage({ id: "studio" }),

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -16,6 +16,7 @@ import {
   Modal,
 } from "src/components/Shared";
 import { useToast } from "src/hooks";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { MovieScenesPanel } from "./MovieScenesPanel";
 import { MovieDetailsPanel } from "./MovieDetailsPanel";
 import { MovieEditPanel } from "./MovieEditPanel";
@@ -58,9 +59,35 @@ export const Movie: React.FC = () => {
     Mousetrap.bind("e", () => setIsEditing(true));
     Mousetrap.bind("d d", () => onDelete());
 
+    // numeric keypresses get caught by jwplayer, so blur the element
+    // if the rating sequence is started
+    Mousetrap.bind("r", () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      Mousetrap.bind("0", () => setRating(NaN));
+      Mousetrap.bind("1", () => setRating(1));
+      Mousetrap.bind("2", () => setRating(2));
+      Mousetrap.bind("3", () => setRating(3));
+      Mousetrap.bind("4", () => setRating(4));
+      Mousetrap.bind("5", () => setRating(5));
+
+      setTimeout(() => {
+        Mousetrap.unbind("0");
+        Mousetrap.unbind("1");
+        Mousetrap.unbind("2");
+        Mousetrap.unbind("3");
+        Mousetrap.unbind("4");
+        Mousetrap.unbind("5");
+      }, 1000);
+    });
+
     return () => {
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
+
+      Mousetrap.unbind("r");
     };
   });
 
@@ -136,6 +163,19 @@ export const Movie: React.FC = () => {
     setIsEditing(!isEditing);
     setFrontImage(undefined);
     setBackImage(undefined);
+  }
+
+  function setRating(v: number | null) {
+    if (movie?.id) {
+      updateMovie({
+        variables: {
+          input: {
+            id: movie?.id,
+            rating: v,
+          },
+        },
+      });
+    }
   }
 
   function renderDeleteAlert() {
@@ -222,6 +262,11 @@ export const Movie: React.FC = () => {
             </div>
           )}
         </div>
+
+        <RatingStars
+          value={movie?.rating ?? undefined}
+          onSetRating={(value) => setRating(value ?? null)}
+        />
 
         {!isEditing && movie ? (
           <>

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import { DurationUtils, TextUtils } from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { TextField, URLField } from "src/utils/field";
 
 interface IMovieDetailsPanel {
@@ -24,21 +23,6 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({ movie }) => {
         </div>
       );
     }
-  }
-
-  function renderRatingField() {
-    if (!movie.rating) {
-      return;
-    }
-
-    return (
-      <>
-        <dt>{intl.formatMessage({ id: "rating" })}</dt>
-        <dd>
-          <RatingStars value={movie.rating} disabled />
-        </dd>
-      </>
-    );
   }
 
   // TODO: CSS class
@@ -67,8 +51,6 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({ movie }) => {
           url={`/studios/${movie.studio?.id}`}
         />
         <TextField id="director" value={movie.director} />
-
-        {renderRatingField()}
 
         <URLField
           id="url"

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -24,7 +24,6 @@ import {
   InputGroup,
 } from "react-bootstrap";
 import { DurationUtils, FormUtils, ImageUtils } from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { MovieScrapeDialog } from "./MovieScrapeDialog";
@@ -76,7 +75,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
       .optional()
       .nullable()
       .matches(/^\d{4}-\d{2}-\d{2}$/),
-    rating: yup.number().optional().nullable(),
     studio_id: yup.string().optional().nullable(),
     director: yup.string().optional().nullable(),
     synopsis: yup.string().optional().nullable(),
@@ -90,7 +88,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     aliases: movie?.aliases,
     duration: movie?.duration,
     date: movie?.date,
-    rating: movie?.rating ?? null,
     studio_id: movie?.studio?.id,
     director: movie?.director,
     synopsis: movie?.synopsis,
@@ -122,18 +119,8 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     encodingImage,
   ]);
 
-  function setRating(v: number) {
-    formik.setFieldValue("rating", v);
-  }
-
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("r 0", () => setRating(NaN));
-    Mousetrap.bind("r 1", () => setRating(1));
-    Mousetrap.bind("r 2", () => setRating(2));
-    Mousetrap.bind("r 3", () => setRating(3));
-    Mousetrap.bind("r 4", () => setRating(4));
-    Mousetrap.bind("r 5", () => setRating(5));
     // Mousetrap.bind("u", (e) => {
     //   setStudioFocus()
     //   e.preventDefault();
@@ -141,12 +128,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     Mousetrap.bind("s s", () => formik.handleSubmit());
 
     return () => {
-      Mousetrap.unbind("r 0");
-      Mousetrap.unbind("r 1");
-      Mousetrap.unbind("r 2");
-      Mousetrap.unbind("r 3");
-      Mousetrap.unbind("r 4");
-      Mousetrap.unbind("r 5");
       // Mousetrap.unbind("u");
       Mousetrap.unbind("s s");
     };
@@ -171,7 +152,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
   function getMovieInput(values: InputValues) {
     const input: Partial<GQL.MovieCreateInput | GQL.MovieUpdateInput> = {
       ...values,
-      rating: values.rating ?? null,
       studio_id: values.studio_id ?? null,
     };
 
@@ -443,20 +423,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
         </Form.Group>
 
         {renderTextField("director", intl.formatMessage({ id: "director" }))}
-
-        <Form.Group controlId="rating" as={Row}>
-          {FormUtils.renderLabel({
-            title: intl.formatMessage({ id: "rating" }),
-          })}
-          <Col xs={9}>
-            <RatingStars
-              value={formik.values.rating ?? undefined}
-              onSetRating={(value) =>
-                formik.setFieldValue("rating", value ?? null)
-              }
-            />
-          </Col>
-        </Form.Group>
 
         <Form.Group controlId="url" as={Row}>
           {FormUtils.renderLabel({

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -37,6 +37,7 @@ import { DeleteScenesDialog } from "../DeleteScenesDialog";
 import { SceneGenerateDialog } from "../SceneGenerateDialog";
 import { SceneVideoFilterPanel } from "./SceneVideoFilterPanel";
 import { OrganizedButton } from "./OrganizedButton";
+import { RatingStars } from "./RatingStars";
 
 interface ISceneParams {
   id?: string;
@@ -101,6 +102,19 @@ export const Scene: React.FC = () => {
     setQueueScenes(scenes);
     setQueueTotal(count);
     setQueueStart(1);
+  }
+
+  function setRating(v: number | null) {
+    if (scene?.id) {
+      updateScene({
+        variables: {
+          input: {
+            id: scene?.id,
+            rating: v,
+          },
+        },
+      });
+    }
   }
 
   // HACK - jwplayer doesn't handle re-rendering when scene changes, so force
@@ -470,6 +484,12 @@ export const Scene: React.FC = () => {
             </Nav.Item>
             <ButtonGroup className="ml-auto">
               <Nav.Item className="ml-auto">
+                <RatingStars
+                  value={scene?.rating ?? undefined}
+                  onSetRating={(value) => setRating(value ?? null)}
+                />
+              </Nav.Item>
+              <Nav.Item className="ml-auto">
                 <ExternalPlayerButton scene={scene} />
               </Nav.Item>
               <Nav.Item className="ml-auto">
@@ -565,6 +585,30 @@ export const Scene: React.FC = () => {
     Mousetrap.bind("p p", () => onQueuePrevious());
     Mousetrap.bind("p r", () => onQueueRandom());
 
+    // numeric keypresses get caught by jwplayer, so blur the element
+    // if the rating sequence is started
+    Mousetrap.bind("r", () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      Mousetrap.bind("0", () => setRating(NaN));
+      Mousetrap.bind("1", () => setRating(1));
+      Mousetrap.bind("2", () => setRating(2));
+      Mousetrap.bind("3", () => setRating(3));
+      Mousetrap.bind("4", () => setRating(4));
+      Mousetrap.bind("5", () => setRating(5));
+
+      setTimeout(() => {
+        Mousetrap.unbind("0");
+        Mousetrap.unbind("1");
+        Mousetrap.unbind("2");
+        Mousetrap.unbind("3");
+        Mousetrap.unbind("4");
+        Mousetrap.unbind("5");
+      }, 1000);
+    });
+
     return () => {
       Mousetrap.unbind("a");
       Mousetrap.unbind("q");
@@ -575,6 +619,8 @@ export const Scene: React.FC = () => {
       Mousetrap.unbind("p n");
       Mousetrap.unbind("p p");
       Mousetrap.unbind("p r");
+
+      Mousetrap.unbind("r");
     };
   });
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -6,7 +6,6 @@ import { TextUtils } from "src/utils";
 import { TagLink, TruncatedText } from "src/components/Shared";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
-import { RatingStars } from "./RatingStars";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;
@@ -95,14 +94,6 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
               />
             </h5>
           ) : undefined}
-          {props.scene.rating ? (
-            <h6>
-              <FormattedMessage id="rating" />:{" "}
-              <RatingStars value={props.scene.rating} />
-            </h6>
-          ) : (
-            ""
-          )}
           {props.scene.file.width && props.scene.file.height && (
             <h6>
               <FormattedMessage id="resolution" />:{" "}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -36,7 +36,6 @@ import { useFormik } from "formik";
 import { Prompt } from "react-router";
 import { ConfigurationContext } from "src/hooks/Config";
 import { SceneMovieTable } from "./SceneMovieTable";
-import { RatingStars } from "./RatingStars";
 import { SceneScrapeDialog } from "./SceneScrapeDialog";
 import { SceneQueryModal } from "./SceneQueryModal";
 
@@ -88,7 +87,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     details: yup.string().optional().nullable(),
     url: yup.string().optional().nullable(),
     date: yup.string().optional().nullable(),
-    rating: yup.number().optional().nullable(),
     gallery_ids: yup.array(yup.string().required()).optional().nullable(),
     studio_id: yup.string().optional().nullable(),
     performer_ids: yup.array(yup.string().required()).optional().nullable(),
@@ -109,7 +107,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     details: scene.details ?? "",
     url: scene.url ?? "",
     date: scene.date ?? "",
-    rating: scene.rating ?? null,
     gallery_ids: (scene.galleries ?? []).map((g) => g.id),
     studio_id: scene.studio?.id,
     performer_ids: (scene.performers ?? []).map((p) => p.id),
@@ -128,10 +125,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     validationSchema: schema,
     onSubmit: (values) => onSave(getSceneInput(values)),
   });
-
-  function setRating(v: number) {
-    formik.setFieldValue("rating", v);
-  }
 
   interface IGallerySelectValue {
     id: string;
@@ -155,35 +148,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
         onDelete();
       });
 
-      // numeric keypresses get caught by jwplayer, so blur the element
-      // if the rating sequence is started
-      Mousetrap.bind("r", () => {
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-
-        Mousetrap.bind("0", () => setRating(NaN));
-        Mousetrap.bind("1", () => setRating(1));
-        Mousetrap.bind("2", () => setRating(2));
-        Mousetrap.bind("3", () => setRating(3));
-        Mousetrap.bind("4", () => setRating(4));
-        Mousetrap.bind("5", () => setRating(5));
-
-        setTimeout(() => {
-          Mousetrap.unbind("0");
-          Mousetrap.unbind("1");
-          Mousetrap.unbind("2");
-          Mousetrap.unbind("3");
-          Mousetrap.unbind("4");
-          Mousetrap.unbind("5");
-        }, 1000);
-      });
-
       return () => {
         Mousetrap.unbind("s s");
         Mousetrap.unbind("d d");
-
-        Mousetrap.unbind("r");
       };
     }
   });
@@ -235,7 +202,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
         variables: {
           input: {
             ...input,
-            rating: input.rating ?? null,
           },
         },
       });
@@ -669,19 +635,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
               intl.formatMessage({ id: "date" }),
               "YYYY-MM-DD"
             )}
-            <Form.Group controlId="rating" as={Row}>
-              {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "rating" }),
-              })}
-              <Col xs={9}>
-                <RatingStars
-                  value={formik.values.rating ?? undefined}
-                  onSetRating={(value) =>
-                    formik.setFieldValue("rating", value ?? null)
-                  }
-                />
-              </Col>
-            </Form.Group>
             <Form.Group controlId="galleries" as={Row}>
               {FormUtils.renderLabel({
                 title: intl.formatMessage({ id: "galleries" }),

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -21,6 +21,7 @@ import {
   ErrorMessage,
 } from "src/components/Shared";
 import { useToast } from "src/hooks";
+import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { StudioScenesPanel } from "./StudioScenesPanel";
 import { StudioGalleriesPanel } from "./StudioGalleriesPanel";
 import { StudioImagesPanel } from "./StudioImagesPanel";
@@ -62,9 +63,35 @@ export const Studio: React.FC = () => {
     Mousetrap.bind("e", () => setIsEditing(true));
     Mousetrap.bind("d d", () => onDelete());
 
+    // numeric keypresses get caught by jwplayer, so blur the element
+    // if the rating sequence is started
+    Mousetrap.bind("r", () => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+
+      Mousetrap.bind("0", () => setRating(NaN));
+      Mousetrap.bind("1", () => setRating(1));
+      Mousetrap.bind("2", () => setRating(2));
+      Mousetrap.bind("3", () => setRating(3));
+      Mousetrap.bind("4", () => setRating(4));
+      Mousetrap.bind("5", () => setRating(5));
+
+      setTimeout(() => {
+        Mousetrap.unbind("0");
+        Mousetrap.unbind("1");
+        Mousetrap.unbind("2");
+        Mousetrap.unbind("3");
+        Mousetrap.unbind("4");
+        Mousetrap.unbind("5");
+      }, 1000);
+    });
+
     return () => {
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
+
+      Mousetrap.unbind("r");
     };
   });
 
@@ -166,6 +193,19 @@ export const Studio: React.FC = () => {
     setIsEditing(!isEditing);
   }
 
+  function setRating(v: number | null) {
+    if (studio?.id) {
+      updateStudio({
+        variables: {
+          input: {
+            id: studio?.id,
+            rating: v,
+          },
+        },
+      });
+    }
+  }
+
   function renderImage() {
     let studioImage = studio?.image_path;
     if (isEditing) {
@@ -226,6 +266,12 @@ export const Studio: React.FC = () => {
             renderImage()
           )}
         </div>
+
+        <RatingStars
+          value={studio?.rating ?? undefined}
+          onSetRating={(value) => setRating(value ?? null)}
+        />
+
         {!isEditing && !isNew && studio ? (
           <>
             <StudioDetailsPanel studio={studio} />

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Badge } from "react-bootstrap";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import { TextUtils } from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { TextField, URLField } from "src/utils/field";
 
 interface IStudioDetailsPanel {
@@ -13,23 +12,6 @@ interface IStudioDetailsPanel {
 export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
   studio,
 }) => {
-  const intl = useIntl();
-
-  function renderRatingField() {
-    if (!studio.rating) {
-      return;
-    }
-
-    return (
-      <>
-        <dt>{intl.formatMessage({ id: "rating" })}</dt>
-        <dd>
-          <RatingStars value={studio.rating} disabled />
-        </dd>
-      </>
-    );
-  }
-
   function renderTagsList() {
     if (!studio?.aliases?.length) {
       return;
@@ -74,7 +56,6 @@ export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
           target="_self"
         />
 
-        {renderRatingField()}
         {renderTagsList()}
       </dl>
     </div>

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -6,7 +6,6 @@ import Mousetrap from "mousetrap";
 import { Icon, StudioSelect, DetailsEditNavbar } from "src/components/Shared";
 import { Button, Form, Col, Row } from "react-bootstrap";
 import { FormUtils, ImageUtils, getStashIDs } from "src/utils";
-import { RatingStars } from "src/components/Scenes/SceneDetails/RatingStars";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { StringListInput } from "../../Shared/StringListInput";
@@ -41,7 +40,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     url: yup.string().optional().nullable(),
     details: yup.string().optional().nullable(),
     image: yup.string().optional().nullable(),
-    rating: yup.number().optional().nullable(),
     parent_id: yup.string().optional().nullable(),
     stash_ids: yup.mixed<GQL.StashIdInput>().optional().nullable(),
     aliases: yup
@@ -62,7 +60,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     url: studio.url ?? "",
     details: studio.details ?? "",
     image: undefined,
-    rating: studio.rating ?? null,
     parent_id: studio.parent_studio?.id,
     stash_ids: studio.stash_ids ?? undefined,
     aliases: studio.aliases,
@@ -75,10 +72,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     validationSchema: schema,
     onSubmit: (values) => onSubmit(getStudioInput(values)),
   });
-
-  function setRating(v: number) {
-    formik.setFieldValue("rating", v);
-  }
 
   function onImageLoad(imageData: string) {
     formik.setFieldValue("image", imageData);
@@ -99,30 +92,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("s s", () => formik.handleSubmit());
-
-    // numeric keypresses get caught by jwplayer, so blur the element
-    // if the rating sequence is started
-    Mousetrap.bind("r", () => {
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-
-      Mousetrap.bind("0", () => setRating(NaN));
-      Mousetrap.bind("1", () => setRating(1));
-      Mousetrap.bind("2", () => setRating(2));
-      Mousetrap.bind("3", () => setRating(3));
-      Mousetrap.bind("4", () => setRating(4));
-      Mousetrap.bind("5", () => setRating(5));
-
-      setTimeout(() => {
-        Mousetrap.unbind("0");
-        Mousetrap.unbind("1");
-        Mousetrap.unbind("2");
-        Mousetrap.unbind("3");
-        Mousetrap.unbind("4");
-        Mousetrap.unbind("5");
-      }, 1000);
-    });
 
     return () => {
       Mousetrap.unbind("s s");
@@ -278,20 +247,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
               }
               ids={formik.values.parent_id ? [formik.values.parent_id] : []}
               excludeIds={studio.id ? [studio.id] : []}
-            />
-          </Col>
-        </Form.Group>
-
-        <Form.Group controlId="rating" as={Row}>
-          {FormUtils.renderLabel({
-            title: intl.formatMessage({ id: "rating" }),
-          })}
-          <Col xs={9}>
-            <RatingStars
-              value={formik.values.rating ?? undefined}
-              onSetRating={(value) =>
-                formik.setFieldValue("rating", value ?? null)
-              }
             />
           </Col>
         </Form.Group>


### PR DESCRIPTION
This extends the changes from https://github.com/stashapp/stash/pull/1844 and applies it to the scenes, images, movies, galleries, and studios.

**Scenes/Images/Galleries**
I moved the star ratings next to the o-counter. It was the simplest place to put it, because that area is always visible across all view widths.
![image](https://user-images.githubusercontent.com/38586902/137561459-37c59c54-9f0f-4a17-a1c0-d9bc1e9bfba1.png)
![image](https://user-images.githubusercontent.com/38586902/137561567-c02ad349-0e32-44a4-8508-5bb4f840d46d.png)
The top margin/padding needs tweaking so the stars are in line with the rest of the buttons, but before I did that I wanted some opinions on putting the stars in that section.

Putting it under the title is another option, but that section becomes hidden in mobile view, leaving only the details tab visible, so it would require adding the rating stars back to the details tab and making them editable.

**Movies/Studios**
I placed the rating stars above the title, because the title is part of the details panel which gets hidden when you're editing. This position lets you see and update the ratings regardless of whether you're viewing details or editing.
![image](https://user-images.githubusercontent.com/38586902/137562199-ae696ccc-8c54-4513-842d-fb9b2102d950.png)
![image](https://user-images.githubusercontent.com/38586902/137562453-a497728e-72f7-4522-af54-65d1e6edd9bf.png)
