### PR TITLE
Fix setting images

### DIFF
--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stashapp/stash/pkg/utils"
 )
 
-func setPerformerImage(ctx context.Context, client *http.Client, p models.ScrapedPerformer, globalConfig GlobalConfig) error {
+func setPerformerImage(ctx context.Context, client *http.Client, p *models.ScrapedPerformer, globalConfig GlobalConfig) error {
 	if p.Image == nil || !strings.HasPrefix(*p.Image, "http") {
 		// nothing to do
 		return nil
@@ -29,7 +29,7 @@ func setPerformerImage(ctx context.Context, client *http.Client, p models.Scrape
 	return nil
 }
 
-func setSceneImage(ctx context.Context, client *http.Client, s models.ScrapedScene, globalConfig GlobalConfig) error {
+func setSceneImage(ctx context.Context, client *http.Client, s *models.ScrapedScene, globalConfig GlobalConfig) error {
 	// don't try to get the image if it doesn't appear to be a URL
 	if s.Image == nil || !strings.HasPrefix(*s.Image, "http") {
 		// nothing to do
@@ -46,7 +46,7 @@ func setSceneImage(ctx context.Context, client *http.Client, s models.ScrapedSce
 	return nil
 }
 
-func setMovieFrontImage(ctx context.Context, client *http.Client, m models.ScrapedMovie, globalConfig GlobalConfig) error {
+func setMovieFrontImage(ctx context.Context, client *http.Client, m *models.ScrapedMovie, globalConfig GlobalConfig) error {
 	// don't try to get the image if it doesn't appear to be a URL
 	if m.FrontImage == nil || !strings.HasPrefix(*m.FrontImage, "http") {
 		// nothing to do
@@ -63,7 +63,7 @@ func setMovieFrontImage(ctx context.Context, client *http.Client, m models.Scrap
 	return nil
 }
 
-func setMovieBackImage(ctx context.Context, client *http.Client, m models.ScrapedMovie, globalConfig GlobalConfig) error {
+func setMovieBackImage(ctx context.Context, client *http.Client, m *models.ScrapedMovie, globalConfig GlobalConfig) error {
 	// don't try to get the image if it doesn't appear to be a URL
 	if m.BackImage == nil || !strings.HasPrefix(*m.BackImage, "http") {
 		// nothing to do

--- a/pkg/scraper/postprocessing.go
+++ b/pkg/scraper/postprocessing.go
@@ -63,7 +63,7 @@ func (c Cache) postScrapePerformer(ctx context.Context, p models.ScrapedPerforme
 	}
 
 	// post-process - set the image if applicable
-	if err := setPerformerImage(ctx, c.client, p, c.globalConfig); err != nil {
+	if err := setPerformerImage(ctx, c.client, &p, c.globalConfig); err != nil {
 		logger.Warnf("Could not set image using URL %s: %s", *p.Image, err.Error())
 	}
 
@@ -80,10 +80,10 @@ func (c Cache) postScrapeMovie(ctx context.Context, m models.ScrapedMovie) (mode
 	}
 
 	// post-process - set the image if applicable
-	if err := setMovieFrontImage(ctx, c.client, m, c.globalConfig); err != nil {
+	if err := setMovieFrontImage(ctx, c.client, &m, c.globalConfig); err != nil {
 		logger.Warnf("could not set front image using URL %s: %v", *m.FrontImage, err)
 	}
-	if err := setMovieBackImage(ctx, c.client, m, c.globalConfig); err != nil {
+	if err := setMovieBackImage(ctx, c.client, &m, c.globalConfig); err != nil {
 		logger.Warnf("could not set back image using URL %s: %v", *m.BackImage, err)
 	}
 
@@ -155,7 +155,7 @@ func (c Cache) postScrapeScene(ctx context.Context, scene models.ScrapedScene) (
 	}
 
 	// post-process - set the image if applicable
-	if err := setSceneImage(ctx, c.client, scene, c.globalConfig); err != nil {
+	if err := setSceneImage(ctx, c.client, &scene, c.globalConfig); err != nil {
 		logger.Warnf("Could not set image using URL %s: %v", *scene.Image, err)
 	}
 


### PR DESCRIPTION
This correct the mistake from the scraper-refactor-patch where images were not being set correctly. They should have been passed by reference to the setter functions, but wasn't because of a mistake on my part. This has been tested with performers, but I'm pretty sure every other part will work as well, since the fix is entirely mechanical.