### PR TITLE
Fix image exclusion pattern applying to all files

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -296,7 +296,7 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	if isVideoFile && (s.ExcludeVideo || matchFileRegex(path, f.videoExcludeRegex)) {
 		logger.Debugf("Skipping %s as it matches video exclusion patterns", path)
 		return false
-	} else if (isImageFile || isZipFile) && s.ExcludeImage || matchFileRegex(path, f.imageExcludeRegex) {
+	} else if (isImageFile || isZipFile) && (s.ExcludeImage || matchFileRegex(path, f.imageExcludeRegex)) {
 		logger.Debugf("Skipping %s as it matches image exclusion patterns", path)
 		return false
 	}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -268,6 +268,7 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	}
 
 	if !info.IsDir() && !isVideoFile && !isImageFile && !isZipFile {
+		logger.Debugf("Skipping %s as it does not match any known file extensions", path)
 		return false
 	}
 
@@ -280,6 +281,7 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	s := getStashFromDirPath(f.stashPaths, path)
 
 	if s == nil {
+		logger.Debugf("Skipping %s as it is not in the stash library", path)
 		return false
 	}
 
@@ -287,12 +289,15 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	// add a trailing separator so that it correctly matches against patterns like path/.*
 	pathExcludeTest := path + string(filepath.Separator)
 	if (s.ExcludeVideo || matchFileRegex(pathExcludeTest, f.videoExcludeRegex)) && (s.ExcludeImage || matchFileRegex(pathExcludeTest, f.imageExcludeRegex)) {
+		logger.Debugf("Skipping directory %s as it matches video and image exclusion patterns", path)
 		return false
 	}
 
 	if isVideoFile && (s.ExcludeVideo || matchFileRegex(path, f.videoExcludeRegex)) {
+		logger.Debugf("Skipping %s as it matches video exclusion patterns", path)
 		return false
 	} else if (isImageFile || isZipFile) && s.ExcludeImage || matchFileRegex(path, f.imageExcludeRegex) {
+		logger.Debugf("Skipping %s as it matches image exclusion patterns", path)
 		return false
 	}
 

--- a/ui/v2.5/src/docs/en/Changelog/v0190.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0190.md
@@ -9,4 +9,5 @@
 * Changed performer aliases to be a list, rather than a string field. ([#3113](https://github.com/stashapp/stash/pull/3113))
 
 ### 🐛 Bug fixes
+* Fixed image exclusion pattern being applied to all files. ([#3241](https://github.com/stashapp/stash/pull/3241))
 * Fixed missing captions not being removed during scan. ([#3240](https://github.com/stashapp/stash/pull/3240))


### PR DESCRIPTION
Fixes #3230 

Also adds more debug logging to the exclusion code to assist debugging.