### PR TITLE
Handle null video durations in migration

### DIFF
--- a/pkg/file/video/scan.go
+++ b/pkg/file/video/scan.go
@@ -75,5 +75,6 @@ func (d *Decorator) IsMissingMetadata(ctx context.Context, fs file.FS, f file.Fi
 	return vf.VideoCodec == unsetString || vf.AudioCodec == unsetString ||
 		vf.Format == unsetString || vf.Width == unsetNumber ||
 		vf.Height == unsetNumber || vf.FrameRate == unsetNumber ||
+		vf.Duration == unsetNumber ||
 		vf.BitRate == unsetNumber || interactive != vf.Interactive
 }

--- a/pkg/sqlite/migrations/32_files.up.sql
+++ b/pkg/sqlite/migrations/32_files.up.sql
@@ -458,7 +458,7 @@ INSERT INTO `video_files`
   )
   SELECT
     `files`.`id`,
-    `scenes`.`duration`,
+    COALESCE(`scenes`.`duration`, -1),
     -- special values for unset to be updated during scan
     COALESCE(`scenes`.`video_codec`, 'unset'),
     COALESCE(`scenes`.`format`, 'unset'),


### PR DESCRIPTION
Handles scenes with `NULL` duration values during the migration.