### PR TITLE
Fix broken and outdated links in the Help document

### DIFF
--- a/ui/v2.5/src/docs/en/Contributing.md
+++ b/ui/v2.5/src/docs/en/Contributing.md
@@ -6,7 +6,7 @@ Financial contributions are welcomed and are accepted using [Open Collective](ht
 
 ## Development-related
 
-The Stash backend is written in golang with a sqlite database. The UI is written in react. Bug fixes, improvements and new features are welcomed. Please see the [README.md](https://github.com/stashapp/stash/raw/develop/README.md) file for details on how to get started. Assistance can be provided via our [Discord](https://discord.gg/2TsNFKt).
+The Stash backend is written in golang with a sqlite database. The UI is written in react. Bug fixes, improvements and new features are welcomed. Please see the [README.md](https://github.com/stashapp/stash/blob/develop/README.md) file for details on how to get started. Assistance can be provided via our [Discord](https://discord.gg/2TsNFKt).
 
 ## Documentation
 

--- a/ui/v2.5/src/docs/en/Interactive.md
+++ b/ui/v2.5/src/docs/en/Interactive.md
@@ -1,3 +1,5 @@
+# Interactivity
+
 Stash currently supports syncing with Handy devices, using funscript files.
 
 In order for stash to connect to your Handy device, the Handy Connection Key must be entered in Settings -> Interface.

--- a/ui/v2.5/src/docs/en/Interface.md
+++ b/ui/v2.5/src/docs/en/Interface.md
@@ -24,7 +24,7 @@ The maximum loop duration option allows looping of shorter videos. Set this valu
 
 The stash UI can be customised using custom CSS. See [here](https://github.com/stashapp/stash/wiki/Custom-CSS-snippets) for a community-curated set of CSS snippets to customise your UI. 
 
-[Stash Plex Theme](https://github.com/stashapp/stash/wiki/Stash-Plex-Theme) is a community created theme inspired by the popular Plex interface.
+[Stash Plex Theme](https://github.com/stashapp/stash/wiki/Theme-Plex) is a community created theme inspired by the popular Plex interface.
 
 
 ## Custom served folders

--- a/ui/v2.5/src/docs/en/Introduction.md
+++ b/ui/v2.5/src/docs/en/Introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Stash works by cataloging your media using the paths that you provide. Once you have [configured](/settings?tab=configuration) the locations where your media is stored, you can click the Scan button in [`Settings -> Tasks`](/settings?tab=tasks) and stash will begin scanning and importing your media into its library.
+Stash works by cataloging your media using the paths that you provide. Once you have [configured](/settings?tab=library) the locations where your media is stored, you can click the Scan button in [`Settings -> Tasks`](/settings?tab=tasks) and stash will begin scanning and importing your media into its library.
 
 For the best experience, it is recommmended that after a scan is finished, that video previews and sprites are generated. You can do this in [`Settings -> Tasks`](/settings?tab=tasks). Note that currently it is only possible to perform one task at a time and there is no task queue, so the Generate task should be performed after Scan is complete.
 

--- a/ui/v2.5/src/docs/en/ScraperDevelopment.md
+++ b/ui/v2.5/src/docs/en/ScraperDevelopment.md
@@ -273,7 +273,7 @@ Collectively, these configurations are known as mapped scraping configurations.
 
 A mapped scraping configuration may contain a `common` field, and must contain `performer`, `scene`, `movie` or `gallery` depending on the scraping type it is configured for. 
 
-Within the `performer`/`scene`/`movie`/`gallery` field are key/value pairs corresponding to the [golang fields](#object-fields) on the performer/scene object. These fields are case-sensitive. 
+Within the `performer`/`scene`/`movie`/`gallery` field are key/value pairs corresponding to the [golang fields](/help/ScraperDevelopment.md#object-fields) on the performer/scene object. These fields are case-sensitive. 
 
 The values of these may be either a simple selector value, which tells the system where to get the value of the field from, or a more advanced configuration (see below). For example, for an xpath configuration:
 


### PR DESCRIPTION
Checked all links (after v0.12.0 update) and fixed broken ones in the Help document.