### PR TITLE
Use 100% width on cards in mobile

### DIFF
--- a/ui/v2.5/src/components/Galleries/styles.scss
+++ b/ui/v2.5/src/components/Galleries/styles.scss
@@ -26,6 +26,10 @@
     overflow: hidden;
     padding: 0;
     padding-bottom: 1rem;
+
+    @media (max-width: 576px) {
+      width: 100%;
+    }
   }
 
   .card-section {

--- a/ui/v2.5/src/components/Images/styles.scss
+++ b/ui/v2.5/src/components/Images/styles.scss
@@ -17,6 +17,10 @@
   &.card {
     overflow: hidden;
     padding: 0;
+
+    @media (max-width: 576px) {
+      width: 100%;
+    }
   }
 
   .rating-banner {

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -68,6 +68,10 @@
 .performer-card {
   width: 20rem;
 
+  @media (max-width: 576px) {
+    width: 100%;
+  }
+
   .thumbnail-section {
     position: relative;
   }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -89,6 +89,10 @@ textarea.scene-description {
 .studio-card {
   padding: 0.5rem;
 
+  @media (max-width: 576px) {
+    width: 100%;
+  }
+
   &-header {
     height: 150px;
     line-height: 150px;
@@ -240,6 +244,10 @@ textarea.scene-description {
 .scene-card.card {
   overflow: hidden;
   padding: 0;
+
+  @media (max-width: 576px) {
+    width: 100%;
+  }
 
   &.fileless {
     background-color: darken($card-bg, 5%);

--- a/ui/v2.5/src/components/Tags/styles.scss
+++ b/ui/v2.5/src/components/Tags/styles.scss
@@ -22,6 +22,10 @@
 .tag-card {
   padding: 0.5rem;
 
+  @media (max-width: 576px) {
+    width: 100%;
+  }
+
   &-image {
     display: block;
     margin: 0 auto;


### PR DESCRIPTION
It's bothered me that the cards don't use all the horizontal space on mobile devices. Changes all cards to use 100% width on smaller devices. Open to feedback on this change.