### PR TITLE
Fix /stream endpoint serving directory for fileless scenes

### DIFF
--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -88,7 +88,14 @@ func (rs sceneRoutes) Routes() chi.Router {
 // region Handlers
 
 func (rs sceneRoutes) StreamDirect(w http.ResponseWriter, r *http.Request) {
+
 	scene := r.Context().Value(sceneKey).(*models.Scene)
+	// #3526 - return 404 if the scene does not have any files
+	if scene.Path == "" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
 	sceneHash := scene.GetHash(config.GetInstance().GetVideoFileNamingAlgorithm())
 
 	filepath := manager.GetInstance().Paths.Scene.GetStreamPath(scene.Path, sceneHash)

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -142,7 +142,11 @@ const ScenePage: React.FC<IProps> = ({
     Mousetrap.bind("q", () => setActiveTabKey("scene-queue-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("scene-edit-panel"));
     Mousetrap.bind("k", () => setActiveTabKey("scene-markers-panel"));
-    Mousetrap.bind("i", () => setActiveTabKey("scene-file-info-panel"));
+    Mousetrap.bind("i", () => {
+      if (scene.files.length > 0) {
+        setActiveTabKey("scene-file-info-panel");
+      }
+    });
     Mousetrap.bind("o", () => {
       onIncrementClick();
     });
@@ -370,14 +374,16 @@ const ScenePage: React.FC<IProps> = ({
               <FormattedMessage id="effect_filters.name" />
             </Nav.Link>
           </Nav.Item>
-          <Nav.Item>
-            <Nav.Link eventKey="scene-file-info-panel">
-              <FormattedMessage id="file_info" />
-              {scene.files.length > 1 && (
-                <Counter count={scene.files.length ?? 0} />
-              )}
-            </Nav.Link>
-          </Nav.Item>
+          {scene.files.length > 0 && (
+            <Nav.Item>
+              <Nav.Link eventKey="scene-file-info-panel">
+                <FormattedMessage id="file_info" />
+                {scene.files.length > 1 && (
+                  <Counter count={scene.files.length ?? 0} />
+                )}
+              </Nav.Link>
+            </Nav.Item>
+          )}
           <Nav.Item>
             <Nav.Link eventKey="scene-edit-panel">
               <FormattedMessage id="actions.edit" />
@@ -450,9 +456,14 @@ const ScenePage: React.FC<IProps> = ({
         <Tab.Pane eventKey="scene-video-filter-panel">
           <SceneVideoFilterPanel scene={scene} />
         </Tab.Pane>
-        <Tab.Pane className="file-info-panel" eventKey="scene-file-info-panel">
-          <SceneFileInfoPanel scene={scene} />
-        </Tab.Pane>
+        {scene.files.length > 0 && (
+          <Tab.Pane
+            className="file-info-panel"
+            eventKey="scene-file-info-panel"
+          >
+            <SceneFileInfoPanel scene={scene} />
+          </Tab.Pane>
+        )}
         <Tab.Pane eventKey="scene-edit-panel">
           <SceneEditPanel
             isVisible={activeTabKey === "scene-edit-panel"}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -142,11 +142,7 @@ const ScenePage: React.FC<IProps> = ({
     Mousetrap.bind("q", () => setActiveTabKey("scene-queue-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("scene-edit-panel"));
     Mousetrap.bind("k", () => setActiveTabKey("scene-markers-panel"));
-    Mousetrap.bind("i", () => {
-      if (scene.files.length > 0) {
-        setActiveTabKey("scene-file-info-panel");
-      }
-    });
+    Mousetrap.bind("i", () => setActiveTabKey("scene-file-info-panel"));
     Mousetrap.bind("o", () => {
       onIncrementClick();
     });
@@ -374,16 +370,14 @@ const ScenePage: React.FC<IProps> = ({
               <FormattedMessage id="effect_filters.name" />
             </Nav.Link>
           </Nav.Item>
-          {scene.files.length > 0 && (
-            <Nav.Item>
-              <Nav.Link eventKey="scene-file-info-panel">
-                <FormattedMessage id="file_info" />
-                {scene.files.length > 1 && (
-                  <Counter count={scene.files.length ?? 0} />
-                )}
-              </Nav.Link>
-            </Nav.Item>
-          )}
+          <Nav.Item>
+            <Nav.Link eventKey="scene-file-info-panel">
+              <FormattedMessage id="file_info" />
+              {scene.files.length > 1 && (
+                <Counter count={scene.files.length ?? 0} />
+              )}
+            </Nav.Link>
+          </Nav.Item>
           <Nav.Item>
             <Nav.Link eventKey="scene-edit-panel">
               <FormattedMessage id="actions.edit" />
@@ -456,14 +450,9 @@ const ScenePage: React.FC<IProps> = ({
         <Tab.Pane eventKey="scene-video-filter-panel">
           <SceneVideoFilterPanel scene={scene} />
         </Tab.Pane>
-        {scene.files.length > 0 && (
-          <Tab.Pane
-            className="file-info-panel"
-            eventKey="scene-file-info-panel"
-          >
-            <SceneFileInfoPanel scene={scene} />
-          </Tab.Pane>
-        )}
+        <Tab.Pane className="file-info-panel" eventKey="scene-file-info-panel">
+          <SceneFileInfoPanel scene={scene} />
+        </Tab.Pane>
         <Tab.Pane eventKey="scene-edit-panel">
           <SceneEditPanel
             isVisible={activeTabKey === "scene-edit-panel"}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -306,12 +306,14 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
   return (
     <>
       <dl className="container scene-file-info details-list">
-        <URLField
-          id="media_info.stream"
-          url={props.scene.paths.stream}
-          value={props.scene.paths.stream}
-          truncate
-        />
+        {props.scene.files.length > 0 && (
+          <URLField
+            id="media_info.stream"
+            url={props.scene.paths.stream}
+            value={props.scene.paths.stream}
+            truncate
+          />
+        )}
         {renderFunscript()}
         {renderInteractiveSpeed()}
         <URLField


### PR DESCRIPTION
Fixes #3526 

`/stream` endpoint now returns 404 if the scene has no files. The `File Info` tab is also now hidden when the scene has no files.