### PR TITLE
Fix generate task override behaviour

### DIFF
--- a/internal/manager/task_generate_interactive_heatmap_speed.go
+++ b/internal/manager/task_generate_interactive_heatmap_speed.go
@@ -22,7 +22,7 @@ func (t *GenerateInteractiveHeatmapSpeedTask) GetDescription() string {
 }
 
 func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
-	if !t.shouldGenerate() {
+	if !t.required() {
 		return
 	}
 
@@ -52,13 +52,18 @@ func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
 	}
 }
 
-func (t *GenerateInteractiveHeatmapSpeedTask) shouldGenerate() bool {
+func (t *GenerateInteractiveHeatmapSpeedTask) required() bool {
 	primaryFile := t.Scene.Files.Primary()
 	if primaryFile == nil || !primaryFile.Interactive {
 		return false
 	}
+
+	if t.Overwrite {
+		return true
+	}
+
 	sceneHash := t.Scene.GetHash(t.fileNamingAlgorithm)
-	return !t.doesHeatmapExist(sceneHash) || primaryFile.InteractiveSpeed == nil || t.Overwrite
+	return !t.doesHeatmapExist(sceneHash) || primaryFile.InteractiveSpeed == nil
 }
 
 func (t *GenerateInteractiveHeatmapSpeedTask) doesHeatmapExist(sceneChecksum string) bool {

--- a/internal/manager/task_generate_phash.go
+++ b/internal/manager/task_generate_phash.go
@@ -24,7 +24,7 @@ func (t *GeneratePhashTask) GetDescription() string {
 }
 
 func (t *GeneratePhashTask) Start(ctx context.Context) {
-	if !t.shouldGenerate() {
+	if !t.required() {
 		return
 	}
 
@@ -49,6 +49,10 @@ func (t *GeneratePhashTask) Start(ctx context.Context) {
 	}
 }
 
-func (t *GeneratePhashTask) shouldGenerate() bool {
-	return t.Overwrite || t.File.Fingerprints.Get(file.FingerprintTypePhash) == nil
+func (t *GeneratePhashTask) required() bool {
+	if t.Overwrite {
+		return true
+	}
+
+	return t.File.Fingerprints.Get(file.FingerprintTypePhash) == nil
 }

--- a/internal/manager/task_generate_preview.go
+++ b/internal/manager/task_generate_preview.go
@@ -30,13 +30,9 @@ func (t *GeneratePreviewTask) GetDescription() string {
 }
 
 func (t *GeneratePreviewTask) Start(ctx context.Context) {
-	if !t.Overwrite && !t.required() {
-		return
-	}
-
 	videoChecksum := t.Scene.GetHash(t.fileNamingAlgorithm)
 
-	if t.Overwrite || !t.doesVideoPreviewExist() {
+	if t.videoPreviewRequired() {
 		ffprobe := instance.FFProbe
 		videoFile, err := ffprobe.NewVideoFile(t.Scene.Path)
 		if err != nil {
@@ -51,7 +47,7 @@ func (t *GeneratePreviewTask) Start(ctx context.Context) {
 		}
 	}
 
-	if t.ImagePreview && (t.Overwrite || !t.doesImagePreviewExist()) {
+	if t.imagePreviewRequired() {
 		if err := t.generateWebp(videoChecksum); err != nil {
 			logger.Errorf("error generating preview webp: %v", err)
 			logErrorOutput(err)
@@ -59,7 +55,7 @@ func (t *GeneratePreviewTask) Start(ctx context.Context) {
 	}
 }
 
-func (t GeneratePreviewTask) generateVideo(videoChecksum string, videoDuration float64, videoFrameRate float64) error {
+func (t *GeneratePreviewTask) generateVideo(videoChecksum string, videoDuration float64, videoFrameRate float64) error {
 	videoFilename := t.Scene.Path
 	useVsync2 := false
 
@@ -78,12 +74,16 @@ func (t GeneratePreviewTask) generateVideo(videoChecksum string, videoDuration f
 	return nil
 }
 
-func (t GeneratePreviewTask) generateWebp(videoChecksum string) error {
+func (t *GeneratePreviewTask) generateWebp(videoChecksum string) error {
 	videoFilename := t.Scene.Path
 	return t.generator.PreviewWebp(context.TODO(), videoFilename, videoChecksum)
 }
 
-func (t GeneratePreviewTask) required() bool {
+func (t *GeneratePreviewTask) required() bool {
+	return t.videoPreviewRequired() || t.imagePreviewRequired()
+}
+
+func (t *GeneratePreviewTask) videoPreviewRequired() bool {
 	if t.Scene.Path == "" {
 		return false
 	}
@@ -92,12 +92,6 @@ func (t GeneratePreviewTask) required() bool {
 		return true
 	}
 
-	videoExists := t.doesVideoPreviewExist()
-	imageExists := !t.ImagePreview || t.doesImagePreviewExist()
-	return !imageExists || !videoExists
-}
-
-func (t *GeneratePreviewTask) doesVideoPreviewExist() bool {
 	sceneChecksum := t.Scene.GetHash(t.fileNamingAlgorithm)
 	if sceneChecksum == "" {
 		return false
@@ -108,10 +102,22 @@ func (t *GeneratePreviewTask) doesVideoPreviewExist() bool {
 		t.videoPreviewExists = &videoExists
 	}
 
-	return *t.videoPreviewExists
+	return !*t.videoPreviewExists
 }
 
-func (t *GeneratePreviewTask) doesImagePreviewExist() bool {
+func (t *GeneratePreviewTask) imagePreviewRequired() bool {
+	if !t.ImagePreview {
+		return false
+	}
+
+	if t.Scene.Path == "" {
+		return false
+	}
+
+	if t.Overwrite {
+		return true
+	}
+
 	sceneChecksum := t.Scene.GetHash(t.fileNamingAlgorithm)
 	if sceneChecksum == "" {
 		return false
@@ -122,5 +128,5 @@ func (t *GeneratePreviewTask) doesImagePreviewExist() bool {
 		t.imagePreviewExists = &imageExists
 	}
 
-	return *t.imagePreviewExists
+	return !*t.imagePreviewExists
 }

--- a/internal/manager/task_generate_screenshot.go
+++ b/internal/manager/task_generate_screenshot.go
@@ -21,19 +21,16 @@ func (t *GenerateCoverTask) GetDescription() string {
 }
 
 func (t *GenerateCoverTask) Start(ctx context.Context) {
+	if !t.required(ctx) {
+		return
+	}
+
 	scenePath := t.Scene.Path
 
-	var required bool
 	if err := t.txnManager.WithReadTxn(ctx, func(ctx context.Context) error {
-		// don't generate the screenshot if it already exists
-		required = t.required(ctx)
 		return t.Scene.LoadPrimaryFile(ctx, t.txnManager.File)
 	}); err != nil {
 		logger.Error(err)
-	}
-
-	if !required {
-		return
 	}
 
 	videoFile := t.Scene.Files.Primary()
@@ -92,7 +89,11 @@ func (t *GenerateCoverTask) Start(ctx context.Context) {
 }
 
 // required returns true if the sprite needs to be generated
-func (t GenerateCoverTask) required(ctx context.Context) bool {
+func (t *GenerateCoverTask) required(ctx context.Context) bool {
+	if t.Scene.Path == "" {
+		return false
+	}
+
 	if t.Overwrite {
 		return true
 	}

--- a/internal/manager/task_generate_sprite.go
+++ b/internal/manager/task_generate_sprite.go
@@ -20,7 +20,7 @@ func (t *GenerateSpriteTask) GetDescription() string {
 }
 
 func (t *GenerateSpriteTask) Start(ctx context.Context) {
-	if !t.Overwrite && !t.required() {
+	if !t.required() {
 		return
 	}
 
@@ -54,6 +54,11 @@ func (t GenerateSpriteTask) required() bool {
 	if t.Scene.Path == "" {
 		return false
 	}
+
+	if t.Overwrite {
+		return true
+	}
+
 	sceneHash := t.Scene.GetHash(t.fileNamingAlgorithm)
 	return !t.doesSpriteExist(sceneHash)
 }

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -490,6 +490,7 @@ func (g *sceneGenerators) Generate(ctx context.Context, s *models.Scene, f *file
 			taskCover := GenerateCoverTask{
 				Scene:      *s,
 				txnManager: instance.Repository,
+				Overwrite:  overwrite,
 			}
 			taskCover.Start(ctx)
 			progress.Increment()

--- a/internal/manager/task_transcode.go
+++ b/internal/manager/task_transcode.go
@@ -101,7 +101,7 @@ func (t *GenerateTranscodeTask) Start(ctc context.Context) {
 // return true if transcode is needed
 // used only when counting files to generate, doesn't affect the actual transcode generation
 // if container is missing from DB it is treated as non supported in order not to delay the user
-func (t *GenerateTranscodeTask) isTranscodeNeeded() bool {
+func (t *GenerateTranscodeTask) required() bool {
 	f := t.Scene.Files.Primary()
 	if f == nil {
 		return false

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -810,7 +810,7 @@
       "markers_tooltip": "20 second videos which begin at the given timecode.",
       "override_preview_generation_options": "Override Preview Generation Options",
       "override_preview_generation_options_desc": "Override Preview Generation Options for this operation. Defaults are set in System -> Preview Generation.",
-      "overwrite": "Overwrite existing generated files",
+      "overwrite": "Overwrite existing files",
       "phash": "Perceptual hashes (for deduplication)",
       "preview_exclude_end_time_desc": "Exclude the last x seconds from scene previews. This can be a value in seconds, or a percentage (eg 2%) of the total scene duration.",
       "preview_exclude_end_time_head": "Exclude end time",


### PR DESCRIPTION
This is a fix for the issue in #3657 - the override option is now properly handled by the cover generator task. The caption for the override switch has also been updated to reflect this change.

And then a minor tweak to the generate task log message - it now only shows the options that were selected.

Fixes #3657