### PR TITLE
fix Clip Gif Support

### DIFF
--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -261,7 +261,10 @@ export const Image: React.FC = () => {
 
   const title = objectTitle(image);
   const ImageView =
-    image.visual_files[0].__typename == "VideoFile" ? "video" : "img";
+    image.visual_files[0].__typename == "VideoFile" &&
+    image.visual_files[0].video_codec != "gif"
+      ? "video"
+      : "img";
 
   return (
     <div className="row">

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -25,6 +25,7 @@ import { ImageDetailPanel } from "./ImageDetailPanel";
 import { DeleteImagesDialog } from "../DeleteImagesDialog";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
 import { objectPath, objectTitle } from "src/core/files";
+import { isVideo } from "src/utils/visualFile";
 
 interface IImageParams {
   id?: string;
@@ -260,11 +261,7 @@ export const Image: React.FC = () => {
   }
 
   const title = objectTitle(image);
-  const ImageView =
-    image.visual_files[0].__typename == "VideoFile" &&
-    image.visual_files[0].video_codec != "gif"
-      ? "video"
-      : "img";
+  const ImageView = isVideo(image.visual_files[0]) ? "video" : "img";
 
   return (
     <div className="row">

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -850,7 +850,10 @@ export const LightboxComponent: React.FC<IProps> = ({
                   scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}
                   setZoom={(v) => setZoom(v)}
                   resetPosition={resetPosition}
-                  isVideo={image.visual_files?.[0]?.__typename == "VideoFile"}
+                  isVideo={
+                    image.visual_files?.[0]?.__typename == "VideoFile" &&
+                    image.visual_files?.[0]?.video_codec != "gif"
+                  }
                 />
               ) : undefined}
             </div>

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -47,6 +47,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { useDebounce } from "../debounce";
+import { isVideo } from "src/utils/visualFile";
 
 const CLASSNAME = "Lightbox";
 const CLASSNAME_HEADER = `${CLASSNAME}-header`;
@@ -850,10 +851,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                   scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}
                   setZoom={(v) => setZoom(v)}
                   resetPosition={resetPosition}
-                  isVideo={
-                    image.visual_files?.[0]?.__typename == "VideoFile" &&
-                    image.visual_files?.[0]?.video_codec != "gif"
-                  }
+                  isVideo={isVideo(image.visual_files?.[0] ?? {})}
                 />
               ) : undefined}
             </div>

--- a/ui/v2.5/src/hooks/Lightbox/types.ts
+++ b/ui/v2.5/src/hooks/Lightbox/types.ts
@@ -10,6 +10,7 @@ interface IFiles {
   __typename?: string;
   width: number;
   height: number;
+  video_codec?: GQL.Maybe<string>;
 }
 
 export interface ILightboxImage {

--- a/ui/v2.5/src/utils/visualFile.ts
+++ b/ui/v2.5/src/utils/visualFile.ts
@@ -1,0 +1,9 @@
+import { Maybe } from "src/core/generated-graphql";
+
+// returns true if the file should be treated as a video in the UI
+export function isVideo(o: {
+  __typename?: string;
+  video_codec?: Maybe<string>;
+}) {
+  return o.__typename == "VideoFile" && o.video_codec != "gif";
+}


### PR DESCRIPTION
Gif files were handled as videofiles, which meant that they were in a videocontainer, so unable to display in lightbox or details page. This fixes that.

Sidenote: webm is currently handled as imagefile due to ffmpegs limits on decoding it, avif works perfectly as a videofile in a videocontainer, so gif was actually the only format broken.

Closes #3762 