### PR TITLE
Don't include stash_ids if not setting

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -4,6 +4,7 @@
 * Improved autotag performance. ([#2368](https://github.com/stashapp/stash/pull/2368))
 
 ### 🐛 Bug fixes
+* Fix error saving a scene from the tagger when the scene has stash ids. ([#2408](https://github.com/stashapp/stash/pull/2408))
 * Perform tag pattern exclusion on stash-box sources. ([#2391](https://github.com/stashapp/stash/pull/2391))
 * Don't generate jpg thumbnails for animated webp files. ([#2388](https://github.com/stashapp/stash/pull/2388))
 * Removed warnings and incorrect error message in json scrapers. ([#2375](https://github.com/stashapp/stash/pull/2375))

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -339,6 +339,9 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
           stash_id: scene.remote_site_id,
         },
       ];
+    } else {
+      // #2348 - don't include stash_ids if we're not setting them
+      delete sceneCreateInput.stash_ids;
     }
 
     await saveScene(sceneCreateInput, includeStashID);


### PR DESCRIPTION
Fixes #2348 

Changed so that stash_ids are not included if they are not being set during the save operation in the scene tagger. 