### PR TITLE
Fix date fields not being nulled correctly when cleared

### DIFF
--- a/internal/api/changeset_translator.go
+++ b/internal/api/changeset_translator.go
@@ -143,7 +143,7 @@ func (t changesetTranslator) optionalDate(value *string, field string) models.Op
 		return models.OptionalDate{}
 	}
 
-	if value == nil {
+	if value == nil || *value == "" {
 		return models.OptionalDate{
 			Set:  true,
 			Null: true,

--- a/pkg/sqlite/record.go
+++ b/pkg/sqlite/record.go
@@ -102,11 +102,11 @@ func (r *updateRecord) setSQLiteDate(destField string, v models.OptionalDate) {
 	if v.Set {
 		if v.Null {
 			r.set(destField, models.SQLiteDate{})
+		} else {
+			r.set(destField, models.SQLiteDate{
+				String: v.Value.String(),
+				Valid:  true,
+			})
 		}
-
-		r.set(destField, models.SQLiteDate{
-			String: v.Value.String(),
-			Valid:  true,
-		})
 	}
 }

--- a/ui/v2.5/src/docs/en/Changelog/v0190.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0190.md
@@ -9,6 +9,7 @@
 * Changed performer aliases to be a list, rather than a string field. ([#3113](https://github.com/stashapp/stash/pull/3113))
 
 ### 🐛 Bug fixes
+* Fixed date fields not being nulled correctly when cleared. ([#3243](https://github.com/stashapp/stash/pull/3243))
 * Fixed scene wall items to show file base name where scene has no title set. ([#3242](https://github.com/stashapp/stash/pull/3242))
 * Fixed image exclusion pattern being applied to all files. ([#3241](https://github.com/stashapp/stash/pull/3241))
 * Fixed missing captions not being removed during scan. ([#3240](https://github.com/stashapp/stash/pull/3240))


### PR DESCRIPTION
Fixes #3222 

This does not fix existing instances of date fields that were incorrect set. This can be data corrected with the following SQL script:
```
UPDATE scenes SET date = NULL WHERE date = '0001-01-01';
UPDATE galleries SET date = NULL WHERE date = '0001-01-01';
UPDATE performers SET birthdate = NULL WHERE birthdate = '0001-01-01';
UPDATE performers SET death_date = NULL WHERE death_date = '0001-01-01';
```

I can try to include this data correction in the next schema migration.