### PR TITLE
Add performer aliases to stash-box tagging/scraping

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -606,6 +606,11 @@ func performerFragmentToScrapedScenePerformer(p graphql.PerformerFragment) *mode
 		sp.FakeTits = enumToStringPtr(p.BreastType, true)
 	}
 
+	if len(p.Aliases) > 0 {
+		alias := strings.Join(p.Aliases, ", ")
+		sp.Aliases = &alias
+	}
+
 	return sp
 }
 

--- a/ui/v2.5/src/components/Changelog/versions/v0120.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0120.md
@@ -9,6 +9,7 @@
 * Added plugin hook for Tag merge operation. ([#2010](https://github.com/stashapp/stash/pull/2010))
 
 ### 🐛 Bug fixes
+* Include performer aliases when scraping from stash-box. ([#2091](https://github.com/stashapp/stash/pull/2091/files))
 * Remove empty folder-based galleries during clean. ([#1954](https://github.com/stashapp/stash/pull/1954))
 * Select first scene result in scene tagger where possible. ([#2051](https://github.com/stashapp/stash/pull/2051))
 * Reject dates with invalid format. ([#2052](https://github.com/stashapp/stash/pull/2052))

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -188,6 +188,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       <div className="row">
         <div className="col-7">
           {renderField("name", performer.name)}
+          {renderField("aliases", performer.aliases)}
           {renderField(
             "gender",
             performer.gender ? genderToString(performer.gender) : ""


### PR DESCRIPTION
For some reason it was never added, it seems.