### PR TITLE
Fix wall items not showing scene titles where title not set

### DIFF
--- a/ui/v2.5/src/components/Wall/WallItem.tsx
+++ b/ui/v2.5/src/components/Wall/WallItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useMemo } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import { TextUtils, NavUtils } from "src/utils";
@@ -6,6 +6,7 @@ import cx from "classnames";
 import { SceneQueue } from "src/models/sceneQueue";
 import { ConfigurationContext } from "src/hooks/Config";
 import { markerTitle } from "src/core/markers";
+import { objectTitle } from "src/core/files";
 
 interface IWallItemProps {
   index?: number;
@@ -180,14 +181,23 @@ export const WallItem: React.FC<IWallItemProps> = (props: IWallItemProps) => {
     }
   }
 
+  const title = useMemo(() => {
+    if (props.sceneMarker) {
+      return `${markerTitle(
+        props.sceneMarker
+      )} - ${TextUtils.secondsToTimestamp(props.sceneMarker.seconds)}`;
+    }
+
+    if (props.scene) {
+      return objectTitle(props.scene);
+    }
+
+    return "";
+  }, [props.sceneMarker, props.scene]);
+
   const renderText = () => {
     if (!showTextContainer) return;
 
-    const title = props.sceneMarker
-      ? `${markerTitle(props.sceneMarker)} - ${TextUtils.secondsToTimestamp(
-          props.sceneMarker.seconds
-        )}`
-      : props.scene?.title ?? "";
     const tags = props.sceneMarker
       ? [props.sceneMarker.primary_tag, ...props.sceneMarker.tags]
       : [];

--- a/ui/v2.5/src/docs/en/Changelog/v0190.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0190.md
@@ -9,5 +9,6 @@
 * Changed performer aliases to be a list, rather than a string field. ([#3113](https://github.com/stashapp/stash/pull/3113))
 
 ### 🐛 Bug fixes
+* Fixed scene wall items to show file base name where scene has no title set. ([#3242](https://github.com/stashapp/stash/pull/3242))
 * Fixed image exclusion pattern being applied to all files. ([#3241](https://github.com/stashapp/stash/pull/3241))
 * Fixed missing captions not being removed during scan. ([#3240](https://github.com/stashapp/stash/pull/3240))


### PR DESCRIPTION
Fixes #3214

Shows the scene basename where title is not set.