### PR TITLE
Fix custom transcode arguments

### DIFF
--- a/pkg/ffmpeg/stream.go
+++ b/pkg/ffmpeg/stream.go
@@ -37,6 +37,8 @@ type StreamManager struct {
 
 type StreamManagerConfig interface {
 	GetMaxStreamingTranscodeSize() models.StreamingResolutionEnum
+	GetLiveTranscodeInputArgs() []string
+	GetLiveTranscodeOutputArgs() []string
 }
 
 func NewStreamManager(cacheDir string, encoder FFMpeg, ffprobe FFProbe, config StreamManagerConfig, lockManager *fsutil.ReadLockManager) *StreamManager {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -287,7 +287,7 @@
         },
         "live_transcode": {
           "input_args": {
-            "heading": "FFmpeg LiveTranscode Input Args",
+            "heading": "FFmpeg Live Transcode Input Args",
             "desc": "Advanced: Additional arguments to pass to ffmpeg before the input field when live transcoding video."
           },
           "output_args": {


### PR DESCRIPTION
Adds back the custom transcode arguments feature which was inadvertently removed as part of the HLS overhaul. Also fixes a related UI string.