### PR TITLE
Fix studio-details classname typo

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -170,7 +170,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
 
   return (
     <div className="row">
-      <div className="studio-detils col-md-4">
+      <div className="studio-details col-md-4">
         <div className="text-center">
           {imageEncoding ? (
             <LoadingIndicator message="Encoding image..." />


### PR DESCRIPTION
Fixes a bug with studio images not getting resized on the studio details page