### PR TITLE
Fix performer image display again and refactoring

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -64,6 +64,23 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
 
   const [organizedLoading, setOrganizedLoading] = useState(false);
 
+  async function onSave(input: GQL.GalleryCreateInput) {
+    await updateGallery({
+      variables: {
+        input: {
+          id: gallery.id,
+          ...input,
+        },
+      },
+    });
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "gallery" }).toLocaleLowerCase() }
+      ),
+    });
+  }
+
   const onOrganizedClick = async () => {
     try {
       setOrganizedLoading(true);
@@ -242,6 +259,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
             <GalleryEditPanel
               isVisible={activeTabKey === "gallery-edit-panel"}
               gallery={gallery}
+              onSubmit={onSave}
               onDelete={() => setIsDeleteAlertOpen(true)}
             />
           </Tab.Pane>

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -147,7 +147,9 @@ export const GalleryEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     if (isVisible) {
       Mousetrap.bind("s s", () => {
-        formik.handleSubmit();
+        if (formik.dirty) {
+          formik.submitForm();
+        }
       });
       Mousetrap.bind("d d", () => {
         onDelete();

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -17,6 +17,7 @@ import { Icon } from "src/components/Shared/Icon";
 import { Counter } from "src/components/Shared/Counter";
 import { useToast } from "src/hooks/Toast";
 import * as Mousetrap from "mousetrap";
+import * as GQL from "src/core/generated-graphql";
 import { OCounterButton } from "src/components/Scenes/SceneDetails/OCounterButton";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
 import { ImageFileInfoPanel } from "./ImageFileInfoPanel";
@@ -50,6 +51,18 @@ export const Image: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = useState("image-details-panel");
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+
+  async function onSave(input: GQL.ImageUpdateInput) {
+    await updateImage({
+      variables: { input },
+    });
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "image" }).toLocaleLowerCase() }
+      ),
+    });
+  }
 
   async function onRescan() {
     if (!image || !image.visual_files.length) {
@@ -225,6 +238,7 @@ export const Image: React.FC = () => {
             <ImageEditPanel
               isVisible={activeTabKey === "image-edit-panel"}
               image={image}
+              onSubmit={onSave}
               onDelete={() => setIsDeleteAlertOpen(true)}
             />
           </Tab.Pane>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage, useIntl } from "react-intl";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
-import { useImageUpdate } from "src/core/StashService";
 import {
   PerformerSelect,
   TagSelect,
@@ -25,12 +24,14 @@ import { DateInput } from "src/components/Shared/DateInput";
 interface IProps {
   image: GQL.ImageDataFragment;
   isVisible: boolean;
+  onSubmit: (input: GQL.ImageUpdateInput) => Promise<void>;
   onDelete: () => void;
 }
 
 export const ImageEditPanel: React.FC<IProps> = ({
   image,
   isVisible,
+  onSubmit,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -40,8 +41,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const { configuration } = React.useContext(ConfigurationContext);
-
-  const [updateImage] = useImageUpdate();
 
   const schema = yup.object({
     title: yup.string().ensure(),
@@ -113,23 +112,11 @@ export const ImageEditPanel: React.FC<IProps> = ({
   async function onSave(input: InputValues) {
     setIsLoading(true);
     try {
-      const result = await updateImage({
-        variables: {
-          input: {
-            id: image.id,
-            ...input,
-          },
-        },
+      await onSubmit({
+        id: image.id,
+        ...input,
       });
-      if (result.data?.imageUpdate) {
-        Toast.success({
-          content: intl.formatMessage(
-            { id: "toast.updated_entity" },
-            { entity: intl.formatMessage({ id: "image" }).toLocaleLowerCase() }
-          ),
-        });
-        formik.resetForm();
-      }
+      formik.resetForm();
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -96,7 +96,9 @@ export const ImageEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     if (isVisible) {
       Mousetrap.bind("s s", () => {
-        formik.handleSubmit();
+        if (formik.dirty) {
+          formik.submitForm();
+        }
       });
       Mousetrap.bind("d d", () => {
         onDelete();

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -95,21 +95,21 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   });
 
   async function onSave(input: GQL.MovieCreateInput) {
-    try {
-      const result = await updateMovie({
-        variables: {
-          input: {
-            id: movie.id,
-            ...input,
-          },
+    await updateMovie({
+      variables: {
+        input: {
+          id: movie.id,
+          ...input,
         },
-      });
-      if (result.data?.movieUpdate) {
-        toggleEditing();
-      }
-    } catch (e) {
-      Toast.error(e);
-    }
+      },
+    });
+    toggleEditing(false);
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "movie" }).toLocaleLowerCase() }
+      ),
+    });
   }
 
   async function onDelete() {
@@ -123,8 +123,12 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     history.push(`/movies`);
   }
 
-  function toggleEditing() {
-    setIsEditing((e) => !e);
+  function toggleEditing(value?: boolean) {
+    if (value !== undefined) {
+      setIsEditing(value);
+    } else {
+      setIsEditing((e) => !e);
+    }
     setFrontImage(undefined);
     setBackImage(undefined);
   }
@@ -238,7 +242,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
               objectName={movie.name}
               isNew={false}
               isEditing={isEditing}
-              onToggleEdit={toggleEditing}
+              onToggleEdit={() => toggleEditing()}
               onSave={() => {}}
               onImageChange={() => {}}
               onDelete={onDelete}
@@ -248,7 +252,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
           <MovieEditPanel
             movie={movie}
             onSubmit={onSave}
-            onCancel={toggleEditing}
+            onCancel={() => toggleEditing()}
             onDelete={onDelete}
             setFrontImage={setFrontImage}
             setBackImage={setBackImage}

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -83,7 +83,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
 
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("e", () => setIsEditing(true));
+    Mousetrap.bind("e", () => toggleEditing());
     Mousetrap.bind("d d", () => {
       onDelete();
     });
@@ -105,8 +105,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
         },
       });
       if (result.data?.movieUpdate) {
-        setIsEditing(false);
-        history.push(`/movies/${result.data.movieUpdate.id}`);
+        toggleEditing();
       }
     } catch (e) {
       Toast.error(e);
@@ -124,8 +123,8 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     history.push(`/movies`);
   }
 
-  function onToggleEdit() {
-    setIsEditing(!isEditing);
+  function toggleEditing() {
+    setIsEditing((e) => !e);
     setFrontImage(undefined);
     setBackImage(undefined);
   }
@@ -239,7 +238,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
               objectName={movie.name}
               isNew={false}
               isEditing={isEditing}
-              onToggleEdit={onToggleEdit}
+              onToggleEdit={toggleEditing}
               onSave={() => {}}
               onImageChange={() => {}}
               onDelete={onDelete}
@@ -249,7 +248,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
           <MovieEditPanel
             movie={movie}
             onSubmit={onSave}
-            onCancel={onToggleEdit}
+            onCancel={toggleEditing}
             onDelete={onDelete}
             setFrontImage={setFrontImage}
             setBackImage={setBackImage}

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieCreate.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieCreate.tsx
@@ -2,15 +2,17 @@ import React, { useMemo, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useMovieCreate } from "src/core/StashService";
 import { useHistory, useLocation } from "react-router-dom";
+import { useIntl } from "react-intl";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { useToast } from "src/hooks/Toast";
 import { MovieEditPanel } from "./MovieEditPanel";
 
 const MovieCreate: React.FC = () => {
   const history = useHistory();
-  const location = useLocation();
+  const intl = useIntl();
   const Toast = useToast();
 
+  const location = useLocation();
   const query = useMemo(() => new URLSearchParams(location.search), [location]);
   const movie = {
     name: query.get("q") ?? undefined,
@@ -24,15 +26,17 @@ const MovieCreate: React.FC = () => {
   const [createMovie] = useMovieCreate();
 
   async function onSave(input: GQL.MovieCreateInput) {
-    try {
-      const result = await createMovie({
-        variables: input,
+    const result = await createMovie({
+      variables: input,
+    });
+    if (result.data?.movieCreate?.id) {
+      history.push(`/movies/${result.data.movieCreate.id}`);
+      Toast.success({
+        content: intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "gallery" }).toLocaleLowerCase() }
+        ),
       });
-      if (result.data?.movieCreate?.id) {
-        history.push(`/movies/${result.data.movieCreate.id}`);
-      }
-    } catch (e) {
-      Toast.error(e);
     }
   }
 

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -122,7 +122,11 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     //   setStudioFocus()
     //   e.preventDefault();
     // });
-    Mousetrap.bind("s s", () => formik.handleSubmit());
+    Mousetrap.bind("s s", () => {
+      if (formik.dirty) {
+        formik.submitForm();
+      }
+    });
 
     return () => {
       // Mousetrap.unbind("u");

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -28,7 +28,7 @@ import { DateInput } from "src/components/Shared/DateInput";
 
 interface IMovieEditPanel {
   movie: Partial<GQL.MovieDataFragment>;
-  onSubmit: (movie: GQL.MovieCreateInput) => void;
+  onSubmit: (movie: GQL.MovieCreateInput) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setFrontImage: (image?: string | null) => void;
@@ -103,7 +103,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     initialValues,
     enableReinitialize: true,
     validationSchema: schema,
-    onSubmit: (values) => onSubmit(values),
+    onSubmit: (values) => onSave(values),
   });
 
   function setRating(v: number) {
@@ -174,6 +174,17 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
       // image is a base64 string
       formik.setFieldValue("back_image", state.back_image);
     }
+  }
+
+  async function onSave(input: InputValues) {
+    setIsLoading(true);
+    try {
+      await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
   }
 
   async function onScrapeMovieURL() {

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieEditPanel.tsx
@@ -116,12 +116,6 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
     setRating
   );
 
-  function onCancelEditing() {
-    setFrontImage(undefined);
-    setBackImage(undefined);
-    onCancel?.();
-  }
-
   // set up hotkeys
   useEffect(() => {
     // Mousetrap.bind("u", (e) => {
@@ -488,7 +482,7 @@ export const MovieEditPanel: React.FC<IMovieEditPanel> = ({
         objectName={movie?.name ?? intl.formatMessage({ id: "movie" })}
         isNew={isNew}
         isEditing={isEditing}
-        onToggleEdit={onCancelEditing}
+        onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onFrontImageChange}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -68,15 +68,17 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
 
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;
-    if (image === null && performerImage) {
-      const performerImageURL = new URL(performerImage);
-      performerImageURL.searchParams.set("default", "true");
-      return performerImageURL.toString();
-    } else if (image) {
-      return image;
+    if (isEditing) {
+      if (image === null && performerImage) {
+        const performerImageURL = new URL(performerImage);
+        performerImageURL.searchParams.set("default", "true");
+        return performerImageURL.toString();
+      } else if (image) {
+        return image;
+      }
     }
     return performerImage;
-  }, [image, performer.image_path]);
+  }, [image, isEditing, performer.image_path]);
 
   const lightboxImages = useMemo(
     () => [{ paths: { thumbnail: activeImage, image: activeImage } }],
@@ -122,11 +124,6 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     setRating
   );
 
-  // reset image if performer changed
-  useEffect(() => {
-    setImage(undefined);
-  }, [performer]);
-
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("a", () => setActiveTabKey("details"));
@@ -158,6 +155,11 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     history.push("/performers");
   }
 
+  function onToggleEdit() {
+    setIsEditing(!isEditing);
+    setImage(undefined);
+  }
+
   function renderImage() {
     if (activeImage) {
       return (
@@ -175,9 +177,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
             objectName={
               performer?.name ?? intl.formatMessage({ id: "performer" })
             }
-            onToggleEdit={() => {
-              setIsEditing(!isEditing);
-            }}
+            onToggleEdit={onToggleEdit}
             onDelete={onDelete}
             onAutoTag={onAutoTag}
             isNew={false}
@@ -297,7 +297,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <PerformerEditPanel
           performer={performer}
           isVisible={isEditing}
-          onCancel={() => setIsEditing(false)}
+          onCancel={onToggleEdit}
           setImage={setImage}
           setEncodingImage={setEncodingImage}
         />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -144,6 +144,24 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     };
   });
 
+  async function onSave(input: GQL.PerformerCreateInput) {
+    await updatePerformer({
+      variables: {
+        input: {
+          id: performer.id,
+          ...input,
+        },
+      },
+    });
+    toggleEditing(false);
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "performer" }).toLocaleLowerCase() }
+      ),
+    });
+  }
+
   async function onDelete() {
     try {
       await deletePerformer({ variables: { id: performer.id } });
@@ -155,8 +173,12 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     history.push("/performers");
   }
 
-  function toggleEditing() {
-    setIsEditing((e) => !e);
+  function toggleEditing(value?: boolean) {
+    if (value !== undefined) {
+      setIsEditing(value);
+    } else {
+      setIsEditing((e) => !e);
+    }
     setImage(undefined);
   }
 
@@ -177,7 +199,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
             objectName={
               performer?.name ?? intl.formatMessage({ id: "performer" })
             }
-            onToggleEdit={toggleEditing}
+            onToggleEdit={() => toggleEditing()}
             onDelete={onDelete}
             onAutoTag={onAutoTag}
             isNew={false}
@@ -297,7 +319,8 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <PerformerEditPanel
           performer={performer}
           isVisible={isEditing}
-          onCancel={toggleEditing}
+          onSubmit={onSave}
+          onCancel={() => toggleEditing()}
           setImage={setImage}
           setEncodingImage={setEncodingImage}
         />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -127,7 +127,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("a", () => setActiveTabKey("details"));
-    Mousetrap.bind("e", () => setIsEditing(!isEditing));
+    Mousetrap.bind("e", () => toggleEditing());
     Mousetrap.bind("c", () => setActiveTabKey("scenes"));
     Mousetrap.bind("g", () => setActiveTabKey("galleries"));
     Mousetrap.bind("m", () => setActiveTabKey("movies"));
@@ -155,8 +155,8 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     history.push("/performers");
   }
 
-  function onToggleEdit() {
-    setIsEditing(!isEditing);
+  function toggleEditing() {
+    setIsEditing((e) => !e);
     setImage(undefined);
   }
 
@@ -177,7 +177,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
             objectName={
               performer?.name ?? intl.formatMessage({ id: "performer" })
             }
-            onToggleEdit={onToggleEdit}
+            onToggleEdit={toggleEditing}
             onDelete={onDelete}
             onAutoTag={onAutoTag}
             isNew={false}
@@ -297,7 +297,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <PerformerEditPanel
           performer={performer}
           isVisible={isEditing}
-          onCancel={onToggleEdit}
+          onCancel={toggleEditing}
           setImage={setImage}
           setEncodingImage={setEncodingImage}
         />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -476,7 +476,9 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   useEffect(() => {
     if (isVisible) {
       Mousetrap.bind("s s", () => {
-        onSave?.(formik.values);
+        if (formik.dirty) {
+          formik.submitForm();
+        }
       });
 
       return () => {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -499,11 +499,6 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     setIsLoading(false);
   }
 
-  function onCancelEditing() {
-    setImage(undefined);
-    onCancel?.();
-  }
-
   // set up hotkeys
   useEffect(() => {
     if (isVisible) {
@@ -729,7 +724,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     return (
       <div className={cx("details-edit", "col-xl-9", classNames)}>
         {!isNew && onCancel ? (
-          <Button className="mr-2" variant="primary" onClick={onCancelEditing}>
+          <Button className="mr-2" variant="primary" onClick={onCancel}>
             <FormattedMessage id="actions.cancel" />
           </Button>
         ) : null}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -8,8 +8,6 @@ import {
   useListPerformerScrapers,
   queryScrapePerformer,
   mutateReloadScrapers,
-  usePerformerUpdate,
-  usePerformerCreate,
   useTagCreate,
   queryScrapePerformerURL,
 } from "src/core/StashService";
@@ -24,7 +22,7 @@ import ImageUtils from "src/utils/image";
 import { getStashIDs } from "src/utils/stashIds";
 import { stashboxDisplayName } from "src/utils/stashbox";
 import { useToast } from "src/hooks/Toast";
-import { Prompt, useHistory } from "react-router-dom";
+import { Prompt } from "react-router-dom";
 import { useFormik } from "formik";
 import {
   genderToString,
@@ -57,6 +55,7 @@ const isScraper = (
 interface IPerformerDetails {
   performer: Partial<GQL.PerformerDataFragment>;
   isVisible: boolean;
+  onSubmit: (performer: GQL.PerformerCreateInput) => Promise<void>;
   onCancel?: () => void;
   setImage: (image?: string | null) => void;
   setEncodingImage: (loading: boolean) => void;
@@ -65,12 +64,12 @@ interface IPerformerDetails {
 export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   performer,
   isVisible,
+  onSubmit,
   onCancel,
   setImage,
   setEncodingImage,
 }) => {
   const Toast = useToast();
-  const history = useHistory();
 
   const isNew = performer.id === undefined;
 
@@ -81,9 +80,6 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
-
-  const [updatePerformer] = usePerformerUpdate();
-  const [createPerformer] = usePerformerCreate();
 
   const Scrapers = useListPerformerScrapers();
   const [queryableScrapers, setQueryableScrapers] = useState<GQL.Scraper[]>([]);
@@ -454,47 +450,24 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     ImageUtils.onImageChange(event, onImageLoad);
   }
 
+  function valuesToInput(input: InputValues): GQL.PerformerCreateInput {
+    return {
+      ...input,
+      gender: input.gender || null,
+      height_cm: input.height_cm || null,
+      weight: input.weight || null,
+      penis_length: input.penis_length || null,
+      circumcised: input.circumcised || null,
+    };
+  }
+
   async function onSave(input: InputValues) {
     setIsLoading(true);
     try {
-      if (isNew) {
-        const result = await createPerformer({
-          variables: {
-            input: {
-              ...input,
-              gender: input.gender || null,
-              height_cm: input.height_cm || null,
-              weight: input.weight || null,
-              penis_length: input.penis_length || null,
-              circumcised: input.circumcised || null,
-            },
-          },
-        });
-        if (result.data?.performerCreate) {
-          history.push(`/performers/${result.data.performerCreate.id}`);
-        }
-      } else {
-        await updatePerformer({
-          variables: {
-            input: {
-              id: performer.id!,
-              ...input,
-              gender: input.gender || null,
-              height_cm: input.height_cm || null,
-              weight: input.weight || null,
-              penis_length: input.penis_length || null,
-              circumcised: input.circumcised || null,
-            },
-          },
-        });
-      }
+      await onSubmit(valuesToInput(input));
+      formik.resetForm();
     } catch (e) {
       Toast.error(e);
-      setIsLoading(false);
-      return;
-    }
-    if (!isNew && onCancel) {
-      onCancel();
     }
     setIsLoading(false);
   }
@@ -694,9 +667,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     }
 
     const currentPerformer = {
-      ...formik.values,
-      gender: formik.values.gender || null,
-      circumcised: formik.values.circumcised || null,
+      ...valuesToInput(formik.values),
       image: formik.values.image ?? performer.image_path,
     };
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -169,6 +169,23 @@ const ScenePage: React.FC<IProps> = ({
     };
   });
 
+  async function onSave(input: GQL.SceneCreateInput) {
+    await updateScene({
+      variables: {
+        input: {
+          id: scene.id,
+          ...input,
+        },
+      },
+    });
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "scene" }).toLocaleLowerCase() }
+      ),
+    });
+  }
+
   const onOrganizedClick = async () => {
     try {
       setOrganizedLoading(true);
@@ -461,6 +478,7 @@ const ScenePage: React.FC<IProps> = ({
           <SceneEditPanel
             isVisible={activeTabKey === "scene-edit-panel"}
             scene={scene}
+            onSubmit={onSave}
             onDelete={() => setIsDeleteAlertOpen(true)}
           />
         </Tab.Pane>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
@@ -17,7 +17,7 @@ const SceneCreate: React.FC = () => {
   const query = useMemo(() => new URLSearchParams(location.search), [location]);
 
   // create scene from provided scene id if applicable
-  const { data, loading } = useFindScene(query.get("from_scene_id") ?? "");
+  const { data, loading } = useFindScene(query.get("from_scene_id") ?? "new");
   const [loadingCoverImage, setLoadingCoverImage] = useState(false);
   const [coverImage, setCoverImage] = useState<string>();
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { SceneEditPanel } from "./SceneEditPanel";
-import { useFindScene } from "src/core/StashService";
+import * as GQL from "src/core/generated-graphql";
+import { mutateCreateScene, useFindScene } from "src/core/StashService";
 import ImageUtils from "src/utils/image";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
+import { useToast } from "src/hooks/Toast";
 
 const SceneCreate: React.FC = () => {
+  const history = useHistory();
   const intl = useIntl();
+  const Toast = useToast();
 
   const location = useLocation();
   const query = useMemo(() => new URLSearchParams(location.search), [location]);
@@ -53,6 +57,23 @@ const SceneCreate: React.FC = () => {
     return <LoadingIndicator />;
   }
 
+  async function onSave(input: GQL.SceneCreateInput) {
+    const fileID = query.get("file_id") ?? undefined;
+    const result = await mutateCreateScene({
+      ...input,
+      file_ids: fileID ? [fileID] : undefined,
+    });
+    if (result.data?.sceneCreate?.id) {
+      history.push(`/scenes/${result.data.sceneCreate.id}`);
+      Toast.success({
+        content: intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "scene" }).toLocaleLowerCase() }
+        ),
+      });
+    }
+  }
+
   return (
     <div className="row new-view justify-content-center" id="create-scene-page">
       <div className="col-md-8">
@@ -64,10 +85,10 @@ const SceneCreate: React.FC = () => {
         </h2>
         <SceneEditPanel
           scene={scene}
-          fileID={query.get("file_id") ?? undefined}
           initialCoverImage={coverImage}
           isVisible
           isNew
+          onSubmit={onSave}
         />
       </div>
     </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -204,7 +204,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     if (isVisible) {
       Mousetrap.bind("s s", () => {
-        formik.handleSubmit();
+        if (formik.dirty) {
+          formik.submitForm();
+        }
       });
       Mousetrap.bind("d d", () => {
         if (onDelete) {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -89,14 +89,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
   const [scrapedScene, setScrapedScene] = useState<GQL.ScrapedScene | null>();
   const [endpoint, setEndpoint] = useState<string>();
 
-  const [coverImagePreview, setCoverImagePreview] = useState<string>();
-
-  useEffect(() => {
-    setCoverImagePreview(
-      initialCoverImage ?? scene.paths?.screenshot ?? undefined
-    );
-  }, [scene.paths?.screenshot, initialCoverImage]);
-
   useEffect(() => {
     setGalleries(
       scene.galleries?.map((g) => ({
@@ -177,6 +169,19 @@ export const SceneEditPanel: React.FC<IProps> = ({
     validationSchema: schema,
     onSubmit: (values) => onSave(values),
   });
+
+  const coverImagePreview = useMemo(() => {
+    const sceneImage = scene.paths?.screenshot;
+    const formImage = formik.values.cover_image;
+    if (formImage === null && sceneImage) {
+      const sceneImageURL = new URL(sceneImage);
+      sceneImageURL.searchParams.set("default", "true");
+      return sceneImageURL.toString();
+    } else if (formImage) {
+      return formImage;
+    }
+    return sceneImage;
+  }, [formik.values.cover_image, scene.paths?.screenshot]);
 
   function setRating(v: number) {
     formik.setFieldValue("rating100", v);
@@ -288,7 +293,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
   const encodingImage = ImageUtils.usePasteImage(onImageLoad);
 
   function onImageLoad(imageData: string) {
-    setCoverImagePreview(imageData);
     formik.setFieldValue("cover_image", imageData);
   }
 
@@ -589,7 +593,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     if (updatedScene.image) {
       // image is a base64 string
       formik.setFieldValue("cover_image", updatedScene.image);
-      setCoverImagePreview(updatedScene.image);
     }
 
     if (updatedScene.remote_site_id && endpoint) {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -69,7 +69,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
 
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("e", () => setIsEditing(true));
+    Mousetrap.bind("e", () => toggleEditing());
     Mousetrap.bind("d d", () => {
       onDelete();
     });
@@ -93,7 +93,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
         },
       });
       if (result.data?.studioUpdate) {
-        setIsEditing(false);
+        toggleEditing();
       }
     } catch (e) {
       Toast.error(e);
@@ -149,8 +149,9 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     );
   }
 
-  function onToggleEdit() {
-    setIsEditing(!isEditing);
+  function toggleEditing() {
+    setIsEditing((e) => !e);
+    setImage(undefined);
   }
 
   function renderImage() {
@@ -213,7 +214,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
               objectName={studio.name ?? intl.formatMessage({ id: "studio" })}
               isNew={false}
               isEditing={isEditing}
-              onToggleEdit={onToggleEdit}
+              onToggleEdit={toggleEditing}
               onSave={() => {}}
               onImageChange={() => {}}
               onClearImage={() => {}}
@@ -225,7 +226,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <StudioEditPanel
             studio={studio}
             onSubmit={onSave}
-            onCancel={onToggleEdit}
+            onCancel={toggleEditing}
             onDelete={onDelete}
             setImage={setImage}
             setEncodingImage={setEncodingImage}

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -83,21 +83,21 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   });
 
   async function onSave(input: GQL.StudioCreateInput) {
-    try {
-      const result = await updateStudio({
-        variables: {
-          input: {
-            id: studio.id,
-            ...input,
-          },
+    await updateStudio({
+      variables: {
+        input: {
+          id: studio.id,
+          ...input,
         },
-      });
-      if (result.data?.studioUpdate) {
-        toggleEditing();
-      }
-    } catch (e) {
-      Toast.error(e);
-    }
+      },
+    });
+    toggleEditing(false);
+    Toast.success({
+      content: intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+      ),
+    });
   }
 
   async function onAutoTag() {
@@ -149,8 +149,12 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     );
   }
 
-  function toggleEditing() {
-    setIsEditing((e) => !e);
+  function toggleEditing(value?: boolean) {
+    if (value !== undefined) {
+      setIsEditing(value);
+    } else {
+      setIsEditing((e) => !e);
+    }
     setImage(undefined);
   }
 
@@ -214,7 +218,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
               objectName={studio.name ?? intl.formatMessage({ id: "studio" })}
               isNew={false}
               isEditing={isEditing}
-              onToggleEdit={toggleEditing}
+              onToggleEdit={() => toggleEditing()}
               onSave={() => {}}
               onImageChange={() => {}}
               onClearImage={() => {}}
@@ -226,7 +230,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <StudioEditPanel
             studio={studio}
             onSubmit={onSave}
-            onCancel={toggleEditing}
+            onCancel={() => toggleEditing()}
             onDelete={onDelete}
             setImage={setImage}
             setEncodingImage={setEncodingImage}

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
@@ -27,15 +27,17 @@ const StudioCreate: React.FC = () => {
   const [createStudio] = useStudioCreate();
 
   async function onSave(input: GQL.StudioCreateInput) {
-    try {
-      const result = await createStudio({
-        variables: { input },
+    const result = await createStudio({
+      variables: { input },
+    });
+    if (result.data?.studioCreate?.id) {
+      history.push(`/studios/${result.data.studioCreate.id}`);
+      Toast.success({
+        content: intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+        ),
       });
-      if (result.data?.studioCreate?.id) {
-        history.push(`/studios/${result.data.studioCreate.id}`);
-      }
-    } catch (e) {
-      Toast.error(e);
     }
   }
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -123,7 +123,11 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
 
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("s s", () => formik.handleSubmit());
+    Mousetrap.bind("s s", () => {
+      if (formik.dirty) {
+        formik.submitForm();
+      }
+    });
 
     return () => {
       Mousetrap.unbind("s s");

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -114,11 +114,6 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     setRating
   );
 
-  function onCancelEditing() {
-    setImage(undefined);
-    onCancel?.();
-  }
-
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("s s", () => formik.handleSubmit());
@@ -331,7 +326,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         objectName={studio?.name ?? intl.formatMessage({ id: "studio" })}
         isNew={isNew}
         isEditing
-        onToggleEdit={onCancelEditing}
+        onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onImageChange}

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -106,30 +106,31 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   });
 
   async function onSave(input: GQL.TagCreateInput) {
-    try {
-      const oldRelations = {
-        parents: tag.parents ?? [],
-        children: tag.children ?? [],
-      };
-      const result = await updateTag({
-        variables: {
-          input: {
-            id: tag.id,
-            ...input,
-          },
+    const oldRelations = {
+      parents: tag.parents ?? [],
+      children: tag.children ?? [],
+    };
+    const result = await updateTag({
+      variables: {
+        input: {
+          id: tag.id,
+          ...input,
         },
+      },
+    });
+    if (result.data?.tagUpdate) {
+      toggleEditing(false);
+      const updated = result.data.tagUpdate;
+      tagRelationHook(updated, oldRelations, {
+        parents: updated.parents,
+        children: updated.children,
       });
-      if (result.data?.tagUpdate) {
-        toggleEditing();
-        const updated = result.data.tagUpdate;
-        tagRelationHook(updated, oldRelations, {
-          parents: updated.parents,
-          children: updated.children,
-        });
-        return updated.id;
-      }
-    } catch (e) {
-      Toast.error(e);
+      Toast.success({
+        content: intl.formatMessage(
+          { id: "toast.updated_entity" },
+          { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
+        ),
+      });
     }
   }
 
@@ -190,8 +191,12 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
     );
   }
 
-  function toggleEditing() {
-    setIsEditing((e) => !e);
+  function toggleEditing(value?: boolean) {
+    if (value !== undefined) {
+      setIsEditing(value);
+    } else {
+      setIsEditing((e) => !e);
+    }
     setImage(undefined);
   }
 
@@ -283,7 +288,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                 objectName={tag.name}
                 isNew={false}
                 isEditing={isEditing}
-                onToggleEdit={toggleEditing}
+                onToggleEdit={() => toggleEditing()}
                 onSave={() => {}}
                 onImageChange={() => {}}
                 onClearImage={() => {}}
@@ -297,7 +302,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <TagEditPanel
               tag={tag}
               onSubmit={onSave}
-              onCancel={toggleEditing}
+              onCancel={() => toggleEditing()}
               onDelete={onDelete}
               setImage={setImage}
               setEncodingImage={setEncodingImage}

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -88,7 +88,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
 
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("e", () => setIsEditing(true));
+    Mousetrap.bind("e", () => toggleEditing());
     Mousetrap.bind("d d", () => {
       onDelete();
     });
@@ -120,7 +120,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
         },
       });
       if (result.data?.tagUpdate) {
-        setIsEditing(false);
+        toggleEditing();
         const updated = result.data.tagUpdate;
         tagRelationHook(updated, oldRelations, {
           parents: updated.parents,
@@ -190,8 +190,8 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
     );
   }
 
-  function onToggleEdit() {
-    setIsEditing(!isEditing);
+  function toggleEditing() {
+    setIsEditing((e) => !e);
     setImage(undefined);
   }
 
@@ -283,7 +283,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                 objectName={tag.name}
                 isNew={false}
                 isEditing={isEditing}
-                onToggleEdit={onToggleEdit}
+                onToggleEdit={toggleEditing}
                 onSave={() => {}}
                 onImageChange={() => {}}
                 onClearImage={() => {}}
@@ -297,7 +297,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <TagEditPanel
               tag={tag}
               onSubmit={onSave}
-              onCancel={onToggleEdit}
+              onCancel={toggleEditing}
               onDelete={onDelete}
               setImage={setImage}
               setEncodingImage={setEncodingImage}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -87,11 +87,6 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     onSubmit: (values) => onSubmit(values),
   });
 
-  function onCancelEditing() {
-    setImage(undefined);
-    onCancel?.();
-  }
-
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("s s", () => formik.handleSubmit());
@@ -275,7 +270,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
         objectName={tag?.name ?? intl.formatMessage({ id: "tag" })}
         isNew={isNew}
         isEditing={isEditing}
-        onToggleEdit={onCancelEditing}
+        onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onImageChange}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -94,7 +94,11 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
 
   // set up hotkeys
   useEffect(() => {
-    Mousetrap.bind("s s", () => formik.handleSubmit());
+    Mousetrap.bind("s s", () => {
+      if (formik.dirty) {
+        formik.submitForm();
+      }
+    });
 
     return () => {
       Mousetrap.unbind("s s");

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -222,8 +222,10 @@ export const useFindGallery = (id: string) => {
   const skip = id === "new";
   return GQL.useFindGalleryQuery({ variables: { id }, skip });
 };
-export const useFindScene = (id: string) =>
-  GQL.useFindSceneQuery({ variables: { id } });
+export const useFindScene = (id: string) => {
+  const skip = id === "new";
+  return GQL.useFindSceneQuery({ variables: { id }, skip });
+};
 export const useSceneStreams = (id: string) =>
   GQL.useSceneStreamsQuery({ variables: { id } });
 


### PR DESCRIPTION
This started as a fix for the issue described in #3778, which is a regression from #3767.

I also ended up doing a bunch of refactoring for consistency between all the edit pages. Specifically, every edit page now:
- shows a toast on update/create
- has an "s s" hotkey that doesn't bypass validation and only submits the form if it is actually dirty (has been modified)
- has a loading spinner that shows while waiting for the mutation to complete
- explicitly resets the form after submitting, ensuring accurate data is always displayed

I've also added a fix for a `findScene: input: findScene strconv.Atoi: parsing "": invalid syntax` error that comes up when opening the scene create page and after creating a new scene.

Fixes #3778