### PR TITLE
Improve dynamic import error message

### DIFF
--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -31,32 +31,32 @@ import { ReleaseNotesDialog } from "./components/Dialogs/ReleaseNotesDialog";
 import { IUIConfig } from "./core/config";
 import { releaseNotes } from "./docs/en/ReleaseNotes";
 import { getPlatformURL, getBaseURL } from "./core/createClient";
-import { lazy_component } from "./utils/lazy_component";
+import { lazyComponent } from "./utils/lazyComponent";
 
-const Performers = lazy_component(
+const Performers = lazyComponent(
   () => import("./components/Performers/Performers")
 );
-const FrontPage = lazy_component(
+const FrontPage = lazyComponent(
   () => import("./components/FrontPage/FrontPage")
 );
-const Scenes = lazy_component(() => import("./components/Scenes/Scenes"));
-const Settings = lazy_component(() => import("./components/Settings/Settings"));
-const Stats = lazy_component(() => import("./components/Stats"));
-const Studios = lazy_component(() => import("./components/Studios/Studios"));
-const Galleries = lazy_component(
+const Scenes = lazyComponent(() => import("./components/Scenes/Scenes"));
+const Settings = lazyComponent(() => import("./components/Settings/Settings"));
+const Stats = lazyComponent(() => import("./components/Stats"));
+const Studios = lazyComponent(() => import("./components/Studios/Studios"));
+const Galleries = lazyComponent(
   () => import("./components/Galleries/Galleries")
 );
 
-const Movies = lazy_component(() => import("./components/Movies/Movies"));
-const Tags = lazy_component(() => import("./components/Tags/Tags"));
-const Images = lazy_component(() => import("./components/Images/Images"));
-const Setup = lazy_component(() => import("./components/Setup/Setup"));
-const Migrate = lazy_component(() => import("./components/Setup/Migrate"));
+const Movies = lazyComponent(() => import("./components/Movies/Movies"));
+const Tags = lazyComponent(() => import("./components/Tags/Tags"));
+const Images = lazyComponent(() => import("./components/Images/Images"));
+const Setup = lazyComponent(() => import("./components/Setup/Setup"));
+const Migrate = lazyComponent(() => import("./components/Setup/Migrate"));
 
-const SceneFilenameParser = lazy_component(
+const SceneFilenameParser = lazyComponent(
   () => import("./components/SceneFilenameParser/SceneFilenameParser")
 );
-const SceneDuplicateChecker = lazy_component(
+const SceneDuplicateChecker = lazyComponent(
   () => import("./components/SceneDuplicateChecker/SceneDuplicateChecker")
 );
 

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 import { Route, Switch, useRouteMatch } from "react-router-dom";
 import { IntlProvider, CustomFormats } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -31,25 +31,32 @@ import { ReleaseNotesDialog } from "./components/Dialogs/ReleaseNotesDialog";
 import { IUIConfig } from "./core/config";
 import { releaseNotes } from "./docs/en/ReleaseNotes";
 import { getPlatformURL, getBaseURL } from "./core/createClient";
+import { lazy_component } from "./utils/lazy_component";
 
-const Performers = lazy(() => import("./components/Performers/Performers"));
-const FrontPage = lazy(() => import("./components/FrontPage/FrontPage"));
-const Scenes = lazy(() => import("./components/Scenes/Scenes"));
-const Settings = lazy(() => import("./components/Settings/Settings"));
-const Stats = lazy(() => import("./components/Stats"));
-const Studios = lazy(() => import("./components/Studios/Studios"));
-const Galleries = lazy(() => import("./components/Galleries/Galleries"));
+const Performers = lazy_component(
+  () => import("./components/Performers/Performers")
+);
+const FrontPage = lazy_component(
+  () => import("./components/FrontPage/FrontPage")
+);
+const Scenes = lazy_component(() => import("./components/Scenes/Scenes"));
+const Settings = lazy_component(() => import("./components/Settings/Settings"));
+const Stats = lazy_component(() => import("./components/Stats"));
+const Studios = lazy_component(() => import("./components/Studios/Studios"));
+const Galleries = lazy_component(
+  () => import("./components/Galleries/Galleries")
+);
 
-const Movies = lazy(() => import("./components/Movies/Movies"));
-const Tags = lazy(() => import("./components/Tags/Tags"));
-const Images = lazy(() => import("./components/Images/Images"));
-const Setup = lazy(() => import("./components/Setup/Setup"));
-const Migrate = lazy(() => import("./components/Setup/Migrate"));
+const Movies = lazy_component(() => import("./components/Movies/Movies"));
+const Tags = lazy_component(() => import("./components/Tags/Tags"));
+const Images = lazy_component(() => import("./components/Images/Images"));
+const Setup = lazy_component(() => import("./components/Setup/Setup"));
+const Migrate = lazy_component(() => import("./components/Setup/Migrate"));
 
-const SceneFilenameParser = lazy(
+const SceneFilenameParser = lazy_component(
   () => import("./components/SceneFilenameParser/SceneFilenameParser")
 );
-const SceneDuplicateChecker = lazy(
+const SceneDuplicateChecker = lazy_component(
   () => import("./components/SceneDuplicateChecker/SceneDuplicateChecker")
 );
 

--- a/ui/v2.5/src/components/ErrorBoundary.tsx
+++ b/ui/v2.5/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { is_lazy_component_error } from "src/utils/lazy_component";
 
 interface IErrorBoundaryProps {
   children?: React.ReactNode;
@@ -10,6 +11,7 @@ type ErrorInfo = {
 
 interface IErrorBoundaryState {
   error?: Error;
+  errorHelp?: string;
   errorInfo?: ErrorInfo;
 }
 
@@ -23,22 +25,30 @@ export class ErrorBoundary extends React.Component<
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    let errorHelp: string | undefined;
+    if (is_lazy_component_error(error)) {
+      errorHelp =
+        "If you recently upgraded Stash, please reload the page or clear your browser cache.";
+    }
     this.setState({
       error,
+      errorHelp,
       errorInfo,
     });
   }
 
   public render() {
-    if (this.state.errorInfo) {
+    const { error, errorHelp, errorInfo } = this.state;
+    if (errorInfo) {
       // Error path
       return (
         <div>
           <h2>Something went wrong.</h2>
+          {errorHelp && <h5>{errorHelp}</h5>}
           <details className="error-message">
-            {this.state.error && this.state.error.toString()}
+            {error?.toString()}
             <br />
-            {this.state.errorInfo.componentStack}
+            {errorInfo.componentStack.trim().replaceAll(/^\s*/gm, "    ")}
           </details>
         </div>
       );

--- a/ui/v2.5/src/components/ErrorBoundary.tsx
+++ b/ui/v2.5/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FormattedMessage } from "react-intl";
 import { isLazyComponentError } from "src/utils/lazyComponent";
 
 interface IErrorBoundaryProps {
@@ -11,7 +12,7 @@ type ErrorInfo = {
 
 interface IErrorBoundaryState {
   error?: Error;
-  errorHelp?: string;
+  errorHelpId?: string;
   errorInfo?: ErrorInfo;
 }
 
@@ -25,26 +26,31 @@ export class ErrorBoundary extends React.Component<
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    let errorHelp: string | undefined;
+    let errorHelpId: string | undefined;
     if (isLazyComponentError(error)) {
-      errorHelp =
-        "If you recently upgraded Stash, please reload the page or clear your browser cache.";
+      errorHelpId = "errors.lazy_component_error_help";
     }
     this.setState({
       error,
-      errorHelp,
+      errorHelpId,
       errorInfo,
     });
   }
 
   public render() {
-    const { error, errorHelp, errorInfo } = this.state;
+    const { error, errorHelpId, errorInfo } = this.state;
     if (errorInfo) {
       // Error path
       return (
         <div>
-          <h2>Something went wrong.</h2>
-          {errorHelp && <h5>{errorHelp}</h5>}
+          <h2>
+            <FormattedMessage id="errors.something_went_wrong" />
+          </h2>
+          {errorHelpId && (
+            <h5>
+              <FormattedMessage id={errorHelpId} />
+            </h5>
+          )}
           <details className="error-message">
             {error?.toString()}
             <br />

--- a/ui/v2.5/src/components/ErrorBoundary.tsx
+++ b/ui/v2.5/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { is_lazy_component_error } from "src/utils/lazy_component";
+import { isLazyComponentError } from "src/utils/lazyComponent";
 
 interface IErrorBoundaryProps {
   children?: React.ReactNode;
@@ -26,7 +26,7 @@ export class ErrorBoundary extends React.Component<
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     let errorHelp: string | undefined;
-    if (is_lazy_component_error(error)) {
+    if (isLazyComponentError(error)) {
       errorHelp =
         "If you recently upgraded Stash, please reload the page or clear your browser cache.";
     }

--- a/ui/v2.5/src/components/Help/context.tsx
+++ b/ui/v2.5/src/components/Help/context.tsx
@@ -1,6 +1,7 @@
-import React, { lazy, Suspense, useState } from "react";
+import React, { Suspense, useState } from "react";
+import { lazy_component } from "src/utils/lazy_component";
 
-const Manual = lazy(() => import("./Manual"));
+const Manual = lazy_component(() => import("./Manual"));
 
 interface IManualContextState {
   openManual: (tab?: string) => void;

--- a/ui/v2.5/src/components/Help/context.tsx
+++ b/ui/v2.5/src/components/Help/context.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useState } from "react";
-import { lazy_component } from "src/utils/lazy_component";
+import { lazyComponent } from "src/utils/lazyComponent";
 
-const Manual = lazy_component(() => import("./Manual"));
+const Manual = lazyComponent(() => import("./Manual"));
 
 interface IManualContextState {
   openManual: (tab?: string) => void;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -29,38 +29,36 @@ import { OrganizedButton } from "./OrganizedButton";
 import { ConfigurationContext } from "src/hooks/Config";
 import { getPlayerPosition } from "src/components/ScenePlayer/util";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
-import { lazy_component } from "src/utils/lazy_component";
+import { lazyComponent } from "src/utils/lazyComponent";
 
-const SubmitStashBoxDraft = lazy_component(
+const SubmitStashBoxDraft = lazyComponent(
   () => import("src/components/Dialogs/SubmitDraft")
 );
-const ScenePlayer = lazy_component(
+const ScenePlayer = lazyComponent(
   () => import("src/components/ScenePlayer/ScenePlayer")
 );
 
-const GalleryViewer = lazy_component(
+const GalleryViewer = lazyComponent(
   () => import("src/components/Galleries/GalleryViewer")
 );
-const ExternalPlayerButton = lazy_component(
+const ExternalPlayerButton = lazyComponent(
   () => import("./ExternalPlayerButton")
 );
 
-const QueueViewer = lazy_component(() => import("./QueueViewer"));
-const SceneMarkersPanel = lazy_component(() => import("./SceneMarkersPanel"));
-const SceneFileInfoPanel = lazy_component(() => import("./SceneFileInfoPanel"));
-const SceneEditPanel = lazy_component(() => import("./SceneEditPanel"));
-const SceneDetailPanel = lazy_component(() => import("./SceneDetailPanel"));
-const SceneMoviePanel = lazy_component(() => import("./SceneMoviePanel"));
-const SceneGalleriesPanel = lazy_component(
+const QueueViewer = lazyComponent(() => import("./QueueViewer"));
+const SceneMarkersPanel = lazyComponent(() => import("./SceneMarkersPanel"));
+const SceneFileInfoPanel = lazyComponent(() => import("./SceneFileInfoPanel"));
+const SceneEditPanel = lazyComponent(() => import("./SceneEditPanel"));
+const SceneDetailPanel = lazyComponent(() => import("./SceneDetailPanel"));
+const SceneMoviePanel = lazyComponent(() => import("./SceneMoviePanel"));
+const SceneGalleriesPanel = lazyComponent(
   () => import("./SceneGalleriesPanel")
 );
-const DeleteScenesDialog = lazy_component(
-  () => import("../DeleteScenesDialog")
-);
-const GenerateDialog = lazy_component(
+const DeleteScenesDialog = lazyComponent(() => import("../DeleteScenesDialog"));
+const GenerateDialog = lazyComponent(
   () => import("../../Dialogs/GenerateDialog")
 );
-const SceneVideoFilterPanel = lazy_component(
+const SceneVideoFilterPanel = lazyComponent(
   () => import("./SceneVideoFilterPanel")
 );
 import { objectPath, objectTitle } from "src/core/files";

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -1,12 +1,5 @@
 import { Tab, Nav, Dropdown, Button, ButtonGroup } from "react-bootstrap";
-import React, {
-  useEffect,
-  useState,
-  useMemo,
-  useContext,
-  lazy,
-  useRef,
-} from "react";
+import React, { useEffect, useState, useMemo, useContext, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useParams, useLocation, useHistory, Link } from "react-router-dom";
 import { Helmet } from "react-helmet";
@@ -36,29 +29,40 @@ import { OrganizedButton } from "./OrganizedButton";
 import { ConfigurationContext } from "src/hooks/Config";
 import { getPlayerPosition } from "src/components/ScenePlayer/util";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
+import { lazy_component } from "src/utils/lazy_component";
 
-const SubmitStashBoxDraft = lazy(
+const SubmitStashBoxDraft = lazy_component(
   () => import("src/components/Dialogs/SubmitDraft")
 );
-const ScenePlayer = lazy(
+const ScenePlayer = lazy_component(
   () => import("src/components/ScenePlayer/ScenePlayer")
 );
 
-const GalleryViewer = lazy(
+const GalleryViewer = lazy_component(
   () => import("src/components/Galleries/GalleryViewer")
 );
-const ExternalPlayerButton = lazy(() => import("./ExternalPlayerButton"));
+const ExternalPlayerButton = lazy_component(
+  () => import("./ExternalPlayerButton")
+);
 
-const QueueViewer = lazy(() => import("./QueueViewer"));
-const SceneMarkersPanel = lazy(() => import("./SceneMarkersPanel"));
-const SceneFileInfoPanel = lazy(() => import("./SceneFileInfoPanel"));
-const SceneEditPanel = lazy(() => import("./SceneEditPanel"));
-const SceneDetailPanel = lazy(() => import("./SceneDetailPanel"));
-const SceneMoviePanel = lazy(() => import("./SceneMoviePanel"));
-const SceneGalleriesPanel = lazy(() => import("./SceneGalleriesPanel"));
-const DeleteScenesDialog = lazy(() => import("../DeleteScenesDialog"));
-const GenerateDialog = lazy(() => import("../../Dialogs/GenerateDialog"));
-const SceneVideoFilterPanel = lazy(() => import("./SceneVideoFilterPanel"));
+const QueueViewer = lazy_component(() => import("./QueueViewer"));
+const SceneMarkersPanel = lazy_component(() => import("./SceneMarkersPanel"));
+const SceneFileInfoPanel = lazy_component(() => import("./SceneFileInfoPanel"));
+const SceneEditPanel = lazy_component(() => import("./SceneEditPanel"));
+const SceneDetailPanel = lazy_component(() => import("./SceneDetailPanel"));
+const SceneMoviePanel = lazy_component(() => import("./SceneMoviePanel"));
+const SceneGalleriesPanel = lazy_component(
+  () => import("./SceneGalleriesPanel")
+);
+const DeleteScenesDialog = lazy_component(
+  () => import("../DeleteScenesDialog")
+);
+const GenerateDialog = lazy_component(
+  () => import("../../Dialogs/GenerateDialog")
+);
+const SceneVideoFilterPanel = lazy_component(
+  () => import("./SceneVideoFilterPanel")
+);
 import { objectPath, objectTitle } from "src/core/files";
 
 interface IProps {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -50,10 +50,10 @@ import {
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import { useRatingKeybinds } from "src/hooks/keybinds";
-import { lazy_component } from "src/utils/lazy_component";
+import { lazyComponent } from "src/utils/lazyComponent";
 
-const SceneScrapeDialog = lazy_component(() => import("./SceneScrapeDialog"));
-const SceneQueryModal = lazy_component(() => import("./SceneQueryModal"));
+const SceneScrapeDialog = lazyComponent(() => import("./SceneScrapeDialog"));
+const SceneQueryModal = lazyComponent(() => import("./SceneQueryModal"));
 
 interface IProps {
   scene: Partial<GQL.SceneDataFragment>;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, lazy } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   Button,
@@ -50,9 +50,10 @@ import {
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import { lazy_component } from "src/utils/lazy_component";
 
-const SceneScrapeDialog = lazy(() => import("./SceneScrapeDialog"));
-const SceneQueryModal = lazy(() => import("./SceneQueryModal"));
+const SceneScrapeDialog = lazy_component(() => import("./SceneScrapeDialog"));
+const SceneQueryModal = lazy_component(() => import("./SceneQueryModal"));
 
 interface IProps {
   scene: Partial<GQL.SceneDataFragment>;

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -4,12 +4,12 @@ import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
 import { TITLE_SUFFIX } from "src/components/Shared/constants";
 import { PersistanceLevel } from "src/hooks/ListHook";
-import { lazy_component } from "src/utils/lazy_component";
+import { lazyComponent } from "src/utils/lazyComponent";
 
-const SceneList = lazy_component(() => import("./SceneList"));
-const SceneMarkerList = lazy_component(() => import("./SceneMarkerList"));
-const Scene = lazy_component(() => import("./SceneDetails/Scene"));
-const SceneCreate = lazy_component(() => import("./SceneDetails/SceneCreate"));
+const SceneList = lazyComponent(() => import("./SceneList"));
+const SceneMarkerList = lazyComponent(() => import("./SceneMarkerList"));
+const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
+const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));
 
 const Scenes: React.FC = () => {
   const intl = useIntl();

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -1,14 +1,15 @@
-import React, { lazy } from "react";
+import React from "react";
 import { Route, Switch } from "react-router-dom";
 import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
 import { TITLE_SUFFIX } from "src/components/Shared/constants";
 import { PersistanceLevel } from "src/hooks/ListHook";
+import { lazy_component } from "src/utils/lazy_component";
 
-const SceneList = lazy(() => import("./SceneList"));
-const SceneMarkerList = lazy(() => import("./SceneMarkerList"));
-const Scene = lazy(() => import("./SceneDetails/Scene"));
-const SceneCreate = lazy(() => import("./SceneDetails/SceneCreate"));
+const SceneList = lazy_component(() => import("./SceneList"));
+const SceneMarkerList = lazy_component(() => import("./SceneMarkerList"));
+const Scene = lazy_component(() => import("./SceneDetails/Scene"));
+const SceneCreate = lazy_component(() => import("./SceneDetails/SceneCreate"));
 
 const Scenes: React.FC = () => {
   const intl = useIntl();

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -1,8 +1,8 @@
 import React, { Suspense, useCallback, useState } from "react";
-import { lazy_component } from "src/utils/lazy_component";
+import { lazyComponent } from "src/utils/lazyComponent";
 import { ILightboxImage } from "./types";
 
-const LightboxComponent = lazy_component(() => import("./Lightbox"));
+const LightboxComponent = lazyComponent(() => import("./Lightbox"));
 
 export interface IState {
   images: ILightboxImage[];

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -1,7 +1,8 @@
-import React, { lazy, Suspense, useCallback, useState } from "react";
+import React, { Suspense, useCallback, useState } from "react";
+import { lazy_component } from "src/utils/lazy_component";
 import { ILightboxImage } from "./types";
 
-const LightboxComponent = lazy(() => import("./Lightbox"));
+const LightboxComponent = lazy_component(() => import("./Lightbox"));
 
 export interface IState {
   images: ILightboxImage[];

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -739,7 +739,7 @@ div.dropdown-menu {
 }
 
 .error-message {
-  white-space: "pre-wrap";
+  white-space: pre-wrap;
 }
 
 .btn-toolbar .form-control {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -840,6 +840,10 @@
     "warmth": "Warmth"
   },
   "empty_server": "Add some scenes to your server to view recommendations on this page.",
+  "errors": {
+    "something_went_wrong": "Something went wrong.",
+    "lazy_component_error_help": "If you recently upgraded Stash, please reload the page or clear your browser cache."
+  },
   "ethnicity": "Ethnicity",
   "existing_value": "existing value",
   "eye_color": "Eye Colour",

--- a/ui/v2.5/src/utils/lazyComponent.ts
+++ b/ui/v2.5/src/utils/lazyComponent.ts
@@ -1,15 +1,15 @@
 import { ComponentType, lazy } from "react";
 
 interface ILazyComponentError {
-  __lazy_component_error?: true;
+  __lazyComponentError?: true;
 }
 
-export const is_lazy_component_error = (e: unknown) => {
-  return !!(e as ILazyComponentError).__lazy_component_error;
+export const isLazyComponentError = (e: unknown) => {
+  return !!(e as ILazyComponentError).__lazyComponentError;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const lazy_component = <T extends ComponentType<any>>(
+export const lazyComponent = <T extends ComponentType<any>>(
   factory: Parameters<typeof lazy<T>>[0]
 ) => {
   return lazy<T>(async () => {
@@ -17,7 +17,7 @@ export const lazy_component = <T extends ComponentType<any>>(
       return await factory();
     } catch (e) {
       // set flag to identify lazy component loading errors
-      (e as ILazyComponentError).__lazy_component_error = true;
+      (e as ILazyComponentError).__lazyComponentError = true;
       throw e;
     }
   });

--- a/ui/v2.5/src/utils/lazy_component.ts
+++ b/ui/v2.5/src/utils/lazy_component.ts
@@ -1,0 +1,24 @@
+import { ComponentType, lazy } from "react";
+
+interface ILazyComponentError {
+  __lazy_component_error?: true;
+}
+
+export const is_lazy_component_error = (e: unknown) => {
+  return !!(e as ILazyComponentError).__lazy_component_error;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const lazy_component = <T extends ComponentType<any>>(
+  factory: Parameters<typeof lazy<T>>[0]
+) => {
+  return lazy<T>(async () => {
+    try {
+      return await factory();
+    } catch (e) {
+      // set flag to identify lazy component loading errors
+      (e as ILazyComponentError).__lazy_component_error = true;
+      throw e;
+    }
+  });
+};


### PR DESCRIPTION
This is an improvement to the `ErrorBoundary` component, specifically to the handling of dynamic import errors for lazy-loaded components. I've seen so many questions or bug reports related to this error after a stash upgrade, so this simply adds a message on the error page to prompt the user to reload or clear the browser cache.
I've also added a minor tweak to display the component trace more nicely on Firefox.