### PR TITLE
Fix filter dialog datepicker button padding

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -154,7 +154,7 @@ input[type="range"].zoom-slider {
       }
     }
 
-    .btn {
+    .card-header .btn {
       border: 0;
       padding-bottom: 0;
       padding-top: 0;


### PR DESCRIPTION
A simple fix for a style I added to #3675 which was causing the date picker button (in the "Created At" filter for example) to have broken padding.