### PR TITLE
Add preview languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The simplest way to tag a large number of files is by using the [Tagger](https:/
 
 # Translation
 [![Translate](https://translate.stashapp.cc/widgets/stash/-/stash-desktop-client/svg-badge.svg)](https://translate.stashapp.cc/engage/stash/)
-🇧🇷 🇨🇳 🇬🇧 🇫🇮 🇫🇷 🇩🇪 🇮🇹 🇪🇸 🇸🇪 🇹🇼
+🇧🇷 🇨🇳 🇬🇧 🇫🇮 🇫🇷 🇩🇪 🇮🇹 🇪🇸 🇸🇪 🇹🇼 🇹🇷
 
-Stash is available in 10 languages (so far!) and it could be in your language too. If you want to help us translate Stash into your language, you can make an account at [translate.stashapp.cc](https://translate.stashapp.cc/projects/stash/stash-desktop-client/) to get started contributing new languages or improving existing ones. Thanks!
+Stash is available in 11 languages (so far!) and it could be in your language too. If you want to help us translate Stash into your language, you can make an account at [translate.stashapp.cc](https://translate.stashapp.cc/projects/stash/stash-desktop-client/) to get started contributing new languages or improving existing ones. Thanks!
 
 # Support (FAQ)
 

--- a/pkg/api/locale.go
+++ b/pkg/api/locale.go
@@ -19,6 +19,10 @@ var matcher = language.NewMatcher([]language.Tag{
 	language.MustParse("sv-SE"),
 	language.MustParse("zh-CN"),
 	language.MustParse("zh-TW"),
+	language.MustParse("hr-HR"),
+	language.MustParse("nl-NL"),
+	language.MustParse("ru-RU"),
+	language.MustParse("tr-TR"),
 })
 
 // newCollator parses a locale into a collator

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -56,7 +56,7 @@ export const SettingsInterfacePanel: React.FC = () => {
           <option value="pt-BR">Português (Brasil) (Preview)</option>
           <option value="ru-RU">Русский (Россия) (Preview)</option>
           <option value="sv-SE">Svenska</option>
-          <option value="tr-TR">Türkçe (Türkiye) (Preview)</option>
+          <option value="tr-TR">Türkçe (Türkiye)</option>
           <option value="zh-TW">繁體中文 (台灣)</option>
           <option value="zh-CN">简体中文 (中国)</option>
         </SelectSetting>

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -44,15 +44,19 @@ export const SettingsInterfacePanel: React.FC = () => {
           value={iface.language ?? undefined}
           onChange={(v) => saveInterface({ language: v })}
         >
-          <option value="en-US">English (United States)</option>
+          <option value="de-DE">Deutsch (Deutschland)</option>
           <option value="en-GB">English (United Kingdom)</option>
-          <option value="es-ES">Spanish (Spain)</option>
-          <option value="de-DE">German (Germany)</option>
-          <option value="pt-BR">Portuguese (Brazil)</option>
-          <option value="fr-FR">French (France)</option>
-          <option value="it-IT">Italian (Italy)</option>
-          <option value="fi-FI">Finnish (Finland)</option>
-          <option value="sv-SE">Swedish (Sweden)</option>
+          <option value="en-US">English (United States)</option>
+          <option value="es-ES">Español (España)</option>
+          <option value="fi-FI">Suomi</option>
+          <option value="fr-FR">Français (France)</option>
+          <option value="hr-HR">Hrvatski (Preview)</option>
+          <option value="it-IT">Italiano</option>
+          <option value="nl-NL">Nederlands (Nederland) (Preview)</option>
+          <option value="pt-BR">Português (Brasil) (Preview)</option>
+          <option value="ru-RU">Русский (Россия) (Preview)</option>
+          <option value="sv-SE">Svenska</option>
+          <option value="tr-TR">Türkçe (Türkiye) (Preview)</option>
           <option value="zh-TW">繁體中文 (台灣)</option>
           <option value="zh-CN">简体中文 (中国)</option>
         </SelectSetting>

--- a/ui/v2.5/src/locales/index.ts
+++ b/ui/v2.5/src/locales/index.ts
@@ -9,6 +9,10 @@ import fiFI from "./fi-FI.json";
 import svSE from "./sv-SE.json";
 import zhTW from "./zh-TW.json";
 import zhCN from "./zh-CN.json";
+import hrHR from "./hr-HR.json";
+import nlNL from "./nl-NL.json";
+import ruRU from "./ru-RU.json";
+import trTR from "./tr-TR.json";
 
 export default {
   deDE,
@@ -22,4 +26,8 @@ export default {
   svSE,
   zhTW,
   zhCN,
+  hrHR,
+  nlNL,
+  ruRU,
+  trTR,
 };


### PR DESCRIPTION
This adds Dutch, Russian, and Croatian, although they are unfinished, so they are marked with "(Preview)". I am also downgrading Portuguese to (Preview) as it is quite out of date. Adds Turkish as a full language.

I also changed the language names to their native tongue, and ordered them by their locale code. 