### PR TITLE
Add Gender Icons to Performers

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0130.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0130.md
@@ -1,4 +1,5 @@
 ### 🎨 Improvements
+* Add gender icons to performers. ([#2179](https://github.com/stashapp/stash/pull/2179))
 * Add button to test credentials when adding/editing stash-box endpoints. ([#2173](https://github.com/stashapp/stash/pull/2173))
 * Show counts on list tabs in Performer, Studio and Tag pages. ([#2169](https://github.com/stashapp/stash/pull/2169))
 

--- a/ui/v2.5/src/components/Performers/GenderIcon.tsx
+++ b/ui/v2.5/src/components/Performers/GenderIcon.tsx
@@ -31,7 +31,7 @@ const GenderIcon: React.FC<IIconProps> = ({ gender, className }) => {
       />
     );
   }
-  return <FontAwesomeIcon className={className} icon={faVenusMars} />;
+  return null;
 };
 
 export default GenderIcon;

--- a/ui/v2.5/src/components/Performers/GenderIcon.tsx
+++ b/ui/v2.5/src/components/Performers/GenderIcon.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {
+  faVenus,
+  faTransgenderAlt,
+  faMars,
+  faVenusMars,
+} from "@fortawesome/free-solid-svg-icons";
+import * as GQL from "src/core/generated-graphql";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { genderToString } from "src/utils/gender";
+import { useIntl } from "react-intl";
+
+interface IconProps {
+  gender?: GQL.Maybe<GQL.GenderEnum>;
+  className?: string;
+}
+
+const GenderIcon: React.FC<IconProps> = ({ gender, className }) => {
+  const intl = useIntl();
+  if (gender) {
+    const icon =
+      gender === GQL.GenderEnum.Male
+        ? faMars
+        : gender === GQL.GenderEnum.Female
+        ? faVenus
+        : faTransgenderAlt;
+    return (
+      <FontAwesomeIcon
+        title={intl.formatMessage({ id: "gender." + gender })}
+        className={className}
+        icon={icon}
+      />
+    );
+  }
+  return <FontAwesomeIcon className={className} icon={faVenusMars} />;
+};
+
+export default GenderIcon;

--- a/ui/v2.5/src/components/Performers/GenderIcon.tsx
+++ b/ui/v2.5/src/components/Performers/GenderIcon.tsx
@@ -7,15 +7,14 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import * as GQL from "src/core/generated-graphql";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { genderToString } from "src/utils/gender";
 import { useIntl } from "react-intl";
 
-interface IconProps {
+interface IIconProps {
   gender?: GQL.Maybe<GQL.GenderEnum>;
   className?: string;
 }
 
-const GenderIcon: React.FC<IconProps> = ({ gender, className }) => {
+const GenderIcon: React.FC<IIconProps> = ({ gender, className }) => {
   const intl = useIntl();
   if (gender) {
     const icon =

--- a/ui/v2.5/src/components/Performers/GenderIcon.tsx
+++ b/ui/v2.5/src/components/Performers/GenderIcon.tsx
@@ -3,7 +3,6 @@ import {
   faVenus,
   faTransgenderAlt,
   faMars,
-  faVenusMars,
 } from "@fortawesome/free-solid-svg-icons";
 import * as GQL from "src/core/generated-graphql";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -16,6 +16,7 @@ import {
   CriterionValue,
 } from "src/models/list-filter/criteria/criterion";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
+import GenderIcon from "./GenderIcon";
 
 export interface IPerformerCardExtraCriteria {
   scenes: Criterion<CriterionValue>[];
@@ -183,6 +184,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     <GridCard
       className="performer-card"
       url={`/performers/${performer.id}`}
+      pretitleIcon={<GenderIcon gender={performer.gender} />}
       title={performer.name ?? ""}
       image={
         <>

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -184,7 +184,9 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     <GridCard
       className="performer-card"
       url={`/performers/${performer.id}`}
-      pretitleIcon={<GenderIcon gender={performer.gender} />}
+      pretitleIcon={
+        <GenderIcon className="gender-icon" gender={performer.gender} />
+      }
       title={performer.name ?? ""}
       image={
         <>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -27,6 +27,7 @@ import { PerformerGalleriesPanel } from "./PerformerGalleriesPanel";
 import { PerformerMoviesPanel } from "./PerformerMoviesPanel";
 import { PerformerImagesPanel } from "./PerformerImagesPanel";
 import { PerformerEditPanel } from "./PerformerEditPanel";
+import GenderIcon from "../GenderIcon";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -317,6 +318,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <div className="row">
           <div className="performer-head col">
             <h2>
+              <GenderIcon gender={performer.gender} className="mr-2" />
               <CountryFlag country={performer.country} className="mr-2" />
               {performer.name}
               {renderIcons()}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -318,7 +318,10 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <div className="row">
           <div className="performer-head col">
             <h2>
-              <GenderIcon gender={performer.gender} className="mr-2" />
+              <GenderIcon
+                gender={performer.gender}
+                className="gender-icon mr-2"
+              />
               <CountryFlag country={performer.country} className="mr-2" />
               {performer.name}
               {renderIcons()}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -4,7 +4,6 @@ import { TagLink } from "src/components/Shared";
 import * as GQL from "src/core/generated-graphql";
 import { TextUtils } from "src/utils";
 import { TextField, URLField } from "src/utils/field";
-import { genderToString } from "src/utils/gender";
 
 interface IPerformerDetails {
   performer: GQL.PerformerDataFragment;
@@ -97,8 +96,12 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
   return (
     <dl className="details-list">
       <TextField
-        id="gender"
-        value={genderToString(performer.gender ?? undefined)}
+        id="gender.gender"
+        value={
+          performer.gender
+            ? intl.formatMessage({ id: "gender." + performer.gender })
+            : undefined
+        }
       />
       <TextField
         id="birthdate"

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -880,7 +880,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
         <Form.Group as={Row}>
           <Form.Label column xs={labelXS} xl={labelXL}>
-            <FormattedMessage id="gender" />
+            <FormattedMessage id="gender.gender" />
           </Form.Label>
           <Col xs="auto">
             <Form.Control

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -429,7 +429,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
           onChange={(value) => setAliases(value)}
         />
         {renderScrapedGenderRow(
-          intl.formatMessage({ id: "gender" }),
+          intl.formatMessage({ id: "gender.gender" }),
           gender,
           (value) => setGender(value)
         )}

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -114,3 +114,21 @@
     }
   }
 }
+
+.flex-aligned {
+  align-items: center;
+  column-gap: 0.5rem;
+  display: flex;
+}
+
+.fa-mars {
+  color: #89cff0;
+}
+
+.fa-venus {
+  color: #f38cac;
+}
+
+.fa-transgender-alt {
+  color: #c8a2c8;
+}

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -9,6 +9,7 @@ interface ICardProps {
   linkClassName?: string;
   thumbnailSectionClassName?: string;
   url: string;
+  pretitleIcon?: JSX.Element;
   title: string;
   image: JSX.Element;
   details?: JSX.Element;
@@ -106,7 +107,8 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
       {maybeRenderInteractiveHeatmap()}
       <div className="card-section">
         <Link to={props.url} onClick={handleImageClick}>
-          <h5 className="card-section-title">
+          <h5 className="card-section-title flex-aligned">
+            {props.pretitleIcon}
             <TruncatedText text={props.title} lineCount={2} />
           </h5>
         </Link>

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -11,7 +11,7 @@ import {
   TruncatedText,
 } from "src/components/Shared";
 import * as GQL from "src/core/generated-graphql";
-import { genderToString, stringToGender } from "src/utils/gender";
+import { stringToGender } from "src/utils/gender";
 
 interface IPerformerModalProps {
   performer: GQL.ScrapedScenePerformerDataFragment;

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -191,7 +191,9 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
           {renderField("aliases", performer.aliases)}
           {renderField(
             "gender",
-            performer.gender ? genderToString(performer.gender) : ""
+            performer.gender
+              ? intl.formatMessage({ id: "gender." + performer.gender })
+              : ""
           )}
           {renderField("birthdate", performer.birthdate)}
           {renderField("death_date", performer.death_date)}

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -691,7 +691,15 @@
   "galleries": "Galleries",
   "gallery": "Gallery",
   "gallery_count": "Gallery Count",
-  "gender": "Gender",
+  "gender": {
+    "gender": "Gender",
+    "MALE": "Male",
+    "FEMALE": "Female",
+    "TRANSGENDER_MALE": "Transgender Male",
+    "TRANSGENDER_FEMALE": "Transgender Female",
+    "INTERSEX": "Intersex",
+    "NON_BINARY": "Non-Binary"
+  },
   "hair_color": "Hair Colour",
   "hasMarkers": "Has Markers",
   "height": "Height",


### PR DESCRIPTION
Closes #434

This adds gender icons to the performer grid and detail pages. Gender types are i18n'd now, the code is adapted from stash-box.

Performer grid:
![Screenshot from 2021-12-28 23-39-28](https://user-images.githubusercontent.com/84814418/147639051-dce48290-dd75-4b42-823b-a72e11e434b1.png)
![Screenshot from 2021-12-28 23-39-46](https://user-images.githubusercontent.com/84814418/147639059-25b4d1be-442e-4e0b-9773-23cc5bd6bc84.png)

Performer detail:
![Screenshot from 2021-12-28 23-40-18](https://user-images.githubusercontent.com/84814418/147639075-ae9a63ff-d8f0-47fb-845d-bf7d314c89f2.png)


