### PR TITLE
Added Label for Russian Subtitle

### DIFF
--- a/ui/v2.5/src/utils/caption.ts
+++ b/ui/v2.5/src/utils/caption.ts
@@ -8,6 +8,7 @@ export const languageMap = new Map<string, string>([
   ["ko", "한국인"],
   ["nl", "Holandés"],
   ["pt", "Português"],
+  ["ru", "Русский"],
   ["00", "Unknown"], // stash reserved language code
 ]);
 


### PR DESCRIPTION
This pull request adds a label for Russian subtitles. I noticed recently that DDF Network/Porn World provides them.