### PR TITLE
Add new fields to scene tagger

### DIFF
--- a/internal/identify/identify.go
+++ b/internal/identify/identify.go
@@ -280,6 +280,16 @@ func getScenePartial(scene *models.Scene, scraped *scraper.ScrapedScene, fieldOp
 			partial.URL = models.NewOptionalString(*scraped.URL)
 		}
 	}
+	if scraped.Director != nil && (scene.Director != *scraped.Director) {
+		if shouldSetSingleValueField(fieldOptions["director"], scene.Director != "") {
+			partial.Director = models.NewOptionalString(*scraped.Director)
+		}
+	}
+	if scraped.Code != nil && (scene.Code != *scraped.Code) {
+		if shouldSetSingleValueField(fieldOptions["code"], scene.Code != "") {
+			partial.Code = models.NewOptionalString(*scraped.Code)
+		}
+	}
 
 	if setOrganized && !scene.Organized {
 		// just reuse the boolean since we know it's true

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/FieldOptions.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/FieldOptions.tsx
@@ -3,7 +3,12 @@ import { Form, Button, Table } from "react-bootstrap";
 import { Icon } from "src/components/Shared";
 import * as GQL from "src/core/generated-graphql";
 import { FormattedMessage, useIntl } from "react-intl";
-import { multiValueSceneFields, SceneField, sceneFields } from "./constants";
+import {
+  multiValueSceneFields,
+  SceneField,
+  sceneFieldMessageID,
+  sceneFields,
+} from "./constants";
 import { ThreeStateBoolean } from "./ThreeStateBoolean";
 import {
   faCheck,
@@ -13,7 +18,7 @@ import {
 
 interface IFieldOptionsEditor {
   options: GQL.IdentifyFieldOptions | undefined;
-  field: string;
+  field: SceneField;
   editField: () => void;
   editOptions: (o?: GQL.IdentifyFieldOptions | null) => void;
   editing: boolean;
@@ -64,7 +69,7 @@ const FieldOptionsEditor: React.FC<IFieldOptionsEditor> = ({
   }, [resetOptions]);
 
   function renderField() {
-    return intl.formatMessage({ id: field });
+    return intl.formatMessage({ id: sceneFieldMessageID(field) });
   }
 
   function renderStrategy() {

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/constants.ts
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/constants.ts
@@ -13,6 +13,8 @@ export const sceneFields = [
   "date",
   "details",
   "url",
+  "code",
+  "director",
   "studio",
   "performers",
   "tags",
@@ -25,3 +27,11 @@ export const multiValueSceneFields: SceneField[] = [
   "performers",
   "tags",
 ];
+
+export function sceneFieldMessageID(field: SceneField) {
+  if (field === "code") {
+    return "scene_code";
+  }
+
+  return field;
+}

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -365,6 +365,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
       url: resolveField("url", stashScene.url, scene.url),
       tag_ids: tagIDs,
       stash_ids: stashScene.stash_ids ?? [],
+      code: resolveField("code", stashScene.code, scene.code),
+      director: resolveField("director", stashScene.director, scene.director),
     };
 
     const includeStashID = !excludedFieldList.includes("stash_ids");
@@ -427,6 +429,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     details: "details",
     studio: "studio",
     stash_ids: "stash_ids",
+    code: "code",
+    director: "director",
   };
 
   const maybeRenderCoverImage = () => {
@@ -510,6 +514,21 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     }
   };
 
+  const maybeRenderStudioCode = () => {
+    if (isActive && scene.code) {
+      return (
+        <h5>
+          <OptionalField
+            exclude={excludedFields[fields.code]}
+            setExclude={(v) => setExcludedField(fields.code, v)}
+          >
+            {scene.code}
+          </OptionalField>
+        </h5>
+      );
+    }
+  };
+
   const maybeRenderDateField = () => {
     if (isActive && scene.date) {
       return (
@@ -519,6 +538,21 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             setExclude={(v) => setExcludedField(fields.date, v)}
           >
             {scene.date}
+          </OptionalField>
+        </h5>
+      );
+    }
+  };
+
+  const maybeRenderDirector = () => {
+    if (scene.director) {
+      return (
+        <h5>
+          <OptionalField
+            exclude={excludedFields[fields.director]}
+            setExclude={(v) => setExcludedField(fields.director, v)}
+          >
+            <FormattedMessage id="director" />: {scene.director}
           </OptionalField>
         </h5>
       );
@@ -688,6 +722,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
               </>
             )}
 
+            {maybeRenderStudioCode()}
             {maybeRenderDateField()}
             {getDurationStatus(scene, stashSceneFile?.duration)}
             {getFingerprintStatus(scene, stashScene)}
@@ -696,6 +731,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         {isActive && (
           <div className="d-flex flex-column">
             {maybeRenderStashBoxID()}
+            {maybeRenderDirector()}
             {maybeRenderURL()}
             {maybeRenderDetails()}
           </div>

--- a/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
+++ b/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
@@ -800,6 +800,8 @@ Details
 ```
 Title
 Details
+Code
+Director
 URL
 Date
 Image


### PR DESCRIPTION
Adds director and studio code to the tagger scene card for selection.

Also updates the scraper documentation to include the new scene fields.

Fixes #3095