### PR TITLE
Fix path filters

### DIFF
--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -786,7 +786,8 @@ func (qb *FileStore) Query(ctx context.Context, options models.FileQueryOptions)
 	distinctIDs(&query, fileTable)
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		searchColumns := []string{"folders.path", "files.basename"}
+		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
+		searchColumns := []string{filepathColumn}
 		query.parseQueryString(searchColumns, *q)
 	}
 

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -454,17 +454,19 @@ func pathCriterionHandler(c *models.StringCriterionInput, pathColumn string, bas
 						f.setError(err)
 						return
 					}
-					f.addWhere(fmt.Sprintf("%s IS NOT NULL AND %s IS NOT NULL AND %[1]s || '%[3]s' || %[2]s regexp ?", pathColumn, basenameColumn, string(filepath.Separator)), c.Value)
+					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
+					f.addWhere(fmt.Sprintf("%s IS NOT NULL AND %s IS NOT NULL AND %s regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
 				case models.CriterionModifierNotMatchesRegex:
 					if _, err := regexp.Compile(c.Value); err != nil {
 						f.setError(err)
 						return
 					}
-					f.addWhere(fmt.Sprintf("%s IS NULL OR %s IS NULL OR %[1]s || '%[3]s' || %[2]s NOT regexp ?", pathColumn, basenameColumn, string(filepath.Separator)), c.Value)
+					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
+					f.addWhere(fmt.Sprintf("%s IS NULL OR %s IS NULL OR %s NOT regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
 				case models.CriterionModifierIsNull:
-					f.addWhere(fmt.Sprintf("(%s IS NULL OR TRIM(%[1]s) = '' OR %s IS NULL OR TRIM(%[2]s) = '')", pathColumn, basenameColumn))
+					f.addWhere(fmt.Sprintf("%s IS NULL OR TRIM(%[1]s) = '' OR %s IS NULL OR TRIM(%[2]s) = ''", pathColumn, basenameColumn))
 				case models.CriterionModifierNotNull:
-					f.addWhere(fmt.Sprintf("(%s IS NOT NULL AND TRIM(%[1]s) != '' AND %s IS NOT NULL AND TRIM(%[2]s) != '')", pathColumn, basenameColumn))
+					f.addWhere(fmt.Sprintf("%s IS NOT NULL AND TRIM(%[1]s) != '' AND %s IS NOT NULL AND TRIM(%[2]s) != ''", pathColumn, basenameColumn))
 				default:
 					panic("unsupported string filter modifier")
 				}

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -719,7 +719,8 @@ func (qb *GalleryStore) makeQuery(ctx context.Context, galleryFilter *models.Gal
 		)
 
 		// add joins for files and checksum
-		searchColumns := []string{"galleries.title", "gallery_folder.path", "folders.path", "files.basename", "files_fingerprints.fingerprint"}
+		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
+		searchColumns := []string{"galleries.title", "gallery_folder.path", filepathColumn, "files_fingerprints.fingerprint"}
 		query.parseQueryString(searchColumns, *q)
 	}
 
@@ -785,12 +786,12 @@ func (qb *GalleryStore) galleryPathCriterionHandler(c *models.StringCriterionInp
 			if modifier := c.Modifier; c.Modifier.IsValid() {
 				switch modifier {
 				case models.CriterionModifierIncludes:
-					clause := getPathSearchClause(pathColumn, basenameColumn, c.Value, addWildcards, not)
+					clause := getPathSearchClauseMany(pathColumn, basenameColumn, c.Value, addWildcards, not)
 					clause2 := getStringSearchClause([]string{folderPathColumn}, c.Value, false)
 					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
 				case models.CriterionModifierExcludes:
 					not = true
-					clause := getPathSearchClause(pathColumn, basenameColumn, c.Value, addWildcards, not)
+					clause := getPathSearchClauseMany(pathColumn, basenameColumn, c.Value, addWildcards, not)
 					clause2 := getStringSearchClause([]string{folderPathColumn}, c.Value, true)
 					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
 				case models.CriterionModifierEquals:
@@ -809,22 +810,24 @@ func (qb *GalleryStore) galleryPathCriterionHandler(c *models.StringCriterionInp
 						f.setError(err)
 						return
 					}
-					clause := makeClause(fmt.Sprintf("(%s IS NOT NULL AND %[1]s regexp ?) OR (%s IS NOT NULL AND %[2]s regexp ?)", pathColumn, basenameColumn), c.Value, c.Value)
-					clause2 := makeClause(fmt.Sprintf("(%s IS NOT NULL AND %[1]s regexp ?)", folderPathColumn), c.Value)
+					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
+					clause := makeClause(fmt.Sprintf("%s IS NOT NULL AND %s IS NOT NULL AND %s regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
+					clause2 := makeClause(fmt.Sprintf("%s IS NOT NULL AND %[1]s regexp ?", folderPathColumn), c.Value)
 					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
 				case models.CriterionModifierNotMatchesRegex:
 					if _, err := regexp.Compile(c.Value); err != nil {
 						f.setError(err)
 						return
 					}
-					f.addWhere(fmt.Sprintf("(%s IS NULL OR %[1]s NOT regexp ?) AND (%s IS NULL OR %[2]s NOT regexp ?)", pathColumn, basenameColumn), c.Value, c.Value)
-					f.addWhere(fmt.Sprintf("(%s IS NULL OR %[1]s NOT regexp ?)", folderPathColumn), c.Value)
+					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
+					f.addWhere(fmt.Sprintf("%s IS NULL OR %s IS NULL OR %s NOT regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
+					f.addWhere(fmt.Sprintf("%s IS NULL OR %[1]s NOT regexp ?", folderPathColumn), c.Value)
 				case models.CriterionModifierIsNull:
-					f.whereClauses = append(f.whereClauses, makeClause(fmt.Sprintf("(%s IS NULL OR TRIM(%[1]s) = '' OR %s IS NULL OR TRIM(%[2]s) = '')", pathColumn, basenameColumn)))
-					f.whereClauses = append(f.whereClauses, makeClause(fmt.Sprintf("(%s IS NULL OR TRIM(%[1]s) = '')", folderPathColumn)))
+					f.addWhere(fmt.Sprintf("%s IS NULL OR TRIM(%[1]s) = '' OR %s IS NULL OR TRIM(%[2]s) = ''", pathColumn, basenameColumn))
+					f.addWhere(fmt.Sprintf("%s IS NULL OR TRIM(%[1]s) = ''", folderPathColumn))
 				case models.CriterionModifierNotNull:
-					clause := makeClause(fmt.Sprintf("(%s IS NOT NULL AND TRIM(%[1]s) != '' AND %s IS NOT NULL AND TRIM(%[2]s) != '')", pathColumn, basenameColumn))
-					clause2 := makeClause(fmt.Sprintf("(%s IS NOT NULL AND TRIM(%[1]s) != '')", folderPathColumn))
+					clause := makeClause(fmt.Sprintf("%s IS NOT NULL AND TRIM(%[1]s) != '' AND %s IS NOT NULL AND TRIM(%[2]s) != ''", pathColumn, basenameColumn))
+					clause2 := makeClause(fmt.Sprintf("%s IS NOT NULL AND TRIM(%[1]s) != ''", folderPathColumn))
 					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
 				default:
 					panic("unsupported string filter modifier")

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -700,7 +700,8 @@ func (qb *ImageStore) makeQuery(ctx context.Context, imageFilter *models.ImageFi
 			},
 		)
 
-		searchColumns := []string{"images.title", "folders.path", "files.basename", "files_fingerprints.fingerprint"}
+		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
+		searchColumns := []string{"images.title", filepathColumn, "files_fingerprints.fingerprint"}
 		query.parseQueryString(searchColumns, *q)
 	}
 

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -933,7 +933,8 @@ func (qb *SceneStore) Query(ctx context.Context, options models.SceneQueryOption
 			},
 		)
 
-		searchColumns := []string{"scenes.title", "scenes.details", "folders.path", "files.basename", "files_fingerprints.fingerprint", "scene_markers.title"}
+		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
+		searchColumns := []string{"scenes.title", "scenes.details", filepathColumn, "files_fingerprints.fingerprint", "scene_markers.title"}
 		query.parseQueryString(searchColumns, *q)
 	}
 

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2098,42 +2098,6 @@ func TestSceneQueryPath(t *testing.T) {
 			[]int{otherSceneIdx},
 		},
 		{
-			"equals folder name",
-			models.StringCriterionInput{
-				Value:    folder,
-				Modifier: models.CriterionModifierEquals,
-			},
-			[]int{sceneIdx},
-			nil,
-		},
-		{
-			"equals folder name trailing slash",
-			models.StringCriterionInput{
-				Value:    folder + string(filepath.Separator),
-				Modifier: models.CriterionModifierEquals,
-			},
-			[]int{sceneIdx},
-			nil,
-		},
-		{
-			"equals base name",
-			models.StringCriterionInput{
-				Value:    basename,
-				Modifier: models.CriterionModifierEquals,
-			},
-			[]int{sceneIdx},
-			nil,
-		},
-		{
-			"equals base name leading slash",
-			models.StringCriterionInput{
-				Value:    string(filepath.Separator) + basename,
-				Modifier: models.CriterionModifierEquals,
-			},
-			[]int{sceneIdx},
-			nil,
-		},
-		{
 			"equals full path wildcard",
 			models.StringCriterionInput{
 				Value:    filepath.Join(folder, "scene_0001_%"),
@@ -2149,24 +2113,6 @@ func TestSceneQueryPath(t *testing.T) {
 				Modifier: models.CriterionModifierNotEquals,
 			},
 			[]int{otherSceneIdx},
-			[]int{sceneIdx},
-		},
-		{
-			"not equals folder name",
-			models.StringCriterionInput{
-				Value:    folder,
-				Modifier: models.CriterionModifierNotEquals,
-			},
-			nil,
-			[]int{sceneIdx},
-		},
-		{
-			"not equals basename",
-			models.StringCriterionInput{
-				Value:    basename,
-				Modifier: models.CriterionModifierNotEquals,
-			},
-			nil,
 			[]int{sceneIdx},
 		},
 		{

--- a/ui/v2.5/src/docs/en/Changelog/v0180.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0180.md
@@ -1,2 +1,5 @@
 ### ✨ New Features
 * Added tag description filter criterion. ([#3011](https://github.com/stashapp/stash/pull/3011))
+
+### 🐛 Bug fixes
+* Fix path filter behaviour to be consistent with previous behaviour. ([#3041](https://github.com/stashapp/stash/pull/3041))


### PR DESCRIPTION
Before files-refactor, the path filter simply treated a file's full path as a single string field. The path filter is now in most scenarios (mostly when `getPathSearchClause` is not used) taking the folder path and file basename separately, which is unintuitive and different to before.
This changes the behaviour back, by concatenating the folder path and file basename in SQL for both the path regex filters and the path component of the generic search query filter. It also changes `galleryPathCriterionHandler` to use `getPathSearchClauseMany` for consistency with `pathCriterionHandler`.

48543d7 also replaces `getPathSearchClause` to concatenate the folder path and file basename as well. This change breaks tests so I've separated it out. I would argue that the old behaviour of having a path 'is' filter matching the entire path only is more intuitive, but the way it is right now with differing behaviour depending on slashes, etc. might be more useful so I will defer judgement.

Fixes #3037