### PR TITLE
Clamp generator parameters

### DIFF
--- a/pkg/manager/generator.go
+++ b/pkg/manager/generator.go
@@ -114,6 +114,15 @@ func (g *GeneratorInfo) configure() error {
 		return err
 	}
 
+	// #2250 - ensure ChunkCount and ChunkDuration are valid
+	if g.ChunkCount < 1 {
+		logger.Warnf("[generator] Segment count (%d) must be > 0. Using 1 instead.", g.ChunkCount)
+		g.ChunkCount = 1
+	}
+	if g.ChunkDuration < 0.75 {
+		logger.Warnf("[generator] Segment duration (%f) must be >= 0.75. Using 0.75 instead.", g.ChunkDuration)
+		g.ChunkDuration = 0.75
+	}
 	g.NthFrame = g.NumberOfFrames / g.ChunkCount
 
 	return nil

--- a/ui/v2.5/src/components/Settings/GeneratePreviewOptions.tsx
+++ b/ui/v2.5/src/components/Settings/GeneratePreviewOptions.tsx
@@ -47,11 +47,12 @@ export const VideoPreviewInput: React.FC<IVideoPreviewInput> = ({
         <Form.Control
           className="text-input"
           type="number"
-          value={previewSegments?.toString() ?? 0}
+          value={previewSegments?.toString() ?? 1}
+          min={1}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             set({
               previewSegments: Number.parseInt(
-                e.currentTarget.value || "0",
+                e.currentTarget.value || "1",
                 10
               ),
             })


### PR DESCRIPTION
Clamps `ChunkCount` to at least `1` and `ChunkDuration` to at least `0.75` during the `configure` call.

Fixes #2250 