### PR TITLE
Fix dataloaders not loading in js plugins

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -122,7 +122,9 @@ func Start() error {
 
 	// register GQL handler with plugin cache
 	// chain the visited plugin handler
-	manager.GetInstance().PluginCache.RegisterGQLHandler(visitedPluginHandler(http.HandlerFunc(gqlHandlerFunc)))
+	// also requires the dataloader middleware
+	gqlHandler := visitedPluginHandler(dataloaders.Middleware(http.HandlerFunc(gqlHandlerFunc)))
+	manager.GetInstance().PluginCache.RegisterGQLHandler(gqlHandler)
 
 	r.HandleFunc("/graphql", gqlHandlerFunc)
 	r.HandleFunc("/playground", gqlPlayground.Handler("GraphQL playground", "/graphql"))

--- a/pkg/plugin/js/gql.go
+++ b/pkg/plugin/js/gql.go
@@ -89,10 +89,11 @@ func gqlRequestFunc(ctx context.Context, vm *otto.Otto, cookie *http.Cookie, gql
 			throw(vm, fmt.Sprintf("could not unmarshal object %s: %s", output, err.Error()))
 		}
 
-		retErr, hasErr := obj["error"]
+		retErr, hasErr := obj["errors"]
 
 		if hasErr {
-			throw(vm, fmt.Sprintf("graphql error: %v", retErr))
+			errOut, _ := json.Marshal(retErr)
+			throw(vm, fmt.Sprintf("graphql error: %s", string(errOut)))
 		}
 
 		v, err := vm.ToValue(obj["data"])


### PR DESCRIPTION
Fixes #3013 

- fixes the GQL handler to include the dataloader middleware
- fixes the javascript plugin GQL request function to correctly handle graphql errors