### PR TITLE
Fix scene marker pinned filters

### DIFF
--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -33,6 +33,7 @@ import { CriterionType } from "src/models/list-filter/types";
 import { useToast } from "src/hooks/Toast";
 import { useConfigureUI } from "src/core/StashService";
 import { IUIConfig } from "src/core/config";
+import { FilterMode } from "src/core/generated-graphql";
 
 interface ICriterionList {
   criteria: string[];
@@ -188,6 +189,21 @@ const CriterionOptionList: React.FC<ICriterionList> = ({
   );
 };
 
+const FilterModeToConfigKey = {
+  [FilterMode.Galleries]: "galleries",
+  [FilterMode.Images]: "images",
+  [FilterMode.Movies]: "movies",
+  [FilterMode.Performers]: "performers",
+  [FilterMode.SceneMarkers]: "sceneMarkers",
+  [FilterMode.Scenes]: "scenes",
+  [FilterMode.Studios]: "studios",
+  [FilterMode.Tags]: "tags",
+};
+
+function filterModeToConfigKey(filterMode: FilterMode) {
+  return FilterModeToConfigKey[filterMode];
+}
+
 interface IEditFilterProps {
   filter: ListFilterModel;
   editingCriterion?: string;
@@ -260,7 +276,7 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
   const [saveUI] = useConfigureUI();
 
   const pinnedFilters = useMemo(
-    () => ui.pinnedFilters?.[currentFilter.mode.toLowerCase()] ?? [],
+    () => ui.pinnedFilters?.[filterModeToConfigKey(currentFilter.mode)] ?? [],
     [currentFilter.mode, ui.pinnedFilters]
   );
   const pinnedElements = useMemo(
@@ -289,7 +305,7 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
   ]);
 
   async function updatePinnedFilters(filters: string[]) {
-    const currentMode = currentFilter.mode.toLowerCase();
+    const configKey = filterModeToConfigKey(currentFilter.mode);
     try {
       await saveUI({
         variables: {
@@ -297,7 +313,7 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
             ...configuration?.ui,
             pinnedFilters: {
               ...ui.pinnedFilters,
-              [currentMode]: filters,
+              [configKey]: filters,
             },
           },
         },


### PR DESCRIPTION
This is a fix for a bug in #3675 I just came across where pinning filters in the scene marker tab wouldn't work.

The issue is that the backend transparently changes `camelCase` keys to `snake_case` keys as the keys are stored case-insensitively in the config file - but that means that if the keys were stored as `snake_case` to begin with then they will be converted to `camelCase` when they are retrieved again. This breaks the scene marker pinned filters because it tries to store under the `scene_markers` key which is then unexpectedly converted to `sceneMarkers`.