### PR TITLE
Fix button spacing, fix gender/country height

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -259,7 +259,6 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       // provided by the server
       return (
         <div>
-          {performer.death_date ? "🪦 " : ""}
           <span className="age">
             {TextUtils.age(performer.birthdate, performer.death_date)}
           </span>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -165,6 +165,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
             isEditing={false}
             onSave={() => {}}
             onImageChange={() => {}}
+            classNames="mb-4"
           />
         </Row>
       </Col>
@@ -258,6 +259,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       // provided by the server
       return (
         <div>
+          {performer.death_date ? "🪦 " : ""}
           <span className="age">
             {TextUtils.age(performer.birthdate, performer.death_date)}
           </span>
@@ -309,7 +311,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     }
   }
 
-  const renderIcons = () => (
+  const renderClickableIcons = () => (
     <span className="name-icons">
       <Button
         className={cx(
@@ -393,11 +395,11 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
             <h2>
               <GenderIcon
                 gender={performer.gender}
-                className="gender-icon mr-2"
+                className="gender-icon mr-2 flag-icon"
               />
               <CountryFlag country={performer.country} className="mr-2" />
               {performer.name}
-              {renderIcons()}
+              {renderClickableIcons()}
             </h2>
             <RatingStars
               value={performer.rating ?? undefined}

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -2,6 +2,7 @@ import { Button, Modal } from "react-bootstrap";
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ImageInput } from "src/components/Shared";
+import cx from "classnames";
 
 interface IProps {
   objectName?: string;
@@ -20,6 +21,7 @@ interface IProps {
   onClearBackImage?: () => void;
   acceptSVG?: boolean;
   customButtons?: JSX.Element;
+  classNames?: string;
 }
 
 export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
@@ -127,7 +129,7 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
   }
 
   return (
-    <div className="details-edit">
+    <div className={cx("details-edit", props.classNames)}>
       {renderEditButton()}
       <ImageInput
         isEditing={props.isEditing}


### PR DESCRIPTION
Per Discord feedback, this increases the margin underneath the new performer buttons, and it gives the gender / country flag icons the same size and lines them up. 

This also adds a small tombstone emoji next to the age if a death date is listed. (Existing behavior is to list either current age or age at time of death)

CC #2218 

|Before|After|
|---|---|
|![Screenshot from 2022-01-07 22-24-15](https://user-images.githubusercontent.com/84814418/148634204-f82d9bed-0379-418b-9a2d-4888c071736d.png)|![Screenshot from 2022-01-07 22-25-14](https://user-images.githubusercontent.com/84814418/148634209-85ce6bbc-00a4-4ae1-894e-3d5fed089df0.png)|
