### PR TITLE
Prevent creation of dupe filters

### DIFF
--- a/ui/v2.5/src/components/List/AddFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/AddFilterDialog.tsx
@@ -37,6 +37,7 @@ interface IAddFilterProps {
   onCancel: () => void;
   filterOptions: ListFilterOptions;
   editingCriterion?: Criterion<CriterionValue>;
+  existingCriterions: Criterion<CriterionValue>[];
 }
 
 export const AddFilterDialog: React.FC<IAddFilterProps> = ({
@@ -44,6 +45,7 @@ export const AddFilterDialog: React.FC<IAddFilterProps> = ({
   onCancel,
   filterOptions,
   editingCriterion,
+  existingCriterions,
 }) => {
   const defaultValue = useRef<string | number | undefined>();
 
@@ -206,6 +208,10 @@ export const AddFilterDialog: React.FC<IAddFilterProps> = ({
 
     const thisOptions = [NoneCriterionOption]
       .concat(filterOptions.criterionOptions)
+      .filter(
+        (c) =>
+          !existingCriterions.find((ec) => ec.criterionOption.type === c.type)
+      )
       .map((c) => {
         return {
           value: c.type,

--- a/ui/v2.5/src/hooks/ListHook.tsx
+++ b/ui/v2.5/src/hooks/ListHook.tsx
@@ -526,6 +526,7 @@ const RenderList = <
           onAddCriterion={onAddCriterion}
           onCancel={onCancelAddCriterion}
           editingCriterion={editingCriterion}
+          existingCriterions={filter.criteria}
         />
       )}
       {newCriterion &&


### PR DESCRIPTION
When duplicating filters only the last one is actually active. This is very confusing, and until we actually support multiple filters of the same type it's better to remove the option.