### PR TITLE
Improve scaling for column wall images

### DIFF
--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -76,9 +76,9 @@ const ImageWall: React.FC<IImageWallProps> = ({ images, handleImageOpen }) => {
   );
 
   function columns(containerWidth: number) {
-    let preferredSize = 250;
+    let preferredSize = 300;
     let columnCount = containerWidth / preferredSize;
-    return Math.floor(columnCount);
+    return Math.round(columnCount);
   }
 
   return (


### PR DESCRIPTION
When using the column direction, galleries with landscape only images wouldn't scale very well(the images would appear too small). I tweaked the scaling method to achieve a better sweet spot. Using the images posted here as a reference https://discord.com/channels/559159668438728723/644934273459290145/1082722647420457020, you would see 5 columns now instead of 6.