### PR TITLE
Fix empty strings overwriting during scrape

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -19,6 +19,7 @@ import {
   ScrapedInputGroupRow,
   ScrapedTextAreaRow,
   ScrapeResult,
+  ZeroableScrapeResult,
 } from "../Shared/ScrapeDialog";
 import { clone, uniq } from "lodash-es";
 import {
@@ -65,8 +66,9 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
   );
 
   const [rating, setRating] = useState(
-    new ScrapeResult<number>(dest.rating100)
+    new ZeroableScrapeResult<number>(dest.rating100)
   );
+  // zero values can be treated as missing for these fields
   const [oCounter, setOCounter] = useState(
     new ScrapeResult<number>(dest.o_counter)
   );
@@ -118,7 +120,7 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
   const [stashIDs, setStashIDs] = useState(new ScrapeResult<GQL.StashId[]>([]));
 
   const [organized, setOrganized] = useState(
-    new ScrapeResult<boolean>(dest.organized)
+    new ZeroableScrapeResult<boolean>(dest.organized)
   );
 
   const [image, setImage] = useState<ScrapeResult<string>>(

--- a/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog.tsx
@@ -36,7 +36,9 @@ export class ScrapeResult<T> {
   ) {
     this.originalValue = originalValue ?? undefined;
     this.newValue = newValue ?? undefined;
-    const hasNewValue = this.newValue !== undefined;
+    // NOTE: this means that zero values are treated as null
+    // this is incorrect for numbers and booleans, but correct for strings
+    const hasNewValue = !!this.newValue;
 
     const valuesEqual = isEqual(originalValue, newValue);
     this.useNewValue = useNewValue ?? (hasNewValue && !valuesEqual);
@@ -65,6 +67,23 @@ export class ScrapeResult<T> {
     if (this.useNewValue) {
       return this.newValue;
     }
+  }
+}
+
+// for types where !!value is a valid value (boolean and number)
+export class ZeroableScrapeResult<T> extends ScrapeResult<T> {
+  public constructor(
+    originalValue?: T | null,
+    newValue?: T | null,
+    useNewValue?: boolean
+  ) {
+    super(originalValue, newValue, useNewValue);
+
+    const hasNewValue = this.newValue !== undefined;
+
+    const valuesEqual = isEqual(originalValue, newValue);
+    this.useNewValue = useNewValue ?? (hasNewValue && !valuesEqual);
+    this.scraped = hasNewValue && !valuesEqual;
   }
 }
 


### PR DESCRIPTION
Fixes issue where an empty string in the scraped results would overwrite an existing value.