### PR TITLE
Lightbox movie covers

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -177,7 +177,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     } else if (image) {
       return (
         <Button
-          className="shadow-none"
+          className="movie-image-container"
           variant="link"
           onClick={() => showLightbox()}
         >
@@ -200,7 +200,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     if (image) {
       return (
         <Button
-          className="shadow-none"
+          className="movie-image-container"
           variant="link"
           onClick={() => showLightbox(index - 1)}
         >

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Button } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
 import Mousetrap from "mousetrap";
@@ -12,6 +13,7 @@ import { useParams, useHistory } from "react-router-dom";
 import { DetailsEditNavbar } from "src/components/Shared/DetailsEditNavbar";
 import { ErrorMessage } from "src/components/Shared/ErrorMessage";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
+import { useLightbox } from "src/hooks/Lightbox/hooks";
 import { ModalComponent } from "src/components/Shared/Modal";
 import { useToast } from "src/hooks/Toast";
 import { MovieScenesPanel } from "./MovieScenesPanel";
@@ -36,6 +38,43 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const [frontImage, setFrontImage] = useState<string | null>();
   const [backImage, setBackImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
+
+  const defaultImage =
+    movie.front_image_path && movie.front_image_path.includes("default=true")
+      ? true
+      : false;
+
+  const lightboxImages = useMemo(() => {
+    const covers = [
+      ...(movie.front_image_path && !defaultImage
+        ? [
+            {
+              paths: {
+                thumbnail: movie.front_image_path,
+                image: movie.front_image_path,
+              },
+            },
+          ]
+        : []),
+      ...(movie.back_image_path
+        ? [
+            {
+              paths: {
+                thumbnail: movie.back_image_path,
+                image: movie.back_image_path,
+              },
+            },
+          ]
+        : []),
+    ];
+    return covers;
+  }, [movie.front_image_path, movie.back_image_path, defaultImage]);
+
+  const index = lightboxImages.length;
+
+  const showLightbox = useLightbox({
+    images: lightboxImages,
+  });
 
   const [updateMovie, { loading: updating }] = useMovieUpdate();
   const [deleteMovie, { loading: deleting }] = useMovieDestroy({
@@ -129,11 +168,21 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
       }
     }
 
-    if (image) {
+    if (image && defaultImage) {
       return (
         <div className="movie-image-container">
           <img alt="Front Cover" src={image} />
         </div>
+      );
+    } else if (image) {
+      return (
+        <Button
+          className="shadow-none"
+          variant="link"
+          onClick={() => showLightbox()}
+        >
+          <img alt="Front Cover" src={image} />
+        </Button>
       );
     }
   }
@@ -150,9 +199,13 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
 
     if (image) {
       return (
-        <div className="movie-image-container">
+        <Button
+          className="shadow-none"
+          variant="link"
+          onClick={() => showLightbox(index - 1)}
+        >
           <img alt="Back Cover" src={image} />
-        </div>
+        </Button>
       );
     }
   }

--- a/ui/v2.5/src/components/Movies/styles.scss
+++ b/ui/v2.5/src/components/Movies/styles.scss
@@ -32,6 +32,7 @@
   max-width: 100%;
 
   .movie-image-container {
+    box-shadow: none;
     margin: 1rem;
   }
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -156,7 +156,11 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   function renderImage() {
     if (activeImage) {
       return (
-        <Button variant="link" onClick={() => showLightbox()}>
+        <Button
+          className="shadow-none"
+          variant="link"
+          onClick={() => showLightbox()}
+        >
           <img className="performer" src={activeImage} alt={performer.name} />
         </Button>
       );

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -156,11 +156,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   function renderImage() {
     if (activeImage) {
       return (
-        <Button
-          className="shadow-none"
-          variant="link"
-          onClick={() => showLightbox()}
-        >
+        <Button variant="link" onClick={() => showLightbox()}>
           <img className="performer" src={activeImage} alt={performer.name} />
         </Button>
       );

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -3,9 +3,15 @@
   margin: 0 auto;
   overflow: hidden;
 
-  .performer-image-container .performer {
-    max-height: calc(100vh - 6rem);
-    max-width: 100%;
+  .performer-image-container {
+    .btn {
+      box-shadow: none;
+    }
+
+    .performer {
+      max-height: calc(100vh - 6rem);
+      max-width: 100%;
+    }
   }
 
   .content-container {


### PR DESCRIPTION
Enables the movie covers to be opened fullsize, in a lightbox, as requested in #2812. The default placeholder image is excluded. Also removes the box-shadow from the performer page image - I just thought it looks a little odd.