### PR TITLE
Use ReadTxn for performer aliases

### DIFF
--- a/internal/api/resolver_model_performer.go
+++ b/internal/api/resolver_model_performer.go
@@ -19,7 +19,7 @@ func (r *performerResolver) Checksum(ctx context.Context, obj *models.Performer)
 
 func (r *performerResolver) Aliases(ctx context.Context, obj *models.Performer) (*string, error) {
 	if !obj.Aliases.Loaded() {
-		if err := r.withTxn(ctx, func(ctx context.Context) error {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 			return obj.LoadAliases(ctx, r.repository.Performer)
 		}); err != nil {
 			return nil, err
@@ -32,7 +32,7 @@ func (r *performerResolver) Aliases(ctx context.Context, obj *models.Performer) 
 
 func (r *performerResolver) AliasList(ctx context.Context, obj *models.Performer) ([]string, error) {
 	if !obj.Aliases.Loaded() {
-		if err := r.withTxn(ctx, func(ctx context.Context) error {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 			return obj.LoadAliases(ctx, r.repository.Performer)
 		}); err != nil {
 			return nil, err


### PR DESCRIPTION
Replaces `withTxn` with `withReadTxn` for the performer alias resolvers, which was causing the performer list to unnecessarily hang while loading if something else was holding the write lock. I looked around a bit and couldn't find any other unnecessary `WithTxn` usages.