### PR TITLE
[WIP] Fix Identify accepting empty results

### DIFF
--- a/pkg/identify/identify.go
+++ b/pkg/identify/identify.go
@@ -68,7 +68,7 @@ func (t *SceneIdentifier) scrapeScene(ctx context.Context, scene *models.Scene) 
 		}
 
 		// if results were found then return
-		if isValidScrape(scraped) {
+		if scraped != nil {
 			return &scrapeResult{
 				result: scraped,
 				source: source,
@@ -272,34 +272,4 @@ func shouldSetSingleValueField(strategy *models.IdentifyFieldOptionsInput, hasEx
 	}
 
 	return !hasExistingValue || fs == models.IdentifyFieldStrategyOverwrite
-}
-
-// isValidScrape checks if a scraped scene contains at least one valid element
-func isValidScrape(s *models.ScrapedScene) bool {
-	if s != nil {
-		switch {
-		case s.Title != nil && *s.Title != "":
-			return true
-		case s.Date != nil && *s.Date != "":
-			return true
-		case s.Details != nil && *s.Details != "":
-			return true
-		case len(s.Fingerprints) > 0:
-			return true
-		case s.Image != nil && *s.Image != "":
-			return true
-		case len(s.Movies) > 0:
-			return true
-		case len(s.Performers) > 0:
-			return true
-		case s.Studio != nil:
-			return true
-		case len(s.Tags) > 0:
-			return true
-		default:
-			return false
-		}
-
-	}
-	return false
 }

--- a/pkg/identify/identify.go
+++ b/pkg/identify/identify.go
@@ -62,12 +62,13 @@ func (t *SceneIdentifier) scrapeScene(ctx context.Context, scene *models.Scene) 
 	for _, source := range t.Sources {
 		// scrape using the source
 		scraped, err := source.Scraper.ScrapeScene(ctx, scene.ID)
-		if err != nil {
-			return nil, fmt.Errorf("error scraping from %v: %v", source.Scraper, err)
+		if err != nil { // if a scraper errors out continue to next scraper
+			logger.Errorf("error scraping from %v: %v", source.Scraper, err)
+			continue
 		}
 
 		// if results were found then return
-		if scraped != nil {
+		if isValidScrape(scraped) {
 			return &scrapeResult{
 				result: scraped,
 				source: source,
@@ -271,4 +272,34 @@ func shouldSetSingleValueField(strategy *models.IdentifyFieldOptionsInput, hasEx
 	}
 
 	return !hasExistingValue || fs == models.IdentifyFieldStrategyOverwrite
+}
+
+// isValidScrape checks if a scraped scene contains at least one valid element
+func isValidScrape(s *models.ScrapedScene) bool {
+	if s != nil {
+		switch {
+		case s.Title != nil && *s.Title != "":
+			return true
+		case s.Date != nil && *s.Date != "":
+			return true
+		case s.Details != nil && *s.Details != "":
+			return true
+		case len(s.Fingerprints) > 0:
+			return true
+		case s.Image != nil && *s.Image != "":
+			return true
+		case len(s.Movies) > 0:
+			return true
+		case len(s.Performers) > 0:
+			return true
+		case s.Studio != nil:
+			return true
+		case len(s.Tags) > 0:
+			return true
+		default:
+			return false
+		}
+
+	}
+	return false
 }

--- a/pkg/identify/identify_test.go
+++ b/pkg/identify/identify_test.go
@@ -8,19 +8,14 @@ import (
 
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/models/mocks"
-	"github.com/stashapp/stash/pkg/utils"
 	"github.com/stretchr/testify/mock"
 )
 
 type mockSceneScraper struct {
-	errIDs  []int
 	results map[int]*models.ScrapedScene
 }
 
 func (s mockSceneScraper) ScrapeScene(ctx context.Context, sceneID int) (*models.ScrapedScene, error) {
-	if utils.IntInclude(s.errIDs, sceneID) {
-		return nil, errors.New("scrape scene error")
-	}
 	return s.results[sceneID], nil
 }
 
@@ -32,9 +27,7 @@ func (s mockHookExecutor) ExecuteSceneUpdatePostHooks(ctx context.Context, input
 
 func TestSceneIdentifier_Identify(t *testing.T) {
 	const (
-		errID1 = iota
-		errID2
-		missingID
+		missingID = iota
 		found1ID
 		found2ID
 		errUpdateID
@@ -46,7 +39,6 @@ func TestSceneIdentifier_Identify(t *testing.T) {
 	sources := []ScraperSource{
 		{
 			Scraper: mockSceneScraper{
-				errIDs: []int{errID1},
 				results: map[int]*models.ScrapedScene{
 					found1ID: {
 						Title: &scrapedTitle,
@@ -56,7 +48,6 @@ func TestSceneIdentifier_Identify(t *testing.T) {
 		},
 		{
 			Scraper: mockSceneScraper{
-				errIDs: []int{errID2},
 				results: map[int]*models.ScrapedScene{
 					found2ID: {
 						Title: &scrapedTitle,
@@ -82,16 +73,6 @@ func TestSceneIdentifier_Identify(t *testing.T) {
 		sceneID int
 		wantErr bool
 	}{
-		{
-			"error scraping",
-			errID1,
-			true,
-		},
-		{
-			"error scraping from second",
-			errID2,
-			true,
-		},
 		{
 			"found in first scraper",
 			found1ID,

--- a/pkg/manager/task_identify.go
+++ b/pkg/manager/task_identify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/stashapp/stash/pkg/identify"
@@ -237,6 +238,10 @@ func (s scraperSource) ScrapeScene(ctx context.Context, sceneID int) (*models.Sc
 	content, err := s.cache.ScrapeID(ctx, s.scraperID, sceneID, models.ScrapeContentTypeScene)
 	if err != nil {
 		return nil, err
+	}
+
+	if reflect.ValueOf(content).IsZero() {
+		return nil, errors.New("no scraped data for scene")
 	}
 
 	if scene, ok := content.(models.ScrapedScene); ok {

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -202,6 +202,12 @@ func (s *scriptScraper) scrapeSceneByScene(ctx context.Context, scene *models.Sc
 
 	err = s.runScraperScript(string(inString), &ret)
 
+	if err == nil {
+		if !isValidScrapedScene(&ret) {
+			return nil, nil
+		}
+	}
+
 	return &ret, err
 }
 


### PR DESCRIPTION
The identify task accepts empty results from a scraper and thus doesnt move on to the next scraper in line.
I added an extra check of the scraped scene so that if it is empty the next scraper will be used.
Also  when a scraper errors out  just try the next one instead of returning out

Steps to reproduce the original issue/bug
- Select a few scenes to identify ( we need scenes that the first source won't have) and add some sources
![sources](https://user-images.githubusercontent.com/48220860/149000397-d9b029e6-4ba9-42b4-9aa2-7bbf7e576602.jpg)
- Hit identify
- Even though the first scraper doesnt return any results for some of the scenes it wont continue to the next source
