### PR TITLE
Set explicit SameSite=Lax on session cookie

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -49,6 +49,7 @@ func NewStore(c SessionConfig) *Store {
 	}
 
 	ret.sessionStore.MaxAge(c.GetMaxSessionAge())
+	ret.sessionStore.Options.SameSite = http.SameSiteLaxMode
 
 	return ret
 }


### PR DESCRIPTION
This explicitly sets SameSite=Lax on the session cookie, to suppress a warning on Firefox. 

SameSite=Lax is now used as default instead of SameSite=None according to the HTTP spec, as it is on Chrome, but Firefox has yet to change and logs a warning to the console about this.

