### PR TITLE
Allow stash to be iframed

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -364,7 +364,6 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 
 		w.Header().Set("Referrer-Policy", "same-origin")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-XSS-Protection", "1")
 		w.Header().Set("Content-Security-Policy", cspDirectives)
 

--- a/ui/v2.5/src/components/Changelog/versions/v0130.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0130.md
@@ -5,6 +5,7 @@
 * Show counts on list tabs in Performer, Studio and Tag pages. ([#2169](https://github.com/stashapp/stash/pull/2169))
 
 ### 🐛 Bug fixes
+* Allow Stash to be iframed. ([#2217](https://github.com/stashapp/stash/pull/2217))
 * Resolve CDP hostname if necessary. ([#2174](https://github.com/stashapp/stash/pull/2174))
 * Generate sprites for short video files. ([#2167](https://github.com/stashapp/stash/pull/2167))
 * Fix stash-box scraping including underscores in ethnicity. ([#2191](https://github.com/stashapp/stash/pull/2191))


### PR DESCRIPTION
This allows sites like organizr to iframe stash.

Fixes #2211

> A "real" site would send this, but for something self hosted it's probably more of a pain