### PR TITLE
Set performer disambiguation for names with parentheses

### DIFF
--- a/pkg/sqlite/migrations/42_postmigrate.go
+++ b/pkg/sqlite/migrations/42_postmigrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -31,7 +32,13 @@ func post42(ctx context.Context, db *sqlx.DB) error {
 	}
 
 	if err := m.migrateDuplicatePerformers(ctx); err != nil {
-		return fmt.Errorf("migrating performer aliases: %w", err)
+		return fmt.Errorf("migrating duplicate performers: %w", err)
+	}
+
+	// do this after duplicate performer detection, since setting disambiguation
+	// breaks the duplicate disambiguation setting code
+	if err := m.migratePerformersDisam(ctx); err != nil {
+		return fmt.Errorf("migrating performer names: %w", err)
 	}
 
 	if err := m.executeSchemaChanges(); err != nil {
@@ -137,6 +144,94 @@ func (m *schema42Migrator) migratePerformerAliases(id int, aliases string) error
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *schema42Migrator) migratePerformersDisam(ctx context.Context) error {
+	logger.Info("Migrating performer disambiguation")
+
+	const (
+		limit    = 1000
+		logEvery = 10000
+	)
+
+	count := 0
+
+	for {
+		gotSome := false
+
+		if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
+			query := `
+SELECT id, name FROM performers WHERE performers.name like '%(%)%'`
+
+			query += fmt.Sprintf(" ORDER BY `id` LIMIT %d", limit)
+
+			rows, err := m.db.Query(query)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var (
+					id   int
+					name string
+				)
+
+				err := rows.Scan(&id, &name)
+				if err != nil {
+					return err
+				}
+
+				gotSome = true
+				count++
+
+				if err := m.massagePerformerName(id, name); err != nil {
+					return err
+				}
+			}
+
+			return rows.Err()
+		}); err != nil {
+			return err
+		}
+
+		if !gotSome {
+			break
+		}
+
+		if count%logEvery == 0 {
+			logger.Infof("Migrated %d performers", count)
+		}
+	}
+
+	return nil
+}
+
+// extracts the performer name and disambiguation from the name field based on
+// the format "name (disambiguation)". The whitespace is optional.
+var performerDisRE = regexp.MustCompile(`([^(]+)\(([^)]+)\)`)
+
+func (m *schema42Migrator) massagePerformerName(performerID int, name string) error {
+
+	r := performerDisRE.FindStringSubmatch(name)
+	if len(r) != 3 {
+		// ignore corner case invalid names
+		return nil
+	}
+
+	// get the performer name and disambiguation from the capturing groups
+	// trimming any whitespace
+	newName := strings.TrimSpace(r[1])
+	newDis := strings.TrimSpace(r[2])
+
+	logger.Infof("Separating %q into %q and disambiguation %q", name, newName, newDis)
+
+	_, err := m.db.Exec("UPDATE performers SET name = ?, disambiguation = ? WHERE id = ?", newName, newDis, performerID)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This modifies the schema 42 post-migration code to detect names with parentheses and automatically separate the name into the base name and disambiguation.

For example, the performer name `Jane Smith (Foobar)` becomes `Jane Smith` with disambiguation set to `Foobar`.

Resolves #3223 