### PR TITLE
Handle file rescan

### DIFF
--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -78,6 +78,14 @@ func (j *cleanJob) cleanEmptyGalleries(ctx context.Context) {
 			found = len(emptyGalleries) > 0
 
 			for _, g := range emptyGalleries {
+				if g.Path == "" {
+					continue
+				}
+
+				if len(j.input.Paths) > 0 && !fsutil.IsPathInDirs(j.input.Paths, g.Path) {
+					continue
+				}
+
 				logger.Infof("Gallery has 0 images. Marking to clean: %s", g.DisplayName())
 				toClean = append(toClean, g.ID)
 			}

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/plugin"
 	"github.com/stashapp/stash/pkg/scene"
+	"github.com/stashapp/stash/pkg/txn"
 )
 
 type cleaner interface {
@@ -49,9 +50,85 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) {
 		return
 	}
 
+	j.cleanEmptyGalleries(ctx)
+
 	j.scanSubs.notify()
 	elapsed := time.Since(start)
 	logger.Info(fmt.Sprintf("Finished Cleaning (%s)", elapsed))
+}
+
+func (j *cleanJob) cleanEmptyGalleries(ctx context.Context) {
+	const batchSize = 1000
+	var toClean []int
+	findFilter := models.BatchFindFilter(batchSize)
+	if err := txn.WithTxn(ctx, j.txnManager, func(ctx context.Context) error {
+		found := true
+		for found {
+			emptyGalleries, _, err := j.txnManager.Gallery.Query(ctx, &models.GalleryFilterType{
+				ImageCount: &models.IntCriterionInput{
+					Value:    0,
+					Modifier: models.CriterionModifierEquals,
+				},
+			}, findFilter)
+
+			if err != nil {
+				return err
+			}
+
+			found = len(emptyGalleries) > 0
+
+			for _, g := range emptyGalleries {
+				logger.Infof("Gallery has 0 images. Marking to clean: %s", g.DisplayName())
+				toClean = append(toClean, g.ID)
+			}
+
+			*findFilter.Page++
+		}
+
+		return nil
+	}); err != nil {
+		logger.Errorf("Error finding empty galleries: %v", err)
+		return
+	}
+
+	if !j.input.DryRun {
+		for _, id := range toClean {
+			j.deleteGallery(ctx, id)
+		}
+	}
+}
+
+func (j *cleanJob) deleteGallery(ctx context.Context, id int) {
+	pluginCache := GetInstance().PluginCache
+	qb := j.txnManager.Gallery
+
+	if err := txn.WithTxn(ctx, j.txnManager, func(ctx context.Context) error {
+		g, err := qb.Find(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		if g == nil {
+			return fmt.Errorf("gallery not found: %d", id)
+		}
+
+		if err := g.LoadPrimaryFile(ctx, j.txnManager.File); err != nil {
+			return err
+		}
+
+		if err := qb.Destroy(ctx, id); err != nil {
+			return err
+		}
+
+		pluginCache.RegisterPostHooks(ctx, id, plugin.GalleryDestroyPost, plugin.GalleryDestroyInput{
+			Checksum: g.PrimaryChecksum(),
+			Path:     g.Path,
+		}, nil)
+
+		return nil
+	}); err != nil {
+		logger.Errorf("Error deleting gallery from database: %s", err.Error())
+	}
 }
 
 type cleanFilter struct {

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -256,6 +256,7 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 			Handler: &gallery.ScanHandler{
 				CreatorUpdater:     db.Gallery,
 				SceneFinderUpdater: db.Scene,
+				ImageFinderUpdater: db.Image,
 				PluginCache:        pluginCache,
 			},
 		},

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -248,6 +248,7 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 					isGenerateThumbnails: options.ScanGenerateThumbnails,
 				},
 				PluginCache: pluginCache,
+				Paths:       instance.Paths,
 			},
 		},
 		&file.FilteredHandler{
@@ -269,6 +270,8 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 					taskQueue: taskQueue,
 					progress:  progress,
 				},
+				FileNamingAlgorithm: instance.Config.GetVideoFileNamingAlgorithm(),
+				Paths:               instance.Paths,
 			},
 		},
 	}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/file/video"
@@ -57,11 +58,13 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 	}
 
 	j.scanner.Scan(ctx, getScanHandlers(j.input, taskQueue, progress), file.ScanOptions{
-		Paths:                  paths,
-		ScanFilters:            []file.PathFilter{newScanFilter(instance.Config, minModTime)},
-		ZipFileExtensions:      instance.Config.GetGalleryExtensions(),
-		ParallelTasks:          instance.Config.GetParallelTasksWithAutoDetection(),
-		HandlerRequiredFilters: []file.Filter{newHandlerRequiredFilter(instance.Config)},
+		Paths:             paths,
+		ScanFilters:       []file.PathFilter{newScanFilter(instance.Config, minModTime)},
+		ZipFileExtensions: instance.Config.GetGalleryExtensions(),
+		ParallelTasks:     instance.Config.GetParallelTasksWithAutoDetection(),
+		HandlerRequiredFilters: []file.Filter{
+			newHandlerRequiredFilter(instance.Config),
+		},
 	}, progress)
 
 	taskQueue.Close()
@@ -95,22 +98,31 @@ type fileCounter interface {
 	CountByFileID(ctx context.Context, fileID file.ID) (int, error)
 }
 
+type galleryFinder interface {
+	fileCounter
+	FindByFolderID(ctx context.Context, folderID file.FolderID) ([]*models.Gallery, error)
+}
+
 // handlerRequiredFilter returns true if a File's handler needs to be executed despite the file not being updated.
 type handlerRequiredFilter struct {
 	extensionConfig
 	SceneFinder   fileCounter
 	ImageFinder   fileCounter
-	GalleryFinder fileCounter
+	GalleryFinder galleryFinder
+
+	FolderCache *lru.LRU
 }
 
 func newHandlerRequiredFilter(c *config.Instance) *handlerRequiredFilter {
 	db := instance.Database
+	processes := c.GetParallelTasksWithAutoDetection()
 
 	return &handlerRequiredFilter{
 		extensionConfig: newExtensionConfig(c),
 		SceneFinder:     db.Scene,
 		ImageFinder:     db.Image,
 		GalleryFinder:   db.Gallery,
+		FolderCache:     lru.New(processes * 2),
 	}
 }
 
@@ -143,7 +155,32 @@ func (f *handlerRequiredFilter) Accept(ctx context.Context, ff file.File) bool {
 	}
 
 	// execute handler if there are no related objects
-	return n == 0
+	if n == 0 {
+		return true
+	}
+
+	// if create galleries from folder is enabled and the file is not in a zip
+	// file, then check if there is a folder-based gallery for the file's
+	// directory
+	if isImageFile && instance.Config.GetCreateGalleriesFromFolders() && ff.Base().ZipFileID == nil {
+		// only do this for the first time it encounters the folder
+		// the first instance should create the gallery
+		_, found := f.FolderCache.Get(ctx, ff.Base().ParentFolderID.String())
+		if found {
+			// should already be handled
+			return false
+		}
+
+		g, _ := f.GalleryFinder.FindByFolderID(ctx, ff.Base().ParentFolderID)
+		f.FolderCache.Add(ctx, ff.Base().ParentFolderID.String(), true)
+
+		if len(g) == 0 {
+			// no folder gallery. Return true so that it creates one.
+			return true
+		}
+	}
+
+	return false
 }
 
 type scanFilter struct {

--- a/pkg/file/clean.go
+++ b/pkg/file/clean.go
@@ -338,7 +338,9 @@ func (j *cleanJob) shouldCleanFolder(ctx context.Context, f *Folder) bool {
 	path := f.Path
 
 	info, err := f.Info(j.FS)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	// ErrInvalid can occur in zip files where the zip file path changed
+	// and the underlying folder did not
+	if err != nil && !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, fs.ErrInvalid) {
 		logger.Errorf("error getting folder info for %q, not cleaning: %v", path, err)
 		return false
 	}

--- a/pkg/file/handler.go
+++ b/pkg/file/handler.go
@@ -29,7 +29,7 @@ func (ff FilterFunc) Accept(ctx context.Context, f File) bool {
 
 // Handler provides a handler for Files.
 type Handler interface {
-	Handle(ctx context.Context, f File) error
+	Handle(ctx context.Context, f File, oldFile File) error
 }
 
 // FilteredHandler is a Handler runs only if the filter accepts the file.
@@ -39,9 +39,9 @@ type FilteredHandler struct {
 }
 
 // Handle runs the handler if the filter accepts the file.
-func (h *FilteredHandler) Handle(ctx context.Context, f File) error {
+func (h *FilteredHandler) Handle(ctx context.Context, f File, oldFile File) error {
 	if h.Accept(ctx, f) {
-		return h.Handler.Handle(ctx, f)
+		return h.Handler.Handle(ctx, f, oldFile)
 	}
 	return nil
 }

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -1008,9 +1008,5 @@ func (s *scanJob) onUnchangedFile(ctx context.Context, f scanFile, existing File
 
 	// if this file is a zip file, then we need to rescan the contents
 	// as well. We do this by returning the file, instead of nil.
-	if isMissingMetdata {
-		return existing, nil
-	}
-
-	return nil, nil
+	return existing, nil
 }

--- a/pkg/fsutil/dir.go
+++ b/pkg/fsutil/dir.go
@@ -34,6 +34,17 @@ func IsPathInDir(dir, pathToCheck string) bool {
 	return false
 }
 
+// IsPathInDirs returns true if pathToCheck is within anys of the paths in dirs.
+func IsPathInDirs(dirs []string, pathToCheck string) bool {
+	for _, dir := range dirs {
+		if IsPathInDir(dir, pathToCheck) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // GetHomeDirectory returns the path of the user's home directory.  ~ on Unix and C:\Users\UserName on Windows
 func GetHomeDirectory() string {
 	currentUser, err := user.Current()

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"time"
 )
 
 type HashAlgorithm string
@@ -47,29 +46,4 @@ func (e *HashAlgorithm) UnmarshalGQL(v interface{}) error {
 
 func (e HashAlgorithm) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-type File struct {
-	Checksum    string    `db:"checksum" json:"checksum"`
-	OSHash      string    `db:"oshash" json:"oshash"`
-	Path        string    `db:"path" json:"path"`
-	Size        string    `db:"size" json:"size"`
-	FileModTime time.Time `db:"file_mod_time" json:"file_mod_time"`
-}
-
-// GetHash returns the hash of the scene, based on the hash algorithm provided. If
-// hash algorithm is MD5, then Checksum is returned. Otherwise, OSHash is returned.
-func (s File) GetHash(hashAlgorithm HashAlgorithm) string {
-	switch hashAlgorithm {
-	case HashAlgorithmMd5:
-		return s.Checksum
-	case HashAlgorithmOshash:
-		return s.OSHash
-	default:
-		panic("unknown hash algorithm")
-	}
-}
-
-func (s File) Equal(o File) bool {
-	return s.Path == o.Path && s.Checksum == o.Checksum && s.OSHash == o.OSHash && s.Size == o.Size && s.FileModTime.Equal(o.FileModTime)
 }

--- a/pkg/scene/hash.go
+++ b/pkg/scene/hash.go
@@ -1,0 +1,19 @@
+package scene
+
+import (
+	"github.com/stashapp/stash/pkg/file"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// GetHash returns the hash of the file, based on the hash algorithm provided. If
+// hash algorithm is MD5, then Checksum is returned. Otherwise, OSHash is returned.
+func GetHash(f file.File, hashAlgorithm models.HashAlgorithm) string {
+	switch hashAlgorithm {
+	case models.HashAlgorithmMd5:
+		return f.Base().Fingerprints.GetString(file.FingerprintTypeMD5)
+	case models.HashAlgorithmOshash:
+		return f.Base().Fingerprints.GetString(file.FingerprintTypeOshash)
+	default:
+		panic("unknown hash algorithm")
+	}
+}


### PR DESCRIPTION
- fixes issue where scene/image/gallery would not be created if it there was none associated with a file that had been subsequently moved
- scene/image/gallery post-update hooks are now called when the underlying file was updated
- scene generated files are now migrated when the underlying file hash has changed
- creates galleries when necessary instead of upfront when detecting a zip file. This fixes the issue where galleries would be created for zip files containing no valid image files
- clean now deletes empty galleries again
- fixes issue in clean where zip file folders would fail to be cleaned when its path is no longer valid because the zip file was moved
- fixes issue where duplicate images would not be associated with galleries - fixes #2939 