### PR TITLE
Use first sorted by path image as cover by default

### DIFF
--- a/internal/api/resolver_model_gallery.go
+++ b/internal/api/resolver_model_gallery.go
@@ -40,7 +40,8 @@ func (r *galleryResolver) Images(ctx context.Context, obj *models.Gallery) (ret 
 
 func (r *galleryResolver) Cover(ctx context.Context, obj *models.Gallery) (ret *models.Image, err error) {
 	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
-		imgs, err := image.FindByGalleryID(repo.Image(), obj.ID, "", "")
+		// #2376 - use first image (sorted by path) if no cover is present
+		imgs, err := image.FindByGalleryID(repo.Image(), obj.ID, "path", models.SortDirectionEnumAsc)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #2376 

If no `cover.jpg` was present, then the first image in the gallery is used as the cover. Without sorting, this was based on insertion order. Changed to sort by path to be consistent with previous behaviour.