### PR TITLE
[Files Refactor] Don't require fingerprint calculation post-migrate

### DIFF
--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -196,7 +195,7 @@ func (t *ImportTask) ImportPerformers(ctx context.Context) {
 	logger.Info("[performers] importing")
 
 	path := t.json.json.Performers
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[performers] failed to read performers directory: %v", err)
@@ -239,7 +238,7 @@ func (t *ImportTask) ImportStudios(ctx context.Context) {
 	logger.Info("[studios] importing")
 
 	path := t.json.json.Studios
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[studios] failed to read studios directory: %v", err)
@@ -328,7 +327,7 @@ func (t *ImportTask) ImportMovies(ctx context.Context) {
 	logger.Info("[movies] importing")
 
 	path := t.json.json.Movies
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[movies] failed to read movies directory: %v", err)
@@ -373,7 +372,7 @@ func (t *ImportTask) ImportFiles(ctx context.Context) {
 	logger.Info("[files] importing")
 
 	path := t.json.json.Files
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[files] failed to read files directory: %v", err)
@@ -463,7 +462,7 @@ func (t *ImportTask) ImportGalleries(ctx context.Context) {
 	logger.Info("[galleries] importing")
 
 	path := t.json.json.Galleries
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[galleries] failed to read galleries directory: %v", err)
@@ -515,7 +514,7 @@ func (t *ImportTask) ImportTags(ctx context.Context) {
 	logger.Info("[tags] importing")
 
 	path := t.json.json.Tags
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[tags] failed to read tags directory: %v", err)
@@ -650,7 +649,7 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 	logger.Info("[scenes] importing")
 
 	path := t.json.json.Scenes
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[scenes] failed to read scenes directory: %v", err)

--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -727,7 +727,7 @@ func (t *ImportTask) ImportImages(ctx context.Context) {
 	logger.Info("[images] importing")
 
 	path := t.json.json.Images
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			logger.Errorf("[images] failed to read images directory: %v", err)

--- a/pkg/models/jsonschema/file_folder.go
+++ b/pkg/models/jsonschema/file_folder.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,7 +104,7 @@ func LoadFileFile(filePath string) (DirEntry, error) {
 	}
 	defer r.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sqlite/migrations/32_files.up.sql
+++ b/pkg/sqlite/migrations/32_files.up.sql
@@ -170,9 +170,9 @@ INSERT INTO `files`
   SELECT
     `path`,
     1,
-    COALESCE(`size`, 0),
-    -- set mod time to epoch so that it the format/size is calculated on scan
-    '1970-01-01 00:00:00',
+    -- special value if null so that it is recalculated
+    COALESCE(`size`, -1),
+    COALESCE(`file_mod_time`, '1970-01-01 00:00:00'),
     `created_at`,
     `updated_at`
   FROM `images`;
@@ -186,9 +186,10 @@ INSERT INTO `image_files`
   )
   SELECT
     `files`.`id`,
-    '',
-    COALESCE(`images`.`width`, 0),
-    COALESCE(`images`.`height`, 0)
+    -- special values so that they are recalculated
+    'unset',
+    COALESCE(`images`.`width`, -1),
+    COALESCE(`images`.`height`, -1)
   FROM `images` INNER JOIN `files` ON `images`.`path` = `files`.`basename` AND `files`.`parent_folder_id` = 1;
 
 INSERT INTO `images_files`
@@ -280,8 +281,9 @@ INSERT INTO `files`
   SELECT
     `path`,
     1,
-    0,
-    '1970-01-01 00:00:00', -- set to placeholder so that size is updated
+    -- special value so that it is recalculated
+    -1,
+    COALESCE(`file_mod_time`, '1970-01-01 00:00:00'),
     `created_at`,
     `updated_at`
   FROM `galleries`
@@ -433,9 +435,9 @@ INSERT INTO `files`
   SELECT
     `path`,
     1,
-    COALESCE(`size`, 0),
-    -- set mod time to epoch so that it the format/size is calculated on scan
-    '1970-01-01 00:00:00',
+    -- special value if null so that it is recalculated
+    COALESCE(`size`, -1),
+    COALESCE(`file_mod_time`, '1970-01-01 00:00:00'),
     `created_at`,
     `updated_at`
   FROM `scenes`;
@@ -457,13 +459,14 @@ INSERT INTO `video_files`
   SELECT
     `files`.`id`,
     `scenes`.`duration`,
-    COALESCE(`scenes`.`video_codec`, ''),
-    COALESCE(`scenes`.`format`, ''),
-    COALESCE(`scenes`.`audio_codec`, ''),
-    COALESCE(`scenes`.`width`, 0),
-    COALESCE(`scenes`.`height`, 0),
-    COALESCE(`scenes`.`framerate`, 0),
-    COALESCE(`scenes`.`bitrate`, 0),
+    -- special values for unset to be updated during scan
+    COALESCE(`scenes`.`video_codec`, 'unset'),
+    COALESCE(`scenes`.`format`, 'unset'),
+    COALESCE(`scenes`.`audio_codec`, 'unset'),
+    COALESCE(`scenes`.`width`, -1),
+    COALESCE(`scenes`.`height`, -1),
+    COALESCE(`scenes`.`framerate`, -1),
+    COALESCE(`scenes`.`bitrate`, -1),
     `scenes`.`interactive`,
     `scenes`.`interactive_speed`
   FROM `scenes` INNER JOIN `files` ON `scenes`.`path` = `files`.`basename` AND `files`.`parent_folder_id` = 1;


### PR DESCRIPTION
Eliminates the need to recalculate fingerprints on the first scan after the 32 migration. For my production database, this reduced the post-migrate scan time from 4 hours to ~1 hour. Also fixes issue where scanning files in zips would incorrectly calculate the progress.