### PR TITLE
Add hint for alias duplicates

### DIFF
--- a/ui/v2.5/src/components/Shared/StringListInput.tsx
+++ b/ui/v2.5/src/components/Shared/StringListInput.tsx
@@ -60,7 +60,7 @@ export const StringListInput: React.FC<IStringListInputProps> = (props) => {
           ))}
         </Form.Group>
       </div>
-      <div className="invalid-feedback">{props.errors}</div>
+      <div className="invalid-feedback mt-n2">{props.errors}</div>
     </>
   );
 };

--- a/ui/v2.5/src/components/Shared/StringListInput.tsx
+++ b/ui/v2.5/src/components/Shared/StringListInput.tsx
@@ -9,6 +9,7 @@ interface IStringListInputProps {
   placeholder?: string;
   className?: string;
   errors?: string;
+  errorIdx?: number[];
 }
 
 export const StringListInput: React.FC<IStringListInputProps> = (props) => {
@@ -35,10 +36,11 @@ export const StringListInput: React.FC<IStringListInputProps> = (props) => {
       <div className={`string-list-input ${props.errors ? "is-invalid" : ""}`}>
         <Form.Group>
           {values.map((v, i) => (
-            // eslint-disable-next-line react/no-array-index-key
             <InputGroup className={props.className} key={i}>
               <Form.Control
-                className="text-input"
+                className={`text-input ${
+                  props.errorIdx?.includes(i) ? "is-invalid" : ""
+                }`}
                 value={v}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                   valueChanged(i, e.currentTarget.value)

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -331,6 +331,11 @@ div.react-datepicker {
   .react-datepicker-time__header {
     background-color: $secondary;
     color: $text-color;
+    padding-top: 0.4rem;
+  }
+
+  .react-datepicker__navigation {
+    top: 0.4rem;
   }
 
   .react-datepicker__day {
@@ -368,11 +373,11 @@ div.react-datepicker {
 
   .react-datepicker__month-dropdown-container {
     margin-left: 0;
-    margin-right: 0.25rem;
+    margin-right: 0.1rem;
   }
 
   .react-datepicker__year-dropdown-container {
-    margin-left: 0.25rem;
+    margin-left: 0.1rem;
     margin-right: 0;
   }
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -31,8 +31,8 @@
 }
 
 .details-edit {
-  /* 
-    The penultimate button should be wrapped in an unstyled div. 
+  /*
+    The penultimate button should be wrapped in an unstyled div.
     This allows the div to expand, to right-justify the last (save / delete) button.
   */
 
@@ -285,8 +285,8 @@ button.collapse-button.btn-primary:not(:disabled):not(.disabled):active {
   opacity: 0.5;
 }
 
-.string-list-input .text-input {
-  margin-bottom: 0.25rem;
+.string-list-input .input-group {
+  margin-bottom: 0.35rem;
 }
 
 .bulk-update-text-input {

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -316,14 +316,6 @@ button.collapse-button.btn-primary:not(:disabled):not(.disabled):active {
   }
 }
 
-.CountrySelect {
-  /* stylelint-disable */
-  .react-select__control:hover {
-    border: none;
-  }
-  /* stylelint-enable */
-}
-
 .date-input.form-control:focus {
   // z-index gets set to 3 in input groups
   z-index: inherit;


### PR DESCRIPTION
This is an implementation for the suggestion in #3639, using the preexisting `is-invalid` class to display a error icon.

I've also fixed the overflow issue with the remove buttons, decreased the spacing above the 'aliases must be unique' message, and increased the spacing between the alias entries.

And then I've also added two unrelated style improvements:
- A tweak to the country select dropdown to show a border on hover, whose removal was causing the contents to move to the left by 1px on hover. All the other dropdowns show a border on hover so I don't know why it was removed for the country field specifically.
- Improved alignment for the left and right arrows in the date picker. It bothered me that they were really far up and not at all aligned with the line showing the selected month and year. The exact alignment is dependent on the actual fonts used on the system, so it doesn't line up perfectly everywhere, but I think it's better now than before.


Closes #3639