### PR TITLE
Make phash a link to duplicates

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0120.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0120.md
@@ -7,6 +7,7 @@
 * Added forward jump 10 second button to video player. ([#1973](https://github.com/stashapp/stash/pull/1973))
 
 ### 🎨 Improvements
+* Made scene phash field in File Info tab a link to show duplicate scenes. ([#2154](https://github.com/stashapp/stash/pull/2154))
 * Show Created/Updated dates in scene/image/gallery details pages. ([#2145](https://github.com/stashapp/stash/pull/2145))
 * Added support for setting scrapers path in the settings page. ([#2124](https://github.com/stashapp/stash/pull/2124))
 * Added keyboard shortcuts to hide scene page sidebar and scene scrubber. ([#2099](https://github.com/stashapp/stash/pull/2099))

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
-import { TextUtils } from "src/utils";
+import { NavUtils, TextUtils } from "src/utils";
 import { TextField, URLField } from "src/utils/field";
 
 interface ISceneFileInfoPanelProps {
@@ -104,11 +104,14 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
         value={props.scene.checksum}
         truncate
       />
-      <TextField
+      <URLField
         id="media_info.phash"
         abbr="Perceptual hash"
         value={props.scene.phash}
+        url={NavUtils.makeScenesPHashMatchUrl(props.scene.phash)}
+        target="_self"
         truncate
+        trusted
       />
       <URLField
         id="path"

--- a/ui/v2.5/src/models/list-filter/criteria/phash.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/phash.ts
@@ -1,5 +1,5 @@
 import { CriterionModifier } from "src/core/generated-graphql";
-import { CriterionOption } from "./criterion";
+import { CriterionOption, StringCriterion } from "./criterion";
 
 export const PhashCriterionOption = new CriterionOption({
   messageID: "media_info.phash",
@@ -13,3 +13,9 @@ export const PhashCriterionOption = new CriterionOption({
     CriterionModifier.NotNull,
   ],
 });
+
+export class PhashCriterion extends StringCriterion {
+  constructor() {
+    super(PhashCriterionOption);
+  }
+}

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -18,6 +18,7 @@ import {
   CriterionValue,
 } from "src/models/list-filter/criteria/criterion";
 import { GalleriesCriterion } from "src/models/list-filter/criteria/galleries";
+import { PhashCriterion } from "src/models/list-filter/criteria/phash";
 
 function addExtraCriteria(
   dest: Criterion<CriterionValue>[],
@@ -270,6 +271,15 @@ const makeSceneMarkerUrl = (
   return `/scenes/${sceneMarker.scene.id}?t=${sceneMarker.seconds}`;
 };
 
+const makeScenesPHashMatchUrl = (phash: GQL.Maybe<string> | undefined) => {
+  if (!phash) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Scenes);
+  const criterion = new PhashCriterion();
+  criterion.value = phash;
+  filter.criteria.push(criterion);
+  return `/scenes?${filter.makeQueryParameters()}`;
+};
+
 const makeGalleryImagesUrl = (
   gallery: Partial<GQL.GalleryDataFragment | GQL.SlimGalleryDataFragment>,
   extraCriteria?: Criterion<CriterionValue>[]
@@ -302,6 +312,7 @@ export default {
   makeTagPerformersUrl,
   makeTagGalleriesUrl,
   makeTagImagesUrl,
+  makeScenesPHashMatchUrl,
   makeSceneMarkerUrl,
   makeMovieScenesUrl,
   makeChildStudiosUrl,


### PR DESCRIPTION
This makes the phash under scenes a link to search for other scenes with the same phash, to de-duplicate a certain scene quickly.