### PR TITLE
Fix card clipping on recommendation row

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -302,7 +302,7 @@
 }
 
 .slick-slide .card {
-  height: 100%;
+  height: 98%;
 }
 
 .slick-slide .studio-card-image {


### PR DESCRIPTION
This pull request addresses the clipping of cards on the recommendation page. The clipping was not visibly apparent initially. Adding a border to the cards better exposes the issue.

Before:
![before](https://user-images.githubusercontent.com/72030708/204403375-abb991e4-08ca-4073-a672-038dd51c8505.png)

After:
![after](https://user-images.githubusercontent.com/72030708/204403395-5129b6d1-7082-44e3-b213-d03ab77ea047.png)
