### PR TITLE
add missing brew packages to build instructions

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,7 @@ NOTE: The `make` command in Windows will be `mingw32-make` with MingW. For examp
 ### macOS
 
 1. If you don't have it already, install the [Homebrew package manager](https://brew.sh).
-2. Install dependencies: `brew install go git yarn gcc make`
+2. Install dependencies: `brew install go git yarn gcc make node ffmpeg`
 
 ## Commands
 


### PR DESCRIPTION
I noticed that these dependencies are missing when building in a fresh environment.