### PR TITLE
Fix identify ScrapedScene conversion

### DIFF
--- a/pkg/manager/task_identify.go
+++ b/pkg/manager/task_identify.go
@@ -239,8 +239,8 @@ func (s scraperSource) ScrapeScene(ctx context.Context, sceneID int) (*models.Sc
 		return nil, err
 	}
 
-	if scene, ok := content.(*models.ScrapedScene); ok {
-		return scene, nil
+	if scene, ok := content.(models.ScrapedScene); ok {
+		return &scene, nil
 	}
 
 	return nil, errors.New("could not convert content to scene")


### PR DESCRIPTION
Minor fix for the identify task which was broken after 4089fcf. Not sure if there's a more idiomatic way of doing this post-refactor.