### PR TITLE
[Feature] Add ruby and faraday gem to stash for use in scrapers

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -11,7 +11,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-linux-arm32v6; \
 
 FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
-RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools && pip install --no-cache-dir mechanicalsoup cloudscraper
+RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools ruby && pip install --no-cache-dir mechanicalsoup cloudscraper && gem install faraday
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 


### PR DESCRIPTION
Adding ruby to stash so that scraper scripts can also be written in Ruby instead of just Python. I've also added the Faraday gem which is a much nicer HTTP client library https://lostisland.github.io/faraday/ than the built in Net::HTTP used on it's own.

> Faraday is an HTTP client library that provides a common interface over many adapters (such as Net::HTTP) and embraces the concept of Rack middleware when processing the request/response cycle.

I've been working on a new version of the vixenNetwork scraper that is written in Ruby instead. It already has feature parity with the existing and I'm working on adding the ability for it to create markers, and have more user configurability like the ability to ignore tags. 