### PR TITLE
Fix latest version error

### DIFF
--- a/internal/api/check_version.go
+++ b/internal/api/check_version.go
@@ -113,7 +113,6 @@ type LatestRelease struct {
 }
 
 func makeGithubRequest(ctx context.Context, url string, output interface{}) error {
-
 	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
 
 	client := &http.Client{
@@ -124,6 +123,7 @@ func makeGithubRequest(ctx context.Context, url string, output interface{}) erro
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 
 	req.Header.Add("Accept", apiAcceptHeader) // gh api recommendation , send header with api version
+	logger.Debugf("Github API request: %s", url)
 	response, err := client.Do(req)
 
 	if err != nil {
@@ -229,19 +229,39 @@ func GetLatestRelease(ctx context.Context) (*LatestRelease, error) {
 }
 
 func getReleaseHash(ctx context.Context, tagName string) (string, error) {
-	url := apiTags
-	tags := []githubTagResponse{}
-	err := makeGithubRequest(ctx, url, &tags)
-	if err != nil {
-		return "", err
+	// Start with a small page size if not searching for latest_develop
+	perPage := 10
+	if tagName == developmentTag {
+		perPage = 100
 	}
 
-	for _, tag := range tags {
-		if tag.Name == tagName {
-			if len(tag.Commit.Sha) != 40 {
-				return "", errors.New("invalid Github API response")
+	// Limit to 5 pages, ie 500 tags - should be plenty
+	for page := 1; page <= 5; {
+		url := fmt.Sprintf("%s?per_page=%d&page=%d", apiTags, perPage, page)
+		tags := []githubTagResponse{}
+		err := makeGithubRequest(ctx, url, &tags)
+		if err != nil {
+			return "", err
+		}
+
+		for _, tag := range tags {
+			if tag.Name == tagName {
+				if len(tag.Commit.Sha) != 40 {
+					return "", errors.New("invalid Github API response")
+				}
+				return tag.Commit.Sha, nil
 			}
-			return tag.Commit.Sha, nil
+		}
+
+		if len(tags) == 0 {
+			break
+		}
+
+		// if not found in the first 10, search again on page 1 with the first 100
+		if perPage == 10 {
+			perPage = 100
+		} else {
+			page++
 		}
 	}
 


### PR DESCRIPTION
This is a fix for 'invalid Github API response' errors when trying to retrieve the latest version on a development build.

The cause is that there are now over 30 tags in the repo, which is the default page size of the GitHub API tags endpoint used to find the latest release hash. The results for this endpoint seem to be sorted in reverse order, so the `latest_develop` tag will always be the last one in the list. I couldn't find a better way, so we have to search through the entire list.

I've set an upper limit of 500 tags to retrieve, so this will break if/when stash hits such a tag count, but I don't think that will happen any time soon.