### PR TITLE
Limiting how many options are shown in select dropdowns

### DIFF
--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -6,6 +6,8 @@ import Select, {
   components as reactSelectComponents,
   GroupedOptionsType,
   OptionsType,
+  MenuListComponentProps,
+  GroupTypeBase,
 } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import debounce from "lodash-es/debounce";
@@ -116,6 +118,55 @@ const getSelectedItems = (selectedItems: ValueType<Option, boolean>) =>
 const getSelectedValues = (selectedItems: ValueType<Option, boolean>) =>
   getSelectedItems(selectedItems).map((item) => item.value);
 
+const LimitedSelectMenu = <T extends boolean>(
+  props: MenuListComponentProps<Option, T, GroupTypeBase<Option>>
+) => {
+  const maxOptionsShown = 200;
+  const [hiddenCount, setHiddenCount] = useState<number>(0);
+  const hiddenCountStyle = {
+    padding: "8px 12px",
+    opacity: "50%",
+  };
+  const menuChildren = useMemo(() => {
+    if (Array.isArray(props.children)) {
+      // limit the number of select options showing in the select dropdowns
+      // always showing the 'Create "..."' option when it exists
+      let creationOptionIndex = (props.children as React.ReactNodeArray).findIndex(
+        (child: React.ReactNode) => {
+          let maybeCreatableOption = child as React.ReactElement<
+            OptionProps<
+              Option & { __isNew__: boolean },
+              T,
+              GroupTypeBase<Option & { __isNew__: boolean }>
+            >,
+            ""
+          >;
+          return maybeCreatableOption?.props?.data?.__isNew__;
+        }
+      );
+      if (creationOptionIndex >= maxOptionsShown) {
+        setHiddenCount(props.children.length - maxOptionsShown - 1);
+        return props.children
+          .slice(0, maxOptionsShown - 1)
+          .concat([props.children[creationOptionIndex]]);
+      } else {
+        setHiddenCount(Math.max(props.children.length - maxOptionsShown, 0));
+        return props.children.slice(0, maxOptionsShown);
+      }
+    }
+    setHiddenCount(0);
+    return props.children;
+  }, [props.children]);
+  return (
+    <reactSelectComponents.MenuList {...props}>
+      {menuChildren}
+      {hiddenCount > 0 && (
+        <div style={hiddenCountStyle}>{hiddenCount} Options Hidden</div>
+      )}
+    </reactSelectComponents.MenuList>
+  );
+};
+
 const SelectComponent = <T extends boolean>({
   type,
   initialIds,
@@ -191,6 +242,7 @@ const SelectComponent = <T extends boolean>({
     menuPortalTarget,
     components: {
       ...components,
+      MenuList: LimitedSelectMenu,
       IndicatorSeparator: () => null,
       ...((!showDropdown || isDisabled) && { DropdownIndicator: () => null }),
       ...(isDisabled && { MultiValueRemove: () => null }),


### PR DESCRIPTION
### General
Introducing a limit to how many options are shown in select dropdowns. Fixes an issue I am experiencing where large numbers of options (>1000 tags) are causing the select dropdown to be unresponsive. Does not effect filtering, always shows 'Create "..."' option if it exists, and shows a notice at the bottom of the dropdown of how many options were hidden from the list if any were.

If the number of items in the list is less than the limit, these changes should have no effect. I used 200 items as the limit, because in my testing 200 items produced no lag on my personal devices.
### Changes
Added a new MenuList object to be used in the SelectComponent, which limits the number of options shown in the dropdown, currently to 200 items.
If the Select is creatable and has an inserted option for 'Create "..."', it will be picked up by the new MenuList and included in the shown options.
If there are any hidden options, a notice will appear at the bottom of the dropdown after the options showing how many were hidden. This notice is not selectable.
### Screenshots
An example of the tags dropdown in the scene edit tab
![image](https://user-images.githubusercontent.com/95883543/199082860-c66c9095-5bbd-418e-bd5f-141e4b6068e0.png)

