### PR TITLE
Add additional fields to bulk performer dialog

### DIFF
--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -9,10 +9,7 @@ import { useToast } from "src/hooks";
 import { FormUtils } from "src/utils";
 import MultiSet from "../Shared/MultiSet";
 import { RatingStars } from "../Scenes/SceneDetails/RatingStars";
-import {
-  genderStrings,
-  stringToGender,
-} from "src/utils/gender";
+import { genderStrings, stringToGender } from "src/utils/gender";
 
 interface IListOperationProps {
   selected: GQL.SlimPerformerDataFragment[];
@@ -300,12 +297,14 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
 
           <Form.Group>
             <Form.Label>
-              <FormattedMessage id="gender"/>
+              <FormattedMessage id="gender" />
             </Form.Label>
             <Form.Control
               as="select"
               className="input-control"
-              onChange={(event) => setGender(stringToGender(event.currentTarget.value))}
+              onChange={(event) =>
+                setGender(stringToGender(event.currentTarget.value))
+              }
             >
               {genderOptions.map((opt) => (
                 <option value={opt} key={opt}>

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -27,6 +27,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
   const [tagIds, setTagIds] = useState<string[]>();
   const [existingTagIds, setExistingTagIds] = useState<string[]>();
   const [favorite, setFavorite] = useState<boolean | undefined>();
+  const [country, setCountry] = useState<string | undefined>();
 
   const [updatePerformers] = useBulkPerformerUpdate(getPerformerInput());
 
@@ -34,6 +35,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
   const [isUpdating, setIsUpdating] = useState(false);
 
   const checkboxRef = React.createRef<HTMLInputElement>();
+  const countryRef = React.createRef<HTMLInputElement>();
 
   function makeBulkUpdateIds(
     ids: string[],
@@ -86,6 +88,10 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
 
     if (favorite !== undefined) {
       performerInput.favorite = favorite;
+    }
+
+    if (country != undefined) {
+      performerInput.country = country;
     }
 
     return performerInput;
@@ -182,6 +188,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     setExistingTagIds(updateTagIds);
     setFavorite(updateFavorite);
     setRating(updateRating);
+    setCountry(undefined); // no country in SlimPerformer
   }, [props.selected, tagMode]);
 
   useEffect(() => {
@@ -189,6 +196,12 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
       checkboxRef.current.indeterminate = favorite === undefined;
     }
   }, [favorite, checkboxRef]);
+
+  useEffect(() => {
+    if (countryRef.current) {
+      countryRef.current.indeterminate = country == undefined;
+    }
+  }, [country, countryRef]);
 
   function cycleFavorite() {
     if (favorite) {
@@ -252,6 +265,18 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
               checked={favorite}
               ref={checkboxRef}
               onChange={() => cycleFavorite()}
+            />
+          </Form.Group>
+
+          <Form.Group controlId="country">
+            <Form.Label>
+              <FormattedMessage id="country" />
+            </Form.Label>
+            <Form.Control
+              type="text"
+              value={country}
+              ref={countryRef}
+              onChange={(event) => setCountry(event.currentTarget.value)}
             />
           </Form.Group>
         </Form>

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -9,6 +9,10 @@ import { useToast } from "src/hooks";
 import { FormUtils } from "src/utils";
 import MultiSet from "../Shared/MultiSet";
 import { RatingStars } from "../Scenes/SceneDetails/RatingStars";
+import {
+  genderStrings,
+  stringToGender,
+} from "src/utils/gender";
 
 interface IListOperationProps {
   selected: GQL.SlimPerformerDataFragment[];
@@ -35,6 +39,8 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
   const [tattoos, setTattoos] = useState<string | undefined>();
   const [piercings, setPiercings] = useState<string | undefined>();
   const [hairColor, setHairColor] = useState<string | undefined>();
+  const [gender, setGender] = useState<GQL.GenderEnum | undefined>();
+  const genderOptions = [""].concat(genderStrings);
 
   const [updatePerformers] = useBulkPerformerUpdate(getPerformerInput());
 
@@ -101,6 +107,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     performerInput.tattoos = tattoos;
     performerInput.piercings = piercings;
     performerInput.hair_color = hairColor;
+    performerInput.gender = gender;
 
     return performerInput;
   }
@@ -169,6 +176,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     let updateTagIds: string[] = [];
     let updateFavorite: boolean | undefined;
     let updateRating: number | undefined;
+    let updateGender: GQL.GenderEnum | undefined;
     let first = true;
 
     state.forEach((performer: GQL.SlimPerformerDataFragment) => {
@@ -180,6 +188,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
         first = false;
         updateFavorite = performer.favorite;
         updateRating = performerRating ?? undefined;
+        updateGender = performer.gender ?? undefined;
       } else {
         if (!_.isEqual(performerTagIDs, updateTagIds)) {
           updateTagIds = [];
@@ -190,12 +199,16 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
         if (performerRating !== updateRating) {
           updateRating = undefined;
         }
+        if (performer.gender !== updateGender) {
+          updateGender = undefined;
+        }
       }
     });
 
     setExistingTagIds(updateTagIds);
     setFavorite(updateFavorite);
     setRating(updateRating);
+    setGender(updateGender);
 
     // these fields are not part of SlimPerformerDataFragment
     setEthnicity(undefined);
@@ -235,6 +248,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           <FormattedMessage id={name} />
         </Form.Label>
         <Form.Control
+          className="input-control"
           type="text"
           value={value}
           onChange={(event) => setter(event.currentTarget.value)}
@@ -282,6 +296,23 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
               ref={checkboxRef}
               onChange={() => cycleFavorite()}
             />
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Label>
+              <FormattedMessage id="gender"/>
+            </Form.Label>
+            <Form.Control
+              as="select"
+              className="input-control"
+              onChange={(event) => setGender(stringToGender(event.currentTarget.value))}
+            >
+              {genderOptions.map((opt) => (
+                <option value={opt} key={opt}>
+                  {opt}
+                </option>
+              ))}
+            </Form.Control>
           </Form.Group>
 
           {renderTextField("country", country, setCountry)}

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -15,24 +15,6 @@ interface IListOperationProps {
   onClose: (applied: boolean) => void;
 }
 
-const ChangeableTextFields = [
-  "ethnicity",
-  "country",
-  "eye_color",
-  "height",
-  "measurements",
-  "fake_tits",
-  "career_length",
-  "tattoos",
-  "piercings",
-  "hair_color"
-]
-
-interface ITextFieldState {
-  value: string | undefined;
-  setter: (newValue: string | undefined) => void;
-}
-
 export const EditPerformersDialog: React.FC<IListOperationProps> = (
   props: IListOperationProps
 ) => {
@@ -45,12 +27,16 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
   const [tagIds, setTagIds] = useState<string[]>();
   const [existingTagIds, setExistingTagIds] = useState<string[]>();
   const [favorite, setFavorite] = useState<boolean | undefined>();
-  const textFields = new Map<string, ITextFieldState>();
-  for (const fieldName of ChangeableTextFields)
-  {
-    const [value, setter] = useState<string | undefined>();
-    textFields.set(fieldName, { value, setter });
-  }
+  const [ethnicity, setEthnicity] = useState<string | undefined>();
+  const [country, setCountry] = useState<string | undefined>();
+  const [eyeColor, setEyeColor] = useState<string | undefined>();
+  const [height, setHeight] = useState<string | undefined>();
+  const [measurements, setMeasurements] = useState<string | undefined>();
+  const [fakeTits, setFakeTits] = useState<string | undefined>();
+  const [careerLength, setCareerLength] = useState<string | undefined>();
+  const [tattoos, setTattoos] = useState<string | undefined>();
+  const [piercings, setPiercings] = useState<string | undefined>();
+  const [hairColor, setHairColor] = useState<string | undefined>();
 
   const [updatePerformers] = useBulkPerformerUpdate(getPerformerInput());
 
@@ -108,15 +94,17 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
       performerInput.tag_ids = makeBulkUpdateIds(tagIds || [], tagMode);
     }
 
-    if (favorite !== undefined) {
-      performerInput.favorite = favorite;
-    }
-
-    for (const [fieldName, fieldState] of textFields) {
-      if (fieldState.value !== undefined) {
-        (performerInput as any)[fieldName] = fieldState.value;
-      }
-    }
+    performerInput.favorite = favorite;
+    performerInput.ethnicity = ethnicity;
+    performerInput.country = country;
+    performerInput.eye_color = eyeColor;
+    performerInput.height = height;
+    performerInput.measurements = measurements;
+    performerInput.fake_tits = fakeTits;
+    performerInput.career_length = careerLength;
+    performerInput.tattoos = tattoos;
+    performerInput.piercings = piercings;
+    performerInput.hair_color = hairColor;
 
     return performerInput;
   }
@@ -213,10 +201,17 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     setFavorite(updateFavorite);
     setRating(updateRating);
 
-    // the text fields are not part of SlimPerformerDataFragment
-    for (const [, textField] of textFields) {
-      textField.setter(undefined);
-    }
+    // these fields are not part of SlimPerformerDataFragment
+    setEthnicity(undefined);
+    setCountry(undefined);
+    setEyeColor(undefined);
+    setHeight(undefined);
+    setMeasurements(undefined);
+    setFakeTits(undefined);
+    setCareerLength(undefined);
+    setTattoos(undefined);
+    setPiercings(undefined);
+    setHairColor(undefined);
   }, [props.selected, tagMode]);
 
   useEffect(() => {
@@ -235,23 +230,24 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     }
   }
 
-  function renderTextFields() {
-    const rows: JSX.Element[] = [];
-    for (const [fieldName, fieldState] of textFields) {
-      rows.push(
-        <Form.Group controlId={fieldName}>
-          <Form.Label>
-            <FormattedMessage id={fieldName} />
-          </Form.Label>
-          <Form.Control
-            type="text"
-            value={fieldState.value}
-            onChange={(event) => fieldState.setter(event.currentTarget.value)}
-          />
-        </Form.Group>
-      );
-    }
-    return rows;
+  function renderTextField(
+    name: string,
+    value: string | undefined,
+    setter: (newValue: string | undefined) => void
+  ) {
+    return (
+      <Form.Group controlId={name}>
+        <Form.Label>
+          <FormattedMessage id={name} />
+        </Form.Label>
+        <Form.Control
+          type="text"
+          value={value}
+          onChange={(event) => setter(event.currentTarget.value)}
+          placeholder={intl.formatMessage({ id: name })}
+        />
+      </Form.Group>
+    );
   }
 
   function render() {
@@ -284,6 +280,27 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           </Col>
         </Form.Group>
         <Form>
+          <Form.Group controlId="favorite">
+            <Form.Check
+              type="checkbox"
+              label="Favorite"
+              checked={favorite}
+              ref={checkboxRef}
+              onChange={() => cycleFavorite()}
+            />
+          </Form.Group>
+
+          {renderTextField("country", country, setCountry)}
+          {renderTextField("ethnicity", ethnicity, setEthnicity)}
+          {renderTextField("hair_color", hairColor, setHairColor)}
+          {renderTextField("eye_color", eyeColor, setEyeColor)}
+          {renderTextField("height", height, setHeight)}
+          {renderTextField("measurements", measurements, setMeasurements)}
+          {renderTextField("fake_tits", fakeTits, setFakeTits)}
+          {renderTextField("tattoos", tattoos, setTattoos)}
+          {renderTextField("piercings", piercings, setPiercings)}
+          {renderTextField("career_length", careerLength, setCareerLength)}
+
           <Form.Group controlId="tags">
             <Form.Label>
               <FormattedMessage id="tags" />
@@ -298,18 +315,6 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
               mode={tagMode}
             />
           </Form.Group>
-
-          <Form.Group controlId="favorite">
-            <Form.Check
-              type="checkbox"
-              label="Favorite"
-              checked={favorite}
-              ref={checkboxRef}
-              onChange={() => cycleFavorite()}
-            />
-          </Form.Group>
-
-          {renderTextFields()}
         </Form>
       </Modal>
     );

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -30,8 +30,6 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
   const [ethnicity, setEthnicity] = useState<string | undefined>();
   const [country, setCountry] = useState<string | undefined>();
   const [eyeColor, setEyeColor] = useState<string | undefined>();
-  const [height, setHeight] = useState<string | undefined>();
-  const [measurements, setMeasurements] = useState<string | undefined>();
   const [fakeTits, setFakeTits] = useState<string | undefined>();
   const [careerLength, setCareerLength] = useState<string | undefined>();
   const [tattoos, setTattoos] = useState<string | undefined>();
@@ -98,8 +96,6 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     performerInput.ethnicity = ethnicity;
     performerInput.country = country;
     performerInput.eye_color = eyeColor;
-    performerInput.height = height;
-    performerInput.measurements = measurements;
     performerInput.fake_tits = fakeTits;
     performerInput.career_length = careerLength;
     performerInput.tattoos = tattoos;
@@ -205,8 +201,6 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     setEthnicity(undefined);
     setCountry(undefined);
     setEyeColor(undefined);
-    setHeight(undefined);
-    setMeasurements(undefined);
     setFakeTits(undefined);
     setCareerLength(undefined);
     setTattoos(undefined);
@@ -294,8 +288,6 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           {renderTextField("ethnicity", ethnicity, setEthnicity)}
           {renderTextField("hair_color", hairColor, setHairColor)}
           {renderTextField("eye_color", eyeColor, setEyeColor)}
-          {renderTextField("height", height, setHeight)}
-          {renderTextField("measurements", measurements, setMeasurements)}
           {renderTextField("fake_tits", fakeTits, setFakeTits)}
           {renderTextField("tattoos", tattoos, setTattoos)}
           {renderTextField("piercings", piercings, setPiercings)}


### PR DESCRIPTION
In regards to #1408 this PR adds additional fields to the bulk performer editing dialog.

## Questions
- [x] Some of the fields seem nonsensical to edit in bulk, e.g. URLs, dates. Are these to be changeable just for the consistency or should the dialog be limited to "useful" fields?
- [x] Is it necessary to prefill the fields with the common/undefined value as with favorite or tags? AFAICT this would mean having to fetch this data from all selected performers as it is not included in the `SlimPerformer` set. 

## ToDos
- [x] Gender field
- [x] ~Weight field~

## Preview
![image](https://user-images.githubusercontent.com/98976436/152422937-b8b6a05b-fefc-4ed9-9ed0-dd937568554c.png)

