### PR TITLE
Fix invalid baseurl if host header already contains port

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -352,7 +352,7 @@ func BaseURLMiddleware(next http.Handler) http.Handler {
 
 		port := ""
 		forwardedPort := r.Header.Get("X-Forwarded-Port")
-		if forwardedPort != "" && forwardedPort != "80" && forwardedPort != "8080" {
+		if forwardedPort != "" && forwardedPort != "80" && forwardedPort != "8080" && forwardedPort != "443" && !strings.Contains(r.Host, ":") {
 			port = ":" + forwardedPort
 		}
 


### PR DESCRIPTION
`Host` may or may not contain the port along with the hostname. If it does, appending the `X-Forwarded-Port` variable will result in an invalid baseurl.