### PR TITLE
Add short sprite error logging

### DIFF
--- a/pkg/manager/generator_sprite.go
+++ b/pkg/manager/generator_sprite.go
@@ -37,7 +37,7 @@ func NewSpriteGenerator(videoFile ffmpeg.VideoFile, videoChecksum string, imageO
 
 	// FFMPEG bombs out if we try to request 89 snapshots from a 2 second video
 	if videoFile.Duration < 3 {
-		return nil, errors.New("Video too short to create sprite")
+		return nil, errors.New("video too short to create sprite")
 	}
 
 	generator, err := newGeneratorInfo(videoFile)

--- a/pkg/manager/generator_sprite.go
+++ b/pkg/manager/generator_sprite.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -33,6 +34,12 @@ func NewSpriteGenerator(videoFile ffmpeg.VideoFile, videoChecksum string, imageO
 	if !exists {
 		return nil, err
 	}
+
+	// FFMPEG bombs out if we try to request 89 snapshots from a 2 second video
+	if videoFile.Duration < 3 {
+		return nil, errors.New("Video too short to create sprite")
+	}
+
 	generator, err := newGeneratorInfo(videoFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #2111 

It isn't possible to generate a sprite for a video file under three seconds in length with our method, so document this and warn.