### PR TITLE
Use case-insensitive matching in nameMatchesPath

### DIFF
--- a/pkg/match/path.go
+++ b/pkg/match/path.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stashapp/stash/pkg/image"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scene"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 const (
@@ -62,7 +63,7 @@ func getPathWords(path string) []string {
 			// just use the first two characters
 			// #2293 - need to convert to unicode runes for the substring, otherwise
 			// the resulting string is corrupted.
-			ret = append(ret, string([]rune(w)[0:2]))
+			ret = utils.StrAppendUnique(ret, string([]rune(w)[0:2]))
 		}
 	}
 
@@ -85,13 +86,7 @@ func nameMatchesPath(name, path string) int {
 	// #2363 - optimisation: only use unicode character regexp if path contains
 	// unicode characters
 	re := nameToRegexp(name, !allASCII(path))
-	found := re.FindAllStringIndex(path, -1)
-
-	if found == nil {
-		return -1
-	}
-
-	return found[len(found)-1][0]
+	return regexpMatchesPath(re, path)
 }
 
 // nameToRegexp compiles a regexp pattern to match paths from the given name.

--- a/pkg/match/path_test.go
+++ b/pkg/match/path_test.go
@@ -55,6 +55,12 @@ func Test_nameMatchesPath(t *testing.T) {
 			6,
 		},
 		{
+			"within string case insensitive",
+			name,
+			"before FIRST last/after",
+			6,
+		},
+		{
 			"not within string",
 			name,
 			"beforefirst last/after",

--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -1,3 +1,6 @@
 ### 🎨 Improvements
 * Allow customisation of UI theme color using `theme_color` property in `config.yml` ([#2365](https://github.com/stashapp/stash/pull/2365))
 * Improved autotag performance. ([#2368](https://github.com/stashapp/stash/pull/2368))
+
+### 🐛 Bug fixes
+* Fix auto-tag not using case-insensitive matching. ([#2378](https://github.com/stashapp/stash/pull/2378))


### PR DESCRIPTION
Fixes #2377 

Also ensures that only unique words are returned in getPathWords.

This should probably be a candidate for a 0.13.1 hotfix release.