### PR TITLE
Disable videojs-mobile-ui on Safari

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -504,7 +504,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       },
     };
     if (!isSafari) {
-        player.mobileUi(mobileUiOptions);
+      player.mobileUi(mobileUiOptions);
     }
 
     function isDirect(src: URL) {

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -490,6 +490,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     interactiveClient.pause();
     interactiveReady.current = false;
 
+    const isSafari = UAParser().browser.name?.includes("Safari");
     const isLandscape = file.height && file.width && file.width > file.height;
     const mobileUiOptions = {
       fullscreen: {
@@ -502,7 +503,9 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
         disabled: true,
       },
     };
-    player.mobileUi(mobileUiOptions);
+    if (!isSafari) {
+        player.mobileUi(mobileUiOptions);
+    }
 
     function isDirect(src: URL) {
       return (
@@ -514,7 +517,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
 
     const { duration } = file;
     const sourceSelector = player.sourceSelector();
-    const isSafari = UAParser().browser.name?.includes("Safari");
     sourceSelector.setSources(
       scene.sceneStreams
         .filter((stream) => {


### PR DESCRIPTION
What the patch does is simply disable mobileui on Safari.

Reference bug: https://github.com/mister-ben/videojs-mobile-ui/issues/100
Fixes: #3728
