### PR TITLE
[Test] Add -hwaccel to ffmpeg args

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -148,7 +148,7 @@ type TranscodeStreamOptions struct {
 
 func (o TranscodeStreamOptions) getStreamArgs() Args {
 	var args Args
-	args = append(args, "-hide_banner")
+	args = append(args, "-hide_banner", "-hwaccel", "auto")
 	args = args.LogLevel(LogLevelError)
 
 	if o.StartTime != 0 {


### PR DESCRIPTION
This is a quick POC branch to test the `-hwaccel` ffmpeg flag in live transcodes. It's hardcoded for testing purposes.