### PR TITLE
Performer tagger modal will load country name instead of code

### DIFF
--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "src/components/Shared";
 import * as GQL from "src/core/generated-graphql";
 import { stringToGender } from "src/utils/gender";
-import country, { getCountryByISO } from "src/utils/country";
+import { getCountryByISO } from "src/utils/country";
 
 interface IPerformerModalProps {
   performer: GQL.ScrapedScenePerformerDataFragment;

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -12,6 +12,7 @@ import {
 } from "src/components/Shared";
 import * as GQL from "src/core/generated-graphql";
 import { stringToGender } from "src/utils/gender";
+import country, { getCountryByISO } from "src/utils/country";
 
 interface IPerformerModalProps {
   performer: GQL.ScrapedScenePerformerDataFragment;
@@ -124,7 +125,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       birthdate: performer.birthdate,
       ethnicity: performer.ethnicity,
       eye_color: performer.eye_color,
-      country: performer.country,
+      country: getCountryByISO(performer.country),
       height: performer.height,
       measurements: performer.measurements,
       fake_tits: performer.fake_tits,
@@ -198,7 +199,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
           {renderField("birthdate", performer.birthdate)}
           {renderField("death_date", performer.death_date)}
           {renderField("ethnicity", performer.ethnicity)}
-          {renderField("country", performer.country)}
+          {renderField("country", getCountryByISO(performer.country))}
           {renderField("hair_color", performer.hair_color)}
           {renderField("eye_color", performer.eye_color)}
           {renderField("height", performer.height)}


### PR DESCRIPTION
When using the performer tagger, it would pull the 2 character country code from StashDB and store that.  It now shows the full country name and stores the full country name instead.  Also verified that it causes no issue with a performer that has no country set on StashDB.