### PR TITLE
Use basename as title if empty when scraping by fragment

### DIFF
--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -128,7 +129,7 @@ func (g Gallery) GetTitle() string {
 		return g.Title
 	}
 
-	return g.Path
+	return filepath.Base(g.Path)
 }
 
 // DisplayName returns a display name for the scene for logging purposes.

--- a/pkg/scraper/stash.go
+++ b/pkg/scraper/stash.go
@@ -319,9 +319,12 @@ func sceneToUpdateInput(scene *models.Scene) models.SceneUpdateInput {
 		return nil
 	}
 
+	// fallback to file basename if title is empty
+	title := scene.GetTitle()
+
 	return models.SceneUpdateInput{
 		ID:      strconv.Itoa(scene.ID),
-		Title:   &scene.Title,
+		Title:   &title,
 		Details: &scene.Details,
 		URL:     &scene.URL,
 		Date:    dateToStringPtr(scene.Date),
@@ -338,9 +341,12 @@ func galleryToUpdateInput(gallery *models.Gallery) models.GalleryUpdateInput {
 		return nil
 	}
 
+	// fallback to file basename if title is empty
+	title := gallery.GetTitle()
+
 	return models.GalleryUpdateInput{
 		ID:      strconv.Itoa(gallery.ID),
-		Title:   &gallery.Title,
+		Title:   &title,
 		Details: &gallery.Details,
 		URL:     &gallery.URL,
 		Date:    dateToStringPtr(gallery.Date),

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -476,7 +476,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
           setScraper(undefined);
           onSceneSelected(s);
         }}
-        name={formik.values.title || ""}
+        name={formik.values.title || objectTitle(scene) || ""}
       />
     );
   };


### PR DESCRIPTION
Attempts to maintain existing functionality for fragment scrapers by setting the title to the basename of the primary file when the title is empty. Title is no longer populated automatically during scan, so this was causing some issues with some scrapers.

Also populates the query field to the scene's primary file basename if title is empty in the scene query dialog.