### PR TITLE
ChapterBug // Fix jump to wrong page

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -466,7 +466,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   function gotoPage(imageIndex: number) {
     const indexInPage = (imageIndex - 1) % pageSize;
     if (pageCallback) {
-      let jumppage = Math.floor(imageIndex / pageSize) + 1;
+      let jumppage = Math.floor((imageIndex - 1) / pageSize) + 1;
       if (page !== jumppage) {
         pageCallback({ page: jumppage });
         oldImages.current = images;


### PR DESCRIPTION
Very simple error for the chapter jumping if (index - 1) % NumberOfImagesPerPage = 0, the jumped page was 1 too large. Classic "start counting from zero" mistake...