### PR TITLE
Fix and improve captions detection

### DIFF
--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -156,6 +156,7 @@ type Finder interface {
 type Getter interface {
 	Finder
 	FindByPath(ctx context.Context, path string) (File, error)
+	FindAllByPath(ctx context.Context, path string) ([]File, error)
 	FindByFingerprint(ctx context.Context, fp Fingerprint) ([]File, error)
 	FindByZipFileID(ctx context.Context, zipFileID ID) ([]File, error)
 	FindAllInPaths(ctx context.Context, p []string, limit, offset int) ([]File, error)

--- a/pkg/file/video/caption.go
+++ b/pkg/file/video/caption.go
@@ -98,13 +98,22 @@ func AssociateCaptions(ctx context.Context, captionPath string, txnMgr txn.Manag
 	captionPrefix := getCaptionPrefix(captionPath)
 	if err := txn.WithTxn(ctx, txnMgr, func(ctx context.Context) error {
 		var err error
-		f, er := fqb.FindByPath(ctx, captionPrefix+"*")
+		files, er := fqb.FindAllByPath(ctx, captionPrefix+"*")
 
 		if er != nil {
 			return fmt.Errorf("searching for scene %s: %w", captionPrefix, er)
 		}
 
-		if f != nil { // found related Scene
+		for _, f := range files {
+			// found some files
+			// filter out non video files
+			switch f.(type) {
+			case *file.VideoFile:
+				break
+			default:
+				continue
+			}
+
 			fileID := f.Base().ID
 			path := f.Base().Path
 

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -575,6 +575,23 @@ func (qb *FileStore) find(ctx context.Context, id file.ID) (file.File, error) {
 
 // FindByPath returns the first file that matches the given path. Wildcard characters are supported.
 func (qb *FileStore) FindByPath(ctx context.Context, p string) (file.File, error) {
+
+	ret, err := qb.FindAllByPath(ctx, p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ret) == 0 {
+		return nil, sql.ErrNoRows
+	}
+
+	return ret[0], nil
+}
+
+// FindAllByPath returns all the files that match the given path.
+// Wildcard characters are supported.
+func (qb *FileStore) FindAllByPath(ctx context.Context, p string) ([]file.File, error) {
 	// separate basename from path
 	basename := filepath.Base(p)
 	dirName := filepath.Dir(p)
@@ -601,7 +618,7 @@ func (qb *FileStore) FindByPath(ctx context.Context, p string) (file.File, error
 		)
 	}
 
-	ret, err := qb.get(ctx, q)
+	ret, err := qb.getMany(ctx, q)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("getting file by path %s: %w", p, err)
 	}

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -583,7 +583,7 @@ func (qb *FileStore) FindByPath(ctx context.Context, p string) (file.File, error
 	}
 
 	if len(ret) == 0 {
-		return nil, sql.ErrNoRows
+		return nil, nil
 	}
 
 	return ret[0], nil


### PR DESCRIPTION
When attempting to match a captions file if an image file with the same name as a video file is present it will be found first:
- sample.en.vtt
- sample.jpg
- sample.mp4

simply because the extension is alphabetically lower than the one for the video file and stash will try to associate the captions file with the image instead of the video file.

This change will find all the files that match the captions filename in the same folder as the captions files just like before, filter out non video files and then assign the captions to all the remaining video files, in case the scene has multiple files with the same name but different extensions (or multiple scenes).

So the new behavior is:
- sample.en.vtt
- sample.jpg - ignored
- sample.mp4 - assign EN captions
- sample.webm - assign EN captions