### PR TITLE
Tweak IS/IS NOT NULL date filter

### DIFF
--- a/pkg/sqlite/sql.go
+++ b/pkg/sqlite/sql.go
@@ -197,9 +197,9 @@ func getDateWhereClause(column string, modifier models.CriterionModifier, value 
 
 	switch modifier {
 	case models.CriterionModifierIsNull:
-		return fmt.Sprintf("(%s IS NULL OR %s = '')", column, column), nil
+		return fmt.Sprintf("(%s IS NULL OR %s = '' OR %s = '0001-01-01')", column, column, column), nil
 	case models.CriterionModifierNotNull:
-		return fmt.Sprintf("(%s IS NOT NULL AND %s != '')", column, column), nil
+		return fmt.Sprintf("(%s IS NOT NULL AND %s != '' AND %s != '0001-01-01')", column, column, column), nil
 	case models.CriterionModifierEquals:
 		return fmt.Sprintf("%s = ?", column), args
 	case models.CriterionModifierNotEquals:


### PR DESCRIPTION
Includes the golang zero value date when checking dates for IS / IS NOT  NULL criterion
I am not sure how but a few of those dates ( 0001-01-01 ) ended up in my database

```bash
sqlite> select count() from scenes where date = "0001-01-01";
42
sqlite> select count() from performers where birthdate = "0001-01-01";
107
sqlite> select count() from performers where death_date = "0001-01-01";
351
sqlite> 
sqlite> select count() from galleries where date = "0001-01-01";
3
sqlite>
```
