### PR TITLE
Tagger: Add primary sort for exact phash matches

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -207,7 +207,7 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
     // Give priority to the most exact matches
     if (exactPhashMatchSceneA != exactPhashMatchSceneB) {
       return exactPhashMatchSceneB - exactPhashMatchSceneA;
-    } else {
+    } else if (exactPhashMatchSceneA > 0) {
       // Same exact matches, check for most durations before moving on to similar phash matches
       if (nbDurationMatchSceneA != nbDurationMatchSceneB) {
         return nbDurationMatchSceneB - nbDurationMatchSceneA;


### PR DESCRIPTION
Resolves #3695 

Currently the scene tagger is sorting multiple results by the number of phash matches up to a distance of 8.

This adds an initial sort before that, which first considers only exact phash matches (using duration as a tiebreaker), before falling back to the existing logic.