### PR TITLE
Added Intel QSV drivers to docker

### DIFF
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -33,7 +33,7 @@ RUN make build
 
 # Final Runnable Image
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates vips-tools ffmpeg mesa-dri-gallium libva-intel-driver
+RUN apk add --no-cache ca-certificates vips-tools ffmpeg
 COPY --from=backend /stash/stash /usr/bin/
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999

--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -33,8 +33,7 @@ RUN make build
 
 # Final Runnable Image
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates vips-tools ffmpeg
-RUN apk add --no-cache mesa-dri-gallium libva-intel-driver
+RUN apk add --no-cache ca-certificates vips-tools ffmpeg mesa-dri-gallium libva-intel-driver
 COPY --from=backend /stash/stash /usr/bin/
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999

--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -34,6 +34,7 @@ RUN make build
 # Final Runnable Image
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates vips-tools ffmpeg
+RUN apk add --no-cache mesa-dri-gallium libva-intel-driver
 COPY --from=backend /stash/stash /usr/bin/
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -32,7 +32,7 @@ ARG STASH_VERSION
 RUN make build
 
 # Final Runnable Image
-FROM nvidia/cuda:12.0.1-runtime-ubuntu22.04
+FROM nvidia/cuda:12.0.1-base-ubuntu22.04
 RUN apt update && apt upgrade -y && apt install -y ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo
 RUN rm -rf /var/lib/apt/lists/*
 COPY --from=backend /stash/stash /usr/bin/

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -36,6 +36,7 @@ FROM nvidia/cuda:12.0.1-runtime-ubuntu22.04
 RUN apt update
 RUN apt upgrade -y
 RUN apt install -y ca-certificates libvips-tools ffmpeg wget
+RUN apt install -y intel-media-va-driver-non-free vainfo
 RUN rm -rf /var/lib/apt/lists/*
 COPY --from=backend /stash/stash /usr/bin/
 

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -33,9 +33,7 @@ RUN make build
 
 # Final Runnable Image
 FROM nvidia/cuda:12.0.1-runtime-ubuntu22.04
-RUN apt update
-RUN apt upgrade -y
-RUN apt install -y ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo
+RUN apt update && apt upgrade -y && apt install -y ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo
 RUN rm -rf /var/lib/apt/lists/*
 COPY --from=backend /stash/stash /usr/bin/
 

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -35,8 +35,7 @@ RUN make build
 FROM nvidia/cuda:12.0.1-runtime-ubuntu22.04
 RUN apt update
 RUN apt upgrade -y
-RUN apt install -y ca-certificates libvips-tools ffmpeg wget
-RUN apt install -y intel-media-va-driver-non-free vainfo
+RUN apt install -y ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo
 RUN rm -rf /var/lib/apt/lists/*
 COPY --from=backend /stash/stash /usr/bin/
 


### PR DESCRIPTION
Intel QSV doesn't work without the intel driver
This commit adds the Intel driver to the CUDA build
We dont add it to the alpine build, because alpine doesnt build ffmpeg with the qsv encoder, and it adds 158MB.
We also save 2139MB by switching the CUDA build to base instead of runtime (its 1105MB with base, 3244MB with runtime).
Ref: https://github.com/stashapp/stash/issues/305#issuecomment-1468650210