### PR TITLE
Add opt-in UI sourcemaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,10 @@ ui: pre-build
 	$(SET) VITE_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
 	cd ui/v2.5 && yarn build
 
+.PHONY: ui-sourcemaps
+ui-sourcemaps: export VITE_APP_SOURCEMAPS := true
+ui-sourcemaps: ui
+
 .PHONY: ui-start
 ui-start: pre-build
 	$(SET) VITE_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,9 @@ ifeq (${SHELL}, cmd)
 endif
 
 ifdef IS_WIN_SHELL
-  SEPARATOR := &&
-  SET := set
   RM := del /s /q
   RMDIR := rmdir /s /q
-  PWD := $(shell echo %cd%)
 else
-  SEPARATOR := ;
-  SET := export
   RM := rm -f
   RMDIR := rm -rf
 endif
@@ -34,10 +29,10 @@ export CGO_ENABLED = 1
 GO_BUILD_TAGS_WINDOWS := sqlite_omit_load_extension sqlite_stat4 osusergo
 GO_BUILD_TAGS_DEFAULT = $(GO_BUILD_TAGS_WINDOWS) netgo
 
-.PHONY: release pre-build
-
+.PHONY: release
 release: pre-ui generate ui build-release
 
+.PHONY: pre-build
 pre-build:
 ifndef BUILD_DATE
 	$(eval BUILD_DATE := $(shell go run -mod=vendor scripts/getDate.go))
@@ -55,29 +50,37 @@ ifndef OFFICIAL_BUILD
 	$(eval OFFICIAL_BUILD := false)
 endif
 
+.PHONY: build-flags
+build-flags: pre-build
+	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/api.buildstamp=$(BUILD_DATE)')
+	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/api.githash=$(GITHASH)')
+	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/api.version=$(STASH_VERSION)')
+	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/manager/config.officialBuild=$(OFFICIAL_BUILD)')
 ifndef GO_BUILD_TAGS
 	$(eval GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT))
 endif
-
+	$(eval BUILD_FLAGS := -mod=vendor -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)")
 
 # NOTE: the build target still includes netgo because we cannot detect
 # Windows easily from the Makefile.
-build: pre-build
+.PHONY: build
+build: build-flags
 build:
-	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/api.version=$(STASH_VERSION)' -X 'github.com/stashapp/stash/internal/api.buildstamp=$(BUILD_DATE)' -X 'github.com/stashapp/stash/internal/api.githash=$(GITHASH)')
-	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash/internal/manager/config.officialBuild=$(OFFICIAL_BUILD)')
-	go build $(OUTPUT) -mod=vendor -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS) $(PLATFORM_SPECIFIC_LDFLAGS)" ./cmd/stash
+	go build $(OUTPUT) $(BUILD_FLAGS) ./cmd/stash
 
 # strips debug symbols from the release build
+.PHONY: build-release
 build-release: EXTRA_LDFLAGS := -s -w
 build-release: GO_BUILD_FLAGS := -trimpath
 build-release: build
 
+.PHONY: build-release-static
 build-release-static: EXTRA_LDFLAGS := -extldflags=-static -s -w
 build-release-static: GO_BUILD_FLAGS := -trimpath
 build-release-static: build
 
 # cross-compile- targets should be run within the compiler docker container
+.PHONY: cross-compile-windows
 cross-compile-windows: export GOOS := windows
 cross-compile-windows: export GOARCH := amd64
 cross-compile-windows: export CC := x86_64-w64-mingw32-gcc
@@ -86,6 +89,7 @@ cross-compile-windows: OUTPUT := -o dist/stash-win.exe
 cross-compile-windows: GO_BUILD_TAGS := $(GO_BUILD_TAGS_WINDOWS)
 cross-compile-windows: build-release-static
 
+.PHONY: cross-compile-macos-intel
 cross-compile-macos-intel: export GOOS := darwin
 cross-compile-macos-intel: export GOARCH := amd64
 cross-compile-macos-intel: export CC := o64-clang
@@ -95,6 +99,7 @@ cross-compile-macos-intel: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 # can't use static build for OSX
 cross-compile-macos-intel: build-release
 
+.PHONY: cross-compile-macos-applesilicon
 cross-compile-macos-applesilicon: export GOOS := darwin
 cross-compile-macos-applesilicon: export GOARCH := arm64
 cross-compile-macos-applesilicon: export CC := oa64e-clang
@@ -104,6 +109,7 @@ cross-compile-macos-applesilicon: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 # can't use static build for OSX
 cross-compile-macos-applesilicon: build-release
 
+.PHONY: cross-compile-macos
 cross-compile-macos:
 	rm -rf dist/Stash.app dist/Stash-macos.zip
 	make cross-compile-macos-applesilicon
@@ -118,18 +124,21 @@ cross-compile-macos:
 	cd dist && zip -r Stash-macos.zip Stash.app && cd ..
 	rm -rf dist/Stash.app
 
+.PHONY: cross-compile-freebsd
 cross-compile-freebsd: export GOOS := freebsd
 cross-compile-freebsd: export GOARCH := amd64
 cross-compile-freebsd: OUTPUT := -o dist/stash-freebsd
 cross-compile-freebsd: GO_BUILD_TAGS += netgo
 cross-compile-freebsd: build-release-static
 
+.PHONY: cross-compile-linux
 cross-compile-linux: export GOOS := linux
 cross-compile-linux: export GOARCH := amd64
 cross-compile-linux: OUTPUT := -o dist/stash-linux
 cross-compile-linux: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 cross-compile-linux: build-release-static
 
+.PHONY: cross-compile-linux-arm64v8
 cross-compile-linux-arm64v8: export GOOS := linux
 cross-compile-linux-arm64v8: export GOARCH := arm64
 cross-compile-linux-arm64v8: export CC := aarch64-linux-gnu-gcc
@@ -137,6 +146,7 @@ cross-compile-linux-arm64v8: OUTPUT := -o dist/stash-linux-arm64v8
 cross-compile-linux-arm64v8: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 cross-compile-linux-arm64v8: build-release-static
 
+.PHONY: cross-compile-linux-arm32v7
 cross-compile-linux-arm32v7: export GOOS := linux
 cross-compile-linux-arm32v7: export GOARCH := arm
 cross-compile-linux-arm32v7: export GOARM := 7
@@ -145,6 +155,7 @@ cross-compile-linux-arm32v7: OUTPUT := -o dist/stash-linux-arm32v7
 cross-compile-linux-arm32v7: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 cross-compile-linux-arm32v7: build-release-static
 
+.PHONY: cross-compile-linux-arm32v6
 cross-compile-linux-arm32v6: export GOOS := linux
 cross-compile-linux-arm32v6: export GOARCH := arm
 cross-compile-linux-arm32v6: export GOARM := 6
@@ -153,6 +164,7 @@ cross-compile-linux-arm32v6: OUTPUT := -o dist/stash-linux-arm32v6
 cross-compile-linux-arm32v6: GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT)
 cross-compile-linux-arm32v6: build-release-static
 
+.PHONY: cross-compile-all
 cross-compile-all:
 	make cross-compile-windows
 	make cross-compile-macos-intel
@@ -164,15 +176,16 @@ cross-compile-all:
 
 .PHONY: touch-ui
 touch-ui:
-ifndef IS_WIN_SHELL
-	@mkdir -p ui/v2.5/build
-	@touch ui/v2.5/build/index.html
-else
+ifdef IS_WIN_SHELL
 	@if not exist "ui\\v2.5\\build" mkdir ui\\v2.5\\build
 	@type nul >> ui/v2.5/build/index.html
+else
+	@mkdir -p ui/v2.5/build
+	@touch ui/v2.5/build/index.html
 endif
 
 # Regenerates GraphQL files
+.PHONY: generate
 generate: generate-backend generate-frontend
 
 .PHONY: generate-frontend
@@ -219,14 +232,14 @@ generate-test-mocks:
 # runs server
 # sets the config file to use the local dev config
 .PHONY: server-start
-server-start: export STASH_CONFIG_FILE=config.yml
-server-start:
-ifndef IS_WIN_SHELL
-	@mkdir -p .local
-else
+server-start: export STASH_CONFIG_FILE := config.yml
+server-start: build-flags
+ifdef IS_WIN_SHELL
 	@if not exist ".local" mkdir .local
+else
+	@mkdir -p .local
 endif
-	cd .local && go run ../cmd/stash
+	cd .local && go run $(BUILD_FLAGS) ../cmd/stash
 
 # removes local dev config files
 .PHONY: server-clean
@@ -239,11 +252,14 @@ server-clean:
 pre-ui:
 	cd ui/v2.5 && yarn install --frozen-lockfile
 
+.PHONY: ui-env
+ui-env: pre-build
+	$(eval export VITE_APP_DATE := $(BUILD_DATE))
+	$(eval export VITE_APP_GITHASH := $(GITHASH))
+	$(eval export VITE_APP_STASH_VERSION := $(STASH_VERSION))
+
 .PHONY: ui
-ui: pre-build
-	$(SET) VITE_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \
-	$(SET) VITE_APP_GITHASH=$(GITHASH) $(SEPARATOR) \
-	$(SET) VITE_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
+ui: ui-env
 	cd ui/v2.5 && yarn build
 
 .PHONY: ui-sourcemaps
@@ -251,10 +267,7 @@ ui-sourcemaps: export VITE_APP_SOURCEMAPS := true
 ui-sourcemaps: ui
 
 .PHONY: ui-start
-ui-start: pre-build
-	$(SET) VITE_APP_DATE="$(BUILD_DATE)" $(SEPARATOR) \
-	$(SET) VITE_APP_GITHASH=$(GITHASH) $(SEPARATOR) \
-	$(SET) VITE_APP_STASH_VERSION=$(STASH_VERSION) $(SEPARATOR) \
+ui-start: ui-env
 	cd ui/v2.5 && yarn start --host
 
 .PHONY: fmt-ui

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ endif
 
 # set LDFLAGS environment variable to any extra ldflags required
 # set OUTPUT to generate a specific binary name
-
 LDFLAGS := $(LDFLAGS)
 ifdef OUTPUT
   OUTPUT := -o $(OUTPUT)
@@ -28,6 +27,12 @@ export CGO_ENABLED = 1
 # and isn't necessary for static builds on Windows
 GO_BUILD_TAGS_WINDOWS := sqlite_omit_load_extension sqlite_stat4 osusergo
 GO_BUILD_TAGS_DEFAULT = $(GO_BUILD_TAGS_WINDOWS) netgo
+
+# set STASH_NOLEGACY environment variable or uncomment to disable legacy browser support
+# STASH_NOLEGACY := true
+
+# set STASH_SOURCEMAPS environment variable or uncomment to enable UI sourcemaps
+# STASH_SOURCEMAPS := true
 
 .PHONY: release
 release: pre-ui generate ui build-release
@@ -257,13 +262,23 @@ ui-env: pre-build
 	$(eval export VITE_APP_DATE := $(BUILD_DATE))
 	$(eval export VITE_APP_GITHASH := $(GITHASH))
 	$(eval export VITE_APP_STASH_VERSION := $(STASH_VERSION))
+ifdef STASH_NOLEGACY
+	$(eval export VITE_APP_NOLEGACY := true)
+endif
+ifdef STASH_SOURCEMAPS
+	$(eval export VITE_APP_SOURCEMAPS := true)
+endif
 
 .PHONY: ui
 ui: ui-env
 	cd ui/v2.5 && yarn build
 
+.PHONY: ui-nolegacy
+ui-nolegacy: STASH_NOLEGACY := true
+ui-nolegacy: ui
+
 .PHONY: ui-sourcemaps
-ui-sourcemaps: export VITE_APP_SOURCEMAPS := true
+ui-sourcemaps: STASH_SOURCEMAPS := true
 ui-sourcemaps: ui
 
 .PHONY: ui-start

--- a/ui/v2.5/vite.config.js
+++ b/ui/v2.5/vite.config.js
@@ -4,11 +4,14 @@ import legacy from "@vitejs/plugin-legacy";
 import tsconfigPaths from "vite-tsconfig-paths";
 import viteCompression from "vite-plugin-compression";
 
+const sourcemap = process.env.VITE_APP_SOURCEMAPS === "true";
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "",
   build: {
     outDir: "build",
+    sourcemap: sourcemap,
     reportCompressedSize: false,
     rollupOptions: {
       output: {

--- a/ui/v2.5/vite.config.js
+++ b/ui/v2.5/vite.config.js
@@ -4,39 +4,47 @@ import legacy from "@vitejs/plugin-legacy";
 import tsconfigPaths from "vite-tsconfig-paths";
 import viteCompression from "vite-plugin-compression";
 
+const nolegacy = process.env.VITE_APP_NOLEGACY === "true";
 const sourcemap = process.env.VITE_APP_SOURCEMAPS === "true";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: "",
-  build: {
-    outDir: "build",
-    sourcemap: sourcemap,
-    reportCompressedSize: false,
-    rollupOptions: {
-      output: {
-        experimentalDeepDynamicChunkOptimization: true,
-      },
-    },
-  },
-  optimizeDeps: {
-    entries: "src/index.tsx",
-  },
-  server: {
-    port: 3000,
-    cors: false,
-  },
-  publicDir: "public",
-  assetsInclude: ["**/*.md"],
-  plugins: [
+export default defineConfig(() => {
+  let plugins = [
     react(),
-    legacy(),
     tsconfigPaths(),
     viteCompression({
       algorithm: "gzip",
-      disable: false,
       deleteOriginFile: true,
+      threshold: 0,
       filter: /\.(js|json|css|svg|md)$/i,
     }),
-  ],
+  ];
+
+  if (!nolegacy) {
+    plugins = [...plugins, legacy()];
+  }
+
+  return {
+    base: "",
+    build: {
+      outDir: "build",
+      sourcemap: sourcemap,
+      reportCompressedSize: false,
+      rollupOptions: {
+        output: {
+          experimentalDeepDynamicChunkOptimization: true,
+        },
+      },
+    },
+    optimizeDeps: {
+      entries: "src/index.tsx",
+    },
+    server: {
+      port: 3000,
+      cors: false,
+    },
+    publicDir: "public",
+    assetsInclude: ["**/*.md"],
+    plugins,
+  };
 });


### PR DESCRIPTION
Adds a Makefile target `ui-sourcemaps` which uses the `VITE_APP_SOURCEMAPS` environment variable to add sourcemaps to the UI build. Sourcemaps can also be enabled by setting `STASH_SOURCEMAPS`, when running plain `make` or `make release` for example. The line in the Makefile can also be uncommented if you don't want to add the environment variable every time. 

Also did some cleanup on the Makefile, which includes adding `.PHONY` everywhere and adding build flags to `server-start`.

Related to #3590

Edit: Added a similar `STASH_NOLEGACY` environment variable to disable legacy chunk generation, which decreases build size and time if you don't need to support legacy browsers.