### PR TITLE
Remove generate preview options from tasks page

### DIFF
--- a/ui/v2.5/src/components/Settings/Inputs.tsx
+++ b/ui/v2.5/src/components/Settings/Inputs.tsx
@@ -192,6 +192,7 @@ export const ChangeButtonSetting = <T extends {}>(props: IDialogSetting<T>) => {
     id,
     className,
     headingID,
+    tooltipID,
     subHeadingID,
     subHeading,
     value,
@@ -203,12 +204,15 @@ export const ChangeButtonSetting = <T extends {}>(props: IDialogSetting<T>) => {
   } = props;
   const intl = useIntl();
 
+  const tooltip = tooltipID ? intl.formatMessage({ id: tooltipID }) : undefined;
   const disabledClassName = disabled ? "disabled" : "";
 
   return (
     <div className={`setting ${className ?? ""} ${disabledClassName}`} id={id}>
       <div>
-        <h3>{headingID ? intl.formatMessage({ id: headingID }) : undefined}</h3>
+        <h3 title={tooltip}>
+          {headingID ? intl.formatMessage({ id: headingID }) : undefined}
+        </h3>
 
         <div className="value">
           {renderValue ? renderValue(value) : undefined}
@@ -320,6 +324,7 @@ export const ModalSetting = <T extends {}>(props: IModalSetting<T>) => {
     onChange,
     renderField,
     renderValue,
+    tooltipID,
     buttonText,
     buttonTextID,
     modalProps,
@@ -351,6 +356,7 @@ export const ModalSetting = <T extends {}>(props: IModalSetting<T>) => {
         buttonText={buttonText}
         buttonTextID={buttonTextID}
         headingID={headingID}
+        tooltipID={tooltipID}
         subHeadingID={subHeadingID}
         subHeading={subHeading}
         value={value}

--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -5,7 +5,6 @@ import {
   VideoPreviewInput,
   VideoPreviewSettingsInput,
 } from "../GeneratePreviewOptions";
-import { useIntl } from "react-intl";
 
 interface IGenerateOptions {
   selection?: boolean;
@@ -18,8 +17,6 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
   options,
   setOptions: setOptionsState,
 }) => {
-  const intl = useIntl();
-
   const previewOptions: GQL.GeneratePreviewOptionsInput =
     options.previewOptions ?? {};
 
@@ -46,27 +43,29 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
         onChange={(v) => setOptions({ imagePreviews: v })}
       />
 
-      <ModalSetting<VideoPreviewSettingsInput>
-        id="video-preview-settings"
-        className="sub-setting"
-        disabled={!options.previews}
-        buttonText={`${intl.formatMessage({
-          id: "dialogs.scene_gen.preview_generation_options",
-        })}…`}
-        value={{
-          previewExcludeEnd: previewOptions.previewExcludeEnd,
-          previewExcludeStart: previewOptions.previewExcludeStart,
-          previewSegmentDuration: previewOptions.previewSegmentDuration,
-          previewSegments: previewOptions.previewSegments,
-        }}
-        onChange={(v) => setOptions({ previewOptions: v })}
-        renderField={(value, setValue) => (
-          <VideoPreviewInput value={value ?? {}} setValue={setValue} />
-        )}
-        renderValue={() => {
-          return <></>;
-        }}
-      />
+      {/* #2251 - only allow preview generation options to be overridden when generating from a selection */}
+      {selection ? (
+        <ModalSetting<VideoPreviewSettingsInput>
+          id="video-preview-settings"
+          className="sub-setting"
+          disabled={!options.previews}
+          headingID="dialogs.scene_gen.override_preview_generation_options"
+          tooltipID="dialogs.scene_gen.override_preview_generation_options_desc"
+          value={{
+            previewExcludeEnd: previewOptions.previewExcludeEnd,
+            previewExcludeStart: previewOptions.previewExcludeStart,
+            previewSegmentDuration: previewOptions.previewSegmentDuration,
+            previewSegments: previewOptions.previewSegments,
+          }}
+          onChange={(v) => setOptions({ previewOptions: v })}
+          renderField={(value, setValue) => (
+            <VideoPreviewInput value={value ?? {}} setValue={setValue} />
+          )}
+          renderValue={() => {
+            return <></>;
+          }}
+        />
+      ) : undefined}
 
       <BooleanSetting
         id="sprite-task"

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -606,6 +606,8 @@
       "marker_screenshots_tooltip": "Marker static JPG images, only required if Preview Type is set to Static Image.",
       "markers": "Marker Previews",
       "markers_tooltip": "20 second videos which begin at the given timecode.",
+      "override_preview_generation_options": "Override Preview Generation Options",
+      "override_preview_generation_options_desc": "Override Preview Generation Options for this operation. Defaults are set in System -> Preview Generation.",
       "overwrite": "Overwrite existing generated files",
       "phash": "Perceptual hashes (for deduplication)",
       "preview_exclude_end_time_desc": "Exclude the last x seconds from scene previews. This can be a value in seconds, or a percentage (eg 2%) of the total scene duration.",


### PR DESCRIPTION
Resolves #2251 

Removes the generate preview options button from the Tasks -> Generate page since it causes confusion and there is no real use case for it. The valid use cases for overriding the generate options are only really via the generate dialog. Running from the tasks page will use the options specified in the System page.

Changes the generate dialog so that the override generation options button is clearer about what it will do:

![image](https://user-images.githubusercontent.com/53250216/155423332-f613ce6d-3d28-461e-be1f-ee2f5ff366e5.png)

Adds a tooltip indicating that the preview options will be changed for this operation only. 