### PR TITLE
Fix conversion of multi word stash-box enums

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -478,6 +478,28 @@ func enumToStringPtr(e fmt.Stringer, titleCase bool) *string {
 	return nil
 }
 
+func translateGender(gender *graphql.GenderEnum) *string {
+	var res models.GenderEnum
+	switch *gender {
+	case graphql.GenderEnumMale:
+		res = models.GenderEnumMale
+	case graphql.GenderEnumFemale:
+		res = models.GenderEnumFemale
+	case graphql.GenderEnumIntersex:
+		res = models.GenderEnumIntersex
+	case graphql.GenderEnumTransgenderFemale:
+		res = models.GenderEnumTransgenderFemale
+	case graphql.GenderEnumTransgenderMale:
+		res = models.GenderEnumTransgenderMale
+	}
+
+	if res != "" {
+		strVal := res.String()
+		return &strVal
+	}
+	return nil
+}
+
 func formatMeasurements(m graphql.MeasurementsFragment) *string {
 	if m.BandSize != nil && m.CupSize != nil && m.Hip != nil && m.Waist != nil {
 		ret := fmt.Sprintf("%d%s-%d-%d", *m.BandSize, *m.CupSize, *m.Waist, *m.Hip)
@@ -587,7 +609,7 @@ func performerFragmentToScrapedScenePerformer(p graphql.PerformerFragment) *mode
 	}
 
 	if p.Gender != nil {
-		sp.Gender = enumToStringPtr(p.Gender, false)
+		sp.Gender = translateGender(p.Gender)
 	}
 
 	if p.Ethnicity != nil {

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -468,7 +468,7 @@ func findURL(urls []*graphql.URLFragment, urlType string) *string {
 
 func enumToStringPtr(e fmt.Stringer, titleCase bool) *string {
 	if e != nil {
-		ret := e.String()
+		ret := strings.ReplaceAll(e.String(), "_", " ")
 		if titleCase {
 			ret = strings.Title(strings.ToLower(ret))
 		}

--- a/ui/v2.5/src/components/Changelog/versions/v0130.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0130.md
@@ -1,4 +1,5 @@
 ### 🐛 Bug fixes
+* Fix stash-box scraping including underscores in ethnicity. ([#2191](https://github.com/stashapp/stash/pull/2191))
 * Fix stash-box batch performer task not setting birthdate. ([#2189](https://github.com/stashapp/stash/pull/2189))
 * Fix error when scanning symlinks. ([#2196](https://github.com/stashapp/stash/issues/2196))
 * Fix timezone issue with Created/Updated dates in scene/image/gallery details pages. ([#2190](https://github.com/stashapp/stash/pull/2190))


### PR DESCRIPTION
Ensures that `MIDDLE_EASTERN` translates to `Middle Eastern`.