### PR TITLE
Fix streaming scenes not able to be deleted

### DIFF
--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -164,7 +164,8 @@ func (rs sceneRoutes) streamTranscode(w http.ResponseWriter, r *http.Request, st
 	encoder := manager.GetInstance().FFMPEG
 
 	lm := manager.GetInstance().ReadLockManager
-	lockCtx := lm.ReadLock(r.Context(), scene.Path)
+	streamRequestCtx := manager.NewStreamRequestContext(w, r)
+	lockCtx := lm.ReadLock(streamRequestCtx, scene.Path)
 	defer lockCtx.Cancel()
 
 	stream, err := encoder.GetTranscodeStream(lockCtx, options)

--- a/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/DeleteScenesDialog.tsx
@@ -60,11 +60,12 @@ export const DeleteScenesDialog: React.FC<IDeleteSceneDialogProps> = (
     try {
       await deleteScene();
       Toast.success({ content: toastMessage });
+      props.onClose(true);
     } catch (e) {
       Toast.error(e);
+      props.onClose(false);
     }
     setIsDeleting(false);
-    props.onClose(true);
   }
 
   function funscriptPath(scenePath: string) {


### PR DESCRIPTION
Fixes #2537

- Fixes regression related to ffmpeg refactor. Now closes streaming connections when the context is cancelled.
- Fixes scene page so that it doesn't navigate away if the delete operation fails.