### PR TITLE
Add tenth place precision star rating

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -488,7 +488,8 @@
             "options": {
               "full": "Full",
               "half": "Half",
-              "quarter": "Quarter"
+              "quarter": "Quarter",
+              "tenth": "Tenth"
             }
           }
         },

--- a/ui/v2.5/src/utils/rating.ts
+++ b/ui/v2.5/src/utils/rating.ts
@@ -7,6 +7,7 @@ export enum RatingStarPrecision {
   Full = "full",
   Half = "half",
   Quarter = "quarter",
+  Tenth = "tenth",
 }
 
 export const defaultRatingSystemType: RatingSystemType = RatingSystemType.Stars;
@@ -37,6 +38,10 @@ export const ratingStarPrecisionIntlMap = new Map<RatingStarPrecision, string>([
     RatingStarPrecision.Quarter,
     "config.ui.editing.rating_system.star_precision.options.quarter",
   ],
+  [
+    RatingStarPrecision.Tenth,
+    "config.ui.editing.rating_system.star_precision.options.tenth",
+  ],
 ]);
 
 export type RatingSystemOptions = {
@@ -66,6 +71,8 @@ export function getRatingPrecision(precision: RatingStarPrecision) {
       return 0.5;
     case RatingStarPrecision.Quarter:
       return 0.25;
+    case RatingStarPrecision.Tenth:
+      return 0.1;
     default:
       return 1;
   }


### PR DESCRIPTION
This pull request adds an option for tenth-place precision star ratings, as I feel the quarter and half-star options aren't precise enough to consider them over the decimal option. It's always jarring to see so many performers with a 5-star rating with quarter precision.