### PR TITLE
Reorder new scene fields

### DIFF
--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/constants.ts
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/constants.ts
@@ -10,11 +10,11 @@ export interface IScraperSource {
 
 export const sceneFields = [
   "title",
+  "code",
   "date",
+  "director",
   "details",
   "url",
-  "code",
-  "director",
   "studio",
   "performers",
   "tags",

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -714,6 +714,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
           {maybeRenderCoverImage()}
           <div className="d-flex flex-column justify-content-center scene-metadata">
             {renderTitle()}
+            {maybeRenderStudioCode()}
 
             {!isActive && (
               <>
@@ -722,8 +723,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
               </>
             )}
 
-            {maybeRenderStudioCode()}
             {maybeRenderDateField()}
+            {maybeRenderDirector()}
             {getDurationStatus(scene, stashSceneFile?.duration)}
             {getFingerprintStatus(scene, stashScene)}
           </div>
@@ -731,7 +732,6 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         {isActive && (
           <div className="d-flex flex-column">
             {maybeRenderStashBoxID()}
-            {maybeRenderDirector()}
             {maybeRenderURL()}
             {maybeRenderDetails()}
           </div>

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -714,7 +714,6 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
           {maybeRenderCoverImage()}
           <div className="d-flex flex-column justify-content-center scene-metadata">
             {renderTitle()}
-            {maybeRenderStudioCode()}
 
             {!isActive && (
               <>
@@ -723,8 +722,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
               </>
             )}
 
+            {maybeRenderStudioCode()}
             {maybeRenderDateField()}
-            {maybeRenderDirector()}
             {getDurationStatus(scene, stashSceneFile?.duration)}
             {getFingerprintStatus(scene, stashScene)}
           </div>
@@ -732,6 +731,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
         {isActive && (
           <div className="d-flex flex-column">
             {maybeRenderStashBoxID()}
+            {maybeRenderDirector()}
             {maybeRenderURL()}
             {maybeRenderDetails()}
           </div>


### PR DESCRIPTION
The new Studio Code and Director field placement are inconsistent in the identify modal. Given the location of those fields on the scene edit form, my eye naturally looks for them around the same location in other places. The inconsistency in the order makes finding those fields less intuitive. This pull request attempts to add some consistency in the placement of those fields.

Here are images of the placement of these fields currently:
![Screenshot 2022-11-25 185402](https://user-images.githubusercontent.com/72030708/204066349-19ac48f9-3be3-4dc8-98bd-3dfa7a148ae2.png)
![Screenshot 2022-11-25 171218 - Copy](https://user-images.githubusercontent.com/72030708/204066366-a4e07000-e8f5-4aaa-a28f-fafe3ddbd39d.png)
