### PR TITLE
Don't trim extension for folders when auto-tagging galleries

### DIFF
--- a/internal/autotag/gallery.go
+++ b/internal/autotag/gallery.go
@@ -7,12 +7,16 @@ import (
 )
 
 func getGalleryFileTagger(s *models.Gallery, cache *match.Cache) tagger {
+	// only trim the extension if gallery is file-based
+	trimExt := s.Zip
+
 	return tagger{
-		ID:    s.ID,
-		Type:  "gallery",
-		Name:  s.GetTitle(),
-		Path:  s.Path.String,
-		cache: cache,
+		ID:      s.ID,
+		Type:    "gallery",
+		Name:    s.GetTitle(),
+		Path:    s.Path.String,
+		trimExt: trimExt,
+		cache:   cache,
 	}
 }
 

--- a/internal/autotag/scene_test.go
+++ b/internal/autotag/scene_test.go
@@ -34,6 +34,7 @@ func generateNamePatterns(name, separator, ext string) []string {
 	ret = append(ret, fmt.Sprintf("aaa%s%s.%s", separator, name, ext))
 	ret = append(ret, fmt.Sprintf("aaa%s%s%sbbb.%s", separator, name, separator, ext))
 	ret = append(ret, fmt.Sprintf("dir/%s%saaa.%s", name, separator, ext))
+	ret = append(ret, fmt.Sprintf("dir%sdir/%s%saaa.%s", separator, name, separator, ext))
 	ret = append(ret, fmt.Sprintf("dir\\%s%saaa.%s", name, separator, ext))
 	ret = append(ret, fmt.Sprintf("%s%saaa/dir/bbb.%s", name, separator, ext))
 	ret = append(ret, fmt.Sprintf("%s%saaa\\dir\\bbb.%s", name, separator, ext))

--- a/internal/autotag/tagger.go
+++ b/internal/autotag/tagger.go
@@ -22,10 +22,11 @@ import (
 )
 
 type tagger struct {
-	ID   int
-	Type string
-	Name string
-	Path string
+	ID      int
+	Type    string
+	Name    string
+	Path    string
+	trimExt bool
 
 	cache *match.Cache
 }
@@ -41,7 +42,7 @@ func (t *tagger) addLog(otherType, otherName string) {
 }
 
 func (t *tagger) tagPerformers(performerReader models.PerformerReader, addFunc addLinkFunc) error {
-	others, err := match.PathToPerformers(t.Path, performerReader, t.cache)
+	others, err := match.PathToPerformers(t.Path, performerReader, t.cache, t.trimExt)
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func (t *tagger) tagPerformers(performerReader models.PerformerReader, addFunc a
 }
 
 func (t *tagger) tagStudios(studioReader models.StudioReader, addFunc addLinkFunc) error {
-	studio, err := match.PathToStudio(t.Path, studioReader, t.cache)
+	studio, err := match.PathToStudio(t.Path, studioReader, t.cache, t.trimExt)
 	if err != nil {
 		return err
 	}
@@ -83,7 +84,7 @@ func (t *tagger) tagStudios(studioReader models.StudioReader, addFunc addLinkFun
 }
 
 func (t *tagger) tagTags(tagReader models.TagReader, addFunc addLinkFunc) error {
-	others, err := match.PathToTags(t.Path, tagReader, t.cache)
+	others, err := match.PathToTags(t.Path, tagReader, t.cache, t.trimExt)
 	if err != nil {
 		return err
 	}

--- a/pkg/match/path.go
+++ b/pkg/match/path.go
@@ -37,13 +37,15 @@ func getPathQueryRegex(name string) string {
 	return ret
 }
 
-func getPathWords(path string) []string {
+func getPathWords(path string, trimExt bool) []string {
 	retStr := path
 
-	// remove the extension
-	ext := filepath.Ext(retStr)
-	if ext != "" {
-		retStr = strings.TrimSuffix(retStr, ext)
+	if trimExt {
+		// remove the extension
+		ext := filepath.Ext(retStr)
+		if ext != "" {
+			retStr = strings.TrimSuffix(retStr, ext)
+		}
 	}
 
 	// handle path separators
@@ -136,8 +138,8 @@ func getPerformers(words []string, performerReader models.PerformerReader, cache
 	return append(performers, swPerformers...), nil
 }
 
-func PathToPerformers(path string, reader models.PerformerReader, cache *Cache) ([]*models.Performer, error) {
-	words := getPathWords(path)
+func PathToPerformers(path string, reader models.PerformerReader, cache *Cache, trimExt bool) ([]*models.Performer, error) {
+	words := getPathWords(path, trimExt)
 
 	performers, err := getPerformers(words, reader, cache)
 	if err != nil {
@@ -172,8 +174,8 @@ func getStudios(words []string, reader models.StudioReader, cache *Cache) ([]*mo
 // PathToStudio returns the Studio that matches the given path.
 // Where multiple matching studios are found, the one that matches the latest
 // position in the path is returned.
-func PathToStudio(path string, reader models.StudioReader, cache *Cache) (*models.Studio, error) {
-	words := getPathWords(path)
+func PathToStudio(path string, reader models.StudioReader, cache *Cache, trimExt bool) (*models.Studio, error) {
+	words := getPathWords(path, trimExt)
 	candidates, err := getStudios(words, reader, cache)
 
 	if err != nil {
@@ -220,8 +222,8 @@ func getTags(words []string, reader models.TagReader, cache *Cache) ([]*models.T
 	return append(tags, swTags...), nil
 }
 
-func PathToTags(path string, reader models.TagReader, cache *Cache) ([]*models.Tag, error) {
-	words := getPathWords(path)
+func PathToTags(path string, reader models.TagReader, cache *Cache, trimExt bool) ([]*models.Tag, error) {
+	words := getPathWords(path, trimExt)
 	tags, err := getTags(words, reader, cache)
 
 	if err != nil {

--- a/ui/v2.5/src/components/Changelog/versions/v0160.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0160.md
@@ -2,4 +2,6 @@
 * Support submitting stash-box scene updates for scenes with stash ids. ([#2577](https://github.com/stashapp/stash/pull/2577))
 
 ### 🐛 Bug fixes
+* Fix folder-based galleries not auto-tagging correctly if folder name contains `.` characters. ([#2658](https://github.com/stashapp/stash/pull/2658))
+* Fix scene cover in scene edit panel not being updated when changing scenes. ([#2657](https://github.com/stashapp/stash/pull/2657))
 * Fix moved gallery zip files not being rescanned. ([#2611](https://github.com/stashapp/stash/pull/2611))


### PR DESCRIPTION
Fixes #2612

Original bug was caused by `getPathWords` stripping the result of `filepath.Ext` from the folder name. This would strip everything after the last `.` character in the folder before performing the query, so a folder name of `01.02.2001 - some stuff` would be truncated to `01`. This behaviour is now turned off when tagging a folder-based gallery.