### PR TITLE
Address additional overflow on performer page

### DIFF
--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -8,6 +8,10 @@
     max-width: 100%;
   }
 
+  .content-container {
+    padding-bottom: 10px;
+  }
+
   .performer-head {
     display: inline-block;
     margin-bottom: 2rem;

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -1,6 +1,6 @@
 #performer-page {
   flex-direction: row;
-  margin: 10px auto;
+  margin: 0 auto;
   overflow: hidden;
 
   .performer-image-container .performer {


### PR DESCRIPTION
This pull request addresses the issue mentioned [here](https://discord.com/channels/559159668438728723/642079454054711306/1084293319179378740). The 10px top and bottom margins unique to the performer page would trigger its own overflow(with or without the new divider), which is no longer fine since the page no longer shares 1 scroll wheel.