### PR TITLE
Fix allTags cache reset

### DIFF
--- a/graphql/documents/queries/misc.graphql
+++ b/graphql/documents/queries/misc.graphql
@@ -6,12 +6,6 @@ query MarkerStrings($q: String, $sort: String) {
   }
 }
 
-query AllTags {
-  allTags {
-    ...TagData
-  }
-}
-
 query AllPerformersForFilter {
   allPerformers {
     ...SlimPerformerData

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -313,7 +313,6 @@ export const usePlugins = () => GQL.usePluginsQuery();
 export const usePluginTasks = () => GQL.usePluginTasksQuery();
 
 export const useMarkerStrings = () => GQL.useMarkerStringsQuery();
-export const useAllTags = () => GQL.useAllTagsQuery();
 export const useAllTagsForFilter = () => GQL.useAllTagsForFilterQuery();
 export const useAllPerformersForFilter = () =>
   GQL.useAllPerformersForFilterQuery();
@@ -408,7 +407,6 @@ const sceneMutationImpactedQueries = [
   GQL.FindMoviesDocument,
   GQL.FindTagDocument,
   GQL.FindTagsDocument,
-  GQL.AllTagsDocument,
 ];
 
 export const useSceneUpdate = () =>
@@ -562,7 +560,6 @@ const imageMutationImpactedQueries = [
   GQL.FindStudiosDocument,
   GQL.FindTagDocument,
   GQL.FindTagsDocument,
-  GQL.AllTagsDocument,
   GQL.FindGalleryDocument,
   GQL.FindGalleriesDocument,
 ];
@@ -696,7 +693,6 @@ const galleryMutationImpactedQueries = [
   GQL.FindStudiosDocument,
   GQL.FindTagDocument,
   GQL.FindTagsDocument,
-  GQL.AllTagsDocument,
   GQL.FindGalleryDocument,
   GQL.FindGalleriesDocument,
 ];
@@ -843,7 +839,6 @@ export const tagMutationImpactedQueries = [
   GQL.FindSceneDocument,
   GQL.FindScenesDocument,
   GQL.FindSceneMarkersDocument,
-  GQL.AllTagsDocument,
   GQL.AllTagsForFilterDocument,
   GQL.FindTagsDocument,
 ];
@@ -851,15 +846,10 @@ export const tagMutationImpactedQueries = [
 export const useTagCreate = () =>
   GQL.useTagCreateMutation({
     refetchQueries: getQueryNames([
-      GQL.AllTagsDocument,
       GQL.AllTagsForFilterDocument,
       GQL.FindTagsDocument,
     ]),
-    update: deleteCache([
-      GQL.FindTagsDocument,
-      GQL.AllTagsDocument,
-      GQL.AllTagsForFilterDocument,
-    ]),
+    update: deleteCache([GQL.AllTagsForFilterDocument, GQL.FindTagsDocument]),
   });
 export const useTagUpdate = () =>
   GQL.useTagUpdateMutation({


### PR DESCRIPTION
This is a quick fix to remove the `AllTags` graphql query which is unused but was causing the cache for `useAllTagsForFilter` to be invalidated on any mutation.