### PR TITLE
Add count attribute to badges

### DIFF
--- a/ui/v2.5/src/components/Shared/Counter.tsx
+++ b/ui/v2.5/src/components/Shared/Counter.tsx
@@ -17,7 +17,7 @@ export const Counter: React.FC<IProps> = ({
   if (abbreviateCounter) {
     const formated = TextUtils.abbreviateCounter(count);
     return (
-      <Badge className="left-spacing" pill variant="secondary" data-count={intl.formatNumber(count)}>
+      <Badge className="left-spacing" pill variant="secondary" data-value={intl.formatNumber(count)}>
         <FormattedNumber
           value={formated.size}
           maximumFractionDigits={formated.digits}
@@ -27,7 +27,7 @@ export const Counter: React.FC<IProps> = ({
     );
   } else {
     return (
-      <Badge className="left-spacing" pill variant="secondary" data-count={intl.formatNumber(count)}>
+      <Badge className="left-spacing" pill variant="secondary" data-value={intl.formatNumber(count)}>
         {intl.formatNumber(count)}
       </Badge>
     );

--- a/ui/v2.5/src/components/Shared/Counter.tsx
+++ b/ui/v2.5/src/components/Shared/Counter.tsx
@@ -17,7 +17,12 @@ export const Counter: React.FC<IProps> = ({
   if (abbreviateCounter) {
     const formated = TextUtils.abbreviateCounter(count);
     return (
-      <Badge className="left-spacing" pill variant="secondary" data-value={intl.formatNumber(count)}>
+      <Badge
+        className="left-spacing"
+        pill
+        variant="secondary"
+        data-value={intl.formatNumber(count)}
+      >
         <FormattedNumber
           value={formated.size}
           maximumFractionDigits={formated.digits}
@@ -27,7 +32,12 @@ export const Counter: React.FC<IProps> = ({
     );
   } else {
     return (
-      <Badge className="left-spacing" pill variant="secondary" data-value={intl.formatNumber(count)}>
+      <Badge
+        className="left-spacing"
+        pill
+        variant="secondary"
+        data-value={intl.formatNumber(count)}
+      >
         {intl.formatNumber(count)}
       </Badge>
     );

--- a/ui/v2.5/src/components/Shared/Counter.tsx
+++ b/ui/v2.5/src/components/Shared/Counter.tsx
@@ -17,7 +17,7 @@ export const Counter: React.FC<IProps> = ({
   if (abbreviateCounter) {
     const formated = TextUtils.abbreviateCounter(count);
     return (
-      <Badge className="left-spacing" pill variant="secondary">
+      <Badge className="left-spacing" pill variant="secondary" data-count={intl.formatNumber(count)}>
         <FormattedNumber
           value={formated.size}
           maximumFractionDigits={formated.digits}
@@ -27,7 +27,7 @@ export const Counter: React.FC<IProps> = ({
     );
   } else {
     return (
-      <Badge className="left-spacing" pill variant="secondary">
+      <Badge className="left-spacing" pill variant="secondary" data-count={intl.formatNumber(count)}>
         {intl.formatNumber(count)}
       </Badge>
     );


### PR DESCRIPTION
This pull request adds a count attribute to badge counters enabling users to select that element based on the count value.