### PR TITLE
Add filesize on scene cards, invisibly

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -291,15 +291,18 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     }
   }
 
-  function maybeRenderDupeCopies(){
+  function maybeRenderDupeCopies() {
     if (props.scene.phash) {
       return (
         <div className="other-copies extra-scene-info">
-          <Button href={NavUtils.makeScenesPHashMatchUrl(props.scene.phash)} className="minimal">
-            <Icon icon="copy"/>
+          <Button
+            href={NavUtils.makeScenesPHashMatchUrl(props.scene.phash)}
+            className="minimal"
+          >
+            <Icon icon="copy" />
           </Button>
         </div>
-      )
+      );
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -10,7 +10,7 @@ import {
   SweatDrops,
   TruncatedText,
 } from "src/components/Shared";
-import { TextUtils } from "src/utils";
+import { NavUtils, TextUtils } from "src/utils";
 import { SceneQueue } from "src/models/sceneQueue";
 import { ConfigurationContext } from "src/hooks/Config";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
@@ -99,7 +99,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     return (
       <div className="scene-specs-overlay">
         {sizeObj != null ? (
-          <span className="overlay-filesize">
+          <span className="overlay-filesize extra-scene-info">
             <FormattedNumber
               value={sizeObj.size}
               maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
@@ -291,6 +291,18 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     }
   }
 
+  function maybeRenderDupeCopies(){
+    if (props.scene.phash) {
+      return (
+        <div className="other-copies extra-scene-info">
+          <Button href={NavUtils.makeScenesPHashMatchUrl(props.scene.phash)} className="minimal">
+            <Icon icon="copy"/>
+          </Button>
+        </div>
+      )
+    }
+  }
+
   function maybeRenderPopoverButtonGroup() {
     if (
       !props.compact &&
@@ -313,6 +325,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
             {maybeRenderOCounter()}
             {maybeRenderGallery()}
             {maybeRenderOrganized()}
+            {maybeRenderDupeCopies()}
           </ButtonGroup>
         </>
       );

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -16,6 +16,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
 import { GridCard } from "../Shared/GridCard";
 import { RatingBanner } from "../Shared/RatingBanner";
+import { FormattedNumber } from "react-intl";
 
 interface IScenePreviewProps {
   isPortrait: boolean;
@@ -91,8 +92,25 @@ export const SceneCard: React.FC<ISceneCardProps> = (
     missingStudioImage || (configuration?.interface.showStudioAsText ?? false);
 
   function maybeRenderSceneSpecsOverlay() {
+    let sizeObj = null;
+    if (props.scene.file.size) {
+      sizeObj = TextUtils.fileSize(parseInt(props.scene.file.size));
+    }
     return (
       <div className="scene-specs-overlay">
+        {sizeObj != null ? (
+          <span className="overlay-filesize">
+            <FormattedNumber
+              value={sizeObj.size}
+              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+                sizeObj.unit
+              )}
+            />
+            {TextUtils.formatFileSizeUnit(sizeObj.unit)}
+          </span>
+        ) : (
+          ""
+        )}
         {props.scene.file.width && props.scene.file.height ? (
           <span className="overlay-resolution">
             {" "}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -160,7 +160,7 @@ textarea.scene-description {
   }
 }
 
-.overlay-filesize {
+.extra-scene-info {
   display: none;
 }
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -160,6 +160,10 @@ textarea.scene-description {
   }
 }
 
+.overlay-filesize {
+  display: none;
+}
+
 .overlay-resolution {
   font-weight: 900;
   margin-right: 0.3rem;


### PR DESCRIPTION
This puts filesize on the scene overlay, next to resolution. I find this extremely useful, but the popular sentiment on the discord was low at best, so this is invisible by default. 

To actually use it, you have to add to your custom CSS:

```
.overlay-filesize {
 display: inline
}
```