### PR TITLE
Add move files external interface

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -245,6 +245,13 @@ type Mutation {
   tagsDestroy(ids: [ID!]!): Boolean!
   tagsMerge(input: TagsMergeInput!): Tag
 
+  """Moves the given files to the given destination. Returns true if successful.
+  Either the destination_folder or destination_folder_id must be provided. If both are provided, the destination_folder_id takes precedence.
+  Destination folder must be a subfolder of one of the stash library paths.
+  If provided, destination_basename must be a valid filename with an extension that
+  matches one of the media extensions.
+  Creates folder hierarchy if needed.
+  """
   moveFiles(input: MoveFilesInput!): Boolean!
   deleteFiles(ids: [ID!]!): Boolean!
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -245,6 +245,7 @@ type Mutation {
   tagsDestroy(ids: [ID!]!): Boolean!
   tagsMerge(input: TagsMergeInput!): Tag
 
+  moveFiles(input: MoveFilesInput!): Boolean!
   deleteFiles(ids: [ID!]!): Boolean!
 
   # Saved filters

--- a/graphql/schema/types/file.graphql
+++ b/graphql/schema/types/file.graphql
@@ -98,12 +98,12 @@ type GalleryFile implements BaseFile {
 
 input MoveFilesInput {
     ids: [ID!]!
-    # only valid for a single file id - must be a full file path
-    destination_path: String
-
-    # valid for single or multiple file ids
+    """valid for single or multiple file ids"""
     destination_folder: String
 
-    # valid for single or multiple file ids
+    """valid for single or multiple file ids"""
     destination_folder_id: ID
+
+    """valid only for single file id. If empty, existing basename is used"""
+    destination_basename: String
 }

--- a/graphql/schema/types/file.graphql
+++ b/graphql/schema/types/file.graphql
@@ -95,3 +95,15 @@ type GalleryFile implements BaseFile {
     created_at: Time!
     updated_at: Time!
 }
+
+input MoveFilesInput {
+    ids: [ID!]!
+    # only valid for a single file id - must be a full file path
+    destination_path: String
+
+    # valid for single or multiple file ids
+    destination_folder: String
+
+    # valid for single or multiple file ids
+    destination_folder_id: ID
+}

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -3,13 +3,120 @@ package api
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/pkg/file"
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 )
 
 func (r *mutationResolver) MoveFiles(ctx context.Context, input MoveFilesInput) (bool, error) {
-	panic("not implemented")
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.File
+		mover := file.NewMover(qb)
+		mover.RegisterHooks(ctx, r.txnManager)
+
+		var (
+			folder   *file.Folder
+			basename string
+		)
+
+		fileIDs, err := stringslice.StringSliceToIntSlice(input.Ids)
+		if err != nil {
+			return fmt.Errorf("converting file ids: %w", err)
+		}
+
+		switch {
+		case input.DestinationFolderID != nil:
+			var err error
+
+			folderID, err := strconv.Atoi(*input.DestinationFolderID)
+			if err != nil {
+				return fmt.Errorf("invalid folder id %s: %w", *input.DestinationFolderID, err)
+			}
+
+			folder, err = r.repository.Folder.Find(ctx, file.FolderID(folderID))
+			if err != nil {
+				return fmt.Errorf("finding destination folder: %w", err)
+			}
+
+			if folder == nil {
+				return fmt.Errorf("folder with id %d not found", input.DestinationFolderID)
+			}
+		case input.DestinationFolder != nil:
+			folderPath := *input.DestinationFolder
+
+			// ensure folder path is within the library
+			if err := r.validateFolderPath(ctx, folderPath); err != nil {
+				return err
+			}
+
+			// get or create folder hierarchy
+			var err error
+			folder, err = file.GetOrCreateFolderHierarchy(ctx, r.repository.Folder, folderPath)
+			if err != nil {
+				return fmt.Errorf("getting or creating folder hierarchy: %w", err)
+			}
+		default:
+			return fmt.Errorf("must specify destination folder or path")
+		}
+
+		if input.DestinationBasename != nil {
+			// ensure only one file was supplied
+			if len(input.Ids) != 1 {
+				return fmt.Errorf("must specify one file when providing destination path")
+			}
+
+			basename = *input.DestinationBasename
+
+			fileExts := manager.GetInstance().Config.GetFileExtensions()
+
+			if err := r.validateFileExtension(ctx, fileExts, basename); err != nil {
+				return err
+			}
+		}
+
+		// create the folder hierarchy in the filesystem if needed
+		if err := mover.CreateFolderHierarchy(folder.Path); err != nil {
+			return fmt.Errorf("creating folder hierarchy %s in filesystem: %w", folder.Path, err)
+		}
+
+		for _, fileIDInt := range fileIDs {
+			fileID := file.ID(fileIDInt)
+			f, err := qb.Find(ctx, fileID)
+			if err != nil {
+				return fmt.Errorf("finding file %d: %w", fileID, err)
+			}
+
+			if err := mover.Move(ctx, f[0], folder, basename); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *mutationResolver) validateFolderPath(ctx context.Context, folderPath string) error {
+	paths := manager.GetInstance().Config.GetStashPaths()
+	if l := paths.GetStashFromDirPath(folderPath); l == nil {
+		return fmt.Errorf("folder path %s must be within a stash library path", folderPath)
+	}
+
+	return nil
+}
+
+func (r *mutationResolver) validateFileExtension(ctx context.Context, exts []string, basename string) error {
+	if !fsutil.MatchExtension(basename, exts) {
+		return fmt.Errorf("file extension for %s is not valid for the library", basename)
+	}
+
+	return nil
 }
 
 func (r *mutationResolver) DeleteFiles(ctx context.Context, ids []string) (ret bool, err error) {

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 )
 
+func (r *mutationResolver) MoveFiles(ctx context.Context, input MoveFilesInput) (bool, error) {
+	panic("not implemented")
+}
+
 func (r *mutationResolver) DeleteFiles(ctx context.Context, ids []string) (ret bool, err error) {
 	fileIDs, err := stringslice.StringSliceToIntSlice(ids)
 	if err != nil {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -625,6 +625,15 @@ func (i *Instance) GetGalleryExtensions() []string {
 	return ret
 }
 
+// GetFileExtensions returns the list of file extensions that should be accepted.
+// It is a combination of the video, image and gallery extensions.
+func (i *Instance) GetFileExtensions() []string {
+	ret := i.GetVideoExtensions()
+	ret = append(ret, i.GetImageExtensions()...)
+	ret = append(ret, i.GetGalleryExtensions()...)
+	return ret
+}
+
 func (i *Instance) GetCreateGalleriesFromFolders() bool {
 	return i.getBool(CreateGalleriesFromFolders)
 }

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -504,27 +504,14 @@ func (i *Instance) getStringMapString(key string) map[string]string {
 	return ret
 }
 
-type StashConfig struct {
-	Path         string `json:"path"`
-	ExcludeVideo bool   `json:"excludeVideo"`
-	ExcludeImage bool   `json:"excludeImage"`
-}
-
-// Stash configuration details
-type StashConfigInput struct {
-	Path         string `json:"path"`
-	ExcludeVideo bool   `json:"excludeVideo"`
-	ExcludeImage bool   `json:"excludeImage"`
-}
-
 // GetStathPaths returns the configured stash library paths.
 // Works opposite to the usual case - it will return the override
 // value only if the main value is not set.
-func (i *Instance) GetStashPaths() []*StashConfig {
+func (i *Instance) GetStashPaths() StashConfigs {
 	i.RLock()
 	defer i.RUnlock()
 
-	var ret []*StashConfig
+	var ret StashConfigs
 
 	v := i.main
 	if !v.IsSet(Stash) {

--- a/internal/manager/config/stash_config.go
+++ b/internal/manager/config/stash_config.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"path/filepath"
+
+	"github.com/stashapp/stash/pkg/fsutil"
+)
+
+// Stash configuration details
+type StashConfigInput struct {
+	Path         string `json:"path"`
+	ExcludeVideo bool   `json:"excludeVideo"`
+	ExcludeImage bool   `json:"excludeImage"`
+}
+
+type StashConfig struct {
+	Path         string `json:"path"`
+	ExcludeVideo bool   `json:"excludeVideo"`
+	ExcludeImage bool   `json:"excludeImage"`
+}
+
+type StashConfigs []*StashConfig
+
+func (s StashConfigs) GetStashFromPath(path string) *StashConfig {
+	for _, f := range s {
+		if fsutil.IsPathInDir(f.Path, filepath.Dir(path)) {
+			return f
+		}
+	}
+	return nil
+}
+
+func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
+	for _, f := range s {
+		if fsutil.IsPathInDir(f.Path, dirPath) {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -37,9 +37,9 @@ func getScanPaths(inputPaths []string) []*config.StashConfig {
 		return stashPaths
 	}
 
-	var ret []*config.StashConfig
+	var ret config.StashConfigs
 	for _, p := range inputPaths {
-		s := getStashFromDirPath(stashPaths, p)
+		s := stashPaths.GetStashFromDirPath(p)
 		if s == nil {
 			logger.Warnf("%s is not in the configured stash paths", p)
 			continue

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -164,9 +164,9 @@ func (f *cleanFilter) Accept(ctx context.Context, path string, info fs.FileInfo)
 
 	if info.IsDir() {
 		fileOrFolder = "Folder"
-		stash = getStashFromDirPath(f.stashPaths, path)
+		stash = f.stashPaths.GetStashFromDirPath(path)
 	} else {
-		stash = getStashFromPath(f.stashPaths, path)
+		stash = f.stashPaths.GetStashFromPath(path)
 	}
 
 	if stash == nil {
@@ -447,23 +447,5 @@ func (h *cleanHandler) handleRelatedImages(ctx context.Context, fileDeleter *fil
 		}
 	}
 
-	return nil
-}
-
-func getStashFromPath(stashes []*config.StashConfig, pathToCheck string) *config.StashConfig {
-	for _, f := range stashes {
-		if fsutil.IsPathInDir(f.Path, filepath.Dir(pathToCheck)) {
-			return f
-		}
-	}
-	return nil
-}
-
-func getStashFromDirPath(stashes []*config.StashConfig, pathToCheck string) *config.StashConfig {
-	for _, f := range stashes {
-		if fsutil.IsPathInDir(f.Path, pathToCheck) {
-			return f
-		}
-	}
 	return nil
 }

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -226,7 +226,7 @@ func (f *handlerRequiredFilter) Accept(ctx context.Context, ff file.File) bool {
 
 type scanFilter struct {
 	extensionConfig
-	stashPaths        []*config.StashConfig
+	stashPaths        config.StashConfigs
 	generatedPath     string
 	videoExcludeRegex []*regexp.Regexp
 	imageExcludeRegex []*regexp.Regexp
@@ -278,7 +278,7 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 		return false
 	}
 
-	s := getStashFromDirPath(f.stashPaths, path)
+	s := f.stashPaths.GetStashFromDirPath(path)
 
 	if s == nil {
 		logger.Debugf("Skipping %s as it is not in the stash library", path)

--- a/pkg/file/delete.go
+++ b/pkg/file/delete.go
@@ -18,7 +18,7 @@ type RenamerRemover interface {
 	Renamer
 	Remove(name string) error
 	RemoveAll(path string) error
-	Stat(name string) (fs.FileInfo, error)
+	Statter
 }
 
 type renamerRemoverImpl struct {
@@ -44,6 +44,15 @@ func (r renamerRemoverImpl) Stat(path string) (fs.FileInfo, error) {
 	return r.StatFn(path)
 }
 
+func newRenamerRemoverImpl() renamerRemoverImpl {
+	return renamerRemoverImpl{
+		RenameFn:    os.Rename,
+		RemoveFn:    os.Remove,
+		RemoveAllFn: os.RemoveAll,
+		StatFn:      os.Stat,
+	}
+}
+
 // Deleter is used to safely delete files and directories from the filesystem.
 // During a transaction, files and directories are marked for deletion using
 // the Files and Dirs methods. This will rename the files/directories to be
@@ -59,12 +68,7 @@ type Deleter struct {
 
 func NewDeleter() *Deleter {
 	return &Deleter{
-		RenamerRemover: renamerRemoverImpl{
-			RenameFn:    os.Rename,
-			RemoveFn:    os.Remove,
-			RemoveAllFn: os.RemoveAll,
-			StatFn:      os.Stat,
-		},
+		RenamerRemover: newRenamerRemoverImpl(),
 	}
 }
 

--- a/pkg/file/delete.go
+++ b/pkg/file/delete.go
@@ -15,7 +15,7 @@ const deleteFileSuffix = ".delete"
 
 // RenamerRemover provides access to the Rename and Remove functions.
 type RenamerRemover interface {
-	Rename(oldpath, newpath string) error
+	Renamer
 	Remove(name string) error
 	RemoveAll(path string) error
 	Stat(name string) (fs.FileInfo, error)

--- a/pkg/file/folder.go
+++ b/pkg/file/folder.go
@@ -30,9 +30,14 @@ func (f *Folder) Info(fs FS) (fs.FileInfo, error) {
 	return f.info(fs, f.Path)
 }
 
+// FolderPathFinder finds Folders by their path.
+type FolderPathFinder interface {
+	FindByPath(ctx context.Context, path string) (*Folder, error)
+}
+
 // FolderGetter provides methods to find Folders.
 type FolderGetter interface {
-	FindByPath(ctx context.Context, path string) (*Folder, error)
+	FolderPathFinder
 	FindByZipFileID(ctx context.Context, zipFileID ID) ([]*Folder, error)
 	FindAllInPaths(ctx context.Context, p []string, limit, offset int) ([]*Folder, error)
 	FindByParentFolderID(ctx context.Context, parentFolderID FolderID) ([]*Folder, error)
@@ -45,6 +50,11 @@ type FolderCounter interface {
 // FolderCreator provides methods to create Folders.
 type FolderCreator interface {
 	Create(ctx context.Context, f *Folder) error
+}
+
+type FolderFinderCreator interface {
+	FolderPathFinder
+	FolderCreator
 }
 
 // FolderUpdater provides methods to update Folders.

--- a/pkg/file/folder.go
+++ b/pkg/file/folder.go
@@ -2,7 +2,9 @@ package file
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strconv"
 	"time"
 )
@@ -78,4 +80,40 @@ type FolderStore interface {
 	FolderCreator
 	FolderUpdater
 	FolderDestroyer
+}
+
+// GetOrCreateFolderHierarchy gets the folder for the given path, or creates a folder hierarchy for the given path if one if no existing folder is found.
+// Does not create any folders in the file system
+func GetOrCreateFolderHierarchy(ctx context.Context, fc FolderFinderCreator, path string) (*Folder, error) {
+	// get or create folder hierarchy
+	folder, err := fc.FindByPath(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if folder == nil {
+		parentPath := filepath.Dir(path)
+		parent, err := GetOrCreateFolderHierarchy(ctx, fc, parentPath)
+		if err != nil {
+			return nil, err
+		}
+
+		now := time.Now()
+
+		folder = &Folder{
+			Path:           path,
+			ParentFolderID: &parent.ID,
+			DirEntry:       DirEntry{
+				// leave mod time empty for now - it will be updated when the folder is scanned
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+
+		if err = fc.Create(ctx, folder); err != nil {
+			return nil, fmt.Errorf("creating folder %s: %w", path, err)
+		}
+	}
+
+	return folder, nil
 }

--- a/pkg/file/move.go
+++ b/pkg/file/move.go
@@ -1,0 +1,79 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/txn"
+)
+
+type Renamer interface {
+	Rename(oldpath, newpath string) error
+}
+
+type Mover struct {
+	Renamer Renamer
+	Updater Updater
+
+	moved map[string]string
+}
+
+func (m *Mover) Move(ctx context.Context, f File, folder Folder, basename string) error {
+	// don't allow moving files in zip files
+	if f.Base().ZipFileID != nil {
+		return fmt.Errorf("cannot move file %s in zip file", f.Base().Path)
+	}
+
+	// modify the database first
+	fBase := f.Base()
+	oldPath := fBase.Path
+	fBase.ParentFolderID = folder.ID
+	fBase.Basename = basename
+
+	if err := m.Updater.Update(ctx, f); err != nil {
+		return fmt.Errorf("updating file %s: %w", oldPath, err)
+	}
+
+	// then move the file
+	newPath := filepath.Join(folder.Path, basename)
+	return m.moveFile(oldPath, newPath)
+}
+
+func (m *Mover) moveFile(oldPath, newPath string) error {
+	if err := m.Renamer.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("renaming file %s to %s: %w", oldPath, newPath, err)
+	}
+
+	if m.moved == nil {
+		m.moved = make(map[string]string)
+	}
+
+	m.moved[newPath] = oldPath
+
+	return nil
+}
+
+func (m *Mover) RegisterHooks(ctx context.Context, mgr txn.Manager) {
+	txn.AddPostCommitHook(ctx, func(ctx context.Context) {
+		m.commit()
+	})
+
+	txn.AddPostRollbackHook(ctx, func(ctx context.Context) {
+		m.rollback()
+	})
+}
+
+func (m *Mover) commit() {
+	m.moved = nil
+}
+
+func (m *Mover) rollback() {
+	// move files back to their original location
+	for newPath, oldPath := range m.moved {
+		if err := m.Renamer.Rename(newPath, oldPath); err != nil {
+			logger.Errorf("error moving file %s back to %s: %s", newPath, oldPath, err.Error())
+		}
+	}
+}


### PR DESCRIPTION
Adds a much needed interface to move a file in the library.

`moveFiles` accepts an input with the following:
- `destination_folder` - full path to destination parent folder. This folder must be within the stash library
- `destination_folder_id` - id of a folder in the stash database
- `destination_basename` - new basename for the file. Only valid if a single id is supplied. Defaults to existing basename. Validates to ensure the new basename is one of the supported extensions. (**TODO** _should I change this to restrict it to keeping the same extension?_)

One of `destination_folder` or `destination_folder_id` is required.

Moves the file in the filesystem and updates the database for the file. Creates any required folders and adds their entries to the database. If the transaction fails, the files are returned to their original location (and logs if it can't do so), and any folders created are removed (and logs if it can't do so).

Note that there is no UI support for this functionality included. I will defer that to after this release. This should simplify some plugins.