### PR TITLE
Revert "Do not display tabs with no content (#2468)"

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0140.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0140.md
@@ -7,7 +7,6 @@
 ### 🎨 Improvements
 * Restyled scene details page on mobile devices. ([#2466](https://github.com/stashapp/stash/pull/2466))
 * Added support for Handy APIv2. ([#2193](https://github.com/stashapp/stash/pull/2193))
-* Hide tabs with no content in Performer, Studio and Tag pages. ([#2468](https://github.com/stashapp/stash/pull/2468))
 * Added support for bulk editing most performer fields. ([#2467](https://github.com/stashapp/stash/pull/2467))
 * Changed video player to videojs. ([#2100](https://github.com/stashapp/stash/pull/2100))
 * Maintain lightbox settings and add lightbox settings to Interface settings page. ([#2406](https://github.com/stashapp/stash/pull/2406))

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -30,7 +30,6 @@ import { PerformerImagesPanel } from "./PerformerImagesPanel";
 import { PerformerEditPanel } from "./PerformerEditPanel";
 import { PerformerSubmitButton } from "./PerformerSubmitButton";
 import GenderIcon from "../GenderIcon";
-import renderNonZero from "src/utils/render";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -185,70 +184,58 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab eventKey="details" title={intl.formatMessage({ id: "details" })}>
           <PerformerDetailsPanel performer={performer} />
         </Tab>
-        {renderNonZero(
-          performer.scene_count,
-          <Tab
-            eventKey="scenes"
-            title={
-              <React.Fragment>
-                {intl.formatMessage({ id: "scenes" })}
-                <Badge className="left-spacing" pill variant="secondary">
-                  {intl.formatNumber(performer.scene_count ?? 0)}
-                </Badge>
-              </React.Fragment>
-            }
-          >
-            <PerformerScenesPanel performer={performer} />
-          </Tab>
-        )}
-        {renderNonZero(
-          performer.gallery_count,
-          <Tab
-            eventKey="galleries"
-            title={
-              <React.Fragment>
-                {intl.formatMessage({ id: "galleries" })}
-                <Badge className="left-spacing" pill variant="secondary">
-                  {intl.formatNumber(performer.gallery_count ?? 0)}
-                </Badge>
-              </React.Fragment>
-            }
-          >
-            <PerformerGalleriesPanel performer={performer} />
-          </Tab>
-        )}
-        {renderNonZero(
-          performer.image_count,
-          <Tab
-            eventKey="images"
-            title={
-              <React.Fragment>
-                {intl.formatMessage({ id: "images" })}
-                <Badge className="left-spacing" pill variant="secondary">
-                  {intl.formatNumber(performer.image_count ?? 0)}
-                </Badge>
-              </React.Fragment>
-            }
-          >
-            <PerformerImagesPanel performer={performer} />
-          </Tab>
-        )}
-        {renderNonZero(
-          performer.movie_count,
-          <Tab
-            eventKey="movies"
-            title={
-              <React.Fragment>
-                {intl.formatMessage({ id: "movies" })}
-                <Badge className="left-spacing" pill variant="secondary">
-                  {intl.formatNumber(performer.movie_count ?? 0)}
-                </Badge>
-              </React.Fragment>
-            }
-          >
-            <PerformerMoviesPanel performer={performer} />
-          </Tab>
-        )}
+        <Tab
+          eventKey="scenes"
+          title={
+            <React.Fragment>
+              {intl.formatMessage({ id: "scenes" })}
+              <Badge className="left-spacing" pill variant="secondary">
+                {intl.formatNumber(performer.scene_count ?? 0)}
+              </Badge>
+            </React.Fragment>
+          }
+        >
+          <PerformerScenesPanel performer={performer} />
+        </Tab>
+        <Tab
+          eventKey="galleries"
+          title={
+            <React.Fragment>
+              {intl.formatMessage({ id: "galleries" })}
+              <Badge className="left-spacing" pill variant="secondary">
+                {intl.formatNumber(performer.gallery_count ?? 0)}
+              </Badge>
+            </React.Fragment>
+          }
+        >
+          <PerformerGalleriesPanel performer={performer} />
+        </Tab>
+        <Tab
+          eventKey="images"
+          title={
+            <React.Fragment>
+              {intl.formatMessage({ id: "images" })}
+              <Badge className="left-spacing" pill variant="secondary">
+                {intl.formatNumber(performer.image_count ?? 0)}
+              </Badge>
+            </React.Fragment>
+          }
+        >
+          <PerformerImagesPanel performer={performer} />
+        </Tab>
+        <Tab
+          eventKey="movies"
+          title={
+            <React.Fragment>
+              {intl.formatMessage({ id: "movies" })}
+              <Badge className="left-spacing" pill variant="secondary">
+                {intl.formatNumber(performer.movie_count ?? 0)}
+              </Badge>
+            </React.Fragment>
+          }
+        >
+          <PerformerMoviesPanel performer={performer} />
+        </Tab>
       </Tabs>
     </React.Fragment>
   );

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -28,7 +28,6 @@ import { StudioPerformersPanel } from "./StudioPerformersPanel";
 import { StudioEditPanel } from "./StudioEditPanel";
 import { StudioDetailsPanel } from "./StudioDetailsPanel";
 import { StudioMoviesPanel } from "./StudioMoviesPanel";
-import renderNonZero from "src/utils/render";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -154,15 +153,6 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     }
   }
 
-  const defaultTab =
-    studio?.scene_count ?? 0 > 0
-      ? "scenes"
-      : studio?.gallery_count ?? 0 > 0
-      ? "galleries"
-      : studio?.image_count ?? 0 > 0
-      ? "images"
-      : "performers";
-
   const activeTabKey =
     tab === "childstudios" ||
     tab === "images" ||
@@ -170,7 +160,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     tab === "performers" ||
     tab === "movies"
       ? tab
-      : defaultTab;
+      : "scenes";
   const setActiveTabKey = (newTab: string | null) => {
     if (tab !== newTab) {
       const tabParam = newTab === "scenes" ? "" : `/${newTab}`;
@@ -226,92 +216,77 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           activeKey={activeTabKey}
           onSelect={setActiveTabKey}
         >
-          {renderNonZero(
-            studio.scene_count,
-            <Tab
-              eventKey="scenes"
-              title={
-                <React.Fragment>
-                  {intl.formatMessage({ id: "scenes" })}
-                  <Badge className="left-spacing" pill variant="secondary">
-                    {intl.formatNumber(studio.scene_count ?? 0)}
-                  </Badge>
-                </React.Fragment>
-              }
-            >
-              <StudioScenesPanel studio={studio} />
-            </Tab>
-          )}
-          {renderNonZero(
-            studio.gallery_count,
-            <Tab
-              eventKey="galleries"
-              title={
-                <React.Fragment>
-                  {intl.formatMessage({ id: "galleries" })}
-                  <Badge className="left-spacing" pill variant="secondary">
-                    {intl.formatNumber(studio.gallery_count ?? 0)}
-                  </Badge>
-                </React.Fragment>
-              }
-            >
-              <StudioGalleriesPanel studio={studio} />
-            </Tab>
-          )}
-          {renderNonZero(
-            studio.image_count,
-            <Tab
-              eventKey="images"
-              title={
-                <React.Fragment>
-                  {intl.formatMessage({ id: "images" })}
-                  <Badge className="left-spacing" pill variant="secondary">
-                    {intl.formatNumber(studio.image_count ?? 0)}
-                  </Badge>
-                </React.Fragment>
-              }
-            >
-              <StudioImagesPanel studio={studio} />
-            </Tab>
-          )}
+          <Tab
+            eventKey="scenes"
+            title={
+              <React.Fragment>
+                {intl.formatMessage({ id: "scenes" })}
+                <Badge className="left-spacing" pill variant="secondary">
+                  {intl.formatNumber(studio.scene_count ?? 0)}
+                </Badge>
+              </React.Fragment>
+            }
+          >
+            <StudioScenesPanel studio={studio} />
+          </Tab>
+          <Tab
+            eventKey="galleries"
+            title={
+              <React.Fragment>
+                {intl.formatMessage({ id: "galleries" })}
+                <Badge className="left-spacing" pill variant="secondary">
+                  {intl.formatNumber(studio.gallery_count ?? 0)}
+                </Badge>
+              </React.Fragment>
+            }
+          >
+            <StudioGalleriesPanel studio={studio} />
+          </Tab>
+          <Tab
+            eventKey="images"
+            title={
+              <React.Fragment>
+                {intl.formatMessage({ id: "images" })}
+                <Badge className="left-spacing" pill variant="secondary">
+                  {intl.formatNumber(studio.image_count ?? 0)}
+                </Badge>
+              </React.Fragment>
+            }
+          >
+            <StudioImagesPanel studio={studio} />
+          </Tab>
           <Tab
             eventKey="performers"
             title={intl.formatMessage({ id: "performers" })}
           >
             <StudioPerformersPanel studio={studio} />
           </Tab>
-          {renderNonZero(
-            studio.movie_count,
-            <Tab
-              eventKey="movies"
-              title={
-                <React.Fragment>
-                  {intl.formatMessage({ id: "movies" })}
-                  <Badge className="left-spacing" pill variant="secondary">
-                    {intl.formatNumber(studio.movie_count ?? 0)}
-                  </Badge>
-                </React.Fragment>
-              }
-            >
-              <StudioMoviesPanel studio={studio} />
-            </Tab>
-          )}
-          {renderNonZero(
-            studio.child_studios?.length,
-            <Tab
-              eventKey="childstudios"
-              title={
-                <React.Fragment>
-                  {intl.formatMessage({ id: "subsidiary_studios" })}
-                  <Badge className="left-spacing" pill variant="secondary">
-                    {intl.formatNumber(studio.child_studios?.length)}
-                  </Badge>
-                </React.Fragment>
-              }
-            >
-              <StudioChildrenPanel studio={studio} />
-            </Tab>
-          )}
+          <Tab
+            eventKey="movies"
+            title={
+              <React.Fragment>
+                {intl.formatMessage({ id: "movies" })}
+                <Badge className="left-spacing" pill variant="secondary">
+                  {intl.formatNumber(studio.movie_count ?? 0)}
+                </Badge>
+              </React.Fragment>
+            }
+          >
+            <StudioMoviesPanel studio={studio} />
+          </Tab>
+          <Tab
+            eventKey="childstudios"
+            title={
+              <React.Fragment>
+                {intl.formatMessage({ id: "subsidiary_studios" })}
+                <Badge className="left-spacing" pill variant="secondary">
+                  {intl.formatNumber(studio.child_studios?.length)}
+                </Badge>
+              </React.Fragment>
+            }
+          >
+            <StudioChildrenPanel studio={studio} />
+          </Tab>
         </Tabs>
       </div>
       {renderDeleteAlert()}

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -30,7 +30,6 @@ import { TagGalleriesPanel } from "./TagGalleriesPanel";
 import { TagDetailsPanel } from "./TagDetailsPanel";
 import { TagEditPanel } from "./TagEditPanel";
 import { TagMergeModal } from "./TagMergeDialog";
-import renderNonZero from "src/utils/render";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -57,24 +56,13 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [updateTag] = useTagUpdate();
   const [deleteTag] = useTagDestroy({ id: tag.id });
 
-  const defaultTab =
-    tag?.scene_count ?? 0 > 0
-      ? "scenes"
-      : tag?.image_count ?? 0 > 0
-      ? "images"
-      : tag?.gallery_count ?? 0 > 0
-      ? "galleries"
-      : tag?.scene_marker_count ?? 0 > 0
-      ? "markers"
-      : "performers";
-
   const activeTabKey =
     tab === "markers" ||
     tab === "images" ||
     tab === "performers" ||
     tab === "galleries"
       ? tab
-      : defaultTab;
+      : "scenes";
   const setActiveTabKey = (newTab: string | null) => {
     if (tab !== newTab) {
       const tabParam = newTab === "scenes" ? "" : `/${newTab}`;
@@ -310,86 +298,71 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             activeKey={activeTabKey}
             onSelect={setActiveTabKey}
           >
-            {renderNonZero(
-              tag.scene_count,
-              <Tab
-                eventKey="scenes"
-                title={
-                  <React.Fragment>
-                    {intl.formatMessage({ id: "scenes" })}
-                    <Badge className="left-spacing" pill variant="secondary">
-                      {intl.formatNumber(tag.scene_count ?? 0)}
-                    </Badge>
-                  </React.Fragment>
-                }
-              >
-                <TagScenesPanel tag={tag} />
-              </Tab>
-            )}
-            {renderNonZero(
-              tag.image_count,
-              <Tab
-                eventKey="images"
-                title={
-                  <React.Fragment>
-                    {intl.formatMessage({ id: "images" })}
-                    <Badge className="left-spacing" pill variant="secondary">
-                      {intl.formatNumber(tag.image_count ?? 0)}
-                    </Badge>
-                  </React.Fragment>
-                }
-              >
-                <TagImagesPanel tag={tag} />
-              </Tab>
-            )}
-            {renderNonZero(
-              tag.gallery_count,
-              <Tab
-                eventKey="galleries"
-                title={
-                  <React.Fragment>
-                    {intl.formatMessage({ id: "galleries" })}
-                    <Badge className="left-spacing" pill variant="secondary">
-                      {intl.formatNumber(tag.gallery_count ?? 0)}
-                    </Badge>
-                  </React.Fragment>
-                }
-              >
-                <TagGalleriesPanel tag={tag} />
-              </Tab>
-            )}
-            {renderNonZero(
-              tag.scene_marker_count,
-              <Tab
-                eventKey="markers"
-                title={
-                  <React.Fragment>
-                    {intl.formatMessage({ id: "markers" })}
-                    <Badge className="left-spacing" pill variant="secondary">
-                      {intl.formatNumber(tag.scene_marker_count ?? 0)}
-                    </Badge>
-                  </React.Fragment>
-                }
-              >
-                <TagMarkersPanel tag={tag} />
-              </Tab>
-            )}
-            {renderNonZero(
-              tag.performer_count,
-              <Tab
-                eventKey="performers"
-                title={
-                  <React.Fragment>
-                    {intl.formatMessage({ id: "performers" })}
-                    <Badge className="left-spacing" pill variant="secondary">
-                      {intl.formatNumber(tag.performer_count ?? 0)}
-                    </Badge>
-                  </React.Fragment>
-                }
-              >
-                <TagPerformersPanel tag={tag} />
-              </Tab>
-            )}
+            <Tab
+              eventKey="scenes"
+              title={
+                <React.Fragment>
+                  {intl.formatMessage({ id: "scenes" })}
+                  <Badge className="left-spacing" pill variant="secondary">
+                    {intl.formatNumber(tag.scene_count ?? 0)}
+                  </Badge>
+                </React.Fragment>
+              }
+            >
+              <TagScenesPanel tag={tag} />
+            </Tab>
+            <Tab
+              eventKey="images"
+              title={
+                <React.Fragment>
+                  {intl.formatMessage({ id: "images" })}
+                  <Badge className="left-spacing" pill variant="secondary">
+                    {intl.formatNumber(tag.image_count ?? 0)}
+                  </Badge>
+                </React.Fragment>
+              }
+            >
+              <TagImagesPanel tag={tag} />
+            </Tab>
+            <Tab
+              eventKey="galleries"
+              title={
+                <React.Fragment>
+                  {intl.formatMessage({ id: "galleries" })}
+                  <Badge className="left-spacing" pill variant="secondary">
+                    {intl.formatNumber(tag.gallery_count ?? 0)}
+                  </Badge>
+                </React.Fragment>
+              }
+            >
+              <TagGalleriesPanel tag={tag} />
+            </Tab>
+            <Tab
+              eventKey="markers"
+              title={
+                <React.Fragment>
+                  {intl.formatMessage({ id: "markers" })}
+                  <Badge className="left-spacing" pill variant="secondary">
+                    {intl.formatNumber(tag.scene_marker_count ?? 0)}
+                  </Badge>
+                </React.Fragment>
+              }
+            >
+              <TagMarkersPanel tag={tag} />
+            </Tab>
+            <Tab
+              eventKey="performers"
+              title={
+                <React.Fragment>
+                  {intl.formatMessage({ id: "performers" })}
+                  <Badge className="left-spacing" pill variant="secondary">
+                    {intl.formatNumber(tag.performer_count ?? 0)}
+                  </Badge>
+                </React.Fragment>
+              }
+            >
+              <TagPerformersPanel tag={tag} />
+            </Tab>
           </Tabs>
         </div>
         {renderDeleteAlert()}

--- a/ui/v2.5/src/utils/render.tsx
+++ b/ui/v2.5/src/utils/render.tsx
@@ -1,9 +1,0 @@
-function renderNonZero(count: number | undefined | null, element: JSX.Element) {
-  if (!count) {
-    return undefined;
-  }
-
-  return element;
-}
-
-export default renderNonZero;


### PR DESCRIPTION
Reverts #2468 since this makes it more difficult to find scenes etc for subsidiary studios and sub-tags.