### PR TITLE
Fix unit conversion rounding

### DIFF
--- a/ui/v2.5/src/utils/units.ts
+++ b/ui/v2.5/src/utils/units.ts
@@ -1,11 +1,11 @@
 export function cmToImperial(cm: number) {
   const cmInInches = 0.393700787;
   const inchesInFeet = 12;
-  const inches = Math.floor(cm * cmInInches);
+  const inches = Math.round(cm * cmInInches);
   const feet = Math.floor(inches / inchesInFeet);
   return [feet, inches % inchesInFeet];
 }
 
 export function kgToLbs(kg: number) {
-  return Math.floor(kg * 2.20462262185);
+  return Math.round(kg * 2.20462262185);
 }


### PR DESCRIPTION
This is a very simple change to the unit conversion functions to use `Math.round` instead of `Math.floor`, which fixes the kind of issue described in #3517, e.g. 193cm is now displayed as 6'4" instead of 6'3" (6'4" is 193.04cm).

Fixes #3517