### PR TITLE
Videojs big buttons

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -8,6 +8,7 @@ import "./live";
 import "./PlaylistButtons";
 import "./persist-volume";
 import "./markers";
+import "./big-buttons";
 import cx from "classnames";
 
 import * as GQL from "src/core/generated-graphql";
@@ -166,6 +167,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     (player as any).markers();
     (player as any).offset();
     (player as any).persistVolume();
+    (player as any).bigButtons();
 
     player.focus();
     playerRef.current = player;
@@ -314,6 +316,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     });
 
     player.on("play", function (this: VideoJsPlayer) {
+      player.poster("");
       if (scene.interactive) {
         interactiveClient.play(this.currentTime());
       }

--- a/ui/v2.5/src/components/ScenePlayer/big-buttons.ts
+++ b/ui/v2.5/src/components/ScenePlayer/big-buttons.ts
@@ -1,0 +1,54 @@
+import videojs, { VideoJsPlayer } from "video.js";
+
+const BigPlayButton = videojs.getComponent("BigPlayButton");
+
+class BigPlayPauseButton extends BigPlayButton {
+  handleClick(event: videojs.EventTarget.Event) {
+    if (this.player().paused()) {
+      // @ts-ignore for some reason handleClick isn't defined in BigPlayButton type. Not sure why
+      super.handleClick(event);
+    } else {
+      this.player().pause();
+    }
+  }
+
+  buildCSSClass() {
+    return "vjs-control vjs-button vjs-big-play-pause-button";
+  }
+}
+
+class BigButtonGroup extends videojs.getComponent("Component") {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  constructor(player: VideoJsPlayer, options: any) {
+    super(player, options);
+
+    this.addChild("seekButton", {
+      direction: "back",
+      seconds: 10,
+    });
+
+    this.addChild("BigPlayPauseButton");
+
+    this.addChild("seekButton", {
+      direction: "forward",
+      seconds: 10,
+    });
+  }
+
+  createEl() {
+    return super.createEl("div", {
+      className: "vjs-big-button-group",
+    });
+  }
+}
+
+const bigButtons = function (this: VideoJsPlayer) {
+  this.addChild("BigButtonGroup");
+};
+
+// Register the plugin with video.js.
+videojs.registerComponent("BigButtonGroup", BigButtonGroup);
+videojs.registerComponent("BigPlayPauseButton", BigPlayPauseButton);
+videojs.registerPlugin("bigButtons", bigButtons);
+
+export default bigButtons;

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -35,35 +35,82 @@ $sceneTabWidth: 450px;
     opacity: 0;
   }
 
+  .vjs-big-button-group {
+    display: none;
+    height: 50px;
+    justify-content: space-between;
+    opacity: 0;
+    padding: 0 10px;
+    position: absolute;
+    top: calc(50% - 25px);
+    width: 100%;
+
+    .vjs-button {
+      font-size: 2em;
+      height: 100%;
+      width: 50px;
+
+      .vjs-icon-placeholder::before {
+        line-height: 1.5;
+      }
+    }
+  }
+
   .vjs-touch-enabled {
     margin: 0 -15px;
     width: 100vw;
 
-    &:hover.vjs-user-active {
-      .vjs-button {
-        pointer-events: auto;
-      }
+    &.vjs-has-started .vjs-big-button-group {
+      display: flex;
+      opacity: 1;
+      visibility: visible;
+    }
+
+    &.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-big-button-group {
+      opacity: 0;
+      pointer-events: none;
+      transition: visibility 1s, opacity 1s;
+      visibility: visible;
+    }
+
+    .vjs-big-play-pause-button .vjs-icon-placeholder::before {
+      content: "\f101";
+      font-family: VideoJS;
+    }
+
+    &.vjs-playing .vjs-big-play-pause-button .vjs-icon-placeholder::before {
+      content: "\f103";
+    }
+
+    // hide the regular play/pause button on touch screens
+    .vjs-play-control {
+      display: none;
+    }
+
+    // hide the regular seek buttons on touch screens
+    .vjs-control-bar .vjs-seek-button {
+      display: none;
     }
 
     // make controls a little more compact on smaller screens
     @media (max-width: 576px) {
       .vjs-control-bar {
         height: 2.5em;
-      }
 
-      .vjs-control-bar .vjs-control:not(.vjs-progress-control) {
-        width: 2.5em;
+        .vjs-control:not(.vjs-progress-control) {
+          width: 2.5em;
+        }
+
+        .vjs-button > .vjs-icon-placeholder::before,
+        .vjs-skip-button::before {
+          font-size: 1.5em;
+          line-height: 2;
+        }
       }
 
       .vjs-time-control {
         font-size: 12px;
         line-height: 4em;
-      }
-
-      .vjs-button > .vjs-icon-placeholder::before,
-      .vjs-skip-button::before {
-        font-size: 1.5em;
-        line-height: 2;
       }
     }
 
@@ -83,8 +130,6 @@ $sceneTabWidth: 450px;
 
     /* Scales control size */
     font-size: 15px;
-    opacity: 0;
-    transition: opacity 0.25s cubic-bezier(0, 0, 0.2, 1);
 
     &::before {
       background: linear-gradient(
@@ -117,13 +162,6 @@ $sceneTabWidth: 450px;
 
   .vjs-remaining-time {
     display: none;
-  }
-
-  &:hover,
-  &.vjs-paused {
-    .vjs-control-bar {
-      opacity: 1;
-    }
   }
 
   .vjs-progress-control {
@@ -433,4 +471,22 @@ $sceneTabWidth: 450px;
   top: -5.4em;
   width: 160px;
   z-index: 1;
+}
+
+.VideoPlayer
+  .video-js
+  .vjs-seek-button.skip-back
+  span.vjs-icon-placeholder::before {
+  -ms-transform: none;
+  -webkit-transform: none;
+  transform: none;
+}
+
+.VideoPlayer
+  .video-js
+  .vjs-seek-button.skip-forward
+  span.vjs-icon-placeholder::before {
+  -ms-transform: scale(-1, 1);
+  -webkit-transform: scale(-1, 1);
+  transform: scale(-1, 1);
 }

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -37,21 +37,21 @@ $sceneTabWidth: 450px;
 
   .vjs-big-button-group {
     display: none;
-    height: 50px;
-    justify-content: space-between;
+    height: 80px;
+    justify-content: space-around;
     opacity: 0;
-    padding: 0 10px;
     position: absolute;
-    top: calc(50% - 25px);
+    top: calc(50% - 40px);
     width: 100%;
 
     .vjs-button {
-      font-size: 2em;
+      font-size: 4em;
       height: 100%;
-      width: 50px;
+      width: 80px;
 
       .vjs-icon-placeholder::before {
-        line-height: 1.5;
+        height: 100%;
+        line-height: 80px;
       }
     }
   }
@@ -111,6 +111,11 @@ $sceneTabWidth: 450px;
       .vjs-time-control {
         font-size: 12px;
         line-height: 4em;
+      }
+
+      .vjs-big-button-group .vjs-button {
+        font-size: 2em;
+        width: 50px;
       }
     }
 

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -91,32 +91,30 @@ $sceneTabWidth: 450px;
     .vjs-control-bar .vjs-seek-button {
       display: none;
     }
+  }
 
-    // make controls a little more compact on smaller screens
-    @media (max-width: 576px) {
-      .vjs-control-bar {
-        height: 2.5em;
-
-        .vjs-control:not(.vjs-progress-control) {
-          width: 2.5em;
-        }
-
-        .vjs-button > .vjs-icon-placeholder::before,
-        .vjs-skip-button::before {
-          font-size: 1.5em;
-          line-height: 2;
-        }
+  // make controls a little more compact on smaller screens
+  @media (max-width: 576px) {
+    .vjs-control-bar {
+      .vjs-control:not(.vjs-progress-control) {
+        width: 2.5em;
       }
 
-      .vjs-time-control {
-        font-size: 12px;
-        line-height: 4em;
+      .vjs-button > .vjs-icon-placeholder::before,
+      .vjs-skip-button::before {
+        font-size: 1.5em;
+        line-height: 2;
       }
+    }
 
-      .vjs-big-button-group .vjs-button {
-        font-size: 2em;
-        width: 50px;
-      }
+    .vjs-time-control {
+      font-size: 12px;
+      line-height: 4em;
+    }
+
+    .vjs-big-button-group .vjs-button {
+      font-size: 2em;
+      width: 50px;
     }
 
     .vjs-current-time {


### PR DESCRIPTION
Adds big play/pause button and skip forward/backward buttons when control bar is visible on touch devices. Restores similar functionality to jwplayer where control bar is shown and dismissed with a tap. The play and skip buttons are removed from the control bar when the big buttons are visible.

![image](https://user-images.githubusercontent.com/53250216/161006230-b31189a9-7f5e-4dc3-8090-166c8fb079ed.png)
![image](https://user-images.githubusercontent.com/53250216/161004639-fe35cab0-60d5-4d49-b3d7-921d3c67fea2.png)
