### PR TITLE
Make title optional for non-user created galleries

### DIFF
--- a/internal/api/resolver_mutation_gallery.go
+++ b/internal/api/resolver_mutation_gallery.go
@@ -177,8 +177,8 @@ func (r *mutationResolver) galleryUpdate(ctx context.Context, input models.Galle
 
 	if input.Title != nil {
 		// ensure title is not empty
-		if *input.Title == "" {
-			return nil, errors.New("title must not be empty")
+		if *input.Title == "" && originalGallery.IsUserCreated() {
+			return nil, errors.New("title must not be empty for user-created galleries")
 		}
 
 		updatedGallery.Title = models.NewOptionalString(*input.Title)

--- a/pkg/models/model_gallery.go
+++ b/pkg/models/model_gallery.go
@@ -37,6 +37,12 @@ type Gallery struct {
 	PerformerIDs RelatedIDs `json:"performer_ids"`
 }
 
+// IsUserCreated returns true if the gallery was created by the user.
+// This is determined by whether the gallery has a primary file or folder.
+func (g *Gallery) IsUserCreated() bool {
+	return g.PrimaryFileID == nil && g.FolderID == nil
+}
+
 func (g *Gallery) LoadFiles(ctx context.Context, l FileLoader) error {
 	return g.Files.load(func() ([]file.File, error) {
 		return l.GetFiles(ctx, g.ID)

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -79,8 +79,13 @@ export const GalleryEditPanel: React.FC<
   const [createGallery] = useGalleryCreate();
   const [updateGallery] = useGalleryUpdate();
 
+  const titleRequired =
+    isNew || (gallery?.files?.length === 0 && !gallery?.folder);
+
   const schema = yup.object({
-    title: yup.string().required(),
+    title: titleRequired
+      ? yup.string().required()
+      : yup.string().optional().nullable(),
     details: yup.string().optional().nullable(),
     url: yup.string().optional().nullable(),
     date: yup.string().optional().nullable(),

--- a/ui/v2.5/src/docs/en/Changelog/v0180.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0180.md
@@ -9,6 +9,7 @@
 * Changed Performer height to be numeric, and changed filtering accordingly. ([#3060](https://github.com/stashapp/stash/pull/3060))
 
 ### 🐛 Bug fixes
+* Fixed Gallery title being incorrectly marked as mandatory for file- and folder-based galleries. ([#3110](https://github.com/stashapp/stash/pull/3110))
 * Fixed Saved Filters not ordered by name. ([#3101](https://github.com/stashapp/stash/pull/3101))
 * Scene Player no longer always resumes playing when seeking. ([#3020](https://github.com/stashapp/stash/pull/3020))
 * Fixed space bar sometimes no playing/pausing the scene player. ([#3020](https://github.com/stashapp/stash/pull/3020))


### PR DESCRIPTION
Fixes issue where title was required when it could be derived from the path.