### PR TITLE
Improve bulk performer editing

### DIFF
--- a/graphql/documents/data/performer-slim.graphql
+++ b/graphql/documents/data/performer-slim.graphql
@@ -4,6 +4,15 @@ fragment SlimPerformerData on Performer {
   gender
   image_path
   favorite
+  country
+  ethnicity
+  hair_color
+  eye_color
+  height
+  fake_tits
+  career_length
+  tattoos
+  piercings
   tags {
     id
     name

--- a/graphql/documents/data/performer-slim.graphql
+++ b/graphql/documents/data/performer-slim.graphql
@@ -2,9 +2,13 @@ fragment SlimPerformerData on Performer {
   id
   name
   gender
+  url
+  twitter
+  instagram
   image_path
   favorite
   country
+  birthdate
   ethnicity
   hair_color
   eye_color
@@ -22,4 +26,6 @@ fragment SlimPerformerData on Performer {
     stash_id
   }
   rating
+  death_date
+  weight
 }

--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -2,6 +2,7 @@
 * Add python location in System Settings for script scrapers and plugins. ([#2409](https://github.com/stashapp/stash/pull/2409))
 
 ### 🎨 Improvements
+* Added support for bulk editing most performer fields. ([#2467](https://github.com/stashapp/stash/pull/2467))
 * Changed video player to videojs. ([#2100](https://github.com/stashapp/stash/pull/2100))
 * Maintain lightbox settings and add lightbox settings to Interface settings page. ([#2406](https://github.com/stashapp/stash/pull/2406))
 * Image lightbox now transitions to next/previous image when scrolling in pan-Y mode. ([#2403](https://github.com/stashapp/stash/pull/2403))

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -28,12 +28,20 @@ interface IListOperationProps {
 
 const performerFields = [
   "favorite",
+  "url",
+  "instagram",
+  "twitter",
   "rating",
   "gender",
+  "birthdate",
+  "death_date",
   "career_length",
   "country",
   "ethnicity",
   "eye_color",
+  "height",
+  // "weight",
+  "measurements",
   "fake_tits",
   "hair_color",
   "tattoos",
@@ -53,6 +61,8 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     aggregateState,
     setAggregateState,
   ] = useState<GQL.BulkPerformerUpdateInput>({});
+  // weight needs conversion to/from number
+  const [weight, setWeight] = useState<string | undefined>();
   const [updateInput, setUpdateInput] = useState<GQL.BulkPerformerUpdateInput>(
     {}
   );
@@ -90,6 +100,10 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
       aggregateState.gender
     );
 
+    if (weight !== undefined) {
+      performerInput.weight = parseFloat(weight);
+    }
+
     return performerInput;
   }
 
@@ -119,6 +133,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
 
     const state = props.selected;
     let updateTagIds: string[] = [];
+    let updateWeight: string | undefined | null = undefined;
     let first = true;
 
     state.forEach((performer: GQL.SlimPerformerDataFragment) => {
@@ -129,10 +144,17 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
       updateTagIds =
         getAggregateState(updateTagIds, performerTagIDs, first) ?? [];
 
+      const thisWeight =
+        performer.weight !== undefined && performer.weight !== null
+          ? performer.weight.toString()
+          : performer.weight;
+      updateWeight = getAggregateState(updateWeight, thisWeight, first);
+
       first = false;
     });
 
     setExistingTagIds(updateTagIds);
+    setWeight(updateWeight);
     setAggregateState(updateState);
     setUpdateInput(updateState);
   }, [props.selected]);
@@ -148,7 +170,7 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           <FormattedMessage id={name} />
         </Form.Label>
         <BulkUpdateTextInput
-          value={value ?? undefined}
+          value={value === null ? "" : value ?? undefined}
           valueChanged={(newValue) => setter(newValue)}
           unsetDisabled={props.selected.length < 2}
         />
@@ -219,6 +241,12 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
             </Form.Control>
           </Form.Group>
 
+          {renderTextField("birthdate", updateInput.birthdate, (v) =>
+            setUpdateField({ birthdate: v })
+          )}
+          {renderTextField("death_date", updateInput.death_date, (v) =>
+            setUpdateField({ death_date: v })
+          )}
           {renderTextField("country", updateInput.country, (v) =>
             setUpdateField({ country: v })
           )}
@@ -231,6 +259,13 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           {renderTextField("eye_color", updateInput.eye_color, (v) =>
             setUpdateField({ eye_color: v })
           )}
+          {renderTextField("height", updateInput.height, (v) =>
+            setUpdateField({ height: v })
+          )}
+          {renderTextField("weight", weight, (v) => setWeight(v))}
+          {renderTextField("measurements", updateInput.measurements, (v) =>
+            setUpdateField({ measurements: v })
+          )}
           {renderTextField("fake_tits", updateInput.fake_tits, (v) =>
             setUpdateField({ fake_tits: v })
           )}
@@ -242,6 +277,15 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
           )}
           {renderTextField("career_length", updateInput.career_length, (v) =>
             setUpdateField({ career_length: v })
+          )}
+          {renderTextField("url", updateInput.url, (v) =>
+            setUpdateField({ url: v })
+          )}
+          {renderTextField("twitter", updateInput.twitter, (v) =>
+            setUpdateField({ twitter: v })
+          )}
+          {renderTextField("instagram", updateInput.instagram, (v) =>
+            setUpdateField({ instagram: v })
           )}
 
           <Form.Group controlId="tags">

--- a/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
+++ b/ui/v2.5/src/components/Performers/EditPerformersDialog.tsx
@@ -11,6 +11,7 @@ import { RatingStars } from "../Scenes/SceneDetails/RatingStars";
 import {
   getAggregateInputValue,
   getAggregateState,
+  getAggregateStateObject,
 } from "src/utils/bulkUpdate";
 import {
   genderStrings,
@@ -24,6 +25,20 @@ interface IListOperationProps {
   selected: GQL.SlimPerformerDataFragment[];
   onClose: (applied: boolean) => void;
 }
+
+const performerFields = [
+  "favorite",
+  "rating",
+  "gender",
+  "career_length",
+  "country",
+  "ethnicity",
+  "eye_color",
+  "fake_tits",
+  "hair_color",
+  "tattoos",
+  "piercings",
+];
 
 export const EditPerformersDialog: React.FC<IListOperationProps> = (
   props: IListOperationProps
@@ -107,63 +122,9 @@ export const EditPerformersDialog: React.FC<IListOperationProps> = (
     let first = true;
 
     state.forEach((performer: GQL.SlimPerformerDataFragment) => {
-      const performerTagIDs = (performer.tags ?? []).map((p) => p.id).sort();
+      getAggregateStateObject(updateState, performer, performerFields, first);
 
-      updateState.favorite = getAggregateState(
-        updateState.favorite,
-        performer.favorite,
-        first
-      );
-      updateState.rating = getAggregateState(
-        updateState.rating,
-        performer.rating,
-        first
-      );
-      updateState.gender = getAggregateState(
-        updateState.gender,
-        performer.gender,
-        first
-      );
-      updateState.career_length = getAggregateState(
-        updateState.career_length,
-        performer.career_length,
-        first
-      );
-      updateState.country = getAggregateState(
-        updateState.country,
-        performer.country,
-        first
-      );
-      updateState.ethnicity = getAggregateState(
-        updateState.ethnicity,
-        performer.ethnicity,
-        first
-      );
-      updateState.eye_color = getAggregateState(
-        updateState.eye_color,
-        performer.eye_color,
-        first
-      );
-      updateState.fake_tits = getAggregateState(
-        updateState.fake_tits,
-        performer.fake_tits,
-        first
-      );
-      updateState.hair_color = getAggregateState(
-        updateState.hair_color,
-        performer.hair_color,
-        first
-      );
-      updateState.tattoos = getAggregateState(
-        updateState.tattoos,
-        performer.tattoos,
-        first
-      );
-      updateState.piercings = getAggregateState(
-        updateState.piercings,
-        performer.piercings,
-        first
-      );
+      const performerTagIDs = (performer.tags ?? []).map((p) => p.id).sort();
 
       updateTagIds =
         getAggregateState(updateTagIds, performerTagIDs, first) ?? [];

--- a/ui/v2.5/src/components/Shared/BulkUpdateTextInput.tsx
+++ b/ui/v2.5/src/components/Shared/BulkUpdateTextInput.tsx
@@ -8,9 +8,11 @@ interface IBulkUpdateTextInputProps extends FormControlProps {
   unsetDisabled?: boolean;
 }
 
-export const BulkUpdateTextInput: React.FC<IBulkUpdateTextInputProps> = (
-  props: IBulkUpdateTextInputProps
-) => {
+export const BulkUpdateTextInput: React.FC<IBulkUpdateTextInputProps> = ({
+  valueChanged,
+  unsetDisabled,
+  ...props
+}) => {
   const intl = useIntl();
 
   const unsetClassName = props.value === undefined ? "unset" : "";
@@ -27,12 +29,12 @@ export const BulkUpdateTextInput: React.FC<IBulkUpdateTextInputProps> = (
             ? `<${intl.formatMessage({ id: "existing_value" })}>`
             : undefined
         }
-        onChange={(event) => props.valueChanged(event.currentTarget.value)}
+        onChange={(event) => valueChanged(event.currentTarget.value)}
       />
-      {!props.unsetDisabled ? (
+      {!unsetDisabled ? (
         <Button
           variant="secondary"
-          onClick={() => props.valueChanged(undefined)}
+          onClick={() => valueChanged(undefined)}
           title={intl.formatMessage({ id: "actions.unset" })}
         >
           <Icon icon="ban" />

--- a/ui/v2.5/src/components/Shared/BulkUpdateTextInput.tsx
+++ b/ui/v2.5/src/components/Shared/BulkUpdateTextInput.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Button, Form, FormControlProps, InputGroup } from "react-bootstrap";
+import { useIntl } from "react-intl";
+import { Icon } from ".";
+
+interface IBulkUpdateTextInputProps extends FormControlProps {
+  valueChanged: (value: string | undefined) => void;
+  unsetDisabled?: boolean;
+}
+
+export const BulkUpdateTextInput: React.FC<IBulkUpdateTextInputProps> = (
+  props: IBulkUpdateTextInputProps
+) => {
+  const intl = useIntl();
+
+  const unsetClassName = props.value === undefined ? "unset" : "";
+
+  return (
+    <InputGroup className={`bulk-update-text-input ${unsetClassName}`}>
+      <Form.Control
+        {...props}
+        className="input-control"
+        type="text"
+        value={props.value ?? ""}
+        placeholder={
+          props.value === undefined
+            ? `<${intl.formatMessage({ id: "existing_value" })}>`
+            : undefined
+        }
+        onChange={(event) => props.valueChanged(event.currentTarget.value)}
+      />
+      {!props.unsetDisabled ? (
+        <Button
+          variant="secondary"
+          onClick={() => props.valueChanged(undefined)}
+          title={intl.formatMessage({ id: "actions.unset" })}
+        >
+          <Icon icon="ban" />
+        </Button>
+      ) : undefined}
+    </InputGroup>
+  );
+};

--- a/ui/v2.5/src/components/Shared/Icon.tsx
+++ b/ui/v2.5/src/components/Shared/Icon.tsx
@@ -20,7 +20,7 @@ interface IIcon {
 const Icon: React.FC<IIcon> = ({ icon, className, color, size }) => (
   <FontAwesomeIcon
     icon={icon}
-    className={`fa-icon ${className}`}
+    className={`fa-icon ${className ?? ""}`}
     color={color}
     size={size}
   />

--- a/ui/v2.5/src/components/Shared/IndeterminateCheckbox.tsx
+++ b/ui/v2.5/src/components/Shared/IndeterminateCheckbox.tsx
@@ -48,7 +48,7 @@ export const IndeterminateCheckbox: React.FC<IIndeterminateCheckbox> = ({
         checked === undefined ? indeterminateClassname : ""
       }`}
       ref={ref}
-      checked={checked}
+      checked={checked ?? false}
       onChange={() => setChecked(cycleState())}
     />
   );

--- a/ui/v2.5/src/components/Shared/MultiSet.tsx
+++ b/ui/v2.5/src/components/Shared/MultiSet.tsx
@@ -74,6 +74,7 @@ const MultiSet: React.FunctionComponent<IMultiSetProps> = (
   function renderModeButton(mode: GQL.BulkUpdateIdMode) {
     return (
       <Button
+        key={mode}
         variant="primary"
         active={props.mode === mode}
         size="sm"

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -271,3 +271,30 @@ button.collapse-button.btn-primary:not(:disabled):not(.disabled):active {
 .string-list-input .input-group {
   margin-bottom: 0.25rem;
 }
+
+.bulk-update-text-input {
+  button {
+    background-color: $secondary;
+    color: $text-muted;
+    font-size: $btn-font-size-sm;
+    margin: $btn-padding-y $btn-padding-x;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    z-index: 4;
+
+    &:hover,
+    &:focus,
+    &:active,
+    &:not(:disabled):not(.disabled):active,
+    &:not(:disabled):not(.disabled):active:focus {
+      background-color: $secondary;
+      border-color: transparent;
+      box-shadow: none;
+    }
+  }
+
+  &.unset button {
+    visibility: hidden;
+  }
+}

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -101,6 +101,7 @@
     },
     "temp_disable": "Disable temporarily…",
     "temp_enable": "Enable temporarily…",
+    "unset": "Unset",
     "use_default": "Use default",
     "view_random": "View Random",
     "continue": "Continue",
@@ -584,6 +585,7 @@
     "delete_object_overflow": "…and {count} other {count, plural, one {{singularEntity}} other {{pluralEntity}}}.",
     "delete_object_title": "Delete {count, plural, one {{singularEntity}} other {{pluralEntity}}}",
     "edit_entity_title": "Edit {count, plural, one {{singularEntity}} other {{pluralEntity}}}",
+    "existing_value": "existing value",
     "export_include_related_objects": "Include related objects in export",
     "export_title": "Export",
     "lightbox": {
@@ -701,6 +703,7 @@
     "warmth": "Warmth"
   },
   "ethnicity": "Ethnicity",
+  "existing_value": "existing value",
   "eye_color": "Eye Colour",
   "fake_tits": "Fake Tits",
   "false": "False",

--- a/ui/v2.5/src/utils/bulkUpdate.ts
+++ b/ui/v2.5/src/utils/bulkUpdate.ts
@@ -124,7 +124,7 @@ export function getAggregateMovieIds(state: IHasMovies[]) {
   return ret;
 }
 
-function makeBulkUpdateIds(
+export function makeBulkUpdateIds(
   ids: string[],
   mode: GQL.BulkUpdateIdMode
 ): GQL.BulkUpdateIds {
@@ -152,6 +152,7 @@ export function getAggregateInputValue<V>(
   }
 }
 
+// TODO - remove - this is incorrect
 export function getAggregateInputIDs(
   mode: GQL.BulkUpdateIdMode,
   inputIds: string[] | undefined,

--- a/ui/v2.5/src/utils/bulkUpdate.ts
+++ b/ui/v2.5/src/utils/bulkUpdate.ts
@@ -173,3 +173,15 @@ export function getAggregateInputIDs(
 
   return undefined;
 }
+
+export function getAggregateState<T>(
+  currentValue: T,
+  newValue: T,
+  first: boolean
+) {
+  if (!first && !_.isEqual(currentValue, newValue)) {
+    return undefined;
+  }
+
+  return newValue;
+}

--- a/ui/v2.5/src/utils/bulkUpdate.ts
+++ b/ui/v2.5/src/utils/bulkUpdate.ts
@@ -186,3 +186,34 @@ export function getAggregateState<T>(
 
   return newValue;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setProperty<T, K extends keyof T>(obj: T, key: K, value: any) {
+  obj[key] = value;
+}
+
+function getProperty<T, K extends keyof T>(obj: T, key: K) {
+  return obj[key];
+}
+
+export function getAggregateStateObject<O, I>(
+  output: O,
+  input: I,
+  fields: string[],
+  first: boolean
+) {
+  fields.forEach((key) => {
+    const outputKey = key as keyof O;
+    const inputKey = key as keyof I;
+
+    const currentValue = getProperty(output, outputKey);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const performerValue = getProperty(input, inputKey) as any;
+
+    setProperty(
+      output,
+      outputKey,
+      getAggregateState(currentValue, performerValue, first)
+    );
+  });
+}


### PR DESCRIPTION
Adds support for editing all performer fields from the bulk edit dialog.

Allows better control over what fields to set. Where a text field value differs between performers, the field value is shown as `<existing value>`. While in this state, the value is unchanged from the original. If the user then enters something into the text field, it is set on all performers. In order to reset back to the original value, a button is displayed on the right if a value is entered.

![image](https://user-images.githubusercontent.com/53250216/161370616-f0dfc8f0-70c9-4735-982d-dbf728950988.png)

I'm aware that the dialog looks quite heavy now. Possible candidate for further clean up later.

Resolves #1582
Relates to #1408, improving on #2282

