### PR TITLE
Extend __typename stripper to fix interface config saving

### DIFF
--- a/ui/v2.5/src/utils/data.ts
+++ b/ui/v2.5/src/utils/data.ts
@@ -5,7 +5,21 @@ interface ITypename {
   __typename?: string;
 }
 
-export function withoutTypename<T extends ITypename>(o: T) {
-  const { __typename, ...ret } = o;
-  return ret;
+const hasTypename = (value: unknown): value is ITypename => (
+  !!(value as ITypename)?.__typename
+);
+
+const processNoneObjValue = (value: unknown): unknown => (
+  Array.isArray(value) ? value.map(
+    v => hasTypename(v) ? withoutTypename(v) : processNoneObjValue(v)
+  ) : value
+);
+
+export function withoutTypename<T extends ITypename>(o: T): Omit<T, '__typename'> {
+  const { __typename, ...data} = o;
+
+  return Object.entries(data).reduce((ret, [key, value]) => ({
+    ...ret,
+    [key]: hasTypename(value) ? withoutTypename(value) : processNoneObjValue(value)
+  }), {} as Omit<T, '__typename'>);
 }

--- a/ui/v2.5/src/utils/data.ts
+++ b/ui/v2.5/src/utils/data.ts
@@ -5,21 +5,28 @@ interface ITypename {
   __typename?: string;
 }
 
-const hasTypename = (value: unknown): value is ITypename => (
-  !!(value as ITypename)?.__typename
-);
+const hasTypename = (value: unknown): value is ITypename =>
+  !!(value as ITypename)?.__typename;
 
-const processNoneObjValue = (value: unknown): unknown => (
-  Array.isArray(value) ? value.map(
-    v => hasTypename(v) ? withoutTypename(v) : processNoneObjValue(v)
-  ) : value
-);
+const processNoneObjValue = (value: unknown): unknown =>
+  Array.isArray(value)
+    ? value.map((v) =>
+        hasTypename(v) ? withoutTypename(v) : processNoneObjValue(v)
+      )
+    : value;
 
-export function withoutTypename<T extends ITypename>(o: T): Omit<T, '__typename'> {
-  const { __typename, ...data} = o;
+export function withoutTypename<T extends ITypename>(
+  o: T
+): Omit<T, "__typename"> {
+  const { __typename, ...data } = o;
 
-  return Object.entries(data).reduce((ret, [key, value]) => ({
-    ...ret,
-    [key]: hasTypename(value) ? withoutTypename(value) : processNoneObjValue(value)
-  }), {} as Omit<T, '__typename'>);
+  return Object.entries(data).reduce(
+    (ret, [key, value]) => ({
+      ...ret,
+      [key]: hasTypename(value)
+        ? withoutTypename(value)
+        : processNoneObjValue(value),
+    }),
+    {} as Omit<T, "__typename">
+  );
 }


### PR DESCRIPTION
A bit dubious type checking, but it should work. Traverses the entire object and strips out `__typename` from all properties.