### PR TITLE
Log errors returned from graphql

### DIFF
--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func gqlErrorHandler(ctx context.Context, e error) *gqlerror.Error {
+	// log all errors - for now just log the error message
+	// we can potentially add more context later
+	logger.Errorf("%s: %v", graphql.GetFieldContext(ctx).Path(), e)
+
+	// log the args in debug level
+	logger.DebugFunc(func() (string, []interface{}) {
+		var args interface{}
+		args = graphql.GetFieldContext(ctx).Args
+
+		s, _ := json.Marshal(args)
+		if len(s) > 0 {
+			args = string(s)
+		}
+
+		return "%s: %v", []interface{}{
+			graphql.GetFieldContext(ctx).Path(),
+			args,
+		}
+	})
+
+	// we may also want to transform the error message for the response
+	// for now just return the original error
+	return graphql.DefaultErrorPresenter(ctx, e)
+}

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -12,23 +12,26 @@ import (
 func gqlErrorHandler(ctx context.Context, e error) *gqlerror.Error {
 	// log all errors - for now just log the error message
 	// we can potentially add more context later
-	logger.Errorf("%s: %v", graphql.GetFieldContext(ctx).Path(), e)
+	fc := graphql.GetFieldContext(ctx)
+	if fc != nil {
+		logger.Errorf("%s: %v", fc.Path(), e)
 
-	// log the args in debug level
-	logger.DebugFunc(func() (string, []interface{}) {
-		var args interface{}
-		args = graphql.GetFieldContext(ctx).Args
+		// log the args in debug level
+		logger.DebugFunc(func() (string, []interface{}) {
+			var args interface{}
+			args = fc.Args
 
-		s, _ := json.Marshal(args)
-		if len(s) > 0 {
-			args = string(s)
-		}
+			s, _ := json.Marshal(args)
+			if len(s) > 0 {
+				args = string(s)
+			}
 
-		return "%s: %v", []interface{}{
-			graphql.GetFieldContext(ctx).Path(),
-			args,
-		}
-	})
+			return "%s: %v", []interface{}{
+				fc.Path(),
+				args,
+			}
+		})
+	}
 
 	// we may also want to transform the error message for the response
 	// for now just return the original error

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -228,8 +228,13 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 		c.Set(config.GalleryCoverRegex, *input.GalleryCoverRegex)
 	}
 
-	if input.Username != nil {
+	if input.Username != nil && *input.Username != c.GetUsername() {
 		c.Set(config.Username, input.Username)
+		if *input.Password == "" {
+			logger.Info("Username cleared")
+		} else {
+			logger.Info("Username changed")
+		}
 	}
 
 	if input.Password != nil {
@@ -238,6 +243,11 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 		currentPWHash := c.GetPasswordHash()
 
 		if *input.Password != currentPWHash {
+			if *input.Password == "" {
+				logger.Info("Password cleared")
+			} else {
+				logger.Info("Password changed")
+			}
 			c.SetPassword(*input.Password)
 		}
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -120,6 +120,8 @@ func Start() error {
 	gqlSrv.SetQueryCache(gqlLru.New(1000))
 	gqlSrv.Use(gqlExtension.Introspection{})
 
+	gqlSrv.SetErrorPresenter(gqlErrorHandler)
+
 	gqlHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		gqlSrv.ServeHTTP(w, r)
 	}

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/internal/manager/config"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/session"
 )
 
@@ -61,7 +62,14 @@ func handleLogin(loginUIBox embed.FS) http.HandlerFunc {
 		}
 
 		err := manager.GetInstance().SessionStore.Login(w, r)
-		if errors.Is(err, session.ErrInvalidCredentials) {
+		if err != nil {
+			// always log the error
+			logger.Errorf("Error logging in: %v", err)
+		}
+
+		var invalidCredentialsError *session.InvalidCredentialsError
+
+		if errors.As(err, &invalidCredentialsError) {
 			// redirect back to the login page with an error
 			redirectToLogin(loginUIBox, w, url, "Username or password is invalid")
 			return

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -235,6 +235,13 @@ func (log *Logger) Tracef(format string, args ...interface{}) {
 	log.addLogItem(l)
 }
 
+func (log *Logger) TraceFunc(fn func() (string, []interface{})) {
+	if log.logger.Level >= logrus.TraceLevel {
+		msg, args := fn()
+		log.Tracef(msg, args...)
+	}
+}
+
 func (log *Logger) Debug(args ...interface{}) {
 	log.logger.Debug(args...)
 	l := &LogItem{
@@ -251,6 +258,17 @@ func (log *Logger) Debugf(format string, args ...interface{}) {
 		Message: fmt.Sprintf(format, args...),
 	}
 	log.addLogItem(l)
+}
+
+func (log *Logger) logFunc(level logrus.Level, logFn func(format string, args ...interface{}), fn func() (string, []interface{})) {
+	if log.logger.Level >= level {
+		msg, args := fn()
+		logFn(msg, args...)
+	}
+}
+
+func (log *Logger) DebugFunc(fn func() (string, []interface{})) {
+	log.logFunc(logrus.DebugLevel, log.logger.Debugf, fn)
 }
 
 func (log *Logger) Info(args ...interface{}) {
@@ -271,6 +289,10 @@ func (log *Logger) Infof(format string, args ...interface{}) {
 	log.addLogItem(l)
 }
 
+func (log *Logger) InfoFunc(fn func() (string, []interface{})) {
+	log.logFunc(logrus.InfoLevel, log.logger.Infof, fn)
+}
+
 func (log *Logger) Warn(args ...interface{}) {
 	log.logger.Warn(args...)
 	l := &LogItem{
@@ -289,6 +311,10 @@ func (log *Logger) Warnf(format string, args ...interface{}) {
 	log.addLogItem(l)
 }
 
+func (log *Logger) WarnFunc(fn func() (string, []interface{})) {
+	log.logFunc(logrus.WarnLevel, log.logger.Warnf, fn)
+}
+
 func (log *Logger) Error(args ...interface{}) {
 	log.logger.Error(args...)
 	l := &LogItem{
@@ -305,6 +331,10 @@ func (log *Logger) Errorf(format string, args ...interface{}) {
 		Message: fmt.Sprintf(format, args...),
 	}
 	log.addLogItem(l)
+}
+
+func (log *Logger) ErrorFunc(fn func() (string, []interface{})) {
+	log.logFunc(logrus.ErrorLevel, log.logger.Errorf, fn)
 }
 
 func (log *Logger) Fatal(args ...interface{}) {

--- a/pkg/logger/basic.go
+++ b/pkg/logger/basic.go
@@ -31,11 +31,21 @@ func (log *BasicLogger) Tracef(format string, args ...interface{}) {
 	log.printf("Trace", format, args...)
 }
 
+func (log *BasicLogger) TraceFunc(fn func() (string, []interface{})) {
+	format, args := fn()
+	log.printf("Trace", format, args...)
+}
+
 func (log *BasicLogger) Debug(args ...interface{}) {
 	log.print("Debug", args...)
 }
 
 func (log *BasicLogger) Debugf(format string, args ...interface{}) {
+	log.printf("Debug", format, args...)
+}
+
+func (log *BasicLogger) DebugFunc(fn func() (string, []interface{})) {
+	format, args := fn()
 	log.printf("Debug", format, args...)
 }
 
@@ -47,6 +57,11 @@ func (log *BasicLogger) Infof(format string, args ...interface{}) {
 	log.printf("Info", format, args...)
 }
 
+func (log *BasicLogger) InfoFunc(fn func() (string, []interface{})) {
+	format, args := fn()
+	log.printf("Info", format, args...)
+}
+
 func (log *BasicLogger) Warn(args ...interface{}) {
 	log.print("Warn", args...)
 }
@@ -55,11 +70,21 @@ func (log *BasicLogger) Warnf(format string, args ...interface{}) {
 	log.printf("Warn", format, args...)
 }
 
+func (log *BasicLogger) WarnFunc(fn func() (string, []interface{})) {
+	format, args := fn()
+	log.printf("Warn", format, args...)
+}
+
 func (log *BasicLogger) Error(args ...interface{}) {
 	log.print("Error", args...)
 }
 
 func (log *BasicLogger) Errorf(format string, args ...interface{}) {
+	log.printf("Error", format, args...)
+}
+
+func (log *BasicLogger) ErrorFunc(fn func() (string, []interface{})) {
+	format, args := fn()
 	log.printf("Error", format, args...)
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,18 +16,23 @@ type LoggerImpl interface {
 
 	Trace(args ...interface{})
 	Tracef(format string, args ...interface{})
+	TraceFunc(fn func() (string, []interface{}))
 
 	Debug(args ...interface{})
 	Debugf(format string, args ...interface{})
+	DebugFunc(fn func() (string, []interface{}))
 
 	Info(args ...interface{})
 	Infof(format string, args ...interface{})
+	InfoFunc(fn func() (string, []interface{}))
 
 	Warn(args ...interface{})
 	Warnf(format string, args ...interface{})
+	WarnFunc(fn func() (string, []interface{}))
 
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
+	ErrorFunc(fn func() (string, []interface{}))
 
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
@@ -61,6 +66,14 @@ func Tracef(format string, args ...interface{}) {
 	}
 }
 
+// TraceFunc calls TraceFunc with the Logger registered using RegisterLogger.
+// If no logger has been registered, then this function is a no-op.
+func TraceFunc(fn func() (string, []interface{})) {
+	if Logger != nil {
+		Logger.TraceFunc(fn)
+	}
+}
+
 // Debug calls Debug with the Logger registered using RegisterLogger.
 // If no logger has been registered, then this function is a no-op.
 func Debug(args ...interface{}) {
@@ -74,6 +87,14 @@ func Debug(args ...interface{}) {
 func Debugf(format string, args ...interface{}) {
 	if Logger != nil {
 		Logger.Debugf(format, args...)
+	}
+}
+
+// DebugFunc calls DebugFunc with the Logger registered using RegisterLogger.
+// If no logger has been registered, then this function is a no-op.
+func DebugFunc(fn func() (string, []interface{})) {
+	if Logger != nil {
+		Logger.DebugFunc(fn)
 	}
 }
 
@@ -93,6 +114,14 @@ func Infof(format string, args ...interface{}) {
 	}
 }
 
+// InfoFunc calls InfoFunc with the Logger registered using RegisterLogger.
+// If no logger has been registered, then this function is a no-op.
+func InfoFunc(fn func() (string, []interface{})) {
+	if Logger != nil {
+		Logger.InfoFunc(fn)
+	}
+}
+
 // Warn calls Warn with the Logger registered using RegisterLogger.
 // If no logger has been registered, then this function is a no-op.
 func Warn(args ...interface{}) {
@@ -109,6 +138,14 @@ func Warnf(format string, args ...interface{}) {
 	}
 }
 
+// WarnFunc calls WarnFunc with the Logger registered using RegisterLogger.
+// If no logger has been registered, then this function is a no-op.
+func WarnFunc(fn func() (string, []interface{})) {
+	if Logger != nil {
+		Logger.WarnFunc(fn)
+	}
+}
+
 // Error calls Error with the Logger registered using RegisterLogger.
 // If no logger has been registered, then this function is a no-op.
 func Error(args ...interface{}) {
@@ -122,6 +159,14 @@ func Error(args ...interface{}) {
 func Errorf(format string, args ...interface{}) {
 	if Logger != nil {
 		Logger.Errorf(format, args...)
+	}
+}
+
+// ErrorFunc calls ErrorFunc with the Logger registered using RegisterLogger.
+// If no logger has been registered, then this function is a no-op.
+func ErrorFunc(fn func() (string, []interface{})) {
+	if Logger != nil {
+		Logger.ErrorFunc(fn)
 	}
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -39,7 +39,8 @@ type InvalidCredentialsError struct {
 }
 
 func (e InvalidCredentialsError) Error() string {
-	return "invalid credentials for user " + e.Username
+	// don't leak the username
+	return "invalid credentials"
 }
 
 var ErrUnauthorized = errors.New("unauthorized")
@@ -73,7 +74,8 @@ func (s *Store) Login(w http.ResponseWriter, r *http.Request) error {
 		return &InvalidCredentialsError{Username: username}
 	}
 
-	logger.Infof("User %s logged in", username)
+	// since we only have one user, don't leak the name
+	logger.Info("User logged in")
 
 	newSession.Values[userIDKey] = username
 
@@ -91,8 +93,6 @@ func (s *Store) Logout(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	username := session.Values[userIDKey]
-
 	delete(session.Values, userIDKey)
 	session.Options.MaxAge = -1
 
@@ -101,7 +101,8 @@ func (s *Store) Logout(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	logger.Infof("User %s logged out", username)
+	// since we only have one user, don't leak the name
+	logger.Infof("User logged out")
 
 	return nil
 }


### PR DESCRIPTION
Adds an error presenter to the graphql interface that logs any encountered errors to the error log level. Also logs the request arguments at the debug log level when an error is encountered.