### PR TITLE
Fix JSON.parse console error

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -181,18 +181,16 @@ func Start() error {
 	})
 	r.HandleFunc("/customlocales", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if !c.GetCustomLocalesEnabled() {
-			return
+		if c.GetCustomLocalesEnabled() {
+			// search for custom-locales.json in current directory, then $HOME/.stash
+			fn := c.GetCustomLocalesPath()
+			exists, _ := fsutil.FileExists(fn)
+			if exists {
+				http.ServeFile(w, r, fn)
+				return
+			}
 		}
-
-		// search for custom-locales.json in current directory, then $HOME/.stash
-		fn := c.GetCustomLocalesPath()
-		exists, _ := fsutil.FileExists(fn)
-		if !exists {
-			return
-		}
-
-		http.ServeFile(w, r, fn)
+		_, _ = w.Write([]byte("{}"))
 	})
 
 	r.HandleFunc("/login*", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This just suppresses a JSON.parse console error when the custom locales from #2837 are disabled.

I've added the fix in the backend because the Content-Type is application/json so the response should always be valid JSON.