### PR TITLE
fix: onQueueMoreScenes was adding new scenes at the start of the queue

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -666,7 +666,7 @@ const SceneLoader: React.FC = () => {
     const { scenes } = query.data.findScenes;
 
     // append scenes to scene list
-    const newScenes = (scenes as QueuedScene[]).concat(queueScenes);
+    const newScenes = queueScenes.concat(scenes as QueuedScene[]);
     setQueueScenes(newScenes);
     // don't change queue start
   }


### PR DESCRIPTION
Changing the order new scenes merge with the current queue for them to be at the bottom.

Should fix: #3850 