### PR TITLE
Fix filter hooks

### DIFF
--- a/ui/v2.5/src/core/performers.ts
+++ b/ui/v2.5/src/core/performers.ts
@@ -15,25 +15,29 @@ export const usePerformerFilterHook = (
       return c.criterionOption.type === "performers";
     }) as PerformersCriterion;
 
-    if (
-      performerCriterion &&
-      (performerCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
-        performerCriterion.modifier === GQL.CriterionModifier.Includes)
-    ) {
-      // add the performer if not present
+    if (performerCriterion) {
       if (
-        !performerCriterion.value.find((p) => {
-          return p.id === performer.id;
-        })
+        performerCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
+        performerCriterion.modifier === GQL.CriterionModifier.Includes
       ) {
-        performerCriterion.value.push(performerValue);
+        // add the performer if not present
+        if (
+          !performerCriterion.value.find((p) => {
+            return p.id === performer.id;
+          })
+        ) {
+          performerCriterion.value.push(performerValue);
+        }
+      } else {
+        // overwrite
+        performerCriterion.value = [performerValue];
       }
 
       performerCriterion.modifier = GQL.CriterionModifier.IncludesAll;
     } else {
-      // overwrite
       performerCriterion = new PerformersCriterion();
       performerCriterion.value = [performerValue];
+      performerCriterion.modifier = GQL.CriterionModifier.IncludesAll;
       filter.criteria.push(performerCriterion);
     }
 

--- a/ui/v2.5/src/core/studios.ts
+++ b/ui/v2.5/src/core/studios.ts
@@ -14,21 +14,11 @@ export const useStudioFilterHook = (studio: GQL.StudioDataFragment) => {
       return c.criterionOption.type === "studios";
     }) as StudiosCriterion;
 
-    if (
-      studioCriterion &&
-      (studioCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
-        studioCriterion.modifier === GQL.CriterionModifier.Includes)
-    ) {
+    if (studioCriterion) {
       // we should be showing studio only. Remove other values
-      studioCriterion.value.items = studioCriterion.value.items.filter(
-        (v) => v.id === studio.id
-      );
-
-      if (studioCriterion.value.items.length === 0) {
-        studioCriterion.value.items.push(studioValue);
-      }
+      studioCriterion.value.items = [studioValue];
+      studioCriterion.modifier = GQL.CriterionModifier.Includes;
     } else {
-      // overwrite
       studioCriterion = new StudiosCriterion();
       studioCriterion.value = {
         items: [studioValue],
@@ -36,6 +26,7 @@ export const useStudioFilterHook = (studio: GQL.StudioDataFragment) => {
           ? -1
           : 0,
       };
+      studioCriterion.modifier = GQL.CriterionModifier.Includes;
       filter.criteria.push(studioCriterion);
     }
 

--- a/ui/v2.5/src/core/tags.ts
+++ b/ui/v2.5/src/core/tags.ts
@@ -19,23 +19,26 @@ export const useTagFilterHook = (tag: GQL.TagDataFragment) => {
       return c.criterionOption.type === "tags";
     }) as TagsCriterion;
 
-    if (
-      tagCriterion &&
-      (tagCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
-        tagCriterion.modifier === GQL.CriterionModifier.Includes)
-    ) {
-      // add the tag if not present
+    if (tagCriterion) {
       if (
-        !tagCriterion.value.items.find((p) => {
-          return p.id === tag.id;
-        })
+        tagCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
+        tagCriterion.modifier === GQL.CriterionModifier.Includes
       ) {
-        tagCriterion.value.items.push(tagValue);
+        // add the tag if not present
+        if (
+          !tagCriterion.value.items.find((p) => {
+            return p.id === tag.id;
+          })
+        ) {
+          tagCriterion.value.items.push(tagValue);
+        }
+      } else {
+        // overwrite
+        tagCriterion.value.items = [tagValue];
       }
 
       tagCriterion.modifier = GQL.CriterionModifier.IncludesAll;
     } else {
-      // overwrite
       tagCriterion = new TagsCriterion(TagsCriterionOption);
       tagCriterion.value = {
         items: [tagValue],
@@ -43,6 +46,7 @@ export const useTagFilterHook = (tag: GQL.TagDataFragment) => {
           ? -1
           : 0,
       };
+      tagCriterion.modifier = GQL.CriterionModifier.IncludesAll;
       filter.criteria.push(tagCriterion);
     }
 


### PR DESCRIPTION
Currently, if you go to a tag scenes page and select a saved filter that has a saved 'excludes/is null/is not null' tag filter option then an additional tag filter option (the 'includes all' filter for the tag page itself) will be created. This additional tag can also be created when modifying the automatically created 'includes all' filter to be a 'excludes/is null/is not null' filter.

This is misleading because multiple filters are currently unsupported so the results will only take one of the filters into account, with the others being ignored. This bug also shows up in the performer and studio pages.

The default filter related to the page itself should take precedence over user-specified filters. This therefore modifies the performer, studio and tag filter hooks to do stricter processing for their respective filters, preventing multiple filters from being created.