### PR TITLE
Automatic database optimization and performance tweaks

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -192,9 +192,9 @@ func (db *Database) open(disableForeignKeys bool) (*sqlx.DB, error) {
 	}
 
 	conn, err := sqlx.Open(sqlite3Driver, url)
-	conn.SetMaxOpenConns(25)
-	conn.SetMaxIdleConns(4)
-	conn.SetConnMaxLifetime(30 * time.Second)
+	conn.SetMaxOpenConns(10)
+	conn.SetMaxIdleConns(10)
+	conn.SetConnMaxIdleTime(30 * time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("db.Open(): %w", err)
 	}

--- a/pkg/sqlite/driver.go
+++ b/pkg/sqlite/driver.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+
+	"github.com/fvbommel/sortorder"
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+const sqlite3Driver = "sqlite3ex"
+
+func init() {
+	// register custom driver
+	sql.Register(sqlite3Driver, &CustomSQLiteDriver{})
+}
+
+type CustomSQLiteDriver struct{}
+
+type CustomSQLiteConn struct {
+	*sqlite3.SQLiteConn
+}
+
+func (d *CustomSQLiteDriver) Open(dsn string) (driver.Conn, error) {
+	sqlite3Driver := &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			funcs := map[string]interface{}{
+				"regexp":            regexFn,
+				"durationToTinyInt": durationToTinyIntFn,
+				"basename":          basenameFn,
+			}
+
+			for name, fn := range funcs {
+				if err := conn.RegisterFunc(name, fn, true); err != nil {
+					return fmt.Errorf("error registering function %s: %v", name, err)
+				}
+			}
+
+			// COLLATE NATURAL_CS - Case sensitive natural sort
+			err := conn.RegisterCollation("NATURAL_CS", func(s string, s2 string) int {
+				if sortorder.NaturalLess(s, s2) {
+					return -1
+				} else {
+					return 1
+				}
+			})
+
+			if err != nil {
+				return fmt.Errorf("error registering natural sort collation: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	conn, err := sqlite3Driver.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CustomSQLiteConn{conn.(*sqlite3.SQLiteConn)}, nil
+}
+
+func (c *CustomSQLiteConn) Close() error {
+	conn := c.SQLiteConn
+
+	_, _ = conn.Exec("PRAGMA analysis_limit=1000; PRAGMA optimize;", []driver.Value{})
+
+	return conn.Close()
+}


### PR DESCRIPTION
This is a fix for an issue that came up in Discord, where some SQL queries are very slow in specific scenarios. The cause is SQLite not using indexes, because the involved tables were very small/empty when the last migration was run (ie since the last `ANALYZE`) but have since greatly increased in size.

The fix is to run `PRAGMA optimize` before closing every database connection, as recommended in the SQLite docs (https://www.sqlite.org/lang_analyze.html). To achieve this with go-sqlite3, a custom database driver wrapper around `sqlite3.SQLiteDriver` was needed.

I've also tweaked the connection pooling configuration for (slightly) better performance, tested with CJ's behemoth of a database. Opening new database connections has a noticeable performance penalty, which is easily seen by removing the `MaxOpenConns` limit. It therefore ends up being more performant to decrease `MaxOpenConns` but make them all stick around as idle connections with `MaxIdleConns`. This also has the benefit of reducing overall memory usage.