### PR TITLE
Scroll to next image using lightbox

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -1,4 +1,5 @@
 ### 🎨 Improvements
+* Image lightbox now transitions to next/previous image when scrolling in pan-Y mode. ([#2403](https://github.com/stashapp/stash/pull/2403))
 * Allow customisation of UI theme color using `theme_color` property in `config.yml` ([#2365](https://github.com/stashapp/stash/pull/2365))
 * Improved autotag performance. ([#2368](https://github.com/stashapp/stash/pull/2368))
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -89,6 +89,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [updateImage] = useImageUpdate();
 
   const [index, setIndex] = useState<number | null>(null);
+  const [movingLeft, setMovingLeft] = useState(false);
   const oldIndex = useRef<number | null>(null);
   const [instantTransition, setInstantTransition] = useState(false);
   const [isSwitchingPage, setIsSwitchingPage] = useState(true);
@@ -261,6 +262,8 @@ export const LightboxComponent: React.FC<IProps> = ({
     (isUserAction = true) => {
       if (isSwitchingPage || index === -1) return;
 
+      setMovingLeft(true);
+
       if (index === 0) {
         // go to next page, or loop back if no callback is set
         if (pageCallback) {
@@ -280,6 +283,8 @@ export const LightboxComponent: React.FC<IProps> = ({
   const handleRight = useCallback(
     (isUserAction = true) => {
       if (isSwitchingPage) return;
+
+      setMovingLeft(false);
 
       if (index === images.length - 1) {
         // go to preview page, or loop back if no callback is set
@@ -685,6 +690,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                   scrollMode={scrollMode}
                   onLeft={handleLeft}
                   onRight={handleRight}
+                  alignBottom={movingLeft}
                   zoom={i === currentIndex ? zoom : 1}
                   setZoom={(v) => setZoom(v)}
                   resetPosition={resetPosition}

--- a/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
@@ -24,6 +24,8 @@ interface IProps {
   scrollMode: ScrollMode;
   resetPosition?: boolean;
   zoom: number;
+  // set to true to align image with bottom instead of top
+  alignBottom?: boolean;
   setZoom: (v: number) => void;
   onLeft: () => void;
   onRight: () => void;
@@ -36,6 +38,7 @@ export const LightboxImage: React.FC<IProps> = ({
   displayMode,
   scaleUp,
   scrollMode,
+  alignBottom,
   zoom,
   setZoom,
   resetPosition,
@@ -132,37 +135,45 @@ export const LightboxImage: React.FC<IProps> = ({
       newPositionY = Math.min((boxHeight - height) / 2, 0);
     } else {
       // otherwise, align top of image with container
-      newPositionY = Math.min((height * newZoom - height) / 2, 0);
+      if (!alignBottom) {
+        newPositionY = Math.min((height * newZoom - height) / 2, 0);
+      } else {
+        newPositionY = boxHeight - height * newZoom;
+      }
     }
 
     setDefaultZoom(newZoom);
     setPositionX(newPositionX);
     setPositionY(newPositionY);
-  }, [width, height, boxWidth, boxHeight, displayMode, scaleUp]);
+  }, [width, height, boxWidth, boxHeight, displayMode, scaleUp, alignBottom]);
 
-  const calculateTopPosition = useCallback(() => {
+  const calculateInitialPosition = useCallback(() => {
     // Center image from container's center
     const newPositionX = Math.min((boxWidth - width) / 2, 0);
     let newPositionY: number;
 
     if (zoom * defaultZoom * height > boxHeight) {
-      newPositionY = (height * zoom * defaultZoom - height) / 2;
+      if (!alignBottom) {
+        newPositionY = (height * zoom * defaultZoom - height) / 2;
+      } else {
+        newPositionY = boxHeight - height * zoom * defaultZoom;
+      }
     } else {
       newPositionY = Math.min((boxHeight - height) / 2, 0);
     }
 
     return [newPositionX, newPositionY];
-  }, [boxWidth, width, boxHeight, height, zoom, defaultZoom]);
+  }, [boxWidth, width, boxHeight, height, zoom, defaultZoom, alignBottom]);
 
   useEffect(() => {
     if (resetPosition !== resetPositionRef.current) {
       resetPositionRef.current = resetPosition;
 
-      const [x, y] = calculateTopPosition();
+      const [x, y] = calculateInitialPosition();
       setPositionX(x);
       setPositionY(y);
     }
-  }, [resetPosition, resetPositionRef, calculateTopPosition]);
+  }, [resetPosition, resetPositionRef, calculateInitialPosition]);
 
   function getScrollMode(ev: React.WheelEvent<HTMLDivElement>) {
     if (ev.shiftKey) {


### PR DESCRIPTION
When scrolling using "pan Y" mode, when scrolling past the end of an image, it will now transition to the next image. Similarly, scrolling up past the top of an image will now move to the previous image, and align the bottom of the image with the bottom of the page - this is similar to how CDisplayEx does it.

Resolves #2389 (with setting persistence being added in a separate PR).