### PR TITLE
Add missing scene player shortcuts to Help -> Keyboard Shortcuts

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -64,6 +64,8 @@
 | `p n` | Play next scene in queue |
 | `p p` | Play previous scene in queue |
 | `p r` | Play random scene in queue |
+| `Space` | Play/pause player |
+| `Enter` | Play/pause player |
 | `←` | Seek backwards by 10 seconds |
 | `→` | Seek forwards by 10 seconds |
 | `Shift + ←` | Seek backwards by 5 seconds |
@@ -73,6 +75,9 @@
 | `{1-9}` | Seek to 10-90% duration |
 | `[` | Scrub backwards 10% duration |
 | `]` | Scrub forwards 10% duration |
+| `↑` | Increase volume 10% |
+| `↓` | Decrease volume 10% |
+| `m` | Toggle mute |
 
 ### Scene Markers tab shortcuts
 


### PR DESCRIPTION
Adds a few missing shortcuts to Help -> Keyboard Shortcuts

![image](https://github.com/stashapp/stash/assets/138962341/116088c4-1e9b-47a7-ae27-7125a9fab5f7)
