### PR TITLE
Update stash-box fingerprint query to fully support distance matching

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -114,12 +114,6 @@ type Query {
   """Scrape a list of performers from a query"""
   scrapeFreeonesPerformerList(query: String!): [String!]! @deprecated(reason: "use scrapeSinglePerformer with scraper_id = builtin_freeones")
 
-  """Query StashBox for scenes"""
-  queryStashBoxScene(input: StashBoxSceneQueryInput!): [ScrapedScene!]! @deprecated(reason: "use scrapeSingleScene or scrapeMultiScenes")
-  """Query StashBox for performers"""
-  queryStashBoxPerformer(input: StashBoxPerformerQueryInput!): [StashBoxPerformerQueryResult!]! @deprecated(reason: "use scrapeSinglePerformer or scrapeMultiPerformers")
-  # === end deprecated methods ===
-
   # Plugins
   """List loaded plugins"""
   plugins: [Plugin!]

--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -133,14 +133,14 @@ input ScrapeSingleSceneInput {
   """Instructs to query by string"""
   query: String
   """Instructs to query by scene fingerprints"""
-  scene_id: ID
+  scene_id: Int
   """Instructs to query by scene fragment"""
   scene_input: ScrapedSceneInput
 }
 
 input ScrapeMultiScenesInput {
   """Instructs to query by scene fingerprints"""
-  scene_ids: [ID!]
+  scene_ids: [Int!]
 }
 
 input ScrapeSinglePerformerInput {

--- a/graphql/stash-box/query.graphql
+++ b/graphql/stash-box/query.graphql
@@ -129,6 +129,12 @@ query FindScenesByFullFingerprints($fingerprints: [FingerprintQueryInput!]!) {
   }
 }
 
+query FindScenesBySceneFingerprints($fingerprints: [[FingerprintQueryInput!]!]!) {
+  findScenesBySceneFingerprints(fingerprints: $fingerprints) {
+    ...SceneFragment
+  }
+}
+
 query SearchScene($term: String!) {
   searchScene(term: $term) {
     ...SceneFragment

--- a/internal/api/resolver_query_scraper.go
+++ b/internal/api/resolver_query_scraper.go
@@ -227,46 +227,6 @@ func (r *queryResolver) ScrapeMovieURL(ctx context.Context, url string) (*models
 	return marshalScrapedMovie(content)
 }
 
-func (r *queryResolver) QueryStashBoxScene(ctx context.Context, input models.StashBoxSceneQueryInput) ([]*models.ScrapedScene, error) {
-	boxes := config.GetInstance().GetStashBoxes()
-
-	if input.StashBoxIndex < 0 || input.StashBoxIndex >= len(boxes) {
-		return nil, fmt.Errorf("%w: invalid stash_box_index %d", ErrInput, input.StashBoxIndex)
-	}
-
-	client := stashbox.NewClient(*boxes[input.StashBoxIndex], r.txnManager)
-
-	if len(input.SceneIds) > 0 {
-		return client.FindStashBoxScenesByFingerprintsFlat(ctx, input.SceneIds)
-	}
-
-	if input.Q != nil {
-		return client.QueryStashBoxScene(ctx, *input.Q)
-	}
-
-	return nil, nil
-}
-
-func (r *queryResolver) QueryStashBoxPerformer(ctx context.Context, input models.StashBoxPerformerQueryInput) ([]*models.StashBoxPerformerQueryResult, error) {
-	boxes := config.GetInstance().GetStashBoxes()
-
-	if input.StashBoxIndex < 0 || input.StashBoxIndex >= len(boxes) {
-		return nil, fmt.Errorf("%w: invalid stash_box_index %d", ErrInput, input.StashBoxIndex)
-	}
-
-	client := stashbox.NewClient(*boxes[input.StashBoxIndex], r.txnManager)
-
-	if len(input.PerformerIds) > 0 {
-		return client.FindStashBoxPerformersByNames(ctx, input.PerformerIds)
-	}
-
-	if input.Q != nil {
-		return client.QueryStashBoxPerformer(ctx, *input.Q)
-	}
-
-	return nil, nil
-}
-
 func (r *queryResolver) getStashBoxClient(index int) (*stashbox.Client, error) {
 	boxes := config.GetInstance().GetStashBoxes()
 
@@ -288,12 +248,7 @@ func (r *queryResolver) ScrapeSingleScene(ctx context.Context, source models.Scr
 
 		switch {
 		case input.SceneID != nil:
-			var sceneID int
-			sceneID, err = strconv.Atoi(*input.SceneID)
-			if err != nil {
-				return nil, fmt.Errorf("%w: sceneID is not an integer: '%s'", ErrInput, *input.SceneID)
-			}
-			c, err = r.scraperCache().ScrapeID(ctx, *source.ScraperID, sceneID, models.ScrapeContentTypeScene)
+			c, err = r.scraperCache().ScrapeID(ctx, *source.ScraperID, *input.SceneID, models.ScrapeContentTypeScene)
 			if c != nil {
 				content = []models.ScrapedContent{c}
 			}
@@ -324,7 +279,7 @@ func (r *queryResolver) ScrapeSingleScene(ctx context.Context, source models.Scr
 
 		switch {
 		case input.SceneID != nil:
-			ret, err = client.FindStashBoxScenesByFingerprintsFlat(ctx, []string{*input.SceneID})
+			ret, err = client.FindStashBoxSceneByFingerprints(ctx, *input.SceneID)
 		case input.Query != nil:
 			ret, err = client.QueryStashBoxScene(ctx, *input.Query)
 		default:

--- a/internal/manager/task_identify.go
+++ b/internal/manager/task_identify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/stashapp/stash/internal/identify"
 	"github.com/stashapp/stash/pkg/job"
@@ -212,7 +211,7 @@ type stashboxSource struct {
 }
 
 func (s stashboxSource) ScrapeScene(ctx context.Context, sceneID int) (*models.ScrapedScene, error) {
-	results, err := s.FindStashBoxScenesByFingerprintsFlat(ctx, []string{strconv.Itoa(sceneID)})
+	results, err := s.FindStashBoxSceneByFingerprints(ctx, sceneID)
 	if err != nil {
 		return nil, fmt.Errorf("error querying stash-box using scene ID %d: %w", sceneID, err)
 	}

--- a/pkg/scraper/stashbox/graphql/generated_client.go
+++ b/pkg/scraper/stashbox/graphql/generated_client.go
@@ -12,6 +12,7 @@ import (
 type StashBoxGraphQLClient interface {
 	FindSceneByFingerprint(ctx context.Context, fingerprint FingerprintQueryInput, httpRequestOptions ...client.HTTPRequestOption) (*FindSceneByFingerprint, error)
 	FindScenesByFullFingerprints(ctx context.Context, fingerprints []*FingerprintQueryInput, httpRequestOptions ...client.HTTPRequestOption) (*FindScenesByFullFingerprints, error)
+	FindScenesBySceneFingerprints(ctx context.Context, fingerprints [][]*FingerprintQueryInput, httpRequestOptions ...client.HTTPRequestOption) (*FindScenesBySceneFingerprints, error)
 	SearchScene(ctx context.Context, term string, httpRequestOptions ...client.HTTPRequestOption) (*SearchScene, error)
 	SearchPerformer(ctx context.Context, term string, httpRequestOptions ...client.HTTPRequestOption) (*SearchPerformer, error)
 	FindPerformerByID(ctx context.Context, id string, httpRequestOptions ...client.HTTPRequestOption) (*FindPerformerByID, error)
@@ -31,32 +32,33 @@ func NewClient(cli *http.Client, baseURL string, options ...client.HTTPRequestOp
 }
 
 type Query struct {
-	FindPerformer                *Performer                   "json:\"findPerformer\" graphql:\"findPerformer\""
-	QueryPerformers              QueryPerformersResultType    "json:\"queryPerformers\" graphql:\"queryPerformers\""
-	FindStudio                   *Studio                      "json:\"findStudio\" graphql:\"findStudio\""
-	QueryStudios                 QueryStudiosResultType       "json:\"queryStudios\" graphql:\"queryStudios\""
-	FindTag                      *Tag                         "json:\"findTag\" graphql:\"findTag\""
-	QueryTags                    QueryTagsResultType          "json:\"queryTags\" graphql:\"queryTags\""
-	FindTagCategory              *TagCategory                 "json:\"findTagCategory\" graphql:\"findTagCategory\""
-	QueryTagCategories           QueryTagCategoriesResultType "json:\"queryTagCategories\" graphql:\"queryTagCategories\""
-	FindScene                    *Scene                       "json:\"findScene\" graphql:\"findScene\""
-	FindSceneByFingerprint       []*Scene                     "json:\"findSceneByFingerprint\" graphql:\"findSceneByFingerprint\""
-	FindScenesByFingerprints     []*Scene                     "json:\"findScenesByFingerprints\" graphql:\"findScenesByFingerprints\""
-	FindScenesByFullFingerprints []*Scene                     "json:\"findScenesByFullFingerprints\" graphql:\"findScenesByFullFingerprints\""
-	QueryScenes                  QueryScenesResultType        "json:\"queryScenes\" graphql:\"queryScenes\""
-	FindSite                     *Site                        "json:\"findSite\" graphql:\"findSite\""
-	QuerySites                   QuerySitesResultType         "json:\"querySites\" graphql:\"querySites\""
-	FindEdit                     *Edit                        "json:\"findEdit\" graphql:\"findEdit\""
-	QueryEdits                   QueryEditsResultType         "json:\"queryEdits\" graphql:\"queryEdits\""
-	FindUser                     *User                        "json:\"findUser\" graphql:\"findUser\""
-	QueryUsers                   QueryUsersResultType         "json:\"queryUsers\" graphql:\"queryUsers\""
-	Me                           *User                        "json:\"me\" graphql:\"me\""
-	SearchPerformer              []*Performer                 "json:\"searchPerformer\" graphql:\"searchPerformer\""
-	SearchScene                  []*Scene                     "json:\"searchScene\" graphql:\"searchScene\""
-	FindDraft                    *Draft                       "json:\"findDraft\" graphql:\"findDraft\""
-	FindDrafts                   []*Draft                     "json:\"findDrafts\" graphql:\"findDrafts\""
-	Version                      Version                      "json:\"version\" graphql:\"version\""
-	GetConfig                    StashBoxConfig               "json:\"getConfig\" graphql:\"getConfig\""
+	FindPerformer                 *Performer                   "json:\"findPerformer\" graphql:\"findPerformer\""
+	QueryPerformers               QueryPerformersResultType    "json:\"queryPerformers\" graphql:\"queryPerformers\""
+	FindStudio                    *Studio                      "json:\"findStudio\" graphql:\"findStudio\""
+	QueryStudios                  QueryStudiosResultType       "json:\"queryStudios\" graphql:\"queryStudios\""
+	FindTag                       *Tag                         "json:\"findTag\" graphql:\"findTag\""
+	QueryTags                     QueryTagsResultType          "json:\"queryTags\" graphql:\"queryTags\""
+	FindTagCategory               *TagCategory                 "json:\"findTagCategory\" graphql:\"findTagCategory\""
+	QueryTagCategories            QueryTagCategoriesResultType "json:\"queryTagCategories\" graphql:\"queryTagCategories\""
+	FindScene                     *Scene                       "json:\"findScene\" graphql:\"findScene\""
+	FindSceneByFingerprint        []*Scene                     "json:\"findSceneByFingerprint\" graphql:\"findSceneByFingerprint\""
+	FindScenesByFingerprints      []*Scene                     "json:\"findScenesByFingerprints\" graphql:\"findScenesByFingerprints\""
+	FindScenesByFullFingerprints  []*Scene                     "json:\"findScenesByFullFingerprints\" graphql:\"findScenesByFullFingerprints\""
+	FindScenesBySceneFingerprints [][]*Scene                   "json:\"findScenesBySceneFingerprints\" graphql:\"findScenesBySceneFingerprints\""
+	QueryScenes                   QueryScenesResultType        "json:\"queryScenes\" graphql:\"queryScenes\""
+	FindSite                      *Site                        "json:\"findSite\" graphql:\"findSite\""
+	QuerySites                    QuerySitesResultType         "json:\"querySites\" graphql:\"querySites\""
+	FindEdit                      *Edit                        "json:\"findEdit\" graphql:\"findEdit\""
+	QueryEdits                    QueryEditsResultType         "json:\"queryEdits\" graphql:\"queryEdits\""
+	FindUser                      *User                        "json:\"findUser\" graphql:\"findUser\""
+	QueryUsers                    QueryUsersResultType         "json:\"queryUsers\" graphql:\"queryUsers\""
+	Me                            *User                        "json:\"me\" graphql:\"me\""
+	SearchPerformer               []*Performer                 "json:\"searchPerformer\" graphql:\"searchPerformer\""
+	SearchScene                   []*Scene                     "json:\"searchScene\" graphql:\"searchScene\""
+	FindDraft                     *Draft                       "json:\"findDraft\" graphql:\"findDraft\""
+	FindDrafts                    []*Draft                     "json:\"findDrafts\" graphql:\"findDrafts\""
+	Version                       Version                      "json:\"version\" graphql:\"version\""
+	GetConfig                     StashBoxConfig               "json:\"getConfig\" graphql:\"getConfig\""
 }
 type Mutation struct {
 	SceneCreate          *Scene                "json:\"sceneCreate\" graphql:\"sceneCreate\""
@@ -190,6 +192,9 @@ type FindSceneByFingerprint struct {
 type FindScenesByFullFingerprints struct {
 	FindScenesByFullFingerprints []*SceneFragment "json:\"findScenesByFullFingerprints\" graphql:\"findScenesByFullFingerprints\""
 }
+type FindScenesBySceneFingerprints struct {
+	FindScenesBySceneFingerprints [][]*SceneFragment "json:\"findScenesBySceneFingerprints\" graphql:\"findScenesBySceneFingerprints\""
+}
 type SearchScene struct {
 	SearchScene []*SceneFragment "json:\"searchScene\" graphql:\"searchScene\""
 }
@@ -226,77 +231,6 @@ const FindSceneByFingerprintDocument = `query FindSceneByFingerprint ($fingerpri
 		... SceneFragment
 	}
 }
-fragment PerformerFragment on Performer {
-	id
-	name
-	disambiguation
-	aliases
-	gender
-	merged_ids
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	birthdate {
-		... FuzzyDateFragment
-	}
-	ethnicity
-	country
-	eye_color
-	hair_color
-	height
-	measurements {
-		... MeasurementsFragment
-	}
-	breast_type
-	career_start_year
-	career_end_year
-	tattoos {
-		... BodyModificationFragment
-	}
-	piercings {
-		... BodyModificationFragment
-	}
-}
-fragment MeasurementsFragment on Measurements {
-	band_size
-	cup_size
-	waist
-	hip
-}
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
-}
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment StudioFragment on Studio {
-	name
-	id
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-}
-fragment TagFragment on Tag {
-	name
-	id
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
-}
-fragment FingerprintFragment on Fingerprint {
-	algorithm
-	hash
-	duration
-}
 fragment SceneFragment on Scene {
 	id
 	title
@@ -333,6 +267,77 @@ fragment PerformerAppearanceFragment on PerformerAppearance {
 	performer {
 		... PerformerFragment
 	}
+}
+fragment PerformerFragment on Performer {
+	id
+	name
+	disambiguation
+	aliases
+	gender
+	merged_ids
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+	birthdate {
+		... FuzzyDateFragment
+	}
+	ethnicity
+	country
+	eye_color
+	hair_color
+	height
+	measurements {
+		... MeasurementsFragment
+	}
+	breast_type
+	career_start_year
+	career_end_year
+	tattoos {
+		... BodyModificationFragment
+	}
+	piercings {
+		... BodyModificationFragment
+	}
+}
+fragment FuzzyDateFragment on FuzzyDate {
+	date
+	accuracy
+}
+fragment URLFragment on URL {
+	url
+	type
+}
+fragment StudioFragment on Studio {
+	name
+	id
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+}
+fragment TagFragment on Tag {
+	name
+	id
+}
+fragment MeasurementsFragment on Measurements {
+	band_size
+	cup_size
+	waist
+	hip
+}
+fragment BodyModificationFragment on BodyModification {
+	location
+	description
+}
+fragment FingerprintFragment on Fingerprint {
+	algorithm
+	hash
+	duration
 }
 `
 
@@ -354,34 +359,11 @@ const FindScenesByFullFingerprintsDocument = `query FindScenesByFullFingerprints
 		... SceneFragment
 	}
 }
-fragment SceneFragment on Scene {
+fragment ImageFragment on Image {
 	id
-	title
-	details
-	duration
-	date
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	studio {
-		... StudioFragment
-	}
-	tags {
-		... TagFragment
-	}
-	performers {
-		... PerformerAppearanceFragment
-	}
-	fingerprints {
-		... FingerprintFragment
-	}
-}
-fragment URLFragment on URL {
 	url
-	type
+	width
+	height
 }
 fragment PerformerAppearanceFragment on PerformerAppearance {
 	as
@@ -423,30 +405,36 @@ fragment PerformerFragment on Performer {
 		... BodyModificationFragment
 	}
 }
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
-}
 fragment MeasurementsFragment on Measurements {
 	band_size
 	cup_size
 	waist
 	hip
 }
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
-}
-fragment FingerprintFragment on Fingerprint {
-	algorithm
-	hash
-	duration
-}
-fragment ImageFragment on Image {
+fragment SceneFragment on Scene {
 	id
-	url
-	width
-	height
+	title
+	details
+	duration
+	date
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+	studio {
+		... StudioFragment
+	}
+	tags {
+		... TagFragment
+	}
+	performers {
+		... PerformerAppearanceFragment
+	}
+	fingerprints {
+		... FingerprintFragment
+	}
 }
 fragment StudioFragment on Studio {
 	name
@@ -461,6 +449,23 @@ fragment StudioFragment on Studio {
 fragment TagFragment on Tag {
 	name
 	id
+}
+fragment FuzzyDateFragment on FuzzyDate {
+	date
+	accuracy
+}
+fragment BodyModificationFragment on BodyModification {
+	location
+	description
+}
+fragment FingerprintFragment on Fingerprint {
+	algorithm
+	hash
+	duration
+}
+fragment URLFragment on URL {
+	url
+	type
 }
 `
 
@@ -477,29 +482,9 @@ func (c *Client) FindScenesByFullFingerprints(ctx context.Context, fingerprints 
 	return &res, nil
 }
 
-const SearchSceneDocument = `query SearchScene ($term: String!) {
-	searchScene(term: $term) {
+const FindScenesBySceneFingerprintsDocument = `query FindScenesBySceneFingerprints ($fingerprints: [[FingerprintQueryInput!]!]!) {
+	findScenesBySceneFingerprints(fingerprints: $fingerprints) {
 		... SceneFragment
-	}
-}
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment ImageFragment on Image {
-	id
-	url
-	width
-	height
-}
-fragment TagFragment on Tag {
-	name
-	id
-}
-fragment PerformerAppearanceFragment on PerformerAppearance {
-	as
-	performer {
-		... PerformerFragment
 	}
 }
 fragment PerformerFragment on Performer {
@@ -540,6 +525,42 @@ fragment FuzzyDateFragment on FuzzyDate {
 	date
 	accuracy
 }
+fragment StudioFragment on Studio {
+	name
+	id
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+}
+fragment TagFragment on Tag {
+	name
+	id
+}
+fragment ImageFragment on Image {
+	id
+	url
+	width
+	height
+}
+fragment PerformerAppearanceFragment on PerformerAppearance {
+	as
+	performer {
+		... PerformerFragment
+	}
+}
+fragment MeasurementsFragment on Measurements {
+	band_size
+	cup_size
+	waist
+	hip
+}
+fragment BodyModificationFragment on BodyModification {
+	location
+	description
+}
 fragment FingerprintFragment on Fingerprint {
 	algorithm
 	hash
@@ -570,6 +591,113 @@ fragment SceneFragment on Scene {
 		... FingerprintFragment
 	}
 }
+fragment URLFragment on URL {
+	url
+	type
+}
+`
+
+func (c *Client) FindScenesBySceneFingerprints(ctx context.Context, fingerprints [][]*FingerprintQueryInput, httpRequestOptions ...client.HTTPRequestOption) (*FindScenesBySceneFingerprints, error) {
+	vars := map[string]interface{}{
+		"fingerprints": fingerprints,
+	}
+
+	var res FindScenesBySceneFingerprints
+	if err := c.Client.Post(ctx, "FindScenesBySceneFingerprints", FindScenesBySceneFingerprintsDocument, &res, vars, httpRequestOptions...); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const SearchSceneDocument = `query SearchScene ($term: String!) {
+	searchScene(term: $term) {
+		... SceneFragment
+	}
+}
+fragment ImageFragment on Image {
+	id
+	url
+	width
+	height
+}
+fragment BodyModificationFragment on BodyModification {
+	location
+	description
+}
+fragment PerformerFragment on Performer {
+	id
+	name
+	disambiguation
+	aliases
+	gender
+	merged_ids
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+	birthdate {
+		... FuzzyDateFragment
+	}
+	ethnicity
+	country
+	eye_color
+	hair_color
+	height
+	measurements {
+		... MeasurementsFragment
+	}
+	breast_type
+	career_start_year
+	career_end_year
+	tattoos {
+		... BodyModificationFragment
+	}
+	piercings {
+		... BodyModificationFragment
+	}
+}
+fragment FuzzyDateFragment on FuzzyDate {
+	date
+	accuracy
+}
+fragment MeasurementsFragment on Measurements {
+	band_size
+	cup_size
+	waist
+	hip
+}
+fragment SceneFragment on Scene {
+	id
+	title
+	details
+	duration
+	date
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+	studio {
+		... StudioFragment
+	}
+	tags {
+		... TagFragment
+	}
+	performers {
+		... PerformerAppearanceFragment
+	}
+	fingerprints {
+		... FingerprintFragment
+	}
+}
+fragment URLFragment on URL {
+	url
+	type
+}
 fragment StudioFragment on Studio {
 	name
 	id
@@ -580,15 +708,20 @@ fragment StudioFragment on Studio {
 		... ImageFragment
 	}
 }
-fragment MeasurementsFragment on Measurements {
-	band_size
-	cup_size
-	waist
-	hip
+fragment TagFragment on Tag {
+	name
+	id
 }
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
+fragment PerformerAppearanceFragment on PerformerAppearance {
+	as
+	performer {
+		... PerformerFragment
+	}
+}
+fragment FingerprintFragment on Fingerprint {
+	algorithm
+	hash
+	duration
 }
 `
 
@@ -610,16 +743,6 @@ const SearchPerformerDocument = `query SearchPerformer ($term: String!) {
 		... PerformerFragment
 	}
 }
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment ImageFragment on Image {
-	id
-	url
-	width
-	height
-}
 fragment FuzzyDateFragment on FuzzyDate {
 	date
 	accuracy
@@ -667,6 +790,16 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
+}
+fragment URLFragment on URL {
+	url
+	type
+}
+fragment ImageFragment on Image {
+	id
+	url
+	width
+	height
 }
 `
 
@@ -766,11 +899,29 @@ const FindSceneByIDDocument = `query FindSceneByID ($id: ID!) {
 		... SceneFragment
 	}
 }
+fragment URLFragment on URL {
+	url
+	type
+}
 fragment ImageFragment on Image {
 	id
 	url
 	width
 	height
+}
+fragment StudioFragment on Studio {
+	name
+	id
+	urls {
+		... URLFragment
+	}
+	images {
+		... ImageFragment
+	}
+}
+fragment TagFragment on Tag {
+	name
+	id
 }
 fragment PerformerAppearanceFragment on PerformerAppearance {
 	as
@@ -816,15 +967,6 @@ fragment FuzzyDateFragment on FuzzyDate {
 	date
 	accuracy
 }
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
-}
-fragment FingerprintFragment on Fingerprint {
-	algorithm
-	hash
-	duration
-}
 fragment SceneFragment on Scene {
 	id
 	title
@@ -850,29 +992,20 @@ fragment SceneFragment on Scene {
 		... FingerprintFragment
 	}
 }
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment StudioFragment on Studio {
-	name
-	id
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-}
-fragment TagFragment on Tag {
-	name
-	id
-}
 fragment MeasurementsFragment on Measurements {
 	band_size
 	cup_size
 	waist
 	hip
+}
+fragment BodyModificationFragment on BodyModification {
+	location
+	description
+}
+fragment FingerprintFragment on Fingerprint {
+	algorithm
+	hash
+	duration
 }
 `
 

--- a/pkg/scraper/stashbox/graphql/generated_models.go
+++ b/pkg/scraper/stashbox/graphql/generated_models.go
@@ -88,8 +88,8 @@ type DraftEntity struct {
 	ID   *string `json:"id,omitempty"`
 }
 
-func (DraftEntity) IsSceneDraftStudio()    {}
 func (DraftEntity) IsSceneDraftPerformer() {}
+func (DraftEntity) IsSceneDraftStudio()    {}
 func (DraftEntity) IsSceneDraftTag()       {}
 
 type DraftEntityInput struct {
@@ -206,15 +206,13 @@ type Fingerprint struct {
 }
 
 type FingerprintEditInput struct {
-	UserIds   []string             `json:"user_ids,omitempty"`
-	Hash      string               `json:"hash"`
-	Algorithm FingerprintAlgorithm `json:"algorithm"`
-	Duration  int                  `json:"duration"`
-	Created   time.Time            `json:"created"`
-	// @deprecated(reason: "unused")
-	Submissions *int `json:"submissions,omitempty"`
-	// @deprecated(reason: "unused")
-	Updated *time.Time `json:"updated,omitempty"`
+	UserIds     []string             `json:"user_ids,omitempty"`
+	Hash        string               `json:"hash"`
+	Algorithm   FingerprintAlgorithm `json:"algorithm"`
+	Duration    int                  `json:"duration"`
+	Created     time.Time            `json:"created"`
+	Submissions *int                 `json:"submissions,omitempty"`
+	Updated     *time.Time           `json:"updated,omitempty"`
 }
 
 type FingerprintInput struct {
@@ -348,8 +346,8 @@ type Performer struct {
 	Updated         time.Time           `json:"updated"`
 }
 
-func (Performer) IsEditTarget()          {}
 func (Performer) IsSceneDraftPerformer() {}
+func (Performer) IsEditTarget()          {}
 
 type PerformerAppearance struct {
 	Performer *Performer `json:"performer,omitempty"`
@@ -845,8 +843,8 @@ type Studio struct {
 	Updated      time.Time `json:"updated"`
 }
 
-func (Studio) IsEditTarget()       {}
 func (Studio) IsSceneDraftStudio() {}
+func (Studio) IsEditTarget()       {}
 
 type StudioCreateInput struct {
 	Name     string      `json:"name"`

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/Yamashou/gqlgenc/client"
-	"github.com/corona10/goimagehash"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/stashapp/stash/pkg/match"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scraper/stashbox/graphql"
-	"github.com/stashapp/stash/pkg/sliceutil/intslice"
 	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 	"github.com/stashapp/stash/pkg/utils"
 )
@@ -78,127 +76,21 @@ func (c Client) QueryStashBoxScene(ctx context.Context, queryStr string) ([]*mod
 	return ret, nil
 }
 
-func phashMatches(hash, other int64) bool {
-	// HACK - stash-box match distance is configurable. This needs to be fixed on
-	// the stash-box end.
-	const stashBoxDistance = 4
-
-	imageHash := goimagehash.NewImageHash(uint64(hash), goimagehash.PHash)
-	otherHash := goimagehash.NewImageHash(uint64(other), goimagehash.PHash)
-
-	distance, _ := imageHash.Distance(otherHash)
-	return distance <= stashBoxDistance
+// FindStashBoxScenesByFingerprints queries stash-box for a scene using the
+// scene's MD5/OSHASH checksum, or PHash.
+func (c Client) FindStashBoxSceneByFingerprints(ctx context.Context, sceneID int) ([]*models.ScrapedScene, error) {
+	res, err := c.FindStashBoxScenesByFingerprints(ctx, []int{sceneID})
+	if len(res) > 0 {
+		return res[0], err
+	}
+	return nil, err
 }
 
 // FindStashBoxScenesByFingerprints queries stash-box for scenes using every
 // scene's MD5/OSHASH checksum, or PHash, and returns results in the same order
 // as the input slice.
-func (c Client) FindStashBoxScenesByFingerprints(ctx context.Context, sceneIDs []string) ([][]*models.ScrapedScene, error) {
-	ids, err := stringslice.StringSliceToIntSlice(sceneIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	var fingerprints []*graphql.FingerprintQueryInput
-	// map fingerprints to their scene index
-	fpToScene := make(map[string][]int)
-	phashToScene := make(map[int64][]int)
-
-	if err := c.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
-		qb := r.Scene()
-
-		for index, sceneID := range ids {
-			scene, err := qb.Find(sceneID)
-			if err != nil {
-				return err
-			}
-
-			if scene == nil {
-				return fmt.Errorf("scene with id %d not found", sceneID)
-			}
-
-			if scene.Checksum.Valid {
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
-					Hash:      scene.Checksum.String,
-					Algorithm: graphql.FingerprintAlgorithmMd5,
-				})
-				fpToScene[scene.Checksum.String] = append(fpToScene[scene.Checksum.String], index)
-			}
-
-			if scene.OSHash.Valid {
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
-					Hash:      scene.OSHash.String,
-					Algorithm: graphql.FingerprintAlgorithmOshash,
-				})
-				fpToScene[scene.OSHash.String] = append(fpToScene[scene.OSHash.String], index)
-			}
-
-			if scene.Phash.Valid {
-				phashStr := utils.PhashToString(scene.Phash.Int64)
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
-					Hash:      phashStr,
-					Algorithm: graphql.FingerprintAlgorithmPhash,
-				})
-				fpToScene[phashStr] = append(fpToScene[phashStr], index)
-				phashToScene[scene.Phash.Int64] = append(phashToScene[scene.Phash.Int64], index)
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	allScenes, err := c.findStashBoxScenesByFingerprints(ctx, fingerprints)
-	if err != nil {
-		return nil, err
-	}
-
-	// set the matched scenes back in their original order
-	ret := make([][]*models.ScrapedScene, len(sceneIDs))
-	for _, s := range allScenes {
-		var addedTo []int
-
-		addScene := func(sceneIndexes []int) {
-			for _, index := range sceneIndexes {
-				if !intslice.IntInclude(addedTo, index) {
-					addedTo = append(addedTo, index)
-					ret[index] = append(ret[index], s)
-				}
-			}
-		}
-
-		for _, fp := range s.Fingerprints {
-			addScene(fpToScene[fp.Hash])
-
-			// HACK - we really need stash-box to return specific hash-to-result sets
-			if fp.Algorithm == graphql.FingerprintAlgorithmPhash.String() {
-				hash, err := utils.StringToPhash(fp.Hash)
-				if err != nil {
-					continue
-				}
-
-				for phash, sceneIndexes := range phashToScene {
-					if phashMatches(hash, phash) {
-						addScene(sceneIndexes)
-					}
-				}
-			}
-		}
-	}
-
-	return ret, nil
-}
-
-// FindStashBoxScenesByFingerprintsFlat queries stash-box for scenes using every
-// scene's MD5/OSHASH checksum, or PHash, and returns results a flat slice.
-func (c Client) FindStashBoxScenesByFingerprintsFlat(ctx context.Context, sceneIDs []string) ([]*models.ScrapedScene, error) {
-	ids, err := stringslice.StringSliceToIntSlice(sceneIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	var fingerprints []*graphql.FingerprintQueryInput
+func (c Client) FindStashBoxScenesByFingerprints(ctx context.Context, ids []int) ([][]*models.ScrapedScene, error) {
+	var fingerprints [][]*graphql.FingerprintQueryInput
 
 	if err := c.txnManager.WithReadTxn(ctx, func(r models.ReaderRepository) error {
 		qb := r.Scene()
@@ -213,26 +105,31 @@ func (c Client) FindStashBoxScenesByFingerprintsFlat(ctx context.Context, sceneI
 				return fmt.Errorf("scene with id %d not found", sceneID)
 			}
 
+			var sceneFPs []*graphql.FingerprintQueryInput
+
 			if scene.Checksum.Valid {
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
+				sceneFPs = append(sceneFPs, &graphql.FingerprintQueryInput{
 					Hash:      scene.Checksum.String,
 					Algorithm: graphql.FingerprintAlgorithmMd5,
 				})
 			}
 
 			if scene.OSHash.Valid {
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
+				sceneFPs = append(sceneFPs, &graphql.FingerprintQueryInput{
 					Hash:      scene.OSHash.String,
 					Algorithm: graphql.FingerprintAlgorithmOshash,
 				})
 			}
 
 			if scene.Phash.Valid {
-				fingerprints = append(fingerprints, &graphql.FingerprintQueryInput{
-					Hash:      utils.PhashToString(scene.Phash.Int64),
+				phashStr := utils.PhashToString(scene.Phash.Int64)
+				sceneFPs = append(sceneFPs, &graphql.FingerprintQueryInput{
+					Hash:      phashStr,
 					Algorithm: graphql.FingerprintAlgorithmPhash,
 				})
 			}
+
+			fingerprints = append(fingerprints, sceneFPs)
 		}
 
 		return nil
@@ -243,27 +140,29 @@ func (c Client) FindStashBoxScenesByFingerprintsFlat(ctx context.Context, sceneI
 	return c.findStashBoxScenesByFingerprints(ctx, fingerprints)
 }
 
-func (c Client) findStashBoxScenesByFingerprints(ctx context.Context, fingerprints []*graphql.FingerprintQueryInput) ([]*models.ScrapedScene, error) {
-	var ret []*models.ScrapedScene
-	for i := 0; i < len(fingerprints); i += 100 {
+func (c Client) findStashBoxScenesByFingerprints(ctx context.Context, scenes [][]*graphql.FingerprintQueryInput) ([][]*models.ScrapedScene, error) {
+	var ret [][]*models.ScrapedScene
+	for i := 0; i < len(scenes); i += 40 {
 		end := i + 100
-		if end > len(fingerprints) {
-			end = len(fingerprints)
+		if end > len(scenes) {
+			end = len(scenes)
 		}
-		scenes, err := c.client.FindScenesByFullFingerprints(ctx, fingerprints[i:end])
+		scenes, err := c.client.FindScenesBySceneFingerprints(ctx, scenes[i:end])
 
 		if err != nil {
 			return nil, err
 		}
 
-		sceneFragments := scenes.FindScenesByFullFingerprints
-
-		for _, s := range sceneFragments {
-			ss, err := c.sceneFragmentToScrapedScene(ctx, s)
-			if err != nil {
-				return nil, err
+		for _, sceneFragments := range scenes.FindScenesBySceneFingerprints {
+			var sceneResults []*models.ScrapedScene
+			for _, scene := range sceneFragments {
+				ss, err := c.sceneFragmentToScrapedScene(ctx, scene)
+				if err != nil {
+					return nil, err
+				}
+				sceneResults = append(sceneResults, ss)
 			}
-			ret = append(ret, ss)
+			ret = append(ret, sceneResults)
 		}
 	}
 


### PR DESCRIPTION
The updated query accepts an array of hashes grouped by scene, and returns the results in the same order. This means stash no longer needs to manage the results.

I've also removed the old, deprecated queries. Additionally I've changed the input value from `ID` to `Int`. ID is mostly intended for globally unique identifiers, and using it for an integer sequence just complicates things since it's mapped to string by default.

Resolves #2269.