### PR TITLE
Fix tagger query path on Windows

### DIFF
--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -108,7 +108,7 @@ export function prepareQueryString(
     s = s.replace(new RegExp(b, "gi"), " ");
   });
   s = parseDate(s);
-  return s.replace(/\./g, " ");
+  return s.replace(/\./g, " ").replace(/ +/g, " ");
 }
 
 export const parsePath = (filePath: string) => {
@@ -121,10 +121,10 @@ export const parsePath = (filePath: string) => {
   }
 
   const path = filePath.toLowerCase();
-  const isWin = /^([a-z]:|\\\\)/.test(path);
-  const normalizedPath = isWin
-    ? path.replace(/^[a-z]:/, "").replace(/\\/g, "/")
-    : path;
+  // Absolute paths on Windows start with a drive letter (e.g. C:\)
+  // Alternatively, they may start with a UNC path (e.g. \\server\share)
+  // Remove the drive letter/UNC and replace backslashes with forward slashes
+  const normalizedPath = path.replace(/^[a-z]:|\\\\/, "").replace(/\\/g, "/");
   const pathComponents = normalizedPath
     .split("/")
     .filter((component) => component.trim().length > 0);
@@ -132,10 +132,13 @@ export const parsePath = (filePath: string) => {
 
   const ext = fileName.match(/\.[a-z0-9]*$/)?.[0] ?? "";
   const file = fileName.slice(0, ext.length * -1);
-  const paths =
-    pathComponents.length >= 2
-      ? pathComponents.slice(0, pathComponents.length - 2)
-      : [];
+
+  // remove any .. or . paths
+  const paths = (
+    pathComponents.length >= 1
+      ? pathComponents.slice(0, pathComponents.length - 1)
+      : []
+  ).filter((p) => p !== ".." && p !== ".");
 
   return { paths, file, ext };
 };


### PR DESCRIPTION
Fixes the `parsePath` method to correctly parse relative windows paths.

The new logic will replace `\` characters with `/`, even on *nix systems and drive letters and UNC paths are stripped from the path - `\\foo` becomes `foo`, `D:\bar` becomes `bar`. Also fixes the following:
* fixes issue where the last directory component was stripped from the path - ie `/foo/bar/baz` became `foo baz` if `Path` query mode was chosen
* strips any `.` and `..` directory components from the list
* replaces any multiple space characters with single spaces

Fixes issue [raised in Discord](https://discord.com/channels/559159668438728723/559159910550732809/1105829146296336404).