### PR TITLE
Tagger use first available URL if no studio URL

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -707,6 +707,13 @@ func (c Client) sceneFragmentToScrapedScene(ctx context.Context, s *graphql.Scen
 		ss.Image = getFirstImage(ctx, c.getHTTPClient(), s.Images)
 	}
 
+	if ss.URL == nil && len(s.Urls) > 0 {
+		// The scene in Stash-box may not have a Studio URL but it does have another URL.
+		// For example it has a www.manyvids.com URL, which is auto set as type ManyVids.
+		// This should be re-visited once Stashapp can support more than one URL.
+		ss.URL = &s.Urls[0].URL
+	}
+
 	if err := txn.WithReadTxn(ctx, c.txnManager, func(ctx context.Context) error {
 		pqb := c.repository.Performer
 		tqb := c.repository.Tag


### PR DESCRIPTION
When tagging scenes from StashDB, if a scene has a URL, but it is not marked as the Studio URL, it will not be displayed in Stash.

This can most easily be seen with Manyvids scenes. When the scene URL is added on StashDB, it is auto set as type ManyVids, even though it is the actual URL.
This change simply assigns the first available URL if there is no Studio URL.

It addresses a Github issue on Stash-box: https://github.com/stashapp/stash-box/issues/343