### PR TITLE
Trim database path in migrate page

### DIFF
--- a/ui/v2.5/src/components/Setup/Migrate.tsx
+++ b/ui/v2.5/src/components/Setup/Migrate.tsx
@@ -16,6 +16,12 @@ export const Migrate: React.FC = () => {
 
   const intl = useIntl();
 
+  // if database path includes path separators, then this is passed through
+  // to the migration path. Extract the base name of the database file.
+  const databasePath = systemStatus
+    ? systemStatus?.systemStatus.databasePath?.split(/[\\/]/).pop()
+    : "";
+
   // make suffix based on current time
   const now = new Date()
     .toISOString()
@@ -24,7 +30,7 @@ export const Migrate: React.FC = () => {
     .replace(/:/g, "")
     .replace(/\..*/, "");
   const defaultBackupPath = systemStatus
-    ? `${systemStatus.systemStatus.databasePath}.${systemStatus.systemStatus.databaseSchema}.${now}`
+    ? `${databasePath}.${systemStatus.systemStatus.databaseSchema}.${now}`
     : "";
 
   const discordLink = (

--- a/ui/v2.5/src/docs/en/Changelog/v0180.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0180.md
@@ -16,6 +16,7 @@
 * Changed Performer height to be numeric, and changed filtering accordingly. ([#3060](https://github.com/stashapp/stash/pull/3060))
 
 ### 🐛 Bug fixes
+* Fixed database backup in incorrect directory during migration when database location is an absolute path. ([#3140](https://github.com/stashapp/stash/pull/3140))
 * Fixed gallery create post hook not being fired during gallery creation. ([#3134](https://github.com/stashapp/stash/pull/3134))
 * Fixed autotag error when tagging a large amount of objects. ([#3106](https://github.com/stashapp/stash/pull/3106))
 * Fixed Gallery title being incorrectly marked as mandatory for file- and folder-based galleries. ([#3110](https://github.com/stashapp/stash/pull/3110))


### PR DESCRIPTION
Fixes issue where if the database path in the config was set to an absolute path, then the default backup file would also be generated with an absolute path, resulting in the default filename not utilising the backups directory. Changes the generated backup file to be a basename only.