### PR TITLE
Include old URL in script input

### DIFF
--- a/pkg/scraper/cache.go
+++ b/pkg/scraper/cache.go
@@ -262,6 +262,9 @@ func (c Cache) ScrapeName(ctx context.Context, id, query string, ty ScrapeConten
 
 // ScrapeFragment uses the given fragment input to scrape
 func (c Cache) ScrapeFragment(ctx context.Context, id string, input Input) (ScrapedContent, error) {
+	// set the deprecated URL field if it's not set
+	input.populateURL()
+
 	s := c.findScraper(id)
 	if s == nil {
 		return nil, fmt.Errorf("%w: id %s", ErrNotFound, id)

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -157,6 +157,14 @@ type Input struct {
 	Gallery   *ScrapedGalleryInput
 }
 
+// populateURL populates the URL field of the input based on the
+// URLs field of the input. Does nothing if the URL field is already set.
+func (i *Input) populateURL() {
+	if i.Scene != nil && i.Scene.URL == nil && len(i.Scene.URLs) > 0 {
+		i.Scene.URL = &i.Scene.URLs[0]
+	}
+}
+
 // simple type definitions that can help customize
 // actions per query
 type QueryType int

--- a/pkg/scraper/stash.go
+++ b/pkg/scraper/stash.go
@@ -324,12 +324,20 @@ func sceneToUpdateInput(scene *models.Scene) models.SceneUpdateInput {
 	// fallback to file basename if title is empty
 	title := scene.GetTitle()
 
+	var url *string
+	urls := scene.URLs.List()
+	if len(urls) > 0 {
+		url = &urls[0]
+	}
+
 	return models.SceneUpdateInput{
 		ID:      strconv.Itoa(scene.ID),
 		Title:   &title,
 		Details: &scene.Details,
-		Urls:    scene.URLs.List(),
-		Date:    dateToStringPtr(scene.Date),
+		// include deprecated URL for now
+		URL:  url,
+		Urls: urls,
+		Date: dateToStringPtr(scene.Date),
 	}
 }
 


### PR DESCRIPTION
Untested - should hopefully fix issue identified where certain scene scrapers are expecting the deprecated `URL` field. Scrapers should eventually be updated to support the new `URLs` field instead so that the old field can be removed.