### PR TITLE
Fix joined hierarchical filtering

### DIFF
--- a/pkg/models/filter.go
+++ b/pkg/models/filter.go
@@ -135,12 +135,15 @@ type HierarchicalMultiCriterionInput struct {
 	Excludes []string          `json:"excludes"`
 }
 
-func (i *HierarchicalMultiCriterionInput) CombineExcludes() {
-	if i.Modifier == CriterionModifierExcludes {
-		i.Modifier = CriterionModifierIncludesAll
-		i.Excludes = append(i.Excludes, i.Value...)
-		i.Value = nil
+func (i HierarchicalMultiCriterionInput) CombineExcludes() HierarchicalMultiCriterionInput {
+	ii := i
+	if ii.Modifier == CriterionModifierExcludes {
+		ii.Modifier = CriterionModifierIncludesAll
+		ii.Excludes = append(ii.Excludes, ii.Value...)
+		ii.Value = nil
 	}
+
+	return ii
 }
 
 type MultiCriterionInput struct {

--- a/pkg/models/filter.go
+++ b/pkg/models/filter.go
@@ -135,6 +135,14 @@ type HierarchicalMultiCriterionInput struct {
 	Excludes []string          `json:"excludes"`
 }
 
+func (i *HierarchicalMultiCriterionInput) CombineExcludes() {
+	if i.Modifier == CriterionModifierExcludes {
+		i.Modifier = CriterionModifierIncludesAll
+		i.Excludes = append(i.Excludes, i.Value...)
+		i.Value = nil
+	}
+}
+
 type MultiCriterionInput struct {
 	Value    []string          `json:"value"`
 	Modifier CriterionModifier `json:"modifier"`

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -1015,7 +1015,8 @@ type joinedHierarchicalMultiCriterionHandlerBuilder struct {
 }
 
 func (m *joinedHierarchicalMultiCriterionHandlerBuilder) addHierarchicalConditionClauses(f *filterBuilder, criterion models.HierarchicalMultiCriterionInput, table, idColumn string) {
-	if criterion.Modifier == models.CriterionModifierEquals {
+	switch criterion.Modifier {
+	case models.CriterionModifierEquals:
 		// includes only the provided ids
 		f.addWhere(fmt.Sprintf("%s.%s IS NOT NULL", table, idColumn))
 		f.addHaving(fmt.Sprintf("count(distinct %s.%s) IS %d", table, idColumn, len(criterion.Value)))
@@ -1024,7 +1025,9 @@ func (m *joinedHierarchicalMultiCriterionHandlerBuilder) addHierarchicalConditio
 			"primaryFK":    m.primaryFK,
 			"primaryTable": m.primaryTable,
 		}), len(criterion.Value))
-	} else {
+	case models.CriterionModifierNotEquals:
+		f.setError(fmt.Errorf("not equals modifier is not supported for hierarchical multi criteria"))
+	default:
 		addHierarchicalConditionClauses(f, criterion, table, idColumn)
 	}
 }

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -1089,6 +1089,11 @@ func (m *joinedHierarchicalMultiCriterionHandlerBuilder) handler(c *models.Hiera
 				primaryKey = "id"
 			}
 
+			if criterion.Modifier == models.CriterionModifierEquals && criterion.Depth != nil && *criterion.Depth != 0 {
+				f.setError(fmt.Errorf("depth is not supported for equals modifier in hierarchical multi criterion input"))
+				return
+			}
+
 			if criterion.Modifier == models.CriterionModifierIsNull || criterion.Modifier == models.CriterionModifierNotNull {
 				var notClause string
 				if criterion.Modifier == models.CriterionModifierNotNull {

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -832,6 +832,33 @@ func (m *stringListCriterionHandlerBuilder) handler(criterion *models.StringCrit
 	}
 }
 
+func studioCriterionHandler(primaryTable string, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if studios == nil {
+			return
+		}
+
+		studiosCopy := *studios
+		switch studiosCopy.Modifier {
+		case models.CriterionModifierEquals:
+			studiosCopy.Modifier = models.CriterionModifierIncludesAll
+		case models.CriterionModifierNotEquals:
+			studiosCopy.Modifier = models.CriterionModifierExcludes
+		}
+
+		hh := hierarchicalMultiCriterionHandlerBuilder{
+			tx: dbWrapper{},
+
+			primaryTable: primaryTable,
+			foreignTable: studioTable,
+			foreignFK:    studioIDColumn,
+			parentFK:     "parent_id",
+		}
+
+		hh.handler(&studiosCopy)(ctx, f)
+	}
+}
+
 type hierarchicalMultiCriterionHandlerBuilder struct {
 	tx dbWrapper
 

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -1182,8 +1182,7 @@ func (h *joinedPerformerTagsHandler) handle(ctx context.Context, f *filterBuilde
 	tags := h.criterion
 
 	if tags != nil {
-		criterion := *tags
-		criterion.CombineExcludes()
+		criterion := tags.CombineExcludes()
 
 		// validate the modifier
 		switch criterion.Modifier {

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -1128,6 +1128,14 @@ func (h *joinedPerformerTagsHandler) handle(ctx context.Context, f *filterBuilde
 		criterion := *tags
 		criterion.CombineExcludes()
 
+		// validate the modifier
+		switch criterion.Modifier {
+		case models.CriterionModifierIncludesAll, models.CriterionModifierIncludes, models.CriterionModifierExcludes, models.CriterionModifierIsNull, models.CriterionModifierNotNull:
+			// valid
+		default:
+			f.setError(fmt.Errorf("invalid modifier %s for performer tags", criterion.Modifier))
+		}
+
 		strFormatMap := utils.StrFormatMap{
 			"primaryTable":   h.primaryTable,
 			"joinTable":      h.joinTable,
@@ -1159,18 +1167,6 @@ func (h *joinedPerformerTagsHandler) handle(ctx context.Context, f *filterBuilde
 			f.addLeftJoin("performers_tags", "", utils.StrFormat("{joinTable}.performer_id = performers_tags.performer_id", strFormatMap))
 
 			switch criterion.Modifier {
-			case models.CriterionModifierEquals:
-				// includes only the provided ids
-				whereClause := utils.StrFormat("performers_tags.tag_id IN {inBinding} AND (SELECT COUNT(*) FROM performers_tags WHERE performers_tags.performer_id = {joinTable}.performer_id) = ?", strFormatMap)
-
-				var args []interface{}
-				for _, tagID := range criterion.Value {
-					args = append(args, tagID)
-				}
-
-				f.addWhere(whereClause, append(args, len(criterion.Value))...)
-
-				f.addHaving("count(distinct performers_tags.tag_id) IS ?", len(criterion.Value))
 			case models.CriterionModifierIncludes:
 				f.addWhere(fmt.Sprintf("performers_tags.tag_id IN (SELECT column2 FROM (%s))", valuesClause))
 			case models.CriterionModifierIncludesAll:

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -694,6 +694,8 @@ func (m *joinedMultiCriterionHandlerBuilder) handler(c *models.MultiCriterionInp
 					})
 					havingClause = fmt.Sprintf("count(distinct %s.%s) IS %d", joinAlias, m.foreignFK, len(criterion.Value))
 					args = append(args, len(criterion.Value))
+				case models.CriterionModifierNotEquals:
+					f.setError(fmt.Errorf("not equals modifier is not supported for multi criterion input"))
 				case models.CriterionModifierIncludesAll:
 					// includes all of the provided ids
 					m.addJoinTable(f)
@@ -1026,7 +1028,7 @@ func (m *joinedHierarchicalMultiCriterionHandlerBuilder) addHierarchicalConditio
 			"primaryTable": m.primaryTable,
 		}), len(criterion.Value))
 	case models.CriterionModifierNotEquals:
-		f.setError(fmt.Errorf("not equals modifier is not supported for hierarchical multi criteria"))
+		f.setError(fmt.Errorf("not equals modifier is not supported for hierarchical multi criterion input"))
 	default:
 		addHierarchicalConditionClauses(f, criterion, table, idColumn)
 	}

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -977,6 +977,12 @@ func (m *hierarchicalMultiCriterionHandlerBuilder) handler(c *models.Hierarchica
 			// make a copy so we don't modify the original
 			criterion := *c
 
+			// don't support equals/not equals
+			if criterion.Modifier == models.CriterionModifierEquals || criterion.Modifier == models.CriterionModifierNotEquals {
+				f.setError(fmt.Errorf("modifier %s is not supported for hierarchical multi criterion", criterion.Modifier))
+				return
+			}
+
 			if criterion.Modifier == models.CriterionModifierIsNull || criterion.Modifier == models.CriterionModifierNotNull {
 				var notClause string
 				if criterion.Modifier == models.CriterionModifierNotNull {

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -981,28 +981,12 @@ func galleryStudioCriterionHandler(qb *GalleryStore, studios *models.Hierarchica
 	return h.handler(studios)
 }
 
-func galleryPerformerTagsCriterionHandler(qb *GalleryStore, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if tags != nil {
-			f.addLeftJoin("performers_galleries", "", "galleries.id = performers_galleries.gallery_id")
-
-			h := joinedHierarchicalMultiCriterionHandlerBuilder{
-				tx: qb.tx,
-
-				primaryTable: "performers_galleries",
-				primaryKey:   performerIDColumn,
-				foreignTable: tagTable,
-				foreignFK:    tagIDColumn,
-
-				relationsTable: "tags_relations",
-				parentFK:       "parent_id",
-				joinTable:      "performers_tags",
-				joinAs:         "gallery_performers_tags",
-				primaryFK:      performerIDColumn,
-			}
-
-			h.handler(tags).handle(ctx, f)
-		}
+func galleryPerformerTagsCriterionHandler(qb *GalleryStore, tags *models.HierarchicalMultiCriterionInput) criterionHandler {
+	return &joinedPerformerTagsHandler{
+		criterion:      tags,
+		primaryTable:   galleryTable,
+		joinTable:      performersGalleriesTable,
+		joinPrimaryKey: galleryIDColumn,
 	}
 }
 

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -984,34 +984,24 @@ func galleryStudioCriterionHandler(qb *GalleryStore, studios *models.Hierarchica
 func galleryPerformerTagsCriterionHandler(qb *GalleryStore, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if tags != nil {
-			if tags.Modifier == models.CriterionModifierIsNull || tags.Modifier == models.CriterionModifierNotNull {
-				var notClause string
-				if tags.Modifier == models.CriterionModifierNotNull {
-					notClause = "NOT"
-				}
+			f.addLeftJoin("performers_galleries", "", "galleries.id = performers_galleries.gallery_id")
 
-				f.addLeftJoin("performers_galleries", "", "galleries.id = performers_galleries.gallery_id")
-				f.addLeftJoin("performers_tags", "", "performers_galleries.performer_id = performers_tags.performer_id")
+			h := joinedHierarchicalMultiCriterionHandlerBuilder{
+				tx: qb.tx,
 
-				f.addWhere(fmt.Sprintf("performers_tags.tag_id IS %s NULL", notClause))
-				return
+				primaryTable: "performers_galleries",
+				primaryKey:   performerIDColumn,
+				foreignTable: tagTable,
+				foreignFK:    tagIDColumn,
+
+				relationsTable: "tags_relations",
+				parentFK:       "parent_id",
+				joinTable:      "performers_tags",
+				joinAs:         "gallery_performers_tags",
+				primaryFK:      performerIDColumn,
 			}
 
-			if len(tags.Value) == 0 {
-				return
-			}
-
-			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
-
-			f.addWith(`performer_tags AS (
-SELECT pg.gallery_id, t.column1 AS root_tag_id FROM performers_galleries pg
-INNER JOIN performers_tags pt ON pt.performer_id = pg.performer_id
-INNER JOIN (` + valuesClause + `) t ON t.column2 = pt.tag_id
-)`)
-
-			f.addLeftJoin("performer_tags", "", "performer_tags.gallery_id = galleries.id")
-
-			addHierarchicalConditionClauses(f, *tags, "performer_tags", "root_tag_id")
+			h.handler(tags).handle(ctx, f)
 		}
 	}
 }

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -670,7 +670,7 @@ func (qb *GalleryStore) makeFilter(ctx context.Context, galleryFilter *models.Ga
 	query.handleCriterion(ctx, galleryPerformersCriterionHandler(qb, galleryFilter.Performers))
 	query.handleCriterion(ctx, galleryPerformerCountCriterionHandler(qb, galleryFilter.PerformerCount))
 	query.handleCriterion(ctx, hasChaptersCriterionHandler(galleryFilter.HasChapters))
-	query.handleCriterion(ctx, galleryStudioCriterionHandler(qb, galleryFilter.Studios))
+	query.handleCriterion(ctx, studioCriterionHandler(galleryTable, galleryFilter.Studios))
 	query.handleCriterion(ctx, galleryPerformerTagsCriterionHandler(qb, galleryFilter.PerformerTags))
 	query.handleCriterion(ctx, galleryAverageResolutionCriterionHandler(qb, galleryFilter.AverageResolution))
 	query.handleCriterion(ctx, galleryImageCountCriterionHandler(qb, galleryFilter.ImageCount))
@@ -966,19 +966,6 @@ func hasChaptersCriterionHandler(hasChapters *string) criterionHandlerFunc {
 			}
 		}
 	}
-}
-
-func galleryStudioCriterionHandler(qb *GalleryStore, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	h := hierarchicalMultiCriterionHandlerBuilder{
-		tx: qb.tx,
-
-		primaryTable: galleryTable,
-		foreignTable: studioTable,
-		foreignFK:    studioIDColumn,
-		parentFK:     "parent_id",
-	}
-
-	return h.handler(studios)
 }
 
 func galleryPerformerTagsCriterionHandler(qb *GalleryStore, tags *models.HierarchicalMultiCriterionInput) criterionHandler {

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2246,6 +2246,21 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 			[]int{galleryIdx1WithImage},
 			false,
 		},
+		{
+			"equals",
+			nil,
+			&models.GalleryFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			[]int{galleryIdxWithTwoPerformerTag},
+			[]int{galleryIdxWithPerformerTag, galleryIdxWithPerformerTwoTags},
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2257,9 +2257,24 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 					},
 				},
 			},
-			[]int{galleryIdxWithTwoPerformerTag},
-			[]int{galleryIdxWithPerformerTag, galleryIdxWithPerformerTwoTags},
-			false,
+			nil,
+			nil,
+			true,
+		},
+		{
+			"not equals",
+			nil,
+			&models.GalleryFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierNotEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			nil,
+			nil,
+			true,
 		},
 	}
 

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2372,6 +2372,8 @@ func TestGalleryQueryStudioDepth(t *testing.T) {
 }
 
 func TestGalleryQueryPerformerTags(t *testing.T) {
+	allDepth := -1
+
 	tests := []struct {
 		name        string
 		findFilter  *models.FindFilterType
@@ -2403,7 +2405,30 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 			false,
 		},
 		{
-			"includes alls",
+			"includes sub-tags",
+			nil,
+			&models.GalleryFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierIncludes,
+				},
+			},
+			[]int{
+				galleryIdxWithPerformerParentTag,
+			},
+			[]int{
+				galleryIdxWithPerformer,
+				galleryIdxWithPerformerTag,
+				galleryIdxWithPerformerTwoTags,
+				galleryIdxWithTwoPerformerTag,
+			},
+			false,
+		},
+		{
+			"includes all",
 			nil,
 			&models.GalleryFilterType{
 				PerformerTags: &models.HierarchicalMultiCriterionInput{
@@ -2435,6 +2460,29 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 			},
 			nil,
 			[]int{galleryIdxWithTwoPerformerTag},
+			false,
+		},
+		{
+			"excludes sub-tags",
+			nil,
+			&models.GalleryFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierExcludes,
+				},
+			},
+			[]int{
+				galleryIdxWithPerformer,
+				galleryIdxWithPerformerTag,
+				galleryIdxWithPerformerTwoTags,
+				galleryIdxWithTwoPerformerTag,
+			},
+			[]int{
+				galleryIdxWithPerformerParentTag,
+			},
 			false,
 		},
 		{
@@ -2505,8 +2553,8 @@ func TestGalleryQueryPerformerTags(t *testing.T) {
 
 			ids := galleriesToIDs(results)
 
-			include := indexesToIDs(imageIDs, tt.includeIdxs)
-			exclude := indexesToIDs(imageIDs, tt.excludeIdxs)
+			include := indexesToIDs(galleryIDs, tt.includeIdxs)
+			exclude := indexesToIDs(galleryIDs, tt.excludeIdxs)
 
 			for _, i := range include {
 				assert.Contains(ids, i)

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -959,27 +959,12 @@ func imageStudioCriterionHandler(qb *ImageStore, studios *models.HierarchicalMul
 	return h.handler(studios)
 }
 
-func imagePerformerTagsCriterionHandler(qb *ImageStore, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if tags != nil {
-			f.addLeftJoin("performers_images", "", "images.id = performers_images.image_id")
-
-			h := joinedHierarchicalMultiCriterionHandlerBuilder{
-				tx: qb.tx,
-
-				primaryTable: "performers_images",
-				primaryKey:   performerIDColumn,
-				foreignTable: tagTable,
-				foreignFK:    tagIDColumn,
-
-				relationsTable: "tags_relations",
-				joinTable:      "performers_tags",
-				joinAs:         "image_performers_tags",
-				primaryFK:      performerIDColumn,
-			}
-
-			h.handler(tags).handle(ctx, f)
-		}
+func imagePerformerTagsCriterionHandler(qb *ImageStore, tags *models.HierarchicalMultiCriterionInput) criterionHandler {
+	return &joinedPerformerTagsHandler{
+		criterion:      tags,
+		primaryTable:   imageTable,
+		joinTable:      performersImagesTable,
+		joinPrimaryKey: imageIDColumn,
 	}
 }
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -669,7 +669,7 @@ func (qb *ImageStore) makeFilter(ctx context.Context, imageFilter *models.ImageF
 	query.handleCriterion(ctx, imageGalleriesCriterionHandler(qb, imageFilter.Galleries))
 	query.handleCriterion(ctx, imagePerformersCriterionHandler(qb, imageFilter.Performers))
 	query.handleCriterion(ctx, imagePerformerCountCriterionHandler(qb, imageFilter.PerformerCount))
-	query.handleCriterion(ctx, imageStudioCriterionHandler(qb, imageFilter.Studios))
+	query.handleCriterion(ctx, studioCriterionHandler(imageTable, imageFilter.Studios))
 	query.handleCriterion(ctx, imagePerformerTagsCriterionHandler(qb, imageFilter.PerformerTags))
 	query.handleCriterion(ctx, imagePerformerFavoriteCriterionHandler(imageFilter.PerformerFavorite))
 	query.handleCriterion(ctx, timestampCriterionHandler(imageFilter.CreatedAt, "images.created_at"))
@@ -944,19 +944,6 @@ GROUP BY performers_images.image_id HAVING SUM(performers.favorite) = 0)`, "nofa
 			}
 		}
 	}
-}
-
-func imageStudioCriterionHandler(qb *ImageStore, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	h := hierarchicalMultiCriterionHandlerBuilder{
-		tx: qb.tx,
-
-		primaryTable: imageTable,
-		foreignTable: studioTable,
-		foreignFK:    studioIDColumn,
-		parentFK:     "parent_id",
-	}
-
-	return h.handler(studios)
 }
 
 func imagePerformerTagsCriterionHandler(qb *ImageStore, tags *models.HierarchicalMultiCriterionInput) criterionHandler {

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -2483,6 +2483,21 @@ func TestImageQueryPerformerTags(t *testing.T) {
 			[]int{imageIdxWithGallery},
 			false,
 		},
+		{
+			"equals",
+			nil,
+			&models.ImageFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			[]int{imageIdxWithTwoPerformerTag},
+			[]int{imageIdxWithPerformerTag, imageIdxWithPerformerTwoTags},
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -2494,9 +2494,24 @@ func TestImageQueryPerformerTags(t *testing.T) {
 					},
 				},
 			},
-			[]int{imageIdxWithTwoPerformerTag},
-			[]int{imageIdxWithPerformerTag, imageIdxWithPerformerTwoTags},
-			false,
+			nil,
+			nil,
+			true,
+		},
+		{
+			"not equals",
+			nil,
+			&models.ImageFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierNotEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			nil,
+			nil,
+			true,
 		},
 	}
 

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -2560,6 +2560,8 @@ func queryImages(ctx context.Context, t *testing.T, sqb models.ImageReader, imag
 }
 
 func TestImageQueryPerformerTags(t *testing.T) {
+	allDepth := -1
+
 	tests := []struct {
 		name        string
 		findFilter  *models.FindFilterType
@@ -2591,7 +2593,30 @@ func TestImageQueryPerformerTags(t *testing.T) {
 			false,
 		},
 		{
-			"includes alls",
+			"includes sub-tags",
+			nil,
+			&models.ImageFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierIncludes,
+				},
+			},
+			[]int{
+				imageIdxWithPerformerParentTag,
+			},
+			[]int{
+				imageIdxWithPerformer,
+				imageIdxWithPerformerTag,
+				imageIdxWithPerformerTwoTags,
+				imageIdxWithTwoPerformerTag,
+			},
+			false,
+		},
+		{
+			"includes all",
 			nil,
 			&models.ImageFilterType{
 				PerformerTags: &models.HierarchicalMultiCriterionInput{
@@ -2623,6 +2648,29 @@ func TestImageQueryPerformerTags(t *testing.T) {
 			},
 			nil,
 			[]int{imageIdxWithTwoPerformerTag},
+			false,
+		},
+		{
+			"excludes sub-tags",
+			nil,
+			&models.ImageFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierExcludes,
+				},
+			},
+			[]int{
+				imageIdxWithPerformer,
+				imageIdxWithPerformerTag,
+				imageIdxWithPerformerTwoTags,
+				imageIdxWithTwoPerformerTag,
+			},
+			[]int{
+				imageIdxWithPerformerParentTag,
+			},
 			false,
 		},
 		{
@@ -2825,7 +2873,7 @@ func TestImageQuerySorting(t *testing.T) {
 			"date",
 			models.SortDirectionEnumDesc,
 			imageIdxWithTwoGalleries,
-			imageIdxWithGrandChildStudio,
+			imageIdxWithPerformerParentTag,
 		},
 	}
 

--- a/pkg/sqlite/movies.go
+++ b/pkg/sqlite/movies.go
@@ -176,7 +176,7 @@ func (qb *movieQueryBuilder) makeFilter(ctx context.Context, movieFilter *models
 	query.handleCriterion(ctx, floatIntCriterionHandler(movieFilter.Duration, "movies.duration", nil))
 	query.handleCriterion(ctx, movieIsMissingCriterionHandler(qb, movieFilter.IsMissing))
 	query.handleCriterion(ctx, stringCriterionHandler(movieFilter.URL, "movies.url"))
-	query.handleCriterion(ctx, movieStudioCriterionHandler(qb, movieFilter.Studios))
+	query.handleCriterion(ctx, studioCriterionHandler(movieTable, movieFilter.Studios))
 	query.handleCriterion(ctx, moviePerformersCriterionHandler(qb, movieFilter.Performers))
 	query.handleCriterion(ctx, dateCriterionHandler(movieFilter.Date, "movies.date"))
 	query.handleCriterion(ctx, timestampCriterionHandler(movieFilter.CreatedAt, "movies.created_at"))
@@ -237,19 +237,6 @@ func movieIsMissingCriterionHandler(qb *movieQueryBuilder, isMissing *string) cr
 			}
 		}
 	}
-}
-
-func movieStudioCriterionHandler(qb *movieQueryBuilder, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	h := hierarchicalMultiCriterionHandlerBuilder{
-		tx: qb.tx,
-
-		primaryTable: movieTable,
-		foreignTable: studioTable,
-		foreignFK:    studioIDColumn,
-		parentFK:     "parent_id",
-	}
-
-	return h.handler(studios)
 }
 
 func moviePerformersCriterionHandler(qb *movieQueryBuilder, performers *models.MultiCriterionInput) criterionHandlerFunc {

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -908,7 +908,11 @@ func performerStudiosCriterionHandler(qb *PerformerStore, studios *models.Hierar
 			}
 
 			const derivedPerformerStudioTable = "performer_studio"
-			valuesClause := getHierarchicalValues(ctx, qb.tx, studios.Value, studioTable, "", "parent_id", "child_id", studios.Depth)
+			valuesClause, err := getHierarchicalValues(ctx, qb.tx, studios.Value, studioTable, "", "parent_id", "child_id", studios.Depth)
+			if err != nil {
+				f.setError(err)
+				return
+			}
 			f.addWith("studio(root_id, item_id) AS (" + valuesClause + ")")
 
 			templStr := `SELECT performer_id FROM {primaryTable}

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -908,7 +908,7 @@ func performerStudiosCriterionHandler(qb *PerformerStore, studios *models.Hierar
 			}
 
 			const derivedPerformerStudioTable = "performer_studio"
-			valuesClause := getHierarchicalValues(ctx, qb.tx, studios.Value, studioTable, "", "parent_id", studios.Depth)
+			valuesClause := getHierarchicalValues(ctx, qb.tx, studios.Value, studioTable, "", "parent_id", "child_id", studios.Depth)
 			f.addWith("studio(root_id, item_id) AS (" + valuesClause + ")")
 
 			templStr := `SELECT performer_id FROM {primaryTable}

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -513,12 +513,13 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 			performerIDs[performerIdxWithTwoTags],
 			clearPerformerPartial(),
 			models.Performer{
-				ID:       performerIDs[performerIdxWithTwoTags],
-				Name:     getPerformerStringValue(performerIdxWithTwoTags, "Name"),
-				Favorite: true,
-				Aliases:  models.NewRelatedStrings([]string{}),
-				TagIDs:   models.NewRelatedIDs([]int{}),
-				StashIDs: models.NewRelatedStashIDs([]models.StashID{}),
+				ID:            performerIDs[performerIdxWithTwoTags],
+				Name:          getPerformerStringValue(performerIdxWithTwoTags, "Name"),
+				Favorite:      getPerformerBoolValue(performerIdxWithTwoTags),
+				Aliases:       models.NewRelatedStrings([]string{}),
+				TagIDs:        models.NewRelatedIDs([]int{}),
+				StashIDs:      models.NewRelatedStashIDs([]models.StashID{}),
+				IgnoreAutoTag: getIgnoreAutoTag(performerIdxWithTwoTags),
 			},
 			false,
 		},
@@ -1920,7 +1921,7 @@ func TestPerformerQuerySortScenesCount(t *testing.T) {
 		assert.True(t, len(performers) > 0)
 		lastPerformer := performers[len(performers)-1]
 
-		assert.Equal(t, performerIDs[performerIdxWithTwoScenes], lastPerformer.ID)
+		assert.Equal(t, performerIDs[performerIdxWithTag], lastPerformer.ID)
 
 		return nil
 	})

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -1905,10 +1905,10 @@ func TestPerformerQuerySortScenesCount(t *testing.T) {
 
 		assert.True(t, len(performers) > 0)
 
-		// first performer should be performerIdxWithTwoScenes
+		// first performer should be performerIdx1WithScene
 		firstPerformer := performers[0]
 
-		assert.Equal(t, performerIDs[performerIdxWithTwoScenes], firstPerformer.ID)
+		assert.Equal(t, performerIDs[performerIdx1WithScene], firstPerformer.ID)
 
 		// sort in ascending order
 		direction = models.SortDirectionEnumAsc
@@ -2061,7 +2061,7 @@ func TestPerformerStore_FindByStashIDStatus(t *testing.T) {
 			name:             "!hasStashID",
 			hasStashID:       false,
 			stashboxEndpoint: getPerformerStringValue(performerIdxWithScene, "endpoint"),
-			include:          []int{performerIdxWithImage},
+			include:          []int{performerIdxWithTwoScenes},
 			exclude:          []int{performerIdx2WithScene},
 			wantErr:          false,
 		},

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1374,50 +1374,12 @@ func sceneMoviesCriterionHandler(qb *SceneStore, movies *models.MultiCriterionIn
 	return h.handler(movies)
 }
 
-func scenePerformerTagsCriterionHandler(qb *SceneStore, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if tags != nil {
-			criterion := *tags
-			criterion.CombineExcludes()
-
-			if criterion.Modifier == models.CriterionModifierIsNull || criterion.Modifier == models.CriterionModifierNotNull {
-				var notClause string
-				if criterion.Modifier == models.CriterionModifierNotNull {
-					notClause = "NOT"
-				}
-
-				f.addLeftJoin("performers_scenes", "", "scenes.id = performers_scenes.scene_id")
-				f.addLeftJoin("performers_tags", "", "performers_scenes.performer_id = performers_tags.performer_id")
-
-				f.addWhere(fmt.Sprintf("performers_tags.tag_id IS %s NULL", notClause))
-				return
-			}
-
-			if len(criterion.Value) == 0 && len(criterion.Excludes) == 0 {
-				return
-			}
-
-			if len(criterion.Value) > 0 {
-				valuesClause := getHierarchicalValues(ctx, qb.tx, criterion.Value, tagTable, "tag_relations", "", "", criterion.Depth)
-
-				f.addLeftJoin("performers_scenes", "", "scenes.id = performers_scenes.scene_id")
-				f.addLeftJoin("performers_tags", "", "performers_scenes.performer_id = performers_tags.performer_id")
-
-				switch criterion.Modifier {
-				case models.CriterionModifierIncludes:
-					f.addWhere(fmt.Sprintf("performers_tags.tag_id IN (SELECT column2 FROM (%s)))", valuesClause))
-				case models.CriterionModifierIncludesAll:
-					f.addWhere(fmt.Sprintf("performers_tags.tag_id IN (SELECT column2 FROM (%s))", valuesClause))
-					f.addHaving(fmt.Sprintf("COUNT(DISTINCT performers_tags.tag_id) = %d", len(criterion.Value)))
-				}
-			}
-
-			if len(criterion.Excludes) > 0 {
-				valuesClause := getHierarchicalValues(ctx, qb.tx, criterion.Excludes, tagTable, "tag_relations", "", "", criterion.Depth)
-
-				f.addWhere(fmt.Sprintf("scenes.id NOT IN (SELECT performers_scenes.scene_id FROM performers_scenes INNER JOIN performers_tags ON performers_scenes.performer_id = performers_tags.performer_id WHERE performers_tags.tag_id IN (SELECT column2 FROM (%s)))", valuesClause))
-			}
-		}
+func scenePerformerTagsCriterionHandler(qb *SceneStore, tags *models.HierarchicalMultiCriterionInput) criterionHandler {
+	return &joinedPerformerTagsHandler{
+		criterion:      tags,
+		primaryTable:   sceneTable,
+		joinTable:      performersScenesTable,
+		joinPrimaryKey: sceneIDColumn,
 	}
 }
 

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -959,7 +959,7 @@ func (qb *SceneStore) makeFilter(ctx context.Context, sceneFilter *models.SceneF
 	query.handleCriterion(ctx, sceneTagCountCriterionHandler(qb, sceneFilter.TagCount))
 	query.handleCriterion(ctx, scenePerformersCriterionHandler(qb, sceneFilter.Performers))
 	query.handleCriterion(ctx, scenePerformerCountCriterionHandler(qb, sceneFilter.PerformerCount))
-	query.handleCriterion(ctx, sceneStudioCriterionHandler(qb, sceneFilter.Studios))
+	query.handleCriterion(ctx, studioCriterionHandler(sceneTable, sceneFilter.Studios))
 	query.handleCriterion(ctx, sceneMoviesCriterionHandler(qb, sceneFilter.Movies))
 	query.handleCriterion(ctx, scenePerformerTagsCriterionHandler(qb, sceneFilter.PerformerTags))
 	query.handleCriterion(ctx, scenePerformerFavoriteCriterionHandler(sceneFilter.PerformerFavorite))
@@ -1350,19 +1350,6 @@ func scenePerformerAgeCriterionHandler(performerAge *models.IntCriterionInput) c
 			f.addWhere(whereClause, args...)
 		}
 	}
-}
-
-func sceneStudioCriterionHandler(qb *SceneStore, studios *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
-	h := hierarchicalMultiCriterionHandlerBuilder{
-		tx: qb.tx,
-
-		primaryTable: sceneTable,
-		foreignTable: studioTable,
-		foreignFK:    studioIDColumn,
-		parentFK:     "parent_id",
-	}
-
-	return h.handler(studios)
 }
 
 func sceneMoviesCriterionHandler(qb *SceneStore, movies *models.MultiCriterionInput) criterionHandlerFunc {

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1377,34 +1377,23 @@ func sceneMoviesCriterionHandler(qb *SceneStore, movies *models.MultiCriterionIn
 func scenePerformerTagsCriterionHandler(qb *SceneStore, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if tags != nil {
-			if tags.Modifier == models.CriterionModifierIsNull || tags.Modifier == models.CriterionModifierNotNull {
-				var notClause string
-				if tags.Modifier == models.CriterionModifierNotNull {
-					notClause = "NOT"
-				}
+			f.addLeftJoin("performers_scenes", "", "scenes.id = performers_scenes.scene_id")
 
-				f.addLeftJoin("performers_scenes", "", "scenes.id = performers_scenes.scene_id")
-				f.addLeftJoin("performers_tags", "", "performers_scenes.performer_id = performers_tags.performer_id")
+			h := joinedHierarchicalMultiCriterionHandlerBuilder{
+				tx: qb.tx,
 
-				f.addWhere(fmt.Sprintf("performers_tags.tag_id IS %s NULL", notClause))
-				return
+				primaryTable: "performers_scenes",
+				primaryKey:   performerIDColumn,
+				foreignTable: tagTable,
+				foreignFK:    tagIDColumn,
+
+				relationsTable: "tags_relations",
+				joinTable:      "performers_tags",
+				joinAs:         "scene_performers_tags",
+				primaryFK:      performerIDColumn,
 			}
 
-			if len(tags.Value) == 0 {
-				return
-			}
-
-			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
-
-			f.addWith(`performer_tags AS (
-SELECT ps.scene_id, t.column1 AS root_tag_id FROM performers_scenes ps
-INNER JOIN performers_tags pt ON pt.performer_id = ps.performer_id
-INNER JOIN (` + valuesClause + `) t ON t.column2 = pt.tag_id
-)`)
-
-			f.addLeftJoin("performer_tags", "", "performer_tags.scene_id = scenes.id")
-
-			addHierarchicalConditionClauses(f, *tags, "performer_tags", "root_tag_id")
+			h.handler(tags).handle(ctx, f)
 		}
 	}
 }

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -209,7 +209,11 @@ func sceneMarkerTagsCriterionHandler(qb *sceneMarkerQueryBuilder, tags *models.H
 			if len(tags.Value) == 0 {
 				return
 			}
-			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "parent_id", "child_id", tags.Depth)
+			valuesClause, err := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "parent_id", "child_id", tags.Depth)
+			if err != nil {
+				f.setError(err)
+				return
+			}
 
 			f.addWith(`marker_tags AS (
 SELECT mt.scene_marker_id, t.column1 AS root_tag_id FROM scene_markers_tags mt

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -209,7 +209,7 @@ func sceneMarkerTagsCriterionHandler(qb *sceneMarkerQueryBuilder, tags *models.H
 			if len(tags.Value) == 0 {
 				return
 			}
-			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
+			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "parent_id", "child_id", tags.Depth)
 
 			f.addWith(`marker_tags AS (
 SELECT mt.scene_marker_id, t.column1 AS root_tag_id FROM scene_markers_tags mt
@@ -229,32 +229,23 @@ INNER JOIN (` + valuesClause + `) t ON t.column2 = m.primary_tag_id
 func sceneMarkerSceneTagsCriterionHandler(qb *sceneMarkerQueryBuilder, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if tags != nil {
-			if tags.Modifier == models.CriterionModifierIsNull || tags.Modifier == models.CriterionModifierNotNull {
-				var notClause string
-				if tags.Modifier == models.CriterionModifierNotNull {
-					notClause = "NOT"
-				}
+			f.addLeftJoin("scenes_tags", "", "scene_markers.scene_id = scenes_tags.scene_id")
 
-				f.addLeftJoin("scenes_tags", "", "scene_markers.scene_id = scenes_tags.scene_id")
+			h := joinedHierarchicalMultiCriterionHandlerBuilder{
+				tx: qb.tx,
 
-				f.addWhere(fmt.Sprintf("scenes_tags.tag_id IS %s NULL", notClause))
-				return
+				primaryTable: "scene_markers",
+				primaryKey:   sceneIDColumn,
+				foreignTable: tagTable,
+				foreignFK:    tagIDColumn,
+
+				relationsTable: "tags_relations",
+				joinTable:      "scenes_tags",
+				joinAs:         "marker_scenes_tags",
+				primaryFK:      sceneIDColumn,
 			}
 
-			if len(tags.Value) == 0 {
-				return
-			}
-
-			valuesClause := getHierarchicalValues(ctx, qb.tx, tags.Value, tagTable, "tags_relations", "", tags.Depth)
-
-			f.addWith(`scene_tags AS (
-SELECT st.scene_id, t.column1 AS root_tag_id FROM scenes_tags st
-INNER JOIN (` + valuesClause + `) t ON t.column2 = st.tag_id
-)`)
-
-			f.addLeftJoin("scene_tags", "", "scene_tags.scene_id = scene_markers.scene_id")
-
-			addHierarchicalConditionClauses(f, *tags, "scene_tags", "root_tag_id")
+			h.handler(tags).handle(ctx, f)
 		}
 	}
 }

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2106,6 +2106,8 @@ func sceneQueryQ(ctx context.Context, t *testing.T, sqb models.SceneReader, q st
 
 	// no Q should return all results
 	filter.Q = nil
+	pp := totalScenes
+	filter.PerPage = &pp
 	scenes = queryScene(ctx, t, sqb, nil, &filter)
 
 	assert.Len(t, scenes, totalScenes)
@@ -3062,7 +3064,13 @@ func queryScenes(ctx context.Context, t *testing.T, queryBuilder models.SceneRea
 		},
 	}
 
-	return queryScene(ctx, t, queryBuilder, &sceneFilter, nil)
+	// needed so that we don't hit the default limit of 25 scenes
+	pp := 1000
+	findFilter := &models.FindFilterType{
+		PerPage: &pp,
+	}
+
+	return queryScene(ctx, t, queryBuilder, &sceneFilter, findFilter)
 }
 
 func createScene(ctx context.Context, width int, height int) (*models.Scene, error) {

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -3476,7 +3476,7 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 			false,
 		},
 		{
-			"includes alls",
+			"includes all",
 			nil,
 			&models.SceneFilterType{
 				PerformerTags: &models.HierarchicalMultiCriterionInput{
@@ -3545,9 +3545,24 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 					},
 				},
 			},
-			[]int{sceneIdxWithTwoPerformerTag},
-			[]int{sceneIdxWithPerformerTag, sceneIdxWithPerformerTwoTags},
-			false,
+			nil,
+			nil,
+			true,
+		},
+		{
+			"not equals",
+			nil,
+			&models.SceneFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierNotEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			nil,
+			nil,
+			true,
 		},
 	}
 

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -3799,6 +3799,30 @@ func TestSceneQueryStudio(t *testing.T) {
 			[]int{sceneIDs[sceneIdxWithGallery]},
 			false,
 		},
+		{
+			"equals",
+			"",
+			models.HierarchicalMultiCriterionInput{
+				Value: []string{
+					strconv.Itoa(studioIDs[studioIdxWithScene]),
+				},
+				Modifier: models.CriterionModifierEquals,
+			},
+			[]int{sceneIDs[sceneIdxWithStudio]},
+			false,
+		},
+		{
+			"not equals",
+			getSceneStringValue(sceneIdxWithStudio, titleField),
+			models.HierarchicalMultiCriterionInput{
+				Value: []string{
+					strconv.Itoa(studioIDs[studioIdxWithScene]),
+				},
+				Modifier: models.CriterionModifierNotEquals,
+			},
+			[]int{},
+			false,
+		},
 	}
 
 	qb := db.Scene

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -3534,6 +3534,21 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 			[]int{sceneIdx1WithPerformer},
 			false,
 		},
+		{
+			"equals",
+			nil,
+			&models.SceneFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Modifier: models.CriterionModifierEquals,
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdx2WithPerformer]),
+					},
+				},
+			},
+			[]int{sceneIdxWithTwoPerformerTag},
+			[]int{sceneIdxWithPerformerTag, sceneIdxWithPerformerTwoTags},
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -3614,6 +3614,8 @@ func TestSceneQueryTags(t *testing.T) {
 }
 
 func TestSceneQueryPerformerTags(t *testing.T) {
+	allDepth := -1
+
 	tests := []struct {
 		name        string
 		findFilter  *models.FindFilterType
@@ -3641,6 +3643,29 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 			},
 			[]int{
 				sceneIdxWithPerformer,
+			},
+			false,
+		},
+		{
+			"includes sub-tags",
+			nil,
+			&models.SceneFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierIncludes,
+				},
+			},
+			[]int{
+				sceneIdxWithPerformerParentTag,
+			},
+			[]int{
+				sceneIdxWithPerformer,
+				sceneIdxWithPerformerTag,
+				sceneIdxWithPerformerTwoTags,
+				sceneIdxWithTwoPerformerTag,
 			},
 			false,
 		},
@@ -3677,6 +3702,29 @@ func TestSceneQueryPerformerTags(t *testing.T) {
 			},
 			nil,
 			[]int{sceneIdxWithTwoPerformerTag},
+			false,
+		},
+		{
+			"excludes sub-tags",
+			nil,
+			&models.SceneFilterType{
+				PerformerTags: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(tagIDs[tagIdxWithParentAndChild]),
+					},
+					Depth:    &allDepth,
+					Modifier: models.CriterionModifierExcludes,
+				},
+			},
+			[]int{
+				sceneIdxWithPerformer,
+				sceneIdxWithPerformerTag,
+				sceneIdxWithPerformerTwoTags,
+				sceneIdxWithTwoPerformerTag,
+			},
+			[]int{
+				sceneIdxWithPerformerParentTag,
+			},
 			false,
 		},
 		{

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -77,6 +77,7 @@ const (
 	sceneIdxWithStudioPerformer
 	sceneIdxWithGrandChildStudio
 	sceneIdxMissingPhash
+	sceneIdxWithPerformerParentTag
 	// new indexes above
 	lastSceneIdx
 
@@ -107,6 +108,7 @@ const (
 	imageIdxWithTwoPerformerTag
 	imageIdxWithPerformerTwoTags
 	imageIdxWithGrandChildStudio
+	imageIdxWithPerformerParentTag
 	// new indexes above
 	totalImages
 )
@@ -133,6 +135,7 @@ const (
 	performerIdxWithSceneStudio
 	performerIdxWithImageStudio
 	performerIdxWithGalleryStudio
+	performerIdxWithParentTag
 	// new indexes above
 	// performers with dup names start from the end
 	performerIdx1WithDupName
@@ -179,6 +182,7 @@ const (
 	galleryIdxWithStudioPerformer
 	galleryIdxWithGrandChildStudio
 	galleryIdxWithoutFile
+	galleryIdxWithPerformerParentTag
 	// new indexes above
 	lastGalleryIdx
 
@@ -356,15 +360,16 @@ var (
 	}
 
 	scenePerformers = linkMap{
-		sceneIdxWithPerformer:        {performerIdxWithScene},
-		sceneIdxWithTwoPerformers:    {performerIdx1WithScene, performerIdx2WithScene},
-		sceneIdxWithThreePerformers:  {performerIdx1WithScene, performerIdx2WithScene, performerIdx3WithScene},
-		sceneIdxWithPerformerTag:     {performerIdxWithTag},
-		sceneIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
-		sceneIdxWithPerformerTwoTags: {performerIdxWithTwoTags},
-		sceneIdx1WithPerformer:       {performerIdxWithTwoScenes},
-		sceneIdx2WithPerformer:       {performerIdxWithTwoScenes},
-		sceneIdxWithStudioPerformer:  {performerIdxWithSceneStudio},
+		sceneIdxWithPerformer:          {performerIdxWithScene},
+		sceneIdxWithTwoPerformers:      {performerIdx1WithScene, performerIdx2WithScene},
+		sceneIdxWithThreePerformers:    {performerIdx1WithScene, performerIdx2WithScene, performerIdx3WithScene},
+		sceneIdxWithPerformerTag:       {performerIdxWithTag},
+		sceneIdxWithTwoPerformerTag:    {performerIdxWithTag, performerIdx2WithTag},
+		sceneIdxWithPerformerTwoTags:   {performerIdxWithTwoTags},
+		sceneIdx1WithPerformer:         {performerIdxWithTwoScenes},
+		sceneIdx2WithPerformer:         {performerIdxWithTwoScenes},
+		sceneIdxWithStudioPerformer:    {performerIdxWithSceneStudio},
+		sceneIdxWithPerformerParentTag: {performerIdxWithParentTag},
 	}
 
 	sceneGalleries = linkMap{
@@ -433,29 +438,31 @@ var (
 		imageIdxWithThreeTags: {tagIdx1WithImage, tagIdx2WithImage, tagIdx3WithImage},
 	}
 	imagePerformers = linkMap{
-		imageIdxWithPerformer:        {performerIdxWithImage},
-		imageIdxWithTwoPerformers:    {performerIdx1WithImage, performerIdx2WithImage},
-		imageIdxWithThreePerformers:  {performerIdx1WithImage, performerIdx2WithImage, performerIdx3WithImage},
-		imageIdxWithPerformerTag:     {performerIdxWithTag},
-		imageIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
-		imageIdxWithPerformerTwoTags: {performerIdxWithTwoTags},
-		imageIdx1WithPerformer:       {performerIdxWithTwoImages},
-		imageIdx2WithPerformer:       {performerIdxWithTwoImages},
-		imageIdxWithStudioPerformer:  {performerIdxWithImageStudio},
+		imageIdxWithPerformer:          {performerIdxWithImage},
+		imageIdxWithTwoPerformers:      {performerIdx1WithImage, performerIdx2WithImage},
+		imageIdxWithThreePerformers:    {performerIdx1WithImage, performerIdx2WithImage, performerIdx3WithImage},
+		imageIdxWithPerformerTag:       {performerIdxWithTag},
+		imageIdxWithTwoPerformerTag:    {performerIdxWithTag, performerIdx2WithTag},
+		imageIdxWithPerformerTwoTags:   {performerIdxWithTwoTags},
+		imageIdx1WithPerformer:         {performerIdxWithTwoImages},
+		imageIdx2WithPerformer:         {performerIdxWithTwoImages},
+		imageIdxWithStudioPerformer:    {performerIdxWithImageStudio},
+		imageIdxWithPerformerParentTag: {performerIdxWithParentTag},
 	}
 )
 
 var (
 	galleryPerformers = linkMap{
-		galleryIdxWithPerformer:        {performerIdxWithGallery},
-		galleryIdxWithTwoPerformers:    {performerIdx1WithGallery, performerIdx2WithGallery},
-		galleryIdxWithThreePerformers:  {performerIdx1WithGallery, performerIdx2WithGallery, performerIdx3WithGallery},
-		galleryIdxWithPerformerTag:     {performerIdxWithTag},
-		galleryIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
-		galleryIdxWithPerformerTwoTags: {performerIdxWithTwoTags},
-		galleryIdx1WithPerformer:       {performerIdxWithTwoGalleries},
-		galleryIdx2WithPerformer:       {performerIdxWithTwoGalleries},
-		galleryIdxWithStudioPerformer:  {performerIdxWithGalleryStudio},
+		galleryIdxWithPerformer:          {performerIdxWithGallery},
+		galleryIdxWithTwoPerformers:      {performerIdx1WithGallery, performerIdx2WithGallery},
+		galleryIdxWithThreePerformers:    {performerIdx1WithGallery, performerIdx2WithGallery, performerIdx3WithGallery},
+		galleryIdxWithPerformerTag:       {performerIdxWithTag},
+		galleryIdxWithTwoPerformerTag:    {performerIdxWithTag, performerIdx2WithTag},
+		galleryIdxWithPerformerTwoTags:   {performerIdxWithTwoTags},
+		galleryIdx1WithPerformer:         {performerIdxWithTwoGalleries},
+		galleryIdx2WithPerformer:         {performerIdxWithTwoGalleries},
+		galleryIdxWithStudioPerformer:    {performerIdxWithGalleryStudio},
+		galleryIdxWithPerformerParentTag: {performerIdxWithParentTag},
 	}
 
 	galleryStudios = map[int]int{
@@ -489,9 +496,10 @@ var (
 
 var (
 	performerTags = linkMap{
-		performerIdxWithTag:     {tagIdxWithPerformer},
-		performerIdx2WithTag:    {tagIdx2WithPerformer},
-		performerIdxWithTwoTags: {tagIdx1WithPerformer, tagIdx2WithPerformer},
+		performerIdxWithTag:       {tagIdxWithPerformer},
+		performerIdx2WithTag:      {tagIdx2WithPerformer},
+		performerIdxWithTwoTags:   {tagIdx1WithPerformer, tagIdx2WithPerformer},
+		performerIdxWithParentTag: {tagIdxWithParentAndChild},
 	}
 )
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -65,6 +65,7 @@ const (
 	sceneIdxWithTwoTags
 	sceneIdxWithThreeTags
 	sceneIdxWithMarkerAndTag
+	sceneIdxWithMarkerTwoTags
 	sceneIdxWithStudio
 	sceneIdx1WithStudio
 	sceneIdx2WithStudio
@@ -347,10 +348,11 @@ var (
 
 var (
 	sceneTags = linkMap{
-		sceneIdxWithTag:          {tagIdxWithScene},
-		sceneIdxWithTwoTags:      {tagIdx1WithScene, tagIdx2WithScene},
-		sceneIdxWithThreeTags:    {tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
-		sceneIdxWithMarkerAndTag: {tagIdx3WithScene},
+		sceneIdxWithTag:           {tagIdxWithScene},
+		sceneIdxWithTwoTags:       {tagIdx1WithScene, tagIdx2WithScene},
+		sceneIdxWithThreeTags:     {tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+		sceneIdxWithMarkerAndTag:  {tagIdx3WithScene},
+		sceneIdxWithMarkerTwoTags: {tagIdx2WithScene, tagIdx3WithScene},
 	}
 
 	scenePerformers = linkMap{
@@ -394,6 +396,7 @@ var (
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, nil},
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers}},
 		{sceneIdxWithMarkerAndTag, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithMarkerTwoTags, tagIdxWithPrimaryMarkers, nil},
 	}
 )
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -60,6 +60,7 @@ const (
 	sceneIdx1WithPerformer
 	sceneIdx2WithPerformer
 	sceneIdxWithTwoPerformers
+	sceneIdxWithThreePerformers
 	sceneIdxWithTag
 	sceneIdxWithTwoTags
 	sceneIdxWithThreeTags
@@ -92,6 +93,7 @@ const (
 	imageIdx1WithPerformer
 	imageIdx2WithPerformer
 	imageIdxWithTwoPerformers
+	imageIdxWithThreePerformers
 	imageIdxWithTag
 	imageIdxWithTwoTags
 	imageIdxWithThreeTags
@@ -112,11 +114,13 @@ const (
 	performerIdxWithScene = iota
 	performerIdx1WithScene
 	performerIdx2WithScene
+	performerIdx3WithScene
 	performerIdxWithTwoScenes
 	performerIdxWithImage
 	performerIdxWithTwoImages
 	performerIdx1WithImage
 	performerIdx2WithImage
+	performerIdx3WithImage
 	performerIdxWithTag
 	performerIdx2WithTag
 	performerIdxWithTwoTags
@@ -124,6 +128,7 @@ const (
 	performerIdxWithTwoGalleries
 	performerIdx1WithGallery
 	performerIdx2WithGallery
+	performerIdx3WithGallery
 	performerIdxWithSceneStudio
 	performerIdxWithImageStudio
 	performerIdxWithGalleryStudio
@@ -160,6 +165,7 @@ const (
 	galleryIdx1WithPerformer
 	galleryIdx2WithPerformer
 	galleryIdxWithTwoPerformers
+	galleryIdxWithThreePerformers
 	galleryIdxWithTag
 	galleryIdxWithTwoTags
 	galleryIdxWithThreeTags
@@ -350,6 +356,7 @@ var (
 	scenePerformers = linkMap{
 		sceneIdxWithPerformer:        {performerIdxWithScene},
 		sceneIdxWithTwoPerformers:    {performerIdx1WithScene, performerIdx2WithScene},
+		sceneIdxWithThreePerformers:  {performerIdx1WithScene, performerIdx2WithScene, performerIdx3WithScene},
 		sceneIdxWithPerformerTag:     {performerIdxWithTag},
 		sceneIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
 		sceneIdxWithPerformerTwoTags: {performerIdxWithTwoTags},
@@ -425,6 +432,7 @@ var (
 	imagePerformers = linkMap{
 		imageIdxWithPerformer:        {performerIdxWithImage},
 		imageIdxWithTwoPerformers:    {performerIdx1WithImage, performerIdx2WithImage},
+		imageIdxWithThreePerformers:  {performerIdx1WithImage, performerIdx2WithImage, performerIdx3WithImage},
 		imageIdxWithPerformerTag:     {performerIdxWithTag},
 		imageIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
 		imageIdxWithPerformerTwoTags: {performerIdxWithTwoTags},
@@ -438,6 +446,7 @@ var (
 	galleryPerformers = linkMap{
 		galleryIdxWithPerformer:        {performerIdxWithGallery},
 		galleryIdxWithTwoPerformers:    {performerIdx1WithGallery, performerIdx2WithGallery},
+		galleryIdxWithThreePerformers:  {performerIdx1WithGallery, performerIdx2WithGallery, performerIdx3WithGallery},
 		galleryIdxWithPerformerTag:     {performerIdxWithTag},
 		galleryIdxWithTwoPerformerTag:  {performerIdxWithTag, performerIdx2WithTag},
 		galleryIdxWithPerformerTwoTags: {performerIdxWithTwoTags},

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -474,46 +474,190 @@ func tagMarkerCountCriterionHandler(qb *tagQueryBuilder, markerCount *models.Int
 	}
 }
 
-func tagParentsCriterionHandler(qb *tagQueryBuilder, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+func tagParentsCriterionHandler(qb *tagQueryBuilder, criterion *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
-		if tags != nil {
-			f.addLeftJoin("tags_relations", "parent_relations", "tags.id = parent_relations.child_id")
+		if criterion != nil {
+			tags := criterion.CombineExcludes()
 
-			h := hierarchicalMultiCriterionHandlerBuilder{
-				tx: qb.tx,
-
-				primaryTable: "parent_relations",
-				foreignTable: tagTable,
-				foreignFK:    "parent_id",
-
-				relationsTable: "tags_relations",
-				parentFK:       "parent_id",
-				childFK:        "child_id",
+			// validate the modifier
+			switch tags.Modifier {
+			case models.CriterionModifierIncludesAll, models.CriterionModifierIncludes, models.CriterionModifierExcludes, models.CriterionModifierIsNull, models.CriterionModifierNotNull:
+				// valid
+			default:
+				f.setError(fmt.Errorf("invalid modifier %s for tag parent/children", criterion.Modifier))
 			}
 
-			h.handler(tags).handle(ctx, f)
+			if tags.Modifier == models.CriterionModifierIsNull || tags.Modifier == models.CriterionModifierNotNull {
+				var notClause string
+				if tags.Modifier == models.CriterionModifierNotNull {
+					notClause = "NOT"
+				}
+
+				f.addLeftJoin("tags_relations", "parent_relations", "tags.id = parent_relations.child_id")
+
+				f.addWhere(fmt.Sprintf("parent_relations.parent_id IS %s NULL", notClause))
+				return
+			}
+
+			if len(tags.Value) == 0 && len(tags.Excludes) == 0 {
+				return
+			}
+
+			if len(tags.Value) > 0 {
+				var args []interface{}
+				for _, val := range tags.Value {
+					args = append(args, val)
+				}
+
+				depthVal := 0
+				if tags.Depth != nil {
+					depthVal = *tags.Depth
+				}
+
+				var depthCondition string
+				if depthVal != -1 {
+					depthCondition = fmt.Sprintf("WHERE depth < %d", depthVal)
+				}
+
+				query := `parents AS (
+		SELECT parent_id AS root_id, child_id AS item_id, 0 AS depth FROM tags_relations WHERE parent_id IN` + getInBinding(len(tags.Value)) + `
+		UNION
+		SELECT root_id, child_id, depth + 1 FROM tags_relations INNER JOIN parents ON item_id = parent_id ` + depthCondition + `
+	)`
+
+				f.addRecursiveWith(query, args...)
+
+				f.addLeftJoin("parents", "", "parents.item_id = tags.id")
+
+				addHierarchicalConditionClauses(f, tags, "parents", "root_id")
+			}
+
+			if len(tags.Excludes) > 0 {
+				var args []interface{}
+				for _, val := range tags.Excludes {
+					args = append(args, val)
+				}
+
+				depthVal := 0
+				if tags.Depth != nil {
+					depthVal = *tags.Depth
+				}
+
+				var depthCondition string
+				if depthVal != -1 {
+					depthCondition = fmt.Sprintf("WHERE depth < %d", depthVal)
+				}
+
+				query := `parents2 AS (
+		SELECT parent_id AS root_id, child_id AS item_id, 0 AS depth FROM tags_relations WHERE parent_id IN` + getInBinding(len(tags.Excludes)) + `
+		UNION
+		SELECT root_id, child_id, depth + 1 FROM tags_relations INNER JOIN parents2 ON item_id = parent_id ` + depthCondition + `
+	)`
+
+				f.addRecursiveWith(query, args...)
+
+				f.addLeftJoin("parents2", "", "parents2.item_id = tags.id")
+
+				addHierarchicalConditionClauses(f, models.HierarchicalMultiCriterionInput{
+					Value:    tags.Excludes,
+					Depth:    tags.Depth,
+					Modifier: models.CriterionModifierExcludes,
+				}, "parents2", "root_id")
+			}
 		}
 	}
 }
 
-func tagChildrenCriterionHandler(qb *tagQueryBuilder, tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+func tagChildrenCriterionHandler(qb *tagQueryBuilder, criterion *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
-		if tags != nil {
-			f.addLeftJoin("tags_relations", "child_relations", "tags.id = child_relations.parent_id")
+		if criterion != nil {
+			tags := criterion.CombineExcludes()
 
-			h := hierarchicalMultiCriterionHandlerBuilder{
-				tx: qb.tx,
-
-				primaryTable: "child_relations",
-				foreignTable: tagTable,
-				foreignFK:    "child_id",
-
-				relationsTable: "tags_relations",
-				parentFK:       "child_id",
-				childFK:        "parent_id",
+			// validate the modifier
+			switch tags.Modifier {
+			case models.CriterionModifierIncludesAll, models.CriterionModifierIncludes, models.CriterionModifierExcludes, models.CriterionModifierIsNull, models.CriterionModifierNotNull:
+				// valid
+			default:
+				f.setError(fmt.Errorf("invalid modifier %s for tag parent/children", criterion.Modifier))
 			}
 
-			h.handler(tags).handle(ctx, f)
+			if tags.Modifier == models.CriterionModifierIsNull || tags.Modifier == models.CriterionModifierNotNull {
+				var notClause string
+				if tags.Modifier == models.CriterionModifierNotNull {
+					notClause = "NOT"
+				}
+
+				f.addLeftJoin("tags_relations", "child_relations", "tags.id = child_relations.parent_id")
+
+				f.addWhere(fmt.Sprintf("child_relations.child_id IS %s NULL", notClause))
+				return
+			}
+
+			if len(tags.Value) == 0 && len(tags.Excludes) == 0 {
+				return
+			}
+
+			if len(tags.Value) > 0 {
+				var args []interface{}
+				for _, val := range tags.Value {
+					args = append(args, val)
+				}
+
+				depthVal := 0
+				if tags.Depth != nil {
+					depthVal = *tags.Depth
+				}
+
+				var depthCondition string
+				if depthVal != -1 {
+					depthCondition = fmt.Sprintf("WHERE depth < %d", depthVal)
+				}
+
+				query := `children AS (
+		SELECT child_id AS root_id, parent_id AS item_id, 0 AS depth FROM tags_relations WHERE child_id IN` + getInBinding(len(tags.Value)) + `
+		UNION
+		SELECT root_id, parent_id, depth + 1 FROM tags_relations INNER JOIN children ON item_id = child_id ` + depthCondition + `
+	)`
+
+				f.addRecursiveWith(query, args...)
+
+				f.addLeftJoin("children", "", "children.item_id = tags.id")
+
+				addHierarchicalConditionClauses(f, tags, "children", "root_id")
+			}
+
+			if len(tags.Excludes) > 0 {
+				var args []interface{}
+				for _, val := range tags.Excludes {
+					args = append(args, val)
+				}
+
+				depthVal := 0
+				if tags.Depth != nil {
+					depthVal = *tags.Depth
+				}
+
+				var depthCondition string
+				if depthVal != -1 {
+					depthCondition = fmt.Sprintf("WHERE depth < %d", depthVal)
+				}
+
+				query := `children2 AS (
+		SELECT child_id AS root_id, parent_id AS item_id, 0 AS depth FROM tags_relations WHERE child_id IN` + getInBinding(len(tags.Excludes)) + `
+		UNION
+		SELECT root_id, parent_id, depth + 1 FROM tags_relations INNER JOIN children2 ON item_id = child_id ` + depthCondition + `
+	)`
+
+				f.addRecursiveWith(query, args...)
+
+				f.addLeftJoin("children2", "", "children2.item_id = tags.id")
+
+				addHierarchicalConditionClauses(f, models.HierarchicalMultiCriterionInput{
+					Value:    tags.Excludes,
+					Depth:    tags.Depth,
+					Modifier: models.CriterionModifierExcludes,
+				}, "children2", "root_id")
+			}
 		}
 	}
 }

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -187,7 +187,7 @@ func TestTagQuerySort(t *testing.T) {
 
 		tags := queryTags(ctx, t, sqb, nil, findFilter)
 		assert := assert.New(t)
-		assert.Equal(tagIDs[tagIdx1WithScene], tags[0].ID)
+		assert.Equal(tagIDs[tagIdx2WithScene], tags[0].ID)
 
 		sortBy = "scene_markers_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -203,7 +203,7 @@ func TestTagQuerySort(t *testing.T) {
 
 		sortBy = "performers_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)
-		assert.Equal(tagIDs[tagIdxWithPerformer], tags[0].ID)
+		assert.Equal(tagIDs[tagIdx2WithPerformer], tags[0].ID)
 
 		return nil
 	})

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -187,7 +187,7 @@ func TestTagQuerySort(t *testing.T) {
 
 		tags := queryTags(ctx, t, sqb, nil, findFilter)
 		assert := assert.New(t)
-		assert.Equal(tagIDs[tagIdxWithScene], tags[0].ID)
+		assert.Equal(tagIDs[tagIdx1WithScene], tags[0].ID)
 
 		sortBy = "scene_markers_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)
@@ -195,11 +195,11 @@ func TestTagQuerySort(t *testing.T) {
 
 		sortBy = "images_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)
-		assert.Equal(tagIDs[tagIdxWithImage], tags[0].ID)
+		assert.Equal(tagIDs[tagIdx1WithImage], tags[0].ID)
 
 		sortBy = "galleries_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)
-		assert.Equal(tagIDs[tagIdxWithGallery], tags[0].ID)
+		assert.Equal(tagIDs[tagIdx1WithGallery], tags[0].ID)
 
 		sortBy = "performers_count"
 		tags = queryTags(ctx, t, sqb, nil, findFilter)

--- a/ui/v2.5/src/components/List/Filters/SelectableFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/SelectableFilter.tsx
@@ -309,14 +309,18 @@ export const HierarchicalObjectsFilter = <
 
   return (
     <Form>
-      <Form.Group>
-        <Form.Check
-          id={criterionOptionTypeToIncludeID()}
-          checked={criterion.value.depth !== 0}
-          label={intl.formatMessage(criterionOptionTypeToIncludeUIString())}
-          onChange={() => onDepthChanged(criterion.value.depth !== 0 ? 0 : -1)}
-        />
-      </Form.Group>
+      {criterion.modifier !== CriterionModifier.Equals && (
+        <Form.Group>
+          <Form.Check
+            id={criterionOptionTypeToIncludeID()}
+            checked={criterion.value.depth !== 0}
+            label={intl.formatMessage(criterionOptionTypeToIncludeUIString())}
+            onChange={() =>
+              onDepthChanged(criterion.value.depth !== 0 ? 0 : -1)
+            }
+          />
+        </Form.Group>
+      )}
 
       {criterion.value.depth !== 0 && (
         <Form.Group>

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -567,6 +567,11 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
 
   protected toCriterionInput(): HierarchicalMultiCriterionInput {
     let excludes: string[] = [];
+
+    // if modifier is equals, depth must be 0
+    const depth =
+      this.modifier === CriterionModifier.Equals ? 0 : this.value.depth;
+
     if (this.value.excluded) {
       excludes = this.value.excluded.map((v) => v.id);
     }
@@ -574,7 +579,7 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
       value: this.value.items.map((v) => v.id),
       excludes: excludes,
       modifier: this.modifier,
-      depth: this.value.depth,
+      depth,
     };
   }
 

--- a/ui/v2.5/src/models/list-filter/criteria/tags.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/tags.ts
@@ -4,14 +4,24 @@ import { CriterionOption, IHierarchicalLabeledIdCriterion } from "./criterion";
 
 export class TagsCriterion extends IHierarchicalLabeledIdCriterion {}
 
-class tagsCriterionOption extends CriterionOption {
-  constructor(messageID: string, value: CriterionType, parameterName: string) {
-    const modifierOptions = [
-      CriterionModifier.Includes,
-      CriterionModifier.IncludesAll,
-      CriterionModifier.Equals,
-    ];
+const tagsModifierOptions = [
+  CriterionModifier.Includes,
+  CriterionModifier.IncludesAll,
+  CriterionModifier.Equals,
+];
 
+const withoutEqualsModifierOptions = [
+  CriterionModifier.Includes,
+  CriterionModifier.IncludesAll,
+];
+
+class tagsCriterionOption extends CriterionOption {
+  constructor(
+    messageID: string,
+    value: CriterionType,
+    parameterName: string,
+    modifierOptions: CriterionModifier[]
+  ) {
     let defaultModifier = CriterionModifier.IncludesAll;
 
     super({
@@ -27,25 +37,30 @@ class tagsCriterionOption extends CriterionOption {
 export const TagsCriterionOption = new tagsCriterionOption(
   "tags",
   "tags",
-  "tags"
+  "tags",
+  tagsModifierOptions
 );
 export const SceneTagsCriterionOption = new tagsCriterionOption(
   "sceneTags",
   "sceneTags",
-  "scene_tags"
+  "scene_tags",
+  tagsModifierOptions
 );
 export const PerformerTagsCriterionOption = new tagsCriterionOption(
   "performerTags",
   "performerTags",
-  "performer_tags"
+  "performer_tags",
+  withoutEqualsModifierOptions
 );
 export const ParentTagsCriterionOption = new tagsCriterionOption(
   "parent_tags",
   "parentTags",
-  "parents"
+  "parents",
+  withoutEqualsModifierOptions
 );
 export const ChildTagsCriterionOption = new tagsCriterionOption(
   "sub_tags",
   "childTags",
-  "children"
+  "children",
+  withoutEqualsModifierOptions
 );


### PR DESCRIPTION
Related to #3772 (ping @DingDongSoLong4)

Fixes the joined hierarchical filtering (scene/image/gallery performer tags, marker scene tags, and parent/sub tags).

This should remove the necessity to restore the excludes pills in the UI.