### PR TITLE
Fix vite manifest.json crash

### DIFF
--- a/ui/v2.5/index.html
+++ b/ui/v2.5/index.html
@@ -13,7 +13,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="/%BASE_URL%/manifest.json" />
+    <link rel="manifest" href="manifest.json" />
     <title>Stash</title>
     <script>window.STASH_BASE_URL = "/%BASE_URL%/"</script>
   </head>


### PR DESCRIPTION
I've confirmed it still works with subpath proxy.