### PR TITLE
Remove performer age image filter criterion

### DIFF
--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -42,7 +42,6 @@ const criterionOptions = [
   PerformerTagsCriterionOption,
   PerformersCriterionOption,
   createMandatoryNumberCriterionOption("performer_count"),
-  createMandatoryNumberCriterionOption("performer_age"),
   PerformerFavoriteCriterionOption,
   StudiosCriterionOption,
   createMandatoryNumberCriterionOption("file_count"),


### PR DESCRIPTION
We don't have a `performer_age` field in `ImageFilterType`, and it can't be easily implemented because image does not currently have a date field. Removing the option from the UI.