### PR TITLE
Fix performer tagger field updating

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -600,6 +600,10 @@ func performerFragmentToScrapedScenePerformer(p graphql.PerformerFragment) *mode
 		sp.EyeColor = enumToStringPtr(p.EyeColor, true)
 	}
 
+	if p.HairColor != nil {
+		sp.HairColor = enumToStringPtr(p.HairColor, true)
+	}
+
 	if p.BreastType != nil {
 		sp.FakeTits = enumToStringPtr(p.BreastType, true)
 	}

--- a/ui/v2.5/src/components/Tagger/PerformerFieldSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerFieldSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button } from "react-bootstrap";
+import { Button, Row, Col } from "react-bootstrap";
 import { useIntl } from "react-intl";
 
 import { Modal, Icon } from "src/components/Shared";
@@ -30,7 +30,7 @@ const PerformerFieldSelect: React.FC<IProps> = ({
     });
 
   const renderField = (name: string) => (
-    <div className="mb-1" key={name}>
+    <Col xs={6} className="mb-1" key={name}>
       <Button
         onClick={() => toggleField(name)}
         variant="secondary"
@@ -39,7 +39,7 @@ const PerformerFieldSelect: React.FC<IProps> = ({
         <Icon icon={excluded[name] ? "times" : "check"} />
       </Button>
       <span className="ml-3">{TextUtils.capitalize(name)}</span>
-    </div>
+    </Col>
   );
 
   return (
@@ -57,7 +57,7 @@ const PerformerFieldSelect: React.FC<IProps> = ({
       <div className="mb-2">
         These fields will be tagged by default. Click the button to toggle.
       </div>
-      {fields.map((f) => renderField(f))}
+      <Row>{fields.map((f) => renderField(f))}</Row>
     </Modal>
   );
 };

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -129,19 +129,9 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       career_length: performer.career_length,
       tattoos: performer.tattoos,
       piercings: performer.piercings,
-      url: performer.url,
-      twitter: performer.twitter,
-      instagram: performer.instagram,
       image: images.length > imageIndex ? images[imageIndex] : undefined,
-      details: performer.details,
-      death_date: performer.death_date,
       hair_color: performer.hair_color,
-      weight: Number.parseFloat(performer.weight ?? "") ?? undefined,
     };
-
-    if (Number.isNaN(performerData.weight ?? 0)) {
-      performerData.weight = undefined;
-    }
 
     if (performer.tags) {
       performerData.tag_ids = performer.tags

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -115,7 +115,9 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       throw new Error("performer name must set");
     }
 
-    const performerData: GQL.PerformerCreateInput = {
+    const performerData: GQL.PerformerCreateInput & {
+      [index: string]: unknown;
+    } = {
       name: performer.name ?? "",
       aliases: performer.aliases,
       gender: stringToGender(performer.gender ?? undefined, true),
@@ -129,9 +131,19 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       career_length: performer.career_length,
       tattoos: performer.tattoos,
       piercings: performer.piercings,
+      url: performer.url,
+      twitter: performer.twitter,
+      instagram: performer.instagram,
       image: images.length > imageIndex ? images[imageIndex] : undefined,
+      details: performer.details,
+      death_date: performer.death_date,
       hair_color: performer.hair_color,
+      weight: Number.parseFloat(performer.weight ?? "") ?? undefined,
     };
+
+    if (Number.isNaN(performerData.weight ?? 0)) {
+      performerData.weight = undefined;
+    }
 
     if (performer.tags) {
       performerData.tag_ids = performer.tags
@@ -152,8 +164,8 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
 
     // handle exclusions
     Object.keys(performerData).forEach((k) => {
-      if (excluded[k]) {
-        (performerData as Record<string, unknown>)[k] = undefined;
+      if (excluded[k] || !performerData[k]) {
+        performerData[k] = undefined;
       }
     });
 

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -60,6 +60,7 @@ export const PERFORMER_FIELDS = [
   "ethnicity",
   "country",
   "eye_color",
+  "hair_color",
   "height",
   "measurements",
   "fake_tits",

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -67,4 +67,10 @@ export const PERFORMER_FIELDS = [
   "career_length",
   "tattoos",
   "piercings",
+  "url",
+  "twitter",
+  "instagram",
+  "details",
+  "death_date",
+  "weight",
 ];


### PR DESCRIPTION
Removed `url/twitter/instagram/details/death_date/weight` fields from the performer tagger since the fields are not populated by stash-box, and not present in the field selector which would allow users to unselect them.

I've also added `hair color` which for some reason was missing. 