### PR TITLE
Always include gallery card in scene details

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -200,13 +200,16 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
                 <FormattedMessage id="details" />
               </Nav.Link>
             </Nav.Item>
-            {gallery.scenes.length > 0 && (
+            {gallery.scenes.length >= 1 ? (
               <Nav.Item>
                 <Nav.Link eventKey="gallery-scenes-panel">
-                  <FormattedMessage id="scenes" />
+                  <FormattedMessage
+                    id="countables.scenes"
+                    values={{ count: gallery.scenes.length }}
+                  />
                 </Nav.Link>
               </Nav.Item>
-            )}
+            ) : undefined}
             {path ? (
               <Nav.Item>
                 <Nav.Link eventKey="gallery-file-info-panel">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -465,6 +465,7 @@ const ScenePage: React.FC<IProps> = ({
         </Tab.Pane>
         {scene.galleries.length === 1 && (
           <Tab.Pane eventKey="scene-galleries-panel">
+            <SceneGalleriesPanel galleries={scene.galleries} />
             <GalleryViewer galleryId={scene.galleries[0].id} />
           </Tab.Pane>
         )}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -463,15 +463,12 @@ const ScenePage: React.FC<IProps> = ({
         <Tab.Pane eventKey="scene-movie-panel">
           <SceneMoviePanel scene={scene} />
         </Tab.Pane>
-        {scene.galleries.length === 1 && (
+        {scene.galleries.length >= 1 && (
           <Tab.Pane eventKey="scene-galleries-panel">
             <SceneGalleriesPanel galleries={scene.galleries} />
-            <GalleryViewer galleryId={scene.galleries[0].id} />
-          </Tab.Pane>
-        )}
-        {scene.galleries.length > 1 && (
-          <Tab.Pane eventKey="scene-galleries-panel">
-            <SceneGalleriesPanel galleries={scene.galleries} />
+            {scene.galleries.length === 1 && (
+              <GalleryViewer galleryId={scene.galleries[0].id} />
+            )}
           </Tab.Pane>
         )}
         <Tab.Pane eventKey="scene-video-filter-panel">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
@@ -13,7 +13,7 @@ export const SceneGalleriesPanel: React.FC<ISceneGalleriesPanelProps> = ({
     <GalleryCard key={gallery.id} gallery={gallery} selecting={false} />
   ));
 
-  return <div className="row justify-content-center">{cards}</div>;
+  return <div className="container scene-galleries">{cards}</div>;
 };
 
 export default SceneGalleriesPanel;


### PR DESCRIPTION
Currently when there is one gallery attached to a scene the gallery's photos are shown in the scene's gallery tab. This is a cool feature but it leaves the user without a link to the gallery from the scene (if there is one, I missed it!). I frequently find myself making an edit on a scene and wanting to replicate it to the attached gallery so end up backing out to find the scene card or opening a new tab and searching the galleries.

This little edit inserts the gallery card above the gallery photos when there is a single gallery so it can used as a navigation element.

While I was staring at the panels I noticed the Scenes panel used _Gallery/ies_ singular and plural and the Gallery panel always used _Scenes_. This brings them in line with each other so the Gallery panel uses _Scene_ when there is a single scene.
