### PR TITLE
Fix preview video stopping media on Android

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -56,6 +56,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
       <video
         disableRemotePlayback
         playsInline
+        muted={!soundActive}
         className="scene-card-preview-video"
         loop
         preload="none"


### PR DESCRIPTION
If you have media playing in the background on Android (eg. Spotify), it stops when playing a scene preview video.
If you have the "Enable sound" setting set to off, this should not happen.

This fixes it by using the HTML \<video\> "muted" attribute when you have Scene / Marker Wall sound disabled in settings.
This also removes the annoying media notification you get every time you play a preview video.