### PR TITLE
Fix UseFileMetadata when scanning

### DIFF
--- a/pkg/manager/task_scan_scene.go
+++ b/pkg/manager/task_scan_scene.go
@@ -38,6 +38,7 @@ func (t *ScanTask) scanScene() *models.Scene {
 		VideoFileCreator:    &instance.FFProbe,
 		PluginCache:         instance.PluginCache,
 		MutexManager:        t.mutexManager,
+		UseFileMetadata:     t.UseFileMetadata,
 	}
 
 	if s != nil {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -264,7 +264,6 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 		if scanner.UseFileMetadata {
 			newScene.Details = sql.NullString{String: videoFile.Comment, Valid: true}
 			newScene.Date.Scan(videoFile.CreationTime)
-
 		}
 
 		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -263,7 +263,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 
 		if scanner.UseFileMetadata {
 			newScene.Details = sql.NullString{String: videoFile.Comment, Valid: true}
-			newScene.Date = models.SQLiteDate{String: videoFile.CreationTime.Format("2006-01-02")}
+			newScene.Date = models.SQLiteDate{String: videoFile.CreationTime.Format("2006-01-02"), Valid: true}
 		}
 
 		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -263,7 +263,8 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 
 		if scanner.UseFileMetadata {
 			newScene.Details = sql.NullString{String: videoFile.Comment, Valid: true}
-			newScene.Date = models.SQLiteDate{String: videoFile.CreationTime.Format("2006-01-02"), Valid: true}
+			newScene.Date.Scan(videoFile.CreationTime)
+
 		}
 
 		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -263,7 +263,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 
 		if scanner.UseFileMetadata {
 			newScene.Details = sql.NullString{String: videoFile.Comment, Valid: true}
-			newScene.Date.Scan(videoFile.CreationTime)
+			_ = newScene.Date.Scan(videoFile.CreationTime)
 		}
 
 		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {


### PR DESCRIPTION
A regression probably from two different PRs
- the UseFileMetadata option wasnt passed from the task to the scene scanner
- the creation time from ffprobe was not set to valid so was ignored 