### PR TITLE
Make: add PIE build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build-flags: pre-build
 ifndef GO_BUILD_TAGS
 	$(eval GO_BUILD_TAGS := $(GO_BUILD_TAGS_DEFAULT))
 endif
-	$(eval BUILD_FLAGS := -mod=vendor -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)")
+	$(eval BUILD_FLAGS := -mod=vendor -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)" -buildmode=pie)
 
 # NOTE: the build target still includes netgo because we cannot detect
 # Windows easily from the Makefile.


### PR DESCRIPTION
PIE: position-independent executable
https://en.wikipedia.org/wiki/Position-independent_code

This is a security hardening measure and it's basically free. I'm not aware of a reason to not do it. And pretty much every program you see in a modern unix-like operating system is built as a PIE.

In Linux, the simplest way to tell if a program is built as a PIE is with the `file` program. It should say `ELF 64-bit LSB pie executable`.
```
$ file /usr/bin/stash 
stash: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=1457dc569036901a9a2aebb1297a0d7164921b97, for GNU/Linux 4.4.0, stripped
```