### PR TITLE
Fix non-x86_64 docker images

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -9,7 +9,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-pi; \
     fi; \
     mv $BIN /stash
 
-FROM --platform=$BUILDPLATFORM alpine:latest AS app
+FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools && pip install mechanicalsoup cloudscraper
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml

--- a/docker/ci/x86_64/docker_push.sh
+++ b/docker/ci/x86_64/docker_push.sh
@@ -10,5 +10,5 @@ done
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 # must build the image from dist directory
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push $DOCKER_TAGS -f docker/ci/x86_64/Dockerfile dist/
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 --push $DOCKER_TAGS -f docker/ci/x86_64/Dockerfile dist/
 


### PR DESCRIPTION
The docker images on arm seeing errors in calling to ffmpeg. It turns out the old code was shipping mislabeled x86_64 images, but Stash ran fine until it had to call dependencies. 

This also enables building a docker image for older raspberry pis (armv6). We already build the binary, so this just packages it.