### PR TITLE
Add default blob data location

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -36,5 +36,7 @@ services:
       - ./metadata:/metadata
       ## Any other cache content.
       - ./cache:/cache
+      ## Where to store binary blob data (scene covers, images)
+      - ./blobs:/blobs
       ## Where to store generated content (screenshots,previews,transcodes,sprites)
       - ./generated:/generated


### PR DESCRIPTION
On a new installation, Stash will default to 'blobs' (which relative to the CWD of /, becomes '/blobs'). In our recommended docker installation, this is NOT mapped and as a result will NOT be persistent across the container being removed or updated.

So by default, we are populating blob data which will be deleted, likely leaving to some confused new users. **This should also be noted for existing installations to make this a persistent path.**