### PR TITLE
Suppress new context canceled errors

### DIFF
--- a/internal/api/routes_image.go
+++ b/internal/api/routes_image.go
@@ -128,7 +128,9 @@ func (rs imageRoutes) ImageCtx(next http.Handler) http.Handler {
 
 			if image != nil {
 				if err := image.LoadPrimaryFile(ctx, rs.fileFinder); err != nil {
-					logger.Errorf("error loading primary file for image %d: %v", imageID, err)
+					if !errors.Is(err, context.Canceled) {
+						logger.Errorf("error loading primary file for image %d: %v", imageID, err)
+					}
 					// set image to nil so that it doesn't try to use the primary file
 					image = nil
 				}

--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -545,7 +545,9 @@ func (rs sceneRoutes) SceneCtx(next http.Handler) http.Handler {
 
 			if scene != nil {
 				if err := scene.LoadPrimaryFile(ctx, rs.fileFinder); err != nil {
-					logger.Errorf("error loading primary file for scene %d: %v", sceneID, err)
+					if !errors.Is(err, context.Canceled) {
+						logger.Errorf("error loading primary file for scene %d: %v", sceneID, err)
+					}
 					// set scene to nil so that it doesn't try to use the primary file
 					scene = nil
 				}


### PR DESCRIPTION
This just suppresses two new context canceled errors from #2945.