### PR TITLE
Return scrape results if only relationships are returned

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
@@ -281,7 +281,10 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
   if (
     [title, url, date, studio, performers, tags, details].every(
       (r) => !r.scraped
-    )
+    ) &&
+    !newStudio &&
+    newPerformers.length === 0 &&
+    newTags.length === 0
   ) {
     props.onClose();
     return <></>;

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
@@ -162,7 +162,7 @@ export const MovieScrapeDialog: React.FC<IMovieScrapeDialogProps> = (
     backImage,
   ];
   // don't show the dialog if nothing was scraped
-  if (allFields.every((r) => !r.scraped)) {
+  if (allFields.every((r) => !r.scraped) && !newStudio) {
     props.onClose();
     return <></>;
   }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -443,7 +443,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
     remoteSiteID,
   ];
   // don't show the dialog if nothing was scraped
-  if (allFields.every((r) => !r.scraped)) {
+  if (allFields.every((r) => !r.scraped) && newTags.length === 0) {
     props.onClose();
     return <></>;
   }

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
@@ -426,7 +426,11 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = ({
       details,
       image,
       stashID,
-    ].every((r) => !r.scraped)
+    ].every((r) => !r.scraped) &&
+    newTags.length === 0 &&
+    newPerformers.length === 0 &&
+    newMovies.length === 0 &&
+    !newStudio
   ) {
     onClose();
     return <></>;


### PR DESCRIPTION
Fixes #3953

Fixes issue where if a scrape result had no non-relationship fields set, then no results would be returned.

Also fixes issue where the UI would not display the scrape dialog if only new objects (tags, performers, studio) were returned.