### PR TITLE
Fix identify defaults always returning nil

### DIFF
--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -936,10 +936,11 @@ func (i *Instance) GetDeleteGeneratedDefault() bool {
 func (i *Instance) GetDefaultIdentifySettings() *models.IdentifyMetadataTaskOptions {
 	i.RLock()
 	defer i.RUnlock()
+	v := i.viper(DefaultIdentifySettings)
 
-	if viper.IsSet(DefaultIdentifySettings) {
+	if v.IsSet(DefaultIdentifySettings) {
 		var ret models.IdentifyMetadataTaskOptions
-		if err := viper.UnmarshalKey(DefaultIdentifySettings, &ret); err != nil {
+		if err := v.UnmarshalKey(DefaultIdentifySettings, &ret); err != nil {
 			return nil
 		}
 		return &ret


### PR DESCRIPTION
Fixes a bug introduced in 49b2860.

Steps to reproduce:
1. Navigate to `/settings?tab=tasks`
2. Click `Identify` and change any default value, click "Set as default".
3. Reload the page

Expected:
When clicking identify again, the values will be the same ones when "Set as default" was clicked.

Actual:
Identify has reverted to its stock value of autotagger only.

Cause:
`ConfigDefaultSettingsResult` from graphql always returns null. This is because `GetDefaultIdentifySettings()` searches a viper instance that has a nil config.

Tested on:
Windows 10
Go v.1.17.1
Fresh config