### PR TITLE
Validate SQLiteDate

### DIFF
--- a/pkg/models/sqlite_date.go
+++ b/pkg/models/sqlite_date.go
@@ -2,9 +2,10 @@ package models
 
 import (
 	"database/sql/driver"
+	"fmt"
+	"strings"
 	"time"
 
-	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -33,14 +34,15 @@ func (t *SQLiteDate) Scan(value interface{}) error {
 
 // Value implements the driver Valuer interface.
 func (t SQLiteDate) Value() (driver.Value, error) {
+	s := strings.TrimSpace(t.String)
 	// handle empty string
-	if t.String == "" {
+	if s == "" {
 		return "", nil
 	}
 
-	result, err := utils.ParseDateStringAsFormat(t.String, "2006-01-02")
+	result, err := utils.ParseDateStringAsFormat(s, "2006-01-02")
 	if err != nil {
-		logger.Debugf("sqlite date conversion error: %s", err.Error())
+		return nil, fmt.Errorf("converting sqlite date %q: %w", s, err)
 	}
 	return result, nil
 }

--- a/pkg/models/sqlite_date.go
+++ b/pkg/models/sqlite_date.go
@@ -34,6 +34,10 @@ func (t *SQLiteDate) Scan(value interface{}) error {
 
 // Value implements the driver Valuer interface.
 func (t SQLiteDate) Value() (driver.Value, error) {
+	if !t.Valid {
+		return nil, nil
+	}
+
 	s := strings.TrimSpace(t.String)
 	// handle empty string
 	if s == "" {

--- a/pkg/models/sqlite_date_test.go
+++ b/pkg/models/sqlite_date_test.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"testing"
+)
+
+func TestSQLiteDate_Value(t *testing.T) {
+	tests := []struct {
+		name    string
+		tr      string
+		want    driver.Value
+		wantErr bool
+	}{
+		{
+			"empty string",
+			"",
+			"",
+			false,
+		},
+		{
+			"whitespace",
+			" ",
+			"",
+			false,
+		},
+		{
+			"RFC3339",
+			"2021-11-22T17:11:55+11:00",
+			"2021-11-22",
+			false,
+		},
+		{
+			"date",
+			"2021-11-22",
+			"2021-11-22",
+			false,
+		},
+		{
+			"date and time",
+			"2021-11-22 17:12:05",
+			"2021-11-22",
+			false,
+		},
+		{
+			"date, time and zone",
+			"2021-11-22 17:33:05 AEST",
+			"2021-11-22",
+			false,
+		},
+		{
+			"whitespaced date",
+			"  2021-11-22 ",
+			"2021-11-22",
+			false,
+		},
+		{
+			"invalid",
+			"foo",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := SQLiteDate{
+				String: tt.tr,
+				Valid:  true,
+			}
+			got, err := d.Value()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SQLiteDate.Value() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SQLiteDate.Value() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/sqlite_date_test.go
+++ b/pkg/models/sqlite_date_test.go
@@ -9,67 +9,69 @@ import (
 func TestSQLiteDate_Value(t *testing.T) {
 	tests := []struct {
 		name    string
-		tr      string
+		tr      SQLiteDate
 		want    driver.Value
 		wantErr bool
 	}{
 		{
 			"empty string",
-			"",
+			SQLiteDate{"", true},
 			"",
 			false,
 		},
 		{
 			"whitespace",
-			" ",
+			SQLiteDate{" ", true},
 			"",
 			false,
 		},
 		{
 			"RFC3339",
-			"2021-11-22T17:11:55+11:00",
+			SQLiteDate{"2021-11-22T17:11:55+11:00", true},
 			"2021-11-22",
 			false,
 		},
 		{
 			"date",
-			"2021-11-22",
+			SQLiteDate{"2021-11-22", true},
 			"2021-11-22",
 			false,
 		},
 		{
 			"date and time",
-			"2021-11-22 17:12:05",
+			SQLiteDate{"2021-11-22 17:12:05", true},
 			"2021-11-22",
 			false,
 		},
 		{
 			"date, time and zone",
-			"2021-11-22 17:33:05 AEST",
+			SQLiteDate{"2021-11-22 17:33:05 AEST", true},
 			"2021-11-22",
 			false,
 		},
 		{
 			"whitespaced date",
-			"  2021-11-22 ",
+			SQLiteDate{"  2021-11-22 ", true},
 			"2021-11-22",
 			false,
 		},
 		{
-			"invalid",
-			"foo",
+			"bad format",
+			SQLiteDate{"foo", true},
 			nil,
 			true,
+		},
+		{
+			"invalid",
+			SQLiteDate{"null", false},
+			nil,
+			false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := SQLiteDate{
-				String: tt.tr,
-				Valid:  true,
-			}
-			got, err := d.Value()
+			got, err := tt.tr.Value()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SQLiteDate.Value() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/ui/v2.5/src/components/Changelog/versions/v0120.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0120.md
@@ -6,5 +6,6 @@
 * Added plugin hook for Tag merge operation. ([#2010](https://github.com/stashapp/stash/pull/2010))
 
 ### 🐛 Bug fixes
+* Reject dates with invalid format. ([#2052](https://github.com/stashapp/stash/pull/2052))
 * Fix Autostart Video on Play Selected and Continue Playlist default settings not working. ([#2050](https://github.com/stashapp/stash/pull/2050))
 * Fix "Custom Performer Images" feature picking up non-image files. ([#2017](https://github.com/stashapp/stash/pull/2017))


### PR DESCRIPTION
Fixes #1976 

Changes `SQLiteDate.Value` to return an error if parsing fails, instead of logging a warning.

Also trims any leading and trailing whitespace before parsing the date string.

Tested by trying to set an invalid date on scenes, which now emits an error. Given that this is a low-level function, this may have unintended side effects elsewhere.