### PR TITLE
Handle unset rating system

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -139,7 +139,7 @@ export const GalleryEditPanel: React.FC<
 
   useRatingKeybinds(
     isVisible,
-    stashConfig?.ui.ratingSystemOptions.type,
+    stashConfig?.ui?.ratingSystemOptions?.type,
     setRating
   );
 

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -75,7 +75,7 @@ export const ImageEditPanel: React.FC<IProps> = ({
 
   useRatingKeybinds(
     true,
-    configuration?.ui.ratingSystemOptions.type,
+    configuration?.ui?.ratingSystemOptions?.type,
     setRating
   );
 

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -122,7 +122,11 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     formik.setFieldValue("rating100", v);
   }
 
-  useRatingKeybinds(true, stashConfig?.ui.ratingSystemOptions.type, setRating);
+  useRatingKeybinds(
+    true,
+    stashConfig?.ui?.ratingSystemOptions?.type,
+    setRating
+  );
 
   // set up hotkeys
   useEffect(() => {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -113,7 +113,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
 
   useRatingKeybinds(
     true,
-    configuration?.ui.ratingSystemOptions.type,
+    configuration?.ui?.ratingSystemOptions?.type,
     setRating
   );
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -190,7 +190,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   useRatingKeybinds(
     isVisible,
-    stashConfig?.ui.ratingSystemOptions.type,
+    stashConfig?.ui?.ratingSystemOptions?.type,
     setRating
   );
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -105,7 +105,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
 
   useRatingKeybinds(
     true,
-    configuration?.ui.ratingSystemOptions.type,
+    configuration?.ui?.ratingSystemOptions?.type,
     setRating
   );
 

--- a/ui/v2.5/src/hooks/keybinds.ts
+++ b/ui/v2.5/src/hooks/keybinds.ts
@@ -71,7 +71,7 @@ export function useRatingKeybinds(
         document.activeElement.blur();
       }
 
-      if (ratingSystem === RatingSystemType.Stars) {
+      if (!ratingSystem || ratingSystem === RatingSystemType.Stars) {
         return handleStarRatingKeybinds();
       } else {
         return handleDecimalKeybinds();


### PR DESCRIPTION
Fix crash when navigating to page with rating system shortcuts, and rating system has not been explicitly set in the config.