### PR TITLE
Fix performer image display

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -122,6 +122,11 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     setRating
   );
 
+  // reset image if performer changed
+  useEffect(() => {
+    setImage(undefined);
+  }, [performer]);
+
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("a", () => setActiveTabKey("details"));

--- a/ui/v2.5/src/components/Shared/ImageInput.tsx
+++ b/ui/v2.5/src/components/Shared/ImageInput.tsx
@@ -53,6 +53,11 @@ export const ImageInput: React.FC<IImageInput> = ({
     );
   }
 
+  function showDialog() {
+    setURL("");
+    setIsShowDialog(true);
+  }
+
   function onConfirmURL() {
     if (!onImageURL) {
       return;
@@ -112,7 +117,7 @@ export const ImageInput: React.FC<IImageInput> = ({
             </Form.Label>
           </div>
           <div>
-            <Button className="minimal" onClick={() => setIsShowDialog(true)}>
+            <Button className="minimal" onClick={showDialog}>
               <Icon icon={faLink} className="fa-fw" />
               <span>{intl.formatMessage({ id: "actions.from_url" })}</span>
             </Button>


### PR DESCRIPTION
This is a fix for the bug described in #3766, which is caused by the stored `image` persisting after a performer change.

I've also made a small change to `ImageInput`, to reset the stored URL before opening the dialog. This means that an inserted URL will not persist if the dialog is opened multiple times - acting more like a modal dialog. I think this behaviour makes more sense, but I wouldn't mind reversing the change.

Fixes #3766