### PR TITLE
Include subsidiary studios/tags in tab badge counters

### DIFF
--- a/graphql/documents/data/studio.graphql
+++ b/graphql/documents/data/studio.graphql
@@ -17,10 +17,15 @@ fragment StudioData on Studio {
   ignore_auto_tag
   image_path
   scene_count
+  scene_count_all
   image_count
+  image_count_all
   gallery_count
+  gallery_count_all
   performer_count
+  performer_count_all
   movie_count
+  movie_count_all
   stash_ids {
     stash_id
     endpoint

--- a/graphql/documents/data/studio.graphql
+++ b/graphql/documents/data/studio.graphql
@@ -17,15 +17,15 @@ fragment StudioData on Studio {
   ignore_auto_tag
   image_path
   scene_count
-  scene_count_all
+  scene_count_all: scene_count(depth: -1)
   image_count
-  image_count_all
+  image_count_all: image_count(depth: -1)
   gallery_count
-  gallery_count_all
+  gallery_count_all: gallery_count(depth: -1)
   performer_count
-  performer_count_all
+  performer_count_all: performer_count(depth: -1)
   movie_count
-  movie_count_all
+  movie_count_all: movie_count(depth: -1)
   stash_ids {
     stash_id
     endpoint

--- a/graphql/documents/data/tag.graphql
+++ b/graphql/documents/data/tag.graphql
@@ -6,15 +6,15 @@ fragment TagData on Tag {
   ignore_auto_tag
   image_path
   scene_count
-  scene_count_all
+  scene_count_all: scene_count(depth: -1)
   scene_marker_count
-  scene_marker_count_all
+  scene_marker_count_all: scene_marker_count(depth: -1)
   image_count
-  image_count_all
+  image_count_all: image_count(depth: -1)
   gallery_count
-  gallery_count_all
+  gallery_count_all: gallery_count(depth: -1)
   performer_count
-  performer_count_all
+  performer_count_all: performer_count(depth: -1)
 
   parents {
     ...SlimTagData

--- a/graphql/documents/data/tag.graphql
+++ b/graphql/documents/data/tag.graphql
@@ -6,10 +6,15 @@ fragment TagData on Tag {
   ignore_auto_tag
   image_path
   scene_count
+  scene_count_all
   scene_marker_count
+  scene_marker_count_all
   image_count
+  image_count_all
   gallery_count
+  gallery_count_all
   performer_count
+  performer_count_all
 
   parents {
     ...SlimTagData

--- a/graphql/schema/types/movie.graphql
+++ b/graphql/schema/types/movie.graphql
@@ -19,7 +19,7 @@ type Movie {
 
   front_image_path: String # Resolver
   back_image_path: String # Resolver
-  scene_count: Int # Resolver
+  scene_count: Int! # Resolver
   scenes: [Scene!]!
 }
 

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -41,10 +41,11 @@ type Performer {
   ignore_auto_tag: Boolean!
 
   image_path: String # Resolver
-  scene_count: Int # Resolver
-  image_count: Int # Resolver
-  gallery_count: Int # Resolver
-  performer_count: Int # Resolver
+  scene_count: Int! # Resolver
+  image_count: Int! # Resolver
+  gallery_count: Int! # Resolver
+  movie_count: Int! # Resolver
+  performer_count: Int! # Resolver
   o_counter: Int # Resolver
   scenes: [Scene!]!
   stash_ids: [StashID!]!
@@ -58,7 +59,6 @@ type Performer {
   weight: Int
   created_at: Time!
   updated_at: Time!
-  movie_count: Int
   movies: [Movie!]!
 }
 

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -9,10 +9,16 @@ type Studio {
   ignore_auto_tag: Boolean!
 
   image_path: String # Resolver
-  scene_count: Int # Resolver
-  image_count: Int # Resolver
-  gallery_count: Int # Resolver
-  performer_count: Int # Resolver
+  scene_count: Int! # Resolver
+  scene_count_all: Int! # Resolver
+  image_count: Int! # Resolver
+  image_count_all: Int! # Resolver
+  gallery_count: Int! # Resolver
+  gallery_count_all: Int! # Resolver
+  performer_count: Int! # Resolver
+  performer_count_all: Int! # Resolver
+  movie_count: Int! # Resolver
+  movie_count_all: Int! # Resolver
   stash_ids: [StashID!]!
   # rating expressed as 1-5
   rating: Int @deprecated(reason: "Use 1-100 range with rating100")
@@ -21,7 +27,6 @@ type Studio {
   details: String
   created_at: Time!
   updated_at: Time!
-  movie_count: Int
   movies: [Movie!]!
 }
 

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -9,16 +9,11 @@ type Studio {
   ignore_auto_tag: Boolean!
 
   image_path: String # Resolver
-  scene_count: Int! # Resolver
-  scene_count_all: Int! # Resolver
-  image_count: Int! # Resolver
-  image_count_all: Int! # Resolver
-  gallery_count: Int! # Resolver
-  gallery_count_all: Int! # Resolver
-  performer_count: Int! # Resolver
-  performer_count_all: Int! # Resolver
-  movie_count: Int! # Resolver
-  movie_count_all: Int! # Resolver
+  scene_count(depth: Int): Int! # Resolver
+  image_count(depth: Int): Int! # Resolver
+  gallery_count(depth: Int): Int! # Resolver
+  performer_count(depth: Int): Int! # Resolver
+  movie_count(depth: Int): Int! # Resolver
   stash_ids: [StashID!]!
   # rating expressed as 1-5
   rating: Int @deprecated(reason: "Use 1-100 range with rating100")

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -8,16 +8,11 @@ type Tag {
   updated_at: Time!
 
   image_path: String # Resolver
-  scene_count: Int! # Resolver
-  scene_count_all: Int! # Resolver
-  scene_marker_count: Int! # Resolver
-  scene_marker_count_all: Int! # Resolver
-  image_count: Int! # Resolver
-  image_count_all: Int! # Resolver
-  gallery_count: Int! # Resolver
-  gallery_count_all: Int! # Resolver
-  performer_count: Int! # Resolver
-  performer_count_all: Int! # Resolver
+  scene_count(depth: Int): Int! # Resolver
+  scene_marker_count(depth: Int): Int! # Resolver
+  image_count(depth: Int): Int! # Resolver
+  gallery_count(depth: Int): Int! # Resolver
+  performer_count(depth: Int): Int! # Resolver
 
   parents: [Tag!]!
   children: [Tag!]!

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -8,11 +8,16 @@ type Tag {
   updated_at: Time!
 
   image_path: String # Resolver
-  scene_count: Int # Resolver
-  scene_marker_count: Int # Resolver
-  image_count: Int # Resolver
-  gallery_count: Int # Resolver
-  performer_count: Int
+  scene_count: Int! # Resolver
+  scene_count_all: Int! # Resolver
+  scene_marker_count: Int! # Resolver
+  scene_marker_count_all: Int! # Resolver
+  image_count: Int! # Resolver
+  image_count_all: Int! # Resolver
+  gallery_count: Int! # Resolver
+  gallery_count_all: Int! # Resolver
+  performer_count: Int! # Resolver
+  performer_count_all: Int! # Resolver
 
   parents: [Tag!]!
   children: [Tag!]!

--- a/internal/api/resolver_model_movie.go
+++ b/internal/api/resolver_model_movie.go
@@ -71,16 +71,15 @@ func (r *movieResolver) BackImagePath(ctx context.Context, obj *models.Movie) (*
 	return &imagePath, nil
 }
 
-func (r *movieResolver) SceneCount(ctx context.Context, obj *models.Movie) (ret *int, err error) {
-	var res int
+func (r *movieResolver) SceneCount(ctx context.Context, obj *models.Movie) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = r.repository.Scene.CountByMovieID(ctx, obj.ID)
+		ret, err = r.repository.Scene.CountByMovieID(ctx, obj.ID)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, err
+	return ret, nil
 }
 
 func (r *movieResolver) Scenes(ctx context.Context, obj *models.Movie) (ret []*models.Scene, err error) {

--- a/internal/api/resolver_model_performer.go
+++ b/internal/api/resolver_model_performer.go
@@ -92,40 +92,59 @@ func (r *performerResolver) Tags(ctx context.Context, obj *models.Performer) (re
 	return ret, firstError(errs)
 }
 
-func (r *performerResolver) SceneCount(ctx context.Context, obj *models.Performer) (ret *int, err error) {
-	var res int
+func (r *performerResolver) SceneCount(ctx context.Context, obj *models.Performer) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = r.repository.Scene.CountByPerformerID(ctx, obj.ID)
+		ret, err = r.repository.Scene.CountByPerformerID(ctx, obj.ID)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *performerResolver) ImageCount(ctx context.Context, obj *models.Performer) (ret *int, err error) {
-	var res int
+func (r *performerResolver) ImageCount(ctx context.Context, obj *models.Performer) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = image.CountByPerformerID(ctx, r.repository.Image, obj.ID)
+		ret, err = image.CountByPerformerID(ctx, r.repository.Image, obj.ID)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *performerResolver) GalleryCount(ctx context.Context, obj *models.Performer) (ret *int, err error) {
-	var res int
+func (r *performerResolver) GalleryCount(ctx context.Context, obj *models.Performer) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = gallery.CountByPerformerID(ctx, r.repository.Gallery, obj.ID)
+		ret, err = gallery.CountByPerformerID(ctx, r.repository.Gallery, obj.ID)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
+}
+
+func (r *performerResolver) MovieCount(ctx context.Context, obj *models.Performer) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Movie.CountByPerformerID(ctx, obj.ID)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *performerResolver) PerformerCount(ctx context.Context, obj *models.Performer) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = performer.CountByAppearsWith(ctx, r.repository.Performer, obj.ID)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
 }
 
 func (r *performerResolver) OCounter(ctx context.Context, obj *models.Performer) (ret *int, err error) {
@@ -196,28 +215,4 @@ func (r *performerResolver) Movies(ctx context.Context, obj *models.Performer) (
 	}
 
 	return ret, nil
-}
-
-func (r *performerResolver) MovieCount(ctx context.Context, obj *models.Performer) (ret *int, err error) {
-	var res int
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = r.repository.Movie.CountByPerformerID(ctx, obj.ID)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	return &res, nil
-}
-
-func (r *performerResolver) PerformerCount(ctx context.Context, obj *models.Performer) (ret *int, err error) {
-	var res int
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = performer.CountByAppearsWith(ctx, r.repository.Performer, obj.ID)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	return &res, nil
 }

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -39,9 +39,9 @@ func (r *studioResolver) Aliases(ctx context.Context, obj *models.Studio) (ret [
 	return ret, err
 }
 
-func (r *studioResolver) SceneCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+func (r *studioResolver) SceneCount(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.CountByStudioID(ctx, r.repository.Scene, obj.ID, false)
+		ret, err = scene.CountByStudioID(ctx, r.repository.Scene, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -50,9 +50,9 @@ func (r *studioResolver) SceneCount(ctx context.Context, obj *models.Studio) (re
 	return ret, nil
 }
 
-func (r *studioResolver) SceneCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
+func (r *studioResolver) ImageCount(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.CountByStudioID(ctx, r.repository.Scene, obj.ID, true)
+		ret, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -61,9 +61,9 @@ func (r *studioResolver) SceneCountAll(ctx context.Context, obj *models.Studio) 
 	return ret, nil
 }
 
-func (r *studioResolver) ImageCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+func (r *studioResolver) GalleryCount(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID, false)
+		ret, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -72,9 +72,9 @@ func (r *studioResolver) ImageCount(ctx context.Context, obj *models.Studio) (re
 	return ret, nil
 }
 
-func (r *studioResolver) ImageCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
+func (r *studioResolver) PerformerCount(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID, true)
+		ret, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -83,64 +83,9 @@ func (r *studioResolver) ImageCountAll(ctx context.Context, obj *models.Studio) 
 	return ret, nil
 }
 
-func (r *studioResolver) GalleryCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *studioResolver) GalleryCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID, true)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *studioResolver) PerformerCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *studioResolver) PerformerCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID, true)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = movie.CountByStudioID(ctx, r.repository.Movie, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *studioResolver) MovieCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = movie.CountByStudioID(ctx, r.repository.Movie, obj.ID, true)
+		ret, err = movie.CountByStudioID(ctx, r.repository.Movie, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stashapp/stash/pkg/gallery"
 	"github.com/stashapp/stash/pkg/image"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/movie"
 	"github.com/stashapp/stash/pkg/performer"
+	"github.com/stashapp/stash/pkg/scene"
 )
 
 func (r *studioResolver) ImagePath(ctx context.Context, obj *models.Studio) (*string, error) {
@@ -37,52 +39,114 @@ func (r *studioResolver) Aliases(ctx context.Context, obj *models.Studio) (ret [
 	return ret, err
 }
 
-func (r *studioResolver) SceneCount(ctx context.Context, obj *models.Studio) (ret *int, err error) {
-	var res int
+func (r *studioResolver) SceneCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = r.repository.Scene.CountByStudioID(ctx, obj.ID)
+		ret, err = scene.CountByStudioID(ctx, r.repository.Scene, obj.ID, false)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, err
+	return ret, nil
 }
 
-func (r *studioResolver) ImageCount(ctx context.Context, obj *models.Studio) (ret *int, err error) {
-	var res int
+func (r *studioResolver) SceneCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID)
+		ret, err = scene.CountByStudioID(ctx, r.repository.Scene, obj.ID, true)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *studioResolver) GalleryCount(ctx context.Context, obj *models.Studio) (ret *int, err error) {
-	var res int
+func (r *studioResolver) ImageCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID)
+		ret, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID, false)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *studioResolver) PerformerCount(ctx context.Context, obj *models.Studio) (ret *int, err error) {
-	var res int
+func (r *studioResolver) ImageCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID)
+		ret, err = image.CountByStudioID(ctx, r.repository.Image, obj.ID, true)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
+}
+
+func (r *studioResolver) GalleryCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID, false)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *studioResolver) GalleryCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = gallery.CountByStudioID(ctx, r.repository.Gallery, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *studioResolver) PerformerCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID, false)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *studioResolver) PerformerCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = performer.CountByStudioID(ctx, r.repository.Performer, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = movie.CountByStudioID(ctx, r.repository.Movie, obj.ID, false)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *studioResolver) MovieCountAll(ctx context.Context, obj *models.Studio) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = movie.CountByStudioID(ctx, r.repository.Movie, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
 }
 
 func (r *studioResolver) ParentStudio(ctx context.Context, obj *models.Studio) (ret *models.Studio, err error) {
@@ -138,16 +202,4 @@ func (r *studioResolver) Movies(ctx context.Context, obj *models.Studio) (ret []
 	}
 
 	return ret, nil
-}
-
-func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio) (ret *int, err error) {
-	var res int
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = r.repository.Movie.CountByStudioID(ctx, obj.ID)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	return &res, nil
 }

--- a/internal/api/resolver_model_tag.go
+++ b/internal/api/resolver_model_tag.go
@@ -44,9 +44,9 @@ func (r *tagResolver) Aliases(ctx context.Context, obj *models.Tag) (ret []strin
 	return ret, err
 }
 
-func (r *tagResolver) SceneCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
+func (r *tagResolver) SceneCount(ctx context.Context, obj *models.Tag, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.CountByTagID(ctx, r.repository.Scene, obj.ID, false)
+		ret, err = scene.CountByTagID(ctx, r.repository.Scene, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -55,9 +55,9 @@ func (r *tagResolver) SceneCount(ctx context.Context, obj *models.Tag) (ret int,
 	return ret, nil
 }
 
-func (r *tagResolver) SceneCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
+func (r *tagResolver) SceneMarkerCount(ctx context.Context, obj *models.Tag, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.CountByTagID(ctx, r.repository.Scene, obj.ID, true)
+		ret, err = scene.MarkerCountByTagID(ctx, r.repository.SceneMarker, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -66,9 +66,9 @@ func (r *tagResolver) SceneCountAll(ctx context.Context, obj *models.Tag) (ret i
 	return ret, nil
 }
 
-func (r *tagResolver) SceneMarkerCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
+func (r *tagResolver) ImageCount(ctx context.Context, obj *models.Tag, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.MarkerCountByTagID(ctx, r.repository.SceneMarker, obj.ID, false)
+		ret, err = image.CountByTagID(ctx, r.repository.Image, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -77,9 +77,9 @@ func (r *tagResolver) SceneMarkerCount(ctx context.Context, obj *models.Tag) (re
 	return ret, nil
 }
 
-func (r *tagResolver) SceneMarkerCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
+func (r *tagResolver) GalleryCount(ctx context.Context, obj *models.Tag, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = scene.MarkerCountByTagID(ctx, r.repository.SceneMarker, obj.ID, true)
+		ret, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err
@@ -88,64 +88,9 @@ func (r *tagResolver) SceneMarkerCountAll(ctx context.Context, obj *models.Tag) 
 	return ret, nil
 }
 
-func (r *tagResolver) ImageCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
+func (r *tagResolver) PerformerCount(ctx context.Context, obj *models.Tag, depth *int) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = image.CountByTagID(ctx, r.repository.Image, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *tagResolver) ImageCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = image.CountByTagID(ctx, r.repository.Image, obj.ID, true)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *tagResolver) GalleryCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *tagResolver) GalleryCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID, true)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *tagResolver) PerformerCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = performer.CountByTagID(ctx, r.repository.Performer, obj.ID, false)
-		return err
-	}); err != nil {
-		return 0, err
-	}
-
-	return ret, nil
-}
-
-func (r *tagResolver) PerformerCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
-	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = performer.CountByTagID(ctx, r.repository.Performer, obj.ID, true)
+		ret, err = performer.CountByTagID(ctx, r.repository.Performer, obj.ID, depth)
 		return err
 	}); err != nil {
 		return 0, err

--- a/internal/api/resolver_model_tag.go
+++ b/internal/api/resolver_model_tag.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stashapp/stash/pkg/gallery"
 	"github.com/stashapp/stash/pkg/image"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/performer"
+	"github.com/stashapp/stash/pkg/scene"
 )
 
 func (r *tagResolver) Parents(ctx context.Context, obj *models.Tag) (ret []*models.Tag, err error) {
@@ -42,64 +44,114 @@ func (r *tagResolver) Aliases(ctx context.Context, obj *models.Tag) (ret []strin
 	return ret, err
 }
 
-func (r *tagResolver) SceneCount(ctx context.Context, obj *models.Tag) (ret *int, err error) {
-	var count int
+func (r *tagResolver) SceneCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		count, err = r.repository.Scene.CountByTagID(ctx, obj.ID)
+		ret, err = scene.CountByTagID(ctx, r.repository.Scene, obj.ID, false)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &count, err
+	return ret, nil
 }
 
-func (r *tagResolver) SceneMarkerCount(ctx context.Context, obj *models.Tag) (ret *int, err error) {
-	var count int
+func (r *tagResolver) SceneCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		count, err = r.repository.SceneMarker.CountByTagID(ctx, obj.ID)
+		ret, err = scene.CountByTagID(ctx, r.repository.Scene, obj.ID, true)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &count, err
+	return ret, nil
 }
 
-func (r *tagResolver) ImageCount(ctx context.Context, obj *models.Tag) (ret *int, err error) {
-	var res int
+func (r *tagResolver) SceneMarkerCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = image.CountByTagID(ctx, r.repository.Image, obj.ID)
+		ret, err = scene.MarkerCountByTagID(ctx, r.repository.SceneMarker, obj.ID, false)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *tagResolver) GalleryCount(ctx context.Context, obj *models.Tag) (ret *int, err error) {
-	var res int
+func (r *tagResolver) SceneMarkerCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID)
+		ret, err = scene.MarkerCountByTagID(ctx, r.repository.SceneMarker, obj.ID, true)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &res, nil
+	return ret, nil
 }
 
-func (r *tagResolver) PerformerCount(ctx context.Context, obj *models.Tag) (ret *int, err error) {
-	var count int
+func (r *tagResolver) ImageCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		count, err = r.repository.Performer.CountByTagID(ctx, obj.ID)
+		ret, err = image.CountByTagID(ctx, r.repository.Image, obj.ID, false)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return &count, err
+	return ret, nil
+}
+
+func (r *tagResolver) ImageCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = image.CountByTagID(ctx, r.repository.Image, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *tagResolver) GalleryCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID, false)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *tagResolver) GalleryCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = gallery.CountByTagID(ctx, r.repository.Gallery, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *tagResolver) PerformerCount(ctx context.Context, obj *models.Tag) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = performer.CountByTagID(ctx, r.repository.Performer, obj.ID, false)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
+func (r *tagResolver) PerformerCountAll(ctx context.Context, obj *models.Tag) (ret int, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = performer.CountByTagID(ctx, r.repository.Performer, obj.ID, true)
+		return err
+	}); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
 }
 
 func (r *tagResolver) ImagePath(ctx context.Context, obj *models.Tag) (*string, error) {

--- a/pkg/gallery/query.go
+++ b/pkg/gallery/query.go
@@ -35,34 +35,24 @@ func CountByPerformerID(ctx context.Context, r CountQueryer, id int) (int, error
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.GalleryFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByTagID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.GalleryFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/gallery/query.go
+++ b/pkg/gallery/query.go
@@ -35,22 +35,34 @@ func CountByPerformerID(ctx context.Context, r CountQueryer, id int) (int, error
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int) (int, error) {
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
 	filter := &models.GalleryFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int) (int, error) {
+func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
 	filter := &models.GalleryFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
 		},
 	}
 

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -52,22 +52,34 @@ func CountByPerformerID(ctx context.Context, r CountQueryer, id int) (int, error
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int) (int, error) {
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
 	filter := &models.ImageFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int) (int, error) {
+func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
 	filter := &models.ImageFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
 		},
 	}
 

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -52,34 +52,24 @@ func CountByPerformerID(ctx context.Context, r CountQueryer, id int) (int, error
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.ImageFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByTagID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.ImageFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/models/mocks/MovieReaderWriter.go
+++ b/pkg/models/mocks/MovieReaderWriter.go
@@ -384,6 +384,27 @@ func (_m *MovieReaderWriter) Query(ctx context.Context, movieFilter *models.Movi
 	return r0, r1, r2
 }
 
+// QueryCount provides a mock function with given fields: ctx, movieFilter, findFilter
+func (_m *MovieReaderWriter) QueryCount(ctx context.Context, movieFilter *models.MovieFilterType, findFilter *models.FindFilterType) (int, error) {
+	ret := _m.Called(ctx, movieFilter, findFilter)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, *models.MovieFilterType, *models.FindFilterType) int); ok {
+		r0 = rf(ctx, movieFilter, findFilter)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.MovieFilterType, *models.FindFilterType) error); ok {
+		r1 = rf(ctx, movieFilter, findFilter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Update provides a mock function with given fields: ctx, updatedMovie
 func (_m *MovieReaderWriter) Update(ctx context.Context, updatedMovie *models.Movie) error {
 	ret := _m.Called(ctx, updatedMovie)

--- a/pkg/models/mocks/SceneMarkerReaderWriter.go
+++ b/pkg/models/mocks/SceneMarkerReaderWriter.go
@@ -252,6 +252,27 @@ func (_m *SceneMarkerReaderWriter) Query(ctx context.Context, sceneMarkerFilter 
 	return r0, r1, r2
 }
 
+// QueryCount provides a mock function with given fields: ctx, sceneMarkerFilter, findFilter
+func (_m *SceneMarkerReaderWriter) QueryCount(ctx context.Context, sceneMarkerFilter *models.SceneMarkerFilterType, findFilter *models.FindFilterType) (int, error) {
+	ret := _m.Called(ctx, sceneMarkerFilter, findFilter)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, *models.SceneMarkerFilterType, *models.FindFilterType) int); ok {
+		r0 = rf(ctx, sceneMarkerFilter, findFilter)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.SceneMarkerFilterType, *models.FindFilterType) error); ok {
+		r1 = rf(ctx, sceneMarkerFilter, findFilter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Update provides a mock function with given fields: ctx, updatedSceneMarker
 func (_m *SceneMarkerReaderWriter) Update(ctx context.Context, updatedSceneMarker *models.SceneMarker) error {
 	ret := _m.Called(ctx, updatedSceneMarker)

--- a/pkg/models/mocks/SceneReaderWriter.go
+++ b/pkg/models/mocks/SceneReaderWriter.go
@@ -731,6 +731,27 @@ func (_m *SceneReaderWriter) Query(ctx context.Context, options models.SceneQuer
 	return r0, r1
 }
 
+// QueryCount provides a mock function with given fields: ctx, sceneFilter, findFilter
+func (_m *SceneReaderWriter) QueryCount(ctx context.Context, sceneFilter *models.SceneFilterType, findFilter *models.FindFilterType) (int, error) {
+	ret := _m.Called(ctx, sceneFilter, findFilter)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, *models.SceneFilterType, *models.FindFilterType) int); ok {
+		r0 = rf(ctx, sceneFilter, findFilter)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.SceneFilterType, *models.FindFilterType) error); ok {
+		r1 = rf(ctx, sceneFilter, findFilter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ResetOCounter provides a mock function with given fields: ctx, id
 func (_m *SceneReaderWriter) ResetOCounter(ctx context.Context, id int) (int, error) {
 	ret := _m.Called(ctx, id)

--- a/pkg/models/movie.go
+++ b/pkg/models/movie.go
@@ -37,6 +37,7 @@ type MovieReader interface {
 	All(ctx context.Context) ([]*Movie, error)
 	Count(ctx context.Context) (int, error)
 	Query(ctx context.Context, movieFilter *MovieFilterType, findFilter *FindFilterType) ([]*Movie, int, error)
+	QueryCount(ctx context.Context, movieFilter *MovieFilterType, findFilter *FindFilterType) (int, error)
 	GetFrontImage(ctx context.Context, movieID int) ([]byte, error)
 	HasFrontImage(ctx context.Context, movieID int) (bool, error)
 	GetBackImage(ctx context.Context, movieID int) ([]byte, error)

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -178,6 +178,7 @@ type SceneReader interface {
 	Wall(ctx context.Context, q *string) ([]*Scene, error)
 	All(ctx context.Context) ([]*Scene, error)
 	Query(ctx context.Context, options SceneQueryOptions) (*SceneQueryResult, error)
+	QueryCount(ctx context.Context, sceneFilter *SceneFilterType, findFilter *FindFilterType) (int, error)
 	GetCover(ctx context.Context, sceneID int) ([]byte, error)
 	HasCover(ctx context.Context, sceneID int) (bool, error)
 }

--- a/pkg/models/scene_marker.go
+++ b/pkg/models/scene_marker.go
@@ -39,6 +39,7 @@ type SceneMarkerReader interface {
 	Count(ctx context.Context) (int, error)
 	All(ctx context.Context) ([]*SceneMarker, error)
 	Query(ctx context.Context, sceneMarkerFilter *SceneMarkerFilterType, findFilter *FindFilterType) ([]*SceneMarker, int, error)
+	QueryCount(ctx context.Context, sceneMarkerFilter *SceneMarkerFilterType, findFilter *FindFilterType) (int, error)
 	GetTagIDs(ctx context.Context, imageID int) ([]int, error)
 }
 

--- a/pkg/movie/query.go
+++ b/pkg/movie/query.go
@@ -1,0 +1,33 @@
+package movie
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type Queryer interface {
+	Query(ctx context.Context, movieFilter *models.MovieFilterType, findFilter *models.FindFilterType) ([]*models.Movie, int, error)
+}
+
+type CountQueryer interface {
+	QueryCount(ctx context.Context, movieFilter *models.MovieFilterType, findFilter *models.FindFilterType) (int, error)
+}
+
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
+	filter := &models.MovieFilterType{
+		Studios: &models.HierarchicalMultiCriterionInput{
+			Value:    []string{strconv.Itoa(id)},
+			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
+		},
+	}
+
+	return r.QueryCount(ctx, filter, nil)
+}

--- a/pkg/movie/query.go
+++ b/pkg/movie/query.go
@@ -15,17 +15,12 @@ type CountQueryer interface {
 	QueryCount(ctx context.Context, movieFilter *models.MovieFilterType, findFilter *models.FindFilterType) (int, error)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.MovieFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/performer/query.go
+++ b/pkg/performer/query.go
@@ -15,11 +15,34 @@ type CountQueryer interface {
 	QueryCount(ctx context.Context, galleryFilter *models.PerformerFilterType, findFilter *models.FindFilterType) (int, error)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int) (int, error) {
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
 	filter := &models.PerformerFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
+		},
+	}
+
+	return r.QueryCount(ctx, filter, nil)
+}
+
+func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
+	filter := &models.PerformerFilterType{
+		Tags: &models.HierarchicalMultiCriterionInput{
+			Value:    []string{strconv.Itoa(id)},
+			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
 		},
 	}
 

--- a/pkg/performer/query.go
+++ b/pkg/performer/query.go
@@ -15,34 +15,24 @@ type CountQueryer interface {
 	QueryCount(ctx context.Context, galleryFilter *models.PerformerFilterType, findFilter *models.FindFilterType) (int, error)
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.PerformerFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByTagID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.PerformerFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/scene/marker_query.go
+++ b/pkg/scene/marker_query.go
@@ -15,17 +15,12 @@ type MarkerCountQueryer interface {
 	QueryCount(ctx context.Context, sceneMarkerFilter *models.SceneMarkerFilterType, findFilter *models.FindFilterType) (int, error)
 }
 
-func MarkerCountByTagID(ctx context.Context, r MarkerCountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func MarkerCountByTagID(ctx context.Context, r MarkerCountQueryer, id int, depth *int) (int, error) {
 	filter := &models.SceneMarkerFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/scene/marker_query.go
+++ b/pkg/scene/marker_query.go
@@ -1,0 +1,33 @@
+package scene
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type MarkerQueryer interface {
+	Query(ctx context.Context, sceneMarkerFilter *models.SceneMarkerFilterType, findFilter *models.FindFilterType) ([]*models.SceneMarker, int, error)
+}
+
+type MarkerCountQueryer interface {
+	QueryCount(ctx context.Context, sceneMarkerFilter *models.SceneMarkerFilterType, findFilter *models.FindFilterType) (int, error)
+}
+
+func MarkerCountByTagID(ctx context.Context, r MarkerCountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
+	filter := &models.SceneMarkerFilterType{
+		Tags: &models.HierarchicalMultiCriterionInput{
+			Value:    []string{strconv.Itoa(id)},
+			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
+		},
+	}
+
+	return r.QueryCount(ctx, filter, nil)
+}

--- a/pkg/scene/query.go
+++ b/pkg/scene/query.go
@@ -134,34 +134,24 @@ func FilterFromPaths(paths []string) *models.SceneFilterType {
 	return ret
 }
 
-func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.SceneFilterType{
 		Studios: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 
 	return r.QueryCount(ctx, filter, nil)
 }
 
-func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
-	depth := 0
-	if all {
-		depth = -1
-	}
-
+func CountByTagID(ctx context.Context, r CountQueryer, id int, depth *int) (int, error) {
 	filter := &models.SceneFilterType{
 		Tags: &models.HierarchicalMultiCriterionInput{
 			Value:    []string{strconv.Itoa(id)},
 			Modifier: models.CriterionModifierIncludes,
-			Depth:    &depth,
+			Depth:    depth,
 		},
 	}
 

--- a/pkg/scene/query.go
+++ b/pkg/scene/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/stashapp/stash/pkg/job"
@@ -12,6 +13,10 @@ import (
 
 type Queryer interface {
 	Query(ctx context.Context, options models.SceneQueryOptions) (*models.SceneQueryResult, error)
+}
+
+type CountQueryer interface {
+	QueryCount(ctx context.Context, sceneFilter *models.SceneFilterType, findFilter *models.FindFilterType) (int, error)
 }
 
 type IDFinder interface {
@@ -127,4 +132,38 @@ func FilterFromPaths(paths []string) *models.SceneFilterType {
 	}
 
 	return ret
+}
+
+func CountByStudioID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
+	filter := &models.SceneFilterType{
+		Studios: &models.HierarchicalMultiCriterionInput{
+			Value:    []string{strconv.Itoa(id)},
+			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
+		},
+	}
+
+	return r.QueryCount(ctx, filter, nil)
+}
+
+func CountByTagID(ctx context.Context, r CountQueryer, id int, all bool) (int, error) {
+	depth := 0
+	if all {
+		depth = -1
+	}
+
+	filter := &models.SceneFilterType{
+		Tags: &models.HierarchicalMultiCriterionInput{
+			Value:    []string{strconv.Itoa(id)},
+			Modifier: models.CriterionModifierIncludes,
+			Depth:    &depth,
+		},
+	}
+
+	return r.QueryCount(ctx, filter, nil)
 }

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -211,9 +211,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
               <Nav.Item>
                 <Nav.Link eventKey="gallery-file-info-panel">
                   <FormattedMessage id="file_info" />
-                  {gallery.files.length > 1 && (
-                    <Counter count={gallery.files.length ?? 0} />
-                  )}
+                  <Counter count={gallery.files.length} hideZero hideOne />
                 </Nav.Link>
               </Nav.Item>
             ) : undefined}

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -195,9 +195,7 @@ export const Image: React.FC = () => {
             <Nav.Item>
               <Nav.Link eventKey="image-file-info-panel">
                 <FormattedMessage id="file_info" />
-                {image.visual_files.length > 1 && (
-                  <Counter count={image.visual_files.length ?? 0} />
-                )}
+                <Counter count={image.visual_files.length} hideZero hideOne />
               </Nav.Link>
             </Nav.Item>
             <Nav.Item>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -227,13 +227,14 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab
           eventKey="scenes"
           title={
-            <React.Fragment>
+            <>
               {intl.formatMessage({ id: "scenes" })}
               <Counter
                 abbreviateCounter={abbreviateCounter}
-                count={performer.scene_count ?? 0}
+                count={performer.scene_count}
+                hideZero
               />
-            </React.Fragment>
+            </>
           }
         >
           <PerformerScenesPanel
@@ -244,13 +245,14 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab
           eventKey="galleries"
           title={
-            <React.Fragment>
+            <>
               {intl.formatMessage({ id: "galleries" })}
               <Counter
                 abbreviateCounter={abbreviateCounter}
-                count={performer.gallery_count ?? 0}
+                count={performer.gallery_count}
+                hideZero
               />
-            </React.Fragment>
+            </>
           }
         >
           <PerformerGalleriesPanel
@@ -261,13 +263,14 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab
           eventKey="images"
           title={
-            <React.Fragment>
+            <>
               {intl.formatMessage({ id: "images" })}
               <Counter
                 abbreviateCounter={abbreviateCounter}
-                count={performer.image_count ?? 0}
+                count={performer.image_count}
+                hideZero
               />
-            </React.Fragment>
+            </>
           }
         >
           <PerformerImagesPanel
@@ -278,13 +281,14 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab
           eventKey="movies"
           title={
-            <React.Fragment>
+            <>
               {intl.formatMessage({ id: "movies" })}
               <Counter
                 abbreviateCounter={abbreviateCounter}
-                count={performer.movie_count ?? 0}
+                count={performer.movie_count}
+                hideZero
               />
-            </React.Fragment>
+            </>
           }
         >
           <PerformerMoviesPanel
@@ -295,13 +299,14 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
         <Tab
           eventKey="appearswith"
           title={
-            <React.Fragment>
+            <>
               {intl.formatMessage({ id: "appears_with" })}
               <Counter
                 abbreviateCounter={abbreviateCounter}
-                count={performer.performer_count ?? 0}
+                count={performer.performer_count}
+                hideZero
               />
-            </React.Fragment>
+            </>
           }
         >
           <PerformerAppearsWithPanel

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -394,9 +394,7 @@ const ScenePage: React.FC<IProps> = ({
           <Nav.Item>
             <Nav.Link eventKey="scene-file-info-panel">
               <FormattedMessage id="file_info" />
-              {scene.files.length > 1 && (
-                <Counter count={scene.files.length ?? 0} />
-              )}
+              <Counter count={scene.files.length} hideZero hideOne />
             </Nav.Link>
           </Nav.Item>
           <Nav.Item>

--- a/ui/v2.5/src/components/Shared/Counter.tsx
+++ b/ui/v2.5/src/components/Shared/Counter.tsx
@@ -6,16 +6,23 @@ import TextUtils from "src/utils/text";
 interface IProps {
   abbreviateCounter?: boolean;
   count: number;
+  hideZero?: boolean;
+  hideOne?: boolean;
 }
 
 export const Counter: React.FC<IProps> = ({
   abbreviateCounter = false,
   count,
+  hideZero = false,
+  hideOne = false,
 }) => {
   const intl = useIntl();
 
+  if (hideZero && count === 0) return null;
+  if (hideOne && count === 1) return null;
+
   if (abbreviateCounter) {
-    const formated = TextUtils.abbreviateCounter(count);
+    const formatted = TextUtils.abbreviateCounter(count);
     return (
       <Badge
         className="left-spacing"
@@ -24,10 +31,10 @@ export const Counter: React.FC<IProps> = ({
         data-value={intl.formatNumber(count)}
       >
         <FormattedNumber
-          value={formated.size}
-          maximumFractionDigits={formated.digits}
+          value={formatted.size}
+          maximumFractionDigits={formatted.digits}
         />
-        {formated.unit}
+        {formatted.unit}
       </Badge>
     );
   } else {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -67,6 +67,19 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const [updateStudio] = useStudioUpdate();
   const [deleteStudio] = useStudioDestroy({ id: studio.id });
 
+  const showAllCounts = (configuration?.ui as IUIConfig)
+    ?.showChildStudioContent;
+  const sceneCount =
+    (showAllCounts ? studio.scene_count_all : studio.scene_count) ?? 0;
+  const galleryCount =
+    (showAllCounts ? studio.gallery_count_all : studio.gallery_count) ?? 0;
+  const imageCount =
+    (showAllCounts ? studio.image_count_all : studio.image_count) ?? 0;
+  const performerCount =
+    (showAllCounts ? studio.performer_count_all : studio.performer_count) ?? 0;
+  const movieCount =
+    (showAllCounts ? studio.movie_count_all : studio.movie_count) ?? 0;
+
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("e", () => toggleEditing());
@@ -257,7 +270,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
                 {intl.formatMessage({ id: "scenes" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
-                  count={studio.scene_count ?? 0}
+                  count={sceneCount}
                 />
               </React.Fragment>
             }
@@ -274,7 +287,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
                 {intl.formatMessage({ id: "galleries" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
-                  count={studio.gallery_count ?? 0}
+                  count={galleryCount}
                 />
               </React.Fragment>
             }
@@ -291,7 +304,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
                 {intl.formatMessage({ id: "images" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
-                  count={studio.image_count ?? 0}
+                  count={imageCount}
                 />
               </React.Fragment>
             }
@@ -308,7 +321,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
                 {intl.formatMessage({ id: "performers" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
-                  count={studio.performer_count ?? 0}
+                  count={performerCount}
                 />
               </React.Fragment>
             }
@@ -325,7 +338,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
                 {intl.formatMessage({ id: "movies" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
-                  count={studio.movie_count ?? 0}
+                  count={movieCount}
                 />
               </React.Fragment>
             }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -266,13 +266,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="scenes"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "scenes" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
                   count={sceneCount}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioScenesPanel
@@ -283,13 +284,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="galleries"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "galleries" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
                   count={galleryCount}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioGalleriesPanel
@@ -300,13 +302,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="images"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "images" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
                   count={imageCount}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioImagesPanel
@@ -317,13 +320,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="performers"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "performers" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
                   count={performerCount}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioPerformersPanel
@@ -334,13 +338,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="movies"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "movies" })}
                 <Counter
                   abbreviateCounter={abbreviateCounter}
                   count={movieCount}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioMoviesPanel
@@ -351,13 +356,14 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
           <Tab
             eventKey="childstudios"
             title={
-              <React.Fragment>
+              <>
                 {intl.formatMessage({ id: "subsidiary_studios" })}
                 <Counter
                   abbreviateCounter={false}
-                  count={studio.child_studios?.length ?? 0}
+                  count={studio.child_studios.length}
+                  hideZero
                 />
-              </React.Fragment>
+              </>
             }
           >
             <StudioChildrenPanel

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -337,13 +337,14 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <Tab
               eventKey="scenes"
               title={
-                <React.Fragment>
+                <>
                   {intl.formatMessage({ id: "scenes" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
                     count={sceneCount}
+                    hideZero
                   />
-                </React.Fragment>
+                </>
               }
             >
               <TagScenesPanel active={activeTabKey == "scenes"} tag={tag} />
@@ -351,13 +352,14 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <Tab
               eventKey="images"
               title={
-                <React.Fragment>
+                <>
                   {intl.formatMessage({ id: "images" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
                     count={imageCount}
+                    hideZero
                   />
-                </React.Fragment>
+                </>
               }
             >
               <TagImagesPanel active={activeTabKey == "images"} tag={tag} />
@@ -365,13 +367,14 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <Tab
               eventKey="galleries"
               title={
-                <React.Fragment>
+                <>
                   {intl.formatMessage({ id: "galleries" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
                     count={galleryCount}
+                    hideZero
                   />
-                </React.Fragment>
+                </>
               }
             >
               <TagGalleriesPanel
@@ -382,13 +385,14 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <Tab
               eventKey="markers"
               title={
-                <React.Fragment>
+                <>
                   {intl.formatMessage({ id: "markers" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
                     count={sceneMarkerCount}
+                    hideZero
                   />
-                </React.Fragment>
+                </>
               }
             >
               <TagMarkersPanel active={activeTabKey == "markers"} tag={tag} />
@@ -396,13 +400,14 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
             <Tab
               eventKey="performers"
               title={
-                <React.Fragment>
+                <>
                   {intl.formatMessage({ id: "performers" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
                     count={performerCount}
+                    hideZero
                   />
-                </React.Fragment>
+                </>
               }
             >
               <TagPerformersPanel

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -72,6 +72,18 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [updateTag] = useTagUpdate();
   const [deleteTag] = useTagDestroy({ id: tag.id });
 
+  const showAllCounts = (configuration?.ui as IUIConfig)?.showChildTagContent;
+  const sceneCount =
+    (showAllCounts ? tag.scene_count_all : tag.scene_count) ?? 0;
+  const imageCount =
+    (showAllCounts ? tag.image_count_all : tag.image_count) ?? 0;
+  const galleryCount =
+    (showAllCounts ? tag.gallery_count_all : tag.gallery_count) ?? 0;
+  const sceneMarkerCount =
+    (showAllCounts ? tag.scene_marker_count_all : tag.scene_marker_count) ?? 0;
+  const performerCount =
+    (showAllCounts ? tag.performer_count_all : tag.performer_count) ?? 0;
+
   const activeTabKey =
     tab === "markers" ||
     tab === "images" ||
@@ -329,7 +341,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                   {intl.formatMessage({ id: "scenes" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
-                    count={tag.scene_count ?? 0}
+                    count={sceneCount}
                   />
                 </React.Fragment>
               }
@@ -343,7 +355,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                   {intl.formatMessage({ id: "images" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
-                    count={tag.image_count ?? 0}
+                    count={imageCount}
                   />
                 </React.Fragment>
               }
@@ -357,7 +369,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                   {intl.formatMessage({ id: "galleries" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
-                    count={tag.gallery_count ?? 0}
+                    count={galleryCount}
                   />
                 </React.Fragment>
               }
@@ -374,7 +386,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                   {intl.formatMessage({ id: "markers" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
-                    count={tag.scene_marker_count ?? 0}
+                    count={sceneMarkerCount}
                   />
                 </React.Fragment>
               }
@@ -388,7 +400,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
                   {intl.formatMessage({ id: "performers" })}
                   <Counter
                     abbreviateCounter={abbreviateCounter}
-                    count={tag.performer_count ?? 0}
+                    count={performerCount}
                   />
                 </React.Fragment>
               }


### PR DESCRIPTION
This is a fix/improvement to the tab badges in the studios and tags pages. The counts displayed on the tab badges will now include subsidiary studios/tags if those options are enabled, meaning that the counts now accurately reflect the number of items which will be displayed by default when you click on the tab.

Potentially closes #3814: this only changes the initial value displayed in the badge, they do not dynamically update. As per my comment there, I don't think dynamically updating the counter is necessary, and getting that to work would likely require larger changes. I also haven't hidden the counter when the tab is selected, but that shouldn't be too hard to make happen if required, although I also don't think that's really needed.

Closes #3492