### PR TITLE
Fix gallery updating

### DIFF
--- a/pkg/gallery/scan.go
+++ b/pkg/gallery/scan.go
@@ -187,7 +187,8 @@ func (scanner *Scanner) ScanNew(ctx context.Context, file file.SourceFile) (retG
 		scanner.PluginCache.ExecutePostHooks(ctx, g.ID, plugin.GalleryUpdatePost, nil, nil)
 	}
 
-	scanImages = isNewGallery
+	// Also scan images if zip file has been moved (ie updated) as the image paths are no longer valid
+	scanImages = isNewGallery || isUpdatedGallery
 	retGallery = g
 
 	return


### PR DESCRIPTION
Fixes a regression from #2594 where galleries that have been renamed on disk only have the gallery path updated on scan and not the actual images themselves. Previously the image paths would have been updated after a second scan but that is no longer the case.