### PR TITLE
Add tzdata package for localtime pass-through

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-linux-arm32v6; \
 FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 RUN apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev \
-    && apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools ruby \
+    && apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools ruby tzdata \
     && pip install mechanicalsoup cloudscraper bencoder.pyx \
     && gem install faraday \
     && apk del .build-deps


### PR DESCRIPTION
Current docker variable to pass localtime to container does not function (`/etc/localtime` does not exist within a running container).  I've never built a container, nor personally use Alpine, but based on my digging it appears the package `tzdata` is required for this functionality