### PR TITLE
Hoist context, enable errchkjson

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     # Linters added by the stash project.
     # - contextcheck
     - dogsled
-    # - errchkjson
+    - errchkjson
     - errorlint
     # - exhaustive
     - exportloopref

--- a/internal/api/resolver_mutation_metadata.go
+++ b/internal/api/resolver_mutation_metadata.go
@@ -61,7 +61,7 @@ func (r *mutationResolver) ExportObjects(ctx context.Context, input models.Expor
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	t.Start(&wg)
+	t.Start(ctx, &wg)
 
 	if t.DownloadHash != "" {
 		baseURL, _ := ctx.Value(BaseURLCtxKey).(string)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -121,7 +121,7 @@ func Initialize() *singleton {
 			logger.Warnf("config file %snot found. Assuming new system...", cfgFile)
 		}
 
-		if err = initFFMPEG(); err != nil {
+		if err = initFFMPEG(ctx); err != nil {
 			logger.Warnf("could not initialize FFMPEG subsystem: %v", err)
 		}
 
@@ -189,9 +189,7 @@ func initProfiling(cpuProfilePath string) {
 	}
 }
 
-func initFFMPEG() error {
-	ctx := context.TODO()
-
+func initFFMPEG(ctx context.Context) error {
 	// only do this if we have a config file set
 	if instance.Config.GetConfigFile() != "" {
 		// use same directory as config path
@@ -405,7 +403,7 @@ func (s *singleton) Setup(ctx context.Context, input models.SetupInput) error {
 
 	s.Config.FinalizeSetup()
 
-	if err := initFFMPEG(); err != nil {
+	if err := initFFMPEG(ctx); err != nil {
 		return fmt.Errorf("error initializing FFMPEG subsystem: %v", err)
 	}
 

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -108,7 +108,7 @@ func (s *singleton) Export(ctx context.Context) (int, error) {
 			full:                true,
 			fileNamingAlgorithm: config.GetVideoFileNamingAlgorithm(),
 		}
-		task.Start(&wg)
+		task.Start(ctx, &wg)
 	})
 
 	return s.JobManager.Add(ctx, "Exporting...", j), nil
@@ -384,7 +384,7 @@ func (s *singleton) StashBoxBatchPerformerTag(ctx context.Context, input models.
 		for _, task := range tasks {
 			wg.Add(1)
 			progress.ExecuteTask(task.Description(), func() {
-				task.Start()
+				task.Start(ctx)
 				wg.Done()
 			})
 

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -192,7 +192,7 @@ func (s *singleton) generateScreenshot(ctx context.Context, sceneId string, at *
 		}
 
 		var scene *models.Scene
-		if err := s.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := s.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			var err error
 			scene, err = r.Scene().Find(sceneIdInt)
 			return err
@@ -241,7 +241,7 @@ func (s *singleton) MigrateHash(ctx context.Context) int {
 		logger.Infof("Migrating generated files for %s naming hash", fileNamingAlgo.String())
 
 		var scenes []*models.Scene
-		if err := s.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := s.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			var err error
 			scenes, err = r.Scene().All()
 			return err
@@ -303,7 +303,7 @@ func (s *singleton) StashBoxBatchPerformerTag(ctx context.Context, input models.
 		// This is why we mark this section nolint. In principle, we should look to
 		// rewrite the section at some point, to avoid the linter warning.
 		if len(input.PerformerIds) > 0 { //nolint:gocritic
-			if err := s.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+			if err := s.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 				performerQuery := r.Performer()
 
 				for _, performerID := range input.PerformerIds {
@@ -343,7 +343,7 @@ func (s *singleton) StashBoxBatchPerformerTag(ctx context.Context, input models.
 			// However, this doesn't really help with readability of the current section. Mark it
 			// as nolint for now. In the future we'd like to rewrite this code by factoring some of
 			// this into separate functions.
-			if err := s.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+			if err := s.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 				performerQuery := r.Performer()
 				var performers []*models.Performer
 				var err error

--- a/internal/manager/task_autotag.go
+++ b/internal/manager/task_autotag.go
@@ -74,7 +74,7 @@ func (j *autoTagJob) autoTagSpecific(ctx context.Context, progress *job.Progress
 	studioCount := len(studioIds)
 	tagCount := len(tagIds)
 
-	if err := j.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := j.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		performerQuery := r.Performer()
 		studioQuery := r.Studio()
 		tagQuery := r.Tag()
@@ -124,7 +124,7 @@ func (j *autoTagJob) autoTagPerformers(ctx context.Context, progress *job.Progre
 	for _, performerId := range performerIds {
 		var performers []*models.Performer
 
-		if err := j.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := j.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			performerQuery := r.Performer()
 
 			if performerId == "*" {
@@ -156,7 +156,7 @@ func (j *autoTagJob) autoTagPerformers(ctx context.Context, progress *job.Progre
 					return nil
 				}
 
-				if err := j.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+				if err := j.txnManager.WithTxn(ctx, func(r models.Repository) error {
 					if err := autotag.PerformerScenes(performer, paths, r.Scene(), &j.cache); err != nil {
 						return err
 					}
@@ -191,7 +191,7 @@ func (j *autoTagJob) autoTagStudios(ctx context.Context, progress *job.Progress,
 	for _, studioId := range studioIds {
 		var studios []*models.Studio
 
-		if err := j.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := j.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			studioQuery := r.Studio()
 			if studioId == "*" {
 				var err error
@@ -223,7 +223,7 @@ func (j *autoTagJob) autoTagStudios(ctx context.Context, progress *job.Progress,
 					return nil
 				}
 
-				if err := j.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+				if err := j.txnManager.WithTxn(ctx, func(r models.Repository) error {
 					aliases, err := r.Studio().GetAliases(studio.ID)
 					if err != nil {
 						return err
@@ -262,7 +262,7 @@ func (j *autoTagJob) autoTagTags(ctx context.Context, progress *job.Progress, pa
 
 	for _, tagId := range tagIds {
 		var tags []*models.Tag
-		if err := j.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := j.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			tagQuery := r.Tag()
 			if tagId == "*" {
 				var err error
@@ -289,7 +289,7 @@ func (j *autoTagJob) autoTagTags(ctx context.Context, progress *job.Progress, pa
 					return nil
 				}
 
-				if err := j.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+				if err := j.txnManager.WithTxn(ctx, func(r models.Repository) error {
 					aliases, err := r.Tag().GetAliases(tag.ID)
 					if err != nil {
 						return err

--- a/internal/manager/task_autotag.go
+++ b/internal/manager/task_autotag.go
@@ -480,7 +480,7 @@ func (t *autoTagFilesTask) processScenes(ctx context.Context, r models.ReaderRep
 
 			var wg sync.WaitGroup
 			wg.Add(1)
-			go tt.Start(&wg)
+			go tt.Start(ctx, &wg)
 			wg.Wait()
 
 			t.progress.Increment()
@@ -533,7 +533,7 @@ func (t *autoTagFilesTask) processImages(ctx context.Context, r models.ReaderRep
 
 			var wg sync.WaitGroup
 			wg.Add(1)
-			go tt.Start(&wg)
+			go tt.Start(ctx, &wg)
 			wg.Wait()
 
 			t.progress.Increment()
@@ -586,7 +586,7 @@ func (t *autoTagFilesTask) processGalleries(ctx context.Context, r models.Reader
 
 			var wg sync.WaitGroup
 			wg.Add(1)
-			go tt.Start(&wg)
+			go tt.Start(ctx, &wg)
 			wg.Wait()
 
 			t.progress.Increment()
@@ -653,9 +653,9 @@ type autoTagSceneTask struct {
 	cache *match.Cache
 }
 
-func (t *autoTagSceneTask) Start(wg *sync.WaitGroup) {
+func (t *autoTagSceneTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
-	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 		if t.performers {
 			if err := autotag.ScenePerformers(t.scene, r.Scene(), r.Performer(), t.cache); err != nil {
 				return fmt.Errorf("error tagging scene performers for %s: %v", t.scene.Path, err)
@@ -689,9 +689,9 @@ type autoTagImageTask struct {
 	cache *match.Cache
 }
 
-func (t *autoTagImageTask) Start(wg *sync.WaitGroup) {
+func (t *autoTagImageTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
-	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 		if t.performers {
 			if err := autotag.ImagePerformers(t.image, r.Image(), r.Performer(), t.cache); err != nil {
 				return fmt.Errorf("error tagging image performers for %s: %v", t.image.Path, err)
@@ -725,9 +725,9 @@ type autoTagGalleryTask struct {
 	cache *match.Cache
 }
 
-func (t *autoTagGalleryTask) Start(wg *sync.WaitGroup) {
+func (t *autoTagGalleryTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
-	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 		if t.performers {
 			if err := autotag.GalleryPerformers(t.gallery, r.Gallery(), r.Performer(), t.cache); err != nil {
 				return fmt.Errorf("error tagging gallery performers for %s: %v", t.gallery.Path.String, err)

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -29,7 +29,7 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) {
 		logger.Infof("Running in Dry Mode")
 	}
 
-	if err := j.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := j.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		total, err := j.getCount(r)
 		if err != nil {
 			return fmt.Errorf("error getting count: %w", err)
@@ -401,7 +401,7 @@ func (j *cleanJob) deleteScene(ctx context.Context, fileNamingAlgorithm models.H
 		Paths:          GetInstance().Paths,
 	}
 	var s *models.Scene
-	if err := j.txnManager.WithTxn(context.TODO(), func(repo models.Repository) error {
+	if err := j.txnManager.WithTxn(ctx, func(repo models.Repository) error {
 		qb := repo.Scene()
 
 		var err error
@@ -431,7 +431,7 @@ func (j *cleanJob) deleteScene(ctx context.Context, fileNamingAlgorithm models.H
 func (j *cleanJob) deleteGallery(ctx context.Context, galleryID int) {
 	var g *models.Gallery
 
-	if err := j.txnManager.WithTxn(context.TODO(), func(repo models.Repository) error {
+	if err := j.txnManager.WithTxn(ctx, func(repo models.Repository) error {
 		qb := repo.Gallery()
 
 		var err error
@@ -459,7 +459,7 @@ func (j *cleanJob) deleteImage(ctx context.Context, imageID int) {
 	}
 
 	var i *models.Image
-	if err := j.txnManager.WithTxn(context.TODO(), func(repo models.Repository) error {
+	if err := j.txnManager.WithTxn(ctx, func(repo models.Repository) error {
 		qb := repo.Image()
 
 		var err error

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -96,7 +96,7 @@ func CreateExportTask(a models.HashAlgorithm, input models.ExportObjectsInput) *
 	}
 }
 
-func (t *ExportTask) Start(wg *sync.WaitGroup) {
+func (t *ExportTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// @manager.total = Scene.count + Gallery.count + Performer.count + Studio.count + Movie.count
 	workerCount := runtime.GOMAXPROCS(0) // set worker count to number of cpus available
@@ -129,7 +129,7 @@ func (t *ExportTask) Start(wg *sync.WaitGroup) {
 
 	paths.EnsureJSONDirs(t.baseDir)
 
-	txnErr := t.txnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	txnErr := t.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		// include movie scenes and gallery images
 		if !t.full {
 			// only include movie scenes if includeDependencies is also set

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -75,7 +75,7 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) {
 				if len(j.input.SceneIDs) > 0 {
 					scenes, err = qb.FindMany(sceneIDs)
 					for _, s := range scenes {
-						j.queueSceneJobs(s, queue, &totals)
+						j.queueSceneJobs(ctx, s, queue, &totals)
 					}
 				}
 
@@ -165,7 +165,7 @@ func (j *GenerateJob) queueTasks(ctx context.Context, queue chan<- Task) totalsG
 					return context.Canceled
 				}
 
-				j.queueSceneJobs(ss, queue, &totals)
+				j.queueSceneJobs(ctx, ss, queue, &totals)
 			}
 
 			if len(scenes) != batchSize {
@@ -185,7 +185,7 @@ func (j *GenerateJob) queueTasks(ctx context.Context, queue chan<- Task) totalsG
 	return totals
 }
 
-func (j *GenerateJob) queueSceneJobs(scene *models.Scene, queue chan<- Task, totals *totalsGenerate) {
+func (j *GenerateJob) queueSceneJobs(ctx context.Context, scene *models.Scene, queue chan<- Task, totals *totalsGenerate) {
 	if utils.IsTrue(j.input.Sprites) {
 		task := &GenerateSpriteTask{
 			Scene:               *scene,
@@ -243,7 +243,7 @@ func (j *GenerateJob) queueSceneJobs(scene *models.Scene, queue chan<- Task, tot
 			Screenshot:          utils.IsTrue(j.input.MarkerScreenshots),
 		}
 
-		markers := task.markersNeeded()
+		markers := task.markersNeeded(ctx)
 		if markers > 0 {
 			totals.markers += int64(markers)
 			totals.tasks++

--- a/internal/manager/task_generate_interactive_heatmap_speed.go
+++ b/internal/manager/task_generate_interactive_heatmap_speed.go
@@ -47,7 +47,7 @@ func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
 
 	var s *models.Scene
 
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		var err error
 		s, err = r.Scene().FindByPath(t.Scene.Path)
 		return err
@@ -56,7 +56,7 @@ func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
 		return
 	}
 
-	if err := t.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 		qb := r.Scene()
 		scenePartial := models.ScenePartial{
 			ID:               s.ID,

--- a/internal/manager/task_generate_markers.go
+++ b/internal/manager/task_generate_markers.go
@@ -35,12 +35,12 @@ func (t *GenerateMarkersTask) GetDescription() string {
 
 func (t *GenerateMarkersTask) Start(ctx context.Context) {
 	if t.Scene != nil {
-		t.generateSceneMarkers()
+		t.generateSceneMarkers(ctx)
 	}
 
 	if t.Marker != nil {
 		var scene *models.Scene
-		if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+		if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 			var err error
 			scene, err = r.Scene().Find(int(t.Marker.SceneID.Int64))
 			return err
@@ -65,9 +65,9 @@ func (t *GenerateMarkersTask) Start(ctx context.Context) {
 	}
 }
 
-func (t *GenerateMarkersTask) generateSceneMarkers() {
+func (t *GenerateMarkersTask) generateSceneMarkers(ctx context.Context) {
 	var sceneMarkers []*models.SceneMarker
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		var err error
 		sceneMarkers, err = r.SceneMarker().FindBySceneID(t.Scene.ID)
 		return err
@@ -167,10 +167,10 @@ func (t *GenerateMarkersTask) generateMarker(videoFile *ffmpeg.VideoFile, scene 
 	}
 }
 
-func (t *GenerateMarkersTask) markersNeeded() int {
+func (t *GenerateMarkersTask) markersNeeded(ctx context.Context) int {
 	markers := 0
 	var sceneMarkers []*models.SceneMarker
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		var err error
 		sceneMarkers, err = r.SceneMarker().FindBySceneID(t.Scene.ID)
 		return err

--- a/internal/manager/task_generate_phash.go
+++ b/internal/manager/task_generate_phash.go
@@ -45,7 +45,7 @@ func (t *GeneratePhashTask) Start(ctx context.Context) {
 		return
 	}
 
-	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 		qb := r.Scene()
 		hashValue := sql.NullInt64{Int64: int64(*hash), Valid: true}
 		scenePartial := models.ScenePartial{

--- a/internal/manager/task_generate_screenshot.go
+++ b/internal/manager/task_generate_screenshot.go
@@ -59,7 +59,7 @@ func (t *GenerateScreenshotTask) Start(ctx context.Context) {
 		return
 	}
 
-	if err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 		qb := r.Scene()
 		updatedTime := time.Now()
 		updatedScene := models.ScenePartial{

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -97,7 +97,6 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 			GenerateThumbnails:   utils.IsTrue(input.ScanGenerateThumbnails),
 			progress:             progress,
 			CaseSensitiveFs:      f.caseSensitiveFs,
-			ctx:                  ctx,
 			mutexManager:         mutexManager,
 		}
 
@@ -248,7 +247,6 @@ func (j *ScanJob) doesPathExist(ctx context.Context, path string) bool {
 }
 
 type ScanTask struct {
-	ctx                  context.Context
 	TxnManager           models.TransactionManager
 	file                 file.SourceFile
 	UseFileMetadata      bool

--- a/internal/manager/task_scan_gallery.go
+++ b/internal/manager/task_scan_gallery.go
@@ -42,7 +42,6 @@ func (t *ScanTask) scanGallery(ctx context.Context) {
 		Scanner:            gallery.FileScanner(&file.FSHasher{}),
 		ImageExtensions:    instance.Config.GetImageExtensions(),
 		StripFileExtension: t.StripFileExtension,
-		Ctx:                t.ctx,
 		CaseSensitiveFs:    t.CaseSensitiveFs,
 		TxnManager:         t.TxnManager,
 		Paths:              instance.Paths,
@@ -52,7 +51,7 @@ func (t *ScanTask) scanGallery(ctx context.Context) {
 
 	var err error
 	if g != nil {
-		g, scanImages, err = scanner.ScanExisting(g, t.file)
+		g, scanImages, err = scanner.ScanExisting(ctx, g, t.file)
 		if err != nil {
 			logger.Error(err.Error())
 			return
@@ -61,7 +60,7 @@ func (t *ScanTask) scanGallery(ctx context.Context) {
 		// scan the zip files if the gallery has no images
 		scanImages = scanImages || images == 0
 	} else {
-		g, scanImages, err = scanner.ScanNew(t.file)
+		g, scanImages, err = scanner.ScanNew(ctx, t.file)
 		if err != nil {
 			logger.Error(err.Error())
 		}

--- a/internal/manager/task_scan_gallery.go
+++ b/internal/manager/task_scan_gallery.go
@@ -78,9 +78,9 @@ func (t *ScanTask) scanGallery(ctx context.Context) {
 }
 
 // associates a gallery to a scene with the same basename
-func (t *ScanTask) associateGallery(wg *sizedwaitgroup.SizedWaitGroup) {
+func (t *ScanTask) associateGallery(ctx context.Context, wg *sizedwaitgroup.SizedWaitGroup) {
 	path := t.file.Path()
-	if err := t.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+	if err := t.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 		qb := r.Gallery()
 		sqb := r.Scene()
 		g, err := qb.FindByPath(path)

--- a/internal/manager/task_scan_gallery.go
+++ b/internal/manager/task_scan_gallery.go
@@ -69,10 +69,10 @@ func (t *ScanTask) scanGallery(ctx context.Context) {
 
 	if g != nil {
 		if scanImages {
-			t.scanZipImages(g)
+			t.scanZipImages(ctx, g)
 		} else {
 			// in case thumbnails have been deleted, regenerate them
-			t.regenerateZipImages(g)
+			t.regenerateZipImages(ctx, g)
 		}
 	}
 }
@@ -133,7 +133,7 @@ func (t *ScanTask) associateGallery(wg *sizedwaitgroup.SizedWaitGroup) {
 	wg.Done()
 }
 
-func (t *ScanTask) scanZipImages(zipGallery *models.Gallery) {
+func (t *ScanTask) scanZipImages(ctx context.Context, zipGallery *models.Gallery) {
 	err := walkGalleryZip(zipGallery.Path.String, func(f *zip.File) error {
 		// copy this task and change the filename
 		subTask := *t
@@ -143,7 +143,7 @@ func (t *ScanTask) scanZipImages(zipGallery *models.Gallery) {
 		subTask.zipGallery = zipGallery
 
 		// run the subtask and wait for it to complete
-		subTask.Start(context.TODO())
+		subTask.Start(ctx)
 		return nil
 	})
 	if err != nil {
@@ -151,9 +151,9 @@ func (t *ScanTask) scanZipImages(zipGallery *models.Gallery) {
 	}
 }
 
-func (t *ScanTask) regenerateZipImages(zipGallery *models.Gallery) {
+func (t *ScanTask) regenerateZipImages(ctx context.Context, zipGallery *models.Gallery) {
 	var images []*models.Image
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		iqb := r.Image()
 
 		var err error

--- a/internal/manager/task_scan_image.go
+++ b/internal/manager/task_scan_image.go
@@ -34,7 +34,6 @@ func (t *ScanTask) scanImage(ctx context.Context) {
 	scanner := image.Scanner{
 		Scanner:            image.FileScanner(&file.FSHasher{}),
 		StripFileExtension: t.StripFileExtension,
-		Ctx:                t.ctx,
 		TxnManager:         t.TxnManager,
 		Paths:              GetInstance().Paths,
 		PluginCache:        instance.PluginCache,
@@ -43,13 +42,13 @@ func (t *ScanTask) scanImage(ctx context.Context) {
 
 	var err error
 	if i != nil {
-		i, err = scanner.ScanExisting(i, t.file)
+		i, err = scanner.ScanExisting(ctx, i, t.file)
 		if err != nil {
 			logger.Error(err.Error())
 			return
 		}
 	} else {
-		i, err = scanner.ScanNew(t.file)
+		i, err = scanner.ScanNew(ctx, t.file)
 		if err != nil {
 			logger.Error(err.Error())
 			return
@@ -79,7 +78,7 @@ func (t *ScanTask) scanImage(ctx context.Context) {
 				}
 
 				if isNewGallery {
-					GetInstance().PluginCache.ExecutePostHooks(t.ctx, galleryID, plugin.GalleryCreatePost, nil, nil)
+					GetInstance().PluginCache.ExecutePostHooks(ctx, galleryID, plugin.GalleryCreatePost, nil, nil)
 				}
 			}
 		}

--- a/internal/manager/task_scan_image.go
+++ b/internal/manager/task_scan_image.go
@@ -18,11 +18,11 @@ import (
 	"github.com/stashapp/stash/pkg/plugin"
 )
 
-func (t *ScanTask) scanImage() {
+func (t *ScanTask) scanImage(ctx context.Context) {
 	var i *models.Image
 	path := t.file.Path()
 
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		var err error
 		i, err = r.Image().FindByPath(path)
 		return err

--- a/internal/manager/task_scan_image.go
+++ b/internal/manager/task_scan_image.go
@@ -58,7 +58,7 @@ func (t *ScanTask) scanImage(ctx context.Context) {
 		if i != nil {
 			if t.zipGallery != nil {
 				// associate with gallery
-				if err := t.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+				if err := t.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 					return gallery.AddImage(r.Gallery(), t.zipGallery.ID, i.ID)
 				}); err != nil {
 					logger.Error(err.Error())
@@ -69,7 +69,7 @@ func (t *ScanTask) scanImage(ctx context.Context) {
 				logger.Infof("Associating image %s with folder gallery", i.Path)
 				var galleryID int
 				var isNewGallery bool
-				if err := t.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+				if err := t.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 					var err error
 					galleryID, isNewGallery, err = t.associateImageWithFolderGallery(i.ID, r.Gallery())
 					return err

--- a/internal/manager/task_scan_scene.go
+++ b/internal/manager/task_scan_scene.go
@@ -31,7 +31,6 @@ func (t *ScanTask) scanScene(ctx context.Context) *models.Scene {
 		Scanner:             scene.FileScanner(&file.FSHasher{}, t.fileNamingAlgorithm, t.calculateMD5),
 		StripFileExtension:  t.StripFileExtension,
 		FileNamingAlgorithm: t.fileNamingAlgorithm,
-		Ctx:                 t.ctx,
 		TxnManager:          t.TxnManager,
 		Paths:               GetInstance().Paths,
 		Screenshotter:       &instance.FFMPEG,
@@ -42,7 +41,7 @@ func (t *ScanTask) scanScene(ctx context.Context) *models.Scene {
 	}
 
 	if s != nil {
-		if err := scanner.ScanExisting(s, t.file); err != nil {
+		if err := scanner.ScanExisting(ctx, s, t.file); err != nil {
 			return logError(err)
 		}
 
@@ -50,7 +49,7 @@ func (t *ScanTask) scanScene(ctx context.Context) *models.Scene {
 	}
 
 	var err error
-	retScene, err = scanner.ScanNew(t.file)
+	retScene, err = scanner.ScanNew(ctx, t.file)
 	if err != nil {
 		return logError(err)
 	}

--- a/internal/manager/task_scan_scene.go
+++ b/internal/manager/task_scan_scene.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stashapp/stash/pkg/scene"
 )
 
-func (t *ScanTask) scanScene() *models.Scene {
+func (t *ScanTask) scanScene(ctx context.Context) *models.Scene {
 	logError := func(err error) *models.Scene {
 		logger.Error(err.Error())
 		return nil
@@ -18,7 +18,7 @@ func (t *ScanTask) scanScene() *models.Scene {
 	var retScene *models.Scene
 	var s *models.Scene
 
-	if err := t.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := t.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		var err error
 		s, err = r.Scene().FindByPath(t.file.Path())
 		return err

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -22,8 +22,8 @@ type StashBoxPerformerTagTask struct {
 	excluded_fields []string
 }
 
-func (t *StashBoxPerformerTagTask) Start() {
-	t.stashBoxPerformerTag(context.TODO())
+func (t *StashBoxPerformerTagTask) Start(ctx context.Context) {
+	t.stashBoxPerformerTag(ctx)
 }
 
 func (t *StashBoxPerformerTagTask) Description() string {

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -156,7 +156,7 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag(ctx context.Context) {
 				partial.URL = &value
 			}
 
-			txnErr := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+			txnErr := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 				_, err := r.Performer().Update(partial)
 
 				if !t.refresh {
@@ -218,7 +218,7 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag(ctx context.Context) {
 				URL:          getNullString(performer.URL),
 				UpdatedAt:    models.SQLiteTimestamp{Timestamp: currentTime},
 			}
-			err := t.txnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+			err := t.txnManager.WithTxn(ctx, func(r models.Repository) error {
 				createdPerformer, err := r.Performer().Create(newPerformer)
 				if err != nil {
 					return err

--- a/pkg/plugin/js/log.go
+++ b/pkg/plugin/js/log.go
@@ -15,7 +15,10 @@ func argToString(call otto.FunctionCall) string {
 	arg := call.Argument(0)
 	if arg.IsObject() {
 		o, _ := arg.Export()
-		data, _ := json.Marshal(o)
+		data, err := json.Marshal(o)
+		if err != nil {
+			logger.Warnf("Couldn't json encode object")
+		}
 		return string(data)
 	}
 

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -71,7 +71,10 @@ func (t *rawPluginTask) Start() error {
 	go func() {
 		defer stdin.Close()
 
-		inBytes, _ := json.Marshal(t.input)
+		inBytes, err := json.Marshal(t.input)
+		if err != nil {
+			logger.Warnf("error marshalling raw command input")
+		}
 		if k, err := io.WriteString(stdin, string(inBytes)); err != nil {
 			logger.Warnf("error writing input to plugins stdin (wrote %v bytes out of %v): %v", k, len(string(inBytes)), err)
 		}

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -32,7 +32,6 @@ type Scanner struct {
 	UseFileMetadata     bool
 	FileNamingAlgorithm models.HashAlgorithm
 
-	Ctx              context.Context
 	CaseSensitiveFs  bool
 	TxnManager       models.TransactionManager
 	Paths            *paths.Paths
@@ -50,7 +49,7 @@ func FileScanner(hasher file.Hasher, fileNamingAlgorithm models.HashAlgorithm, c
 	}
 }
 
-func (scanner *Scanner) ScanExisting(existing file.FileBased, file file.SourceFile) (err error) {
+func (scanner *Scanner) ScanExisting(ctx context.Context, existing file.FileBased, file file.SourceFile) (err error) {
 	scanned, err := scanner.Scanner.ScanExisting(existing, file)
 	if err != nil {
 		return err
@@ -110,7 +109,7 @@ func (scanner *Scanner) ScanExisting(existing file.FileBased, file file.SourceFi
 			scanner.MutexManager.Claim(mutexType, scanned.New.Checksum, done)
 		}
 
-		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+		if err := scanner.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 			defer close(done)
 			qb := r.Scene()
 
@@ -144,7 +143,7 @@ func (scanner *Scanner) ScanExisting(existing file.FileBased, file file.SourceFi
 			MigrateHash(scanner.Paths, oldHash, newHash)
 		}
 
-		scanner.PluginCache.ExecutePostHooks(scanner.Ctx, s.ID, plugin.SceneUpdatePost, nil, nil)
+		scanner.PluginCache.ExecutePostHooks(ctx, s.ID, plugin.SceneUpdatePost, nil, nil)
 	}
 
 	// We already have this item in the database
@@ -154,7 +153,7 @@ func (scanner *Scanner) ScanExisting(existing file.FileBased, file file.SourceFi
 	return nil
 }
 
-func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, err error) {
+func (scanner *Scanner) ScanNew(ctx context.Context, file file.SourceFile) (retScene *models.Scene, err error) {
 	scanned, err := scanner.Scanner.ScanNew(file)
 	if err != nil {
 		return nil, err
@@ -178,7 +177,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 	// check for scene by checksum and oshash - MD5 should be
 	// redundant, but check both
 	var s *models.Scene
-	if err := scanner.TxnManager.WithReadTxn(context.TODO(), func(r models.ReaderRepository) error {
+	if err := scanner.TxnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		qb := r.Scene()
 		if checksum != "" {
 			s, _ = qb.FindByChecksum(checksum)
@@ -220,7 +219,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 				Path:        &path,
 				Interactive: &interactive,
 			}
-			if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+			if err := scanner.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 				_, err := r.Scene().Update(scenePartial)
 				return err
 			}); err != nil {
@@ -228,7 +227,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 			}
 
 			scanner.makeScreenshots(path, nil, sceneHash)
-			scanner.PluginCache.ExecutePostHooks(scanner.Ctx, s.ID, plugin.SceneUpdatePost, nil, nil)
+			scanner.PluginCache.ExecutePostHooks(ctx, s.ID, plugin.SceneUpdatePost, nil, nil)
 		}
 	} else {
 		logger.Infof("%s doesn't exist. Creating new item...", path)
@@ -265,7 +264,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 			_ = newScene.Date.Scan(videoFile.CreationTime)
 		}
 
-		if err := scanner.TxnManager.WithTxn(context.TODO(), func(r models.Repository) error {
+		if err := scanner.TxnManager.WithTxn(ctx, func(r models.Repository) error {
 			var err error
 			retScene, err = r.Scene().Create(newScene)
 			return err
@@ -274,7 +273,7 @@ func (scanner *Scanner) ScanNew(file file.SourceFile) (retScene *models.Scene, e
 		}
 
 		scanner.makeScreenshots(path, videoFile, sceneHash)
-		scanner.PluginCache.ExecutePostHooks(scanner.Ctx, retScene.ID, plugin.SceneCreatePost, nil, nil)
+		scanner.PluginCache.ExecutePostHooks(ctx, retScene.ID, plugin.SceneCreatePost, nil, nil)
 	}
 
 	return retScene, nil

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -32,7 +32,7 @@ func newScriptScraper(scraper scraperTypeConfig, config config, globalConfig Glo
 	}
 }
 
-func (s *scriptScraper) runScraperScript(inString string, out interface{}) error {
+func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, out interface{}) error {
 	command := s.scraper.Script
 
 	var cmd *exec.Cmd
@@ -46,7 +46,7 @@ func (s *scriptScraper) runScraperScript(inString string, out interface{}) error
 		}
 
 		if p != nil {
-			cmd = p.Command(context.TODO(), command[1:])
+			cmd = p.Command(ctx, command[1:])
 		}
 
 		// if could not find python, just use the command args as-is
@@ -133,7 +133,7 @@ func (s *scriptScraper) scrapeByName(ctx context.Context, name string, ty models
 	switch ty {
 	case models.ScrapeContentTypePerformer:
 		var performers []models.ScrapedPerformer
-		err = s.runScraperScript(input, &performers)
+		err = s.runScraperScript(ctx, input, &performers)
 		if err == nil {
 			for _, p := range performers {
 				v := p
@@ -142,7 +142,7 @@ func (s *scriptScraper) scrapeByName(ctx context.Context, name string, ty models
 		}
 	case models.ScrapeContentTypeScene:
 		var scenes []models.ScrapedScene
-		err = s.runScraperScript(input, &scenes)
+		err = s.runScraperScript(ctx, input, &scenes)
 		if err == nil {
 			for _, s := range scenes {
 				v := s
@@ -187,19 +187,19 @@ func (s *scriptScraper) scrape(ctx context.Context, input string, ty models.Scra
 	switch ty {
 	case models.ScrapeContentTypePerformer:
 		var performer *models.ScrapedPerformer
-		err := s.runScraperScript(input, &performer)
+		err := s.runScraperScript(ctx, input, &performer)
 		return performer, err
 	case models.ScrapeContentTypeGallery:
 		var gallery *models.ScrapedGallery
-		err := s.runScraperScript(input, &gallery)
+		err := s.runScraperScript(ctx, input, &gallery)
 		return gallery, err
 	case models.ScrapeContentTypeScene:
 		var scene *models.ScrapedScene
-		err := s.runScraperScript(input, &scene)
+		err := s.runScraperScript(ctx, input, &scene)
 		return scene, err
 	case models.ScrapeContentTypeMovie:
 		var movie *models.ScrapedMovie
-		err := s.runScraperScript(input, &movie)
+		err := s.runScraperScript(ctx, input, &movie)
 		return movie, err
 	}
 
@@ -215,7 +215,7 @@ func (s *scriptScraper) scrapeSceneByScene(ctx context.Context, scene *models.Sc
 
 	var ret *models.ScrapedScene
 
-	err = s.runScraperScript(string(inString), &ret)
+	err = s.runScraperScript(ctx, string(inString), &ret)
 
 	return ret, err
 }
@@ -229,7 +229,7 @@ func (s *scriptScraper) scrapeGalleryByGallery(ctx context.Context, gallery *mod
 
 	var ret *models.ScrapedGallery
 
-	err = s.runScraperScript(string(inString), &ret)
+	err = s.runScraperScript(ctx, string(inString), &ret)
 
 	return ret, err
 }


### PR DESCRIPTION
This PR does 3 things:

* Enable `errchkjson` in the linter. This warns if a `Marshal` is called on data which can fail to encode. The two cases of `time.Time` and `interface{}` in the repo where it happens are extended with a warning on error.
* Connect `context.TODO()` to contexts that sit in the call chain anyway. I've refrained from handling the context too much in the job manager because it shouldn't grab the context from a request but the context of the lifetime of the stash server. I'd rather try to tackle that separately and it also requires some thinking beforehand.
* Remove contexts from structs. It is usually bad form (see e.g., https://go.dev/blog/context-and-structs ). And in all cases the call chain has the context available anyway, so we don't have to stuff it into the struct and then pull it out from there again in the next function. We can just pass it along in a func parameter. The flexibility this provides is explained in the blog post.