### PR TITLE
Add Tasks table to Logs Page

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsLogsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsLogsPanel.tsx
@@ -109,7 +109,7 @@ export const SettingsLogsPanel: React.FC = () => {
 
   return (
     <>
-      <h1>{intl.formatMessage({ id: "config.tasks.job_queue" })}</h1>
+      <h2>{intl.formatMessage({ id: "config.tasks.job_queue" })}</h2>
       <JobTable />
       <SettingSection headingID="config.categories.logs">
         <SelectSetting

--- a/ui/v2.5/src/components/Settings/SettingsLogsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsLogsPanel.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useReducer, useState } from "react";
+import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import { useLogs, useLoggingSubscribe } from "src/core/StashService";
 import { SelectSetting } from "./Inputs";
 import { SettingSection } from "./SettingSection";
-
+import { JobTable } from "./Tasks/JobTable";
 function convertTime(logEntry: GQL.LogEntryDataFragment) {
   function pad(val: number) {
     let ret = val.toString();
@@ -79,6 +80,7 @@ export const SettingsLogsPanel: React.FC = () => {
   const { data: existingData } = useLogs();
   const [currentData, dispatchLogUpdate] = useReducer(logReducer, []);
   const [logLevel, setLogLevel] = useState<string>("Info");
+  const intl = useIntl();
 
   useEffect(() => {
     const newData = (data?.loggingSubscribe ?? []).map((e) => new LogEntry(e));
@@ -107,6 +109,8 @@ export const SettingsLogsPanel: React.FC = () => {
 
   return (
     <>
+      <h1>{intl.formatMessage({ id: "config.tasks.job_queue" })}</h1>
+      <JobTable />
       <SettingSection headingID="config.categories.logs">
         <SelectSetting
           id="log-level"


### PR DESCRIPTION
I often switch between these, as the current task informs what log lines to look for. I figure putting them in the same place just makes sense

![Screenshot from 2022-01-18 15-57-59](https://user-images.githubusercontent.com/84814418/150038034-bfe8d543-cf2e-4f8a-a4c2-4fb572251bbb.png)
