### PR TITLE
Fix ffmpeg downloader on windows

### DIFF
--- a/pkg/ffmpeg/downloader.go
+++ b/pkg/ffmpeg/downloader.go
@@ -46,7 +46,7 @@ func Download(ctx context.Context, configDirectory string) error {
 	}
 
 	// validate that the urls contained what we needed
-	executables := []string{"ffmpeg", "ffprobe"}
+	executables := []string{getFFMPEGFilename(), getFFProbeFilename()}
 	for _, executable := range executables {
 		_, err := os.Stat(filepath.Join(configDirectory, executable))
 		if err != nil {


### PR DESCRIPTION
Pulled from #2073:

This fixes windows users having to restart stash after an error in the setup process.