### PR TITLE
Reuse static server for multiple requests

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -184,6 +184,7 @@ func Start(uiBox embed.FS, loginUIBox embed.FS) {
 	}
 
 	customUILocation := c.GetCustomUILocation()
+	static := statigz.FileServer(uiBox)
 
 	// Serve the web app
 	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
@@ -222,7 +223,7 @@ func Start(uiBox embed.FS, loginUIBox embed.FS) {
 			}
 			r.URL.Path = uiRootDir + r.URL.Path
 
-			statigz.FileServer(uiBox).ServeHTTP(w, r)
+			static.ServeHTTP(w, r)
 		}
 	})
 


### PR DESCRIPTION
Hello, `statigz.FileServer` function indexes and hashes provided file system to optimize performance of serving, it is intended to be initialized before serving requests to avoid extra work for each request.

This PR moves file server setup outside of http handler to improve performance.

Thanks.