### PR TITLE
Allow custom UI theme with config file

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -58,11 +58,6 @@ func Start(uiBox embed.FS, loginUIBox embed.FS) {
 		})
 		r.Use(httplog.RequestLogger(httpLogger))
 	}
-	uiPropPath := c.GetUIPropertiesPath()
-	exists, _ := utils.FileExists(uiPropPath)
-	if !exists {
-		c.CreateUIProperties()
-	}
 	r.Use(SecurityHeadersMiddleware)
 	r.Use(middleware.DefaultCompress)
 	r.Use(middleware.StripSlashes)
@@ -211,7 +206,7 @@ func Start(uiBox embed.FS, loginUIBox embed.FS) {
 		}
 
 		if ext == ".html" || ext == "" {
-			themeColor := c.GetUIProperty("theme_color")
+			themeColor := c.GetThemeColor()
 
 			data, err := uiBox.ReadFile(uiRootDir + "/index.html")
 			if err != nil {

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -200,6 +200,8 @@ var (
 	defaultMenuItems         = []string{"scenes", "images", "movies", "markers", "galleries", "performers", "studios", "tags"}
 )
 
+type AppConfigProperties map[string]string
+
 type MissingConfigError struct {
 	missingFields []string
 }
@@ -908,8 +910,6 @@ func (i *Instance) GetCSSPath() string {
 
 	return fn
 }
-
-type AppConfigProperties map[string]string
 
 func ReadPropertiesFile(filename string) (AppConfigProperties, error) {
 	config := AppConfigProperties{}

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -908,6 +908,46 @@ func (i *Instance) GetCSSPath() string {
 	return fn
 }
 
+func (i *Instance) GetUIPropertiesPath() string {
+	// use custom.css in the same directory as the config file
+	configFileUsed := i.GetConfigFile()
+	configDir := filepath.Dir(configFileUsed)
+
+	fn := filepath.Join(configDir, "ui.properties")
+
+	return fn
+}
+
+func (i *Instance) CreateUIProperties() {
+	content := "#menu bar color\ntheme_color=#202b33\n"
+	fn := i.GetUIPropertiesPath()
+	i.Lock()
+	defer i.Unlock()
+
+	buf := []byte(content)
+
+	if err := os.WriteFile(fn, buf, 0777); err != nil {
+		logger.Warnf("error while writing %v bytes to %v: %v", len(buf), fn, err)
+	}
+}
+
+func (i *Instance) GetUIProperty(property string) string {
+	fn := i.GetUIPropertiesPath()
+
+	exists, _ := utils.FileExists(fn)
+	if !exists {
+		return ""
+	}
+
+	prop, err := os.ReadPropertiesFile(fn)
+
+	if err != nil {
+		return ""
+	}
+
+	return prop[property]
+}
+
 func (i *Instance) GetCSS() string {
 	fn := i.GetCSSPath()
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -202,8 +202,6 @@ var (
 	defaultMenuItems         = []string{"scenes", "images", "movies", "markers", "galleries", "performers", "studios", "tags"}
 )
 
-type AppConfigProperties map[string]string
-
 type MissingConfigError struct {
 	missingFields []string
 }

--- a/ui.properties
+++ b/ui.properties
@@ -1,0 +1,2 @@
+#menu bar color
+theme_color=#202b33

--- a/ui/v2.5/index.html
+++ b/ui/v2.5/index.html
@@ -3,7 +3,8 @@
   <head>
     <base href="/">
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" href="favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"

--- a/ui/v2.5/index.html
+++ b/ui/v2.5/index.html
@@ -9,7 +9,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <meta name="theme-color" content="#202b33" />
+    <meta name="theme-color" content="%COLOR%" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Currently, browsers that support menu bar colors use the default Stashblue color. When users modify the styling with their own CSS the same blue Stashmenu bar remains present which gets in the way of custom styling. This pr introduces a `ui.properties` file which at the moment can be used to defined a custom theme color in place of the default Stashblue color. The `ui.properties` file will currently be created in the Stash config directory. The hard coded #202b33 color was moved to that file so it can be overridden. In the future, I imagine this file could be used for other things such as allowing users to provide their own mobile icon or favcon for Stash.