### PR TITLE
Login fixes

### DIFF
--- a/internal/api/authentication.go
+++ b/internal/api/authentication.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stashapp/stash/pkg/session"
 )
 
-const loginEndPoint = "/login"
+const (
+	loginEndPoint  = "/login"
+	logoutEndPoint = "/logout"
+)
 
 const (
 	tripwireActivatedErrMsg = "Stash is exposed to the public internet without authentication, and is not serving any more content to protect your privacy. " +
@@ -27,7 +30,7 @@ const (
 
 func allowUnauthenticated(r *http.Request) bool {
 	// #2715 - allow access to UI files
-	return strings.HasPrefix(r.URL.Path, loginEndPoint) || r.URL.Path == "/css" || strings.HasPrefix(r.URL.Path, "/assets")
+	return strings.HasPrefix(r.URL.Path, loginEndPoint) || r.URL.Path == logoutEndPoint || r.URL.Path == "/css" || strings.HasPrefix(r.URL.Path, "/assets")
 }
 
 func authenticateHandler() func(http.Handler) http.Handler {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -135,7 +135,7 @@ func Start() error {
 
 	// session handlers
 	r.Post(loginEndPoint, handleLogin(loginUIBox))
-	r.Get("/logout", handleLogout(loginUIBox))
+	r.Get(logoutEndPoint, handleLogout(loginUIBox))
 
 	r.Get(loginEndPoint, getLoginHandler(loginUIBox))
 

--- a/ui/login/login.css
+++ b/ui/login/login.css
@@ -115,3 +115,18 @@ button, input {
     font-weight: 500;
     padding-bottom: 1rem;
 }
+
+@media (max-width: 576px) {
+    .card {
+        width: 100%;
+    }
+
+    .dialog {
+        height: auto;
+        margin-top: 50%;
+    }
+
+    .btn-primary {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
Fixes `/logout` redirect behaviour. Currently, going to `/logout` while logged out redirects to `/login` with a result redirect to `/logout`, causing the system to immediately log the user out after logging in.

Also changes the styling of the login page for small devices. Increases the width of the dialog and login button to 100% and repositions the dialog vertically.

![image](https://user-images.githubusercontent.com/53250216/225792692-e1e5a279-3609-4481-83f6-b5438ba69aea.png)
