### PR TITLE
[Fix] add space between "Stash" and "IDs" on studio panels

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
@@ -59,7 +59,7 @@ export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
     return (
       <>
         <dt>
-          <FormattedMessage id="StashIDs" />
+          <FormattedMessage id="Stash IDs" />
         </dt>
         <dd>
           <ul className="pl-0">

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -171,7 +171,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
 
     return (
       <Row>
-        <Form.Label column>StashIDs</Form.Label>
+        <Form.Label column>Stash IDs</Form.Label>
         <Col xs={9}>
           <ul className="pl-0">
             {formik.values.stash_ids.map((stashID) => {


### PR DESCRIPTION
After https://github.com/stashapp/stash/pull/2810 merged I realized that I missed in my first pass that there should be a space her in both the part I added and where I copied the logic from to match how it is displayed on the scene page and be in a format that a user would actually expect to read it in.

How it looks fixed:
![image](https://user-images.githubusercontent.com/1358708/188746000-07993e41-cfda-42f4-a51e-7ff2f7453e5e.png)

![image](https://user-images.githubusercontent.com/1358708/188746056-1108c8d4-d2b9-44a9-a2b8-51f0a2316fee.png)
