### PR TITLE
Fix clip log message

### DIFF
--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/file/video"
+	"github.com/stashapp/stash/pkg/logger"
 	_ "golang.org/x/image/webp"
 )
 
@@ -22,15 +23,14 @@ type Decorator struct {
 
 func (d *Decorator) Decorate(ctx context.Context, fs file.FS, f file.File) (file.File, error) {
 	base := f.Base()
-	r, err := fs.Open(base.Path)
-	if err != nil {
-		return f, fmt.Errorf("reading image file %q: %w", base.Path, err)
-	}
-	defer r.Close()
 
-	probe, err := d.FFProbe.NewVideoFile(base.Path)
-	if err != nil {
-		fmt.Printf("Warning: File %q could not be read with ffprobe: %s, assuming ImageFile", base.Path, err)
+	decorateFallback := func() (file.File, error) {
+		r, err := fs.Open(base.Path)
+		if err != nil {
+			return f, fmt.Errorf("reading image file %q: %w", base.Path, err)
+		}
+		defer r.Close()
+
 		c, format, err := image.DecodeConfig(r)
 		if err != nil {
 			return f, fmt.Errorf("decoding image file %q: %w", base.Path, err)
@@ -41,6 +41,19 @@ func (d *Decorator) Decorate(ctx context.Context, fs file.FS, f file.File) (file
 			Width:    c.Width,
 			Height:   c.Height,
 		}, nil
+	}
+
+	// ignore clips in non-OsFS filesystems as ffprobe cannot read them
+	// TODO - copy to temp file if not an OsFS
+	if _, isOs := fs.(*file.OsFS); !isOs {
+		logger.Debugf("assuming ImageFile for non-OsFS file %q", base.Path)
+		return decorateFallback()
+	}
+
+	probe, err := d.FFProbe.NewVideoFile(base.Path)
+	if err != nil {
+		logger.Warnf("File %q could not be read with ffprobe: %s, assuming ImageFile", base.Path, err)
+		return decorateFallback()
 	}
 
 	isClip := true


### PR DESCRIPTION
This is a fix for an issue with #3583 that came up in Discord - when scanning new images in zip files an error message is printed to the console for every file. The image decorator will now always treat files from non-OsFS filesystems as images and not clips, since ffprobe cannot read from them at the moment and will thus always fail anyway.