### PR TITLE
Treat edited values as scraped

### DIFF
--- a/ui/v2.5/src/components/Changelog/versions/v0160.md
+++ b/ui/v2.5/src/components/Changelog/versions/v0160.md
@@ -7,6 +7,7 @@
 * Moved Filter and Saved Filters buttons out of the query input field. ([#2668](https://github.com/stashapp/stash/pull/2668))
 
 ### 🐛 Bug fixes
+* Fix fields disappearing after creating missing objects in the scrape dialog. ([#2702](https://github.com/stashapp/stash/pull/2702))
 * Fix saved filters with uppercase characters not appearing in filtered results. ([#2698](https://github.com/stashapp/stash/pull/2698))
 * Fix query results not updating when clearing search query field. ([#2686](https://github.com/stashapp/stash/pull/2686))
 * Fix incorrect field name in movie export json. ([#2664](https://github.com/stashapp/stash/pull/2664))

--- a/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
@@ -45,7 +45,7 @@ export class ScrapeResult<T> {
     const ret = clone(this);
 
     ret.newValue = value;
-    ret.useNewValue = isEqual(ret.newValue, ret.originalValue);
+    ret.useNewValue = !isEqual(ret.newValue, ret.originalValue);
 
     // #2691 - if we're setting the value, assume it should be treated as
     // scraped

--- a/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
@@ -46,7 +46,10 @@ export class ScrapeResult<T> {
 
     ret.newValue = value;
     ret.useNewValue = isEqual(ret.newValue, ret.originalValue);
-    ret.scraped = ret.useNewValue;
+
+    // #2691 - if we're setting the value, assume it should be treated as
+    // scraped
+    ret.scraped = true;
 
     return ret;
   }


### PR DESCRIPTION
Fixes #2691 

Treats `ScrapeResult` as a scraped value when it is edited by the user. This should fix the issue where the UI incorrectly omitted scrape rows when all candidate new values have been created.