### PR TITLE
Add folder move detection

### DIFF
--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -154,10 +154,12 @@ type Getter interface {
 	FindByFingerprint(ctx context.Context, fp Fingerprint) ([]File, error)
 	FindByZipFileID(ctx context.Context, zipFileID ID) ([]File, error)
 	FindAllInPaths(ctx context.Context, p []string, limit, offset int) ([]File, error)
+	FindByFileInfo(ctx context.Context, info fs.FileInfo, size int64) ([]File, error)
 }
 
 type Counter interface {
 	CountAllInPaths(ctx context.Context, p []string) (int, error)
+	CountByFolderID(ctx context.Context, folderID FolderID) (int, error)
 }
 
 // Creator provides methods to create Files.

--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -1,0 +1,195 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"github.com/stashapp/stash/pkg/logger"
+)
+
+type folderRenameCandidate struct {
+	folder *Folder
+	found  int
+	files  int
+}
+
+type folderRenameDetector struct {
+	// candidates is a map of folder id to the number of files that match
+	candidates map[FolderID]folderRenameCandidate
+	// rejects is a set of folder ids which were found to still exist
+	rejects map[FolderID]struct{}
+}
+
+func (d *folderRenameDetector) isReject(id FolderID) bool {
+	_, ok := d.rejects[id]
+	return ok
+}
+
+func (d *folderRenameDetector) getCandidate(id FolderID) *folderRenameCandidate {
+	c, ok := d.candidates[id]
+	if !ok {
+		return nil
+	}
+
+	return &c
+}
+
+func (d *folderRenameDetector) setCandidate(c folderRenameCandidate) {
+	d.candidates[c.folder.ID] = c
+}
+
+func (d *folderRenameDetector) reject(id FolderID) {
+	d.rejects[id] = struct{}{}
+}
+
+// bestCandidate returns the folder that is the best candidate for a rename.
+// This is the folder that has the largest number of its original files that
+// are still present in the new location.
+func (d *folderRenameDetector) bestCandidate() *Folder {
+	if len(d.candidates) == 0 {
+		return nil
+	}
+
+	var best *folderRenameCandidate
+
+	for _, c := range d.candidates {
+		// ignore folders that have less than 50% of their original files
+		if c.found < c.files/2 {
+			continue
+		}
+
+		// prefer the folder with the most files if the ratio is the same
+		if best == nil || c.found > best.found {
+			cc := c
+			best = &cc
+		}
+	}
+
+	if best == nil {
+		return nil
+	}
+
+	return best.folder
+}
+
+func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*Folder, error) {
+	// in order for a folder to be considered moved, the existing folder must be
+	// missing, and the majority of the old folder's files must be present, unchanged,
+	// in the new folder.
+
+	detector := folderRenameDetector{
+		candidates: make(map[FolderID]folderRenameCandidate),
+		rejects:    make(map[FolderID]struct{}),
+	}
+	// rejects is a set of folder ids which were found to still exist
+
+	if err := symWalk(file.fs, file.Path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// don't let errors prevent scanning
+			logger.Errorf("error scanning %s: %v", path, err)
+			return nil
+		}
+
+		// ignore root
+		if path == file.Path {
+			return nil
+		}
+
+		// ignore directories
+		if d.IsDir() {
+			return fs.SkipDir
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("reading info for %q: %w", path, err)
+		}
+
+		if !s.acceptEntry(ctx, path, info) {
+			return nil
+		}
+
+		size, err := getFileSize(file.fs, path, info)
+		if err != nil {
+			return fmt.Errorf("getting file size for %q: %w", path, err)
+		}
+
+		// check if the file exists in the database based on basename, size and mod time
+		existing, err := s.Repository.Store.FindByFileInfo(ctx, info, size)
+		if err != nil {
+			return fmt.Errorf("checking for existing file %q: %w", path, err)
+		}
+
+		for _, e := range existing {
+			// ignore files in zip files
+			if e.Base().ZipFileID != nil {
+				continue
+			}
+
+			parentFolderID := e.Base().ParentFolderID
+
+			if detector.isReject(parentFolderID) {
+				// folder was found to still exist, not a candidate
+				continue
+			}
+
+			c := detector.getCandidate(parentFolderID)
+
+			if c == nil {
+				// need to check if the folder exists in the filesystem
+				pf, err := s.Repository.FolderStore.Find(ctx, e.Base().ParentFolderID)
+				if err != nil {
+					return fmt.Errorf("getting parent folder %d: %w", e.Base().ParentFolderID, err)
+				}
+
+				if pf == nil {
+					// shouldn't happen, but just in case
+					continue
+				}
+
+				// parent folder must be missing
+				_, err = file.fs.Lstat(pf.Path)
+				if err == nil {
+					// parent folder exists, not a candidate
+					detector.reject(parentFolderID)
+					continue
+				}
+
+				if !errors.Is(err, fs.ErrNotExist) {
+					return fmt.Errorf("checking for parent folder %q: %w", pf.Path, err)
+				}
+
+				// parent folder is missing, possible candidate
+				// count the total number of files in the existing folder
+				count, err := s.Repository.Store.CountByFolderID(ctx, parentFolderID)
+				if err != nil {
+					return fmt.Errorf("counting files in folder %d: %w", parentFolderID, err)
+				}
+
+				if count == 0 {
+					// no files in the folder, not a candidate
+					detector.reject(parentFolderID)
+					continue
+				}
+
+				c = &folderRenameCandidate{
+					folder: pf,
+					found:  0,
+					files:  count,
+				}
+			}
+
+			// increment the count and set it in the map
+			c.found++
+			detector.setCandidate(*c)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("walking filesystem for folder rename detection: %w", err)
+	}
+
+	return detector.bestCandidate(), nil
+}


### PR DESCRIPTION
Attempts to detect when a folder has been moved during a scan and updates the existing folder entry.

When a new folder is encountered during scan (ie a folder that is not registered in the database), the system will perform move detection with the following algorithm:
- scan each file under the new folder (only - does not recurse to subdirectories). For each file:
  - try to find a file in the database with the same basename, size and mod time. 
  - for each existing file found, check if the parent folder exists in the file system. If it does not, add the missing folder as a candidate. Keep a count of matching files for each missing folder
- a rename will be detected if any folder candidates have >= 50% of their files in the new location. If there are multiple candidates, the candidate with the most matching files will be selected.

A folder must have at least one file in order to be detected for a rename.

To use an example:

Existing file system:
```
/foo
  /bar
    /1.jpg
    /2.jpg
    /baz
      /3.jpg
```

If `/foo/bar/baz` is moved to `/foo/bar/xyz`, then the scan detect `xyz` as a new folder, triggering rename detection. This will find `3.jpg` under `xyz`, and find the matching file in the database under the old location `/foo/bar/baz`. Since all of the files under `baz` match in the new folder, `/foo/bar/baz` will be updated to `/foo/bar/xyz`.

If `/foo` is moved to `/oof`, then `/foo` will _not_ be detected as a rename, since it has no files. A new folder `/oof` will be created. However `/foo/bar` has been moved to `/oof/bar` and it should be detected as a rename since all of its files will match against the old location. Likewise `/foo/bar/baz` will be detected as a rename to `/oof/bar/baz`.

There are many corner cases for this, and I haven't yet exhaustively tested them.

One such corner case is splitting a directory into multiples:
```
/foo/bar
  /1.jpg
  /2.jpg

to

/foo/baz
  /1.jpg
/foo/xyz
  /2.jpg
```

In this scenario, one of the folders will be detected as a move (50% of files match) and the other will be a new folder. Which folder is currently undefined, but perhaps it should use the path as a tie breaker.

If there were three files in the original directory, and all three ended up in different directories, then no folder will be detected as a rename, since no folder will have >=50% matching files.

Resolves #2721.