### PR TITLE
Set us up for Search Engine experiments - Introduce an event dispatcher

### DIFF
--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -1,0 +1,105 @@
+// package event dispatches change-events in stash
+package event
+
+import (
+	"context"
+	"sync"
+)
+
+// ChangeType defines what has changed
+type ChangeType int
+
+const (
+	SceneMarker ChangeType = iota
+	Scene
+	Image
+	Gallery
+	Movie
+	Performer
+	Studio
+	Tag
+)
+
+// Change represents a pair of a Type and the ID which has changed
+type Change struct {
+	Type ChangeType
+	ID   int
+}
+
+// Dispatcher represents a single event dispatcher
+type Dispatcher struct {
+	incoming chan Change
+	mu       sync.Mutex
+	chans    []chan Change
+}
+
+// NewDispatcher creates a new even dispatcher
+func NewDispatcher() *Dispatcher {
+	incoming := make(chan Change, 1)
+	return &Dispatcher{
+		incoming: incoming,
+	}
+}
+
+// Start starts the dispatcher goroutine under the given context
+func (d *Dispatcher) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case change := <-d.incoming:
+				d.broadcast(change)
+			}
+		}
+	}()
+}
+
+// Register registers chan for receiving events. It is up to the caller to ensure
+// the channel doesn't block. I.e., events must be lifted from chan quickly.
+func (d *Dispatcher) Register(c chan Change) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.chans = append(d.chans, c)
+}
+
+// Unregister removes a channel for dispatches
+func (d *Dispatcher) Unregister(c chan Change) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Find the index at which the chan occur
+	idx := -1
+	for i := range d.chans {
+		if d.chans[i] == c {
+			idx = i
+			break
+		}
+	}
+
+	// If already unregistered, ignore
+	if idx == -1 {
+		return
+	}
+
+	// Swap chan to last element, cut it off
+	last := len(d.chans) - 1
+	d.chans[idx] = d.chans[last]
+	d.chans = d.chans[:last]
+}
+
+// Publish broadcasts a change
+func (d *Dispatcher) Publish(c Change) {
+	d.incoming <- c
+}
+
+// broadcast fans-out a change to all channels registered
+func (d *Dispatcher) broadcast(change Change) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for _, ch := range d.chans {
+		ch <- change
+	}
+}

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -1,0 +1,68 @@
+package event
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func randomEvent() Change {
+	id := rand.Int()
+	ty := rand.Intn(3)
+
+	return Change{
+		ID:   id,
+		Type: ChangeType(ty),
+	}
+}
+
+func TestDispatcher(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	d := NewDispatcher()
+	d.Start(ctx)
+
+	numCh := 4
+	chs := make([]chan Change, 0, numCh)
+	for i := 0; i < numCh; i++ {
+		ch := make(chan Change, 1)
+		d.Register(ch)
+		chs = append(chs, ch)
+	}
+
+	trials := 20
+	timeOut := 5 * time.Second
+	// Each trial:
+	// * Unregisters a random channel
+	// * Publishes a random message which should then go to all other channels.
+	// * Checks that the unregistered channel doesn't receive the event
+	// * Re-registers the unregistered channel
+	for i := 0; i < trials; i++ {
+		have := randomEvent()
+		j := rand.Intn(numCh)
+		d.Unregister(chs[j])
+		d.Publish(have)
+		for k := range chs {
+			if k == j {
+				select {
+				case e := <-chs[k]:
+					t.Errorf("received event %v on unregistered channel", e)
+				default:
+				}
+			} else {
+				select {
+				case got := <-chs[k]:
+					if got.ID != have.ID || got.Type != have.Type {
+						t.Errorf("chan[%d]: got: %+v; want %+v", k, got, have)
+					}
+				case <-time.After(timeOut):
+					t.Fatal("Did not receive event in time")
+				}
+			}
+		}
+		d.Register(chs[j])
+	}
+
+	cancel()
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stashapp/stash/pkg/database"
 	"github.com/stashapp/stash/pkg/dlna"
+	"github.com/stashapp/stash/pkg/event"
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/job"
 	"github.com/stashapp/stash/pkg/logger"
@@ -36,7 +37,8 @@ type singleton struct {
 	FFMPEG  ffmpeg.Encoder
 	FFProbe ffmpeg.FFProbe
 
-	SessionStore *session.Store
+	eventDispatcher *event.Dispatcher
+	SessionStore    *session.Store
 
 	JobManager *job.Manager
 
@@ -72,11 +74,14 @@ func Initialize() *singleton {
 		initLog()
 		initProfiling(cfg.GetCPUProfilePath())
 
+		dispatcher := event.NewDispatcher()
+
 		instance = &singleton{
-			Config:        cfg,
-			JobManager:    job.NewManager(),
-			DownloadStore: NewDownloadStore(),
-			PluginCache:   plugin.NewCache(cfg),
+			Config:          cfg,
+			JobManager:      job.NewManager(),
+			DownloadStore:   NewDownloadStore(),
+			eventDispatcher: dispatcher,
+			PluginCache:     plugin.NewCache(cfg, dispatcher),
 
 			TxnManager: sqlite.NewTransactionManager(),
 

--- a/pkg/plugin/hooks.go
+++ b/pkg/plugin/hooks.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"github.com/stashapp/stash/pkg/event"
 	"github.com/stashapp/stash/pkg/plugin/common"
 )
 
@@ -122,4 +123,27 @@ func (e HookTriggerEnum) String() string {
 
 func addHookContext(argsMap common.ArgsMap, hookContext common.HookContext) {
 	argsMap[common.HookContextKey] = hookContext
+}
+
+func changeFromHookTrigger(e HookTriggerEnum) event.ChangeType {
+	switch e {
+	case SceneMarkerCreatePost, SceneMarkerUpdatePost, SceneMarkerDestroyPost:
+		return event.SceneMarker
+	case SceneCreatePost, SceneUpdatePost, SceneDestroyPost:
+		return event.Scene
+	case ImageCreatePost, ImageUpdatePost, ImageDestroyPost:
+		return event.Image
+	case GalleryCreatePost, GalleryUpdatePost, GalleryDestroyPost:
+		return event.Gallery
+	case MovieCreatePost, MovieUpdatePost, MovieDestroyPost:
+		return event.Movie
+	case PerformerCreatePost, PerformerUpdatePost, PerformerDestroyPost:
+		return event.Performer
+	case StudioCreatePost, StudioUpdatePost, StudioDestroyPost:
+		return event.Studio
+	case TagCreatePost, TagUpdatePost, TagDestroyPost:
+		return event.Tag
+	}
+
+	panic("missing case in changeFromHookTrigger")
 }


### PR DESCRIPTION
# Background

A search engine would like to receive online updates as there are changes to data. This change enables that functionality.

# PR

Introduce package event with a dispatcher subsystem. Add this to the
manager and to the plugin subsystem.

Whenever the plugin subsystem execute a PostHook, we dispatch an
Change event on the event dispatcher bus. This currently has no
effect, but allows us to register subsystems on the event bus for
further processing. In particular, search.

By design, we opt to hook the plugin system and pass to the event bus
for now. One, it makes it easier to remove again, and two, the context
handling inside the plugin subsystem doesn't want to live on the
other side of an event bus.

While here, write a test for the dispatcher code.