### PR TITLE
[Files Refactor] Optimize database after migration

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -346,8 +346,12 @@ func (db *Database) RunMigrations() error {
 		return fmt.Errorf("re-initializing the database: %w", err)
 	}
 
-	// run a vacuum on the database
-	logger.Info("Performing vacuum on database")
+	// optimize database after migration
+	logger.Info("Optimizing database")
+	_, err = db.db.Exec("ANALYZE")
+	if err != nil {
+		logger.Warnf("error while performing post-migration optimization: %v", err)
+	}
 	_, err = db.db.Exec("VACUUM")
 	if err != nil {
 		logger.Warnf("error while performing post-migration vacuum: %v", err)


### PR DESCRIPTION
Following https://github.com/stashapp/stash/issues/2737#issuecomment-1213201606 and https://github.com/stashapp/stash/issues/2737#issuecomment-1214221532, I've done some investigation into the effects of `ANALYZE` and `PRAGMA optimize` commands on a migrated database. 

A `PRAGMA optimize` essentially detects whether an `ANALYZE` is required and then runs it on any needed tables, so running both `ANALYZE` and `PRAGMA optimize` together is unnecessary.

This PR simply runs an `ANALYZE` after a migration is complete - which drastically improves subsequent scan times.

For a migration from schema 31 to 32 of a ~4.5GB database consisting of ~30 000 files:
| Type | First Scan | Second Scan |
| ----------- | ----------- | ----------- |
| no analyze | 61m 26s | 58m 30s |
| analyze | 1m 49s | 1m 2s | 

The analyze itself adds ~1s to the migration time, significantly less than the `VACUUM` which is done afterwards.

Ideally we would also run `PRAGMA analysis_limit=400; PRAGMA optimize;` after closing every database connection as [recommended](https://www.sqlite.org/lang_analyze.html) by the SQLite devs, but unless I'm missing something there is no straightforward way to do this using go-sqlite3 (issue [mattn/go-sqlite3#984](https://github.com/mattn/go-sqlite3/issues/984)).