### PR TITLE
Honor DLNA sort order for content exceeding the first page

### DIFF
--- a/internal/dlna/cds.go
+++ b/internal/dlna/cds.go
@@ -440,15 +440,21 @@ func getRootObjects() []interface{} {
 	return objs
 }
 
+func getSortDirection(sceneFilter *models.SceneFilterType, sort string) models.SortDirectionEnum {
+	direction := models.SortDirectionEnumDesc
+	if sort == "title" {
+		direction = models.SortDirectionEnumAsc
+	}
+
+	return direction
+}
+
 func (me *contentDirectoryService) getVideos(sceneFilter *models.SceneFilterType, parentID string, host string) []interface{} {
 	var objs []interface{}
 
 	if err := txn.WithReadTxn(context.TODO(), me.txnManager, func(ctx context.Context) error {
 		sort := me.VideoSortOrder
-		direction := models.SortDirectionEnumDesc
-		if sort == "title" {
-			direction = models.SortDirectionEnumAsc
-		}
+		direction := getSortDirection(sceneFilter, sort)
 		findFilter := &models.FindFilterType{
 			PerPage:   &pageSize,
 			Sort:      &sort,
@@ -497,8 +503,10 @@ func (me *contentDirectoryService) getPageVideos(sceneFilter *models.SceneFilter
 			parentID:    parentID,
 		}
 
+		sort := me.VideoSortOrder
+		direction := getSortDirection(sceneFilter, sort)
 		var err error
-		objs, err = pager.getPageVideos(ctx, me.repository.SceneFinder, me.repository.FileFinder, page, host)
+		objs, err = pager.getPageVideos(ctx, me.repository.SceneFinder, me.repository.FileFinder, page, host, sort, direction)
 		if err != nil {
 			return err
 		}

--- a/internal/dlna/paging.go
+++ b/internal/dlna/paging.go
@@ -60,14 +60,14 @@ func (p *scenePager) getPages(ctx context.Context, r scene.Queryer, total int) (
 	return objs, nil
 }
 
-func (p *scenePager) getPageVideos(ctx context.Context, r SceneFinder, f file.Finder, page int, host string) ([]interface{}, error) {
+func (p *scenePager) getPageVideos(ctx context.Context, r SceneFinder, f file.Finder, page int, host string, sort string, direction models.SortDirectionEnum) ([]interface{}, error) {
 	var objs []interface{}
 
-	sort := "title"
 	findFilter := &models.FindFilterType{
-		PerPage: &pageSize,
-		Page:    &page,
-		Sort:    &sort,
+		PerPage:   &pageSize,
+		Page:      &page,
+		Sort:      &sort,
+		Direction: &direction,
 	}
 
 	scenes, err := scene.Query(ctx, r, p.sceneFilter, findFilter)


### PR DESCRIPTION
This pull request is a necessary follow-up to my previous [pull request](https://github.com/stashapp/stash/pull/3645), which introduced sorting options for DLNA. The previous pull request only worked for list sizes that didn't exceed the default page size. List sizes that required paging would not sort correctly. This pull request addresses that issue.