### PR TITLE
Fix entity creation bug during tag/performer scraping

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
@@ -405,12 +405,12 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = ({
         variables: { input },
       });
 
+      const newValue = [...(performers.newValue ?? [])];
+      if (result.data?.performerCreate)
+        newValue.push(result.data.performerCreate.id);
+
       // add the new performer to the new performers value
-      const performerClone = performers.cloneWithValue(performers.newValue);
-      if (!performerClone.newValue) {
-        performerClone.newValue = [];
-      }
-      performerClone.newValue.push(result.data!.performerCreate!.id);
+      const performerClone = performers.cloneWithValue(newValue);
       setPerformers(performerClone);
 
       // remove the performer from the list
@@ -490,12 +490,11 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = ({
         },
       });
 
+      const newValue = [...(tags.newValue ?? [])];
+      if (result.data?.tagCreate) newValue.push(result.data.tagCreate.id);
+
       // add the new tag to the new tags value
-      const tagClone = tags.cloneWithValue(tags.newValue);
-      if (!tagClone.newValue) {
-        tagClone.newValue = [];
-      }
-      tagClone.newValue.push(result.data!.tagCreate!.id);
+      const tagClone = tags.cloneWithValue(newValue);
       setTags(tagClone);
 
       // remove the tag from the list


### PR DESCRIPTION
Changes tag/performer scrape rows to add new new entities before cloning rather than after. The previous implementation would fail to add the new entity if the scene didn't already have an entity due to isEqual being run before the new entity was added, meaning it would compare two empty arrays.

To reproduce, scrape a scene without any current performers, and with a scraped performer that doesn't exist. Attempting to create and add the permer will cause the field to disappear, though the performer will be added when saving.