### PR TITLE
Player touch control improvements

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -34,28 +34,6 @@ $sceneTabWidth: 450px;
     outline: none;
   }
 
-  .vjs-big-button-group {
-    display: none;
-    height: 80px;
-    justify-content: space-around;
-    opacity: 0;
-    position: absolute;
-    top: calc(50% - 40px);
-    width: 100%;
-    z-index: 1;
-
-    .vjs-button {
-      font-size: 4em;
-      height: 100%;
-      width: 80px;
-
-      .vjs-icon-placeholder::before {
-        height: 100%;
-        line-height: 80px;
-      }
-    }
-  }
-
   &.vjs-has-started {
     .vjs-touch-overlay {
       display: block;
@@ -305,28 +283,6 @@ $sceneTabWidth: 450px;
 
   @media (pointer: coarse) {
     &.vjs-touch-enabled {
-      &.vjs-has-started .vjs-big-button-group {
-        display: flex;
-        opacity: 1;
-        visibility: visible;
-      }
-
-      &.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-big-button-group {
-        opacity: 0;
-        pointer-events: none;
-        transition: visibility 1s, opacity 1s;
-        visibility: visible;
-      }
-
-      .vjs-big-play-pause-button .vjs-icon-placeholder::before {
-        content: "\f101";
-        font-family: VideoJS;
-      }
-
-      &.vjs-playing .vjs-big-play-pause-button .vjs-icon-placeholder::before {
-        content: "\f103";
-      }
-
       .vjs-vtt-thumbnail-display {
         bottom: 2.8em;
       }
@@ -382,11 +338,6 @@ $sceneTabWidth: 450px;
 
     .vjs-time-control {
       font-size: 12px;
-    }
-
-    .vjs-big-button-group .vjs-button {
-      font-size: 2em;
-      width: 50px;
     }
 
     .vjs-current-time {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -51,12 +51,17 @@ $sceneTabWidth: 450px;
     display: none;
 
     .vjs-play-control {
-      height: calc(80% - 14em);
+      height: 100px;
       opacity: 1;
       pointer-events: auto;
       transition: visibility 0.1s, opacity 0.1s;
       visibility: visible;
+      width: 100px;
       z-index: 1;
+
+      .vjs-icon-placeholder::before {
+        background-size: 80%;
+      }
     }
 
     &.skip {
@@ -183,19 +188,19 @@ $sceneTabWidth: 450px;
     background: none;
     border: none;
     font-size: inherit;
-    height: calc(80% - 14em);
+    height: 100px;
     left: 50%;
     margin: 0;
     position: absolute;
     top: 50%;
     transform: translate(-50%, -50%);
-    width: 30%;
+    width: 100px;
 
     .vjs-icon-placeholder::before {
       background-image: url('data:image/svg+xml;utf8,<svg fill="%23FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
       background-position: center center;
       background-repeat: no-repeat;
-      background-size: 60%;
+      background-size: 80%;
       content: "";
     }
   }
@@ -338,6 +343,16 @@ $sceneTabWidth: 450px;
 
     .vjs-time-control {
       font-size: 12px;
+    }
+
+    .vjs-big-play-button {
+      height: 60px;
+      width: 60px;
+    }
+
+    .vjs-touch-overlay .vjs-play-control {
+      height: 60px;
+      width: 60px;
     }
 
     .vjs-current-time {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -56,8 +56,65 @@ $sceneTabWidth: 450px;
     }
   }
 
-  .vjs-touch-overlay .vjs-play-control {
-    z-index: 1;
+  &.vjs-has-started {
+    .vjs-touch-overlay {
+      display: block;
+    }
+
+    &.vjs-user-inactive.vjs-playing .vjs-touch-overlay .vjs-play-control {
+      opacity: 0;
+      pointer-events: none;
+      transition: visibility 1s, opacity 1s;
+      visibility: visible;
+    }
+  }
+
+  .vjs-touch-overlay {
+    display: none;
+
+    .vjs-play-control {
+      height: calc(80% - 14em);
+      opacity: 1;
+      pointer-events: auto;
+      transition: visibility 0.1s, opacity 0.1s;
+      visibility: visible;
+      z-index: 1;
+    }
+
+    &.skip {
+      -webkit-animation: none;
+      animation: none;
+      background: none;
+      opacity: 1;
+
+      &::before {
+        -webkit-animation: fadeAndScale 0.6s linear;
+        animation: fadeAndScale 0.6s linear;
+        background-image: url('data:image/svg+xml;utf8,<svg fill="%23FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M4 18l8.5-6L4 6v12zm9-12v12l8.5-6L13 6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+        background-position: 80% center;
+        background-repeat: no-repeat;
+        background-size: 10%;
+        bottom: 0;
+        content: "";
+        left: 0;
+        opacity: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      &.reverse {
+        -webkit-animation: none;
+        animation: none;
+        background: none;
+        opacity: 1;
+
+        &::before {
+          background-image: url('data:image/svg+xml;utf8,<svg fill="%23FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 18V6l-8.5 6 8.5 6zm.5-6l8.5 6V6l-8.5 6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+          background-position: 20% center;
+        }
+      }
+    }
   }
 
   .vjs-control-bar {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -204,7 +204,22 @@ $sceneTabWidth: 450px;
   &:hover .vjs-big-play-button {
     background: none;
     border: none;
-    font-size: 10em;
+    font-size: inherit;
+    height: calc(80% - 14em);
+    left: 50%;
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 30%;
+
+    .vjs-icon-placeholder::before {
+      background-image: url('data:image/svg+xml;utf8,<svg fill="%23FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: 60%;
+      content: "";
+    }
   }
 
   .vjs-skip-button {


### PR DESCRIPTION
This is a bit of CSS trickery to fix some of the issues pointed out in #3649, while still keeping double tap to seek enabled. The big play/pause button is now coupled to the control bar below, and its clickable area is a whole lot smaller. I've also removed some of the unused styles left over from the big-buttons plugin.

I believe this fixes the first three issues in #3649, but not the last two, relating to the touchstart event. That would require either disabling videojs-mobile-ui touch controls and using big-buttons again (ie #3650) or adding a custom replacement plugin to do the same job.

I don't use mobile all that often, and I don't really have a preference for double tap to seek over the old big buttons, so if the touchstart issue is deemed big enough then feel free to merge #3650 and not this.

I do think the better long-term solution would be to add a custom plugin and ditch videojs-mobile-ui entirely though, so that we can have both big buttons and double tap to seek. I'll get around to doing that eventually.