### PR TITLE
[Files Refactor] Fix lint github action error

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,8 +42,8 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # Disable gosimple, staticcheck and unused to avoid out of memory error
-          args: --modules-download-mode=vendor --timeout=3m -D gosimple,staticcheck,unused
+          # Use .golangci.action.yml config to avoid out of memory error
+          args: --modules-download-mode=vendor --timeout=3m -c .golangci.action.yml
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,7 +42,8 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --modules-download-mode=vendor --timeout=3m
+          # Disable gosimple, staticcheck and unused to avoid out of memory error
+          args: --modules-download-mode=vendor --timeout=3m -D gosimple,staticcheck,unused
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.golangci.action.yml
+++ b/.golangci.action.yml
@@ -1,0 +1,97 @@
+# This config file is used by Lint action, since the default config
+# emits out of memory errors.
+# Disables gosimple, staticcheck and unused linters
+
+# options for analysis running
+run:
+  timeout: 3m
+  modules-download-mode: vendor
+
+linters:
+  disable-all: true
+  enable:
+    # Default set of linters from golangci-lint
+    - deadcode
+    - errcheck
+    # - gosimple
+    - govet
+    - ineffassign
+    # - staticcheck
+    - structcheck
+    - typecheck
+    # - unused
+    - varcheck
+    # Linters added by the stash project.
+    # - contextcheck
+    - dogsled
+    - errchkjson
+    - errorlint
+    # - exhaustive
+    - exportloopref
+    - gocritic
+    # - goerr113
+    - gofmt
+    # - gomnd
+    # - ifshort
+    - misspell
+    # - nakedret
+    - noctx
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+
+# Project-specific linter overrides
+linters-settings:
+  gofmt:
+    simplify: false
+
+  errorlint:
+    # Disable errorf because there are false positives, where you don't want to wrap
+    #  an error.
+    errorf: false
+    asserts: true
+    comparison: true
+
+  revive:
+    ignore-generated-header: true
+    severity: error
+    confidence: 0.8
+    error-code: 1
+    warning-code: 1
+    rules:
+      - name: blank-imports
+        disabled: true
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+        disabled: true
+      - name: if-return
+        disabled: true
+      - name: increment-decrement
+      - name: var-naming
+        disabled: true
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+        disabled: true
+      - name: indent-error-flow
+        disabled: true
+      - name: errorf
+      - name: empty-block
+        disabled: true
+      - name: superfluous-else
+      - name: unused-parameter
+        disabled: true
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  rowserrcheck:
+    packages:
+      - github.com/jmoiron/sqlx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,12 +12,12 @@ linters:
     # Disabled due to out of memory error
     # - gosimple
     # - staticcheck
+    # - unused
     - govet
     - ineffassign
     - structcheck
     - typecheck
-    - unused
-    # - varcheck
+    - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
     # - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,17 +9,16 @@ linters:
     # Default set of linters from golangci-lint
     - deadcode
     - errcheck
-    # Disabled due to out of memory error
-    # - gosimple
-    # - staticcheck
-    # - unused
+    - gosimple
     - govet
     - ineffassign
+    - staticcheck
+    - unused
     - structcheck
     - typecheck
     - varcheck
-    # # Linters added by the stash project.
-    # # - contextcheck
+    # Linters added by the stash project.
+    # - contextcheck
     - dogsled
     - errchkjson
     - errorlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,20 +10,19 @@ linters:
     - deadcode
     - errcheck
     - gosimple
-    # removed to fix timeout error
-    # - govet
-    # - ineffassign
-    # - staticcheck
-    # - structcheck
-    # - typecheck
-    # - unused
-    # - varcheck
-    # # Linters added by the stash project.
-    # # - contextcheck
-    # - dogsled
-    # - errchkjson
-    # - errorlint
-    # # - exhaustive
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    # Linters added by the stash project.
+    # - contextcheck
+    - dogsled
+    - errchkjson
+    - errorlint
+    # - exhaustive
     # - exportloopref
     # - gocritic
     # # - goerr113

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     - ineffassign
     - structcheck
     - typecheck
-    # - unused
+    - unused
     # - varcheck
     # # Linters added by the stash project.
     # # - contextcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,12 +12,12 @@ linters:
     # Disabled due to out of memory error
     # - gosimple
     - govet
-    # - ineffassign
-    # - staticcheck
-    # - structcheck
-    # - typecheck
-    # - unused
-    # - varcheck
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
     # - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,9 +13,9 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - unused
     - structcheck
     - typecheck
+    - unused
     - varcheck
     # Linters added by the stash project.
     # - contextcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,22 +20,22 @@ linters:
     - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
-    # - dogsled
-    # - errchkjson
-    # - errorlint
-    # # - exhaustive
-    # - exportloopref
-    # - gocritic
-    # # - goerr113
-    # - gofmt
-    # # - gomnd
-    # # - ifshort
-    # - misspell
-    # # - nakedret
-    # - noctx
-    # - revive
-    # - rowserrcheck
-    # - sqlclosecheck
+    - dogsled
+    - errchkjson
+    - errorlint
+    # - exhaustive
+    - exportloopref
+    - gocritic
+    # - goerr113
+    - gofmt
+    # - gomnd
+    # - ifshort
+    - misspell
+    # - nakedret
+    - noctx
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
 
 # Project-specific linter overrides
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
   enable:
     # Default set of linters from golangci-lint
     - deadcode
-    # - errcheck
+    - errcheck
     # - gosimple
     # removed to fix timeout error
     # - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,8 @@ linters:
     # - gosimple
     - govet
     - ineffassign
-    - staticcheck
-    - structcheck
+    # - staticcheck
+    # - structcheck
     # - typecheck
     # - unused
     # - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     # - gosimple
     - govet
     - ineffassign
-    # - staticcheck
+    - staticcheck
     # - structcheck
     # - typecheck
     # - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,9 @@ linters:
   disable-all: true
   enable:
     # Default set of linters from golangci-lint
-    - deadcode
-    - errcheck
-    # - gosimple
+    # - deadcode
+    # - errcheck
+    - gosimple
     # removed to fix timeout error
     # - govet
     # - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,8 @@ linters:
     - ineffassign
     - structcheck
     - typecheck
-    - unused
-    - varcheck
+    # - unused
+    # - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
     # - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,13 +11,13 @@ linters:
     - errcheck
     # Disabled due to out of memory error
     # - gosimple
+    # - staticcheck
     - govet
     - ineffassign
-    - staticcheck
-    # - structcheck
-    # - typecheck
-    # - unused
-    # - varcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
     # - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,30 +12,30 @@ linters:
     - gosimple
     # removed to fix timeout error
     # - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
-    # Linters added by the stash project.
-    # - contextcheck
-    - dogsled
-    - errchkjson
-    - errorlint
-    # - exhaustive
-    - exportloopref
-    - gocritic
-    # - goerr113
-    - gofmt
-    # - gomnd
-    # - ifshort
-    - misspell
-    # - nakedret
-    - noctx
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
+    # - ineffassign
+    # - staticcheck
+    # - structcheck
+    # - typecheck
+    # - unused
+    # - varcheck
+    # # Linters added by the stash project.
+    # # - contextcheck
+    # - dogsled
+    # - errchkjson
+    # - errorlint
+    # # - exhaustive
+    # - exportloopref
+    # - gocritic
+    # # - goerr113
+    # - gofmt
+    # # - gomnd
+    # # - ifshort
+    # - misspell
+    # # - nakedret
+    # - noctx
+    # - revive
+    # - rowserrcheck
+    # - sqlclosecheck
 
 # Project-specific linter overrides
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,21 +8,22 @@ linters:
   enable:
     # Default set of linters from golangci-lint
     - deadcode
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
-    # Linters added by the stash project.
-    # - contextcheck
-    - dogsled
-    - errchkjson
-    - errorlint
-    # - exhaustive
+    # - errcheck
+    # - gosimple
+    # removed to fix timeout error
+    # - govet
+    # - ineffassign
+    # - staticcheck
+    # - structcheck
+    # - typecheck
+    # - unused
+    # - varcheck
+    # # Linters added by the stash project.
+    # # - contextcheck
+    # - dogsled
+    # - errchkjson
+    # - errorlint
+    # # - exhaustive
     # - exportloopref
     # - gocritic
     # # - goerr113

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,31 +11,31 @@ linters:
     - errcheck
     # Disabled due to out of memory error
     # - gosimple
-    # - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
-    # Linters added by the stash project.
-    # - contextcheck
-    - dogsled
-    - errchkjson
-    - errorlint
-    # - exhaustive
-    - exportloopref
-    - gocritic
-    # - goerr113
-    - gofmt
-    # - gomnd
-    # - ifshort
-    - misspell
-    # - nakedret
-    - noctx
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
+    - govet
+    # - ineffassign
+    # - staticcheck
+    # - structcheck
+    # - typecheck
+    # - unused
+    # - varcheck
+    # # Linters added by the stash project.
+    # # - contextcheck
+    # - dogsled
+    # - errchkjson
+    # - errorlint
+    # # - exhaustive
+    # - exportloopref
+    # - gocritic
+    # # - goerr113
+    # - gofmt
+    # # - gomnd
+    # # - ifshort
+    # - misspell
+    # # - nakedret
+    # - noctx
+    # - revive
+    # - rowserrcheck
+    # - sqlclosecheck
 
 # Project-specific linter overrides
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,35 +7,36 @@ linters:
   disable-all: true
   enable:
     # Default set of linters from golangci-lint
-    # - deadcode
-    # - errcheck
-    - gosimple
+    - deadcode
+    - errcheck
+    # Disabled due to out of memory error
+    # - gosimple
     # removed to fix timeout error
-    # - govet
-    # - ineffassign
-    # - staticcheck
-    # - structcheck
-    # - typecheck
-    # - unused
-    # - varcheck
-    # # Linters added by the stash project.
-    # # - contextcheck
-    # - dogsled
-    # - errchkjson
-    # - errorlint
-    # # - exhaustive
-    # - exportloopref
-    # - gocritic
-    # # - goerr113
-    # - gofmt
-    # # - gomnd
-    # # - ifshort
-    # - misspell
-    # # - nakedret
-    # - noctx
-    # - revive
-    # - rowserrcheck
-    # - sqlclosecheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    # Linters added by the stash project.
+    # - contextcheck
+    - dogsled
+    - errchkjson
+    - errorlint
+    # - exhaustive
+    - exportloopref
+    - gocritic
+    # - goerr113
+    - gofmt
+    # - gomnd
+    # - ifshort
+    - misspell
+    # - nakedret
+    - noctx
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
 
 # Project-specific linter overrides
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,9 @@ linters:
     - ineffassign
     - staticcheck
     - structcheck
-    - typecheck
-    - unused
-    - varcheck
+    # - typecheck
+    # - unused
+    # - varcheck
     # # Linters added by the stash project.
     # # - contextcheck
     # - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,7 @@ linters:
     - errcheck
     # Disabled due to out of memory error
     # - gosimple
-    # removed to fix timeout error
-    - govet
+    # - govet
     - ineffassign
     - staticcheck
     - structcheck


### PR DESCRIPTION
Disables `gosimple`, `staticcheck` and `unused` linters in the github action to avoid the error 137 we've been having.