### PR TITLE
Add busy timeout to database connection

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -213,7 +213,7 @@ func (db *Database) Close() error {
 
 func (db *Database) open(disableForeignKeys bool) (*sqlx.DB, error) {
 	// https://github.com/mattn/go-sqlite3
-	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL"
+	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL&_busy_timeout=50"
 	if !disableForeignKeys {
 		url += "&_fk=true"
 	}


### PR DESCRIPTION
Add a busy timeout to the database connection, which means a connection will wait for the database to be unlocked instead of throwing a 'database is locked' error immediately.

I looked at some issues in the go-sqlite repo and 50ms looks to be the value that others are using, and it seems to be sufficient here as well. It can easily be increased if necessary in the future.

Fixed the issue mentioned in https://github.com/stashapp/stash/pull/3527#issuecomment-1470920492.