### PR TITLE
Use hotkeys '[' and ']' to scrub video player forwards and backwards by 10% of the scene

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -40,7 +40,8 @@ function handleHotkeys(player: VideoJsPlayer, event: VideoJS.KeyboardEvent) {
   function seekPercentRelative(percent: number) {
     const duration = player.duration();
     const currentTime = player.currentTime();
-    const time = (currentTime + duration * percent) % duration;
+    const time = currentTime + duration * percent;
+    if (time > duration) return;
     player.currentTime(time);
   }
 

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -37,6 +37,13 @@ function handleHotkeys(player: VideoJsPlayer, event: VideoJS.KeyboardEvent) {
     player.currentTime(time);
   }
 
+  function seekPercentRelative(percent: number) {
+    const duration = player.duration();
+    const currentTime = player.currentTime()
+    const time = (currentTime + (duration * percent)) % duration;
+    player.currentTime(time);
+  }
+
   if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
     return;
   }
@@ -95,6 +102,12 @@ function handleHotkeys(player: VideoJsPlayer, event: VideoJS.KeyboardEvent) {
       break;
     case 57: // 9
       seekPercent(0.9);
+      break;
+    case 221: // ]
+      seekPercentRelative(0.1)
+      break;
+    case 219: // [
+      seekPercentRelative(-0.1)
       break;
   }
 }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -39,8 +39,8 @@ function handleHotkeys(player: VideoJsPlayer, event: VideoJS.KeyboardEvent) {
 
   function seekPercentRelative(percent: number) {
     const duration = player.duration();
-    const currentTime = player.currentTime()
-    const time = (currentTime + (duration * percent)) % duration;
+    const currentTime = player.currentTime();
+    const time = (currentTime + duration * percent) % duration;
     player.currentTime(time);
   }
 
@@ -104,10 +104,10 @@ function handleHotkeys(player: VideoJsPlayer, event: VideoJS.KeyboardEvent) {
       seekPercent(0.9);
       break;
     case 221: // ]
-      seekPercentRelative(0.1)
+      seekPercentRelative(0.1);
       break;
     case 219: // [
-      seekPercentRelative(-0.1)
+      seekPercentRelative(-0.1);
       break;
   }
 }

--- a/ui/v2.5/src/docs/en/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/KeyboardShortcuts.md
@@ -64,6 +64,9 @@
 | `p n` | Play next scene in queue |
 | `p p` | Play previous scene in queue |
 | `p r` | Play random scene in queue |
+| `{1-9}` | Seek to 10-90% duration |
+| `[` | Scrub backwards 10% duration |
+| `]` | Scrub forwards 10% duration |
 
 ### Scene Markers tab shortcuts
 


### PR DESCRIPTION
**This is my first ever PR into any GitHub repo. Please be patient with me :D**

---
name: Use hotkeys '[' and ']' to scrub video player forwards and backwards by 10% of the scene
about: Use hotkeys '[' and ']' to scrub video player forwards and backwards by 10% of the scene
title: "[Feature] Use hotkeys '[' and ']' to scrub video player forwards and backwards by 10% of the scene"
labels: enhancement
assignees: 'WithoutPants, bnkai, Leopere'

---
# Scope
Currently, the video player allows scrubbing forward and backwards to specific points in a scene by using the hotkeys `0-9`. For instance, a user can scrub to `30%` through the scene by using the hot key `3`. Users can also scrub forwards and backwards by 5 seconds by using the arrow keys.

However we do not currently have a "single-key" solution to allow a user to scrub through an entire scene quickly.

This change implements the bracket keys: `[`, `]` as a "single-key" solution to allow users to quickly scrub though an entire scene.

<!-- Declare any issues by typing `fixes #1` or `closes #1` for example so that the automation can kick in when this is merged -->
## Closes/Fixes Issues

**I haven't opened an Issue for this. Should I?**

<!-- What have you tested specifically and what possible impacts/areas there are that may need retesting by others. -->
## Other testing QA Notes
 - Manual testing using Chrome on Windows 10
   - Tested with a playlist
   - Tested with a single video 
 - `mingw32-make validate`
 -   - Note: Backend validation failed, but Frontend validation passed. My change is only to the Frontend. So I'm comfortable ignoring the validation failures in the backend for this PR