### PR TITLE
Fix queries referencing non-existent tables

### DIFF
--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -1003,15 +1003,15 @@ func galleryPerformerTagsCriterionHandler(qb *GalleryStore, tags *models.Hierarc
 
 			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
 
-			f.addWith(`performer_tags AS (
+			f.addWith(`performers_tags AS (
 SELECT pg.gallery_id, t.column1 AS root_tag_id FROM performers_galleries pg
 INNER JOIN performers_tags pt ON pt.performer_id = pg.performer_id
 INNER JOIN (` + valuesClause + `) t ON t.column2 = pt.tag_id
 )`)
 
-			f.addLeftJoin("performer_tags", "", "performer_tags.gallery_id = galleries.id")
+			f.addLeftJoin("performers_tags", "", "performers_tags.gallery_id = galleries.id")
 
-			addHierarchicalConditionClauses(f, tags, "performer_tags", "root_tag_id")
+			addHierarchicalConditionClauses(f, tags, "performers_tags", "root_tag_id")
 		}
 	}
 }

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -977,15 +977,15 @@ func imagePerformerTagsCriterionHandler(qb *ImageStore, tags *models.Hierarchica
 
 			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
 
-			f.addWith(`performer_tags AS (
+			f.addWith(`performers_tags AS (
 SELECT pi.image_id, t.column1 AS root_tag_id FROM performers_images pi
 INNER JOIN performers_tags pt ON pt.performer_id = pi.performer_id
 INNER JOIN (` + valuesClause + `) t ON t.column2 = pt.tag_id
 )`)
 
-			f.addLeftJoin("performer_tags", "", "performer_tags.image_id = images.id")
+			f.addLeftJoin("performers_tags", "", "performers_tags.image_id = images.id")
 
-			addHierarchicalConditionClauses(f, tags, "performer_tags", "root_tag_id")
+			addHierarchicalConditionClauses(f, tags, "performers_tags", "root_tag_id")
 		}
 	}
 }

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1369,15 +1369,15 @@ func scenePerformerTagsCriterionHandler(qb *SceneStore, tags *models.Hierarchica
 
 			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
 
-			f.addWith(`performer_tags AS (
+			f.addWith(`performers_tags AS (
 SELECT ps.scene_id, t.column1 AS root_tag_id FROM performers_scenes ps
 INNER JOIN performers_tags pt ON pt.performer_id = ps.performer_id
 INNER JOIN (` + valuesClause + `) t ON t.column2 = pt.tag_id
 )`)
 
-			f.addLeftJoin("performer_tags", "", "performer_tags.scene_id = scenes.id")
+			f.addLeftJoin("performers_tags", "", "performers_tags.scene_id = scenes.id")
 
-			addHierarchicalConditionClauses(f, tags, "performer_tags", "root_tag_id")
+			addHierarchicalConditionClauses(f, tags, "performers_tags", "root_tag_id")
 		}
 	}
 }

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -211,7 +211,7 @@ func sceneMarkerTagsCriterionHandler(qb *sceneMarkerQueryBuilder, tags *models.H
 			}
 			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
 
-			f.addWith(`marker_tags AS (
+			f.addWith(`scene_markers_tags AS (
 SELECT mt.scene_marker_id, t.column1 AS root_tag_id FROM scene_markers_tags mt
 INNER JOIN (` + valuesClause + `) t ON t.column2 = mt.tag_id
 UNION
@@ -219,9 +219,9 @@ SELECT m.id, t.column1 FROM scene_markers m
 INNER JOIN (` + valuesClause + `) t ON t.column2 = m.primary_tag_id
 )`)
 
-			f.addLeftJoin("marker_tags", "", "marker_tags.scene_marker_id = scene_markers.id")
+			f.addLeftJoin("scene_markers_tags", "", "scene_markers_tags.scene_marker_id = scene_markers.id")
 
-			addHierarchicalConditionClauses(f, tags, "marker_tags", "root_tag_id")
+			addHierarchicalConditionClauses(f, tags, "scene_markers_tags", "root_tag_id")
 		}
 	}
 }


### PR DESCRIPTION
`performer_tags` and `marker_tags` tables do not exist but `performers_tags` and `scene_markers_tags` do

While working on something in python to help write queries as code easier, graphql returned an error when using the `AND` operator on the `performer_tags` criterion for scenes. The following query  

```gql
{
  findScenes(
    filter: {per_page: 1}
    scene_filter: {AND: {performer_tags: {modifier: INCLUDES, value: ["1"]}}}
  ) {
    scenes {
      id
    }
  }
}
```

results in an error

```json
{
  "errors": [
    {
      "message": "error finding IDs: running query: SELECT DISTINCT scenes.id FROM scenes LEFT JOIN performer_tags ON performer_tags.scene_id = scenes.id WHERE ((performer_tags.root_tag_id IS NOT NULL)) LIMIT 1 OFFSET 0  [[]]: error executing `SELECT DISTINCT scenes.id FROM scenes LEFT JOIN performer_tags ON performer_tags.scene_id = scenes.id WHERE ((performer_tags.root_tag_id IS NOT NULL)) LIMIT 1 OFFSET 0 ` [[]]: no such table: performer_tags",
      "path": [
        "findScenes"
      ]
    }
  ],
  "data": null
}
```

while the equivalent query without the `AND` 

```gql
{
  findScenes(
    filter: {per_page: 1}
    scene_filter: {performer_tags: {modifier: INCLUDES, value: ["1"]}}
  ) {
    scenes {
      id
    }
  }
}
```
returns successfully

```json
{
  "data": {
    "findScenes": {
      "scenes": []
    }
  }
}
```

Admittedly I haven't dug deep enough into the source to know if there's something else going on here but it will definitely take me a while to fully understand the db code and get a development env setup so I figured I would offer this up for review in the meantime.
