### PR TITLE
Fix https detection with reverse proxy

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -407,7 +407,7 @@ func BaseURLMiddleware(next http.Handler) http.Handler {
 		ctx := r.Context()
 
 		scheme := "http"
-		if r.TLS != nil {
+		if strings.Compare("https", r.URL.Scheme) == 0 || r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 			scheme = "https"
 		}
 		prefix := getProxyPrefix(r.Header)


### PR DESCRIPTION
Fixes issue where links would be returned with `http` instead of `https` when running via reverse proxy with https.