### PR TITLE
add conditionals to avoid url base duplication on stashbox submit

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -1046,10 +1047,20 @@ func (c Client) SubmitPerformerDraft(ctx context.Context, performer *models.Perf
 
 	var urls []string
 	if len(strings.TrimSpace(performer.Twitter)) > 0 {
-		urls = append(urls, "https://twitter.com/"+strings.TrimSpace(performer.Twitter))
+		reg := regexp.MustCompile(`https?:\/\/(?:www\.)?twitter\.com`)
+		if reg.MatchString(performer.Twitter) {
+			urls = append(urls, strings.TrimSpace(performer.Twitter))
+		} else {
+			urls = append(urls, "https://twitter.com/"+strings.TrimSpace(performer.Twitter))
+		}
 	}
 	if len(strings.TrimSpace(performer.Instagram)) > 0 {
-		urls = append(urls, "https://instagram.com/"+strings.TrimSpace(performer.Instagram))
+		reg := regexp.MustCompile(`https?:\/\/(?:www\.)?instagram\.com`)
+		if reg.MatchString(performer.Instagram) {
+			urls = append(urls, strings.TrimSpace(performer.Instagram))
+		} else {
+			urls = append(urls, "https://instagram.com/"+strings.TrimSpace(performer.Instagram))
+		}
 	}
 	if len(strings.TrimSpace(performer.URL)) > 0 {
 		urls = append(urls, strings.TrimSpace(performer.URL))


### PR DESCRIPTION
Currently twitter and instagram URL bases are appended to twitter and instagram before submitting to stashbox. This means that if the existing entry had the full url instead of just a username, the base gets duplicated. This adds logic to prevent that duplication.