### PR TITLE
Fix LocalForage not saving items

### DIFF
--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -69,7 +69,7 @@ export function useLocalForage<T>(
   }, [loading, key, defaultValue]);
 
   useEffect(() => {
-    if (isEqual(Cache[key], data)) {
+    if (!isEqual(Cache[key], data)) {
       Cache[key] = {
         ...Cache[key],
         ...data,


### PR DESCRIPTION
Fixes a typo in afd0a9e which prevents modified LocalForage items from being saved.