### PR TITLE
Additional performer urls

### DIFF
--- a/graphql/documents/data/performer-slim.graphql
+++ b/graphql/documents/data/performer-slim.graphql
@@ -13,4 +13,5 @@ fragment SlimPerformerData on Performer {
     stash_id
   }
   rating
+  urls
 }

--- a/graphql/documents/data/performer.graphql
+++ b/graphql/documents/data/performer.graphql
@@ -37,4 +37,5 @@ fragment PerformerData on Performer {
   death_date
   hair_color
   weight
+  urls
 }

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -44,6 +44,7 @@ type Performer {
   updated_at: Time!
   movie_count: Int
   movies: [Movie!]!
+  urls: [String!]!
 }
 
 input PerformerCreateInput {
@@ -73,6 +74,7 @@ input PerformerCreateInput {
   death_date: String
   hair_color: String
   weight: Int
+  urls: [String!]
 }
 
 input PerformerUpdateInput {
@@ -103,6 +105,7 @@ input PerformerUpdateInput {
   death_date: String
   hair_color: String
   weight: Int
+  urls: [String!]
 }
 
 input BulkPerformerUpdateInput {

--- a/pkg/api/resolver_model_performer.go
+++ b/pkg/api/resolver_model_performer.go
@@ -277,3 +277,14 @@ func (r *performerResolver) MovieCount(ctx context.Context, obj *models.Performe
 
 	return &res, nil
 }
+
+func (r *performerResolver) Urls(ctx context.Context, obj *models.Performer) (ret []string, err error) {
+	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
+		ret, err = repo.Performer().GetUrls(obj.ID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, err
+}

--- a/pkg/api/resolver_mutation_performer.go
+++ b/pkg/api/resolver_mutation_performer.go
@@ -275,6 +275,13 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 			}
 		}
 
+		// Save the urls
+		if translator.hasField("urls") {
+			if err := qb.UpdateUrls(performerID, input.Urls); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}); err != nil {
 		return nil, err

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -23,7 +23,7 @@ import (
 var DB *sqlx.DB
 var WriteMu sync.Mutex
 var dbPath string
-var appSchemaVersion uint = 28
+var appSchemaVersion uint = 29
 var databaseSchemaVersion uint
 
 //go:embed migrations/*.sql

--- a/pkg/database/migrations/29_performers_urls.up.sql
+++ b/pkg/database/migrations/29_performers_urls.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `performers_urls` (
+  `performer_id` integer NOT NULL,
+  `url` varchar(255) NOT NULL,
+  foreign key(`performer_id`) references `performers`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `index_performers_urls_on_performer_id` on `performers_urls` (`performer_id`);

--- a/pkg/manager/jsonschema/performer.go
+++ b/pkg/manager/jsonschema/performer.go
@@ -36,6 +36,7 @@ type Performer struct {
 	HairColor    string           `json:"hair_color,omitempty"`
 	Weight       int              `json:"weight,omitempty"`
 	StashIDs     []models.StashID `json:"stash_ids,omitempty"`
+	Urls         []string         `json:"urls,omitempty"`
 }
 
 func LoadPerformerFile(filePath string) (*Performer, error) {

--- a/pkg/models/mocks/PerformerReaderWriter.go
+++ b/pkg/models/mocks/PerformerReaderWriter.go
@@ -381,6 +381,29 @@ func (_m *PerformerReaderWriter) GetTagIDs(performerID int) ([]int, error) {
 	return r0, r1
 }
 
+// GetUrls provides a mock function with given fields: performerID
+func (_m *PerformerReaderWriter) GetUrls(performerID int) ([]string, error) {
+	ret := _m.Called(performerID)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(int) []string); ok {
+		r0 = rf(performerID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(performerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Query provides a mock function with given fields: performerFilter, findFilter
 func (_m *PerformerReaderWriter) Query(performerFilter *models.PerformerFilterType, findFilter *models.FindFilterType) ([]*models.Performer, int, error) {
 	ret := _m.Called(performerFilter, findFilter)
@@ -515,6 +538,20 @@ func (_m *PerformerReaderWriter) UpdateTags(performerID int, tagIDs []int) error
 	var r0 error
 	if rf, ok := ret.Get(0).(func(int, []int) error); ok {
 		r0 = rf(performerID, tagIDs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateUrls provides a mock function with given fields: performerID, urls
+func (_m *PerformerReaderWriter) UpdateUrls(performerID int, urls []string) error {
+	ret := _m.Called(performerID, urls)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int, []string) error); ok {
+		r0 = rf(performerID, urls)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -19,6 +19,7 @@ type PerformerReader interface {
 	GetImage(performerID int) ([]byte, error)
 	GetStashIDs(performerID int) ([]*StashID, error)
 	GetTagIDs(performerID int) ([]int, error)
+	GetUrls(performerID int) ([]string, error)
 }
 
 type PerformerWriter interface {
@@ -30,6 +31,7 @@ type PerformerWriter interface {
 	DestroyImage(performerID int) error
 	UpdateStashIDs(performerID int, stashIDs []StashID) error
 	UpdateTags(performerID int, tagIDs []int) error
+	UpdateUrls(performerID int, urls []string) error
 }
 
 type PerformerReaderWriter interface {

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -14,6 +14,8 @@ const performerTable = "performers"
 const performerIDColumn = "performer_id"
 const performersTagsTable = "performers_tags"
 const performersImageTable = "performers_image" // performer cover image
+const performersUrlsTable = "performers_urls"
+const performersUrlColumn = "url"
 
 var countPerformersForTagQuery = `
 SELECT tag_id AS id FROM performers_tags
@@ -606,4 +608,23 @@ func (qb *performerQueryBuilder) FindByStashIDStatus(hasStashID bool, stashboxEn
 
 	args := []interface{}{stashboxEndpoint}
 	return qb.queryPerformers(query, args)
+}
+
+func (qb *performerQueryBuilder) urlRepository() *stringRepository {
+	return &stringRepository{
+		repository: repository{
+			tx:        qb.tx,
+			tableName: performersUrlsTable,
+			idColumn:  performerIDColumn,
+		},
+		stringColumn: performersUrlColumn,
+	}
+}
+
+func (qb *performerQueryBuilder) GetUrls(performerID int) ([]string, error) {
+	return qb.urlRepository().get(performerID)
+}
+
+func (qb *performerQueryBuilder) UpdateUrls(performerID int, urls []string) error {
+	return qb.urlRepository().replace(performerID, urls)
 }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -72,6 +72,31 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     );
   }
 
+  function renderUrls() {
+    if (!performer.urls.length) {
+      return;
+    }
+
+    return (
+      <>
+        <dt>Additional URLs</dt>
+        <dd>
+          <ul className="pl-0">
+            {performer.urls.map((url) => {
+              return (
+                <li key={url} className="row no-gutters">
+                  <a href={url} target="_blank" rel="noopener noreferrer">
+                    {url}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </dd>
+      </>
+    );
+  }
+
   const formatHeight = (height?: string | null) => {
     if (!height) {
       return "";
@@ -143,6 +168,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
       />
       {renderTagsField()}
       {renderStashIDs()}
+      {renderUrls()}
     </dl>
   );
 };

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -523,8 +523,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     }
   }
 
-  async function onScrapePerformerURL() {
-    const { url } = formik.values;
+  async function onScrapePerformerURL(url: string) {
     if (!url) return;
     setIsLoading(true);
     try {
@@ -835,6 +834,11 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     );
   };
 
+  const editUrl = (url: string) => {
+    urlInputRef!.current!.value = url;
+    removeUrl(url);
+  };
+
   const addUrl = (url: string) => {
     if (urlInputRef.current?.value) {
       urlInputRef.current.value = "";
@@ -856,18 +860,43 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           <ul className="pl-0">
             {formik.values.urls.map((url) => {
               return (
-                <li key={url} className="row no-gutters mb-1">
+                <li key={url} className="row no-gutters mb-1 d-flex">
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mr-auto"
+                  >
+                    {url}
+                  </a>
+                  {urlScrapable(url) ? (
+                    <Button
+                      variant="secondary"
+                      className="mr-2 py-0"
+                      title="Scrape URL"
+                      onClick={() => onScrapePerformerURL(url)}
+                    >
+                      <Icon icon="file-download" />
+                    </Button>
+                  ) : (
+                    ""
+                  )}
+                  <Button
+                    variant="secondary"
+                    className="mr-2 py-0"
+                    title="Edit URL"
+                    onClick={() => editUrl(url)}
+                  >
+                    <Icon icon="pencil-alt" />
+                  </Button>
                   <Button
                     variant="danger"
-                    className="mr-2 py-0"
+                    className="py-0"
                     title="Delete URL"
                     onClick={() => removeUrl(url)}
                   >
                     <Icon icon="trash-alt" />
                   </Button>
-                  <a href={url} target="_blank" rel="noopener noreferrer">
-                    {url}
-                  </a>
                 </li>
               );
             })}
@@ -1005,7 +1034,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           <Col xs={fieldXS} xl={fieldXL}>
             <URLField
               {...formik.getFieldProps("url")}
-              onScrapeClick={onScrapePerformerURL}
+              onScrapeClick={onScrapePerformerURL.bind(this, formik.values.url)}
               urlScrapable={urlScrapable}
             />
           </Col>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerURLInput.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerURLInput.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from "react";
+import { Button, Form, InputGroup } from "react-bootstrap";
+import { useIntl } from "react-intl";
+import { Icon } from "src/components/Shared";
+
+interface IInstanceProps {
+  instance: IPerformerURLInputInstance;
+  onSave: (instance: IPerformerURLInputInstance) => void;
+  onDelete: (id: number) => void;
+  onScrape: (url: string) => void;
+  urlScrapable(url: string): boolean;
+}
+
+const Instance: React.FC<IInstanceProps> = ({
+  instance,
+  onSave,
+  onDelete,
+  onScrape,
+  urlScrapable,
+}) => {
+  const intl = useIntl();
+  const handleInput = (key: string, value: string) => {
+    const newObj = {
+      ...instance,
+      [key]: value,
+    };
+    onSave(newObj);
+  };
+
+  return (
+    <Form.Group className="row no-gutters">
+      <InputGroup className="col">
+        <Form.Control
+          placeholder="URL"
+          className="text-input"
+          value={instance?.url}
+          onInput={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleInput("url", e.currentTarget.value.trim())
+          }
+        />
+        <InputGroup.Append>
+          <Button
+            className="scrape-url-button text-input"
+            variant="secondary"
+            onClick={() => onScrape(instance?.url ?? "")}
+            disabled={!instance?.url || !urlScrapable(instance?.url)}
+            title={intl.formatMessage({ id: "actions.scrape" })}
+          >
+            <Icon icon="file-download" />
+          </Button>
+          <Button
+            className=""
+            variant="danger"
+            title={intl.formatMessage({ id: "actions.delete" })}
+            onClick={() => onDelete(instance.index)}
+          >
+            <Icon icon="minus" />
+          </Button>
+        </InputGroup.Append>
+      </InputGroup>
+    </Form.Group>
+  );
+};
+
+interface IPerformerURLInputProps {
+  urls: IPerformerURLInputInstance[];
+  saveURLs: (boxes: IPerformerURLInputInstance[]) => void;
+  onScrapeClick(url: string): void;
+  urlScrapable(url: string): boolean;
+}
+
+export interface IPerformerURLInputInstance {
+  url?: string;
+  index: number;
+}
+
+export const PerformerURLInput: React.FC<IPerformerURLInputProps> = ({
+  urls,
+  saveURLs,
+  onScrapeClick,
+  urlScrapable,
+}) => {
+  const intl = useIntl();
+  const [index, setIndex] = useState(1000);
+
+  const handleSave = (instance: IPerformerURLInputInstance) =>
+    saveURLs(
+      urls.map((url) => (url.index === instance.index ? instance : url))
+    );
+  const handleDelete = (id: number) =>
+    saveURLs(urls.filter((url) => url.index !== id));
+  const handleAdd = () => {
+    saveURLs([...urls, { index }]);
+    setIndex(index + 1);
+  };
+
+  return (
+    <Form.Group>
+      {urls.map((instance) => (
+        <Instance
+          instance={instance}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          onScrape={onScrapeClick}
+          urlScrapable={urlScrapable}
+          key={instance.index}
+        />
+      ))}
+      <Button
+        className="minimal"
+        title={intl.formatMessage({ id: "actions.add" })}
+        onClick={handleAdd}
+      >
+        <Icon icon="plus" />
+      </Button>
+    </Form.Group>
+  );
+};


### PR DESCRIPTION
Basic support for additional performer urls, partial solution to https://github.com/stashapp/stash/issues/1868. Adds a performers_urls table (performer_id, url). It doesn't replace the performer url field and I haven't made an attempt to integrate the additional urls with any other features like scraping or filtering. For now it's just a simple way to store additional performer urls.

Edit tab
![image](https://user-images.githubusercontent.com/38586902/140449724-c4f80cf1-391e-48f0-8068-1bc7bc434dd3.png)

Details tab
![image](https://user-images.githubusercontent.com/38586902/140441778-24d08e17-2ac5-460d-a925-91e7025624dd.png)