### PR TITLE
Only set video algorithm after migration 12

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -326,6 +326,12 @@ func (i *Instance) Set(key string, value interface{}) {
 	i.main.Set(key, value)
 }
 
+func (i *Instance) SetDefault(key string, value interface{}) {
+	i.Lock()
+	defer i.Unlock()
+	i.main.SetDefault(key, value)
+}
+
 func (i *Instance) SetPassword(value string) {
 	// if blank, don't bother hashing; we want it to be blank
 	if value == "" {
@@ -1302,13 +1308,6 @@ func (i *Instance) Validate() error {
 	}
 
 	return nil
-}
-
-func (i *Instance) SetChecksumDefaultValues(defaultAlgorithm models.HashAlgorithm, usingMD5 bool) {
-	i.Lock()
-	defer i.Unlock()
-	i.main.SetDefault(VideoFileNamingAlgorithm, defaultAlgorithm)
-	i.main.SetDefault(CalculateMD5, usingMD5)
 }
 
 func (i *Instance) setDefaultValues(write bool) error {

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -108,7 +108,6 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.Set(DisableDropdownCreatePerformer, i.GetDisableDropdownCreate().Performer)
 				i.Set(DisableDropdownCreateStudio, i.GetDisableDropdownCreate().Studio)
 				i.Set(DisableDropdownCreateTag, i.GetDisableDropdownCreate().Tag)
-				i.SetChecksumDefaultValues(i.GetVideoFileNamingAlgorithm(), i.IsCalculateMD5())
 				i.Set(AutostartVideoOnPlaySelected, i.GetAutostartVideoOnPlaySelected())
 				i.Set(ContinuePlaylistDefault, i.GetContinuePlaylistDefault())
 				i.Set(PythonPath, i.GetPythonPath())

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -484,10 +484,6 @@ func (s *Manager) PostInit(ctx context.Context) error {
 		return err
 	}
 
-	if database.Ready() == nil {
-		s.PostMigrate(ctx)
-	}
-
 	return nil
 }
 
@@ -670,9 +666,6 @@ func (s *Manager) Migrate(ctx context.Context, input MigrateInput) error {
 
 		return errors.New(errStr)
 	}
-
-	// perform post-migration operations
-	s.PostMigrate(ctx)
 
 	// if no backup path was provided, then delete the created backup
 	if input.BackupPath == "" {

--- a/internal/manager/post_migrate.go
+++ b/internal/manager/post_migrate.go
@@ -1,8 +1,0 @@
-package manager
-
-import "context"
-
-// PostMigrate is executed after migrations have been executed.
-func (s *Manager) PostMigrate(ctx context.Context) {
-	setInitialMD5Config(ctx, s.Repository, s.Repository.Scene)
-}

--- a/pkg/sqlite/migrations/12_postmigrate.go
+++ b/pkg/sqlite/migrations/12_postmigrate.go
@@ -1,0 +1,60 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stashapp/stash/internal/manager/config"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/sqlite"
+)
+
+func post12(ctx context.Context, db *sqlx.DB) error {
+	m := schema12Migrator{
+		migrator: migrator{
+			db: db,
+		},
+	}
+
+	return m.migrateConfig(ctx)
+}
+
+type schema12Migrator struct {
+	migrator
+}
+
+func (m *schema12Migrator) migrateConfig(ctx context.Context) error {
+	// if there are no scene files in the database, then default the
+	// VideoFileNamingAlgorithm config setting to oshash and calculateMD5 to
+	// false, otherwise set them to true for backwards compatibility purposes
+	var count int
+	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
+		query := "SELECT COUNT(*) from `scenes`"
+
+		return tx.Get(&count, query)
+	}); err != nil {
+		return err
+	}
+
+	usingMD5 := count != 0
+	defaultAlgorithm := models.HashAlgorithmOshash
+	if usingMD5 {
+		logger.Infof("Defaulting video file naming algorithm to %s", models.HashAlgorithmMd5)
+		defaultAlgorithm = models.HashAlgorithmMd5
+	}
+
+	c := config.GetInstance()
+
+	c.SetDefault(config.VideoFileNamingAlgorithm, defaultAlgorithm)
+	c.SetDefault(config.CalculateMD5, usingMD5)
+	if err := c.Write(); err != nil {
+		logger.Errorf("Error while writing configuration file: %s", err.Error())
+	}
+
+	return nil
+}
+
+func init() {
+	sqlite.RegisterPostMigration(12, post12)
+}

--- a/ui/v2.5/src/docs/en/Changelog/v0170.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0170.md
@@ -18,6 +18,7 @@ After migrating, please run a scan on your entire library to populate missing da
 * Moved Changelogs to Settings page. ([#2726](https://github.com/stashapp/stash/pull/2726))
 
 ### 🐛 Bug fixes
+* Fix generated file naming algorithm being set incorrectly in certain circumstances. ([#2496](https://github.com/stashapp/stash/pull/2946))
 * Fix continue queue checkbox value not persisting. ([#2895](https://github.com/stashapp/stash/pull/2895))
 * Fix `autostartVideoOnPlaySelected` option not applying when navigating from scene queue. ([#2896](https://github.com/stashapp/stash/pull/2896))
 * Fix incorrect gallery value in Scene edit tab after navigating from scene queue. ([#2897](https://github.com/stashapp/stash/pull/2897))


### PR DESCRIPTION
This fixes a latent bug where if a config file was corrupted and the database had existing scenes, then the video algorithm would be set to `oshash` and `calculateMD5` would be set to true.

It was caused by a post-migration step for schema version 12 which would run at startup, rather than once after the migration.

Extracted from #2491 