### PR TITLE
Fix moveFiles for zip files

### DIFF
--- a/internal/manager/repository.go
+++ b/internal/manager/repository.go
@@ -35,7 +35,6 @@ type SceneReaderWriter interface {
 
 type FileReaderWriter interface {
 	file.Store
-	file.Finder
 	Query(ctx context.Context, options models.FileQueryOptions) (*models.FileQueryResult, error)
 	GetCaptions(ctx context.Context, fileID file.ID) ([]*models.VideoCaption, error)
 	IsPrimary(ctx context.Context, fileID file.ID) (bool, error)
@@ -43,7 +42,6 @@ type FileReaderWriter interface {
 
 type FolderReaderWriter interface {
 	file.FolderStore
-	Find(ctx context.Context, id file.FolderID) (*file.Folder, error)
 }
 
 type Repository struct {

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -180,6 +180,11 @@ type Destroyer interface {
 	Destroy(ctx context.Context, id ID) error
 }
 
+type GetterUpdater interface {
+	Getter
+	Updater
+}
+
 type GetterDestroyer interface {
 	Getter
 	Destroyer

--- a/pkg/file/folder.go
+++ b/pkg/file/folder.go
@@ -32,6 +32,10 @@ func (f *Folder) Info(fs FS) (fs.FileInfo, error) {
 	return f.info(fs, f.Path)
 }
 
+type FolderFinder interface {
+	Find(ctx context.Context, id FolderID) (*Folder, error)
+}
+
 // FolderPathFinder finds Folders by their path.
 type FolderPathFinder interface {
 	FindByPath(ctx context.Context, path string) (*Folder, error)
@@ -39,6 +43,7 @@ type FolderPathFinder interface {
 
 // FolderGetter provides methods to find Folders.
 type FolderGetter interface {
+	FolderFinder
 	FolderPathFinder
 	FindByZipFileID(ctx context.Context, zipFileID ID) ([]*Folder, error)
 	FindAllInPaths(ctx context.Context, p []string, limit, offset int) ([]*Folder, error)


### PR DESCRIPTION
This is a bugfix for the `moveFiles` endpoint only moving the zip file itself and not the files contained within, causing the image files to point to nonexistent paths.