### PR TITLE
Fix golangci-lint error

### DIFF
--- a/pkg/scraper/cookies.go
+++ b/pkg/scraper/cookies.go
@@ -69,7 +69,7 @@ var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123
 
 func randomSequence(n int) string {
 	b := make([]rune, n)
-	rand.Seed(time.Now().UnixNano())
+	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range b {
 		b[i] = characters[rand.Intn(len(characters))]
 	}


### PR DESCRIPTION
Fixes a lint error on the newest version of golangci-lint related to the deprecation of `rand.Seed` in Go 1.20.