### PR TITLE
Performer Active Years is submitted to Stashbox

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -1011,6 +1011,17 @@ func (c Client) SubmitPerformerDraft(ctx context.Context, performer *models.Perf
 	if performer.Aliases != "" {
 		draft.Aliases = &performer.Aliases
 	}
+	if performer.CareerLength != "" {
+		var career = strings.Split(performer.CareerLength, "-")
+		if i, err := strconv.Atoi(strings.TrimSpace(career[0])); err == nil {
+			draft.CareerStartYear = &i
+		}
+		if len(career) == 2 {
+			if y, err := strconv.Atoi(strings.TrimSpace(career[1])); err == nil {
+				draft.CareerEndYear = &y
+			}
+		}
+	}
 
 	var urls []string
 	if len(strings.TrimSpace(performer.Twitter)) > 0 {


### PR DESCRIPTION
When submitting a performer to Stashbox, this allows the Active Years to be submitted.

Only works if the CareerLength field is using the "standard" format set by `formatCareerLength` something like `2009 - 2020` (also works if only start year is set)


(submitting a PR to StashBox too, to allow the UI to receive that info)