### PR TITLE
Varied macOS fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ ui-start: pre-build
 	$(SET) VITE_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \
 	$(SET) VITE_APP_GITHASH=$(GITHASH) $(SEPARATOR) \
 	$(SET) VITE_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
-	cd ui/v2.5 && yarn start
+	cd ui/v2.5 && yarn start --host
 
 .PHONY: fmt-ui
 fmt-ui:

--- a/pkg/ffmpeg/downloader.go
+++ b/pkg/ffmpeg/downloader.go
@@ -45,7 +45,7 @@ func Download(ctx context.Context, configDirectory string) error {
 		}
 	}
 
-	//validate that the urls contained what we needed
+	// validate that the urls contained what we needed
 	executables := []string{"ffmpeg", "ffprobe"}
 	for _, executable := range executables {
 		_, err := os.Stat(filepath.Join(configDirectory, executable))
@@ -126,7 +126,6 @@ func DownloadSingle(ctx context.Context, configDirectory, url string) error {
 
 	logger.Info("Downloading complete")
 
-	//not all files may end in .zip
 	if resp.Header.Get("Content-Type") == "application/zip" {
 		logger.Infof("Unzipping %s...", archivePath)
 		if err := unzip(archivePath, configDirectory); err != nil {

--- a/ui/v2.5/src/core/createClient.ts
+++ b/ui/v2.5/src/core/createClient.ts
@@ -83,7 +83,7 @@ const typePolicies: TypePolicies = {
 
 export const getBaseURL = () => {
   const baseURL = window.STASH_BASE_URL;
-  if (baseURL === "%BASE_URL%") return "/";
+  if (baseURL === "/%BASE_URL%/") return "/";
   return baseURL;
 };
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -743,3 +743,11 @@ dl.details-list {
   grid-column-gap: 10px;
   grid-template-columns: minmax(16.67%, auto) 1fr;
 }
+
+// Fix Safari styling on dropdowns
+select {
+  -webkit-appearance: none;
+  appearance: none;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4.95 10' fill='%23fff'><polygon points='1.41 4.67 2.48 3.18 3.54 4.67 1.41 4.67'/><polygon points='3.54 5.33 2.48 6.82 1.41 5.33 3.54 5.33'/></svg>")
+    no-repeat right 2px center;
+}


### PR DESCRIPTION
- Downloading ffmpeg was broken on macos / any platform with multiple download urls.

- Safari styles selects very strangely, this removes the gloss.

> Before:
> ![Screenshot from 2021-11-19 12-13-07](https://user-images.githubusercontent.com/84814418/142697936-4b12cd77-7d9f-4826-be42-8214b96de188.png)
> After:
> ![Screenshot from 2021-11-19 12-40-03](https://user-images.githubusercontent.com/84814418/142697940-b38e19e4-f270-4412-9c76-50f1f23fc53e.png)
> 

- The dev server was broken + didn't attach to all interfaces.

