### PR TITLE
Fix oshash calculation for symlinks

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0130.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0130.md
@@ -1,2 +1,3 @@
 ### 🐛 Bug fixes
+* Fix error when scanning symlinks. ([#2196](https://github.com/stashapp/stash/issues/2196))
 * Fix timezone issue with Created/Updated dates in scene/image/gallery details pages. ([#2190](https://github.com/stashapp/stash/pull/2190))


### PR DESCRIPTION
Fixes #2196
For symlinks the size we fed to oshash was wrong as it was the one from the symlink. 
Use an os.Stat to get the size of the actual file