### PR TITLE
Add nowrap to rating stars and overflow-wrap to title for mobile

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/lightbox.scss
+++ b/ui/v2.5/src/hooks/Lightbox/lightbox.scss
@@ -83,11 +83,14 @@
 
       &:nth-child(2) {
         text-align: center;
+        overflow-wrap: anywhere;
       }
     }
 
     .rating-stars {
       padding-left: 0.38rem;
+      display: flex;
+      flex-wrap: nowrap;
     }
 
     &-left {


### PR DESCRIPTION
On mobile the rating stars overflow and disappear into nothing while the title is always displayed and never wraps. Since the rating stars are interactive elements, they should have a higher priority and always be displayed:
![2022 07 09-12 00 52  f6EJ92Vrfy](https://user-images.githubusercontent.com/16577545/178101159-a4f0fa6d-9c27-4727-969d-b48a9b7d7d79.png)

This PR makes the rating stars use a flex container with the `flex-wrap: nowrap` property to guarantee its display. Since a longer title would overflow I also added the `overflow-wrap: anywhere` property so long names without breakable contents can be displayed properly.