### PR TITLE
Require source selector click to show

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -170,6 +170,10 @@ $sceneTabWidth: 450px;
   }
 
   .vjs-source-selector {
+    &.vjs-hover .vjs-menu { 
+      display: none 
+    }
+
     .vjs-menu li {
       font-size: 0.8em;
     }

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -170,8 +170,8 @@ $sceneTabWidth: 450px;
   }
 
   .vjs-source-selector {
-    &.vjs-hover .vjs-menu { 
-      display: none 
+    &.vjs-hover .vjs-menu {
+      display: none;
     }
 
     .vjs-menu li {


### PR DESCRIPTION
Changes the source selector to require a click to show the menu instead of showing it on hover. This irritated me during scrubbing. I wanted to also do this for the playback rates, but they don't bring up a menu on click, changing the playback rate instead. I can hide the menu in injected css instead.