### PR TITLE
Fix config path regression

### DIFF
--- a/pkg/manager/config/init.go
+++ b/pkg/manager/config/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -72,8 +73,8 @@ func initConfig(instance *Instance, flags flagStruct) error {
 	// The config file is called config.  Leave off the file extension.
 	v.SetConfigName("config")
 
-	v.AddConfigPath(".")            // Look for config in the working directory
-	v.AddConfigPath("$HOME/.stash") // Look for the config in the home directory
+	v.AddConfigPath(".")                                // Look for config in the working directory
+	v.AddConfigPath(filepath.FromSlash("$HOME/.stash")) // Look for the config in the home directory
 
 	configFile := ""
 	envConfigFile := os.Getenv("STASH_CONFIG_FILE")


### PR DESCRIPTION
Due to `viper` module update https://github.com/spf13/viper/commit/ce534045f9aced17db5c844ccbb7c9348e716827
Was causing the config path to not be expanded, making stash think this is a new setup.