### PR TITLE
Add Create and Tagger sections to the Tasks page

### DIFF
--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -375,19 +375,34 @@ export const LibraryTasks: React.FC = () => {
         <Setting
           heading={
             <>
-              <FormattedMessage id="config.tasks.tagger.heading" />
+              <FormattedMessage id="config.tasks.scene_tagger.heading" />
               <ManualLink tab="Tagger">
                 <Icon icon={faQuestionCircle} />
               </ManualLink>
             </>
           }
-          subHeadingID="config.tasks.tagger.description"
+          subHeadingID="config.tasks.scene_tagger.description"
         >
           <Link to={"scenes?disp=3"}>
             <Button variant="primary">
               <FormattedMessage id="scenes" defaultMessage="Scenes" />
             </Button>
           </Link>
+        </Setting>
+      </SettingSection>
+
+      <SettingSection>
+        <Setting
+          heading={
+            <>
+              <FormattedMessage id="config.tasks.performer_tagger.heading" />
+              <ManualLink tab="Tagger">
+                <Icon icon={faQuestionCircle} />
+              </ManualLink>
+            </>
+          }
+          subHeadingID="config.tasks.performer_tagger.description"
+        >
           <Link to={"performers?disp=3"}>
             <Button variant="primary">
               <FormattedMessage id="performers" defaultMessage="Performers" />

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Button, Form } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import {
   mutateMetadataScan,
   mutateMetadataAutoTag,
@@ -328,6 +329,71 @@ export const LibraryTasks: React.FC = () => {
         >
           <ScanOptions options={scanOptions} setOptions={setScanOptions} />
         </SettingGroup>
+      </SettingSection>
+
+      <SettingSection>
+        <Setting
+          heading={
+            <>
+              <FormattedMessage id="config.tasks.create.heading" />
+              <ManualLink tab="Tasks">
+                <Icon icon={faQuestionCircle} />
+              </ManualLink>
+            </>
+          }
+          subHeadingID="config.tasks.create.description"
+        >
+          <Link to={"/performers/new"}>
+            <Button variant="primary">
+              <FormattedMessage id="performer" defaultMessage="Performer" />
+            </Button>
+          </Link>
+          <Link to={"/studios/new"}>
+            <Button variant="primary">
+              <FormattedMessage id="studio" defaultMessage="Studio" />
+            </Button>
+          </Link>
+          <Link to={"/tags/new"}>
+            <Button variant="primary">
+              <FormattedMessage id="tag" defaultMessage="Tag" />
+            </Button>
+          </Link>
+          <Link to={"/movies/new"}>
+            <Button variant="primary">
+              <FormattedMessage id="movie" defaultMessage="Movie" />
+            </Button>
+          </Link>
+          <Link to={"/galleries/new"}>
+            <Button variant="primary">
+              <FormattedMessage id="gallery" defaultMessage="Gallery" />
+            </Button>
+          </Link>
+        </Setting>
+      </SettingSection>
+
+      <SettingSection>
+        <Setting
+          heading={
+            <>
+              <FormattedMessage id="config.tasks.tagger.heading" />
+              <ManualLink tab="Tagger">
+                <Icon icon={faQuestionCircle} />
+              </ManualLink>
+            </>
+          }
+          subHeadingID="config.tasks.tagger.description"
+        >
+          <Link to={"scenes?disp=3"}>
+            <Button variant="primary">
+              <FormattedMessage id="scenes" defaultMessage="Scenes" />
+            </Button>
+          </Link>
+          <Link to={"performers?disp=3"}>
+            <Button variant="primary">
+              <FormattedMessage id="performers" defaultMessage="Performers" />
+            </Button>
+          </Link>
+        </Setting>
       </SettingSection>
 
       <SettingSection>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -396,17 +396,21 @@
       "migrate_hash_files": "Used after changing the Generated file naming hash to rename existing generated files to the new hash format.",
       "migrations": "Migrations",
       "only_dry_run": "Only perform a dry run. Don't remove anything",
+      "performer_tagger": {
+        "description": "Batch add performers or update existing performer metadata using stash-box.",
+        "heading": "Performer Tagger"
+      },
       "plugin_tasks": "Plugin Tasks",
       "scan": {
         "scanning_all_paths": "Scanning all paths",
         "scanning_paths": "Scanning the following paths"
       },
       "scan_for_content_desc": "Scan for new content and add it to the database.",
-      "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata",
-      "tagger": {
-        "description": "Set metadata using stash-box and scraper sources.",
-        "heading": "Tagger"
-      }
+      "scene_tagger": {
+        "description": "Interactively set scene metadata using stash-box and scraper sources.",
+        "heading": "Scene Tagger"
+      },
+      "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata"
     },
     "tools": {
       "scene_duplicate_checker": "Scene Duplicate Checker",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -346,6 +346,10 @@
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",
       "backup_database": "Performs a backup of the database to the same directory as the database, with the filename format {filename_format}",
       "cleanup_desc": "Check for missing files and remove them from the database. This is a destructive action.",
+      "create": {
+        "description": "Create stash metadata objects.",
+        "heading": "Create"
+      },
       "data_management": "Data management",
       "defaults_set": "Defaults have been set and will be used when clicking the {action} button on the Tasks page.",
       "dont_include_file_extension_as_part_of_the_title": "Don't include file extension as part of the title",
@@ -398,7 +402,11 @@
         "scanning_paths": "Scanning the following paths"
       },
       "scan_for_content_desc": "Scan for new content and add it to the database.",
-      "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata"
+      "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata",
+      "tagger": {
+        "description": "Set metadata using stash-box and scraper sources.",
+        "heading": "Tagger"
+      }
     },
     "tools": {
       "scene_duplicate_checker": "Scene Duplicate Checker",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38586902/180497523-e2f58057-f9b0-491b-9d59-e62ea6c04100.png)

This adds two new task groups, "Create" and "Tagger", under the Library section after the Scan task. The create group is a collection of the "New" buttons one finds on the respective object pages, but all collected in one place. The tagger group has buttons that take you to the scene tagger view and the performer tagger view.

The idea behind this came about from a thread on the discord about improving the newbie experience. A common issue is new users will Scan and then try to Identify or Autotag and get frustrated when nothing happens. They don't know they should be creating objects first or will never discover where the Tagger is, because it's hidden on the scene and performer pages. Allowing new users to discover the create and tagger capabilities from the tasks page and placing it right after the scan section makes for a much more logical progression since those are the things we would recommend new users do after a scan.