### PR TITLE
Fix deceptive WEBM playback in Safari

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -16,12 +16,12 @@ $sceneTabWidth: 450px;
     height: 100vh;
   }
 
-  &.portrait .video-js {
+  &.portrait .video-wrapper {
     height: 177.78vw;
   }
 }
 
-.video-js {
+.video-wrapper {
   height: 56.25vw;
   overflow: hidden;
   width: 100%;
@@ -29,6 +29,11 @@ $sceneTabWidth: 450px;
   @media (min-width: 1200px) {
     height: 100%;
   }
+}
+
+.video-js {
+  height: 100%;
+  width: 100%;
 
   .vjs-button {
     outline: none;
@@ -109,7 +114,7 @@ $sceneTabWidth: 450px;
     width: 100%;
 
     .vjs-progress-holder {
-      margin: 0 1rem;
+      margin: 0 15px;
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -761,7 +761,6 @@ const SceneLoader: React.FC = () => {
       <div className={`scene-player-container ${collapsed ? "expanded" : ""}`}>
         <ScenePlayer
           key="ScenePlayer"
-          className="w-100 m-sm-auto no-gutter"
           scene={scene}
           hideScrubberOverride={hideScrubber}
           autoplay={autoplay}

--- a/ui/v2.5/vite.config.js
+++ b/ui/v2.5/vite.config.js
@@ -10,7 +10,11 @@ const sourcemap = process.env.VITE_APP_SOURCEMAPS === "true";
 // https://vitejs.dev/config/
 export default defineConfig(() => {
   let plugins = [
-    react(),
+    react({
+      babel: {
+        compact: true,
+      },
+    }),
     tsconfigPaths(),
     viteCompression({
       algorithm: "gzip",


### PR DESCRIPTION
This is a fix for a bug where in the source selector it appears as if Safari is successfully playing a WEBM video, but it is in fact just streaming the file directly. This is due to the `source-selector` plugin sending the entire list of sources through to video.js instead of only the selected one, meaning that video.js can skip sources it knows are unsupported, outside of the plugin's control. I've also fixed DASH playback on iPadOS, previously it would just always error despite DASH actually being supported.

And then there's also a fix for a Babel warning in the dev server about deoptimizing `generated-graphql.tsx`, and a fix for vite HMR in the scene player - the player no longer just disappears if the component is hot-reloaded.