### PR TITLE
Suppress benign broken pipe and context closed warnings

### DIFF
--- a/internal/api/routes_image.go
+++ b/internal/api/routes_image.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strconv"
+	"syscall"
 
 	"github.com/go-chi/chi"
 	"github.com/stashapp/stash/internal/manager"
@@ -84,11 +85,11 @@ func (rs imageRoutes) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		if manager.GetInstance().Config.IsWriteImageThumbnails() {
 			logger.Debugf("writing thumbnail to disk: %s", img.Path)
 			if err := fsutil.WriteFile(filepath, data); err != nil {
-				logger.Errorf("error writing thumbnail for image %s: %s", img.Path, err)
+				logger.Errorf("error writing thumbnail for image %s: %v", img.Path, err)
 			}
 		}
-		if n, err := w.Write(data); err != nil {
-			logger.Errorf("error writing thumbnail response. Wrote %v bytes: %v", n, err)
+		if n, err := w.Write(data); err != nil && !errors.Is(err, syscall.EPIPE) {
+			logger.Errorf("error serving thumbnail (wrote %v bytes out of %v): %v", n, len(data), err)
 		}
 	}
 }
@@ -114,7 +115,7 @@ func (rs imageRoutes) ImageCtx(next http.Handler) http.Handler {
 		imageID, _ := strconv.Atoi(imageIdentifierQueryParam)
 
 		var image *models.Image
-		readTxnErr := txn.WithTxn(r.Context(), rs.txnManager, func(ctx context.Context) error {
+		_ = txn.WithTxn(r.Context(), rs.txnManager, func(ctx context.Context) error {
 			qb := rs.imageFinder
 			if imageID == 0 {
 				images, _ := qb.FindByChecksum(ctx, imageIdentifierQueryParam)
@@ -131,10 +132,6 @@ func (rs imageRoutes) ImageCtx(next http.Handler) http.Handler {
 
 			return nil
 		})
-		if readTxnErr != nil {
-			logger.Warnf("read transaction failure while trying to read image by id: %v", readTxnErr)
-		}
-
 		if image == nil {
 			http.Error(w, http.StatusText(404), 404)
 			return

--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -2,10 +2,12 @@ package ffmpeg
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/stashapp/stash/pkg/logger"
 )
@@ -35,8 +37,8 @@ func (s *Stream) Serve(w http.ResponseWriter, r *http.Request) {
 	// process killing should be handled by command context
 
 	_, err := io.Copy(w, s.Stdout)
-	if err != nil {
-		logger.Errorf("[stream] error serving transcoded video file: %s", err.Error())
+	if err != nil && !errors.Is(err, syscall.EPIPE) {
+		logger.Errorf("[stream] error serving transcoded video file: %v", err)
 	}
 }
 

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -2,10 +2,12 @@ package file
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"net/http"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/stashapp/stash/pkg/logger"
@@ -137,8 +139,9 @@ func (f *BaseFile) Serve(fs FS, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if k, err := w.Write(data); err != nil {
-			logger.Warnf("failure while serving image (wrote %v bytes out of %v): %v", k, len(data), err)
+		k, err := w.Write(data)
+		if err != nil && !errors.Is(err, syscall.EPIPE) {
+			logger.Warnf("error serving file (wrote %v bytes out of %v): %v", k, len(data), err)
 		}
 
 		return

--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -84,14 +84,10 @@ func FileExists(path string) (bool, error) {
 func WriteFile(path string, file []byte) error {
 	pathErr := EnsureDirAll(filepath.Dir(path))
 	if pathErr != nil {
-		return fmt.Errorf("cannot ensure path %s", pathErr)
+		return fmt.Errorf("cannot ensure path exists: %w", pathErr)
 	}
 
-	err := os.WriteFile(path, file, 0755)
-	if err != nil {
-		return fmt.Errorf("write error for thumbnail %s: %s ", path, err)
-	}
-	return nil
+	return os.WriteFile(path, file, 0755)
 }
 
 // GetNameFromPath returns the name of a file from its path


### PR DESCRIPTION
This is the same idea as #1932, extended to more places. 

When I open almost any page that loads images of some kind, my console gets spammed with benign 'context canceled' and 'broken pipe' warnings. This has always been the case, but since files-refactor the number has noticeably increased.

This also fixes an occasional nil pointer dereference panic that I was getting due to the `PerformerCtx` handler adding a `nil` performer to the context when the database query returns no row without an error.