### PR TITLE
Use absolute paths when creating config file

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -586,18 +586,25 @@ func (s *Manager) Setup(ctx context.Context, input SetupInput) error {
 	// create the config directory if it does not exist
 	// don't do anything if config is already set in the environment
 	if !config.FileEnvSet() {
-		configDir := filepath.Dir(input.ConfigLocation)
+		// #3304 - if config path is relative, it breaks the ffmpeg/ffprobe
+		// paths since they must not be relative. The config file property is
+		// resolved to an absolute path when stash is run normally, so convert
+		// relative paths to absolute paths during setup.
+		configFile, _ := filepath.Abs(input.ConfigLocation)
+
+		configDir := filepath.Dir(configFile)
+
 		if exists, _ := fsutil.DirExists(configDir); !exists {
 			if err := os.Mkdir(configDir, 0755); err != nil {
 				return fmt.Errorf("error creating config directory: %v", err)
 			}
 		}
 
-		if err := fsutil.Touch(input.ConfigLocation); err != nil {
+		if err := fsutil.Touch(configFile); err != nil {
 			return fmt.Errorf("error creating config file: %v", err)
 		}
 
-		s.Config.SetConfigFile(input.ConfigLocation)
+		s.Config.SetConfigFile(configFile)
 	}
 
 	// create the generated directory if it does not exist


### PR DESCRIPTION
Fixes #3304 

During setup from the current working directory, the config directory ends up being resolved to a relative path. On subsequent runs, it is resolved to an absolute directory. This meant that ffmpeg/ffprobe could not be run correctly after initial setup because they were also resolved to relative paths. This PR changes the behaviour to convert the config path to an absolute path during setup.