### PR TITLE
Have Gallery info panel say "Downloaded From" next to URL

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
@@ -23,7 +23,7 @@ export const GalleryFileInfoPanel: React.FC<IGalleryFileInfoPanelProps> = (
         truncate
       />
       <URLField
-        id="path"
+        id="media_info.downloaded_from"
         url={props.gallery.url}
         value={props.gallery.url}
         truncate

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -206,7 +206,10 @@ export function createStringCriterionOption(
 
 export class StringCriterion extends Criterion<string> {
   public getLabelValue() {
-    return this.value;
+    let ret = this.value;
+    ret = StringCriterion.unreplaceSpecialCharacter(ret, "&");
+    ret = StringCriterion.unreplaceSpecialCharacter(ret, "+");
+    return ret;
   }
 
   public encodeValue() {
@@ -219,6 +222,10 @@ export class StringCriterion extends Criterion<string> {
 
   private static replaceSpecialCharacter(str: string, c: string) {
     return str.replaceAll(c, encodeURIComponent(c));
+  }
+
+  private static unreplaceSpecialCharacter(str: string, c: string) {
+    return str.replaceAll(encodeURIComponent(c), c);
   }
 
   constructor(type: CriterionOption) {
@@ -435,7 +442,9 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
   }
 
   public getLabelValue(): string {
-    const labels = (this.value.items ?? []).map((v) => v.label).join(", ");
+    const labels = decodeURI(
+      (this.value.items ?? []).map((v) => v.label).join(", ")
+    );
 
     if (this.value.depth === 0) {
       return labels;


### PR DESCRIPTION
In the gallery info panel it says "Path" next to the URL.  This updates it to say "Downloaded From" next to the URL, like it does in the scene view for the URL.