### PR TITLE
Folder Gallery creation on a per folder basis

### DIFF
--- a/pkg/image/scan.go
+++ b/pkg/image/scan.go
@@ -307,32 +307,20 @@ func (h *ScanHandler) getOrCreateGallery(ctx context.Context, f file.File) (*mod
 		return h.getOrCreateZipBasedGallery(ctx, f.Base().ZipFile)
 	}
 
-	// Look for specific filenames in Folder to find out if the Folder is marked to be handled differently as the setting
+	// Look for specific filename in Folder to find out if the Folder is marked to be handled differently as the setting
 	folderPath := filepath.Dir(f.Base().Path)
-	forceGalleryFileNames := [...]string{".forcegallery", ".Forcegallery", ".ForceGallery", ".forceGallery", ".FORCEGALLERY"}
-	noGalleryFileNames := [...]string{".nogallery", ".Nogallery", ".NoGallery", ".noGallery", ".NOGALLERY"}
 
 	forceGallery := false
-	for _, filename := range forceGalleryFileNames {
-		if _, err := os.Stat(filepath.Join(folderPath, filename)); err == nil {
-			forceGallery = true
-			break
-		} else if errors.Is(err, os.ErrNotExist) {
-			continue
-		} else {
-			return nil, fmt.Errorf("Could not test Path %s: %w", folderPath, err)
-		}
+	if _, err := os.Stat(filepath.Join(folderPath, ".forcegallery")); err == nil {
+		forceGallery = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("Could not test Path %s: %w", folderPath, err)
 	}
 	exemptGallery := false
-	for _, filename := range noGalleryFileNames {
-		if _, err := os.Stat(filepath.Join(folderPath, filename)); err == nil {
-			exemptGallery = true
-			break
-		} else if errors.Is(err, os.ErrNotExist) {
-			continue
-		} else {
-			return nil, fmt.Errorf("Could not test Path %s: %w", folderPath, err)
-		}
+	if _, err := os.Stat(filepath.Join(folderPath, ".nogallery")); err == nil {
+		exemptGallery = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("Could not test Path %s: %w", folderPath, err)
 	}
 
 	if forceGallery || (h.ScanConfig.GetCreateGalleriesFromFolders() && !exemptGallery) {

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -44,7 +44,7 @@ If you wish to apply this on a per folder basis, you can create a file called **
 
 This will either exclude the folder from becoming a gallery even if the setting is set, or create a gallery from the folder even if the setting is not set. 
 
-You can use CamelCase/camelCase, CAPITALIZED or noncapitalized naming for those files.
+The file will only be recognized if written in lower case letters.
 
 Files with a dot in front are handled as hidden in the Linux OS and Mac OS, so you will not see those files after creation on your system without setting your file manager accordingly.
 

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -36,6 +36,18 @@ exclude:
 
 _a useful [link](https://regex101.com/) to experiment with regexps_
 
+## Gallery Creation from Folders
+
+In the Library section you can find an option to create a gallery from each folder containing images. This will be applied on all libraries when activated, including the base folder of a library. 
+
+If you wish to apply this on a per folder basis, you can create a file called **.nogallery** or **.forcegallery** in a folder that should act different than this global setting.
+
+This will either exclude the folder from becoming a gallery even if the setting is set, or create a gallery from the folder even if the setting is not set. 
+
+You can use CamelCase/camelCase, CAPITALIZED or noncapitalized naming for those files.
+
+Files with a dot in front are handled as hidden in the Linux OS and Mac OS, so you will not see those files after creation on your system without setting your file manager accordingly.
+
 ## Hashing algorithms
 
 Stash identifies video files by calculating a hash of the file. There are two algorithms available for hashing: `oshash` and `MD5`. `MD5` requires reading the entire file, and can therefore be slow, particularly when reading files over a network. `oshash` (which uses OpenSubtitle's hashing algorithm) only reads 64k from each end of the file.

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -281,7 +281,7 @@
       "check_for_insecure_certificates_desc": "Some sites use insecure ssl certificates. When unticked the scraper skips the insecure certificates check and allows scraping of those sites. If you get a certificate error when scraping untick this.",
       "chrome_cdp_path": "Chrome CDP path",
       "chrome_cdp_path_desc": "File path to the Chrome executable, or a remote address (starting with http:// or https://, for example http://localhost:9222/json/version) to a Chrome instance.",
-      "create_galleries_from_folders_desc": "If true, creates galleries from folders containing images.",
+      "create_galleries_from_folders_desc": "If true, creates galleries from folders containing images by default. Create a File called .forceGallery or .noGallery in a folder to enforce/prevent this.",
       "create_galleries_from_folders_label": "Create galleries from folders containing images",
       "database": "Database",
       "db_path_head": "Database Path",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -281,7 +281,7 @@
       "check_for_insecure_certificates_desc": "Some sites use insecure ssl certificates. When unticked the scraper skips the insecure certificates check and allows scraping of those sites. If you get a certificate error when scraping untick this.",
       "chrome_cdp_path": "Chrome CDP path",
       "chrome_cdp_path_desc": "File path to the Chrome executable, or a remote address (starting with http:// or https://, for example http://localhost:9222/json/version) to a Chrome instance.",
-      "create_galleries_from_folders_desc": "If true, creates galleries from folders containing images by default. Create a File called .forceGallery or .noGallery in a folder to enforce/prevent this.",
+      "create_galleries_from_folders_desc": "If true, creates galleries from folders containing images by default. Create a File called .forcegallery or .nogallery in a folder to enforce/prevent this.",
       "create_galleries_from_folders_label": "Create galleries from folders containing images",
       "database": "Database",
       "db_path_head": "Database Path",


### PR DESCRIPTION
As I've described in #3708, this commit allows to create galleries from folders by setting a .forcegallery file inside of a folder, even if the setting "Create galleries from folders containing images" in the Library section is not activated.
Also, by creating a .nogallery file inside a directory, a folder is not turned into a gallery even if the setting is activated.

The check is case insensitive and the content of the file is irrelevant (although an empty file is the typical usage for such a system), in theory even a folder with that name should work. For those not familiar, on Linux, Mac and Android, files starting with a dot are hidden, so in case hidden files/folders are not set visible in your file manager, after creation this file will not show up anymore. 

Closes #3708 

A little Question about the translation system, I've expanded the text of an existing value (to document the behavior for the user). Do I need to mark this in some way so the translators are informed that this value needs to be retranslated/expanded? I have no idea how this system works unfortunately.

