### PR TITLE
CSS: Fix mobile filter tags

### DIFF
--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -55,6 +55,8 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   }
 
   return (
-    <div className="d-flex justify-content-center mb-2 wrap-tags">{renderFilterTags()}</div>
+    <div className="d-flex justify-content-center mb-2 wrap-tags">
+      {renderFilterTags()}
+    </div>
   );
 };

--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -55,6 +55,6 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   }
 
   return (
-    <div className="d-flex justify-content-center">{renderFilterTags()}</div>
+    <div className="d-flex justify-content-center mb-2 wrap-tags">{renderFilterTags()}</div>
   );
 };

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -346,6 +346,7 @@ div.dropdown-menu {
   /* stylelint-disable */
   .badge {
     white-space: normal !important;
+    margin: unset;
   }
   /* stylelint-enable */
 }
@@ -356,6 +357,7 @@ div.dropdown-menu {
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
+  margin: 5px;
   padding: 2px 6px;
 
   &:hover {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -339,12 +339,15 @@ div.dropdown-menu {
 }
 
 .wrap-tags {
+  column-gap: 10px;
   flex-wrap: wrap;
   row-gap: 10px;
-  column-gap: 10px;
+
+  /* stylelint-disable */
   .badge {
     white-space: normal !important;
   }
+  /* stylelint-enable */
 }
 
 .tag-item {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -338,13 +338,21 @@ div.dropdown-menu {
   margin-right: 10px;
 }
 
+.wrap-tags {
+  flex-wrap: wrap;
+  row-gap: 10px;
+  column-gap: 10px;
+  .badge {
+    white-space: normal !important;
+  }
+}
+
 .tag-item {
   background-color: $muted-gray;
   color: $dark-text;
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
-  margin: 5px;
   padding: 2px 6px;
 
   &:hover {


### PR DESCRIPTION
Before: Unreadable filters on mobile, lots of horizontal overflow that broke the footer bar constantly
![Screen Shot 2022-05-13 at 10 39 34](https://user-images.githubusercontent.com/84814418/168364064-73b012f7-894f-4317-90e9-f3d955d6a87b.png)

After: Actually usable
![Screen Shot 2022-05-13 at 11 37 27](https://user-images.githubusercontent.com/84814418/168364132-59d0ce68-2396-49aa-b5b1-6b1744bfba6c.png)

This has been bugging me for forever lmao