### PR TITLE
Fix trace loglevel

### DIFF
--- a/graphql/schema/types/logging.graphql
+++ b/graphql/schema/types/logging.graphql
@@ -2,6 +2,7 @@
 scalar Time
 
 enum LogLevel {
+    Trace
     Debug
     Info
     Progress

--- a/pkg/api/resolver_subscription_logging.go
+++ b/pkg/api/resolver_subscription_logging.go
@@ -11,6 +11,8 @@ func getLogLevel(logType string) models.LogLevel {
 	switch logType {
 	case "progress":
 		return models.LogLevelProgress
+	case "trace":
+		return models.LogLevelTrace
 	case "debug":
 		return models.LogLevelDebug
 	case "info":


### PR DESCRIPTION
This fixes switching between trace and debug log levels not doing anything, because the trace logs were displaying as debug logs in the `Settings -> Logs` page.