### PR TITLE
Fail if attempting to delete a file that is undeletable

### DIFF
--- a/pkg/api/resolver_mutation_gallery.go
+++ b/pkg/api/resolver_mutation_gallery.go
@@ -453,7 +453,7 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 				}
 
 				// Check if all images are writable first before trying to do delete,
-				// to reduce the footprint of a transaction rollback if it is
+				// to reduce the footprint of a transaction rollback if it is needed
 				imgToImgGalleries := make(map[*models.Image][]*models.Gallery)
 				for _, img := range currGalleryImgs {
 					imgGalleries, err := qb.FindByImageID(img.ID)

--- a/pkg/api/resolver_mutation_gallery.go
+++ b/pkg/api/resolver_mutation_gallery.go
@@ -481,6 +481,13 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 						imgsDeleted = append(imgsDeleted, img)
 					}
 				}
+
+				for _, gallery := range galleries {
+					err = manager.DeleteGalleryFile(gallery)
+					if err != nil {
+						return err
+					}
+				}
 			}
 
 			if err := qb.Destroy(id); err != nil {
@@ -491,17 +498,6 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 		return nil
 	}); err != nil {
 		return false, err
-	}
-
-	// Delete gallery folder / Zip archive
-	if input.DeleteFile != nil && *input.DeleteFile {
-
-		for _, gallery := range galleries {
-			err = manager.DeleteGalleryFile(gallery)
-			if err != nil {
-				return false, err
-			}
-		}
 	}
 
 	// call post hook after performing the other actions

--- a/pkg/api/resolver_mutation_gallery.go
+++ b/pkg/api/resolver_mutation_gallery.go
@@ -432,7 +432,10 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 					// if delete generated is true, then delete the generated files
 					// for the gallery
 					if input.DeleteGenerated != nil && *input.DeleteGenerated {
-						manager.DeleteGeneratedImageFiles(img)
+						err = manager.DeleteGeneratedImageFiles(img)
+						if err != nil {
+							return err
+						}
 					}
 
 					if err := iqb.Destroy(img.ID); err != nil {
@@ -465,7 +468,10 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 						// if delete generated is true, then delete the generated files
 						// for the gallery
 						if input.DeleteGenerated != nil && *input.DeleteGenerated {
-							manager.DeleteGeneratedImageFiles(img)
+							err = manager.DeleteGeneratedImageFiles(img)
+							if err != nil {
+								return err
+							}
 						}
 
 						if err := iqb.Destroy(img.ID); err != nil {

--- a/pkg/api/resolver_mutation_image.go
+++ b/pkg/api/resolver_mutation_image.go
@@ -295,7 +295,6 @@ func (r *mutationResolver) ImageDestroy(ctx context.Context, input models.ImageD
 		}
 
 		// if delete file is true, then delete the file as well
-		// if it fails, just log a message
 		if input.DeleteFile != nil && *input.DeleteFile {
 			err = manager.DeleteImageFile(image)
 			if err != nil {

--- a/pkg/api/resolver_mutation_image.go
+++ b/pkg/api/resolver_mutation_image.go
@@ -305,7 +305,10 @@ func (r *mutationResolver) ImageDestroy(ctx context.Context, input models.ImageD
 		// if delete generated is true, then delete the generated files
 		// for the image
 		if input.DeleteGenerated != nil && *input.DeleteGenerated {
-			manager.DeleteGeneratedImageFiles(image)
+			err = manager.DeleteGeneratedImageFiles(image)
+			if err != nil {
+				return err
+			}
 		}
 
 		return qb.Destroy(imageID)
@@ -351,7 +354,10 @@ func (r *mutationResolver) ImagesDestroy(ctx context.Context, input models.Image
 			// if delete generated is true, then delete the generated files
 			// for the image
 			if input.DeleteGenerated != nil && *input.DeleteGenerated {
-				manager.DeleteGeneratedImageFiles(image)
+				err = manager.DeleteGeneratedImageFiles(image)
+				if err != nil {
+					return err
+				}
 			}
 
 			images = append(images, image)

--- a/pkg/api/resolver_mutation_scene.go
+++ b/pkg/api/resolver_mutation_scene.go
@@ -480,7 +480,10 @@ func (r *mutationResolver) SceneDestroy(ctx context.Context, input models.SceneD
 		// if delete generated is true, then delete the generated files
 		// for the scene
 		if input.DeleteGenerated != nil && *input.DeleteGenerated {
-			manager.DeleteGeneratedSceneFiles(scene, config.GetInstance().GetVideoFileNamingAlgorithm())
+			err = manager.DeleteGeneratedSceneFiles(scene, config.GetInstance().GetVideoFileNamingAlgorithm())
+			if err != nil {
+				return err
+			}
 		}
 
 		postCommitFunc, err = manager.DestroyScene(scene, repo)
@@ -527,7 +530,10 @@ func (r *mutationResolver) ScenesDestroy(ctx context.Context, input models.Scene
 			// if delete generated is true, then delete the generated files
 			// for the scene
 			if input.DeleteGenerated != nil && *input.DeleteGenerated {
-				manager.DeleteGeneratedSceneFiles(scene, fileNamingAlgo)
+				err = manager.DeleteGeneratedSceneFiles(scene, fileNamingAlgo)
+				if err != nil {
+					return err
+				}
 			}
 
 			f, err := manager.DestroyScene(scene, repo)

--- a/pkg/manager/gallery.go
+++ b/pkg/manager/gallery.go
@@ -1,17 +1,20 @@
 package manager
 
 import (
+	"io/fs"
 	"os"
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func DeleteGalleryFile(gallery *models.Gallery) {
+func DeleteGalleryFile(gallery *models.Gallery) error {
 	if gallery.Path.Valid {
 		err := os.Remove(gallery.Path.String)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", gallery.Path.String, err.Error())
 		}
+		return err
 	}
+	return fs.ErrInvalid
 }

--- a/pkg/manager/gallery.go
+++ b/pkg/manager/gallery.go
@@ -5,11 +5,21 @@ import (
 	"os"
 
 	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 )
 
 func DeleteGalleryFile(gallery *models.Gallery) error {
 	if gallery.Path.Valid {
+
+		// If trying to delete the stash itself, quietly fail.
+		stashConfigs := config.GetInstance().GetStashPaths()
+		for _, config := range stashConfigs {
+			if gallery.Path.String == config.Path {
+				return nil
+			}
+		}
+
 		err := os.Remove(gallery.Path.String)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", gallery.Path.String, err.Error())

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stashapp/stash/pkg/utils"
 )
 
+const stashDeletePostfix = ".stashdelete"
+
 // DeleteGeneratedImageFiles deletes generated files for the provided image.
 func DeleteGeneratedImageFiles(image *models.Image) error {
 	thumbPath := GetInstance().Paths.Generated.GetThumbnailPath(image.Checksum, models.DefaultGthumbWidth)
@@ -27,6 +29,46 @@ func DeleteGeneratedImageFiles(image *models.Image) error {
 // DeleteImageFile deletes the image file from the filesystem.
 func DeleteImageFile(image *models.Image) error {
 	err := os.Remove(image.Path)
+	if err != nil {
+		logger.Warnf("Could not delete file %s: %s", image.Path, err.Error())
+	}
+	return err
+}
+
+// MarkImageFileForDeleteion checks if a file is writable by renaming it.
+// Use DeleteMarkedImageFile afterwards to actually delete.
+func MarkImageFileForDeletion(image *models.Image) error {
+	// handle image deleted outside of Stash
+	_, err := os.Stat(image.Path)
+	if os.IsNotExist(err) {
+		logger.Debugf("Could not mark for deletion: %s: %s", image.Path, err.Error())
+		return nil
+	}
+	err = os.Rename(image.Path, image.Path+stashDeletePostfix)
+	if err != nil {
+		logger.Errorf("Could not mark for deletion: %s: %s", image.Path, err.Error())
+	}
+	return err
+}
+
+func UnmarkImageFileForDeletion(image *models.Image) {
+	err := os.Rename(image.Path+stashDeletePostfix, image.Path)
+	if err != nil {
+		logger.Debug("Could not unmark file %s: %s", image.Path, err.Error())
+	}
+}
+
+func DeleteMarkedImageFile(image *models.Image) error {
+	// handle missing renamed image, probably file was already deleted
+	_, err := os.Stat(image.Path + stashDeletePostfix)
+	if os.IsNotExist(err) {
+		err = DeleteImageFile(image)
+		if err != nil {
+			logger.Debugf("Could not delete file %s: %s", image.Path, err.Error())
+		}
+		return nil
+	}
+	err = os.Remove(image.Path + stashDeletePostfix)
 	if err != nil {
 		logger.Warnf("Could not delete file %s: %s", image.Path, err.Error())
 	}

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -23,11 +23,12 @@ func DeleteGeneratedImageFiles(image *models.Image) {
 }
 
 // DeleteImageFile deletes the image file from the filesystem.
-func DeleteImageFile(image *models.Image) {
+func DeleteImageFile(image *models.Image) error {
 	err := os.Remove(image.Path)
 	if err != nil {
 		logger.Warnf("Could not delete file %s: %s", image.Path, err.Error())
 	}
+	return err
 }
 
 func walkGalleryZip(path string, walkFunc func(file *zip.File) error) error {

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -54,7 +54,7 @@ func MarkImageFileForDeletion(image *models.Image) error {
 func UnmarkImageFileForDeletion(image *models.Image) {
 	err := os.Rename(image.Path+stashDeletePostfix, image.Path)
 	if err != nil {
-		logger.Debug("Could not unmark file %s: %s", image.Path, err.Error())
+		logger.Debugf("Could not unmark file %s: %s", image.Path, err.Error())
 	}
 }
 

--- a/pkg/manager/image.go
+++ b/pkg/manager/image.go
@@ -11,7 +11,7 @@ import (
 )
 
 // DeleteGeneratedImageFiles deletes generated files for the provided image.
-func DeleteGeneratedImageFiles(image *models.Image) {
+func DeleteGeneratedImageFiles(image *models.Image) error {
 	thumbPath := GetInstance().Paths.Generated.GetThumbnailPath(image.Checksum, models.DefaultGthumbWidth)
 	exists, _ := utils.FileExists(thumbPath)
 	if exists {
@@ -19,7 +19,9 @@ func DeleteGeneratedImageFiles(image *models.Image) {
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", thumbPath, err.Error())
 		}
+		return err
 	}
+	return nil
 }
 
 // DeleteImageFile deletes the image file from the filesystem.

--- a/pkg/manager/scene.go
+++ b/pkg/manager/scene.go
@@ -176,7 +176,7 @@ func DeleteSceneMarkerFiles(scene *models.Scene, seconds int, fileNamingAlgo mod
 }
 
 // DeleteSceneFile deletes the scene video file from the filesystem.
-func DeleteSceneFile(scene *models.Scene) {
+func DeleteSceneFile(scene *models.Scene) error {
 	// kill any running encoders
 	KillRunningStreams(scene.Path)
 
@@ -184,6 +184,7 @@ func DeleteSceneFile(scene *models.Scene) {
 	if err != nil {
 		logger.Warnf("Could not delete file %s: %s", scene.Path, err.Error())
 	}
+	return err
 }
 
 func GetSceneFileContainer(scene *models.Scene) (ffmpeg.Container, error) {

--- a/pkg/manager/scene.go
+++ b/pkg/manager/scene.go
@@ -59,11 +59,11 @@ func DestroySceneMarker(scene *models.Scene, sceneMarker *models.SceneMarker, qb
 }
 
 // DeleteGeneratedSceneFiles deletes generated files for the provided scene.
-func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAlgorithm) {
+func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAlgorithm) error {
 	sceneHash := scene.GetHash(fileNamingAlgo)
 
 	if sceneHash == "" {
-		return
+		return nil
 	}
 
 	markersFolder := filepath.Join(GetInstance().Paths.Generated.Markers, sceneHash)
@@ -73,6 +73,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.RemoveAll(markersFolder)
 		if err != nil {
 			logger.Warnf("Could not delete folder %s: %s", markersFolder, err.Error())
+			return err
 		}
 	}
 
@@ -82,6 +83,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(thumbPath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", thumbPath, err.Error())
+			return err
 		}
 	}
 
@@ -91,6 +93,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(normalPath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", normalPath, err.Error())
+			return err
 		}
 	}
 
@@ -100,6 +103,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(streamPreviewPath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", streamPreviewPath, err.Error())
+			return err
 		}
 	}
 
@@ -109,6 +113,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(streamPreviewImagePath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", streamPreviewImagePath, err.Error())
+			return err
 		}
 	}
 
@@ -121,6 +126,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(transcodePath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", transcodePath, err.Error())
+			return err
 		}
 	}
 
@@ -130,6 +136,7 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(spritePath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", spritePath, err.Error())
+			return err
 		}
 	}
 
@@ -139,8 +146,10 @@ func DeleteGeneratedSceneFiles(scene *models.Scene, fileNamingAlgo models.HashAl
 		err := os.Remove(vttPath)
 		if err != nil {
 			logger.Warnf("Could not delete file %s: %s", vttPath, err.Error())
+			return err
 		}
 	}
+	return nil
 }
 
 // DeleteSceneMarkerFiles deletes generated files for a scene marker with the


### PR DESCRIPTION
Currently, if attempting to delete a scene/image that is unable to be deleted (immutable bit set, read-only filesystem, insufficient permissions, etc.), Stash will delete the database entry and related files and claim that the file was deleted. On a subsequent scan, the file will magically reappear. 

This PR tries to delete the file first (if file deletion is set), and then carries on with the other actions if it succeeds. If it fails, the UI is notified.