### PR TITLE
Sort duplicate scenes by path

### DIFF
--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1627,11 +1627,11 @@ func sortByPath(scenes [][]*models.Scene) {
 		firstPathJ := getFirstSortedPath(scenes[j])
 		return firstPathI < firstPathJ
 	}
-	sort.Slice(scenes, lessFunc)
+	sort.SliceStable(scenes, lessFunc)
 }
 
 func getFirstSortedPath(scenes []*models.Scene) string {
-	paths := make([]string, len(scenes))
+	paths := make([]string, 0)
 	for _, scene := range scenes {
 		paths = append(paths, scene.Path)
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1623,19 +1623,19 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 
 func sortByPath(scenes [][]*models.Scene) {
 	lessFunc := func(i int, j int) bool {
-		firstPathI := getFirstSortedPath(scenes[i])
-		firstPathJ := getFirstSortedPath(scenes[j])
+		firstPathI := getFirstPath(scenes[i])
+		firstPathJ := getFirstPath(scenes[j])
 		return firstPathI < firstPathJ
 	}
 	sort.SliceStable(scenes, lessFunc)
 }
 
-func getFirstSortedPath(scenes []*models.Scene) string {
-	paths := make([]string, 0)
+func getFirstPath(scenes []*models.Scene) string {
+	var firstPath string
 	for _, scene := range scenes {
-		paths = append(paths, scene.Path)
+		if firstPath == "" || scene.Path < firstPath {
+			firstPath = scene.Path
+		}
 	}
-	sort.Strings(paths)
-	firstPath := paths[0]
 	return firstPath
 }

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1632,8 +1632,8 @@ func sortByPath(scenes [][]*models.Scene) {
 
 func getFirstPath(scenes []*models.Scene) string {
 	var firstPath string
-	for _, scene := range scenes {
-		if firstPath == "" || scene.Path < firstPath {
+	for i, scene := range scenes {
+		if i == 0 || scene.Path < firstPath {
 			firstPath = scene.Path
 		}
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -1615,5 +1616,26 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 		}
 	}
 
+	sortByPath(duplicates)
+
 	return duplicates, nil
+}
+
+func sortByPath(scenes [][]*models.Scene) {
+	lessFunc := func(i int, j int) bool {
+		firstPathI := getFirstSortedPath(scenes[i])
+		firstPathJ := getFirstSortedPath(scenes[j])
+		return firstPathI < firstPathJ
+	}
+	sort.Slice(scenes, lessFunc)
+}
+
+func getFirstSortedPath(scenes []*models.Scene) string {
+	paths := make([]string, len(scenes))
+	for _, scene := range scenes {
+		paths = append(paths, scene.Path)
+	}
+	sort.Strings(paths)
+	firstPath := paths[0]
+	return firstPath
 }


### PR DESCRIPTION
# Problem

I do have many duplicates I pretty much have to live with (CGI porn often comes in slightly different variants that are almost identical except for a few details, or even just the audio).

# Solution

In the absence of any more sophisticated solution (filter/exclusion rule, etc.) I have implemented a simple solution that sorts by path instead of the current sorting, which is a bit meaningless in this context (scene ID).