### PR TITLE
Filter query

### DIFF
--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -35,6 +35,7 @@ import { useConfigureUI } from "src/core/StashService";
 import { IUIConfig } from "src/core/config";
 import { FilterMode } from "src/core/generated-graphql";
 import { useFocusOnce } from "src/utils/focus";
+import Mousetrap from "mousetrap";
 
 interface ICriterionList {
   criteria: string[];
@@ -229,7 +230,7 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
   );
   const [criterion, setCriterion] = useState<Criterion<CriterionValue>>();
 
-  const searchRef = useFocusOnce();
+  const [searchRef, setSearchFocus] = useFocusOnce();
 
   const { criteria } = currentFilter;
 
@@ -321,6 +322,17 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
     optionSelected,
     editingCriterionChanged,
   ]);
+
+  useEffect(() => {
+    Mousetrap.bind("/", (e) => {
+      setSearchFocus();
+      e.preventDefault();
+    });
+
+    return () => {
+      Mousetrap.unbind("/");
+    };
+  });
 
   async function updatePinnedFilters(filters: string[]) {
     const configKey = filterModeToConfigKey(currentFilter.mode);

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -193,7 +193,13 @@ export function makeItemList<T extends QueryResult, E extends IDataItem>({
 
     // set up hotkeys
     useEffect(() => {
-      Mousetrap.bind("f", () => setShowEditFilter(true));
+      Mousetrap.bind("f", (e) => {
+        setShowEditFilter(true);
+        // prevent default behavior of typing f in a text field
+        // otherwise the filter dialog closes, the query field is focused and
+        // f is typed.
+        e.preventDefault();
+      });
 
       return () => {
         Mousetrap.unbind("f");

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -118,6 +118,15 @@ input[type="range"].zoom-slider {
 }
 
 .edit-filter-dialog {
+  .modal-header {
+    align-items: center;
+    padding: 0.5rem 1rem;
+
+    .search-input {
+      width: auto;
+    }
+  }
+
   .modal-body {
     padding-left: 0;
     padding-right: 0;

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -24,7 +24,7 @@
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `/` | Focus search field |
+| `/` | Focus search field / focus query field in filter dialog |
 | `f` | Show Add Filter dialog |
 | `r` | Reshuffle if sorted by random |
 | `v g` | Set view to grid |

--- a/ui/v2.5/src/utils/focus.ts
+++ b/ui/v2.5/src/utils/focus.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 
 const useFocus = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,6 +12,21 @@ const useFocus = () => {
 
   // eslint-disable-next-line no-undef
   return [htmlElRef, setFocus] as const;
+};
+
+// focuses on the element only once on mount
+export const useFocusOnce = () => {
+  const [htmlElRef, setFocus] = useFocus();
+  const focused = useRef(false);
+
+  useEffect(() => {
+    if (!focused.current) {
+      setFocus();
+      focused.current = true;
+    }
+  }, [setFocus]);
+
+  return htmlElRef;
 };
 
 export default useFocus;

--- a/ui/v2.5/src/utils/focus.ts
+++ b/ui/v2.5/src/utils/focus.ts
@@ -26,7 +26,7 @@ export const useFocusOnce = () => {
     }
   }, [setFocus]);
 
-  return htmlElRef;
+  return [htmlElRef, setFocus] as const;
 };
 
 export default useFocus;


### PR DESCRIPTION
Resolves #3609

 Adds a query text field to the filter dialog to allow filtering of criteria:

![image](https://github.com/stashapp/stash/assets/53250216/440f13d3-55ae-4cfa-ba6c-8db8dcd05c03)

Field is focused when the dialog is opened, and can be refocused with the `/` keyboard shortcut.