### PR TITLE
Draft: Support direct streaming of audio files. 

### DIFF
--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -53,6 +53,9 @@ const (
 	MimeMp4            string     = "video/mp4"
 	MimeHLS            string     = "application/vnd.apple.mpegurl"
 	MimeMpegts         string     = "video/MP2T"
+	MimeAudioMpeg      string     = "audio/mpeg"
+	MimeAudioOgg       string     = "audio/ogg"
+	MimeAudioWav       string     = "audio/wav"
 )
 
 // only support H264 by default, since Safari does not support VP8/VP9
@@ -141,6 +144,21 @@ func IsValidAudioForContainer(audio AudioCodec, format Container) bool {
 		return IsValidAudio(audio, validAudioForWebm)
 	case Mp4:
 		return IsValidAudio(audio, validAudioForMp4)
+	}
+	return false
+
+}
+
+func IsAudioContainer(format Container) bool {
+	switch format {
+	case "mp3":
+		return true
+	case "flac":
+		return true
+	case "ogg":
+		return true
+	case "wav":
+		return true
 	}
 	return false
 

--- a/pkg/manager/scene.go
+++ b/pkg/manager/scene.go
@@ -264,6 +264,14 @@ func GetSceneStreamPaths(scene *models.Scene, directStreamURL string, maxStreami
 			MimeType: &mimeMp4,
 			Label:    &label,
 		})
+	} else if GetAudioMimeType(scene.Format.String) != "" {
+		label := "Direct audio stream"
+		mimetype := GetAudioMimeType(scene.Format.String)
+		ret = append(ret, &models.SceneStreamEndpoint{
+			URL:      directStreamURL,
+			MimeType: &mimetype,
+			Label:    &label,
+		})
 	}
 
 	// only add mkv stream endpoint if the scene container is an mkv already
@@ -362,4 +370,16 @@ func HasTranscode(scene *models.Scene, fileNamingAlgo models.HashAlgorithm) bool
 	transcodePath := instance.Paths.Scene.GetTranscodePath(sceneHash)
 	ret, _ := utils.FileExists(transcodePath)
 	return ret
+}
+
+func GetAudioMimeType(format string) string {
+	switch format {
+	case "mp3":
+		return ffmpeg.MimeAudioMpeg
+	case "wav":
+		return ffmpeg.MimeAudioWav
+	case "ogg":
+		return ffmpeg.MimeAudioOgg
+	}
+	return ""
 }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -108,25 +108,6 @@ export class ScenePlayerImpl extends React.Component<
       }
     });
 
-    //
-    this.player.on("meta", (metadata: any) => {
-      if (
-        metadata.metadataType === "media" &&
-        !metadata.width &&
-        !metadata.height
-      ) {
-        // Occurs during preload when videos with supported audio/unsupported video are preloaded.
-        // Treat this as a decoding error and try the next source without playing.
-        // However on Safari we get an media event when m3u8 is loaded which needs to be ignored.
-        const currentFile = this.player.getPlaylistItem().file;
-        if (currentFile != null && !currentFile.includes("m3u8")) {
-          const state = this.player.getState();
-          const play = state === "buffering" || state === "playing";
-          this.handleError(play);
-        }
-      }
-    });
-
     this.player.on("firstFrame", () => {
       if (this.props.timestamp > 0) {
         this.player.seek(this.props.timestamp);


### PR DESCRIPTION
/closes #1258

More or less open for discussion. This was the quickest attempt to make audio files workable for me.
I think audio can be treated as any other video - so there is no new backend machinery required. You could make "movies" out of them - which I think would be highly desirable for multipart hypnosis sessions.

The thumbnail scraper may need to be adjusted to return a static dummy image for audio or simply a black screen. A proper cover image could still be provided as manual thumbnail.

