### PR TITLE
Fix custom CSS/JS requiring force-reload

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -339,6 +339,9 @@ func serveFiles(w http.ResponseWriter, r *http.Request, name string, paths []str
 		}
 	}
 
+	// Always revalidate with server
+	w.Header().Set("Cache-Control", "no-cache")
+
 	bufferReader := bytes.NewReader(buffer.Bytes())
 	http.ServeContent(w, r, name, latestModTime, bufferReader)
 }


### PR DESCRIPTION
This is a simple fix for custom CSS/JS requiring a force-reload (ie a cache clear) to show changes.