### PR TITLE
Fix image thumbnail generation

### DIFF
--- a/internal/api/routes_image.go
+++ b/internal/api/routes_image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os/exec"
 	"strconv"
 
 	"github.com/go-chi/chi"
@@ -50,6 +51,11 @@ func (rs imageRoutes) Thumbnail(w http.ResponseWriter, r *http.Request) {
 			// don't log for unsupported image format
 			if !errors.Is(err, image.ErrNotSupportedForThumbnail) {
 				logger.Errorf("error generating thumbnail for image: %s", err.Error())
+
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					logger.Errorf("stderr: %s", string(exitErr.Stderr))
+				}
 			}
 
 			// backwards compatibility - fallback to original image instead

--- a/internal/manager/task_scan_image.go
+++ b/internal/manager/task_scan_image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -158,6 +159,11 @@ func (t *ScanTask) generateThumbnail(i *models.Image) {
 			// don't log for animated images
 			if !errors.Is(err, image.ErrNotSupportedForThumbnail) {
 				logger.Errorf("error getting thumbnail for image %s: %s", i.Path, err.Error())
+
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					logger.Errorf("stderr: %s", string(exitErr.Stderr))
+				}
 			}
 			return
 		}

--- a/pkg/ffmpeg/generate.go
+++ b/pkg/ffmpeg/generate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 )
@@ -35,8 +36,14 @@ func (f FFMpeg) Generate(ctx context.Context, args Args) error {
 }
 
 // GenerateOutput runs ffmpeg with the given args and returns it standard output.
-func (f FFMpeg) GenerateOutput(ctx context.Context, args []string) ([]byte, error) {
+func (f FFMpeg) GenerateOutput(ctx context.Context, args []string, stdin io.Reader) ([]byte, error) {
 	cmd := f.Command(ctx, args)
+	cmd.Stdin = stdin
 
-	return cmd.Output()
+	ret, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error running ffmpeg command <%s>: %w", strings.Join(args, " "), err)
+	}
+
+	return ret, nil
 }

--- a/pkg/ffmpeg/transcoder/image.go
+++ b/pkg/ffmpeg/transcoder/image.go
@@ -20,6 +20,8 @@ func ImageThumbnail(input string, options ImageThumbnailOptions) ffmpeg.Args {
 	videoFilter = videoFilter.ScaleMaxSize(options.MaxDimensions)
 
 	var args ffmpeg.Args
+	args = append(args, "-hide_banner")
+	args = args.LogLevel(ffmpeg.LogLevelError)
 
 	args = args.Overwrite().
 		ImageFormat(options.InputFormat).

--- a/pkg/hash/videophash/phash.go
+++ b/pkg/hash/videophash/phash.go
@@ -44,7 +44,7 @@ func generateSpriteScreenshot(encoder ffmpeg.FFMpeg, input string, t float64) (i
 	}
 
 	args := transcoder.ScreenshotTime(input, t, options)
-	data, err := encoder.GenerateOutput(context.Background(), args)
+	data, err := encoder.GenerateOutput(context.Background(), args, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/thumbnail.go
+++ b/pkg/image/thumbnail.go
@@ -117,5 +117,5 @@ func (e *ThumbnailEncoder) ffmpegImageThumbnail(image *bytes.Buffer, format stri
 		Quality:       ffmpegImageQuality,
 	})
 
-	return e.ffmpeg.GenerateOutput(context.TODO(), args)
+	return e.ffmpeg.GenerateOutput(context.TODO(), args, image)
 }


### PR DESCRIPTION
PR #2392 changed the image thumbnail generation code. Unfortunately, I neglected to plug in the input image when generating image thumbnails using ffmpeg. This has been addressed. This PR also improves logging when ffmpeg encounters errors while generating thumbnails.

No changelog entry needed as this was introduced in development.