### PR TITLE
move scrape-url-button style to component styles

### DIFF
--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -1,9 +1,3 @@
-#performer-edit {
-  .scrape-url-button:disabled {
-    opacity: 0.5;
-  }
-}
-
 #performer-page {
   flex-direction: row;
   margin: 10px auto;

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -254,3 +254,7 @@ button.collapse-button.btn-primary:not(:disabled):not(.disabled):active {
 .ModalComponent .modal-footer {
   justify-content: space-between;
 }
+
+.scrape-url-button:disabled {
+  opacity: 0.5;
+}


### PR DESCRIPTION
Followup style update to https://github.com/stashapp/stash/pull/1903

The performer edit url scrape button had a style which made the difference between disabled and enabled more noticeable. That style is now moved to the component and generalized to apply to all url scrape buttons, not just the performer edit.