### PR TITLE
Fix lightbox issues

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -1,3 +1,5 @@
+##### 💥 Note: Image Slideshow Delay (in Interface Settings) is now in seconds rather than milliseconds and has not been converted. Please adjust your settings as needed.
+
 ### ✨ New Features
 * Add python location in System Settings for script scrapers and plugins. ([#2409](https://github.com/stashapp/stash/pull/2409))
 

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -65,6 +65,8 @@ interface IImageListImages {
   onChangePage: (page: number) => void;
   pageCount: number;
   onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+  slideshowRunning: boolean;
+  setSlideshowRunning: (running: boolean) => void;
 }
 
 const ImageListImages: React.FC<IImageListImages> = ({
@@ -74,8 +76,9 @@ const ImageListImages: React.FC<IImageListImages> = ({
   onChangePage,
   pageCount,
   onSelectChange,
+  slideshowRunning,
+  setSlideshowRunning,
 }) => {
-  const [slideshowRunning, setSlideshowRunning] = useState<boolean>(false);
   const handleLightBoxPage = useCallback(
     (direction: number) => {
       if (direction === -1) {
@@ -125,7 +128,7 @@ const ImageListImages: React.FC<IImageListImages> = ({
       setSlideshowRunning(true);
       showLightbox(index, true);
     },
-    [showLightbox]
+    [showLightbox, setSlideshowRunning]
   );
 
   function onPreview(index: number, ev: MouseEvent) {
@@ -197,6 +200,7 @@ export const ImageList: React.FC<IImageList> = ({
   const history = useHistory();
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
+  const [slideshowRunning, setSlideshowRunning] = useState<boolean>(false);
 
   const otherOperations = (extraOperations ?? []).concat([
     {
@@ -336,6 +340,8 @@ export const ImageList: React.FC<IImageList> = ({
         onSelectChange={selectChange}
         pageCount={pageCount}
         selectedIds={selectedIds}
+        slideshowRunning={slideshowRunning}
+        setSlideshowRunning={setSlideshowRunning}
       />
     );
   }

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -151,10 +151,12 @@ export const LightboxComponent: React.FC<IProps> = ({
     ? config.interface.imageLightbox.slideshowDelay * SECONDS_TO_MS
     : undefined;
 
+  const savedDelay = lightboxSettings?.slideshowDelay
+    ? lightboxSettings.slideshowDelay * SECONDS_TO_MS
+    : undefined;
+
   const slideshowDelay =
-    lightboxSettings?.slideshowDelay ??
-    configuredDelay ??
-    DEFAULT_SLIDESHOW_DELAY;
+    savedDelay ?? configuredDelay ?? DEFAULT_SLIDESHOW_DELAY;
 
   function setSlideshowDelay(v: number) {
     setLightboxSettings({ slideshowDelay: v });
@@ -413,7 +415,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         ? numberValue
         : MIN_VALID_INTERVAL_SECONDS;
 
-    setSlideshowDelay(numberValue * SECONDS_TO_MS);
+    setSlideshowDelay(numberValue);
 
     if (slideshowInterval !== null) {
       setSlideshowInterval(numberValue * SECONDS_TO_MS);

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -422,145 +422,140 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const currentIndex = index === null ? initialIndex : index;
 
-  const OptionsForm: React.FC<{}> = () => (
-    <>
-      {slideshowEnabled ? (
-        <Form.Group controlId="delay" as={Row} className="form-container">
-          <Col xs={4}>
-            <Form.Label className="col-form-label">
-              <FormattedMessage id="dialogs.lightbox.delay" />
-            </Form.Label>
-          </Col>
-          <Col xs={8}>
-            <Form.Control
-              type="number"
-              className="text-input"
-              min={1}
-              value={displayedSlideshowInterval ?? 0}
-              onChange={onDelayChange}
-              size="sm"
-            />
-          </Col>
-        </Form.Group>
-      ) : undefined}
+  // #2451: making OptionsForm an inline component means it
+  // get re-rendered each time. This makes the text
+  // field lose focus on input. Use function instead.
+  function renderOptionsForm() {
+    return (
+      <>
+        {slideshowEnabled ? (
+          <Form.Group controlId="delay" as={Row} className="form-container">
+            <Col xs={4}>
+              <Form.Label className="col-form-label">
+                <FormattedMessage id="dialogs.lightbox.delay" />
+              </Form.Label>
+            </Col>
+            <Col xs={8}>
+              <Form.Control
+                type="number"
+                className="text-input"
+                min={1}
+                value={displayedSlideshowInterval ?? 0}
+                onChange={onDelayChange}
+                size="sm"
+              />
+            </Col>
+          </Form.Group>
+        ) : undefined}
 
-      <Form.Group controlId="displayMode" as={Row}>
-        <Col xs={4}>
-          <Form.Label className="col-form-label">
-            <FormattedMessage id="dialogs.lightbox.display_mode.label" />
-          </Form.Label>
-        </Col>
-        <Col xs={8}>
-          <Form.Control
-            as="select"
-            onChange={(e) =>
-              setDisplayMode(e.target.value as GQL.ImageLightboxDisplayMode)
-            }
-            value={displayMode}
-            className="btn-secondary mx-1 mb-1"
-          >
-            {Array.from(imageLightboxDisplayModeIntlMap.entries()).map((v) => (
-              <option key={v[0]} value={v[0]}>
-                {intl.formatMessage({
-                  id: v[1],
-                })}
-              </option>
-            ))}
-          </Form.Control>
-        </Col>
-      </Form.Group>
-      <Form.Group>
-        <Form.Group controlId="scaleUp" as={Row} className="mb-1">
-          <Col>
-            <Form.Check
-              type="checkbox"
-              label={intl.formatMessage({
-                id: "dialogs.lightbox.scale_up.label",
-              })}
-              checked={lightboxSettings?.scaleUp ?? false}
-              disabled={displayMode === GQL.ImageLightboxDisplayMode.Original}
-              onChange={(v) => setScaleUp(v.currentTarget.checked)}
-            />
-          </Col>
-        </Form.Group>
-        <Form.Text className="text-muted">
-          {intl.formatMessage({
-            id: "dialogs.lightbox.scale_up.description",
-          })}
-        </Form.Text>
-      </Form.Group>
-      <Form.Group>
-        <Form.Group controlId="resetZoomOnNav" as={Row} className="mb-1">
-          <Col>
-            <Form.Check
-              type="checkbox"
-              label={intl.formatMessage({
-                id: "dialogs.lightbox.reset_zoom_on_nav",
-              })}
-              checked={lightboxSettings?.resetZoomOnNav ?? false}
-              onChange={(v) => setResetZoomOnNav(v.currentTarget.checked)}
-            />
-          </Col>
-        </Form.Group>
-      </Form.Group>
-      <Form.Group controlId="scrollMode">
-        <Form.Group as={Row} className="mb-1">
+        <Form.Group controlId="displayMode" as={Row}>
           <Col xs={4}>
             <Form.Label className="col-form-label">
-              <FormattedMessage id="dialogs.lightbox.scroll_mode.label" />
+              <FormattedMessage id="dialogs.lightbox.display_mode.label" />
             </Form.Label>
           </Col>
           <Col xs={8}>
             <Form.Control
               as="select"
               onChange={(e) =>
-                setScrollMode(e.target.value as GQL.ImageLightboxScrollMode)
+                setDisplayMode(e.target.value as GQL.ImageLightboxDisplayMode)
               }
-              value={
-                lightboxSettings?.scrollMode ?? GQL.ImageLightboxScrollMode.Zoom
-              }
+              value={displayMode}
               className="btn-secondary mx-1 mb-1"
             >
-              <option
-                value={GQL.ImageLightboxScrollMode.Zoom}
-                key={GQL.ImageLightboxScrollMode.Zoom}
-              >
-                {intl.formatMessage({
-                  id: "dialogs.lightbox.scroll_mode.zoom",
-                })}
-              </option>
-              <option
-                value={GQL.ImageLightboxScrollMode.PanY}
-                key={GQL.ImageLightboxScrollMode.PanY}
-              >
-                {intl.formatMessage({
-                  id: "dialogs.lightbox.scroll_mode.pan_y",
-                })}
-              </option>
+              {Array.from(imageLightboxDisplayModeIntlMap.entries()).map(
+                (v) => (
+                  <option key={v[0]} value={v[0]}>
+                    {intl.formatMessage({
+                      id: v[1],
+                    })}
+                  </option>
+                )
+              )}
             </Form.Control>
           </Col>
         </Form.Group>
-        <Form.Text className="text-muted">
-          {intl.formatMessage({
-            id: "dialogs.lightbox.scroll_mode.description",
-          })}
-        </Form.Text>
-      </Form.Group>
-    </>
-  );
-
-  const optionsPopover = (
-    <>
-      <Popover.Title>
-        {intl.formatMessage({
-          id: "dialogs.lightbox.options",
-        })}
-      </Popover.Title>
-      <Popover.Content>
-        <OptionsForm />
-      </Popover.Content>
-    </>
-  );
+        <Form.Group>
+          <Form.Group controlId="scaleUp" as={Row} className="mb-1">
+            <Col>
+              <Form.Check
+                type="checkbox"
+                label={intl.formatMessage({
+                  id: "dialogs.lightbox.scale_up.label",
+                })}
+                checked={lightboxSettings?.scaleUp ?? false}
+                disabled={displayMode === GQL.ImageLightboxDisplayMode.Original}
+                onChange={(v) => setScaleUp(v.currentTarget.checked)}
+              />
+            </Col>
+          </Form.Group>
+          <Form.Text className="text-muted">
+            {intl.formatMessage({
+              id: "dialogs.lightbox.scale_up.description",
+            })}
+          </Form.Text>
+        </Form.Group>
+        <Form.Group>
+          <Form.Group controlId="resetZoomOnNav" as={Row} className="mb-1">
+            <Col>
+              <Form.Check
+                type="checkbox"
+                label={intl.formatMessage({
+                  id: "dialogs.lightbox.reset_zoom_on_nav",
+                })}
+                checked={lightboxSettings?.resetZoomOnNav ?? false}
+                onChange={(v) => setResetZoomOnNav(v.currentTarget.checked)}
+              />
+            </Col>
+          </Form.Group>
+        </Form.Group>
+        <Form.Group controlId="scrollMode">
+          <Form.Group as={Row} className="mb-1">
+            <Col xs={4}>
+              <Form.Label className="col-form-label">
+                <FormattedMessage id="dialogs.lightbox.scroll_mode.label" />
+              </Form.Label>
+            </Col>
+            <Col xs={8}>
+              <Form.Control
+                as="select"
+                onChange={(e) =>
+                  setScrollMode(e.target.value as GQL.ImageLightboxScrollMode)
+                }
+                value={
+                  lightboxSettings?.scrollMode ??
+                  GQL.ImageLightboxScrollMode.Zoom
+                }
+                className="btn-secondary mx-1 mb-1"
+              >
+                <option
+                  value={GQL.ImageLightboxScrollMode.Zoom}
+                  key={GQL.ImageLightboxScrollMode.Zoom}
+                >
+                  {intl.formatMessage({
+                    id: "dialogs.lightbox.scroll_mode.zoom",
+                  })}
+                </option>
+                <option
+                  value={GQL.ImageLightboxScrollMode.PanY}
+                  key={GQL.ImageLightboxScrollMode.PanY}
+                >
+                  {intl.formatMessage({
+                    id: "dialogs.lightbox.scroll_mode.pan_y",
+                  })}
+                </option>
+              </Form.Control>
+            </Col>
+          </Form.Group>
+          <Form.Text className="text-muted">
+            {intl.formatMessage({
+              id: "dialogs.lightbox.scroll_mode.description",
+            })}
+          </Form.Text>
+        </Form.Group>
+      </>
+    );
+  }
 
   if (!isVisible) {
     return <></>;
@@ -654,13 +649,18 @@ export const LightboxComponent: React.FC<IProps> = ({
                     {...props}
                     style={{ ...props.style }}
                   >
-                    {optionsPopover}
+                    <Popover.Title>
+                      {intl.formatMessage({
+                        id: "dialogs.lightbox.options",
+                      })}
+                    </Popover.Title>
+                    <Popover.Content>{renderOptionsForm()}</Popover.Content>
                   </div>
                 )}
               </Overlay>
             </div>
             <InputGroup className={CLASSNAME_OPTIONS_INLINE}>
-              <OptionsForm />
+              {renderOptionsForm()}
             </InputGroup>
           </div>
           {slideshowEnabled && (

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -147,9 +147,13 @@ export const LightboxComponent: React.FC<IProps> = ({
     setLightboxSettings({ scrollMode: v });
   }
 
+  const configuredDelay = config?.interface.imageLightbox.slideshowDelay
+    ? config.interface.imageLightbox.slideshowDelay * SECONDS_TO_MS
+    : undefined;
+
   const slideshowDelay =
     lightboxSettings?.slideshowDelay ??
-    config?.interface.imageLightbox.slideshowDelay ??
+    configuredDelay ??
     DEFAULT_SLIDESHOW_DELAY;
 
   function setSlideshowDelay(v: number) {
@@ -264,7 +268,7 @@ export const LightboxComponent: React.FC<IProps> = ({
     if (slideshowInterval) {
       setSlideshowInterval(null);
     } else {
-      setSlideshowInterval(slideshowDelay * SECONDS_TO_MS);
+      setSlideshowInterval(slideshowDelay);
     }
   }, [slideshowInterval, slideshowDelay]);
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -175,7 +175,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [
     displayedSlideshowInterval,
     setDisplayedSlideshowInterval,
-  ] = useState<string>(slideshowDelay.toString());
+  ] = useState<string>((slideshowDelay / SECONDS_TO_MS).toString());
 
   useEffect(() => {
     if (images !== oldImages.current && isSwitchingPage) {

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -793,7 +793,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         </div>
         <div>
           {currentImage?.title && (
-            <Link to={`/images/${currentImage.id}`} onClick={() => hide()}>
+            <Link to={`/images/${currentImage.id}`} onClick={() => close()}>
               {currentImage.title ?? ""}
             </Link>
           )}

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -40,9 +40,11 @@ export function useLocalForage<T>(
   useEffect(() => {
     async function runAsync() {
       try {
-        const serialized = await localForage.getItem<string>(key);
-        const parsed = JSON.parse(serialized ?? "null");
-        if (!Object.is(parsed, null)) {
+        let parsed = await localForage.getItem<T>(key);
+        if (typeof parsed === "string") {
+          parsed = JSON.parse(parsed ?? "null");
+        }
+        if (parsed !== null) {
           setData(parsed);
           Cache[key] = parsed;
         } else {
@@ -72,7 +74,7 @@ export function useLocalForage<T>(
         ...Cache[key],
         ...data,
       };
-      localForage.setItem(key, JSON.stringify(Cache[key]));
+      localForage.setItem(key, Cache[key]);
     }
   });
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -523,7 +523,7 @@
       },
       "slideshow_delay": {
         "description": "Slideshow is available in galleries when in wall view mode",
-        "heading": "Slideshow Delay"
+        "heading": "Slideshow Delay (seconds)"
       },
       "title": "User Interface"
     }


### PR DESCRIPTION
Fixes #2451 
Fixes #2469 

- this makes the delay setting in interface settings in seconds rather than milliseconds, to be consistent with the lightbox interface. I will add a note in the changelog notifying users of this, since no conversion of existing values will be done.
- fixed slideshow delay setting to use the correct interval value
- fixed issue that caused focus to be lost on the delay input field when typing

Also changes the localforage hook to store objects directly instead of converting to and from json strings.