### PR TITLE
Fix UI crash when scraping new scene

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -436,7 +436,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
     const currentScene = getSceneInput(formik.values);
     if (!currentScene.cover_image) {
-      currentScene.cover_image = scene.paths!.screenshot;
+      currentScene.cover_image = scene.paths?.screenshot;
     }
 
     return (


### PR DESCRIPTION
Fixes issue where scraping from UI in the new scene page would cause a UI crash.