### PR TITLE
Encode query string

### DIFF
--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -166,7 +166,7 @@ export class ListFilterModel {
         this.displayMode !== DEFAULT_PARAMS.displayMode
           ? this.displayMode
           : undefined,
-      q: this.searchTerm,
+      q: this.searchTerm ? encodeURIComponent(this.searchTerm) : undefined,
       p:
         this.currentPage !== DEFAULT_PARAMS.currentPage
           ? this.currentPage


### PR DESCRIPTION
Fixes #2505 

Encodes the query string when setting the URL so that special characters `#`, `&`, `+` work correctly when refreshing and going back.