### PR TITLE
Update scene filename parser input styling

### DIFF
--- a/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
@@ -11,6 +11,7 @@ import {
   StudioSelect,
 } from "src/components/Shared";
 import { TextUtils } from "src/utils";
+import cx from "classnames";
 
 class ParserResult<T> {
   public value?: T;
@@ -165,12 +166,12 @@ function SceneParserRatingField(
         <Form.Group>
           <Form.Control
             disabled
-            className={props.className}
+            className={cx("input-control text-input", props.className)}
             defaultValue={result.originalValue || ""}
           />
           <Form.Control
             as="select"
-            className={props.className}
+            className={cx("input-control", props.className)}
             disabled={!props.parserResult.isSet}
             value={props.parserResult.value?.toString()}
             onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
@@ -393,7 +394,7 @@ export const SceneParserRow = (props: ISceneParserRowProps) => {
       {props.showFields.get("Rating") && (
         <SceneParserRatingField
           key="rating"
-          className="parser-field-rating input-control text-input"
+          className="parser-field-rating"
           parserResult={props.scene.rating}
           onSetChanged={(isSet) =>
             onRatingChanged(isSet, props.scene.rating.value ?? undefined)

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
@@ -217,7 +217,12 @@ function SceneParserPerformerField(props: ISceneParserFieldProps<string[]>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <PerformerSelect isDisabled isMulti ids={originalPerformers} className="parser-field-performers-select" />
+          <PerformerSelect
+            isDisabled
+            isMulti
+            ids={originalPerformers}
+            className="parser-field-performers-select"
+          />
           <PerformerSelect
             className="parser-field-performers-select"
             isMulti
@@ -255,7 +260,12 @@ function SceneParserTagField(props: ISceneParserFieldProps<string[]>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <TagSelect isDisabled isMulti ids={originalTags} className="parser-field-tags-select" />
+          <TagSelect
+            isDisabled
+            isMulti
+            ids={originalTags}
+            className="parser-field-tags-select"
+          />
           <TagSelect
             className="parser-field-tags-select"
             isMulti
@@ -295,7 +305,11 @@ function SceneParserStudioField(props: ISceneParserFieldProps<string>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <StudioSelect isDisabled ids={originalStudio} className="parser-field-studio-select" />
+          <StudioSelect
+            isDisabled
+            ids={originalStudio}
+            className="parser-field-studio-select"
+          />
           <StudioSelect
             className="parser-field-studio-select"
             isDisabled={!props.parserResult.isSet}

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneParserRow.tsx
@@ -121,7 +121,7 @@ function SceneParserStringField(props: ISceneParserFieldProps<string>) {
       <td>
         <Form.Group>
           <Form.Control
-            readOnly
+            disabled
             className={props.className}
             defaultValue={result.originalValue || ""}
           />
@@ -164,7 +164,7 @@ function SceneParserRatingField(
       <td>
         <Form.Group>
           <Form.Control
-            readOnly
+            disabled
             className={props.className}
             defaultValue={result.originalValue || ""}
           />
@@ -216,8 +216,9 @@ function SceneParserPerformerField(props: ISceneParserFieldProps<string[]>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <PerformerSelect isDisabled isMulti ids={originalPerformers} />
+          <PerformerSelect isDisabled isMulti ids={originalPerformers} className="parser-field-performers-select" />
           <PerformerSelect
+            className="parser-field-performers-select"
             isMulti
             isDisabled={!props.parserResult.isSet}
             onSelect={(items) => {
@@ -253,8 +254,9 @@ function SceneParserTagField(props: ISceneParserFieldProps<string[]>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <TagSelect isDisabled isMulti ids={originalTags} />
+          <TagSelect isDisabled isMulti ids={originalTags} className="parser-field-tags-select" />
           <TagSelect
+            className="parser-field-tags-select"
             isMulti
             isDisabled={!props.parserResult.isSet}
             onSelect={(items) => {
@@ -292,8 +294,9 @@ function SceneParserStudioField(props: ISceneParserFieldProps<string>) {
       </td>
       <td>
         <Form.Group className={props.className}>
-          <StudioSelect isDisabled ids={originalStudio} />
+          <StudioSelect isDisabled ids={originalStudio} className="parser-field-studio-select" />
           <StudioSelect
+            className="parser-field-studio-select"
             isDisabled={!props.parserResult.isSet}
             onSelect={(items) => {
               maybeValueChanged(items[0].id);
@@ -403,7 +406,7 @@ export const SceneParserRow = (props: ISceneParserRowProps) => {
       {props.showFields.get("Performers") && (
         <SceneParserPerformerField
           key="performers"
-          className="parser-field-performers input-control text-input"
+          className="parser-field-performers"
           parserResult={props.scene.performers}
           originalParserResult={props.scene.performers}
           onSetChanged={(set) =>
@@ -417,7 +420,7 @@ export const SceneParserRow = (props: ISceneParserRowProps) => {
       {props.showFields.get("Tags") && (
         <SceneParserTagField
           key="tags"
-          className="parser-field-tags input-control text-input"
+          className="parser-field-tags"
           parserResult={props.scene.tags}
           originalParserResult={props.scene.tags}
           onSetChanged={(isSet) =>
@@ -431,7 +434,7 @@ export const SceneParserRow = (props: ISceneParserRowProps) => {
       {props.showFields.get("Studio") && (
         <SceneParserStudioField
           key="studio"
-          className="parser-field-studio input-control text-input"
+          className="parser-field-studio"
           parserResult={props.scene.studio}
           originalParserResult={props.scene.studio}
           onSetChanged={(set) =>

--- a/ui/v2.5/src/components/SceneFilenameParser/styles.scss
+++ b/ui/v2.5/src/components/SceneFilenameParser/styles.scss
@@ -26,6 +26,12 @@
     width: 30ch;
   }
 
+  .parser-field-performers-select,
+  .parser-field-tags-select,
+  .parser-field-studio-select {
+    margin-bottom: 0.5rem;
+  }
+
   .parser-field-tags {
     width: 30ch;
   }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -73,13 +73,6 @@ dd {
   }
 }
 
-.text-input,
-.text-input:focus,
-.text-input[readonly],
-.text-input:disabled {
-  background-color: $textfield-bg;
-}
-
 .input-control,
 .input-control:focus,
 .input-control:disabled {
@@ -88,6 +81,13 @@ dd {
 
 .input-control:disabled {
   opacity: 0.8;
+}
+
+.text-input,
+.text-input:focus,
+.text-input[readonly],
+.text-input:disabled {
+  background-color: $textfield-bg;
 }
 
 textarea.text-input {


### PR DESCRIPTION
Changes:
* Change the order of the `.input-control` and `.text-input` rules in `src/index.scss` to fix text input background color inconsistency
* Change readOnly to disabled to make it more clear the value can't be changed
* Bottom padding for selects to better differentiate between the existing select values and the new ones

Before
![image](https://user-images.githubusercontent.com/38586902/140389269-27ecb961-ec75-4b6a-baf6-ddb8b001dc41.png)

After
![image](https://user-images.githubusercontent.com/38586902/140389427-940be3b7-f6d0-49a0-b522-77dcd540d59b.png)
