### PR TITLE
Fix path filtering when directory has whitespace in it

### DIFF
--- a/ui/v2.5/src/components/List/Filters/PathFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/PathFilter.tsx
@@ -39,6 +39,7 @@ export const PathFilter: React.FC<IInputFilterProps> = ({
           currentDirectory={criterion.value ? criterion.value.toString() : ""}
           setCurrentDirectory={(v) => onValueChanged(v)}
           collapsible
+          quoteSpaced
           defaultDirectories={libraryPaths}
         />
       )}

--- a/ui/v2.5/src/components/List/Filters/PathFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/PathFilter.tsx
@@ -40,6 +40,7 @@ export const PathFilter: React.FC<IInputFilterProps> = ({
           setCurrentDirectory={(v) => onValueChanged(v)}
           collapsible
           quoteSpaced
+          hideError
           defaultDirectories={libraryPaths}
         />
       )}

--- a/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
@@ -13,6 +13,7 @@ interface IProps {
   defaultDirectories?: string[];
   appendButton?: JSX.Element;
   collapsible?: boolean;
+  quoteSpaced?: boolean;
 }
 
 export const FolderSelect: React.FC<IProps> = ({
@@ -21,10 +22,17 @@ export const FolderSelect: React.FC<IProps> = ({
   defaultDirectories,
   appendButton,
   collapsible = false,
+  quoteSpaced = false,
 }) => {
   const [showBrowser, setShowBrowser] = React.useState(false);
   const [directory, setDirectory] = useState(currentDirectory);
-  const { data, error, loading } = useDirectory(directory);
+
+  const isQuoted =
+    quoteSpaced && directory.startsWith('"') && directory.endsWith('"');
+  const { data, error, loading } = useDirectory(
+    isQuoted ? directory.slice(1, -1) : directory
+  );
+
   const intl = useIntl();
 
   const selectableDirectories: string[] = currentDirectory
@@ -40,6 +48,10 @@ export const FolderSelect: React.FC<IProps> = ({
   }, [currentDirectory, directory, debouncedSetDirectory]);
 
   function setInstant(value: string) {
+    if (quoteSpaced && value.includes(" ")) {
+      value = `"${value}"`;
+    }
+
     setCurrentDirectory(value);
     setDirectory(value);
   }

--- a/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
@@ -14,6 +14,7 @@ interface IProps {
   appendButton?: JSX.Element;
   collapsible?: boolean;
   quoteSpaced?: boolean;
+  hideError?: boolean;
 }
 
 export const FolderSelect: React.FC<IProps> = ({
@@ -23,6 +24,7 @@ export const FolderSelect: React.FC<IProps> = ({
   appendButton,
   collapsible = false,
   quoteSpaced = false,
+  hideError = false,
 }) => {
   const [showBrowser, setShowBrowser] = React.useState(false);
   const [directory, setDirectory] = useState(currentDirectory);
@@ -35,9 +37,12 @@ export const FolderSelect: React.FC<IProps> = ({
 
   const intl = useIntl();
 
+  const defaultDirectoriesOrEmpty = defaultDirectories ?? [];
+
   const selectableDirectories: string[] = currentDirectory
-    ? data?.directory.directories ?? defaultDirectories ?? []
-    : defaultDirectories ?? [];
+    ? data?.directory.directories ??
+      (error && hideError ? [] : defaultDirectoriesOrEmpty)
+    : defaultDirectoriesOrEmpty;
 
   const debouncedSetDirectory = useDebouncedSetState(setDirectory, 250);
 
@@ -107,13 +112,13 @@ export const FolderSelect: React.FC<IProps> = ({
           <InputGroup.Append className="align-self-center">
             {loading ? (
               <LoadingIndicator inline small message="" />
-            ) : (
+            ) : !hideError ? (
               <Icon icon={faTimes} color="red" className="ml-3" />
-            )}
+            ) : undefined}
           </InputGroup.Append>
         ) : undefined}
       </InputGroup>
-      {error !== undefined && (
+      {!hideError && error !== undefined && (
         <h5 className="mt-4 text-break">Error: {error.message}</h5>
       )}
       <Collapse in={!collapsible || showBrowser}>


### PR DESCRIPTION
Changes the behaviour of the directory selector in the path filter to quote the path value if it contains spaces. Also suppresses the display of errors in the path filter dialog.

Resolves #3597 - it won't work when trying to filter with a quoted path non-quoted path parts (ie `"full/quoted path" foo bar), but this is a more niche use case and should be addressed separately.