### PR TITLE
Apply python path resolution to plugins

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -12,6 +12,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-pi; \
 FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools && pip install --no-cache-dir mechanicalsoup cloudscraper
+RUN ln -s /usr/bin/python3 /usr/bin/python
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 EXPOSE 9999

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/plugin/common"
+	"github.com/stashapp/stash/pkg/scraper"
 )
 
 type rawTaskBuilder struct{}
@@ -37,6 +38,13 @@ func (t *rawPluginTask) Start() error {
 	command := t.plugin.getExecCommand(t.operation)
 	if len(command) == 0 {
 		return fmt.Errorf("empty exec value in operation %s", t.operation.Name)
+	}
+
+	if command[0] == "python" || command[0] == "python3" {
+		executable, err := scraper.FindPythonExecutable()
+		if err == nil {
+			command[0] = executable
+		}
 	}
 
 	cmd := exec.Command(command[0], command[1:]...)

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/plugin/common"
-	"github.com/stashapp/stash/pkg/scraper"
 )
 
 type rawTaskBuilder struct{}
@@ -30,6 +29,19 @@ type rawPluginTask struct {
 	done      chan bool
 }
 
+func FindPythonExecutable() (string, error) {
+	_, err := exec.LookPath("python3")
+
+	if err != nil {
+		_, err = exec.LookPath("python")
+		if err != nil {
+			return "", err
+		}
+		return "python", nil
+	}
+	return "python3", nil
+}
+
 func (t *rawPluginTask) Start() error {
 	if t.started {
 		return errors.New("task already started")
@@ -41,7 +53,7 @@ func (t *rawPluginTask) Start() error {
 	}
 
 	if command[0] == "python" || command[0] == "python3" {
-		executable, err := scraper.FindPythonExecutable()
+		executable, err := FindPythonExecutable()
 		if err == nil {
 			command[0] = executable
 		}

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -31,7 +31,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 	command := s.scraper.Script
 
 	if command[0] == "python" || command[0] == "python3" {
-		executable, err := FindPythonExecutable()
+		executable, err := findPythonExecutable()
 		if err == nil {
 			command[0] = executable
 		}
@@ -235,7 +235,7 @@ func (s *scriptScraper) scrapeMovieByURL(url string) (*models.ScrapedMovie, erro
 	return &ret, err
 }
 
-func FindPythonExecutable() (string, error) {
+func findPythonExecutable() (string, error) {
 	_, err := exec.LookPath("python3")
 
 	if err != nil {

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -31,7 +31,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 	command := s.scraper.Script
 
 	if command[0] == "python" || command[0] == "python3" {
-		executable, err := findPythonExecutable()
+		executable, err := FindPythonExecutable()
 		if err == nil {
 			command[0] = executable
 		}
@@ -235,7 +235,7 @@ func (s *scriptScraper) scrapeMovieByURL(url string) (*models.ScrapedMovie, erro
 	return &ret, err
 }
 
-func findPythonExecutable() (string, error) {
+func FindPythonExecutable() (string, error) {
 	_, err := exec.LookPath("python3")
 
 	if err != nil {


### PR DESCRIPTION
Resolves #1989. 

Plugins didn't use the python command resolution, only scrapers. I've fixed that.

To be doubly sure I've also symlinked python->python3 in the docker images.