### PR TITLE
Set crossorigin use-credentials for manifest.json.

### DIFF
--- a/ui/v2.5/index.html
+++ b/ui/v2.5/index.html
@@ -14,7 +14,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" crossorigin="use-credentials" href="manifest.json" />
     <title>Stash</title>
     <script>window.STASH_BASE_URL = "/%BASE_URL%/"</script>
   </head>


### PR DESCRIPTION
This is necessary when running behind a password-protected reverse
proxy, as otherwise Chrome doesn't send HTTP basic auth credentials when
requesting this file.

See
https://stackoverflow.com/questions/6294622/html5-manifest-cache-behind-basic-auth
for more information.