### PR TITLE
Make changes to fix special characters in Criterion labels (#1819)

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -206,7 +206,10 @@ export function createStringCriterionOption(
 
 export class StringCriterion extends Criterion<string> {
   public getLabelValue() {
-    return this.value;
+    let ret = this.value;
+    ret = StringCriterion.unreplaceSpecialCharacter(ret, "&");
+    ret = StringCriterion.unreplaceSpecialCharacter(ret, "+");
+    return ret;
   }
 
   public encodeValue() {
@@ -219,6 +222,10 @@ export class StringCriterion extends Criterion<string> {
 
   private static replaceSpecialCharacter(str: string, c: string) {
     return str.replaceAll(c, encodeURIComponent(c));
+  }
+
+  private static unreplaceSpecialCharacter(str: string, c: string) {
+    return str.replaceAll(encodeURIComponent(c), c);
   }
 
   constructor(type: CriterionOption) {
@@ -435,7 +442,9 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
   }
 
   public getLabelValue(): string {
-    const labels = (this.value.items ?? []).map((v) => v.label).join(", ");
+    const labels = decodeURI(
+      (this.value.items ?? []).map((v) => v.label).join(", ")
+    );
 
     if (this.value.depth === 0) {
       return labels;


### PR DESCRIPTION
Reverse the '&' and '+' replacement done on StringCriterion
Decodes special characters in IHierarchicalLabeledIdCriterion

Issue #1819 

209-212 just undo what was done during encodeValue().  The downside is that if somebody has %2B in their string it will decode that to a '+' instead of showing '%2B' if that was desired.  Likewise if they have an encoded '&' that they purposefully want.  But that seems rare. This only affects the display of this data.

I also noticed that a more widespread issue was happening with the IHierarchicalLabeledIdCriterion where it was URI encoded in the database but not decoded for display.  So you would see strings like "Bob%20Ross" doing similar steps but with something like filtering by studio.  This fixes that as well.  Again it only alters the display value, nothing in the URL or data passed around for the application.