### PR TITLE
Fix performer tags not applying on scene scrapers

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -840,7 +840,7 @@ func (s mappedScraper) processScene(ctx context.Context, q mappedQuery, r mapped
 			for _, p := range performerTagResults {
 				tag := &models.ScrapedTag{}
 				p.apply(tag)
-				performer.Tags = append(ret.Tags, tag)
+				performer.Tags = append(performer.Tags, tag)
 			}
 
 			ret.Performers = append(ret.Performers, performer)

--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -840,7 +840,7 @@ func (s mappedScraper) processScene(ctx context.Context, q mappedQuery, r mapped
 			for _, p := range performerTagResults {
 				tag := &models.ScrapedTag{}
 				p.apply(tag)
-				ret.Tags = append(ret.Tags, tag)
+				performer.Tags = append(ret.Tags, tag)
 			}
 
 			ret.Performers = append(ret.Performers, performer)


### PR DESCRIPTION
Given a scraper such as

```
name: Tester
sceneByFragment:
  action: scrapeXPath
  queryURL: https://stashapp.cc/
  scraper: sceneScraper
xPathScrapers:
  sceneScraper:
    scene:
      Title: //meta[@property='og:site_name']/@content
      Performers:
        Name:
          fixed: Performer
        Tags:
          Name:
            fixed: example
```

The tag "example" would be applied to the scene and not the performer. This PR fixes that behaviour so the tag is applied on the performer instead as galleries do.