### PR TITLE
Minor gallery-related fixes

### DIFF
--- a/graphql/documents/data/scene-slim.graphql
+++ b/graphql/documents/data/scene-slim.graphql
@@ -46,6 +46,9 @@ fragment SlimSceneData on Scene {
     files {
       path
     }
+    folder {
+      path
+    }
     title
   }
 

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/styles.scss
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/styles.scss
@@ -32,7 +32,3 @@
     margin-right: 0.25em;
   }
 }
-
-.field-options-table td:first-child {
-  padding-left: 0.75rem;
-}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -48,6 +48,7 @@ import {
   faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import { objectTitle } from "src/core/files";
+import { galleryTitle } from "src/core/galleries";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 
 const SceneScrapeDialog = lazy(() => import("./SceneScrapeDialog"));
@@ -100,7 +101,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     setGalleries(
       scene.galleries?.map((g) => ({
         id: g.id,
-        title: objectTitle(g),
+        title: galleryTitle(g),
       })) ?? []
     );
   }, [scene.galleries]);

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -1,14 +1,13 @@
-// @ts-nocheck
-/* eslint-disable jsx-a11y/control-has-associated-label */
 import React from "react";
-import { Table, Button, Form } from "react-bootstrap";
+import { Table, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
-import { Icon } from "src/components/Shared/Icon";
 import { FormattedMessage } from "react-intl";
 import { objectTitle } from "src/core/files";
+import { galleryTitle } from "src/core/galleries";
+import SceneQueue from "src/models/sceneQueue";
 
 interface ISceneListTableProps {
   scenes: GQL.SlimSceneDataFragment[];
@@ -20,14 +19,14 @@ interface ISceneListTableProps {
 export const SceneListTable: React.FC<ISceneListTableProps> = (
   props: ISceneListTableProps
 ) => {
-  const renderTags = (tags: GQL.SlimTagDataFragment[]) =>
+  const renderTags = (tags: Partial<GQL.TagDataFragment>[]) =>
     tags.map((tag) => (
       <Link key={tag.id} to={NavUtils.makeTagScenesUrl(tag)}>
         <h6>{tag.name}</h6>
       </Link>
     ));
 
-  const renderPerformers = (performers: Partial<GQL.Performer>[]) =>
+  const renderPerformers = (performers: Partial<GQL.PerformerDataFragment>[]) =>
     performers.map((performer) => (
       <Link key={performer.id} to={NavUtils.makePerformerScenesUrl(performer)}>
         <h6>{performer.name}</h6>
@@ -35,16 +34,21 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
     ));
 
   const renderMovies = (scene: GQL.SlimSceneDataFragment) =>
-    scene.movies.map((sceneMovie) =>
-      !sceneMovie.movie ? undefined : (
-        <Link
-          key={sceneMovie.movie.id}
-          to={NavUtils.makeMovieScenesUrl(sceneMovie.movie)}
-        >
-          <h6>{sceneMovie.movie.name}</h6>
-        </Link>
-      )
-    );
+    scene.movies.map((sceneMovie) => (
+      <Link
+        key={sceneMovie.movie.id}
+        to={NavUtils.makeMovieScenesUrl(sceneMovie.movie)}
+      >
+        <h6>{sceneMovie.movie.name}</h6>
+      </Link>
+    ));
+
+  const renderGalleries = (scene: GQL.SlimSceneDataFragment) =>
+    scene.galleries.map((gallery) => (
+      <Link key={gallery.id} to={`/galleries/${gallery.id}`}>
+        <h6>{galleryTitle(gallery)}</h6>
+      </Link>
+    ));
 
   const renderSceneRow = (scene: GQL.SlimSceneDataFragment, index: number) => {
     const sceneLink = props.queue
@@ -64,7 +68,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
               type="checkbox"
               checked={props.selectedIds.has(scene.id)}
               onChange={() =>
-                props.onSelectChange!(
+                props.onSelectChange(
                   scene.id,
                   !props.selectedIds.has(scene.id),
                   shiftKey
@@ -106,15 +110,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
           )}
         </td>
         <td>{renderMovies(scene)}</td>
-        <td>
-          {scene.gallery && (
-            <Button className="minimal">
-              <Link to={`/galleries/${scene.gallery.id}`}>
-                <Icon icon={faImage} />
-              </Link>
-            </Button>
-          )}
-        </td>
+        <td>{renderGalleries(scene)}</td>
       </tr>
     );
   };
@@ -148,7 +144,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
               <FormattedMessage id="movies" />
             </th>
             <th>
-              <FormattedMessage id="gallery" />
+              <FormattedMessage id="galleries" />
             </th>
           </tr>
         </thead>

--- a/ui/v2.5/src/styles/_theme.scss
+++ b/ui/v2.5/src/styles/_theme.scss
@@ -126,14 +126,6 @@ hr {
     border: none;
     border-color: #414c53;
     padding: 0.25rem 0.75rem;
-
-    &:first-child {
-      padding-left: 0;
-    }
-
-    &:last-child {
-      padding-right: 0;
-    }
   }
 }
 


### PR DESCRIPTION
These are fixes for some minor gallery-related bugs that I came across:

- Gallery icons on scene cards in scene lists have blank tooltips if the gallery is unnamed and is a non-zip gallery
- Gallery items on the scene edit page have no title if the gallery is unnamed and is a non-zip gallery
- The gallery column in the scene list table doesn't actually show anything

I've also changed the padding around tables as items were being cut off (this is easily visible on the performer list).
