### PR TITLE
Minor UI fix for StashId display in FileInfoPanel

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -158,7 +158,7 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
       <>
         <dt>StashIDs</dt>
         <dd>
-          <ul>
+          <dl>
             {props.scene.stash_ids.map((stashID) => {
               const base = getStashboxBase(stashID.endpoint);
               const link = base ? (
@@ -173,12 +173,12 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
                 stashID.stash_id
               );
               return (
-                <li key={stashID.stash_id} className="row no-gutters">
+                <dd key={stashID.stash_id} className="row no-gutters">
                   {link}
-                </li>
+                </dd>
               );
             })}
-          </ul>
+          </dl>
         </dd>
       </>
     );


### PR DESCRIPTION
Replace `<ul>` and `<li>` with `<dl>` and `<dd>` tags in SceneFileInfoPanel.tsx

Fixes #3049 