### PR TITLE
Don't regenerate covers if present during scan

### DIFF
--- a/internal/manager/task_generate_screenshot.go
+++ b/internal/manager/task_generate_screenshot.go
@@ -23,10 +23,17 @@ func (t *GenerateCoverTask) GetDescription() string {
 func (t *GenerateCoverTask) Start(ctx context.Context) {
 	scenePath := t.Scene.Path
 
+	var required bool
 	if err := t.txnManager.WithReadTxn(ctx, func(ctx context.Context) error {
+		// don't generate the screenshot if it already exists
+		required = t.required(ctx)
 		return t.Scene.LoadPrimaryFile(ctx, t.txnManager.File)
 	}); err != nil {
 		logger.Error(err)
+	}
+
+	if !required {
+		return
 	}
 
 	videoFile := t.Scene.Files.Primary()

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -1114,11 +1114,14 @@ func verifyPerformerAge(t *testing.T, ageCriterion models.IntCriterionInput) {
 
 			d := performer.Birthdate.Time
 			age := cd.Year() - d.Year()
-			if cd.YearDay() < d.YearDay() {
+			// using YearDay screws up on leap years
+			if cd.Month() < d.Month() || (cd.Month() == d.Month() && cd.Day() < d.Day()) {
 				age = age - 1
 			}
 
-			verifyInt(t, age, ageCriterion)
+			if !verifyInt(t, age, ageCriterion) {
+				t.Errorf("Performer birthdate: %s, deathdate: %s", performer.Birthdate.String(), performer.DeathDate.String())
+			}
 		}
 
 		return nil

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2836,21 +2836,23 @@ func verifyScenesOCounter(t *testing.T, oCounterCriterion models.IntCriterionInp
 	})
 }
 
-func verifyInt(t *testing.T, value int, criterion models.IntCriterionInput) {
+func verifyInt(t *testing.T, value int, criterion models.IntCriterionInput) bool {
 	t.Helper()
 	assert := assert.New(t)
 	if criterion.Modifier == models.CriterionModifierEquals {
-		assert.Equal(criterion.Value, value)
+		return assert.Equal(criterion.Value, value)
 	}
 	if criterion.Modifier == models.CriterionModifierNotEquals {
-		assert.NotEqual(criterion.Value, value)
+		return assert.NotEqual(criterion.Value, value)
 	}
 	if criterion.Modifier == models.CriterionModifierGreaterThan {
-		assert.Greater(value, criterion.Value)
+		return assert.Greater(value, criterion.Value)
 	}
 	if criterion.Modifier == models.CriterionModifierLessThan {
-		assert.Less(value, criterion.Value)
+		return assert.Less(value, criterion.Value)
 	}
+
+	return true
 }
 
 func TestSceneQueryDuration(t *testing.T) {


### PR DESCRIPTION
Fixes issue where scanning a moved scene file would regenerate the scene cover, regardless of whether the cover was already set.