### PR TITLE
Order gallery images by path

### DIFF
--- a/internal/api/resolver_model_gallery.go
+++ b/internal/api/resolver_model_gallery.go
@@ -26,7 +26,10 @@ func (r *galleryResolver) Title(ctx context.Context, obj *models.Gallery) (*stri
 func (r *galleryResolver) Images(ctx context.Context, obj *models.Gallery) (ret []*models.Image, err error) {
 	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
 		var err error
-		ret, err = repo.Image().FindByGalleryID(obj.ID)
+
+		// #2376 - sort images by path
+		ret, err = image.FindByGalleryID(repo.Image(), obj.ID, "path", models.SortDirectionEnumAsc)
+
 		return err
 	}); err != nil {
 		return nil, err
@@ -37,7 +40,7 @@ func (r *galleryResolver) Images(ctx context.Context, obj *models.Gallery) (ret 
 
 func (r *galleryResolver) Cover(ctx context.Context, obj *models.Gallery) (ret *models.Image, err error) {
 	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
-		imgs, err := repo.Image().FindByGalleryID(obj.ID)
+		imgs, err := image.FindByGalleryID(repo.Image(), obj.ID, "", "")
 		if err != nil {
 			return err
 		}

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -68,3 +68,26 @@ func CountByTagID(r models.ImageReader, id int) (int, error) {
 
 	return r.QueryCount(filter, nil)
 }
+
+func FindByGalleryID(r models.ImageReader, galleryID int, sortBy string, sortDir models.SortDirectionEnum) ([]*models.Image, error) {
+	perPage := -1
+
+	findFilter := models.FindFilterType{
+		PerPage: &perPage,
+	}
+
+	if sortBy != "" {
+		findFilter.Sort = &sortBy
+	}
+
+	if sortDir.IsValid() {
+		findFilter.Direction = &sortDir
+	}
+
+	return Query(r, &models.ImageFilterType{
+		Galleries: &models.MultiCriterionInput{
+			Value:    []string{strconv.Itoa(galleryID)},
+			Modifier: models.CriterionModifierIncludes,
+		},
+	}, &findFilter)
+}


### PR DESCRIPTION
Changes `gallery.Images` resolver to query using the `Query` function and to sort by path.

Fixes #2376 