### PR TITLE
Fix GraphQL Playground CSP directives for Firefox

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -357,7 +357,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		}
 		connectableOrigins += "; "
 
-		cspDirectives := "default-src data: 'self' 'unsafe-inline';" + connectableOrigins + "img-src data: *; script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline' 'unsafe-eval'; style-src-elem 'self' https://cdn.jsdelivr.net 'unsafe-inline' ; media-src 'self' blob:; child-src 'none'; object-src 'none'; form-action 'self'"
+		cspDirectives := "default-src data: 'self' 'unsafe-inline';" + connectableOrigins + "img-src data: *; script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline' 'unsafe-eval'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; style-src-elem 'self' https://cdn.jsdelivr.net 'unsafe-inline'; media-src 'self' blob:; child-src 'none'; object-src 'none'; form-action 'self'"
 
 		w.Header().Set("Referrer-Policy", "same-origin")
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
In #2484, the CSP directives were updated to fix the GraphQL Playground, but that fix only works in Chromium browsers, as Firefox doesn't support the [style-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem) directive. This just adds a fallback style-src, similar to the example in the Firefox [bug page](https://bugzilla.mozilla.org/show_bug.cgi?id=1529338) for adding style-src-elem and style-src-attr support.

Resolves #2512.