### PR TITLE
[Files Refactor] Set primary flag when cleaning

### DIFF
--- a/internal/api/resolver_mutation_gallery.go
+++ b/internal/api/resolver_mutation_gallery.go
@@ -338,6 +338,10 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 				return fmt.Errorf("gallery with id %d not found", id)
 			}
 
+			if err := gallery.LoadFiles(ctx, qb); err != nil {
+				return fmt.Errorf("loading files for gallery %d", id)
+			}
+
 			galleries = append(galleries, gallery)
 
 			imgsDestroyed, err = r.galleryService.Destroy(ctx, gallery, fileDeleter, deleteGenerated, deleteFile)

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -335,7 +335,7 @@ func (t *ExportTask) populateGalleryImages(ctx context.Context, repo Repository)
 
 		images, err := imageReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %s", g.Checksum, err.Error())
+			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %s", g.Checksum(), err.Error())
 			continue
 		}
 

--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -107,9 +107,10 @@ type GalleryPartial struct {
 	CreatedAt OptionalTime
 	UpdatedAt OptionalTime
 
-	SceneIDs     *UpdateIDs
-	TagIDs       *UpdateIDs
-	PerformerIDs *UpdateIDs
+	SceneIDs      *UpdateIDs
+	TagIDs        *UpdateIDs
+	PerformerIDs  *UpdateIDs
+	PrimaryFileID *file.ID
 }
 
 func NewGalleryPartial() GalleryPartial {

--- a/pkg/models/model_image.go
+++ b/pkg/models/model_image.go
@@ -121,9 +121,10 @@ type ImagePartial struct {
 	CreatedAt OptionalTime
 	UpdatedAt OptionalTime
 
-	GalleryIDs   *UpdateIDs
-	TagIDs       *UpdateIDs
-	PerformerIDs *UpdateIDs
+	GalleryIDs    *UpdateIDs
+	TagIDs        *UpdateIDs
+	PerformerIDs  *UpdateIDs
+	PrimaryFileID *file.ID
 }
 
 func NewImagePartial() ImagePartial {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -143,11 +143,12 @@ type ScenePartial struct {
 	CreatedAt OptionalTime
 	UpdatedAt OptionalTime
 
-	GalleryIDs   *UpdateIDs
-	TagIDs       *UpdateIDs
-	PerformerIDs *UpdateIDs
-	MovieIDs     *UpdateMovieIDs
-	StashIDs     *UpdateStashIDs
+	GalleryIDs    *UpdateIDs
+	TagIDs        *UpdateIDs
+	PerformerIDs  *UpdateIDs
+	MovieIDs      *UpdateMovieIDs
+	StashIDs      *UpdateStashIDs
+	PrimaryFileID *file.ID
 }
 
 func NewScenePartial() ScenePartial {

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -246,6 +246,12 @@ func (qb *GalleryStore) UpdatePartial(ctx context.Context, id int, partial model
 		}
 	}
 
+	if partial.PrimaryFileID != nil {
+		if err := galleriesFilesTableMgr.setPrimary(ctx, id, *partial.PrimaryFileID); err != nil {
+			return nil, err
+		}
+	}
+
 	return qb.Find(ctx, id)
 }
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -193,6 +193,12 @@ func (qb *ImageStore) UpdatePartial(ctx context.Context, id int, partial models.
 		}
 	}
 
+	if partial.PrimaryFileID != nil {
+		if err := imagesFilesTableMgr.setPrimary(ctx, id, *partial.PrimaryFileID); err != nil {
+			return nil, err
+		}
+	}
+
 	return qb.find(ctx, id)
 }
 

--- a/pkg/sqlite/migrations/32_files.up.sql
+++ b/pkg/sqlite/migrations/32_files.up.sql
@@ -86,6 +86,7 @@ CREATE TABLE `images_files` (
 );
 
 CREATE INDEX `index_images_files_on_file_id` on `images_files` (`file_id`);
+CREATE UNIQUE INDEX `unique_index_images_files_on_primary` on `images_files` (`image_id`) WHERE `primary` = 1;
 
 CREATE TABLE `galleries_files` (
     `gallery_id` integer NOT NULL,
@@ -97,6 +98,7 @@ CREATE TABLE `galleries_files` (
 );
 
 CREATE INDEX `index_galleries_files_file_id` ON `galleries_files` (`file_id`);
+CREATE UNIQUE INDEX `unique_index_galleries_files_on_primary` on `galleries_files` (`gallery_id`) WHERE `primary` = 1;
 
 CREATE TABLE `scenes_files` (
     `scene_id` integer NOT NULL,
@@ -108,6 +110,7 @@ CREATE TABLE `scenes_files` (
 );
 
 CREATE INDEX `index_scenes_files_file_id` ON `scenes_files` (`file_id`);
+CREATE UNIQUE INDEX `unique_index_scenes_files_on_primary` on `scenes_files` (`scene_id`) WHERE `primary` = 1;
 
 PRAGMA foreign_keys=OFF;
 

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -256,6 +256,11 @@ func (qb *SceneStore) UpdatePartial(ctx context.Context, id int, partial models.
 			return nil, err
 		}
 	}
+	if partial.PrimaryFileID != nil {
+		if err := scenesFilesTableMgr.setPrimary(ctx, id, *partial.PrimaryFileID); err != nil {
+			return nil, err
+		}
+	}
 
 	return qb.Find(ctx, id)
 }

--- a/ui/v2.5/src/components/Setup/Migrate.tsx
+++ b/ui/v2.5/src/components/Setup/Migrate.tsx
@@ -60,7 +60,7 @@ export const Migrate: React.FC = () => {
       return;
 
     const notes = [];
-    for (let i = status.databaseSchema; i <= status.appSchema; ++i) {
+    for (let i = status.databaseSchema + 1; i <= status.appSchema; ++i) {
       const note = migrationNotes[i];
       if (note) {
         notes.push(note);


### PR DESCRIPTION
Fixes bug where cleaning a primary file would not set the primary flag on another file.