### PR TITLE
add divider on more details pages

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -281,11 +281,14 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
     Mousetrap.bind("a", () => setActiveTabKey("gallery-details-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("gallery-edit-panel"));
     Mousetrap.bind("f", () => setActiveTabKey("gallery-file-info-panel"));
+    Mousetrap.bind(",", () => setCollapsed(!collapsed));
+
 
     return () => {
       Mousetrap.unbind("a");
       Mousetrap.unbind("e");
       Mousetrap.unbind("f");
+      Mousetrap.unbind(",");
     };
   });
 

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -283,7 +283,6 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
     Mousetrap.bind("f", () => setActiveTabKey("gallery-file-info-panel"));
     Mousetrap.bind(",", () => setCollapsed(!collapsed));
 
-
     return () => {
       Mousetrap.unbind("a");
       Mousetrap.unbind("e");

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -49,6 +49,8 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const intl = useIntl();
   const { tab = "details" } = useParams<IPerformerParams>();
 
+  const [collapsed, setCollapsed] = useState(false);
+
   // Configuration settings
   const { configuration } = React.useContext(ConfigurationContext);
   const abbreviateCounter =
@@ -386,13 +388,21 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       />
     );
 
+  function getCollapseButtonText() {
+    return collapsed ? ">" : "<";
+  }
+
   return (
     <div id="performer-page" className="row">
       <Helmet>
         <title>{performer.name}</title>
       </Helmet>
 
-      <div className="performer-image-container col-md-4 text-center">
+      <div
+        className={`performer-image-container col-md-4 text-center ${
+          collapsed ? "collapsed" : ""
+        }`}
+      >
         {imageEncoding ? (
           <LoadingIndicator message="Encoding image..." />
         ) : (
@@ -405,7 +415,12 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
           </Button>
         )}
       </div>
-      <div className="col-md-8">
+      <div className="col-divider d-none d-xl-block">
+        <Button onClick={() => setCollapsed(!collapsed)}>
+          {getCollapseButtonText()}
+        </Button>
+      </div>
+      <div className={`col-md-8 ${collapsed ? "expanded" : ""}`}>
         <div className="row">
           <div className="performer-head col">
             <h2>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -395,7 +395,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       </Helmet>
 
       <div
-        className={`performer-image-container col-md-4 text-center col-md-4 text-center ${
+        className={`performer-image-container details-tab text-center text-center ${
           collapsed ? "collapsed" : ""
         }`}
       >
@@ -411,12 +411,12 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
           </Button>
         )}
       </div>
-      <div className="col-divider d-none d-xl-block">
+      <div className="details-divider d-none d-xl-block">
         <Button onClick={() => setCollapsed(!collapsed)}>
           {getCollapseButtonText()}
         </Button>
       </div>
-      <div className={`col-md-8 ${collapsed ? "expanded" : ""}`}>
+      <div className={`content-container ${collapsed ? "expanded" : ""}`}>
         <div className="row">
           <div className="performer-head col">
             <h2>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -118,6 +118,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     Mousetrap.bind("g", () => setActiveTabKey("galleries"));
     Mousetrap.bind("m", () => setActiveTabKey("movies"));
     Mousetrap.bind("f", () => setFavorite(!performer.favorite));
+    Mousetrap.bind(",", () => setCollapsed(!collapsed));
 
     return () => {
       Mousetrap.unbind("a");
@@ -125,6 +126,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       Mousetrap.unbind("c");
       Mousetrap.unbind("f");
       Mousetrap.unbind("o");
+      Mousetrap.unbind(",");
     };
   });
 
@@ -410,11 +412,6 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         )}
       </div>
       <div className="col-divider d-none d-xl-block">
-        <Button onClick={() => setCollapsed(!collapsed)}>
-          {getCollapseButtonText()}
-        </Button>
-      </div>
-      <div className={`col-md-8 ${collapsed ? "expanded" : ""}`}>
         <Button onClick={() => setCollapsed(!collapsed)}>
           {getCollapseButtonText()}
         </Button>

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Tab } from "react-bootstrap";
+import { Button, Tabs, Tab } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -44,6 +44,8 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const Toast = useToast();
   const intl = useIntl();
   const { tab = "details" } = useParams<IStudioParams>();
+
+  const [collapsed, setCollapsed] = useState(false);
 
   // Configuration settings
   const { configuration } = React.useContext(ConfigurationContext);
@@ -177,9 +179,15 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     }
   };
 
+  function getCollapseButtonText() {
+    return collapsed ? ">" : "<";
+  }
+
   return (
     <div className="row">
-      <div className="studio-details col-md-4">
+      <div
+        className={`studio-details col-md-4 ${collapsed ? "collapsed" : ""}`}
+      >
         <div className="text-center">
           {imageEncoding ? (
             <LoadingIndicator message="Encoding image..." />
@@ -217,7 +225,12 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           />
         )}
       </div>
-      <div className="col col-md-8">
+      <div className="col-divider d-none d-xl-block">
+        <Button onClick={() => setCollapsed(!collapsed)}>
+          {getCollapseButtonText()}
+        </Button>
+      </div>
+      <div className={`col col-md-8 ${collapsed ? "expanded" : ""}`}>
         <Tabs
           id="studio-tabs"
           mountOnEnter

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -185,7 +185,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   return (
     <div className="row">
       <div
-        className={`studio-details col-md-4 ${collapsed ? "collapsed" : ""}`}
+        className={`studio-details details-tab ${collapsed ? "collapsed" : ""}`}
       >
         <div className="text-center">
           {encodingImage ? (
@@ -225,12 +225,12 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           />
         )}
       </div>
-      <div className="col-divider d-none d-xl-block">
+      <div className="details-divider d-none d-xl-block">
         <Button onClick={() => setCollapsed(!collapsed)}>
           {getCollapseButtonText()}
         </Button>
       </div>
-      <div className={`col col-md-8 ${collapsed ? "expanded" : ""}`}>
+      <div className={`col content-container ${collapsed ? "expanded" : ""}`}>
         <Tabs
           id="studio-tabs"
           mountOnEnter

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -68,10 +68,12 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     Mousetrap.bind("d d", () => {
       onDelete();
     });
+    Mousetrap.bind(",", () => setCollapsed(!collapsed));
 
     return () => {
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
+      Mousetrap.unbind(",");
     };
   });
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -90,6 +90,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
     Mousetrap.bind("d d", () => {
       onDelete();
     });
+    Mousetrap.bind(",", () => setCollapsed(!collapsed));
 
     return () => {
       if (isEditing) {
@@ -98,6 +99,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
 
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
+      Mousetrap.unbind(",");
     };
   });
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -313,10 +313,10 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
           )}
         </div>
         <div className="col-divider d-none d-xl-block">
-        <Button onClick={() => setCollapsed(!collapsed)}>
-          {getCollapseButtonText()}
-        </Button>
-      </div>
+          <Button onClick={() => setCollapsed(!collapsed)}>
+            {getCollapseButtonText()}
+          </Button>
+        </div>
         <div className={`col col-md-8 ${collapsed ? "expanded" : ""}`}>
           <Tabs
             id="tag-tabs"

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -259,7 +259,9 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
         <title>{tag.name}</title>
       </Helmet>
       <div className="row">
-        <div className={`tag-details col-md-4 ${collapsed ? "collapsed" : ""}`}>
+        <div
+          className={`tag-details details-tab ${collapsed ? "collapsed" : ""}`}
+        >
           <div className="text-center logo-container">
             {encodingImage ? (
               <LoadingIndicator message="Encoding image..." />
@@ -298,12 +300,12 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             />
           )}
         </div>
-        <div className="col-divider d-none d-xl-block">
+        <div className="details-divider d-none d-xl-block">
           <Button onClick={() => setCollapsed(!collapsed)}>
             {getCollapseButtonText()}
           </Button>
         </div>
-        <div className={`col col-md-8 ${collapsed ? "expanded" : ""}`}>
+        <div className={`col content-container ${collapsed ? "expanded" : ""}`}>
           <Tabs
             id="tag-tabs"
             mountOnEnter

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Tab, Dropdown } from "react-bootstrap";
+import { Button, Tabs, Tab, Dropdown } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -49,6 +49,8 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const history = useHistory();
   const Toast = useToast();
   const intl = useIntl();
+
+  const [collapsed, setCollapsed] = useState(false);
 
   // Configuration settings
   const { configuration } = React.useContext(ConfigurationContext);
@@ -262,13 +264,17 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
     );
   }
 
+  function getCollapseButtonText() {
+    return collapsed ? ">" : "<";
+  }
+
   return (
     <>
       <Helmet>
         <title>{tag.name}</title>
       </Helmet>
       <div className="row">
-        <div className="tag-details col-md-4">
+        <div className={`tag-details col-md-4 ${collapsed ? "collapsed" : ""}`}>
           <div className="text-center logo-container">
             {imageEncoding ? (
               <LoadingIndicator message="Encoding image..." />
@@ -306,7 +312,12 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             />
           )}
         </div>
-        <div className="col col-md-8">
+        <div className="col-divider d-none d-xl-block">
+        <Button onClick={() => setCollapsed(!collapsed)}>
+          {getCollapseButtonText()}
+        </Button>
+      </div>
+        <div className={`col col-md-8 ${collapsed ? "expanded" : ""}`}>
           <Tabs
             id="tag-tabs"
             mountOnEnter

--- a/ui/v2.5/src/docs/en/Changelog/v0200.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0200.md
@@ -12,7 +12,7 @@
 
 ### 🎨 Improvements
 * Improved Images wall view layout and added Interface settings to adjust the layout. ([#3511](https://github.com/stashapp/stash/pull/3511))
-* Added collapsible divider to Gallery page. ([#3508](https://github.com/stashapp/stash/pull/3508))
+* Added collapsible divider to Gallery, Performer, Studio and Tag pages. ([#3508](https://github.com/stashapp/stash/pull/3508), [#3514](https://github.com/stashapp/stash/pull/3514))
 * Overhauled and improved HLS streaming. ([#3274](https://github.com/stashapp/stash/pull/3274))
 
 ### 🐛 Bug fixes

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -770,6 +770,7 @@ div.dropdown-menu {
 $colTabWidth: 550px;
 
 @media (min-width: 1200px) {
+  /* stylelint-disable */
   .col-md-4 {
     flex: 0 0 $colTabWidth !important;
     max-height: calc(100vh - 4rem);
@@ -819,6 +820,7 @@ $colTabWidth: 550px;
       max-width: calc(100% - 15px) !important;
     }
   }
+  /* stylelint-enable */
 }
 
 .pre {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -767,14 +767,32 @@ div.dropdown-menu {
   }
 }
 
-$colTabWidth: 550px;
+$detailTabWidth: calc(100% / 3);
 
+.content-container,
+.details-tab {
+  padding-left: 15px;
+  padding-right: 15px;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .details-tab {
+    flex: 0 0 $detailTabWidth;
+    max-width: $detailTabWidth;
+  }
+
+  .content-container {
+    flex: 0 0 calc(100% - #{$detailTabWidth});
+    max-width: calc(100% - #{$detailTabWidth});
+  }
+}
 @media (min-width: 1200px) {
-  /* stylelint-disable */
-  .col-md-4 {
-    flex: 0 0 $colTabWidth !important;
+  .details-tab {
+    flex: 0 0 $detailTabWidth;
     max-height: calc(100vh - 4rem);
-    max-width: $colTabWidth !important;
+    max-width: $detailTabWidth;
     overflow: auto;
 
     &.collapsed {
@@ -782,10 +800,10 @@ $colTabWidth: 550px;
     }
   }
 
-  .col-divider {
+  .details-divider {
     flex: 0 0 15px;
-    max-width: 15px;
     height: calc(100vh - 4rem);
+    max-width: 15px;
 
     button {
       background-color: transparent;
@@ -809,18 +827,17 @@ $colTabWidth: 550px;
     }
   }
 
-  .col-md-8 {
-    flex: 0 0 calc(100% - #{$colTabWidth} - 15px) !important;
+  .content-container {
+    flex: 0 0 calc(100% - #{$detailTabWidth} - 15px);
     max-height: calc(100vh - 4rem);
-    max-width: calc(100% - #{$colTabWidth} - 15px) !important;
+    max-width: calc(100% - #{$detailTabWidth} - 15px);
     overflow: auto;
 
     &.expanded {
-      flex: 0 0 calc(100% - 15px) !important;
-      max-width: calc(100% - 15px) !important;
+      flex: 0 0 calc(100% - 15px);
+      max-width: calc(100% - 15px);
     }
   }
-  /* stylelint-enable */
 }
 
 .pre {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -767,6 +767,60 @@ div.dropdown-menu {
   }
 }
 
+$colTabWidth: 550px;
+
+@media (min-width: 1200px) {
+  .col-md-4 {
+    flex: 0 0 $colTabWidth !important;
+    max-height: calc(100vh - 4rem);
+    max-width: $colTabWidth !important;
+    overflow: auto;
+
+    &.collapsed {
+      display: none;
+    }
+  }
+
+  .col-divider {
+    flex: 0 0 15px;
+    max-width: 15px;
+    height: calc(100vh - 4rem);
+
+    button {
+      background-color: transparent;
+      border: 0;
+      color: $link-color;
+      cursor: pointer;
+      font-size: 10px;
+      font-weight: 800;
+      height: 100%;
+      line-height: 100%;
+      padding: 0;
+      text-align: center;
+      width: 100%;
+
+      &:active:not(:hover),
+      &:focus:not(:hover) {
+        background-color: transparent;
+        border: 0;
+        box-shadow: none;
+      }
+    }
+  }
+
+  .col-md-8 {
+    flex: 0 0 calc(100% - #{$colTabWidth} - 15px) !important;
+    max-height: calc(100vh - 4rem);
+    max-width: calc(100% - #{$colTabWidth} - 15px) !important;
+    overflow: auto;
+
+    &.expanded {
+      flex: 0 0 calc(100% - 15px) !important;
+      max-width: calc(100% - 15px) !important;
+    }
+  }
+}
+
 .pre {
   white-space: pre-line;
 }


### PR DESCRIPTION
This pull request adds dividers to the performers, studio, and tags details pages making the left tab collapsable to get a fuller view of the content. This change includes CSS to ensure the left and right tabs don't share the same scroll wheel, so the details stay in view as you scroll through content.