### PR TITLE
Deprecate x-forwarded-port

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -385,13 +385,7 @@ func BaseURLMiddleware(next http.Handler) http.Handler {
 		}
 		prefix := getProxyPrefix(r.Header)
 
-		port := ""
-		forwardedPort := r.Header.Get("X-Forwarded-Port")
-		if forwardedPort != "" && forwardedPort != "80" && forwardedPort != "8080" && forwardedPort != "443" && !strings.Contains(r.Host, ":") {
-			port = ":" + forwardedPort
-		}
-
-		baseURL := scheme + "://" + r.Host + port + prefix
+		baseURL := scheme + "://" + r.Host + prefix
 
 		externalHost := config.GetInstance().GetExternalHost()
 		if externalHost != "" {


### PR DESCRIPTION
This was never necessary. Host headers from modern browsers include the port number, unless it can be inferred from the protocol (80, 443).

This is causing serious problems with proxy users. At least, any assets that use baseurl (practically all media) are routed around the reverse proxy, and from external networks are inaccessible. 

Fixes about a half dozen affected users on discord, and #2224 #2211 
