### PR TITLE
Fix hamming distance calculation in tagger

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -44,7 +44,6 @@
     "formik": "^2.2.6",
     "graphql": "^15.4.0",
     "graphql-tag": "^2.11.0",
-    "hamming-distance": "^1.0.0",
     "i18n-iso-countries": "^6.4.0",
     "intersection-observer": "^0.12.0",
     "localforage": "1.9.0",

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -4,7 +4,7 @@ import { Badge, Button, Col, Form, Row } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { uniq } from "lodash";
 import { blobToBase64 } from "base64-blob";
-import distance from "hamming-distance";
+import { distance } from "src/utils/hamming";
 
 import * as GQL from "src/core/generated-graphql";
 import {

--- a/ui/v2.5/src/utils/hamming.ts
+++ b/ui/v2.5/src/utils/hamming.ts
@@ -4,8 +4,8 @@ const hexToBinary = (hex: string) =>
     .map((i) => parseInt(i, 16).toString(2).padStart(4, "0"))
     .join("");
 
-export const distance = (a: string, b: string): number | undefined => {
-  if (a.length !== b.length) return;
+export const distance = (a: string, b: string | undefined | null): number => {
+  if (!b || a.length !== b.length) return 32;
 
   const aBinary = hexToBinary(a);
   const bBinary = hexToBinary(b);

--- a/ui/v2.5/src/utils/hamming.ts
+++ b/ui/v2.5/src/utils/hamming.ts
@@ -1,21 +1,19 @@
-const hexToBinary = (hex: string) => (
-	hex.split('').map(i => (
-		parseInt(i, 16).toString(2).padStart(4, '0')
-	)).join('')
-);
+const hexToBinary = (hex: string) =>
+  hex
+    .split("")
+    .map((i) => parseInt(i, 16).toString(2).padStart(4, "0"))
+    .join("");
 
-export const distance = (a: string, b: string): number|undefined=> {
-  if (a.length !== b.length)
-    return;
+export const distance = (a: string, b: string): number | undefined => {
+  if (a.length !== b.length) return;
 
   const aBinary = hexToBinary(a);
   const bBinary = hexToBinary(b);
 
   let counter = 0;
   for (let i = 0; i < aBinary.length; i++) {
-    if (aBinary[i] !== bBinary[i])
-      counter++;
+    if (aBinary[i] !== bBinary[i]) counter++;
   }
 
   return counter;
-}
+};

--- a/ui/v2.5/src/utils/hamming.ts
+++ b/ui/v2.5/src/utils/hamming.ts
@@ -1,0 +1,21 @@
+const hexToBinary = (hex: string) => (
+	hex.split('').map(i => (
+		parseInt(i, 16).toString(2).padStart(4, '0')
+	)).join('')
+);
+
+export const distance = (a: string, b: string): number|undefined=> {
+  if (a.length !== b.length)
+    return;
+
+  const aBinary = hexToBinary(a);
+  const bBinary = hexToBinary(b);
+
+  let counter = 0;
+  for (let i = 0; i < aBinary.length; i++) {
+    if (aBinary[i] !== bBinary[i])
+      counter++;
+  }
+
+  return counter;
+}

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -90,7 +90,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz#1310a1678cb8427c07a753750da4f8ce442bdd0c"
   integrity sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
   dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/compat-data" "^7.13.8"
+    "@babel/helper-validator-option" "^7.12.17"
+    browserslist "^4.14.5"
+    semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.13.0":
   version "7.13.11"
@@ -208,6 +211,11 @@
   version "7.15.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+
+"@babel/helper-validator-option@^7.12.17":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helpers@^7.13.10":
   version "7.13.10"
@@ -2051,7 +2059,7 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.12.0:
+browserslist@^4.12.0, browserslist@^4.14.5:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
   integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
@@ -2565,7 +2573,7 @@ debug@^4.3.2:
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
-    postcss "^7.0.5"
+    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -3739,11 +3747,6 @@ graphql@^15.3.0, graphql@^15.4.0:
   version "15.5.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
-
-hamming-distance@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/hamming-distance/-/hamming-distance-1.0.0.tgz"
-  integrity sha1-Ob+kbGHznodCHkA1ob5Pcl3XuTE=
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -5804,11 +5807,6 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picocolors@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
-  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -5920,14 +5918,6 @@ postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-postcss@^7.0.5:
-  version "7.0.39"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
-  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
-  dependencies:
-    picocolors "^0.2.1"
-    source-map "^0.6.1"
 
 postcss@^8.1.0:
   version "8.2.8"


### PR DESCRIPTION
`hamming-distance` uses node Buffers, which vite doesn't patch in. Since it's fairly simple I've reimplemented it directly. Probably not a very fast implementation, but since 64bit integers aren't easy to work with in javascript, the alternatives get really ugly.