### PR TITLE
Fix slideshow autoplaying when on another tab

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0150.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0150.md
@@ -3,6 +3,7 @@
 * Display error message on fatal error when running stash with double-click in Windows. ([#2543](https://github.com/stashapp/stash/pull/2543))
 
 ### 🐛 Bug fixes
+* Fix lightbox autoplaying while offscreen. ([#2563](https://github.com/stashapp/stash/pull/2563))
 * Fix playback rate resetting when seeking. ([#2550](https://github.com/stashapp/stash/pull/2550))
 * Fix video not starting when clicking scene scrubber. ([#2546](https://github.com/stashapp/stash/pull/2546))
 * Update vtt files when scene hash changes. ([#2554](https://github.com/stashapp/stash/pulls?q=is%3Apr+is%3Aclosed))

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -274,8 +274,11 @@ export const LightboxComponent: React.FC<IProps> = ({
     }
   }, [slideshowInterval, slideshowDelay]);
 
-  usePageVisibility(() => {
-    toggleSlideshow();
+  // stop slideshow when the page is hidden
+  usePageVisibility((hidden: boolean) => {
+    if (hidden) {
+      setSlideshowInterval(null);
+    }
   });
 
   const close = useCallback(() => {

--- a/ui/v2.5/src/hooks/PageVisibility.ts
+++ b/ui/v2.5/src/hooks/PageVisibility.ts
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
-const usePageVisibility = (visibilityChangeCallback: () => void): void => {
-  const savedVisibilityChangedCallback = useRef<() => void>();
+const usePageVisibility = (visibilityChangeCallback: (hidden: boolean) => void): void => {
+  const savedVisibilityChangedCallback = useRef<(hidden: boolean) => void>();
 
   useEffect(() => {
     // resolve event names for different browsers
@@ -31,18 +31,24 @@ const usePageVisibility = (visibilityChangeCallback: () => void): void => {
 
     savedVisibilityChangedCallback.current = visibilityChangeCallback;
 
+    function fireCallback() {
+      const callback = savedVisibilityChangedCallback.current;
+      if (callback) {
+        const isHidden = document.visibilityState !== "visible";
+        callback(isHidden);
+      }
+    }
+
     document.addEventListener(
       visibilityChange,
-      savedVisibilityChangedCallback.current
+      fireCallback
     );
 
     return () => {
-      if (savedVisibilityChangedCallback.current) {
-        document.removeEventListener(
-          visibilityChange,
-          savedVisibilityChangedCallback.current
-        );
-      }
+      document.removeEventListener(
+        visibilityChange,
+        fireCallback
+      );
     };
   }, [visibilityChangeCallback]);
 };

--- a/ui/v2.5/src/hooks/PageVisibility.ts
+++ b/ui/v2.5/src/hooks/PageVisibility.ts
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
-const usePageVisibility = (visibilityChangeCallback: (hidden: boolean) => void): void => {
+const usePageVisibility = (
+  visibilityChangeCallback: (hidden: boolean) => void
+): void => {
   const savedVisibilityChangedCallback = useRef<(hidden: boolean) => void>();
 
   useEffect(() => {
@@ -39,16 +41,10 @@ const usePageVisibility = (visibilityChangeCallback: (hidden: boolean) => void):
       }
     }
 
-    document.addEventListener(
-      visibilityChange,
-      fireCallback
-    );
+    document.addEventListener(visibilityChange, fireCallback);
 
     return () => {
-      document.removeEventListener(
-        visibilityChange,
-        fireCallback
-      );
+      document.removeEventListener(visibilityChange, fireCallback);
     };
   }, [visibilityChangeCallback]);
 };


### PR DESCRIPTION
Fixes #2562 

`usePageVisibility` fires whenever page visibility changes, and the callback in the lightbox code was toggling the slideshow, rather than stopping it, which should have been the intention.