### PR TITLE
Option to leave stats page blank

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -203,7 +203,7 @@ export const SettingsInterfacePanel: React.FC = () => {
 
       <SettingSection headingID="config.ui.stat_panel.heading">
         <BooleanSetting
-          id="blank_stats-view"
+          id="blank-stats-view"
           headingID="config.ui.stat_panel.options.blank_slate.heading"
           subHeadingID="config.ui.stat_panel.options.blank_slate.description"
           checked={ui.blankStatsView ?? undefined}

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -201,6 +201,16 @@ export const SettingsInterfacePanel: React.FC = () => {
         />
       </SettingSection>
 
+      <SettingSection headingID="config.ui.stat_panel.heading">
+        <BooleanSetting
+          id="show-child-studio-content"
+          headingID="config.ui.stat_panel.options.blank_slate.heading"
+          subHeadingID="config.ui.stat_panel.options.blank_slate.description"
+          checked={ui.blankStatsView ?? undefined}
+          onChange={(v) => saveUI({ blankStatsView: v })}
+        />
+      </SettingSection>
+
       <SettingSection headingID="config.ui.scene_wall.heading">
         <BooleanSetting
           id="wall-show-title"

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -203,7 +203,7 @@ export const SettingsInterfacePanel: React.FC = () => {
 
       <SettingSection headingID="config.ui.stat_panel.heading">
         <BooleanSetting
-          id="show-child-studio-content"
+          id="blank_stats-view"
           headingID="config.ui.stat_panel.options.blank_slate.heading"
           subHeadingID="config.ui.stat_panel.options.blank_slate.description"
           checked={ui.blankStatsView ?? undefined}

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -10,12 +10,11 @@ export const Stats: React.FC = () => {
   const { configuration } = useContext(ConfigurationContext);
   const uiConfig = configuration?.ui as IUIConfig | undefined;
   const blankStatsView = uiConfig?.blankStatsView ?? false;
+  const { data, error, loading } = useStats();
 
   if (blankStatsView) {
     return <div className="mt-5"></div>;
   } else {
-    const { data, error, loading } = useStats();
-
     if (error) return <span>{error.message}</span>;
     if (loading || !data) return <LoadingIndicator />;
 

--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -1,121 +1,131 @@
-import React from "react";
+import React, { useContext } from "react";
+import { ConfigurationContext } from "src/hooks/Config";
 import { useStats } from "src/core/StashService";
 import { FormattedMessage, FormattedNumber } from "react-intl";
 import { LoadingIndicator } from "src/components/Shared";
 import { TextUtils } from "src/utils";
+import { IUIConfig } from "src/core/config";
 
 export const Stats: React.FC = () => {
-  const { data, error, loading } = useStats();
+  const { configuration } = useContext(ConfigurationContext);
+  const uiConfig = configuration?.ui as IUIConfig | undefined;
+  const blankStatsView = uiConfig?.blankStatsView ?? false;
 
-  if (error) return <span>{error.message}</span>;
-  if (loading || !data) return <LoadingIndicator />;
+  if (blankStatsView) {
+    return <div className="mt-5"></div>;
+  } else {
+    const { data, error, loading } = useStats();
 
-  const scenesSize = TextUtils.fileSize(data.stats.scenes_size);
-  const imagesSize = TextUtils.fileSize(data.stats.images_size);
+    if (error) return <span>{error.message}</span>;
+    if (loading || !data) return <LoadingIndicator />;
 
-  const scenesDuration = TextUtils.secondsAsTimeString(
-    data.stats.scenes_duration,
-    3
-  );
+    const scenesSize = TextUtils.fileSize(data.stats.scenes_size);
+    const imagesSize = TextUtils.fileSize(data.stats.images_size);
 
-  return (
-    <div className="mt-5">
-      <div className="col col-sm-8 m-sm-auto row stats">
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber
-              value={scenesSize.size}
-              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
-                scenesSize.unit
-              )}
-            />
-            {` ${TextUtils.formatFileSizeUnit(scenesSize.unit)}`}
-          </p>
-          <p className="heading">
-            <FormattedMessage id="stats.scenes_size" />
-          </p>
+    const scenesDuration = TextUtils.secondsAsTimeString(
+      data.stats.scenes_duration,
+      3
+    );
+
+    return (
+      <div className="mt-5">
+        <div className="col col-sm-8 m-sm-auto row stats">
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber
+                value={scenesSize.size}
+                maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+                  scenesSize.unit
+                )}
+              />
+              {` ${TextUtils.formatFileSizeUnit(scenesSize.unit)}`}
+            </p>
+            <p className="heading">
+              <FormattedMessage id="stats.scenes_size" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.scene_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="scenes" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.movie_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="movies" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">{scenesDuration || "-"}</p>
+            <p className="heading">
+              <FormattedMessage id="stats.scenes_duration" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.performer_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="performers" />
+            </p>
+          </div>
         </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.scene_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="scenes" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.movie_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="movies" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">{scenesDuration || "-"}</p>
-          <p className="heading">
-            <FormattedMessage id="stats.scenes_duration" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.performer_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="performers" />
-          </p>
+        <div className="col col-sm-8 m-sm-auto row stats">
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber
+                value={imagesSize.size}
+                maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+                  imagesSize.unit
+                )}
+              />
+              {` ${TextUtils.formatFileSizeUnit(imagesSize.unit)}`}
+            </p>
+            <p className="heading">
+              <FormattedMessage id="stats.image_size" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.gallery_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="galleries" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.image_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="images" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.studio_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="studios" />
+            </p>
+          </div>
+          <div className="stats-element">
+            <p className="title">
+              <FormattedNumber value={data.stats.tag_count} />
+            </p>
+            <p className="heading">
+              <FormattedMessage id="tags" />
+            </p>
+          </div>
         </div>
       </div>
-      <div className="col col-sm-8 m-sm-auto row stats">
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber
-              value={imagesSize.size}
-              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
-                imagesSize.unit
-              )}
-            />
-            {` ${TextUtils.formatFileSizeUnit(imagesSize.unit)}`}
-          </p>
-          <p className="heading">
-            <FormattedMessage id="stats.image_size" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.gallery_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="galleries" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.image_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="images" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.studio_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="studios" />
-          </p>
-        </div>
-        <div className="stats-element">
-          <p className="title">
-            <FormattedNumber value={data.stats.tag_count} />
-          </p>
-          <p className="heading">
-            <FormattedMessage id="tags" />
-          </p>
-        </div>
-      </div>
-    </div>
-  );
+    );
+  }
 };
 
 export default Stats;

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -29,6 +29,8 @@ export type FrontPageContent = ISavedFilterRow | ICustomFilter;
 export interface IUIConfig {
   frontPageContent?: FrontPageContent[];
 
+  blankStatsView?: boolean;
+
   showChildTagContent?: boolean;
   showChildStudioContent?: boolean;
   showTagCardOnHover?: boolean;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -599,6 +599,15 @@
         "description": "Slideshow is available in galleries when in wall view mode",
         "heading": "Slideshow Delay (seconds)"
       },
+      "stat_panel": {
+        "heading": "Stats view",
+        "options": {
+          "blank_slate": {
+            "description": "Leave stats page blank making it ideal for custom charts",
+            "heading": "Blank Slate"
+          }
+        }
+      },
       "studio_panel": {
         "heading": "Studio view",
         "options": {


### PR DESCRIPTION
This pull request adds an option to leave the stats page blank, making it ideal for custom charts via plugins or userscripts to run without waiting and dealing with load times that would vary based on the size of a user's stash.

Screenshot of new interface setting:
![Screenshot 2023-01-04 103932](https://user-images.githubusercontent.com/72030708/210611535-7f3f97b2-96ef-4ace-aafb-1ac97fa79a73.png)

Screenshot of blank stats page:
![Screenshot 2023-01-04 103958](https://user-images.githubusercontent.com/72030708/210611656-286a733a-bfa1-4b47-9d08-7ba7001aae6b.png)