### PR TITLE
CSS update to unify popover location

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -69,11 +69,7 @@
   white-space: normal;
 }
 
-.recommendations-container .studio-card hr,
-.recommendations-container .movie-card hr,
-.recommendations-container .gallery-card hr,
-.recommendations-container .image-card hr,
-.recommendations-container .tag-card hr {
+.card hr {
   margin-top: auto;
 }
 


### PR DESCRIPTION
This is an extension to the https://github.com/stashapp/stash/pull/3207 pull request. The CSS update here is the final piece to achieve popovers that are consistently placed at the bottom of each card. 

![Screenshot 2023-01-04 192040](https://user-images.githubusercontent.com/72030708/210680232-f9854d40-a829-4783-8ec9-cd7b44c7843c.png)

Compared to:

![Screenshot 2023-01-04 192102](https://user-images.githubusercontent.com/72030708/210680244-0da7d63b-fde7-461a-93ad-bca3b4023561.png)

This change was intentionally omitted in the previous pull request to avoid messing with custom CSS users might have. Based on recent discussions in the discord channel, it sounds like this would be a welcome inclusion.