### PR TITLE
Bug: noticed that high performance preview generation had been turned off.

### DIFF
--- a/internal/manager/task_generate_preview.go
+++ b/internal/manager/task_generate_preview.go
@@ -57,7 +57,7 @@ func (t *GeneratePreviewTask) Start(ctx context.Context) {
 func (t GeneratePreviewTask) generateVideo(videoChecksum string, videoDuration float64) error {
 	videoFilename := t.Scene.Path
 
-	if err := t.generator.PreviewVideo(context.TODO(), videoFilename, videoDuration, videoChecksum, t.Options, true); err != nil {
+	if err := t.generator.PreviewVideo(context.TODO(), videoFilename, videoDuration, videoChecksum, t.Options, false); err != nil {
 		logger.Warnf("[generator] failed generating scene preview, trying fallback")
 		if err := t.generator.PreviewVideo(context.TODO(), videoFilename, videoDuration, videoChecksum, t.Options, true); err != nil {
 			return err


### PR DESCRIPTION
I assume duration a refactoring the faster previewVideo call was incorrectly changed to the fallback version.