### PR TITLE
Fix panic when custom performer image location is invalid

### DIFF
--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -32,6 +32,10 @@ func newImageBox(box fs.FS) (*imageBox, error) {
 	}
 
 	err := fs.WalkDir(box, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if d.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
Fixes #2843 

Targeted at `files-refactor` for now. Will be switched to `develop` once `files-refactor` is merged.