### PR TITLE
Add keyboard shortcut to toggle video looping in scene player

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -82,7 +82,7 @@ function handleHotkeys(player: VideoJsPlayer, event: videojs.KeyboardEvent) {
   }
 
   // toggle player looping with shift+l
-  if (event.shiftKey && event.which === 76){
+  if (event.shiftKey && event.which === 76) {
     player.loop(!player.loop());
     return;
   }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -81,6 +81,12 @@ function handleHotkeys(player: VideoJsPlayer, event: videojs.KeyboardEvent) {
       break;
   }
 
+  // toggle player looping with shift+l
+  if (event.shiftKey && event.which === 76){
+    player.loop(!player.loop());
+    return;
+  }
+
   if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
     return;
   }

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -73,6 +73,7 @@
 | `{1-9}` | Seek to 10-90% duration |
 | `[` | Scrub backwards 10% duration |
 | `]` | Scrub forwards 10% duration |
+| `Shift + l` | Toggle player looping |
 
 ### Scene Markers tab shortcuts
 


### PR DESCRIPTION
Adds a keyboard shortcut to the scene player for toggling video looping.

Pressing `shift+l` will toggle player looping when the player is focused. 

The key combo was chosen to be consistent with mpv, as suggested in issue #3264 (issue otherwise unrelated). However, I'm open to other suggestions. 