### PR TITLE
Fix endless toast errors in Settings

### DIFF
--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -381,12 +381,19 @@
   }
 
   .fa-icon {
-    animation: fadeOut 2s forwards;
-    animation-delay: 2s;
     color: $success;
     height: 2rem;
     margin: 0;
     width: 2rem;
+  }
+
+  &.success .fa-icon {
+    animation: fadeOut 2s forwards;
+    animation-delay: 2s;
+  }
+
+  &.failed .fa-icon {
+    color: $danger;
   }
 }
 


### PR DESCRIPTION
Fixes issue in the settings pages where if setting failed, then the Toast error messages would flood the page.

Now, if a save operation fails, the error toast is showed once, and the loading indicator changes to a cross and stays on the page until the operation succeeds again (once the user corrects the error).

![image](https://user-images.githubusercontent.com/53250216/146697156-2ab7fabb-c97a-4e7a-ae4c-cd5074c9892c.png)
