### PR TITLE
Fixes scene card width on front page for mobile

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -306,17 +306,17 @@
 }
 
 @media (max-width: 576px) {
-  .slick-list .scene-card,
-  .slick-list .studio-card,
-  .slick-list .gallery-card {
+  .slick-list .scene-card.card,
+  .slick-list .studio-card.card,
+  .slick-list .gallery-card.card {
     width: 20rem;
   }
 
-  .slick-list .movie-card {
+  .slick-list .movie-card.card {
     width: 16rem;
   }
 
-  .slick-list .performer-card {
+  .slick-list .performer-card.card {
     width: 16rem;
   }
 


### PR DESCRIPTION
This pull request should address the issue raised by this user on the discord channel https://discordapp.com/channels/559159668438728723/559159910550732809/1104182109867880558 where the scene cards are now larger than expected.