### PR TITLE
Show error if savedFilterId not present

### DIFF
--- a/ui/v2.5/src/components/FrontPage/Control.tsx
+++ b/ui/v2.5/src/components/FrontPage/Control.tsx
@@ -164,6 +164,10 @@ interface IProps {
 export const Control: React.FC<IProps> = ({ content }) => {
   switch (content.__typename) {
     case "SavedFilter":
+      if (!(content as ISavedFilterRow).savedFilterId) {
+        return <div>Error: missing savedFilterId</div>;
+      }
+
       return (
         <SavedFilterResults
           savedFilterID={(content as ISavedFilterRow).savedFilterId.toString()}


### PR DESCRIPTION
Fixes crash if the UI front page configuration is corrupted.