### PR TITLE
Fix UI crash when scraping scene with no phash

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -79,10 +79,12 @@ const getFingerprintStatus = (
   const checksumMatch = scene.fingerprints?.some(
     (f) => f.hash === stashScene.checksum || f.hash === stashScene.oshash
   );
-  const phashMatches =
-    scene.fingerprints?.filter(
-      (f) => f.algorithm === "PHASH" && distance(f.hash, stashScene.phash) <= 8
-    ) ?? [];
+  const phashMatches = stashScene.phash
+    ? scene.fingerprints?.filter(
+        (f) =>
+          f.algorithm === "PHASH" && distance(f.hash, stashScene.phash) <= 8
+      ) ?? []
+    : [];
 
   const phashList = (
     <div className="m-2">


### PR DESCRIPTION
UI crash occurs when scraping a scene without phash set, and the result set has phashes. 