### PR TITLE
Reimplement case-insensitivity move bug fix

### DIFF
--- a/pkg/file/fs.go
+++ b/pkg/file/fs.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"io/fs"
 	"os"
+
+	"github.com/stashapp/stash/pkg/fsutil"
 )
 
 // Opener provides an interface to open a file.
@@ -26,6 +28,7 @@ type FS interface {
 	Lstat(name string) (fs.FileInfo, error)
 	Open(name string) (fs.ReadDirFile, error)
 	OpenZip(name string) (*ZipFS, error)
+	IsPathCaseSensitive(path string) (bool, error)
 }
 
 // OsFS is a file system backed by the OS.
@@ -50,4 +53,8 @@ func (f *OsFS) OpenZip(name string) (*ZipFS, error) {
 	}
 
 	return newZipFS(f, name, info)
+}
+
+func (f *OsFS) IsPathCaseSensitive(path string) (bool, error) {
+	return fsutil.IsFsPathCaseSensitive(path)
 }

--- a/pkg/file/zip.go
+++ b/pkg/file/zip.go
@@ -83,6 +83,10 @@ func (f *ZipFS) OpenZip(name string) (*ZipFS, error) {
 	return nil, errZipFSOpenZip
 }
 
+func (f *ZipFS) IsPathCaseSensitive(path string) (bool, error) {
+	return true, nil
+}
+
 type zipReadDirFile struct {
 	fs.File
 }


### PR DESCRIPTION
Reimplement #1426 fix.

Changes `sqlite.FileStore.FindByPath` to use `=` instead of `like` if there are no wildcards, since `like` uses case-insensitive matching.
