### PR TITLE
Fix undefined containerHeight error with imageWall columns

### DIFF
--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -83,13 +83,15 @@ const ImageWall: React.FC<IImageWallProps> = ({ images, handleImageOpen }) => {
 
   return (
     <div className="gallery">
-      <Gallery
-        photos={photos}
-        onClick={showLightboxOnClick}
-        margin={uiConfig?.imageWallOptions?.margin!}
-        direction={uiConfig?.imageWallOptions?.direction!}
-        columns={columns}
-      />
+      {photos.length ? (
+        <Gallery
+          photos={photos}
+          onClick={showLightboxOnClick}
+          margin={uiConfig?.imageWallOptions?.margin!}
+          direction={uiConfig?.imageWallOptions?.direction!}
+          columns={columns}
+        />
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
The pull request should address the error mentioned here https://discord.com/channels/559159668438728723/559159910550732809/1083806722143035433. I interestingly was not able to reproduce this on my windows test/dev environment but was on my Unraid server. From my testing, the error scenario is likely when a selected query returns 0 photos.