### PR TITLE
Error reliably on invalid filters

### DIFF
--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -823,7 +823,9 @@ func (qb *FileStore) Query(ctx context.Context, options models.FileQueryOptions)
 	}
 	filter := qb.makeFilter(ctx, fileFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
 
 	qb.setQuerySort(&query, findFilter)
 	query.sortAndPagination += getPagination(findFilter)

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -736,7 +736,9 @@ func (qb *GalleryStore) makeQuery(ctx context.Context, galleryFilter *models.Gal
 	}
 	filter := qb.makeFilter(ctx, galleryFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
 
 	qb.setGallerySort(&query, findFilter)
 	query.sortAndPagination += getPagination(findFilter)

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -728,7 +728,9 @@ func (qb *ImageStore) makeQuery(ctx context.Context, imageFilter *models.ImageFi
 	}
 	filter := qb.makeFilter(ctx, imageFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
 
 	qb.setImageSortAndPagination(&query, findFilter)
 

--- a/pkg/sqlite/movies.go
+++ b/pkg/sqlite/movies.go
@@ -180,7 +180,9 @@ func (qb *movieQueryBuilder) Query(ctx context.Context, movieFilter *models.Movi
 
 	filter := qb.makeFilter(ctx, movieFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, 0, err
+	}
 
 	query.sortAndPagination = qb.getMovieSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult, err := query.executeFind(ctx)

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -639,7 +639,9 @@ func (qb *PerformerStore) makeQuery(ctx context.Context, performerFilter *models
 	}
 	filter := qb.makeFilter(ctx, performerFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
 
 	query.sortAndPagination = qb.getPerformerSort(findFilter) + getPagination(findFilter)
 

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -22,8 +22,6 @@ type queryBuilder struct {
 	recursiveWith bool
 
 	sortAndPagination string
-
-	err error
 }
 
 func (qb queryBuilder) body() string {
@@ -61,20 +59,11 @@ func (qb queryBuilder) findIDs(ctx context.Context) ([]int, error) {
 }
 
 func (qb queryBuilder) executeFind(ctx context.Context) ([]int, int, error) {
-	if qb.err != nil {
-		return nil, 0, qb.err
-	}
-
 	body := qb.body()
-
 	return qb.repository.executeFindQuery(ctx, body, qb.args, qb.sortAndPagination, qb.whereClauses, qb.havingClauses, qb.withClauses, qb.recursiveWith)
 }
 
 func (qb queryBuilder) executeCount(ctx context.Context) (int, error) {
-	if qb.err != nil {
-		return 0, qb.err
-	}
-
 	body := qb.body()
 
 	withClause := ""
@@ -136,11 +125,10 @@ func (qb *queryBuilder) addJoins(joins ...join) {
 	qb.joins.add(joins...)
 }
 
-func (qb *queryBuilder) addFilter(f *filterBuilder) {
+func (qb *queryBuilder) addFilter(f *filterBuilder) error {
 	err := f.getError()
 	if err != nil {
-		qb.err = err
-		return
+		return err
 	}
 
 	clause, args := f.generateWithClauses()
@@ -172,6 +160,8 @@ func (qb *queryBuilder) addFilter(f *filterBuilder) {
 	}
 
 	qb.addJoins(f.getAllJoins()...)
+
+	return nil
 }
 
 func (qb *queryBuilder) parseQueryString(columns []string, q string) {

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -990,7 +990,9 @@ func (qb *SceneStore) Query(ctx context.Context, options models.SceneQueryOption
 	}
 	filter := qb.makeFilter(ctx, sceneFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
 
 	qb.setSceneSort(&query, findFilter)
 	query.sortAndPagination += getPagination(findFilter)

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -158,7 +158,9 @@ func (qb *sceneMarkerQueryBuilder) Query(ctx context.Context, sceneMarkerFilter 
 
 	filter := qb.makeFilter(ctx, sceneMarkerFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, 0, err
+	}
 
 	query.sortAndPagination = qb.getSceneMarkerSort(&query, findFilter) + getPagination(findFilter)
 	idsResult, countResult, err := query.executeFind(ctx)

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -287,7 +287,9 @@ func (qb *studioQueryBuilder) Query(ctx context.Context, studioFilter *models.St
 	}
 	filter := qb.makeFilter(ctx, studioFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, 0, err
+	}
 
 	query.sortAndPagination = qb.getStudioSort(findFilter) + getPagination(findFilter)
 	idsResult, countResult, err := query.executeFind(ctx)

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -366,7 +366,9 @@ func (qb *tagQueryBuilder) Query(ctx context.Context, tagFilter *models.TagFilte
 	}
 	filter := qb.makeFilter(ctx, tagFilter)
 
-	query.addFilter(filter)
+	if err := query.addFilter(filter); err != nil {
+		return nil, 0, err
+	}
 
 	query.sortAndPagination = qb.getTagSort(&query, findFilter) + getPagination(findFilter)
 	idsResult, countResult, err := query.executeFind(ctx)


### PR DESCRIPTION
This fixes an issue where an invalid scene/image filter (ie an invalid regex) causes all filters to be ignored instead of returning an error. This can be easily seen by adding a scene/image regex filter for `(?>a)`, which causes all items to be returned instead of giving an error, which is what happens with the other item types.