### PR TITLE
Handle bad funscript at values

### DIFF
--- a/internal/manager/task_generate_interactive_heatmap_speed.go
+++ b/internal/manager/task_generate_interactive_heatmap_speed.go
@@ -30,7 +30,7 @@ func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
 	funscriptPath := video.GetFunscriptPath(t.Scene.Path)
 	heatmapPath := instance.Paths.Scene.GetInteractiveHeatmapPath(videoChecksum)
 
-	generator := NewInteractiveHeatmapSpeedGenerator(funscriptPath, heatmapPath)
+	generator := NewInteractiveHeatmapSpeedGenerator(funscriptPath, heatmapPath, t.Scene.Files.Primary().Duration)
 
 	err := generator.Generate()
 

--- a/ui/v2.5/src/docs/en/Changelog/v0180.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0180.md
@@ -13,6 +13,7 @@
 * Added tag description filter criterion. ([#3011](https://github.com/stashapp/stash/pull/3011))
 
 ### 🎨 Improvements
+* Generated heatmaps now only show ranges within the duration of the scene. ([#3182](https://github.com/stashapp/stash/pull/3182))
 * Added File Modification Time to File Info panels. ([#3054](https://github.com/stashapp/stash/pull/3054))
 * Added counter to File Info tabs for objects with multiple files. ([#3054](https://github.com/stashapp/stash/pull/3054))
 * Added file count in Scene Duplicate Checker for scenes with multiple files. ([#3054](https://github.com/stashapp/stash/pull/3054))


### PR DESCRIPTION
Fixes #3181 

This PR throws out any `at` values that are outside the duration range of the scene primary file. This means that generated graphs will only show the ranges within the duration of the scene. 