### PR TITLE
Handle large and all entity queries

### DIFF
--- a/pkg/models/find_filter.go
+++ b/pkg/models/find_filter.go
@@ -96,15 +96,15 @@ func (ff FindFilterType) GetPage() int {
 func (ff FindFilterType) GetPageSize() int {
 	const defaultPerPage = 25
 	const minPerPage = 0
-	const maxPerPage = 1000
 
 	if ff.PerPage == nil {
 		return defaultPerPage
 	}
 
-	if *ff.PerPage > maxPerPage {
-		return maxPerPage
-	} else if *ff.PerPage < minPerPage {
+	// removed the maxPerPage check. We already all -1 to indicate all results
+	// so there is no conceivable reason we should limit the page size
+
+	if *ff.PerPage < minPerPage {
 		// negative page sizes should return all results
 		// this is a sanity check in case GetPageSize is
 		// called with a negative page size.

--- a/pkg/sqlite/batch.go
+++ b/pkg/sqlite/batch.go
@@ -1,0 +1,20 @@
+package sqlite
+
+const defaultBatchSize = 1000
+
+// batchExec executes the provided function in batches of the provided size.
+func batchExec(ids []int, batchSize int, fn func(batch []int) error) error {
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		batch := ids[i:end]
+		if err := fn(batch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -260,17 +260,23 @@ func (qb *ImageStore) Find(ctx context.Context, id int) (*models.Image, error) {
 }
 
 func (qb *ImageStore) FindMany(ctx context.Context, ids []int) ([]*models.Image, error) {
-	q := qb.selectDataset().Prepared(true).Where(qb.table().Col(idColumn).In(ids))
-	unsorted, err := qb.getMany(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
 	images := make([]*models.Image, len(ids))
 
-	for _, s := range unsorted {
-		i := intslice.IntIndex(ids, s.ID)
-		images[i] = s
+	if err := batchExec(ids, defaultBatchSize, func(batch []int) error {
+		q := qb.selectDataset().Prepared(true).Where(qb.table().Col(idColumn).In(batch))
+		unsorted, err := qb.getMany(ctx, q)
+		if err != nil {
+			return err
+		}
+
+		for _, s := range unsorted {
+			i := intslice.IntIndex(ids, s.ID)
+			images[i] = s
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	for i := range images {

--- a/pkg/sqlite/movies.go
+++ b/pkg/sqlite/movies.go
@@ -70,17 +70,23 @@ func (qb *movieQueryBuilder) Find(ctx context.Context, id int) (*models.Movie, e
 
 func (qb *movieQueryBuilder) FindMany(ctx context.Context, ids []int) ([]*models.Movie, error) {
 	tableMgr := movieTableMgr
-	q := goqu.Select("*").From(tableMgr.table).Where(tableMgr.byIDInts(ids...))
-	unsorted, err := qb.getMany(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
 	ret := make([]*models.Movie, len(ids))
 
-	for _, s := range unsorted {
-		i := intslice.IntIndex(ids, s.ID)
-		ret[i] = s
+	if err := batchExec(ids, defaultBatchSize, func(batch []int) error {
+		q := goqu.Select("*").From(tableMgr.table).Where(tableMgr.byIDInts(batch...))
+		unsorted, err := qb.getMany(ctx, q)
+		if err != nil {
+			return err
+		}
+
+		for _, s := range unsorted {
+			i := intslice.IntIndex(ids, s.ID)
+			ret[i] = s
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	for i := range ret {

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -80,17 +80,23 @@ func (qb *studioQueryBuilder) Find(ctx context.Context, id int) (*models.Studio,
 
 func (qb *studioQueryBuilder) FindMany(ctx context.Context, ids []int) ([]*models.Studio, error) {
 	tableMgr := studioTableMgr
-	q := goqu.Select("*").From(tableMgr.table).Where(tableMgr.byIDInts(ids...))
-	unsorted, err := qb.getMany(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
 	ret := make([]*models.Studio, len(ids))
 
-	for _, s := range unsorted {
-		i := intslice.IntIndex(ids, s.ID)
-		ret[i] = s
+	if err := batchExec(ids, defaultBatchSize, func(batch []int) error {
+		q := goqu.Select("*").From(tableMgr.table).Where(tableMgr.byIDInts(batch...))
+		unsorted, err := qb.getMany(ctx, q)
+		if err != nil {
+			return err
+		}
+
+		for _, s := range unsorted {
+			i := intslice.IntIndex(ids, s.ID)
+			ret[i] = s
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	for i := range ret {

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -40,7 +40,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useDebounce } from "src/hooks/debounce";
 
-const maxPageSize = 1000;
 interface IListFilterProps {
   onFilterUpdate: (newFilter: ListFilterModel) => void;
   filter: ListFilterModel;
@@ -132,11 +131,6 @@ export const ListFilter: React.FC<IListFilterProps> = ({
     let pp = parseInt(val, 10);
     if (Number.isNaN(pp) || pp <= 0) {
       return;
-    }
-
-    // don't allow page sizes over 1000
-    if (pp > maxPageSize) {
-      pp = maxPageSize;
     }
 
     const newFilter = cloneDeep(filter);
@@ -377,7 +371,6 @@ export const ListFilter: React.FC<IListFilterProps> = ({
                   <Form.Control
                     type="number"
                     min={1}
-                    max={maxPageSize}
                     className="text-input"
                     ref={perPageInput}
                     onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Resolves #3199 

Batches `FindMany` queries per 1000 ids. Also removes the upper limit on the page size in the backend interface and in the UI. If we accept `-1` value page size, then we shouldn't be limiting the upper limit.