### PR TITLE
add `pre-ui` to default make target and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export CGO_ENABLED = 1
 
 .PHONY: release pre-build
 
-release: generate ui build-release
+release: pre-ui generate ui build-release
 
 pre-build:
 ifndef BUILD_DATE

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -43,9 +43,10 @@ NOTE: The `make` command in Windows will be `mingw32-make` with MingW. For examp
 
 ## Building a release
 
-1. Run `make generate` to create generated files
-2. Run `make ui` to compile the frontend
-3. Run `make build` to build the executable for your current platform
+1. Run `make pre-ui` to install UI dependencies
+2. Run `make generate` to create generated files
+3. Run `make ui` to compile the frontend
+4. Run `make build` to build the executable for your current platform
 
 ## Cross compiling
 


### PR DESCRIPTION
Without `pre-ui`, `make` fails. `pre-ui` is already used in the GitHub workflows but omitted from the Makefile and docs.

This is also directly related to the ancient issue #1901. But was that issue ever resolved? Or is this a regression?
I don't care enough to do an archaeological excavation through `git log`. The build process needs to be simplified more.