### PR TITLE
Experiment/Draft: Refactor i18n localization to use countables

### DIFF
--- a/ui/v2.5/src/components/Galleries/DeleteGalleriesDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/DeleteGalleriesDialog.tsx
@@ -16,8 +16,14 @@ export const DeleteGalleriesDialog: React.FC<IDeleteGalleryDialogProps> = (
   props: IDeleteGalleryDialogProps
 ) => {
   const intl = useIntl();
-  const singularEntity = intl.formatMessage({ id: "gallery" });
-  const pluralEntity = intl.formatMessage({ id: "galleries" });
+  const singularEntity = intl.formatMessage(
+    { id: "countables.galleries" },
+    { count: 1 }
+  );
+  const pluralEntity = intl.formatMessage(
+    { id: "countables.galleries" },
+    { count: props.selected.length }
+  );
 
   const header = intl.formatMessage(
     { id: "dialogs.delete_entity_title" },
@@ -83,8 +89,15 @@ export const DeleteGalleriesDialog: React.FC<IDeleteGalleryDialogProps> = (
           <FormattedMessage
             values={{
               count: fsGalleries.length,
-              singularEntity: intl.formatMessage({ id: "file" }),
-              pluralEntity: intl.formatMessage({ id: "files" }),
+              singularEntity: intl
+                .formatMessage({ id: "countables.files" }, { count: 1 })
+                .toLocaleLowerCase(),
+              pluralEntity: intl
+                .formatMessage(
+                  { id: "countables.files" },
+                  { count: fsGalleries.length }
+                )
+                .toLocaleLowerCase(),
             }}
             id="dialogs.delete_alert"
           />
@@ -97,8 +110,15 @@ export const DeleteGalleriesDialog: React.FC<IDeleteGalleryDialogProps> = (
             <FormattedMessage
               values={{
                 count: fsGalleries.length - 5,
-                singularEntity: intl.formatMessage({ id: "file" }),
-                pluralEntity: intl.formatMessage({ id: "files" }),
+                singularEntity: intl
+                  .formatMessage({ id: "countables.files" }, { count: 1 })
+                  .toLocaleLowerCase(),
+                pluralEntity: intl
+                  .formatMessage(
+                    { id: "countables.files" },
+                    { count: fsGalleries.length - 5 }
+                  )
+                  .toLocaleLowerCase(),
               }}
               id="dialogs.delete_object_overflow"
             />

--- a/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/EditGalleriesDialog.tsx
@@ -146,7 +146,9 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
         content: intl.formatMessage(
           { id: "toast.updated_entity" },
           {
-            entity: intl.formatMessage({ id: "galleries" }).toLocaleLowerCase(),
+            entity: intl
+              .formatMessage({ id: "countables.galleries" }, { count: 100 })
+              .toLocaleLowerCase(),
           }
         ),
       });
@@ -360,8 +362,14 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
           { id: "dialogs.edit_entity_title" },
           {
             count: props?.selected?.length ?? 1,
-            singularEntity: intl.formatMessage({ id: "gallery" }),
-            pluralEntity: intl.formatMessage({ id: "galleries" }),
+            singularEntity: intl.formatMessage(
+              { id: "countables.galleries" },
+              { count: 1 }
+            ),
+            pluralEntity: intl.formatMessage(
+              { id: "countables.galleries" },
+              { count: props?.selected?.length ?? 1 }
+            ),
           }
         )}
         accept={{
@@ -391,7 +399,10 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="studio" as={Row}>
             {FormUtils.renderLabel({
-              title: intl.formatMessage({ id: "studio" }),
+              title: intl.formatMessage(
+                { id: "countables.studios" },
+                { count: 1 }
+              ),
             })}
             <Col xs={9}>
               <StudioSelect
@@ -406,14 +417,17 @@ export const EditGalleriesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="performers">
             <Form.Label>
-              <FormattedMessage id="performers" />
+              <FormattedMessage
+                id="countables.performers"
+                values={{ count: 100 }}
+              />
             </Form.Label>
             {renderMultiSelect("performers", performerIds)}
           </Form.Group>
 
           <Form.Group controlId="tags">
             <Form.Label>
-              <FormattedMessage id="tags" />
+              <FormattedMessage id="countables.tags" values={{ count: 100 }} />
             </Form.Label>
             {renderMultiSelect("tags", tagIds)}
           </Form.Group>

--- a/ui/v2.5/src/components/Galleries/Galleries.tsx
+++ b/ui/v2.5/src/components/Galleries/Galleries.tsx
@@ -11,9 +11,12 @@ import { GalleryList } from "./GalleryList";
 const Galleries = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "galleries",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.galleries",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -81,7 +81,10 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
         { id: "toast.rescanning_entity" },
         {
           count: 1,
-          singularEntity: intl.formatMessage({ id: "gallery" }),
+          singularEntity: intl.formatMessage(
+            { id: "countables.galleries" },
+            { count: 1 }
+          ),
         }
       ),
     });
@@ -135,7 +138,12 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
           >
             <FormattedMessage
               id="actions.delete_entity"
-              values={{ entityType: intl.formatMessage({ id: "gallery" }) }}
+              values={{
+                entityType: intl.formatMessage(
+                  { id: "countables.galleries" },
+                  { count: 1 }
+                ),
+              }}
             />
           </Dropdown.Item>
         </Dropdown.Menu>
@@ -157,13 +165,19 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
           <Nav variant="tabs" className="mr-auto">
             <Nav.Item>
               <Nav.Link eventKey="gallery-details-panel">
-                <FormattedMessage id="details" />
+                <FormattedMessage
+                  id="countables.details"
+                  values={{ count: 100 }}
+                />
               </Nav.Link>
             </Nav.Item>
             {gallery.scenes.length > 0 && (
               <Nav.Item>
                 <Nav.Link eventKey="gallery-scenes-panel">
-                  <FormattedMessage id="scenes" />
+                  <FormattedMessage
+                    id="countables.scenes"
+                    values={{ count: 100 }}
+                  />
                 </Nav.Link>
               </Nav.Item>
             )}
@@ -233,7 +247,10 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
           <Nav variant="tabs" className="mr-auto">
             <Nav.Item>
               <Nav.Link eventKey="images">
-                <FormattedMessage id="images" />
+                <FormattedMessage
+                  id="countables.images"
+                  values={{ count: 100 }}
+                />
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryAddPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryAddPanel.tsx
@@ -69,8 +69,14 @@ export const GalleryAddPanel: React.FC<IGalleryAddProps> = ({ gallery }) => {
           { id: "toast.added_entity" },
           {
             count: imageCount,
-            singularEntity: intl.formatMessage({ id: "image" }),
-            pluralEntity: intl.formatMessage({ id: "images" }),
+            singularEntity: intl.formatMessage(
+              { id: "countables.images" },
+              { count: 1 }
+            ),
+            pluralEntity: intl.formatMessage(
+              { id: "countables.images" },
+              { count: imageCount }
+            ),
           }
         ),
       });
@@ -83,7 +89,12 @@ export const GalleryAddPanel: React.FC<IGalleryAddProps> = ({ gallery }) => {
     {
       text: intl.formatMessage(
         { id: "actions.add_to_entity" },
-        { entityType: intl.formatMessage({ id: "gallery" }) }
+        {
+          entityType: intl.formatMessage(
+            { id: "countables.galleries" },
+            { count: 1 }
+          ),
+        }
       ),
       onClick: addImages,
       isDisplayed: showWhenSelected,

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
@@ -11,7 +11,12 @@ const GalleryCreate: React.FC = () => {
         <h2>
           <FormattedMessage
             id="actions.create_entity"
-            values={{ entityType: intl.formatMessage({ id: "gallery" }) }}
+            values={{
+              entityType: intl.formatMessage(
+                { id: "countables.galleries" },
+                { count: 1 }
+              ),
+            }}
           />
         </h2>
         <GalleryEditPanel

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -214,7 +214,7 @@ export const GalleryEditPanel: React.FC<
               { id: "toast.updated_entity" },
               {
                 entity: intl
-                  .formatMessage({ id: "gallery" })
+                  .formatMessage({ id: "countables.galleries" }, { count: 1 })
                   .toLocaleLowerCase(),
               }
             ),
@@ -478,7 +478,10 @@ export const GalleryEditPanel: React.FC<
 
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "studio" }),
+                title: intl.formatMessage(
+                  { id: "countables.studios" },
+                  { count: 1 }
+                ),
               })}
               <Col xs={9}>
                 <StudioSelect
@@ -495,7 +498,10 @@ export const GalleryEditPanel: React.FC<
 
             <Form.Group controlId="performers" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "performers" }),
+                title: intl.formatMessage(
+                  { id: "countables.performers" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -518,7 +524,10 @@ export const GalleryEditPanel: React.FC<
 
             <Form.Group controlId="tags" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "tags" }),
+                title: intl.formatMessage(
+                  { id: "countables.tags" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -541,7 +550,10 @@ export const GalleryEditPanel: React.FC<
 
             <Form.Group controlId="scenes" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "scenes" }),
+                title: intl.formatMessage(
+                  { id: "countables.scenes" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -559,7 +571,10 @@ export const GalleryEditPanel: React.FC<
           <div className="col-12 col-lg-6 col-xl-12">
             <Form.Group controlId="details">
               <Form.Label>
-                <FormattedMessage id="details" />
+                <FormattedMessage
+                  id="countables.details"
+                  values={{ count: 100 }}
+                />
               </Form.Label>
               <Form.Control
                 as="textarea"

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
@@ -68,7 +68,12 @@ export const GalleryImagesPanel: React.FC<IGalleryDetailsProps> = ({
       Toast.success({
         content: intl.formatMessage(
           { id: "toast.added_entity" },
-          { entity: intl.formatMessage({ id: "images" }) }
+          {
+            entity: intl.formatMessage(
+              { id: "countables.images" },
+              { count: 100 }
+            ),
+          }
         ),
       });
     } catch (e) {

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
@@ -305,7 +305,10 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
             <FormattedMessage
               id="actions.created_entity"
               values={{
-                entity_type: intl.formatMessage({ id: "studio" }),
+                entity_type: intl.formatMessage(
+                  { id: "countables.studios" },
+                  { count: 1 }
+                ),
                 entity_name: <b>{toCreate.name}</b>,
               }}
             />
@@ -346,7 +349,10 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
             <FormattedMessage
               id="actions.created_entity"
               values={{
-                entity_type: intl.formatMessage({ id: "performer" }),
+                entity_type: intl.formatMessage(
+                  { id: "countables.performers" },
+                  { count: 1 }
+                ),
                 entity_name: <b>{toCreate.name}</b>,
               }}
             />
@@ -388,7 +394,10 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
             <FormattedMessage
               id="actions.created_entity"
               values={{
-                entity_type: intl.formatMessage({ id: "tag" }),
+                entity_type: intl.formatMessage(
+                  { id: "countables.tags" },
+                  { count: 1 }
+                ),
                 entity_name: <b>{toCreate.name}</b>,
               }}
             />
@@ -449,28 +458,31 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
           onChange={(value) => setDate(value)}
         />
         {renderScrapedStudioRow(
-          intl.formatMessage({ id: "studios" }),
+          intl.formatMessage({ id: "countables.studios" }, { count: 100 }),
           studio,
           (value) => setStudio(value),
           newStudio,
           createNewStudio
         )}
         {renderScrapedPerformersRow(
-          intl.formatMessage({ id: "performers" }),
+          intl.formatMessage({ id: "countables.performers" }, { count: 100 }),
           performers,
           (value) => setPerformers(value),
           newPerformers,
           createNewPerformer
         )}
         {renderScrapedTagsRow(
-          intl.formatMessage({ id: "tags" }),
+          intl.formatMessage({ id: "countables.tags" }, { count: 100 }),
           tags,
           (value) => setTags(value),
           newTags,
           createNewTag
         )}
         <ScrapedTextAreaRow
-          title={intl.formatMessage({ id: "details" })}
+          title={intl.formatMessage(
+            { id: "countables.details" },
+            { count: 100 }
+          )}
           result={details}
           onChange={(value) => setDetails(value)}
         />
@@ -482,7 +494,12 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
     <ScrapeDialog
       title={intl.formatMessage(
         { id: "dialogs.scrape_entity_title" },
-        { entity_type: intl.formatMessage({ id: "gallery" }) }
+        {
+          entity_type: intl.formatMessage(
+            { id: "countables.galleries" },
+            { count: 1 }
+          ),
+        }
       )}
       renderScrapeRows={renderScrapeRows}
       onClose={(apply) => {

--- a/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
@@ -16,8 +16,14 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
   props: IDeleteImageDialogProps
 ) => {
   const intl = useIntl();
-  const singularEntity = intl.formatMessage({ id: "image" });
-  const pluralEntity = intl.formatMessage({ id: "images" });
+  const singularEntity = intl.formatMessage(
+    { id: "countables.images" },
+    { count: 1 }
+  );
+  const pluralEntity = intl.formatMessage(
+    { id: "countables.images" },
+    { count: props.selected.length }
+  );
 
   const header = intl.formatMessage(
     { id: "dialogs.delete_entity_title" },
@@ -78,8 +84,15 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
           <FormattedMessage
             values={{
               count: props.selected.length,
-              singularEntity: intl.formatMessage({ id: "file" }),
-              pluralEntity: intl.formatMessage({ id: "files" }),
+              singularEntity: intl
+                .formatMessage({ id: "countables.files" }, { count: 1 })
+                .toLocaleLowerCase(),
+              pluralEntity: intl
+                .formatMessage(
+                  { id: "countables.files" },
+                  { count: props.selected.length }
+                )
+                .toLocaleLowerCase(),
             }}
             id="dialogs.delete_alert"
           />
@@ -92,8 +105,15 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
             <FormattedMessage
               values={{
                 count: props.selected.length - 5,
-                singularEntity: intl.formatMessage({ id: "file" }),
-                pluralEntity: intl.formatMessage({ id: "files" }),
+                singularEntity: intl
+                  .formatMessage({ id: "countables.files" }, { count: 1 })
+                  .toLocaleLowerCase(),
+                pluralEntity: intl
+                  .formatMessage(
+                    { id: "countables.files" },
+                    { count: props.selected.length - 5 }
+                  )
+                  .toLocaleLowerCase(),
               }}
               id="dialogs.delete_object_overflow"
             />

--- a/ui/v2.5/src/components/Images/EditImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/EditImagesDialog.tsx
@@ -145,7 +145,11 @@ export const EditImagesDialog: React.FC<IListOperationProps> = (
       Toast.success({
         content: intl.formatMessage(
           { id: "toast.updated_entity" },
-          { entity: intl.formatMessage({ id: "images" }).toLocaleLowerCase() }
+          {
+            entity: intl
+              .formatMessage({ id: "countables.images" }, { count: 100 })
+              .toLocaleLowerCase(),
+          }
         ),
       });
       props.onClose(true);
@@ -355,8 +359,14 @@ export const EditImagesDialog: React.FC<IListOperationProps> = (
           { id: "dialogs.edit_entity_title" },
           {
             count: props?.selected?.length ?? 1,
-            singularEntity: intl.formatMessage({ id: "image" }),
-            pluralEntity: intl.formatMessage({ id: "images" }),
+            singularEntity: intl.formatMessage(
+              { id: "countables.images" },
+              { count: 1 }
+            ),
+            pluralEntity: intl.formatMessage(
+              { id: "countables.images" },
+              { count: props?.selected?.length ?? 1 }
+            ),
           }
         )}
         accept={{
@@ -386,7 +396,10 @@ export const EditImagesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="studio" as={Row}>
             {FormUtils.renderLabel({
-              title: intl.formatMessage({ id: "studio" }),
+              title: intl.formatMessage(
+                { id: "countables.studios" },
+                { count: 1 }
+              ),
             })}
             <Col xs={9}>
               <StudioSelect
@@ -401,14 +414,17 @@ export const EditImagesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="performers">
             <Form.Label>
-              <FormattedMessage id="performers" />
+              <FormattedMessage
+                id="countables.performers"
+                values={{ count: 100 }}
+              />
             </Form.Label>
             {renderMultiSelect("performers", performerIds)}
           </Form.Group>
 
           <Form.Group controlId="tags">
             <Form.Label>
-              <FormattedMessage id="tags" />
+              <FormattedMessage id="countables.tags" values={{ count: 100 }} />
             </Form.Label>
             {renderMultiSelect("tags", tagIds)}
           </Form.Group>

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -61,7 +61,10 @@ export const Image: React.FC = () => {
         { id: "toast.rescanning_entity" },
         {
           count: 1,
-          singularEntity: intl.formatMessage({ id: "image" }),
+          singularEntity: intl.formatMessage(
+            { id: "countables.images" },
+            { count: 1 }
+          ),
         }
       ),
     });
@@ -159,7 +162,12 @@ export const Image: React.FC = () => {
           >
             <FormattedMessage
               id="actions.delete_entity"
-              values={{ entityType: intl.formatMessage({ id: "image" }) }}
+              values={{
+                entityType: intl.formatMessage(
+                  { id: "countables.images" },
+                  { count: 1 }
+                ),
+              }}
             />
           </Dropdown.Item>
         </Dropdown.Menu>
@@ -181,7 +189,10 @@ export const Image: React.FC = () => {
           <Nav variant="tabs" className="mr-auto">
             <Nav.Item>
               <Nav.Link eventKey="image-details-panel">
-                <FormattedMessage id="details" />
+                <FormattedMessage
+                  id="countables.details"
+                  values={{ count: 100 }}
+                />
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -125,7 +125,11 @@ export const ImageEditPanel: React.FC<IProps> = ({
         Toast.success({
           content: intl.formatMessage(
             { id: "toast.updated_entity" },
-            { entity: intl.formatMessage({ id: "image" }).toLocaleLowerCase() }
+            {
+              entity: intl
+                .formatMessage({ id: "countables.images" }, { count: 1 })
+                .toLocaleLowerCase(),
+            }
           ),
         });
         formik.resetForm({ values: formik.values });
@@ -205,7 +209,10 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "studio" }),
+                title: intl.formatMessage(
+                  { id: "countables.studios" },
+                  { count: 100 }
+                ),
               })}
               <Col xs={9}>
                 <StudioSelect
@@ -222,7 +229,10 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="performers" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "performers" }),
+                title: intl.formatMessage(
+                  { id: "countables.performers" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -245,7 +255,10 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="tags" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "tags" }),
+                title: intl.formatMessage(
+                  { id: "countables.tags" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,

--- a/ui/v2.5/src/components/Images/Images.tsx
+++ b/ui/v2.5/src/components/Images/Images.tsx
@@ -10,9 +10,12 @@ import { ImageList } from "./ImageList";
 const Images: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "images",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.images",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -27,7 +27,8 @@ export const MovieCard: FunctionComponent<IProps> = (props: IProps) => {
       <>
         <hr />
         <span className="movie-scene-number">
-          <FormattedMessage id="scene" /> #{props.sceneIndex}
+          <FormattedMessage id="countables.scenes" values={{ count: 1 }} /> #
+          {props.sceneIndex}
         </span>
       </>
     );

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -124,7 +124,9 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
             values={{
               entityName:
                 movie.name ??
-                intl.formatMessage({ id: "movie" }).toLocaleLowerCase(),
+                intl
+                  .formatMessage({ id: "countables.movies" }, { count: 1 })
+                  .toLocaleLowerCase(),
             }}
           />
         </p>

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -357,7 +357,12 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
         <h2>
           {intl.formatMessage(
             { id: "actions.add_entity" },
-            { entityType: intl.formatMessage({ id: "movie" }) }
+            {
+              entityType: intl.formatMessage(
+                { id: "countables.movies" },
+                { count: 1 }
+              ),
+            }
           )}
         </h2>
       )}
@@ -410,7 +415,10 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
 
         <Form.Group controlId="studio" as={Row}>
           {FormUtils.renderLabel({
-            title: intl.formatMessage({ id: "studio" }),
+            title: intl.formatMessage(
+              { id: "countables.studios" },
+              { count: 1 }
+            ),
           })}
           <Col xs={9}>
             <StudioSelect

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
@@ -256,7 +256,12 @@ export const MovieScrapeDialog: React.FC<IMovieScrapeDialogProps> = (
     <ScrapeDialog
       title={intl.formatMessage(
         { id: "dialogs.scrape_entity_title" },
-        { entity_type: intl.formatMessage({ id: "movie" }) }
+        {
+          entity_type: intl.formatMessage(
+            { id: "countables.movies" },
+            { count: 1 }
+          ),
+        }
       )}
       renderScrapeRows={renderScrapeRows}
       onClose={(apply) => {

--- a/ui/v2.5/src/components/Movies/MovieList.tsx
+++ b/ui/v2.5/src/components/Movies/MovieList.tsx
@@ -64,8 +64,14 @@ export const MovieList: React.FC<IMovieList> = ({ filterHook }) => {
     <DeleteEntityDialog
       selected={selectedMovies}
       onClose={onClose}
-      singularEntity={intl.formatMessage({ id: "movie" })}
-      pluralEntity={intl.formatMessage({ id: "movies" })}
+      singularEntity={intl.formatMessage(
+        { id: "countables.movies" },
+        { count: 1 }
+      )}
+      pluralEntity={intl.formatMessage(
+        { id: "countables.movies" },
+        { count: 100 }
+      )}
       destroyMutation={useMoviesDestroy}
     />
   );

--- a/ui/v2.5/src/components/Movies/Movies.tsx
+++ b/ui/v2.5/src/components/Movies/Movies.tsx
@@ -10,9 +10,12 @@ import { MovieList } from "./MovieList";
 const Movies: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "movies",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.movies",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -100,7 +100,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           { id: "toast.updated_entity" },
           {
             entity: intl
-              .formatMessage({ id: "performers" })
+              .formatMessage({ id: "countables.performers" }, { count: 100 })
               .toLocaleLowerCase(),
           }
         ),
@@ -232,7 +232,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
         <Form>
           <Form.Group controlId="tags">
             <Form.Label>
-              <FormattedMessage id="tags" />
+              <FormattedMessage id="countables.tags" values={{ count: 100 }} />
             </Form.Label>
             <MultiSet
               type="tags"

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -144,19 +144,37 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       id="performer-details"
       unmountOnExit
     >
-      <Tab eventKey="details" title={intl.formatMessage({ id: "details" })}>
+      <Tab
+        eventKey="details"
+        title={intl.formatMessage({ id: "countables.details" }, { count: 100 })}
+      >
         <PerformerDetailsPanel performer={performer} />
       </Tab>
-      <Tab eventKey="scenes" title={intl.formatMessage({ id: "scenes" })}>
+      <Tab
+        eventKey="scenes"
+        title={intl.formatMessage({ id: "countables.scenes" }, { count: 100 })}
+      >
         <PerformerScenesPanel performer={performer} />
       </Tab>
-      <Tab eventKey="galleries" title={intl.formatMessage({ id: "galleries" })}>
+      <Tab
+        eventKey="galleries"
+        title={intl.formatMessage(
+          { id: "countables.galleries" },
+          { count: 100 }
+        )}
+      >
         <PerformerGalleriesPanel performer={performer} />
       </Tab>
-      <Tab eventKey="images" title={intl.formatMessage({ id: "images" })}>
+      <Tab
+        eventKey="images"
+        title={intl.formatMessage({ id: "countables.images" }, { count: 100 })}
+      >
         <PerformerImagesPanel performer={performer} />
       </Tab>
-      <Tab eventKey="movies" title={intl.formatMessage({ id: "movies" })}>
+      <Tab
+        eventKey="movies"
+        title={intl.formatMessage({ id: "countables.movies" }, { count: 100 })}
+      >
         <PerformerMoviesPanel performer={performer} />
       </Tab>
       <Tab eventKey="edit" title={intl.formatMessage({ id: "actions.edit" })}>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -24,7 +24,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
     return (
       <>
         <dt>
-          <FormattedMessage id="tags" />
+          <FormattedMessage id="countables.tags" values={{ count: 100 }} />
         </dt>
         <dd>
           <ul className="pl-0">

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -742,7 +742,11 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     return (
       <Form.Group controlId="tags" as={Row}>
         <Form.Label column sm={labelXS} xl={labelXL}>
-          <FormattedMessage id="tags" defaultMessage="Tags" />
+          <FormattedMessage
+            id="countables.tags"
+            values={{ count: 100 }}
+            defaultMessage="Tags"
+          />
         </Form.Label>
         <Col xs={fieldXS} xl={fieldXL}>
           <TagSelect
@@ -955,7 +959,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         {renderTextField("instagram", "Instagram")}
         <Form.Group controlId="details" as={Row}>
           <Form.Label column sm={labelXS} xl={labelXL}>
-            <FormattedMessage id="details" />
+            <FormattedMessage id="countables.details" values={{ count: 100 }} />
           </Form.Label>
           <Col sm={fieldXS} xl={fieldXL}>
             <Form.Control

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -514,12 +514,15 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
           onChange={(value) => setInstagram(value)}
         />
         <ScrapedTextAreaRow
-          title={intl.formatMessage({ id: "details" })}
+          title={intl.formatMessage(
+            { id: "countables.details" },
+            { count: 100 }
+          )}
           result={details}
           onChange={(value) => setDetails(value)}
         />
         {renderScrapedTagsRow(
-          intl.formatMessage({ id: "tags" }),
+          intl.formatMessage({ id: "countables.tags" }, { count: 100 }),
           tags,
           (value) => setTags(value),
           newTags,
@@ -545,7 +548,12 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
     <ScrapeDialog
       title={intl.formatMessage(
         { id: "dialogs.scrape_entity_title" },
-        { entity_type: intl.formatMessage({ id: "performer" }) }
+        {
+          entity_type: intl.formatMessage(
+            { id: "countables.performers" },
+            { count: 1 }
+          ),
+        }
       )}
       renderScrapeRows={renderScrapeRows}
       onClose={(apply) => {

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -114,8 +114,14 @@ export const PerformerList: React.FC<IPerformerList> = ({
     <DeleteEntityDialog
       selected={selectedPerformers}
       onClose={onClose}
-      singularEntity={intl.formatMessage({ id: "performer" })}
-      pluralEntity={intl.formatMessage({ id: "performers" })}
+      singularEntity={intl.formatMessage(
+        { id: "countables.performers" },
+        { count: 1 }
+      )}
+      pluralEntity={intl.formatMessage(
+        { id: "countables.performers" },
+        { count: 100 }
+      )}
       destroyMutation={usePerformersDestroy}
     />
   );

--- a/ui/v2.5/src/components/Performers/Performers.tsx
+++ b/ui/v2.5/src/components/Performers/Performers.tsx
@@ -11,9 +11,12 @@ import { PerformerList } from "./PerformerList";
 const Performers: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "performers",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.performers",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -444,7 +444,12 @@ export const SceneDuplicateChecker: React.FC = () => {
             <tr>
               <th> </th>
               <th> </th>
-              <th>{intl.formatMessage({ id: "details" })}</th>
+              <th>
+                {intl.formatMessage(
+                  { id: "countables.details" },
+                  { count: 100 }
+                )}
+              </th>
               <th> </th>
               <th>{intl.formatMessage({ id: "duration" })}</th>
               <th>{intl.formatMessage({ id: "filesize" })}</th>

--- a/ui/v2.5/src/components/SceneFilenameParser/SceneFilenameParser.tsx
+++ b/ui/v2.5/src/components/SceneFilenameParser/SceneFilenameParser.tsx
@@ -191,7 +191,11 @@ export const SceneFilenameParser: React.FC = () => {
       Toast.success({
         content: intl.formatMessage(
           { id: "toast.updated_entity" },
-          { entity: intl.formatMessage({ id: "scenes" }).toLocaleLowerCase() }
+          {
+            entity: intl
+              .formatMessage({ id: "countables.scenes" }, { count: 100 })
+              .toLocaleLowerCase(),
+          }
         ),
       });
     } catch (e) {
@@ -363,17 +367,23 @@ export const SceneFilenameParser: React.FC = () => {
                   onSelectAllRatingSet
                 )}
                 {renderHeader(
-                  intl.formatMessage({ id: "performers" }),
+                  intl.formatMessage(
+                    { id: "countables.performers" },
+                    { count: 100 }
+                  ),
                   allPerformerSet,
                   onSelectAllPerformerSet
                 )}
                 {renderHeader(
-                  intl.formatMessage({ id: "tags" }),
+                  intl.formatMessage({ id: "countables.tags" }, { count: 100 }),
                   allTagSet,
                   onSelectAllTagSet
                 )}
                 {renderHeader(
-                  intl.formatMessage({ id: "studio" }),
+                  intl.formatMessage(
+                    { id: "countables.studios" },
+                    { count: 1 }
+                  ),
                   allStudioSet,
                   onSelectAllStudioSet
                 )}

--- a/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
@@ -16,8 +16,14 @@ export const DeleteScenesDialog: React.FC<IDeleteSceneDialogProps> = (
   props: IDeleteSceneDialogProps
 ) => {
   const intl = useIntl();
-  const singularEntity = intl.formatMessage({ id: "scene" });
-  const pluralEntity = intl.formatMessage({ id: "scenes" });
+  const singularEntity = intl.formatMessage(
+    { id: "countables.scenes" },
+    { count: 1 }
+  );
+  const pluralEntity = intl.formatMessage(
+    { id: "countables.scenes" },
+    { count: props.selected.length }
+  );
 
   const header = intl.formatMessage(
     { id: "dialogs.delete_entity_title" },
@@ -78,8 +84,15 @@ export const DeleteScenesDialog: React.FC<IDeleteSceneDialogProps> = (
           <FormattedMessage
             values={{
               count: props.selected.length,
-              singularEntity: intl.formatMessage({ id: "file" }),
-              pluralEntity: intl.formatMessage({ id: "files" }),
+              singularEntity: intl
+                .formatMessage({ id: "countables.files" }, { count: 1 })
+                .toLocaleLowerCase(),
+              pluralEntity: intl
+                .formatMessage(
+                  { id: "countables.files" },
+                  { count: props.selected.length }
+                )
+                .toLocaleLowerCase(),
             }}
             id="dialogs.delete_alert"
           />
@@ -92,8 +105,15 @@ export const DeleteScenesDialog: React.FC<IDeleteSceneDialogProps> = (
             <FormattedMessage
               values={{
                 count: props.selected.length - 5,
-                singularEntity: intl.formatMessage({ id: "file" }),
-                pluralEntity: intl.formatMessage({ id: "files" }),
+                singularEntity: intl
+                  .formatMessage({ id: "countables.files" }, { count: 1 })
+                  .toLocaleLowerCase(),
+                pluralEntity: intl
+                  .formatMessage(
+                    { id: "countables.files" },
+                    { count: props.selected.length - 5 }
+                  )
+                  .toLocaleLowerCase(),
               }}
               id="dialogs.delete_object_overflow"
             />

--- a/ui/v2.5/src/components/Scenes/EditScenesDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/EditScenesDialog.tsx
@@ -162,7 +162,11 @@ export const EditScenesDialog: React.FC<IListOperationProps> = (
       Toast.success({
         content: intl.formatMessage(
           { id: "toast.updated_entity" },
-          { entity: intl.formatMessage({ id: "scenes" }).toLocaleLowerCase() }
+          {
+            entity: intl
+              .formatMessage({ id: "countables.scenes" }, { count: 100 })
+              .toLocaleLowerCase(),
+          }
         ),
       });
       props.onClose(true);
@@ -411,8 +415,14 @@ export const EditScenesDialog: React.FC<IListOperationProps> = (
           { id: "dialogs.edit_entity_title" },
           {
             count: props?.selected?.length ?? 1,
-            singularEntity: intl.formatMessage({ id: "scene" }),
-            pluralEntity: intl.formatMessage({ id: "scenes" }),
+            singularEntity: intl.formatMessage(
+              { id: "countables.scenes" },
+              { count: 1 }
+            ),
+            pluralEntity: intl.formatMessage(
+              { id: "countables.scenes" },
+              { count: props?.selected?.length ?? 1 }
+            ),
           }
         )}
         accept={{
@@ -442,7 +452,10 @@ export const EditScenesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="studio" as={Row}>
             {FormUtils.renderLabel({
-              title: intl.formatMessage({ id: "studio" }),
+              title: intl.formatMessage(
+                { id: "countables.studios" },
+                { count: 1 }
+              ),
             })}
             <Col xs={9}>
               <StudioSelect
@@ -457,21 +470,27 @@ export const EditScenesDialog: React.FC<IListOperationProps> = (
 
           <Form.Group controlId="performers">
             <Form.Label>
-              <FormattedMessage id="performers" />
+              <FormattedMessage
+                id="countables.performers"
+                values={{ count: 100 }}
+              />
             </Form.Label>
             {renderMultiSelect("performers", performerIds)}
           </Form.Group>
 
           <Form.Group controlId="tags">
             <Form.Label>
-              <FormattedMessage id="tags" />
+              <FormattedMessage id="countables.tags" values={{ count: 100 }} />
             </Form.Label>
             {renderMultiSelect("tags", tagIds)}
           </Form.Group>
 
           <Form.Group controlId="movies">
             <Form.Label>
-              <FormattedMessage id="movies" />
+              <FormattedMessage
+                id="countables.movies"
+                values={{ count: 100 }}
+              />
             </Form.Label>
             {renderMultiSelect("movies", movieIds)}
           </Form.Group>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -201,7 +201,7 @@ const ScenePage: React.FC<IProps> = ({ scene, refetch }) => {
         {
           count: 1,
           singularEntity: intl
-            .formatMessage({ id: "scene" })
+            .formatMessage({ id: "countables.scenes" }, { count: 1 })
             .toLocaleLowerCase(),
         }
       ),
@@ -382,7 +382,12 @@ const ScenePage: React.FC<IProps> = ({ scene, refetch }) => {
         >
           <FormattedMessage
             id="actions.delete_entity"
-            values={{ entityType: intl.formatMessage({ id: "scene" }) }}
+            values={{
+              entityType: intl.formatMessage(
+                { id: "countables.scenes" },
+                { count: 1 }
+              ),
+            }}
           />
         </Dropdown.Item>
       </Dropdown.Menu>
@@ -398,7 +403,10 @@ const ScenePage: React.FC<IProps> = ({ scene, refetch }) => {
         <Nav variant="tabs" className="mr-auto">
           <Nav.Item>
             <Nav.Link eventKey="scene-details-panel">
-              <FormattedMessage id="scenes" />
+              <FormattedMessage
+                id="countables.scenes"
+                values={{ count: 100 }}
+              />
             </Nav.Link>
           </Nav.Item>
           {(queueScenes ?? []).length > 0 ? (
@@ -412,7 +420,10 @@ const ScenePage: React.FC<IProps> = ({ scene, refetch }) => {
           )}
           <Nav.Item>
             <Nav.Link eventKey="scene-markers-panel">
-              <FormattedMessage id="markers" />
+              <FormattedMessage
+                id="countables.markers"
+                values={{ count: 100 }}
+              />
             </Nav.Link>
           </Nav.Item>
           {scene.movies.length > 0 ? (

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -18,7 +18,7 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
     return (
       <>
         <h6>
-          <FormattedMessage id="details" />
+          <FormattedMessage id="countables: details" values={{ count: 100 }} />
         </h6>
         <p className="pre">{props.scene.details}</p>
       </>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -245,7 +245,11 @@ export const SceneEditPanel: React.FC<IProps> = ({
         Toast.success({
           content: intl.formatMessage(
             { id: "toast.updated_entity" },
-            { entity: intl.formatMessage({ id: "scene" }).toLocaleLowerCase() }
+            {
+              entity: intl
+                .formatMessage({ id: "countables.scenes" }, { count: 1 })
+                .toLocaleLowerCase(),
+            }
           ),
         });
         // clear the cover image so that it doesn't appear dirty
@@ -668,7 +672,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
             </Form.Group>
             <Form.Group controlId="galleries" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "galleries" }),
+                title: intl.formatMessage(
+                  { id: "countables.galleries" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -684,7 +691,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="studio" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "studios" }),
+                title: intl.formatMessage(
+                  { id: "countables.studios" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -705,7 +715,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="performers" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "performers" }),
+                title: intl.formatMessage(
+                  { id: "countables.performers" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -728,9 +741,15 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="moviesScenes" as={Row}>
               {FormUtils.renderLabel({
-                title: `${intl.formatMessage({
-                  id: "movies",
-                })}/${intl.formatMessage({ id: "scenes" })}`,
+                title: `${intl.formatMessage(
+                  {
+                    id: "countables.movies",
+                  },
+                  { count: 100 }
+                )}/${intl.formatMessage(
+                  { id: "countables.scenes" },
+                  { count: 100 }
+                )}`,
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -751,7 +770,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
             <Form.Group controlId="tags" as={Row}>
               {FormUtils.renderLabel({
-                title: intl.formatMessage({ id: "tags" }),
+                title: intl.formatMessage(
+                  { id: "countables.tags" },
+                  { count: 100 }
+                ),
                 labelProps: {
                   column: true,
                   sm: 3,
@@ -810,7 +832,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
           <div className="col-12 col-lg-5 col-xl-12">
             <Form.Group controlId="details">
               <Form.Label>
-                <FormattedMessage id="details" />
+                <FormattedMessage
+                  id="countables.details"
+                  values={{ count: 100 }}
+                />
               </Form.Label>
               <Form.Control
                 as="textarea"

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMovieTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMovieTable.tsx
@@ -74,7 +74,7 @@ export const SceneMovieTable: React.FunctionComponent<IProps> = (
       <div className="movie-table">
         <Row>
           <Form.Label column xs={9}>
-            {intl.formatMessage({ id: "movie" })}
+            {intl.formatMessage({ id: "countables.movies" }, { count: 1 })}
           </Form.Label>
           <Form.Label column xs={3}>
             {intl.formatMessage({ id: "movie_scene_number" })}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneQueryModal.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneQueryModal.tsx
@@ -192,7 +192,12 @@ export const SceneQueryModal: React.FC<IProps> = ({
       modalProps={{ size: "lg", dialogClassName: "scrape-query-dialog" }}
       header={intl.formatMessage(
         { id: "dialogs.scrape_entity_query" },
-        { entity_type: intl.formatMessage({ id: "scene" }) }
+        {
+          entity_type: intl.formatMessage(
+            { id: "countables.scenes" },
+            { count: 1 }
+          ),
+        }
       )}
       accept={{
         text: intl.formatMessage({ id: "actions.cancel" }),

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
@@ -558,35 +558,38 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = (
           onChange={(value) => setDate(value)}
         />
         {renderScrapedStudioRow(
-          intl.formatMessage({ id: "studios" }),
+          intl.formatMessage({ id: "countables.studios" }, { count: 100 }),
           studio,
           (value) => setStudio(value),
           newStudio,
           createNewStudio
         )}
         {renderScrapedPerformersRow(
-          intl.formatMessage({ id: "performers" }),
+          intl.formatMessage({ id: "countables.performers" }, { count: 100 }),
           performers,
           (value) => setPerformers(value),
           newPerformers,
           createNewPerformer
         )}
         {renderScrapedMoviesRow(
-          intl.formatMessage({ id: "movies" }),
+          intl.formatMessage({ id: "countables.movies" }, { count: 100 }),
           movies,
           (value) => setMovies(value),
           newMovies,
           createNewMovie
         )}
         {renderScrapedTagsRow(
-          intl.formatMessage({ id: "tags" }),
+          intl.formatMessage({ id: "countables.tags" }, { count: 100 }),
           tags,
           (value) => setTags(value),
           newTags,
           createNewTag
         )}
         <ScrapedTextAreaRow
-          title={intl.formatMessage({ id: "details" })}
+          title={intl.formatMessage(
+            { id: "countables.details" },
+            { count: 100 }
+          )}
           result={details}
           onChange={(value) => setDetails(value)}
         />
@@ -604,7 +607,12 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = (
     <ScrapeDialog
       title={intl.formatMessage(
         { id: "dialogs.scrape_entity_title" },
-        { entity_type: intl.formatMessage({ id: "scene" }) }
+        {
+          entity_type: intl.formatMessage(
+            { id: "countables.scenes" },
+            { count: 1 }
+          ),
+        }
       )}
       renderScrapeRows={renderScrapeRows}
       onClose={(apply) => {

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -128,19 +128,28 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
               <FormattedMessage id="duration" />
             </th>
             <th>
-              <FormattedMessage id="tags" />
+              <FormattedMessage id="countables.tags" values={{ count: 100 }} />
             </th>
             <th>
-              <FormattedMessage id="performers" />
+              <FormattedMessage
+                id="countables.performers"
+                values={{ count: 100 }}
+              />
             </th>
             <th>
-              <FormattedMessage id="studio" />
+              <FormattedMessage id="countables.studios" values={{ count: 1 }} />
             </th>
             <th>
-              <FormattedMessage id="movies" />
+              <FormattedMessage
+                id="countables.movies"
+                values={{ count: 100 }}
+              />
             </th>
             <th>
-              <FormattedMessage id="gallery" />
+              <FormattedMessage
+                id="countables.galleries"
+                values={{ count: 1 }}
+              />
             </th>
           </tr>
         </thead>

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -83,9 +83,12 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({ filterHook }) => {
       );
     }
   }
-  const title_template = `${intl.formatMessage({
-    id: "markers",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.markers",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
 
   return (
     <>

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -11,9 +11,12 @@ import { SceneMarkerList } from "./SceneMarkerList";
 const Scenes: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "scenes",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.scenes",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsConfigurationPanel.tsx
@@ -870,7 +870,9 @@ export const SettingsConfigurationPanel: React.FC = () => {
       <hr />
 
       <Form.Group>
-        <h4>{intl.formatMessage({ id: "images" })}</h4>
+        <h4>
+          {intl.formatMessage({ id: "countables.images" }, { count: 100 })}
+        </h4>
 
         <Form.Group>
           <Form.Check
@@ -892,7 +894,9 @@ export const SettingsConfigurationPanel: React.FC = () => {
       <hr />
 
       <Form.Group>
-        <h4>{intl.formatMessage({ id: "performers" })}</h4>
+        <h4>
+          {intl.formatMessage({ id: "countables.performers" }, { count: 100 })}
+        </h4>
         <Form.Group>
           <h6>
             {intl.formatMessage({

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -334,9 +334,10 @@ export const SettingsInterfacePanel: React.FC = () => {
           <Form.Check
             id="disableDropdownCreate_performer"
             checked={disableDropdownCreate.performer ?? false}
-            label={intl.formatMessage({
-              id: "performer",
-            })}
+            label={intl.formatMessage(
+              { id: "countables.performers" },
+              { count: 1 }
+            )}
             onChange={() => {
               setDisableDropdownCreate({
                 ...disableDropdownCreate,
@@ -348,9 +349,10 @@ export const SettingsInterfacePanel: React.FC = () => {
           <Form.Check
             id="disableDropdownCreate_studio"
             checked={disableDropdownCreate.studio ?? false}
-            label={intl.formatMessage({
-              id: "studio",
-            })}
+            label={intl.formatMessage(
+              { id: "countables.studios" },
+              { count: 1 }
+            )}
             onChange={() => {
               setDisableDropdownCreate({
                 ...disableDropdownCreate,
@@ -362,9 +364,7 @@ export const SettingsInterfacePanel: React.FC = () => {
           <Form.Check
             id="disableDropdownCreate_tag"
             checked={disableDropdownCreate.tag ?? false}
-            label={intl.formatMessage({
-              id: "tag",
-            })}
+            label={intl.formatMessage({ id: "countables.tags" }, { count: 1 })}
             onChange={() => {
               setDisableDropdownCreate({
                 ...disableDropdownCreate,

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -169,7 +169,12 @@ export const SettingsScrapingPanel: React.FC = () => {
         case ScrapeType.Fragment:
           return intl.formatMessage(
             { id: "config.scraping.entity_metadata" },
-            { entityType: intl.formatMessage({ id: "scene" }) }
+            {
+              entityType: intl.formatMessage(
+                { id: "countables.scenes" },
+                { count: 1 }
+              ),
+            }
           );
         default:
           return t;
@@ -191,7 +196,12 @@ export const SettingsScrapingPanel: React.FC = () => {
         case ScrapeType.Fragment:
           return intl.formatMessage(
             { id: "config.scraping.entity_metadata" },
-            { entityType: intl.formatMessage({ id: "gallery" }) }
+            {
+              entityType: intl.formatMessage(
+                { id: "countables.galleries" },
+                { count: 1 }
+              ),
+            }
           );
         default:
           return t;
@@ -213,7 +223,12 @@ export const SettingsScrapingPanel: React.FC = () => {
         case ScrapeType.Fragment:
           return intl.formatMessage(
             { id: "config.scraping.entity_metadata" },
-            { entityType: intl.formatMessage({ id: "movie" }) }
+            {
+              entityType: intl.formatMessage(
+                { id: "countables.movies" },
+                { count: 1 }
+              ),
+            }
           );
         default:
           return t;
@@ -247,7 +262,12 @@ export const SettingsScrapingPanel: React.FC = () => {
     return renderTable(
       intl.formatMessage(
         { id: "config.scraping.entity_scrapers" },
-        { entityType: intl.formatMessage({ id: "scene" }) }
+        {
+          entityType: intl.formatMessage(
+            { id: "countables.scenes" },
+            { count: 1 }
+          ),
+        }
       ),
       elements
     );
@@ -269,7 +289,12 @@ export const SettingsScrapingPanel: React.FC = () => {
     return renderTable(
       intl.formatMessage(
         { id: "config.scraping.entity_scrapers" },
-        { entityType: intl.formatMessage({ id: "gallery" }) }
+        {
+          entityType: intl.formatMessage(
+            { id: "countables.galleries" },
+            { count: 1 }
+          ),
+        }
       ),
       elements
     );
@@ -293,7 +318,12 @@ export const SettingsScrapingPanel: React.FC = () => {
     return renderTable(
       intl.formatMessage(
         { id: "config.scraping.entity_scrapers" },
-        { entityType: intl.formatMessage({ id: "performer" }) }
+        {
+          entityType: intl.formatMessage(
+            { id: "countables.performers" },
+            { count: 1 }
+          ),
+        }
       ),
       elements
     );
@@ -313,7 +343,12 @@ export const SettingsScrapingPanel: React.FC = () => {
     return renderTable(
       intl.formatMessage(
         { id: "config.scraping.entity_scrapers" },
-        { entityType: intl.formatMessage({ id: "movie" }) }
+        {
+          entityType: intl.formatMessage(
+            { id: "countables.movies" },
+            { count: 1 }
+          ),
+        }
       ),
       elements
     );

--- a/ui/v2.5/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsTasksPanel/SettingsTasksPanel.tsx
@@ -485,19 +485,28 @@ export const SettingsTasksPanel: React.FC = () => {
             <Form.Check
               id="autotag-performers"
               checked={autoTagPerformers}
-              label={intl.formatMessage({ id: "performers" })}
+              label={intl.formatMessage(
+                { id: "countables.performers" },
+                { count: 100 }
+              )}
               onChange={() => setAutoTagPerformers(!autoTagPerformers)}
             />
             <Form.Check
               id="autotag-studios"
               checked={autoTagStudios}
-              label={intl.formatMessage({ id: "studios" })}
+              label={intl.formatMessage(
+                { id: "countables.studios" },
+                { count: 100 }
+              )}
               onChange={() => setAutoTagStudios(!autoTagStudios)}
             />
             <Form.Check
               id="autotag-tags"
               checked={autoTagTags}
-              label={intl.formatMessage({ id: "tags" })}
+              label={intl.formatMessage(
+                { id: "countables.tags" },
+                { count: 100 }
+              )}
               onChange={() => setAutoTagTags(!autoTagTags)}
             />
           </Form.Group>

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -41,7 +41,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.scene_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="scenes" />
+            <FormattedMessage id="countables.scenes" values={{ count: 100 }} />
           </p>
         </div>
         <div className="stats-element">
@@ -49,7 +49,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.movie_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="movies" />
+            <FormattedMessage id="countables.movies" values={{ count: 100 }} />
           </p>
         </div>
         <div className="stats-element">
@@ -63,7 +63,10 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.performer_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="performers" />
+            <FormattedMessage
+              id="countables.performers"
+              values={{ count: 100 }}
+            />
           </p>
         </div>
       </div>
@@ -87,7 +90,10 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.gallery_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="galleries" />
+            <FormattedMessage
+              id="countables.galleries"
+              values={{ count: 100 }}
+            />
           </p>
         </div>
         <div className="stats-element">
@@ -95,7 +101,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.image_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="images" />
+            <FormattedMessage id="countables.images" values={{ count: 100 }} />
           </p>
         </div>
         <div className="stats-element">
@@ -103,7 +109,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.studio_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="studios" />
+            <FormattedMessage id="countables.studios" values={{ count: 100 }} />
           </p>
         </div>
         <div className="stats-element">
@@ -111,7 +117,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.tag_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="tags" />
+            <FormattedMessage id="countables.tags" values={{ count: 100 }} />
           </p>
         </div>
       </div>

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -126,7 +126,9 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
             values={{
               entityName:
                 studio.name ??
-                intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
+                intl
+                  .formatMessage({ id: "countables.studios" }, { count: 1 })
+                  .toLocaleLowerCase(),
             }}
           />
         </p>
@@ -182,12 +184,19 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <>
             <Helmet>
               <title>
-                {studio.name ?? intl.formatMessage({ id: "studio" })}
+                {studio.name ??
+                  intl.formatMessage(
+                    { id: "countables.studios" },
+                    { count: 1 }
+                  )}
               </title>
             </Helmet>
             <StudioDetailsPanel studio={studio} />
             <DetailsEditNavbar
-              objectName={studio.name ?? intl.formatMessage({ id: "studio" })}
+              objectName={
+                studio.name ??
+                intl.formatMessage({ id: "countables.studios" }, { count: 1 })
+              }
               isNew={false}
               isEditing={isEditing}
               onToggleEdit={onToggleEdit}
@@ -216,25 +225,49 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           activeKey={activeTabKey}
           onSelect={setActiveTabKey}
         >
-          <Tab eventKey="scenes" title={intl.formatMessage({ id: "scenes" })}>
+          <Tab
+            eventKey="scenes"
+            title={intl.formatMessage(
+              { id: "countables.scenes" },
+              { count: 100 }
+            )}
+          >
             <StudioScenesPanel studio={studio} />
           </Tab>
           <Tab
             eventKey="galleries"
-            title={intl.formatMessage({ id: "galleries" })}
+            title={intl.formatMessage(
+              { id: "countables.galleries" },
+              { count: 100 }
+            )}
           >
             <StudioGalleriesPanel studio={studio} />
           </Tab>
-          <Tab eventKey="images" title={intl.formatMessage({ id: "images" })}>
+          <Tab
+            eventKey="images"
+            title={intl.formatMessage(
+              { id: "countables.images" },
+              { count: 100 }
+            )}
+          >
             <StudioImagesPanel studio={studio} />
           </Tab>
           <Tab
             eventKey="performers"
-            title={intl.formatMessage({ id: "performers" })}
+            title={intl.formatMessage(
+              { id: "countables.performers" },
+              { count: 100 }
+            )}
           >
             <StudioPerformersPanel studio={studio} />
           </Tab>
-          <Tab eventKey="movies" title={intl.formatMessage({ id: "movies" })}>
+          <Tab
+            eventKey="movies"
+            title={intl.formatMessage(
+              { id: "countables.movies" },
+              { count: 100 }
+            )}
+          >
             <StudioMoviesPanel studio={studio} />
           </Tab>
           <Tab

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
@@ -54,7 +54,12 @@ const StudioCreate: React.FC = () => {
         <h2>
           {intl.formatMessage(
             { id: "actions.add_entity" },
-            { entityType: intl.formatMessage({ id: "studio" }) }
+            {
+              entityType: intl.formatMessage(
+                { id: "countables.studios" },
+                { count: 1 }
+              ),
+            }
           )}
         </h2>
         <div className="text-center">

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -254,7 +254,10 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
 
         <Form.Group controlId="details" as={Row}>
           {FormUtils.renderLabel({
-            title: intl.formatMessage({ id: "details" }),
+            title: intl.formatMessage(
+              { id: "countables.details" },
+              { count: 100 }
+            ),
           })}
           <Col xs={9}>
             <Form.Control

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -121,8 +121,14 @@ export const StudioList: React.FC<IStudioList> = ({
     <DeleteEntityDialog
       selected={selectedStudios}
       onClose={onClose}
-      singularEntity={intl.formatMessage({ id: "studio" })}
-      pluralEntity={intl.formatMessage({ id: "studios" })}
+      singularEntity={intl.formatMessage(
+        { id: "countables.studios" },
+        { count: 1 }
+      )}
+      pluralEntity={intl.formatMessage(
+        { id: "countables.studios" },
+        { count: 100 }
+      )}
       destroyMutation={useStudiosDestroy}
     />
   );

--- a/ui/v2.5/src/components/Studios/Studios.tsx
+++ b/ui/v2.5/src/components/Studios/Studios.tsx
@@ -10,9 +10,12 @@ import { StudioList } from "./StudioList";
 const Studios: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "studios",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.studios",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -571,7 +571,10 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
       <div>
         <Form.Group controlId="tags" as={Row}>
           {FormUtils.renderLabel({
-            title: `${intl.formatMessage({ id: "tags" })}:`,
+            title: `${intl.formatMessage(
+              { id: "countables.tags" },
+              { count: 100 }
+            )}:`,
           })}
           <Col sm={9} xl={12}>
             <TagSelect

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -179,7 +179,9 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             values={{
               entityName:
                 tag.name ??
-                intl.formatMessage({ id: "tag" }).toLocaleLowerCase(),
+                intl
+                  .formatMessage({ id: "countables.tags" }, { count: 1 })
+                  .toLocaleLowerCase(),
             }}
           />
         </p>
@@ -297,27 +299,48 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             activeKey={activeTabKey}
             onSelect={setActiveTabKey}
           >
-            <Tab eventKey="scenes" title={intl.formatMessage({ id: "scenes" })}>
+            <Tab
+              eventKey="scenes"
+              title={intl.formatMessage(
+                { id: "countables.scenes" },
+                { count: 100 }
+              )}
+            >
               <TagScenesPanel tag={tag} />
             </Tab>
-            <Tab eventKey="images" title={intl.formatMessage({ id: "images" })}>
+            <Tab
+              eventKey="images"
+              title={intl.formatMessage(
+                { id: "countables.images" },
+                { count: 100 }
+              )}
+            >
               <TagImagesPanel tag={tag} />
             </Tab>
             <Tab
               eventKey="galleries"
-              title={intl.formatMessage({ id: "galleries" })}
+              title={intl.formatMessage(
+                { id: "countables.galleries" },
+                { count: 100 }
+              )}
             >
               <TagGalleriesPanel tag={tag} />
             </Tab>
             <Tab
               eventKey="markers"
-              title={intl.formatMessage({ id: "markers" })}
+              title={intl.formatMessage(
+                { id: "countables.markers" },
+                { count: 100 }
+              )}
             >
               <TagMarkersPanel tag={tag} />
             </Tab>
             <Tab
               eventKey="performers"
-              title={intl.formatMessage({ id: "performers" })}
+              title={intl.formatMessage(
+                { id: "countables.performers" },
+                { count: 100 }
+              )}
             >
               <TagPerformersPanel tag={tag} />
             </Tab>

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -112,7 +112,12 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
         <h2>
           <FormattedMessage
             id="actions.add_entity"
-            values={{ entityType: intl.formatMessage({ id: "tag" }) }}
+            values={{
+              entityType: intl.formatMessage(
+                { id: "countables.tags" },
+                { count: 1 }
+              ),
+            }}
           />
         </h2>
       )}

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -136,8 +136,14 @@ export const TagList: React.FC<ITagList> = ({ filterHook }) => {
     <DeleteEntityDialog
       selected={selectedTags}
       onClose={onClose}
-      singularEntity={intl.formatMessage({ id: "tag" })}
-      pluralEntity={intl.formatMessage({ id: "tags" })}
+      singularEntity={intl.formatMessage(
+        { id: "countables.tags" },
+        { count: 1 }
+      )}
+      pluralEntity={intl.formatMessage(
+        { id: "countables.tags" },
+        { count: 100 }
+      )}
       destroyMutation={useTagsDestroy}
       onDeleted={() => {
         selectedTags.forEach((t) =>
@@ -199,8 +205,14 @@ export const TagList: React.FC<ITagList> = ({ filterHook }) => {
           { id: "toast.delete_past_tense" },
           {
             count: 1,
-            singularEntity: intl.formatMessage({ id: "tag" }),
-            pluralEntity: intl.formatMessage({ id: "tags" }),
+            singularEntity: intl.formatMessage(
+              { id: "countables.tags" },
+              { count: 1 }
+            ),
+            pluralEntity: intl.formatMessage(
+              { id: "countables.tags" },
+              { count: 100 }
+            ),
           }
         ),
       });

--- a/ui/v2.5/src/components/Tags/Tags.tsx
+++ b/ui/v2.5/src/components/Tags/Tags.tsx
@@ -10,9 +10,12 @@ import { TagList } from "./TagList";
 const Tags: React.FC = () => {
   const intl = useIntl();
 
-  const title_template = `${intl.formatMessage({
-    id: "tags",
-  })} ${TITLE_SUFFIX}`;
+  const title_template = `${intl.formatMessage(
+    {
+      id: "countables.tags",
+    },
+    { count: 100 }
+  )} ${TITLE_SUFFIX}`;
   return (
     <>
       <Helmet

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -456,6 +456,7 @@
   },
   "configuration": "Configuration",
   "countables": {
+    "details": "{count, plural, one {Detail} other {Details}}",
     "galleries": "{count, plural, one {Gallery} other {Galleries}}",
     "images": "{count, plural, one {Image} other {Images}}",
     "markers": "{count, plural, one {Marker} other {Markers}}",


### PR DESCRIPTION
This is just an experimental attempt at refactoring based on https://github.com/stashapp/stash/issues/1924
I'm looking for feedback on the implementation to see if this sort of refactor is worth continuing and applying to more strings.

The scope of the changes so far is limited to just the existing keys under `countables`  (galleries, images, markers, movies, performers, scenes, studios, tags, files) + added details countable.

I didn't remove any of the root-level keys that the countables replace (e.g. file/files, gallery/galleries), though that should be done eventually since the goal of the refactor is to make them obsolete

I also didn't dig into the more complicated refactoring cases where the i18n key is abstracted away from the intl.formatMessage call. Some of the cases I describe at the end of https://github.com/stashapp/stash/issues/1924#issuecomment-955242754

This was also done before I discovered the issue with generic translation strings that I describe in https://github.com/stashapp/stash/issues/1924#issuecomment-955738823 So to address that would require refactoring away the singularEntity/pluralEntity constructions altogether and adding more explicit translation strings Is this something we want to pursue? It would require getting updated translations for every language.

Another question would be if all root-level nouns should be moved under countables, not just the nouns for which we actually use both singular and plural. `countables` then just turns into the place where nouns go and you'd have to define a singular and plural form for every noun, regardless of which forms will be needed.