### PR TITLE
Handle request cancellation more gracefully

### DIFF
--- a/pkg/api/check_version.go
+++ b/pkg/api/check_version.go
@@ -120,7 +120,7 @@ func makeGithubRequest(ctx context.Context, url string, output interface{}) erro
 
 	if err != nil {
 		//lint:ignore ST1005 Github is a proper capitalized noun
-		return fmt.Errorf("Github API request failed: %s", err)
+		return fmt.Errorf("Github API request failed: %w", err)
 	}
 
 	if response.StatusCode != http.StatusOK {
@@ -133,12 +133,12 @@ func makeGithubRequest(ctx context.Context, url string, output interface{}) erro
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		//lint:ignore ST1005 Github is a proper capitalized noun
-		return fmt.Errorf("Github API read response failed: %s", err)
+		return fmt.Errorf("Github API read response failed: %w", err)
 	}
 
 	err = json.Unmarshal(data, output)
 	if err != nil {
-		return fmt.Errorf("unmarshalling Github API response failed: %s", err)
+		return fmt.Errorf("unmarshalling Github API response failed: %w", err)
 	}
 
 	return nil
@@ -248,7 +248,15 @@ func getShaFromTags(ctx context.Context, shortHash bool, name string) string {
 	err := makeGithubRequest(ctx, url, &tags)
 
 	if err != nil {
-		logger.Errorf("Github Tags Api %v", err)
+		// If the context is canceled, we don't want to log this as an error
+		// in the path. The function here just gives up and returns "" if
+		// something goes wrong. Hence, log the error at the info-level so
+		// it's still present, but don't treat this as an error.
+		if errors.Is(err, context.Canceled) {
+			logger.Infof("aborting sha request due to context cancellation")
+		} else {
+			logger.Errorf("Github Tags Api: %v", err)
+		}
 		return ""
 	}
 	_, gitShort, _ := GetVersion() // retrieve short hash to check actual length


### PR DESCRIPTION
The version checking code performs its own error management and will
not pass errors to the caller. Hence, it needs to be aware of the types
of errors which can be returned.

In particular, the context.Canceled error will be returned if the
context is aborted through cancelation. This happens when the request
is terminated by tapping CTRL-C or if the browser request is terminated
while we are sitting waiting for the GH API.