### PR TITLE
Fix zip gallery moving

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -769,7 +769,14 @@ func (s *scanJob) handleRename(ctx context.Context, f File, fp []Fingerprint) (F
 
 	var missing []File
 
+	fZipID := f.Base().ZipFileID
 	for _, other := range others {
+		// if file is from a zip file, then only rename if both files are from the same zip file
+		otherZipID := other.Base().ZipFileID
+		if otherZipID != nil && (fZipID == nil || *otherZipID != *fZipID) {
+			continue
+		}
+
 		// if file does not exist, then update it to the new path
 		fs, err := s.getFileFS(other.Base())
 		if err != nil {


### PR DESCRIPTION
Currently, the `ZipFileID` of a folder is not properly kept up to date with the actual zip gallery associated with the folder. 

When a zip file is renamed on disk, the next scan will create new folder entries with the correct `ZipFileID`, but the old folder entries do not have their `ZipFileID` cleared. Additionally, if a folder entry in the database with the same name as a new zip file already exists, then that folder does not have a new `ZipFileID` set. This is a fix for these two issues.

This also fixes another sort-of related issue I found. To replicate it: add a zip gallery with an image to stash, then move the zip file somewhere outside of a library path. Copy the image from inside the zip gallery to a standalone image in a library path and scan. Stash will detect that the image file has been renamed, and update the file which was previously in the zip file to now be outside the zip file. If you then move the zip file back into the same place it was previously, Stash will not rescan (assuming your OS didn't reset the modtime) and the zip file will appear to have no images.
The fix is to prevent stash from replacing a file in a zip file with a new file from outside that zip file. It will still replace the file if the file is renamed within the zip file or if the entire zip file itself is moved.