### PR TITLE
Fix gallery checksum resolver error

### DIFF
--- a/internal/api/resolver_model_gallery.go
+++ b/internal/api/resolver_model_gallery.go
@@ -177,6 +177,18 @@ func (r *galleryResolver) Date(ctx context.Context, obj *models.Gallery) (*strin
 	return nil, nil
 }
 
+func (r *galleryResolver) Checksum(ctx context.Context, obj *models.Gallery) (string, error) {
+	if !obj.Files.PrimaryLoaded() {
+		if err := r.withTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadPrimaryFile(ctx, r.repository.File)
+		}); err != nil {
+			return "", err
+		}
+	}
+
+	return obj.PrimaryChecksum(), nil
+}
+
 func (r *galleryResolver) Scenes(ctx context.Context, obj *models.Gallery) (ret []*models.Scene, err error) {
 	if !obj.SceneIDs.Loaded() {
 		if err := r.withTxn(ctx, func(ctx context.Context) error {

--- a/internal/api/resolver_mutation_gallery.go
+++ b/internal/api/resolver_mutation_gallery.go
@@ -373,7 +373,7 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 	for _, gallery := range galleries {
 		r.hookExecutor.ExecutePostHooks(ctx, gallery.ID, plugin.GalleryDestroyPost, plugin.GalleryDestroyInput{
 			GalleryDestroyInput: input,
-			Checksum:            gallery.Checksum(),
+			Checksum:            gallery.PrimaryChecksum(),
 			Path:                gallery.Path,
 		}, nil)
 	}

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -268,7 +268,7 @@ func (h *cleanHandler) handleRelatedGalleries(ctx context.Context, fileID file.I
 			}
 
 			mgr.PluginCache.RegisterPostHooks(ctx, g.ID, plugin.GalleryDestroyPost, plugin.GalleryDestroyInput{
-				Checksum: g.Checksum(),
+				Checksum: g.PrimaryChecksum(),
 				Path:     g.Path,
 			}, nil)
 		} else {

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -335,7 +335,7 @@ func (t *ExportTask) populateGalleryImages(ctx context.Context, repo Repository)
 
 		images, err := imageReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %s", g.Checksum(), err.Error())
+			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %s", g.PrimaryChecksum(), err.Error())
 			continue
 		}
 
@@ -765,7 +765,7 @@ func exportGallery(ctx context.Context, wg *sync.WaitGroup, jobChan <-chan *mode
 			continue
 		}
 
-		galleryHash := g.Checksum()
+		galleryHash := g.PrimaryChecksum()
 
 		newGalleryJSON, err := gallery.ToBasicJSON(g)
 		if err != nil {

--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -78,7 +78,8 @@ func (g *Gallery) LoadTagIDs(ctx context.Context, l TagIDLoader) error {
 	})
 }
 
-func (g Gallery) Checksum() string {
+func (g Gallery) PrimaryChecksum() string {
+	// renamed from Checksum to prevent gqlgen from using it in the resolver
 	if p := g.Files.Primary(); p != nil {
 		v := p.Base().Fingerprints.Get(file.FingerprintTypeMD5)
 		if v == nil {

--- a/pkg/scraper/query_url.go
+++ b/pkg/scraper/query_url.go
@@ -51,7 +51,7 @@ func queryURLParameterFromURL(url string) queryURLParameters {
 
 func queryURLParametersFromGallery(gallery *models.Gallery) queryURLParameters {
 	ret := make(queryURLParameters)
-	ret["checksum"] = gallery.Checksum()
+	ret["checksum"] = gallery.PrimaryChecksum()
 
 	if gallery.Path != "" {
 		ret["filename"] = filepath.Base(gallery.Path)

--- a/pkg/scraper/stash.go
+++ b/pkg/scraper/stash.go
@@ -282,7 +282,7 @@ func (s *stashScraper) scrapeGalleryByGallery(ctx context.Context, gallery *mode
 		Checksum *string `graphql:"checksum" json:"checksum"`
 	}
 
-	checksum := gallery.Checksum()
+	checksum := gallery.PrimaryChecksum()
 	input := GalleryHashInput{
 		Checksum: &checksum,
 	}


### PR DESCRIPTION
The presence of `Checksum` in the `models.Gallery` struct means that it is called as a resolver. This method requires the primary file relationship to be loaded prior, resulting in a panic when executed as a resolver. Renamed the method to `PrimaryChecksum` and added resolver to the `api` package which loads the relationship first.