### PR TITLE
Fix duplicate log messages

### DIFF
--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -928,6 +928,12 @@ export const useLogs = () =>
     fetchPolicy: "no-cache",
   });
 
+export const queryLogs = () =>
+  client.query<GQL.LogsQuery>({
+    query: GQL.LogsDocument,
+    fetchPolicy: "no-cache",
+  });
+
 export const useJobQueue = () =>
   GQL.useJobQueueQuery({
     fetchPolicy: "no-cache",


### PR DESCRIPTION
When a scan is finished, duplicate log messages regarding that scan are created in the logging tab if it is open. The duplicates are only on the UI side and can be cleared by just navigating somewhere else and back, but this prevents them from appearing in the first place.

I've also increased the number of displayed log messages, as well as put a limit on the number of messages kept in memory, preventing infinite growth - something which can occur with the trace log messages of large scans.