### PR TITLE
Change row orders in SceneDetailPanel.tsx

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -114,14 +114,6 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
               )}
             </h6>
           )}
-          <h6>
-            <FormattedMessage id="created_at" />:{" "}
-            {TextUtils.formatDate(intl, props.scene.created_at)}{" "}
-          </h6>
-          <h6>
-            <FormattedMessage id="updated_at" />:{" "}
-            {TextUtils.formatDate(intl, props.scene.updated_at)}{" "}
-          </h6>
         </div>
         {props.scene.studio && (
           <div className="col-3 d-xl-none">
@@ -141,6 +133,14 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
           {renderTags()}
           {renderPerformers()}
         </div>
+          <h6>
+            <FormattedMessage id="created_at" />:{" "}
+            {TextUtils.formatDate(intl, props.scene.created_at)}{" "}
+          </h6>
+          <h6>
+            <FormattedMessage id="updated_at" />:{" "}
+            {TextUtils.formatDate(intl, props.scene.updated_at)}{" "}
+          </h6>
       </div>
     </>
   );


### PR DESCRIPTION
Moved "**Created At:**" and "**Updated At:**" rows to the bottom. `SceneDetailPanel.tsx` still needs a UI revamp and these two rows made that tab look worse after being added to v0.12.0. 

**Current:**

![1_current](https://user-images.githubusercontent.com/66418211/147763983-e0844cf6-def0-4b6a-bcfa-0981209ad533.png)

**Proposed:**

![2_suggested](https://user-images.githubusercontent.com/66418211/147764002-cfd656c2-7196-4f59-8a18-e07ca0df8fc6.png)


**Related issues:**
https://github.com/stashapp/stash/issues/1652#issue-975333906
https://github.com/stashapp/stash/issues/2078#issue-1066400001