### PR TITLE
Only show one modal when tagging performers

### DIFF
--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -335,7 +335,7 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
           {modalPerformer && (
             <PerformerModal
               closeModal={() => setModalPerformer(undefined)}
-              modalVisible={modalPerformer !== undefined}
+              modalVisible={modalPerformer.stored_id === performer.id}
               performer={modalPerformer}
               onSave={handlePerformerUpdate}
               excludedPerformerFields={config.excludedPerformerFields}


### PR DESCRIPTION
For stupid reasons the current performer tagger implementation opens one modal per performer currently visible when refreshing a performer. It works fine, but is unnecessarily laggy.