### PR TITLE
Remove single unicode character from autotag query

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,9 +35,10 @@ func main() {
 	manager.Initialize()
 	api.Start(uiBox, loginUIBox)
 
-	// stop any profiling at exit
-	defer pprof.StopCPUProfile()
 	blockForever()
+
+	// stop any profiling at exit
+	pprof.StopCPUProfile()
 
 	manager.GetInstance().Shutdown(0)
 }

--- a/pkg/match/path.go
+++ b/pkg/match/path.go
@@ -71,11 +71,21 @@ func getPathWords(path string) []string {
 // nameMatchesPath returns the index in the path for the right-most match.
 // Returns -1 if not found.
 func nameMatchesPath(name, path string) int {
+	re := nameToRegexp(name)
+	found := re.FindAllStringIndex(path, -1)
+
+	if found == nil {
+		return -1
+	}
+
+	return found[len(found)-1][0]
+}
+
+func nameToRegexp(name string) *regexp.Regexp {
 	// escape specific regex characters
 	name = regexp.QuoteMeta(name)
 
 	name = strings.ToLower(name)
-	path = strings.ToLower(path)
 
 	// handle path separators
 	const separator = `[` + separatorChars + `]`
@@ -84,12 +94,15 @@ func nameMatchesPath(name, path string) int {
 	reStr = `(?:^|_|[^\p{L}\w\d])` + reStr + `(?:$|_|[^\p{L}\w\d])`
 
 	re := regexp.MustCompile(reStr)
-	found := re.FindAllStringIndex(path, -1)
+	return re
+}
 
+func regexpMatchesPath(r *regexp.Regexp, path string) int {
+	path = strings.ToLower(path)
+	found := r.FindAllStringIndex(path, -1)
 	if found == nil {
 		return -1
 	}
-
 	return found[len(found)-1][0]
 }
 
@@ -208,8 +221,9 @@ func PathToScenes(name string, paths []string, sceneReader models.SceneReader) (
 	}
 
 	var ret []*models.Scene
+	r := nameToRegexp(name)
 	for _, p := range scenes {
-		if nameMatchesPath(name, p.Path) != -1 {
+		if regexpMatchesPath(r, p.Path) != -1 {
 			ret = append(ret, p)
 		}
 	}
@@ -240,8 +254,9 @@ func PathToImages(name string, paths []string, imageReader models.ImageReader) (
 	}
 
 	var ret []*models.Image
+	r := nameToRegexp(name)
 	for _, p := range images {
-		if nameMatchesPath(name, p.Path) != -1 {
+		if regexpMatchesPath(r, p.Path) != -1 {
 			ret = append(ret, p)
 		}
 	}
@@ -272,8 +287,9 @@ func PathToGalleries(name string, paths []string, galleryReader models.GalleryRe
 	}
 
 	var ret []*models.Gallery
+	r := nameToRegexp(name)
 	for _, p := range gallerys {
-		if nameMatchesPath(name, p.Path.String) != -1 {
+		if regexpMatchesPath(r, p.Path.String) != -1 {
 			ret = append(ret, p)
 		}
 	}

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -21,7 +21,11 @@ WHERE performers_tags.tag_id = ?
 GROUP BY performers_tags.performer_id
 `
 
-const singleFirstCharacterRegex = `^[\w\p{L}][.\-_ ]`
+// KNOWN ISSUE: using \p{L} to find single unicode character names results in
+// very slow queries.
+// Suggested solution will be to cache single-character names and not include it
+// in the autotag query.
+const singleFirstCharacterRegex = `^[\w][.\-_ ]`
 
 type performerQueryBuilder struct {
 	repository


### PR DESCRIPTION
Fix for slow autotag performance. 

The inclusion of `\p{L}` in the performer/tag/studio autotag query slows it significantly. Reverted to use `\w` only.

This reopens #2293 with a known issue that autotag will now miss performer/tag/studios including a single unicode character word in the title. It's a very minor corner case, but an issue nonetheless.

The eventual solution will be to query for single character objects up front in the autotag task and cache them, instead of querying for them every time.