### PR TITLE
Various bug fixes

### DIFF
--- a/internal/dlna/cds.go
+++ b/internal/dlna/cds.go
@@ -493,7 +493,7 @@ func (me *contentDirectoryService) getPageVideos(sceneFilter *models.SceneFilter
 		}
 
 		var err error
-		objs, err = pager.getPageVideos(ctx, me.repository.SceneFinder, page, host)
+		objs, err = pager.getPageVideos(ctx, me.repository.SceneFinder, me.repository.FileFinder, page, host)
 		if err != nil {
 			return err
 		}

--- a/internal/dlna/paging.go
+++ b/internal/dlna/paging.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scene"
 )
@@ -59,7 +60,7 @@ func (p *scenePager) getPages(ctx context.Context, r scene.Queryer, total int) (
 	return objs, nil
 }
 
-func (p *scenePager) getPageVideos(ctx context.Context, r SceneFinder, page int, host string) ([]interface{}, error) {
+func (p *scenePager) getPageVideos(ctx context.Context, r SceneFinder, f file.Finder, page int, host string) ([]interface{}, error) {
 	var objs []interface{}
 
 	sort := "title"
@@ -75,6 +76,10 @@ func (p *scenePager) getPageVideos(ctx context.Context, r SceneFinder, page int,
 	}
 
 	for _, s := range scenes {
+		if err := s.LoadPrimaryFile(ctx, f); err != nil {
+			return nil, err
+		}
+
 		objs = append(objs, sceneToContainer(s, p.parentID, host))
 	}
 

--- a/internal/manager/fingerprint.go
+++ b/internal/manager/fingerprint.go
@@ -84,8 +84,7 @@ func (c *fingerprintCalculator) CalculateFingerprints(f *file.BaseFile, o file.O
 		ret = append(ret, *fp)
 
 		// only calculate MD5 if enabled in config
-		// always re-calculate MD5 if the file already has it
-		calculateMD5 = c.Config.IsCalculateMD5() || f.Fingerprints.For(file.FingerprintTypeMD5) != nil
+		calculateMD5 = c.Config.IsCalculateMD5()
 	}
 
 	if calculateMD5 {

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -50,7 +50,7 @@ func (e *DirEntry) info(fs FS, path string) (fs.FileInfo, error) {
 // File represents a file in the file system.
 type File interface {
 	Base() *BaseFile
-	SetFingerprints(fp []Fingerprint)
+	SetFingerprints(fp Fingerprints)
 	Open(fs FS) (io.ReadCloser, error)
 }
 
@@ -76,7 +76,7 @@ type BaseFile struct {
 
 // SetFingerprints sets the fingerprints of the file.
 // If a fingerprint of the same type already exists, it is overwritten.
-func (f *BaseFile) SetFingerprints(fp []Fingerprint) {
+func (f *BaseFile) SetFingerprints(fp Fingerprints) {
 	for _, v := range fp {
 		f.SetFingerprint(v)
 	}

--- a/pkg/file/fingerprint.go
+++ b/pkg/file/fingerprint.go
@@ -14,6 +14,18 @@ type Fingerprint struct {
 
 type Fingerprints []Fingerprint
 
+func (f *Fingerprints) Remove(type_ string) {
+	var ret Fingerprints
+
+	for _, ff := range *f {
+		if ff.Type != type_ {
+			ret = append(ret, ff)
+		}
+	}
+
+	*f = ret
+}
+
 func (f Fingerprints) Equals(other Fingerprints) bool {
 	if len(f) != len(other) {
 		return false

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -758,6 +758,16 @@ func (c Client) GetUser(ctx context.Context) (*graphql.Me, error) {
 	return c.client.Me(ctx)
 }
 
+func appendFingerprintUnique(v []*graphql.FingerprintInput, toAdd *graphql.FingerprintInput) []*graphql.FingerprintInput {
+	for _, vv := range v {
+		if vv.Algorithm == toAdd.Algorithm && vv.Hash == toAdd.Hash {
+			return v
+		}
+	}
+
+	return append(v, toAdd)
+}
+
 func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpoint string, imagePath string) (*string, error) {
 	draft := graphql.SceneDraftInput{}
 	var image io.Reader
@@ -820,7 +830,7 @@ func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpo
 					Algorithm: graphql.FingerprintAlgorithmOshash,
 					Duration:  int(duration),
 				}
-				fingerprints = append(fingerprints, &fingerprint)
+				fingerprints = appendFingerprintUnique(fingerprints, &fingerprint)
 			}
 
 			if checksum := f.Fingerprints.GetString(file.FingerprintTypeMD5); checksum != "" {
@@ -829,7 +839,7 @@ func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpo
 					Algorithm: graphql.FingerprintAlgorithmMd5,
 					Duration:  int(duration),
 				}
-				fingerprints = append(fingerprints, &fingerprint)
+				fingerprints = appendFingerprintUnique(fingerprints, &fingerprint)
 			}
 
 			if phash := f.Fingerprints.GetInt64(file.FingerprintTypePhash); phash != 0 {
@@ -838,7 +848,7 @@ func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpo
 					Algorithm: graphql.FingerprintAlgorithmPhash,
 					Duration:  int(duration),
 				}
-				fingerprints = append(fingerprints, &fingerprint)
+				fingerprints = appendFingerprintUnique(fingerprints, &fingerprint)
 			}
 		}
 	}


### PR DESCRIPTION
- prevent identical scene fingerprints from being submitted in scene drafts
- fix panic when navigating pages from the DLNA interface (#2911)
- don't recalculate MD5 checksum if it is disabled; clear MD5 fingerprint if the oshash is changed and the MD5 was not recalculated