### PR TITLE
Address issue loading all subtitles

### DIFF
--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -367,7 +367,7 @@ func (rs sceneRoutes) Caption(w http.ResponseWriter, r *http.Request, lang strin
 
 	for _, caption := range captions {
 		if lang != caption.LanguageCode || ext != caption.CaptionType {
-			return
+			continue
 		}
 
 		sub, err := video.ReadSubs(caption.Path(s.Path))


### PR DESCRIPTION
This pull request fixes the issue preventing all subtitles from getting loaded. For whatever reason, when I was debugging yesterday, my breakpoint in `(sceneRoutes).CaptionLang()` was only getting hit once. Today when debugging, I was actually getting into CaptionLang for each language which led me to discover that during the refactor a return statement was mistakingly used within the for loop in `(sceneRoutes).Caption()` preventing us from reading subtitles past the first index.