### PR TITLE
Filter edit fixes

### DIFF
--- a/ui/v2.5/src/components/List/CriterionEditor.tsx
+++ b/ui/v2.5/src/components/List/CriterionEditor.tsx
@@ -174,6 +174,7 @@ const GenericCriterionEditor: React.FC<IGenericCriterionEditor> = ({
         <CountrySelect
           value={criterion.value}
           onChange={(v) => onValueChanged(v)}
+          menuPortalTarget={document.body}
         />
       );
     }

--- a/ui/v2.5/src/components/List/Filters/FilterButton.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterButton.tsx
@@ -19,7 +19,7 @@ export const FilterButton: React.FC<IFilterButtonProps> = ({
     <Button variant="secondary" className="filter-button" onClick={onClick}>
       <Icon icon={faFilter} />
       {count ? (
-        <Badge pill variant="danger">
+        <Badge pill variant="info">
           {count}
         </Badge>
       ) : undefined}

--- a/ui/v2.5/src/components/Shared/CountrySelect.tsx
+++ b/ui/v2.5/src/components/Shared/CountrySelect.tsx
@@ -11,6 +11,7 @@ interface IProps {
   className?: string;
   showFlag?: boolean;
   isClearable?: boolean;
+  menuPortalTarget?: HTMLElement | null;
 }
 
 export const CountrySelect: React.FC<IProps> = ({
@@ -20,6 +21,7 @@ export const CountrySelect: React.FC<IProps> = ({
   isClearable = true,
   showFlag,
   className,
+  menuPortalTarget,
 }) => {
   const { locale } = useIntl();
   const options = getCountries(locale);
@@ -44,6 +46,7 @@ export const CountrySelect: React.FC<IProps> = ({
         IndicatorSeparator: null,
       }}
       className={`CountrySelect ${className}`}
+      menuPortalTarget={menuPortalTarget}
     />
   );
 };

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -77,12 +77,8 @@ export class ListFilterModel {
 
   // returns the number of filters applied
   public count() {
-    const count = this.criteria.length;
-    if (this.searchTerm) {
-      return count + 1;
-    }
-
-    return count;
+    // don't include search term
+    return this.criteria.length;
   }
 
   public configureFromDecodedParams(params: IDecodedParams) {


### PR DESCRIPTION
From feedback from @echo6ix in #3515.

Fixes country selector not displaying correctly in the dialog.

Changes the badge colour to the `info` variant: 
![image](https://user-images.githubusercontent.com/53250216/225799749-58523192-f9b9-41f2-982c-2e535750cca5.png)

Removes the search term from the filter count, since it was misleading.

I've left the positioning as is for now. I couldn't get a position based on the feedback that I was happy with. If you have a css snippet to apply, I'm happy to look at it.