### PR TITLE
True case insensitive regex support

### DIFF
--- a/pkg/manager/exclude_files.go
+++ b/pkg/manager/exclude_files.go
@@ -38,7 +38,7 @@ func excludeFiles(files []string, patterns []string) ([]string, int) {
 
 func matchFileRegex(file string, fileRegexps []*regexp.Regexp) bool {
 	for _, regPattern := range fileRegexps {
-		if regPattern.MatchString(strings.ToLower(file)) {
+		if regPattern.MatchString(file) {
 			return true
 		}
 	}
@@ -60,7 +60,10 @@ func generateRegexps(patterns []string) []*regexp.Regexp {
 	var fileRegexps []*regexp.Regexp
 
 	for _, pattern := range patterns {
-		reg, err := regexp.Compile(strings.ToLower(pattern))
+		if !strings.HasPrefix(pattern, "(?i)") {
+			pattern = "(?i)" + pattern
+		}
+		reg, err := regexp.Compile(pattern)
 		if err != nil {
 			logger.Errorf("Exclude :%v", err)
 		} else {
@@ -78,7 +81,7 @@ func generateRegexps(patterns []string) []*regexp.Regexp {
 
 func matchFileSimple(file string, regExps []*regexp.Regexp) bool {
 	for _, regPattern := range regExps {
-		if regPattern.MatchString(strings.ToLower(file)) {
+		if regPattern.MatchString(file) {
 			return true
 		}
 	}

--- a/pkg/manager/exclude_files_test.go
+++ b/pkg/manager/exclude_files_test.go
@@ -26,7 +26,9 @@ var excludeTestFilenames = []string{
 	"\\\\network\\videos\\filename  windows network.mp4",
 	"\\\\network\\share\\windows network wanted.mp4",
 	"\\\\network\\share\\windows network wanted sample.mp4",
-	"\\\\network\\private\\windows.network.skip.mp4"}
+	"\\\\network\\private\\windows.network.skip.mp4",
+	"/stash/videos/a5.mp4",
+	"/stash/videos/mIxEdCaSe.mp4"}
 
 var excludeTests = []struct {
 	testPattern []string
@@ -42,6 +44,10 @@ var excludeTests = []struct {
 	{[]string{"^\\\\\\\\network"}, 4},                              // windows net share
 	{[]string{"\\\\private\\\\"}, 1},                               // windows net share
 	{[]string{"\\\\private\\\\", "sample\\.mp4"}, 3},               // windows net share
+	{[]string{"\\D\\d\\.mp4"}, 1},                                  // validates that \D doesn't get converted to lowercase \d
+	{[]string{"mixedcase\\.mp4"}, 1},                               // validates we can match the mixed case file
+	{[]string{"MIXEDCASE\\.mp4"}, 1},                               // validates we can match the mixed case file
+	{[]string{"(?i)MIXEDCASE\\.mp4"}, 1},                           // validates we can match the mixed case file without adding another (?i) to it
 }
 
 func TestExcludeFiles(t *testing.T) {


### PR DESCRIPTION
It looks like regular expressions and filenames both were having strings.ToLower applied to them.  There are many special meta-sequences in regex that are upper case and converting them to lower case reverses them.  For instance \D means any non-digit character and the current code was converting it to \d meaning any digit.

To fix this I now prepend (?i) to the beginning of any regex that does not have (?i) at the start already.  This maintains the case insensitivity while allowing uppercase meta-sequences to be used.

I also added some test cases to ensure the functionality.