### PR TITLE
Fix scan cover defaults

### DIFF
--- a/pkg/sqlite/migrations/45_postmigrate.go
+++ b/pkg/sqlite/migrations/45_postmigrate.go
@@ -278,6 +278,16 @@ func (m *schema45Migrator) migrateConfig(ctx context.Context) error {
 		logger.Errorf("Error while writing configuration file: %s", err.Error())
 	}
 
+	// if default scan settings are set, then set to generate scene covers by default
+	scanDefaults := c.GetDefaultScanSettings()
+	if scanDefaults != nil {
+		scanDefaults.ScanGenerateCovers = true
+		c.Set(config.DefaultScanSettings, scanDefaults)
+		if err := c.Write(); err != nil {
+			logger.Errorf("Error while writing configuration file: %s", err.Error())
+		}
+	}
+
 	return nil
 }
 

--- a/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
@@ -29,7 +29,7 @@ export const ScanOptions: React.FC<IScanOptions> = ({
       <BooleanSetting
         id="scan-generate-covers"
         headingID="config.tasks.generate_video_covers_during_scan"
-        checked={scanGenerateCovers ?? false}
+        checked={scanGenerateCovers ?? true}
         onChange={(v) => setOptions({ scanGenerateCovers: v })}
       />
       <BooleanSetting


### PR DESCRIPTION
Changes the 45 post-migration code to default the generate covers scan option to true. Also changes the UI to default this value to true.