### PR TITLE
[Feature] Show StashIDs on studio details panel

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
@@ -51,6 +51,43 @@ export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
     );
   }
 
+  function renderStashIDs() {
+    if (!studio.stash_ids?.length) {
+      return;
+    }
+
+    return (
+      <>
+        <dt>
+          <FormattedMessage id="StashIDs" />
+        </dt>
+        <dd>
+          <ul className="pl-0">
+            {studio.stash_ids.map((stashID) => {
+              const base = stashID.endpoint.match(/https?:\/\/.*?\//)?.[0];
+              const link = base ? (
+                <a
+                  href={`${base}studios/${stashID.stash_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {stashID.stash_id}
+                </a>
+              ) : (
+                stashID.stash_id
+              );
+              return (
+                <li key={stashID.stash_id} className="row no-gutters">
+                  {link}
+                </li>
+              );
+            })}
+          </ul>
+        </dd>
+      </>
+    );
+  }
+
   return (
     <div className="studio-details">
       <div>
@@ -76,6 +113,7 @@ export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
 
         {renderRatingField()}
         {renderTagsList()}
+        {renderStashIDs()}
       </dl>
     </div>
   );


### PR DESCRIPTION
This PR allows StashIDs to show on the details page without having to click the Edit button.

![image](https://user-images.githubusercontent.com/1358708/183329697-924e6c27-325c-43c9-a8f6-cde48ad768f9.png)

The function was lifted straight out of `StudioEditPanel.tsx` and then i just removed the trash button.