### PR TITLE
Fix export zip paths when exporting from Windows

### DIFF
--- a/internal/manager/import.go
+++ b/internal/manager/import.go
@@ -79,7 +79,7 @@ func performImport(ctx context.Context, i importer, duplicateBehaviour ImportDup
 		if duplicateBehaviour == ImportDuplicateEnumFail {
 			return fmt.Errorf("existing object with name '%s'", name)
 		} else if duplicateBehaviour == ImportDuplicateEnumIgnore {
-			logger.Info("Skipping existing object")
+			logger.Infof("Skipping existing object %q", name)
 			return nil
 		}
 

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -261,7 +261,10 @@ func (t *ExportTask) zipWalkFunc(outDir string, z *zip.Writer) filepath.WalkFunc
 func (t *ExportTask) zipFile(fn, outDir string, z *zip.Writer) error {
 	bn := filepath.Base(fn)
 
-	f, err := z.Create(filepath.Join(outDir, bn))
+	p := filepath.Join(outDir, bn)
+	p = filepath.ToSlash(p)
+
+	f, err := z.Create(p)
 	if err != nil {
 		return fmt.Errorf("error creating zip entry for %s: %s", fn, err.Error())
 	}

--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -581,7 +581,7 @@ func (t *ImportTask) ImportTag(ctx context.Context, tagJSON *jsonschema.Tag, pen
 		if err := t.ImportTag(ctx, childTagJSON, pendingParent, fail, readerWriter); err != nil {
 			var parentError tag.ParentTagNotExistError
 			if errors.As(err, &parentError) {
-				pendingParent[parentError.MissingParent()] = append(pendingParent[parentError.MissingParent()], tagJSON)
+				pendingParent[parentError.MissingParent()] = append(pendingParent[parentError.MissingParent()], childTagJSON)
 				continue
 			}
 


### PR DESCRIPTION
Fixes issue where it wasn't possible to import an exported zip that was exported in Windows.

Also fixes recursive loop that could occur when importing a tag hierarchy.