### PR TITLE
Fix zip gallery renaming

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -218,20 +218,10 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f FS, zipFile *scanFile) fs
 			return nil
 		}
 
-		var zipFileID *ID
-		if zipFile != nil {
-			zipFileID, err = s.getZipFileID(ctx, zipFile)
-			if err != nil {
-				return err
-			}
-		}
-
 		ff := scanFile{
 			BaseFile: &BaseFile{
 				DirEntry: DirEntry{
-					ModTime:   modTime(info),
-					ZipFileID: zipFileID,
-					ZipFile:   zipFile,
+					ModTime: modTime(info),
 				},
 				Path:     path,
 				Basename: filepath.Base(path),
@@ -239,6 +229,15 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f FS, zipFile *scanFile) fs
 			},
 			fs:   f,
 			info: info,
+		}
+
+		if zipFile != nil {
+			zipFileID, err := s.getZipFileID(ctx, zipFile)
+			if err != nil {
+				return err
+			}
+			ff.ZipFileID = zipFileID
+			ff.ZipFile = zipFile
 		}
 
 		if info.IsDir() {

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -129,9 +129,8 @@ func (s *Scanner) Scan(ctx context.Context, handlers []Handler, options ScanOpti
 
 type scanFile struct {
 	*BaseFile
-	fs      FS
-	info    fs.FileInfo
-	zipFile *scanFile
+	fs   FS
+	info fs.FileInfo
 }
 
 func (s *scanJob) withTxn(ctx context.Context, fn func(ctx context.Context) error) error {
@@ -219,10 +218,20 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f FS, zipFile *scanFile) fs
 			return nil
 		}
 
+		var zipFileID *ID
+		if zipFile != nil {
+			zipFileID, err = s.getZipFileID(ctx, zipFile)
+			if err != nil {
+				return err
+			}
+		}
+
 		ff := scanFile{
 			BaseFile: &BaseFile{
 				DirEntry: DirEntry{
-					ModTime: modTime(info),
+					ModTime:   modTime(info),
+					ZipFileID: zipFileID,
+					ZipFile:   zipFile,
 				},
 				Path:     path,
 				Basename: filepath.Base(path),
@@ -230,9 +239,6 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f FS, zipFile *scanFile) fs
 			},
 			fs:   f,
 			info: info,
-			// there is no guarantee that the zip file has been scanned
-			// so we can't just plug in the id.
-			zipFile: zipFile,
 		}
 
 		if info.IsDir() {
@@ -348,7 +354,7 @@ func (s *scanJob) processQueue(ctx context.Context) error {
 func (s *scanJob) incrementProgress(f scanFile) {
 	// don't increment for files inside zip files since these aren't
 	// counted during the initial walking
-	if s.ProgressReports != nil && f.zipFile == nil {
+	if s.ProgressReports != nil && f.ZipFile == nil {
 		s.ProgressReports.Increment()
 	}
 }
@@ -453,21 +459,10 @@ func (s *scanJob) onNewFolder(ctx context.Context, file scanFile) (*Folder, erro
 	now := time.Now()
 
 	toCreate := &Folder{
-		DirEntry: DirEntry{
-			ModTime: file.ModTime,
-		},
+		DirEntry:  file.DirEntry,
 		Path:      file.Path,
 		CreatedAt: now,
 		UpdatedAt: now,
-	}
-
-	zipFileID, err := s.getZipFileID(ctx, file.zipFile)
-	if err != nil {
-		return nil, err
-	}
-
-	if zipFileID != nil {
-		toCreate.ZipFileID = zipFileID
 	}
 
 	dir := filepath.Dir(file.Path)
@@ -600,15 +595,6 @@ func (s *scanJob) onNewFile(ctx context.Context, f scanFile) (File, error) {
 	}
 
 	baseFile.ParentFolderID = *parentFolderID
-
-	zipFileID, err := s.getZipFileID(ctx, f.zipFile)
-	if err != nil {
-		return nil, err
-	}
-
-	if zipFileID != nil {
-		baseFile.ZipFileID = zipFileID
-	}
 
 	const useExisting = false
 	fp, err := s.calculateFingerprints(f.fs, baseFile, path, useExisting)
@@ -744,7 +730,8 @@ func (s *scanJob) handleRename(ctx context.Context, f File, fp []Fingerprint) (F
 		// TODO - handle #1426 scenario
 		fs, err := s.getFileFS(other.Base())
 		if err != nil {
-			return nil, fmt.Errorf("getting FS for %q: %w", other.Base().Path, err)
+			missing = append(missing, other)
+			continue
 		}
 
 		if _, err := fs.Lstat(other.Base().Path); err != nil {


### PR DESCRIPTION
This is a fix for #3034, whose root cause is stash incorrectly creating a folder-based gallery when rescanning renamed zip galleries. This happens because `BaseFile.ZipFile` is not set on a scanned file, which later causes `getOrCreateGallery` to create a folder-based gallery instead of finding the existing zip gallery.
This just sets `BaseFile.ZipFile` and `BaseFile.ZipFileID` to stop these duplicate galleries being created.

This also fixes a bug I found while testing where a 'getting FS' error is given when you add a new gallery which contains images which are also in another zip gallery which no longer exists on disk but is still in the database. `handleRename` now just treats any error from `getFileFS` as if the file doesn't exist, making zip files consistent with normal files - an inaccessible file due to something like permissions is treated as not existing.

Fixes #3034