### PR TITLE
Combine system preview generation options

### DIFF
--- a/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
@@ -51,12 +51,14 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
       return;
     }
 
+    // combine the defaults with the system preview generation settings
     if (configuration?.defaults.generate) {
       const { generate } = configuration.defaults;
       setOptions(withoutTypename(generate));
       setConfigRead(true);
-    } else if (configuration?.general) {
-      // backwards compatibility
+    }
+
+    if (configuration?.general) {
       const { general } = configuration;
       setOptions((existing) => ({
         ...existing,

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -111,6 +111,7 @@ export const LibraryTasks: React.FC = () => {
   type DialogOpenState = typeof dialogOpen;
 
   const { configuration } = React.useContext(ConfigurationContext);
+  const [configRead, setConfigRead] = useState(false);
 
   useEffect(() => {
     if (!configuration?.defaults) {
@@ -126,33 +127,41 @@ export const LibraryTasks: React.FC = () => {
       setAutoTagOptions(withoutTypename(autoTag));
     }
 
-    if (configuration?.defaults.generate) {
-      const { generate } = configuration.defaults;
-      setGenerateOptions(withoutTypename(generate));
-    } else if (configuration?.general) {
-      // backwards compatibility
-      const { general } = configuration;
-      setGenerateOptions((existing) => ({
-        ...existing,
-        previewOptions: {
-          ...existing.previewOptions,
-          previewSegments:
-            general.previewSegments ?? existing.previewOptions?.previewSegments,
-          previewSegmentDuration:
-            general.previewSegmentDuration ??
-            existing.previewOptions?.previewSegmentDuration,
-          previewExcludeStart:
-            general.previewExcludeStart ??
-            existing.previewOptions?.previewExcludeStart,
-          previewExcludeEnd:
-            general.previewExcludeEnd ??
-            existing.previewOptions?.previewExcludeEnd,
-          previewPreset:
-            general.previewPreset ?? existing.previewOptions?.previewPreset,
-        },
-      }));
+    // combine the defaults with the system preview generation settings
+    // only do this once
+    if (!configRead) {
+      if (configuration?.defaults.generate) {
+        const { generate } = configuration.defaults;
+        setGenerateOptions(withoutTypename(generate));
+      }
+
+      if (configuration?.general) {
+        const { general } = configuration;
+        setGenerateOptions((existing) => ({
+          ...existing,
+          previewOptions: {
+            ...existing.previewOptions,
+            previewSegments:
+              general.previewSegments ??
+              existing.previewOptions?.previewSegments,
+            previewSegmentDuration:
+              general.previewSegmentDuration ??
+              existing.previewOptions?.previewSegmentDuration,
+            previewExcludeStart:
+              general.previewExcludeStart ??
+              existing.previewOptions?.previewExcludeStart,
+            previewExcludeEnd:
+              general.previewExcludeEnd ??
+              existing.previewOptions?.previewExcludeEnd,
+            previewPreset:
+              general.previewPreset ?? existing.previewOptions?.previewPreset,
+          },
+        }));
+      }
+
+      setConfigRead(true);
     }
-  }, [configuration]);
+  }, [configuration, configRead]);
 
   function setDialogOpen(s: Partial<DialogOpenState>) {
     setDialogOpenState((v) => {


### PR DESCRIPTION
Changes the behaviour of the generation task so that it always uses the Preview Generation settings from the `System` page by default.