### PR TITLE
Make scenes page list view checkbox fill entire cell

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -53,13 +53,12 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
 
     const title = objectTitle(scene);
     return (
-      <tr className="h-100" key={scene.id}>
-        <td className="h-100 p-0">
-          <label className="h-100 m-0 d-block">
+      <tr key={scene.id}>
+        <td>
+          <label>
             <Form.Control
               type="checkbox"
               checked={props.selectedIds.has(scene.id)}
-              className="h-100"
               onChange={() =>
                 props.onSelectChange!(
                   scene.id,
@@ -117,8 +116,8 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
   };
 
   return (
-    <div className="row table-list justify-content-center">
-      <Table striped bordered className="h-100">
+    <div className="row scene-table table-list justify-content-center">
+      <Table striped bordered>
         <thead>
           <tr>
             <th />

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -53,26 +53,29 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
 
     const title = objectTitle(scene);
     return (
-      <tr key={scene.id}>
-        <td>
-          <Form.Control
-            type="checkbox"
-            checked={props.selectedIds.has(scene.id)}
-            onChange={() =>
-              props.onSelectChange!(
-                scene.id,
-                !props.selectedIds.has(scene.id),
-                shiftKey
-              )
-            }
-            onClick={(
-              event: React.MouseEvent<HTMLInputElement, MouseEvent>
-            ) => {
-              // eslint-disable-next-line prefer-destructuring
-              shiftKey = event.shiftKey;
-              event.stopPropagation();
-            }}
-          />
+      <tr className="h-100" key={scene.id}>
+        <td className="h-100 p-0">
+          <label className="h-100 m-0 d-block">
+            <Form.Control
+              type="checkbox"
+              checked={props.selectedIds.has(scene.id)}
+              className="h-100"
+              onChange={() =>
+                props.onSelectChange!(
+                  scene.id,
+                  !props.selectedIds.has(scene.id),
+                  shiftKey
+                )
+              }
+              onClick={(
+                event: React.MouseEvent<HTMLInputElement, MouseEvent>
+              ) => {
+                // eslint-disable-next-line prefer-destructuring
+                shiftKey = event.shiftKey;
+                event.stopPropagation();
+              }}
+            />
+          </label>
         </td>
         <td>
           <Link to={sceneLink}>
@@ -115,7 +118,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
 
   return (
     <div className="row table-list justify-content-center">
-      <Table striped bordered>
+      <Table striped bordered className="h-100">
         <thead>
           <tr>
             <th />

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -647,9 +647,11 @@ input[type="range"].blue-slider {
   input {
     height: 100%;
   }
+
   td {
     padding: 0;
   }
+
   label {
     display: block;
     margin: 0;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -638,3 +638,21 @@ input[type="range"].blue-slider {
     margin-bottom: 0;
   }
 }
+
+.scene-table {
+  table,
+  tr,
+  td,
+  label,
+  input {
+    height: 100%;
+  }
+  td {
+    padding: 0;
+  }
+  label {
+    display: block;
+    margin: 0;
+    padding: 0.5rem;
+  }
+}


### PR DESCRIPTION
The current checkbox inputs on the scenes page listview are hard to click, so I wrapped them in a label that fills the table cell. Clicking any part of the table cell will now check the input.

The blue outlines show the clickable area that will check the inputs:

Before
![image](https://user-images.githubusercontent.com/38586902/193654856-2eb0d5fd-aa9a-46a1-b2a3-ac9e60950aaa.png)

After
![image](https://user-images.githubusercontent.com/38586902/193655023-cde4a814-965b-43cf-aaf3-8c522bf77d1e.png)
