### PR TITLE
Select first tagger result if resolved

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0120.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0120.md
@@ -6,6 +6,7 @@
 * Added plugin hook for Tag merge operation. ([#2010](https://github.com/stashapp/stash/pull/2010))
 
 ### 🐛 Bug fixes
+* Select first scene result in scene tagger where possible. ([#2051](https://github.com/stashapp/stash/pull/2051))
 * Reject dates with invalid format. ([#2052](https://github.com/stashapp/stash/pull/2052))
 * Fix Autostart Video on Play Selected and Continue Playlist default settings not working. ([#2050](https://github.com/stashapp/stash/pull/2050))
 * Fix "Custom Performer Images" feature picking up non-image files. ([#2017](https://github.com/stashapp/stash/pull/2017))

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -655,7 +655,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
 
 export interface ISceneSearchResults {
   target: GQL.SlimSceneDataFragment;
-  scenes: GQL.ScrapedSceneDataFragment[];
+  scenes: IScrapedScene[];
 }
 
 export const SceneSearchResults: React.FC<ISceneSearchResults> = ({
@@ -667,6 +667,8 @@ export const SceneSearchResults: React.FC<ISceneSearchResults> = ({
   useEffect(() => {
     if (!scenes) {
       setSelectedResult(undefined);
+    } else if (scenes.length > 0 && scenes[0].resolved) {
+      setSelectedResult(0);
     }
   }, [scenes]);
 


### PR DESCRIPTION
Fixes regression in 0.11 where the first result in the scene tagger would not be selected, requiring the user to perform an extra click to save the results. Changed the behaviour so that if the scene is already resolved, then it will be selected. Scrapers which require an extra resolution step will not have this behaviour.