### PR TITLE
Files refactor fixes

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -71,10 +71,19 @@ input ScanMetaDataFilterInput {
 input ScanMetadataInput {
   paths: [String!]
 
+  # useFileMetadata is deprecated with the new file management system
+  # if this functionality is desired, then we can make a built in scraper instead.
+
   """Set name, date, details from metadata (if present)"""
-  useFileMetadata: Boolean
+  useFileMetadata: Boolean @deprecated(reason: "Not implemented")
+
+  # stripFileExtension is deprecated since we no longer set the title from the 
+  # filename - it is automatically returned if the object has no title. If this
+  # functionality is desired, then we could make this an option to not include
+  # the extension in the auto-generated title.
+
   """Strip file extension from title"""
-  stripFileExtension: Boolean
+  stripFileExtension: Boolean @deprecated(reason: "Not implemented")
   """Generate previews during scan"""
   scanGeneratePreviews: Boolean
   """Generate image previews during scan"""

--- a/internal/api/resolver_mutation_stash_box.go
+++ b/internal/api/resolver_mutation_stash_box.go
@@ -59,7 +59,7 @@ func (r *mutationResolver) SubmitStashBoxSceneDraft(ctx context.Context, input S
 		}
 		filepath := manager.GetInstance().Paths.Scene.GetScreenshotPath(scene.GetHash(config.GetInstance().GetVideoFileNamingAlgorithm()))
 
-		res, err = client.SubmitSceneDraft(ctx, id, boxes[input.StashBoxIndex].Endpoint, filepath)
+		res, err = client.SubmitSceneDraft(ctx, scene, boxes[input.StashBoxIndex].Endpoint, filepath)
 		return err
 	})
 

--- a/internal/api/routes_image.go
+++ b/internal/api/routes_image.go
@@ -66,7 +66,7 @@ func (rs imageRoutes) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			// don't log for unsupported image format
 			if !errors.Is(err, image.ErrNotSupportedForThumbnail) {
-				logger.Errorf("error generating thumbnail for image: %s", err.Error())
+				logger.Errorf("error generating thumbnail for %s: %v", f.Path, err)
 
 				var exitErr *exec.ExitError
 				if errors.As(err, &exitErr) {

--- a/internal/manager/config/tasks.go
+++ b/internal/manager/config/tasks.go
@@ -2,8 +2,10 @@ package config
 
 type ScanMetadataOptions struct {
 	// Set name, date, details from metadata (if present)
+	// Deprecated: not implemented
 	UseFileMetadata bool `json:"useFileMetadata"`
 	// Strip file extension from title
+	// Deprecated: not implemented
 	StripFileExtension bool `json:"stripFileExtension"`
 	// Generate previews during scan
 	ScanGeneratePreviews bool `json:"scanGeneratePreviews"`

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -198,6 +198,8 @@ func initialize() error {
 		Repository:   db.Gallery,
 		ImageFinder:  db.Image,
 		ImageService: instance.ImageService,
+		File:         db.File,
+		Folder:       db.Folder,
 	}
 
 	instance.JobManager = initJobManager()

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -268,15 +268,15 @@ func initialize() error {
 	return nil
 }
 
-func videoFileFilter(f file.File) bool {
+func videoFileFilter(ctx context.Context, f file.File) bool {
 	return isVideo(f.Base().Basename)
 }
 
-func imageFileFilter(f file.File) bool {
+func imageFileFilter(ctx context.Context, f file.File) bool {
 	return isImage(f.Base().Basename)
 }
 
-func galleryFileFilter(f file.File) bool {
+func galleryFileFilter(ctx context.Context, f file.File) bool {
 	return isZip(f.Base().Basename)
 }
 

--- a/internal/manager/repository.go
+++ b/internal/manager/repository.go
@@ -86,6 +86,7 @@ type SceneService interface {
 
 type ImageService interface {
 	Destroy(ctx context.Context, image *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) error
+	DestroyZipImages(ctx context.Context, zipFile file.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 }
 
 type GalleryService interface {

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -60,11 +60,9 @@ type cleanFilter struct {
 func newCleanFilter(c *config.Instance) *cleanFilter {
 	return &cleanFilter{
 		scanFilter: scanFilter{
+			extensionConfig:   newExtensionConfig(c),
 			stashPaths:        c.GetStashPaths(),
 			generatedPath:     c.GetGeneratedPath(),
-			vidExt:            c.GetVideoExtensions(),
-			imgExt:            c.GetImageExtensions(),
-			zipExt:            c.GetGalleryExtensions(),
 			videoExcludeRegex: generateRegexps(c.GetExcludes()),
 			imageExcludeRegex: generateRegexps(c.GetImageExcludes()),
 		},

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -57,10 +57,11 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 	}
 
 	j.scanner.Scan(ctx, getScanHandlers(j.input, taskQueue, progress), file.ScanOptions{
-		Paths:             paths,
-		ScanFilters:       []file.PathFilter{newScanFilter(instance.Config, minModTime)},
-		ZipFileExtensions: instance.Config.GetGalleryExtensions(),
-		ParallelTasks:     instance.Config.GetParallelTasksWithAutoDetection(),
+		Paths:                  paths,
+		ScanFilters:            []file.PathFilter{newScanFilter(instance.Config, minModTime)},
+		ZipFileExtensions:      instance.Config.GetGalleryExtensions(),
+		ParallelTasks:          instance.Config.GetParallelTasksWithAutoDetection(),
+		HandlerRequiredFilters: []file.Filter{newHandlerRequiredFilter(instance.Config)},
 	}, progress)
 
 	taskQueue.Close()
@@ -76,12 +77,79 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 	j.subscriptions.notify()
 }
 
+type extensionConfig struct {
+	vidExt []string
+	imgExt []string
+	zipExt []string
+}
+
+func newExtensionConfig(c *config.Instance) extensionConfig {
+	return extensionConfig{
+		vidExt: c.GetVideoExtensions(),
+		imgExt: c.GetImageExtensions(),
+		zipExt: c.GetGalleryExtensions(),
+	}
+}
+
+type fileCounter interface {
+	CountByFileID(ctx context.Context, fileID file.ID) (int, error)
+}
+
+// handlerRequiredFilter returns true if a File's handler needs to be executed despite the file not being updated.
+type handlerRequiredFilter struct {
+	extensionConfig
+	SceneFinder   fileCounter
+	ImageFinder   fileCounter
+	GalleryFinder fileCounter
+}
+
+func newHandlerRequiredFilter(c *config.Instance) *handlerRequiredFilter {
+	db := instance.Database
+
+	return &handlerRequiredFilter{
+		extensionConfig: newExtensionConfig(c),
+		SceneFinder:     db.Scene,
+		ImageFinder:     db.Image,
+		GalleryFinder:   db.Gallery,
+	}
+}
+
+func (f *handlerRequiredFilter) Accept(ctx context.Context, ff file.File) bool {
+	path := ff.Base().Path
+	isVideoFile := fsutil.MatchExtension(path, f.vidExt)
+	isImageFile := fsutil.MatchExtension(path, f.imgExt)
+	isZipFile := fsutil.MatchExtension(path, f.zipExt)
+
+	var counter fileCounter
+
+	switch {
+	case isVideoFile:
+		// return true if there are no scenes associated
+		counter = f.SceneFinder
+	case isImageFile:
+		counter = f.ImageFinder
+	case isZipFile:
+		counter = f.GalleryFinder
+	}
+
+	if counter == nil {
+		return false
+	}
+
+	n, err := counter.CountByFileID(ctx, ff.Base().ID)
+	if err != nil {
+		// just ignore
+		return false
+	}
+
+	// execute handler if there are no related objects
+	return n == 0
+}
+
 type scanFilter struct {
+	extensionConfig
 	stashPaths        []*config.StashConfig
 	generatedPath     string
-	vidExt            []string
-	imgExt            []string
-	zipExt            []string
 	videoExcludeRegex []*regexp.Regexp
 	imageExcludeRegex []*regexp.Regexp
 	minModTime        time.Time
@@ -89,11 +157,9 @@ type scanFilter struct {
 
 func newScanFilter(c *config.Instance, minModTime time.Time) *scanFilter {
 	return &scanFilter{
+		extensionConfig:   newExtensionConfig(c),
 		stashPaths:        c.GetStashPaths(),
 		generatedPath:     c.GetGeneratedPath(),
-		vidExt:            c.GetVideoExtensions(),
-		imgExt:            c.GetImageExtensions(),
-		zipExt:            c.GetGalleryExtensions(),
 		videoExcludeRegex: generateRegexps(c.GetExcludes()),
 		imageExcludeRegex: generateRegexps(c.GetImageExcludes()),
 		minModTime:        minModTime,

--- a/pkg/file/delete.go
+++ b/pkg/file/delete.go
@@ -180,7 +180,8 @@ func Destroy(ctx context.Context, destroyer Destroyer, f File, fileDeleter *Dele
 		return err
 	}
 
-	if deleteFile {
+	// don't delete files in zip files
+	if deleteFile && f.Base().ZipFileID != nil {
 		if err := fileDeleter.Files([]string{f.Base().Path}); err != nil {
 			return err
 		}

--- a/pkg/file/delete.go
+++ b/pkg/file/delete.go
@@ -188,3 +188,39 @@ func Destroy(ctx context.Context, destroyer Destroyer, f File, fileDeleter *Dele
 
 	return nil
 }
+
+type FolderGetterDestroyer interface {
+	FolderGetter
+	FolderDestroyer
+}
+
+type ZipDestroyer struct {
+	FileDestroyer   Destroyer
+	FolderDestroyer FolderGetterDestroyer
+}
+
+func (d *ZipDestroyer) DestroyZip(ctx context.Context, f File, fileDeleter *Deleter, deleteFile bool) error {
+	// destroy contained folders
+	folders, err := d.FolderDestroyer.FindByZipFileID(ctx, f.Base().ID)
+	if err != nil {
+		return err
+	}
+
+	for _, ff := range folders {
+		if err := d.FolderDestroyer.Destroy(ctx, ff.ID); err != nil {
+			return err
+		}
+	}
+
+	if err := d.FileDestroyer.Destroy(ctx, f.Base().ID); err != nil {
+		return err
+	}
+
+	if deleteFile {
+		if err := fileDeleter.Files([]string{f.Base().Path}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -198,7 +198,7 @@ type FilteredDecorator struct {
 
 // Decorate runs the decorator if the filter accepts the file.
 func (d *FilteredDecorator) Decorate(ctx context.Context, fs FS, f File) (File, error) {
-	if d.Accept(f) {
+	if d.Accept(ctx, f) {
 		return d.Decorator.Decorate(ctx, fs, f)
 	}
 	return f, nil

--- a/pkg/file/handler.go
+++ b/pkg/file/handler.go
@@ -18,13 +18,13 @@ func (pff PathFilterFunc) Accept(path string) bool {
 
 // Filter provides a filter function for Files.
 type Filter interface {
-	Accept(f File) bool
+	Accept(ctx context.Context, f File) bool
 }
 
-type FilterFunc func(f File) bool
+type FilterFunc func(ctx context.Context, f File) bool
 
-func (ff FilterFunc) Accept(f File) bool {
-	return ff(f)
+func (ff FilterFunc) Accept(ctx context.Context, f File) bool {
+	return ff(ctx, f)
 }
 
 // Handler provides a handler for Files.
@@ -40,7 +40,7 @@ type FilteredHandler struct {
 
 // Handle runs the handler if the filter accepts the file.
 func (h *FilteredHandler) Handle(ctx context.Context, f File) error {
-	if h.Accept(f) {
+	if h.Accept(ctx, f) {
 		return h.Handler.Handle(ctx, f)
 	}
 	return nil

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -792,7 +792,7 @@ func (s *scanJob) handleRename(ctx context.Context, f File, fp []Fingerprint) (F
 		return nil, err
 	}
 
-	return other, nil
+	return f, nil
 }
 
 func (s *scanJob) isHandlerRequired(ctx context.Context, f File) bool {

--- a/pkg/gallery/scan.go
+++ b/pkg/gallery/scan.go
@@ -64,8 +64,10 @@ func (h *ScanHandler) Handle(ctx context.Context, f file.File) error {
 			UpdatedAt: now,
 		}
 
+		logger.Infof("%s doesn't exist. Creating new gallery...", f.Base().Path)
+
 		if err := h.CreatorUpdater.Create(ctx, newGallery, []file.ID{baseFile.ID}); err != nil {
-			return fmt.Errorf("creating new image: %w", err)
+			return fmt.Errorf("creating new gallery: %w", err)
 		}
 
 		h.PluginCache.ExecutePostHooks(ctx, newGallery.ID, plugin.GalleryCreatePost, nil, nil)

--- a/pkg/gallery/service.go
+++ b/pkg/gallery/service.go
@@ -20,10 +20,13 @@ type ImageFinder interface {
 
 type ImageService interface {
 	Destroy(ctx context.Context, i *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) error
+	DestroyZipImages(ctx context.Context, zipFile file.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 }
 
 type Service struct {
 	Repository   Repository
 	ImageFinder  ImageFinder
 	ImageService ImageService
+	File         file.Store
+	Folder       file.FolderStore
 }

--- a/pkg/gallery/service.go
+++ b/pkg/gallery/service.go
@@ -8,8 +8,12 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 )
 
-type Repository interface {
+type FinderByFile interface {
 	FindByFileID(ctx context.Context, fileID file.ID) ([]*models.Gallery, error)
+}
+
+type Repository interface {
+	FinderByFile
 	Destroy(ctx context.Context, id int) error
 }
 

--- a/pkg/image/delete.go
+++ b/pkg/image/delete.go
@@ -33,11 +33,44 @@ func (d *FileDeleter) MarkGeneratedFiles(image *models.Image) error {
 
 // Destroy destroys an image, optionally marking the file and generated files for deletion.
 func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool) error {
+	const fromZip = false
+	return s.destroyImage(ctx, i, fileDeleter, deleteGenerated, deleteFile, fromZip)
+}
+
+// DestroyZipImages destroys all images in zip, optionally marking the files and generated files for deletion.
+// Returns a slice of images that were destroyed.
+func (s *Service) DestroyZipImages(ctx context.Context, zipFile file.File, fileDeleter *FileDeleter, deleteGenerated bool) ([]*models.Image, error) {
 	// TODO - we currently destroy associated files so that they will be rescanned.
 	// A better way would be to keep the file entries in the database, and recreate
 	// associated objects during the scan process if there are none already.
 
-	if err := s.destroyFiles(ctx, i, fileDeleter, deleteFile); err != nil {
+	var imgsDestroyed []*models.Image
+
+	imgs, err := s.Repository.FindByZipFileID(ctx, zipFile.Base().ID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, img := range imgs {
+		const deleteFileInZip = false
+		const fromZip = true
+		if err := s.destroyImage(ctx, img, fileDeleter, deleteGenerated, deleteFileInZip, fromZip); err != nil {
+			return nil, err
+		}
+
+		imgsDestroyed = append(imgsDestroyed, img)
+	}
+
+	return imgsDestroyed, nil
+}
+
+// Destroy destroys an image, optionally marking the file and generated files for deletion.
+func (s *Service) destroyImage(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, fromZip bool) error {
+	// TODO - we currently destroy associated files so that they will be rescanned.
+	// A better way would be to keep the file entries in the database, and recreate
+	// associated objects during the scan process if there are none already.
+
+	if err := s.destroyFiles(ctx, i, fileDeleter, deleteFile, fromZip); err != nil {
 		return err
 	}
 
@@ -50,7 +83,7 @@ func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *Fil
 	return s.Repository.Destroy(ctx, i.ID)
 }
 
-func (s *Service) destroyFiles(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteFile bool) error {
+func (s *Service) destroyFiles(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteFile bool, fromZip bool) error {
 	for _, f := range i.Files {
 		// only delete files where there is no other associated image
 		otherImages, err := s.Repository.FindByFileID(ctx, f.ID)
@@ -64,7 +97,7 @@ func (s *Service) destroyFiles(ctx context.Context, i *models.Image, fileDeleter
 		}
 
 		// don't delete files in zip archives
-		if deleteFile && f.ZipFileID == nil {
+		if fromZip || f.ZipFileID == nil {
 			if err := file.Destroy(ctx, s.File, f, fileDeleter.Deleter, deleteFile); err != nil {
 				return err
 			}

--- a/pkg/image/scan.go
+++ b/pkg/image/scan.go
@@ -115,6 +115,8 @@ func (h *ScanHandler) Handle(ctx context.Context, f file.File) error {
 			}
 		}
 
+		logger.Infof("%s doesn't exist. Creating new image...", f.Base().Path)
+
 		if err := h.CreatorUpdater.Create(ctx, &models.ImageCreateInput{
 			Image:   newImage,
 			FileIDs: []file.ID{imageFile.ID},

--- a/pkg/image/service.go
+++ b/pkg/image/service.go
@@ -9,6 +9,7 @@ import (
 
 type FinderByFile interface {
 	FindByFileID(ctx context.Context, fileID file.ID) ([]*models.Image, error)
+	FindByZipFileID(ctx context.Context, zipFileID file.ID) ([]*models.Image, error)
 }
 
 type Repository interface {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -88,6 +88,8 @@ func (h *ScanHandler) Handle(ctx context.Context, f file.File) error {
 			UpdatedAt: now,
 		}
 
+		logger.Infof("%s doesn't exist. Creating new scene...", f.Base().Path)
+
 		if err := h.CreatorUpdater.Create(ctx, newScene, []file.ID{videoFile.ID}); err != nil {
 			return fmt.Errorf("creating new scene: %w", err)
 		}

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -388,6 +388,13 @@ func (qb *GalleryStore) FindByFileID(ctx context.Context, fileID file.ID) ([]*mo
 	return ret, nil
 }
 
+func (qb *GalleryStore) CountByFileID(ctx context.Context, fileID file.ID) (int, error) {
+	joinTable := galleriesFilesJoinTable
+
+	q := dialect.Select(goqu.COUNT("*")).From(joinTable).Where(joinTable.Col(fileIDColumn).Eq(fileID))
+	return count(ctx, q)
+}
+
 func (qb *GalleryStore) FindByFingerprints(ctx context.Context, fp []file.Fingerprint) ([]*models.Gallery, error) {
 	table := qb.queryTable()
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -379,6 +379,13 @@ func (qb *ImageStore) FindByFileID(ctx context.Context, fileID file.ID) ([]*mode
 	return ret, nil
 }
 
+func (qb *ImageStore) CountByFileID(ctx context.Context, fileID file.ID) (int, error) {
+	joinTable := imagesFilesJoinTable
+
+	q := dialect.Select(goqu.COUNT("*")).From(joinTable).Where(joinTable.Col(fileIDColumn).Eq(fileID))
+	return count(ctx, q)
+}
+
 func (qb *ImageStore) FindByFingerprints(ctx context.Context, fp []file.Fingerprint) ([]*models.Image, error) {
 	table := imagesQueryTable
 

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -470,6 +470,13 @@ func (qb *SceneStore) FindByFileID(ctx context.Context, fileID file.ID) ([]*mode
 	return ret, nil
 }
 
+func (qb *SceneStore) CountByFileID(ctx context.Context, fileID file.ID) (int, error) {
+	joinTable := scenesFilesJoinTable
+
+	q := dialect.Select(goqu.COUNT("*")).From(joinTable).Where(joinTable.Col(fileIDColumn).Eq(fileID))
+	return count(ctx, q)
+}
+
 func (qb *SceneStore) FindByFingerprints(ctx context.Context, fp []file.Fingerprint) ([]*models.Scene, error) {
 	table := qb.queryTable()
 

--- a/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
@@ -12,8 +12,6 @@ export const ScanOptions: React.FC<IScanOptions> = ({
   setOptions: setOptionsState,
 }) => {
   const {
-    useFileMetadata,
-    stripFileExtension,
     scanGeneratePreviews,
     scanGenerateImagePreviews,
     scanGenerateSprites,
@@ -62,18 +60,6 @@ export const ScanOptions: React.FC<IScanOptions> = ({
         checked={scanGenerateThumbnails ?? false}
         headingID="config.tasks.generate_thumbnails_during_scan"
         onChange={(v) => setOptions({ scanGenerateThumbnails: v })}
-      />
-      <BooleanSetting
-        id="strip-file-extension"
-        checked={stripFileExtension ?? false}
-        headingID="config.tasks.dont_include_file_extension_as_part_of_the_title"
-        onChange={(v) => setOptions({ stripFileExtension: v })}
-      />
-      <BooleanSetting
-        id="use-file-metadata"
-        checked={useFileMetadata ?? false}
-        headingID="config.tasks.set_name_date_details_from_metadata_if_present"
-        onChange={(v) => setOptions({ useFileMetadata: v })}
       />
     </>
   );

--- a/ui/v2.5/src/docs/en/Changelog/v0170.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0170.md
@@ -10,12 +10,12 @@ Please report all issues to the following Github issue: https://github.com/stash
 * import/export functionality is currently disabled. Needs further design.
 * missing covers are not currently regenerated. Need to consider further, especially around scene cover redesign.
 * deleting galleries is currently slow.
-* Don't include file extension as part of the title scan flag is not supported.
-* Set name, date, details from embedded file metadata scan flag is not supported.
 
 ### ✨ New Features
 * Added support for identical files. Identical files are assigned to the same scene/gallery/image and can be viewed in File Info. ([#2676](https://github.com/stashapp/stash/pull/2676))
 * Added release notes dialog. ([#2726](https://github.com/stashapp/stash/pull/2726))
 
 ### 🎨 Improvements
+* Object titles are now displayed as the file basename if the title is not explicitly set. The `Don't include file extension as part of the title` scan flag is no longer supported.
+* `Set name, date, details from embedded file metadata` scan flag is no longer supported. This functionality may be implemented as a built-in scraper in the future.
 * Moved Changelogs to Settings page. ([#2726](https://github.com/stashapp/stash/pull/2726))

--- a/ui/v2.5/src/docs/en/ReleaseNotes/index.ts
+++ b/ui/v2.5/src/docs/en/ReleaseNotes/index.ts
@@ -10,7 +10,7 @@ interface IReleaseNotes {
 
 export const releaseNotes: IReleaseNotes[] = [
   {
-    date: 20220707,
+    date: 20220714,
     content: v0170,
   },
 ];

--- a/ui/v2.5/src/docs/en/ReleaseNotes/v0170.md
+++ b/ui/v2.5/src/docs/en/ReleaseNotes/v0170.md
@@ -10,9 +10,10 @@ Please report all issues to the following Github issue: https://github.com/stash
 * import/export functionality is currently disabled. Needs further design.
 * missing covers are not currently regenerated. Need to consider further, especially around scene cover redesign.
 * deleting galleries is currently slow.
-* Don't include file extension as part of the title scan flag is not supported.
-* Set name, date, details from embedded file metadata scan flag is not supported.
+
 
 ### Other changes:
 
 * Changelog has been moved from the stats page to a section in the Settings page.
+* Object titles are now displayed as the file basename if the title is not explicitly set. The `Don't include file extension as part of the title` scan flag is no longer supported.
+* `Set name, date, details from embedded file metadata` scan flag is no longer supported. This functionality may be implemented as a built-in scraper in the future.


### PR DESCRIPTION
Target: `files-refactor`

- fixes issue where deleting a zip gallery would not remove the file entry from the database, preventing the gallery from being rescanned
- re-added `minModTime` scan filter option
- deprecated `useFileMetadata` and `stripFileExtension` scan options. These are probably better suited as scrapers, plugins or scripts.