### PR TITLE
Fix scene studio results when doing a search scrape

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -822,7 +822,7 @@ func (s mappedScraper) scrapePerformers(ctx context.Context, q mappedQuery) ([]*
 	return ret, nil
 }
 
-func (s mappedScraper) processScene(ctx context.Context, q mappedQuery, r mappedResult) *ScrapedScene {
+func (s mappedScraper) processScene(ctx context.Context, q mappedQuery, r mappedResult, resultIndex int) *ScrapedScene {
 	var ret ScrapedScene
 
 	sceneScraperConfig := s.Scene
@@ -876,9 +876,10 @@ func (s mappedScraper) processScene(ctx context.Context, q mappedQuery, r mapped
 		logger.Debug(`Processing scene studio:`)
 		studioResults := sceneStudioMap.process(ctx, q, s.Common)
 
-		if len(studioResults) > 0 {
+		if len(studioResults) > 0 && resultIndex < len(studioResults) {
 			studio := &models.ScrapedStudio{}
-			studioResults[0].apply(studio)
+			// when doing a `search` scrape get the related studio
+			studioResults[resultIndex].apply(studio)
 			ret.Studio = studio
 		}
 	}
@@ -908,9 +909,9 @@ func (s mappedScraper) scrapeScenes(ctx context.Context, q mappedQuery) ([]*Scra
 
 	logger.Debug(`Processing scenes:`)
 	results := sceneMap.process(ctx, q, s.Common)
-	for _, r := range results {
+	for i, r := range results {
 		logger.Debug(`Processing scene:`)
-		ret = append(ret, s.processScene(ctx, q, r))
+		ret = append(ret, s.processScene(ctx, q, r, i))
 	}
 
 	return ret, nil
@@ -928,7 +929,7 @@ func (s mappedScraper) scrapeScene(ctx context.Context, q mappedQuery) (*Scraped
 	logger.Debug(`Processing scene:`)
 	results := sceneMap.process(ctx, q, s.Common)
 	if len(results) > 0 {
-		ret = s.processScene(ctx, q, results[0])
+		ret = s.processScene(ctx, q, results[0], 0)
 	}
 
 	return ret, nil


### PR DESCRIPTION
Current issue / bug
When doing a search scrape (with xpath or json scrapers) for scenes the studio meta returned is wrong. Instead of returning the correct studio name the name returned  is always from the first scraped result

Steps to reproduce.
- Get a (xpath/json) scene scraper that returns studio names when searching ( only existing in PRs <https://github.com/stashapp/CommunityScrapers/pull/1183> <https://github.com/stashapp/CommunityScrapers/pull/1182> for now ) or modify  <https://github.com/stashapp/CommunityScrapers/blob/master/scrapers/ThePornDB.yml> by adding the studio name in the `sceneSearch`
For example add  the below
```yaml
      Studio:
        Name: data.#.site.name
```
after line 74 in `ThePornDB.yml`
- Set the log to debug
- Edit a scene and reload scrapers, use the scrape Query to do a search by name for any of the above scrapers
- Observe the log and see that the correct studio names where printed
- From the UI ( or the scrapeSingleScene query returned ) you can see that the results have all the `first` studio name

The specific fix only patches the existing processScene function to make it work for the above use case.
If a search is made  and thus ScrapeScenes is used we pass along the `index` from the results to be processed.
The patch doesnt address any other issues or limitations of the current search functionality ( performers/tags need a more complex solution and no (xpath/json) scrapers use them for searches anyway)
