### PR TITLE
[Files Refactor] Use batching for pre/post-migration

### DIFF
--- a/ui/v2.5/src/docs/en/MigrationNotes/32.md
+++ b/ui/v2.5/src/docs/en/MigrationNotes/32.md
@@ -1,4 +1,4 @@
-**For best results, perform a scan and clean of your library before running this migration.**
+**For best results, perform a scan and clean of your library using v0.16.1 before running this migration.**
 
 This migration significantly changes the way that stash stores information about your files. This migration is not reversible.
 

--- a/ui/v2.5/src/docs/en/MigrationNotes/32.md
+++ b/ui/v2.5/src/docs/en/MigrationNotes/32.md
@@ -1,4 +1,4 @@
-**For best results, perform a scan and clean of your library using v0.16.1 before running this migration.**
+**For best results, ensure that zip-based gallery paths are correct by performing a scan and clean of your library using v0.16.1 prior to running this migration.**
 
 This migration significantly changes the way that stash stores information about your files. This migration is not reversible.
 

--- a/ui/v2.5/src/docs/en/MigrationNotes/32.md
+++ b/ui/v2.5/src/docs/en/MigrationNotes/32.md
@@ -1,3 +1,5 @@
+**For best results, perform a scan and clean of your library before running this migration.**
+
 This migration significantly changes the way that stash stores information about your files. This migration is not reversible.
 
 After migrating, please run a scan on your entire library to populate missing data, and to ingest identical files which were previously ignored.


### PR DESCRIPTION
Uses batching for the pre- and post-migration steps, and does additional logging to indicate progress.

Also adds note to the release notes to ideally clean and scan before migrating.