### PR TITLE
Prevent fullscreen break when loading scene

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -543,6 +543,17 @@ const SceneLoader: React.FC = () => {
   const { configuration } = useContext(ConfigurationContext);
   const { data, loading, error } = useFindScene(id ?? "");
 
+  const [scene, setScene] = useState<GQL.SceneDataFragment | undefined>(
+    data?.findScene ?? undefined
+  );
+
+  // only update scene when loading is done
+  useEffect(() => {
+    if (!loading) {
+      setScene(data?.findScene ?? undefined);
+    }
+  }, [data, loading]);
+
   const queryParams = useMemo(
     () => new URLSearchParams(location.search),
     [location.search]
@@ -754,32 +765,34 @@ const SceneLoader: React.FC = () => {
     }
   }
 
-  if (loading) return <LoadingIndicator />;
+  if (!scene && loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;
 
-  const scene = data?.findScene;
-  if (!scene) return <ErrorMessage error={`No scene found with id ${id}.`} />;
+  if (!loading && !scene)
+    return <ErrorMessage error={`No scene found with id ${id}.`} />;
 
   return (
     <div className="row">
-      <ScenePage
-        scene={scene}
-        setTimestamp={setTimestamp}
-        queueScenes={queueScenes ?? []}
-        queueStart={queueStart}
-        onDelete={onDelete}
-        onQueueNext={onQueueNext}
-        onQueuePrevious={onQueuePrevious}
-        onQueueRandom={onQueueRandom}
-        continuePlaylist={continuePlaylist}
-        loadScene={loadScene}
-        queueHasMoreScenes={queueHasMoreScenes}
-        onQueueLessScenes={onQueueLessScenes}
-        onQueueMoreScenes={onQueueMoreScenes}
-        collapsed={collapsed}
-        setCollapsed={setCollapsed}
-        setContinuePlaylist={setContinuePlaylist}
-      />
+      {scene && (
+        <ScenePage
+          scene={scene}
+          setTimestamp={setTimestamp}
+          queueScenes={queueScenes ?? []}
+          queueStart={queueStart}
+          onDelete={onDelete}
+          onQueueNext={onQueueNext}
+          onQueuePrevious={onQueuePrevious}
+          onQueueRandom={onQueueRandom}
+          continuePlaylist={continuePlaylist}
+          loadScene={loadScene}
+          queueHasMoreScenes={queueHasMoreScenes}
+          onQueueLessScenes={onQueueLessScenes}
+          onQueueMoreScenes={onQueueMoreScenes}
+          collapsed={collapsed}
+          setCollapsed={setCollapsed}
+          setContinuePlaylist={setContinuePlaylist}
+        />
+      )}
       <div className={`scene-player-container ${collapsed ? "expanded" : ""}`}>
         <ScenePlayer
           key="ScenePlayer"


### PR DESCRIPTION
Fixes #3615 

Basically maintains the existing value of `scene` while loading the next scene. This means that the loading spinner won't be displayed while loading a new scene, but the video player will be maintained during the loading period.