### PR TITLE
Fixed cross-compile doc command

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,7 +53,7 @@ This project uses a modification of the [CI-GoReleaser](https://github.com/bep/d
 where the app can be cross-compiled.  This process is kicked off by CI via the `scripts/cross-compile.sh` script.  Run the following
 command to open a bash shell to the container to poke around:
 
-`docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash -i -t stashappdev/compiler:latest /bin/bash`
+`docker run --rm --mount type=bind,source="$(pwd)",target=/stash -w /stash -i -t stashapp/compiler:latest /bin/bash`
 
 ## Profiling
 


### PR DESCRIPTION
Current doc pointed at the old image of the cross compiler docker image.
Thanks bnkai for telling me :)