### PR TITLE
Use the popover property consistently across cards

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -217,9 +217,9 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
           ) : (
             ""
           )}
-          {maybeRenderPopoverButtonGroup()}
         </>
       }
+      popovers={maybeRenderPopoverButtonGroup()}
       selected={selected}
       selecting={selecting}
       onSelectedChanged={onSelectedChanged}

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -155,9 +155,9 @@ export const StudioCard: React.FC<IProps> = ({
           {maybeRenderParent(studio, hideParent)}
           {maybeRenderChildren(studio)}
           <RatingBanner rating={studio.rating100} />
-          {maybeRenderPopoverButtonGroup()}
         </div>
       }
+      popovers={maybeRenderPopoverButtonGroup()}
       selected={selected}
       selecting={selecting}
       onSelectedChanged={onSelectedChanged}

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -196,9 +196,9 @@ export const TagCard: React.FC<IProps> = ({
           {maybeRenderDescription()}
           {maybeRenderParents()}
           {maybeRenderChildren()}
-          {maybeRenderPopoverButtonGroup()}
         </>
       }
+      popovers={maybeRenderPopoverButtonGroup()}
       selected={selected}
       selecting={selecting}
       onSelectedChanged={onSelectedChanged}


### PR DESCRIPTION
For some strange reason, performer, studio, and tag cards don't use the popovers property to handle the popovers, while the gallery, image, movie, and scene cards do. This pull request fixes this inconsistency. With this fix, it is now possible to add simple CSS to fix the hovering popover issue than can sometimes be seen in cards.

With this fix, the `margin-top: auto` style on the `hr` element can now consistently position the popover at the bottom of the card. Lucie Novac's card shows the issue without this fix. Salee Lee's card was edited in the image below to simulate this fix.

![Screenshot 2022-11-28 190946](https://user-images.githubusercontent.com/72030708/204414362-b9645377-e17e-43df-bd83-ee86ff27bb54.png)