### PR TITLE
Fix checkbox labels

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -569,7 +569,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
 
         <Form.Group>
           <Form.Check
-            id="log-terminal"
+            id="create-galleries-from-folders"
             checked={createGalleriesFromFolders}
             label={intl.formatMessage({
               id: "config.general.create_galleries_from_folders_label",

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -592,6 +592,7 @@ export const SettingsConfigurationPanel: React.FC = () => {
         <h4>{intl.formatMessage({ id: "config.general.hashing" })}</h4>
         <Form.Group>
           <Form.Check
+            id="calculate-md5-and-ohash"
             checked={calculateMD5}
             label={intl.formatMessage({
               id: "config.general.calculate_md5_and_ohash_label",

--- a/ui/v2.5/src/components/Settings/SettingsDLNAPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsDLNAPanel.tsx
@@ -465,6 +465,7 @@ export const SettingsDLNAPanel: React.FC = () => {
           </Form.Group>
           <Form.Group>
             <Form.Check
+              id="dlna-enabled-by-default"
               checked={values.enabled}
               label={intl.formatMessage({
                 id: "config.dlna.enabled_by_default",

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -274,8 +274,9 @@ export const SettingsInterfacePanel: React.FC = () => {
 
       <Form.Group>
         <h5>{intl.formatMessage({ id: "config.ui.scene_player.heading" })}</h5>
-        <Form.Group id="auto-start-video">
+        <Form.Group>
           <Form.Check
+            id="auto-start-video"
             checked={autostartVideo}
             label={intl.formatMessage({
               id: "config.ui.scene_player.options.auto_start_video",


### PR DESCRIPTION
I noticed that the id of the "create galleries from folders" config option checkbox had the same id as the "log to terminal" option, so clicking the label of "log to terminal" was toggling the "create galleries from folders" checkbox. Fixed by giving it its own id.

I also went through and tested clicking checkbox labels on the various settings pages and added ids to checkboxes that were missing them, so clicking their labels will now toggle the checkbox.