### PR TITLE
Fix iOS captions

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -275,7 +275,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
         chaptersButton: false,
       },
       html5: {
-        nativeTextTracks: true,
         dash: {
           updateSettings: [
             {
@@ -296,7 +295,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       nativeControlsForTouch: false,
       playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
       inactivityTimeout: 2000,
-      preload: "none",
+      preload: "auto",
       playsinline: true,
       userActions: {
         hotkeys: function (this: VideoJsPlayer, event) {

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -295,7 +295,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       nativeControlsForTouch: false,
       playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
       inactivityTimeout: 2000,
-      preload: "auto",
+      preload: "none",
       playsinline: true,
       userActions: {
         hotkeys: function (this: VideoJsPlayer, event) {

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -275,7 +275,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
         chaptersButton: false,
       },
       html5: {
-        nativeTextTracks: false,
+        nativeTextTracks: true,
         dash: {
           updateSettings: [
             {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -23,6 +23,7 @@ $sceneTabWidth: 450px;
 
 .video-wrapper {
   height: 56.25vw;
+  max-height: calc(100vh - #{$menuHeight});
   overflow: hidden;
   width: 100%;
 


### PR DESCRIPTION
iOS doesn't support fullscreen html captions and needs native text tracks.
By default video.js uses native text tracks when supported, which i reverted to.
An additional bug was that the video could exceed the container size (mostly when captions were enabled on iOS), which was fixed by adding a max-height to the video-wrapper.

Unrelated i also set preload to auto, such that interactive users can start loading the video immediately, shouldn't be too offensive.

Fixes: https://github.com/stashapp/stash/issues/3666