### PR TITLE
Include missing fields in performer batch tag

### DIFF
--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -119,24 +119,28 @@ func (t *StashBoxPerformerTagTask) stashBoxPerformerTag(ctx context.Context) {
 				aliases = []string{}
 			}
 			newPerformer := models.Performer{
-				Aliases:      models.NewRelatedStrings(aliases),
-				Birthdate:    getDate(performer.Birthdate),
-				CareerLength: getString(performer.CareerLength),
-				Country:      getString(performer.Country),
-				CreatedAt:    currentTime,
-				Ethnicity:    getString(performer.Ethnicity),
-				EyeColor:     getString(performer.EyeColor),
-				FakeTits:     getString(performer.FakeTits),
-				Gender:       models.GenderEnum(getString(performer.Gender)),
-				Height:       getIntPtr(performer.Height),
-				Weight:       getIntPtr(performer.Weight),
-				Instagram:    getString(performer.Instagram),
-				Measurements: getString(performer.Measurements),
-				Name:         *performer.Name,
-				Piercings:    getString(performer.Piercings),
-				Tattoos:      getString(performer.Tattoos),
-				Twitter:      getString(performer.Twitter),
-				URL:          getString(performer.URL),
+				Aliases:        models.NewRelatedStrings(aliases),
+				Disambiguation: getString(performer.Disambiguation),
+				Details:        getString(performer.Details),
+				Birthdate:      getDate(performer.Birthdate),
+				DeathDate:      getDate(performer.DeathDate),
+				CareerLength:   getString(performer.CareerLength),
+				Country:        getString(performer.Country),
+				CreatedAt:      currentTime,
+				Ethnicity:      getString(performer.Ethnicity),
+				EyeColor:       getString(performer.EyeColor),
+				HairColor:      getString(performer.HairColor),
+				FakeTits:       getString(performer.FakeTits),
+				Gender:         models.GenderEnum(getString(performer.Gender)),
+				Height:         getIntPtr(performer.Height),
+				Weight:         getIntPtr(performer.Weight),
+				Instagram:      getString(performer.Instagram),
+				Measurements:   getString(performer.Measurements),
+				Name:           *performer.Name,
+				Piercings:      getString(performer.Piercings),
+				Tattoos:        getString(performer.Tattoos),
+				Twitter:        getString(performer.Twitter),
+				URL:            getString(performer.URL),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
 						Endpoint: t.box.Endpoint,
@@ -192,6 +196,10 @@ func (t *StashBoxPerformerTagTask) getPartial(performer *models.ScrapedPerformer
 		value := getDate(performer.Birthdate)
 		partial.Birthdate = models.NewOptionalDate(*value)
 	}
+	if performer.DeathDate != nil && *performer.DeathDate != "" && !excluded["deathdate"] {
+		value := getDate(performer.DeathDate)
+		partial.Birthdate = models.NewOptionalDate(*value)
+	}
 	if performer.CareerLength != nil && !excluded["career_length"] {
 		partial.CareerLength = models.NewOptionalString(*performer.CareerLength)
 	}
@@ -203,6 +211,9 @@ func (t *StashBoxPerformerTagTask) getPartial(performer *models.ScrapedPerformer
 	}
 	if performer.EyeColor != nil && !excluded["eye_color"] {
 		partial.EyeColor = models.NewOptionalString(*performer.EyeColor)
+	}
+	if performer.HairColor != nil && !excluded["hair_color"] {
+		partial.HairColor = models.NewOptionalString(*performer.HairColor)
 	}
 	if performer.FakeTits != nil && !excluded["fake_tits"] {
 		partial.FakeTits = models.NewOptionalString(*performer.FakeTits)
@@ -230,6 +241,9 @@ func (t *StashBoxPerformerTagTask) getPartial(performer *models.ScrapedPerformer
 	}
 	if excluded["name"] && performer.Name != nil {
 		partial.Name = models.NewOptionalString(*performer.Name)
+	}
+	if performer.Disambiguation != nil && !excluded["disambiguation"] {
+		partial.Disambiguation = models.NewOptionalString(*performer.Disambiguation)
 	}
 	if performer.Piercings != nil && !excluded["piercings"] {
 		partial.Piercings = models.NewOptionalString(*performer.Piercings)


### PR DESCRIPTION
Adds hair colour, disambiguation and death date fields to the batch performer tag task. Some of these may not be returned from stash box but are included for completeness.

Fixes #3669 