### PR TITLE
Update Metadata Bugfix

### DIFF
--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -71,13 +71,11 @@ func (d *Decorator) IsMissingMetadata(ctx context.Context, fs file.FS, f file.Fi
 
 	imf, isImage := f.(*file.ImageFile)
 	vf, isVideo := f.(*file.VideoFile)
-	if !isImage && !isVideo {
-		return true
-	}
 
-	if isImage {
+	switch {
+	case isImage:
 		return imf.Format == unsetString || imf.Width == unsetNumber || imf.Height == unsetNumber
-	} else {
+	case isVideo:
 		interactive := false
 		if _, err := fs.Lstat(video.GetFunscriptPath(vf.Base().Path)); err == nil {
 			interactive = true
@@ -88,5 +86,7 @@ func (d *Decorator) IsMissingMetadata(ctx context.Context, fs file.FS, f file.Fi
 			vf.Height == unsetNumber || vf.FrameRate == unsetNumber ||
 			vf.Duration == unsetNumber ||
 			vf.BitRate == unsetNumber || interactive != vf.Interactive
+	default:
+		return true
 	}
 }

--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -76,16 +76,8 @@ func (d *Decorator) IsMissingMetadata(ctx context.Context, fs file.FS, f file.Fi
 	case isImage:
 		return imf.Format == unsetString || imf.Width == unsetNumber || imf.Height == unsetNumber
 	case isVideo:
-		interactive := false
-		if _, err := fs.Lstat(video.GetFunscriptPath(vf.Base().Path)); err == nil {
-			interactive = true
-		}
-
-		return vf.VideoCodec == unsetString || vf.AudioCodec == unsetString ||
-			vf.Format == unsetString || vf.Width == unsetNumber ||
-			vf.Height == unsetNumber || vf.FrameRate == unsetNumber ||
-			vf.Duration == unsetNumber ||
-			vf.BitRate == unsetNumber || interactive != vf.Interactive
+		videoFileDecorator := video.Decorator{FFProbe: d.FFProbe}
+		return videoFileDecorator.IsMissingMetadata(ctx, fs, vf)
 	default:
 		return true
 	}

--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -69,10 +69,24 @@ func (d *Decorator) IsMissingMetadata(ctx context.Context, fs file.FS, f file.Fi
 		unsetNumber = -1
 	)
 
-	imf, ok := f.(*file.ImageFile)
-	if !ok {
+	imf, isImage := f.(*file.ImageFile)
+	vf, isVideo := f.(*file.VideoFile)
+	if !isImage && !isVideo {
 		return true
 	}
 
-	return imf.Format == unsetString || imf.Width == unsetNumber || imf.Height == unsetNumber
+	if isImage {
+		return imf.Format == unsetString || imf.Width == unsetNumber || imf.Height == unsetNumber
+	} else {
+		interactive := false
+		if _, err := fs.Lstat(video.GetFunscriptPath(vf.Base().Path)); err == nil {
+			interactive = true
+		}
+
+		return vf.VideoCodec == unsetString || vf.AudioCodec == unsetString ||
+			vf.Format == unsetString || vf.Width == unsetNumber ||
+			vf.Height == unsetNumber || vf.FrameRate == unsetNumber ||
+			vf.Duration == unsetNumber ||
+			vf.BitRate == unsetNumber || interactive != vf.Interactive
+	}
 }


### PR DESCRIPTION
Currently, all clips are recognized as incomplete metadata due to the recognition technique of incomplete metadata for image objects not being updated to also look for videofiles. This is added here. Speeds up scan time enormously, depending on number of clips.

Closes #3752 