### PR TITLE
Handle missing studio ids in getHierarchicalValues

### DIFF
--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2116,6 +2116,8 @@ func TestSceneQuery(t *testing.T) {
 	var (
 		endpoint = sceneStashID(sceneIdxWithGallery).Endpoint
 		stashID  = sceneStashID(sceneIdxWithGallery).StashID
+
+		depth = -1
 	)
 
 	tests := []struct {
@@ -2216,6 +2218,20 @@ func TestSceneQuery(t *testing.T) {
 				},
 			},
 			[]int{sceneIdxWithGallery},
+			nil,
+			false,
+		},
+		{
+			"with studio id 0 including child studios",
+			nil,
+			&models.SceneFilterType{
+				Studios: &models.HierarchicalMultiCriterionInput{
+					Value:    []string{"0"},
+					Modifier: models.CriterionModifierIncludes,
+					Depth:    &depth,
+				},
+			},
+			nil,
 			nil,
 			false,
 		},


### PR DESCRIPTION
Fixes #3835 

Handles the scenario where an id doesn't exist in the applicable table by just returning the set of values, similar to if the depth is set to 0.