### PR TITLE
Correct title ordering for objects without titles

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -428,6 +428,7 @@ func registerCustomDriver() {
 				funcs := map[string]interface{}{
 					"regexp":            regexFn,
 					"durationToTinyInt": durationToTinyIntFn,
+					"basename":          basenameFn,
 				}
 
 				for name, fn := range funcs {

--- a/pkg/sqlite/functions.go
+++ b/pkg/sqlite/functions.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -29,4 +30,8 @@ func durationToTinyIntFn(str string) (int64, error) {
 	}
 
 	return int64(seconds), nil
+}
+
+func basenameFn(str string) (string, error) {
+	return filepath.Base(str), nil
 }

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -1109,7 +1109,7 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 	case "title":
 		addFileTable()
 		addFolderTable()
-		query.sortAndPagination += " ORDER BY galleries.title COLLATE NATURAL_CS " + direction + ", folders.path " + direction + ", file_folder.path " + direction + ", files.basename COLLATE NATURAL_CS " + direction
+		query.sortAndPagination += " ORDER BY COALESCE(galleries.title, folders.path, files.basename) COLLATE NATURAL_CS " + direction + ", file_folder.path " + direction
 	default:
 		query.sortAndPagination += getSort(sort, direction, "galleries")
 	}

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -1109,7 +1109,7 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 	case "title":
 		addFileTable()
 		addFolderTable()
-		query.sortAndPagination += " ORDER BY COALESCE(galleries.title, folders.path, files.basename) COLLATE NATURAL_CS " + direction + ", file_folder.path " + direction
+		query.sortAndPagination += " ORDER BY COALESCE(galleries.title, files.basename, basename(COALESCE(folders.path, ''))) COLLATE NATURAL_CS " + direction + ", file_folder.path " + direction
 	default:
 		query.sortAndPagination += getSort(sort, direction, "galleries")
 	}

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2414,6 +2414,13 @@ func TestGalleryQuerySorting(t *testing.T) {
 			-1,
 			-1,
 		},
+		{
+			"title",
+			"title",
+			models.SortDirectionEnumDesc,
+			-1,
+			-1,
+		},
 	}
 
 	qb := db.Gallery

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1019,7 +1019,7 @@ func (qb *ImageStore) setImageSortAndPagination(q *queryBuilder, findFilter *mod
 		case "title":
 			addFilesJoin()
 			addFolderJoin()
-			sortClause = " ORDER BY images.title COLLATE NATURAL_CS " + direction + ", folders.path " + direction + ", files.basename COLLATE NATURAL_CS " + direction
+			sortClause = " ORDER BY COALESCE(images.title, files.basename) COLLATE NATURAL_CS " + direction + ", folders.path " + direction
 		default:
 			sortClause = getSort(sort, direction, "images")
 		}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1446,7 +1446,7 @@ func (qb *SceneStore) setSceneSort(query *queryBuilder, findFilter *models.FindF
 	case "title":
 		addFileTable()
 		addFolderTable()
-		query.sortAndPagination += " ORDER BY scenes.title COLLATE NATURAL_CS " + direction + ", folders.path " + direction + ", files.basename COLLATE NATURAL_CS " + direction
+		query.sortAndPagination += " ORDER BY COALESCE(scenes.title, files.basename) COLLATE NATURAL_CS " + direction + ", folders.path " + direction
 	case "play_count":
 		// handle here since getSort has special handling for _count suffix
 		query.sortAndPagination += " ORDER BY scenes.play_count " + direction

--- a/ui/v2.5/src/docs/en/Changelog/v0190.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0190.md
@@ -9,6 +9,7 @@
 * Changed performer aliases to be a list, rather than a string field. ([#3113](https://github.com/stashapp/stash/pull/3113))
 
 ### 🐛 Bug fixes
+* Fixed objects without titles not being sorted correctly with objects with titles. ([#3244](https://github.com/stashapp/stash/pull/3244))
 * Fixed incorrect new Performer pill being removed when creating Performer from scrape dialog. ([#3251](https://github.com/stashapp/stash/pull/3251))
 * Fixed date fields not being nulled correctly when cleared. ([#3243](https://github.com/stashapp/stash/pull/3243))
 * Fixed scene wall items to show file base name where scene has no title set. ([#3242](https://github.com/stashapp/stash/pull/3242))


### PR DESCRIPTION
Fixes #3229 

When sorting by title, sorts by the first non-null value of `title` or file `basename` - or folder basename for galleries.