### PR TITLE
Allow serving of interactive CSVs directly to Handy

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -93,6 +93,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   }
   handyKey
   funscriptOffset
+  useStashHostedFunscript
 }
 
 fragment ConfigDLNAData on ConfigDLNAResult {

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -354,6 +354,8 @@ input ConfigInterfaceInput {
   handyKey: String
   """Funscript Time Offset"""
   funscriptOffset: Int
+  """Whether to use Stash Hosted Funscript"""
+  useStashHostedFunscript: Boolean
   """True if we should not auto-open a browser window on startup"""
   noBrowser: Boolean
   """True if we should send notifications to the desktop"""
@@ -425,6 +427,8 @@ type ConfigInterfaceResult {
   handyKey: String
   """Funscript Time Offset"""
   funscriptOffset: Int
+  """Whether to use Stash Hosted Funscript"""
+  useStashHostedFunscript: Boolean
 }
 
 input ConfigDLNAInput {

--- a/internal/api/authentication.go
+++ b/internal/api/authentication.go
@@ -26,7 +26,7 @@ const (
 
 func allowUnauthenticated(r *http.Request) bool {
 	// #2715 - allow access to UI files
-	return strings.HasPrefix(r.URL.Path, loginEndpoint) || r.URL.Path == logoutEndpoint || r.URL.Path == "/css" || strings.HasPrefix(r.URL.Path, "/assets")
+	return strings.HasPrefix(r.URL.Path, loginEndpoint) || r.URL.Path == logoutEndpoint || r.URL.Path == "/css" || strings.HasPrefix(r.URL.Path, "/assets") || strings.HasSuffix(r.URL.Path, "/interactive_csv")
 }
 
 func authenticateHandler() func(http.Handler) http.Handler {

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -479,6 +479,10 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 		c.Set(config.FunscriptOffset, *input.FunscriptOffset)
 	}
 
+	if input.UseStashHostedFunscript != nil {
+		c.Set(config.UseStashHostedFunscript, *input.UseStashHostedFunscript)
+	}
+
 	if err := c.Write(); err != nil {
 		return makeConfigInterfaceResult(), err
 	}

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -159,6 +159,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 	language := config.GetLanguage()
 	handyKey := config.GetHandyKey()
 	scriptOffset := config.GetFunscriptOffset()
+	useStashHostedFunscript := config.GetUseStashHostedFunscript()
 	imageLightboxOptions := config.GetImageLightboxOptions()
 	// FIXME - misnamed output field means we have redundant fields
 	disableDropdownCreate := config.GetDisableDropdownCreate()
@@ -190,8 +191,9 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 		DisabledDropdownCreate: disableDropdownCreate,
 		DisableDropdownCreate:  disableDropdownCreate,
 
-		HandyKey:        &handyKey,
-		FunscriptOffset: &scriptOffset,
+		HandyKey:                &handyKey,
+		FunscriptOffset:         &scriptOffset,
+		UseStashHostedFunscript: &useStashHostedFunscript,
 	}
 }
 

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -192,8 +192,10 @@ const (
 	DisableDropdownCreateStudio    = "disable_dropdown_create.studio"
 	DisableDropdownCreateTag       = "disable_dropdown_create.tag"
 
-	HandyKey        = "handy_key"
-	FunscriptOffset = "funscript_offset"
+	HandyKey                       = "handy_key"
+	FunscriptOffset                = "funscript_offset"
+	UseStashHostedFunscript        = "use_stash_hosted_funscript"
+	useStashHostedFunscriptDefault = false
 
 	DrawFunscriptHeatmapRange        = "draw_funscript_heatmap_range"
 	drawFunscriptHeatmapRangeDefault = true
@@ -1258,6 +1260,10 @@ func (i *Instance) GetHandyKey() string {
 
 func (i *Instance) GetFunscriptOffset() int {
 	return i.getInt(FunscriptOffset)
+}
+
+func (i *Instance) GetUseStashHostedFunscript() bool {
+	return i.getBoolDefault(UseStashHostedFunscript, useStashHostedFunscriptDefault)
 }
 
 func (i *Instance) GetDeleteFileDefault() bool {

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -93,6 +93,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.Set(CSSEnabled, i.GetCSSEnabled())
 				i.Set(CSSEnabled, i.GetCustomLocalesEnabled())
 				i.Set(HandyKey, i.GetHandyKey())
+				i.Set(UseStashHostedFunscript, i.GetUseStashHostedFunscript())
 				i.Set(DLNAServerName, i.GetDLNAServerName())
 				i.Set(DLNADefaultEnabled, i.GetDLNADefaultEnabled())
 				i.Set(DLNADefaultIPWhitelist, i.GetDLNADefaultIPWhitelist())

--- a/internal/manager/generator_interactive_heatmap_speed.go
+++ b/internal/manager/generator_interactive_heatmap_speed.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -11,6 +12,7 @@ import (
 	"sort"
 
 	"github.com/lucasb-eyer/go-colorful"
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 )
 
@@ -363,4 +365,55 @@ func getSegmentColor(intensity float64) colorful.Color {
 	}
 
 	return c
+}
+
+func LoadFunscriptData(path string) (Script, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Script{}, err
+	}
+
+	var funscript Script
+	err = json.Unmarshal(data, &funscript)
+	if err != nil {
+		return Script{}, err
+	}
+
+	if funscript.Actions == nil {
+		return Script{}, fmt.Errorf("actions list missing in %s", path)
+	}
+
+	sort.SliceStable(funscript.Actions, func(i, j int) bool { return funscript.Actions[i].At < funscript.Actions[j].At })
+
+	return funscript, nil
+}
+
+func convertRange(value int, fromLow int, fromHigh int, toLow int, toHigh int) int {
+	return ((value-fromLow)*(toHigh-toLow))/(fromHigh-fromLow) + toLow
+}
+
+func ConvertFunscriptToCSV(funscriptPath string, csvPath string) error {
+	funscript, err := LoadFunscriptData(funscriptPath)
+
+	if err != nil {
+		return err
+	}
+
+	var buffer bytes.Buffer
+	for _, action := range funscript.Actions {
+		pos := action.Pos
+
+		if funscript.Inverted {
+			pos = convertRange(pos, 0, 100, 100, 0)
+		}
+
+		if funscript.Range > 0 {
+			pos = convertRange(pos, 0, funscript.Range, 0, 100)
+		}
+
+		buffer.WriteString(fmt.Sprintf("%d,%d\r\n", action.At, pos))
+	}
+	fsutil.WriteFile(csvPath, buffer.Bytes())
+
+	return nil
 }

--- a/internal/manager/generator_interactive_heatmap_speed.go
+++ b/internal/manager/generator_interactive_heatmap_speed.go
@@ -413,7 +413,5 @@ func ConvertFunscriptToCSV(funscriptPath string, csvPath string) error {
 
 		buffer.WriteString(fmt.Sprintf("%d,%d\r\n", action.At, pos))
 	}
-	fsutil.WriteFile(csvPath, buffer.Bytes())
-
-	return nil
+	return fsutil.WriteFile(csvPath, buffer.Bytes())
 }

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -749,6 +749,14 @@ export const SettingsInterfacePanel: React.FC = () => {
           value={iface.funscriptOffset ?? undefined}
           onChange={(v) => saveInterface({ funscriptOffset: v })}
         />
+
+        <BooleanSetting
+          id="use-stash-hosted-funscript"
+          headingID="config.ui.use_stash_hosted_funscript.heading"
+          subHeadingID="config.ui.use_stash_hosted_funscript.description"
+          checked={iface.useStashHostedFunscript ?? false}
+          onChange={(v) => saveInterface({ useStashHostedFunscript: v })}
+        />
       </SettingSection>
     </>
   );

--- a/ui/v2.5/src/hooks/Interactive/context.tsx
+++ b/ui/v2.5/src/hooks/Interactive/context.tsx
@@ -81,6 +81,7 @@ export const InteractiveProvider: React.FC = ({ children }) => {
     undefined
   );
   const [scriptOffset, setScriptOffset] = useState<number>(0);
+  const [useStashHostedFunscript, setUseStashHostedFunscript] = useState<boolean>(false);
   const [interactive] = useState<InteractiveAPI>(new InteractiveAPI("", 0));
 
   const [initialised, setInitialised] = useState(false);
@@ -118,6 +119,7 @@ export const InteractiveProvider: React.FC = ({ children }) => {
 
     setHandyKey(stashConfig.interface.handyKey ?? undefined);
     setScriptOffset(stashConfig.interface.funscriptOffset ?? 0);
+    setUseStashHostedFunscript(stashConfig.interface.useStashHostedFunscript ?? false);
   }, [stashConfig]);
 
   useEffect(() => {
@@ -129,11 +131,12 @@ export const InteractiveProvider: React.FC = ({ children }) => {
 
     interactive.handyKey = handyKey ?? "";
     interactive.scriptOffset = scriptOffset;
+    interactive.useStashHostedFunscript = useStashHostedFunscript;
 
     if (oldKey !== interactive.handyKey && interactive.handyKey) {
       initialise();
     }
-  }, [handyKey, scriptOffset, config, interactive, initialise]);
+  }, [handyKey, scriptOffset, useStashHostedFunscript, config, interactive, initialise]);
 
   const sync = useCallback(async () => {
     if (

--- a/ui/v2.5/src/hooks/Interactive/context.tsx
+++ b/ui/v2.5/src/hooks/Interactive/context.tsx
@@ -81,7 +81,8 @@ export const InteractiveProvider: React.FC = ({ children }) => {
     undefined
   );
   const [scriptOffset, setScriptOffset] = useState<number>(0);
-  const [useStashHostedFunscript, setUseStashHostedFunscript] = useState<boolean>(false);
+  const [useStashHostedFunscript, setUseStashHostedFunscript] =
+    useState<boolean>(false);
   const [interactive] = useState<InteractiveAPI>(new InteractiveAPI("", 0));
 
   const [initialised, setInitialised] = useState(false);
@@ -119,7 +120,9 @@ export const InteractiveProvider: React.FC = ({ children }) => {
 
     setHandyKey(stashConfig.interface.handyKey ?? undefined);
     setScriptOffset(stashConfig.interface.funscriptOffset ?? 0);
-    setUseStashHostedFunscript(stashConfig.interface.useStashHostedFunscript ?? false);
+    setUseStashHostedFunscript(
+      stashConfig.interface.useStashHostedFunscript ?? false
+    );
   }, [stashConfig]);
 
   useEffect(() => {
@@ -136,7 +139,14 @@ export const InteractiveProvider: React.FC = ({ children }) => {
     if (oldKey !== interactive.handyKey && interactive.handyKey) {
       initialise();
     }
-  }, [handyKey, scriptOffset, useStashHostedFunscript, config, interactive, initialise]);
+  }, [
+    handyKey,
+    scriptOffset,
+    useStashHostedFunscript,
+    config,
+    interactive,
+    initialise,
+  ]);
 
   const sync = useCallback(async () => {
     if (

--- a/ui/v2.5/src/hooks/Interactive/interactive.ts
+++ b/ui/v2.5/src/hooks/Interactive/interactive.ts
@@ -97,11 +97,13 @@ export class Interactive {
   _playing: boolean;
   _scriptOffset: number;
   _handy: Handy;
+  _useStashHostedFunscript: boolean;
 
   constructor(handyKey: string, scriptOffset: number) {
     this._handy = new Handy();
     this._handy.connectionKey = handyKey;
     this._scriptOffset = scriptOffset;
+    this._useStashHostedFunscript = false;
     this._connected = false;
     this._playing = false;
   }
@@ -128,11 +130,11 @@ export class Interactive {
   }
 
   set useStashHostedFunscript(useStashHostedFunscript: boolean) {
-    this._handy.useStashHostedFunscript = useStashHostedFunscript;
+    this._useStashHostedFunscript = useStashHostedFunscript;
   }
 
   get useStashHostedFunscript(): boolean {
-    return this._handy.useStashHostedFunscript;
+    return this._useStashHostedFunscript;
   }
 
   set scriptOffset(offset: number) {
@@ -147,7 +149,7 @@ export class Interactive {
 
     var funscriptUrl;
 
-    if (this._handy.useStashHostedFunscript) {
+    if (this._useStashHostedFunscript) {
       funscriptUrl = funscriptPath.replace("/funscript", "/interactive_csv")
     }
     else {

--- a/ui/v2.5/src/hooks/Interactive/interactive.ts
+++ b/ui/v2.5/src/hooks/Interactive/interactive.ts
@@ -150,18 +150,17 @@ export class Interactive {
     var funscriptUrl;
 
     if (this._useStashHostedFunscript) {
-      funscriptUrl = funscriptPath.replace("/funscript", "/interactive_csv")
-    }
-    else {
+      funscriptUrl = funscriptPath.replace("/funscript", "/interactive_csv");
+    } else {
       const csv = await fetch(funscriptPath)
-      .then((response) => response.json())
-      .then((json) => convertFunscriptToCSV(json));
+        .then((response) => response.json())
+        .then((json) => convertFunscriptToCSV(json));
       const fileName = `${Math.round(Math.random() * 100000000)}.csv`;
       const csvFile = new File([csv], fileName);
-      
+
       funscriptUrl = await uploadCsv(csvFile).then((response) => response.url);
     }
-    
+
     console.log("funscriptUrl:" + funscriptUrl);
 
     await this._handy.setMode(HandyMode.hssp);

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -693,7 +693,11 @@
           }
         }
       },
-      "title": "User Interface"
+      "title": "User Interface",
+      "use_stash_hosted_funscript": {
+        "description": "When enabled, given that the stash instance is accessible from the Handy (like on the same network), the funscript will be transferred directly from Stash server to Handy, without going through TheHandy servers.",
+        "heading": "Use the funscript hosted by stash funscript"
+      }
     }
   },
   "configuration": "Configuration",


### PR DESCRIPTION
### Description

This PR allows the interactive videos to directly serve the funscript files (in the CSV format) directly to Handy. 
This is possible when Handy is on the same WiFi network as the stash server, or when the stash server is hosted on the internet. 
This decreases the reliance on the TheHandy funscript hosting server and makes for a faster initial setup of loading the interactive script. 

- Added the following endpoint to serve CSV of funscript directly to Handy
  - `/<id>/interactive_csv`
  - For now, I bypassed the authentication for this just this API endpoint. Maybe a better way is to use the API key as a query parameter. 
- Added a setting `use-stash-hosted-funscript` which toggles between 
  1. the original way of uploading the funscript file to TheHandy server to get a temporary CSV format URL 
  2. the new way of just using the newly added endpoint as the CSV format URL
- Another thing to note is that I convert the funscript file to CSV and save it in the same folder as the Funscript (since the Handy needs it in a CSV format), lazily (meaning the CSV file is generated on first request) and use the CSV file it if it exists. 
  - Maybe we could change it to save it in the cache folder, but it worked fine for me. 

I did run the formatting and linting commands before making the PR. 

First time submitting a PR here, let me know if there any issues, and hope that it gets merged. :)

