### PR TITLE
fix: return newly created filter

### DIFF
--- a/internal/api/resolver_mutation_saved_filter.go
+++ b/internal/api/resolver_mutation_saved_filter.go
@@ -42,6 +42,7 @@ func (r *mutationResolver) SaveFilter(ctx context.Context, input SaveFilterInput
 	}); err != nil {
 		return nil, err
 	}
+	ret = &newFilter
 	return ret, err
 }
 


### PR DESCRIPTION
Reported [on Discord](https://discord.com/channels/559159668438728723/559159910550732809/1119544758973497354), this bug caused the GraphQL queries for `saveFilter` to return an error because the default value of `ret` was `nil`.

Filters were still being saved just fine, but the frontend displayed an error message.