### PR TITLE
Fix graphql caching issues

### DIFF
--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -1975,16 +1975,7 @@ export const queryLogs = () =>
     fetchPolicy: "no-cache",
   });
 
-export const useSystemStatus = () =>
-  GQL.useSystemStatusQuery({
-    fetchPolicy: "no-cache",
-  });
-
-export const querySystemStatus = () =>
-  client.query<GQL.SystemStatusQuery>({
-    query: GQL.SystemStatusDocument,
-    fetchPolicy: "no-cache",
-  });
+export const useSystemStatus = () => GQL.useSystemStatusQuery();
 
 export const useJobsSubscribe = () => GQL.useJobsSubscribeSubscription();
 

--- a/ui/v2.5/src/core/createClient.ts
+++ b/ui/v2.5/src/core/createClient.ts
@@ -27,10 +27,12 @@ const readReference = (typename: string): FieldReadFunction => {
         });
 };
 
-// A read function that returns null if no valid reference is available.
+// A read function that returns null if a cached reference is invalid.
 // Means that a dangling reference implies the object was deleted.
-const readDanglingNull: FieldReadFunction = (existing, { canRead }) =>
-  canRead(existing) ? existing : null;
+const readDanglingNull: FieldReadFunction = (existing, { canRead }) => {
+  if (existing === undefined) return undefined;
+  return canRead(existing) ? existing : null;
+};
 
 const typePolicies: TypePolicies = {
   Query: {
@@ -60,7 +62,7 @@ const typePolicies: TypePolicies = {
         read: readReference("SavedFilter"),
       },
       findDefaultFilter: {
-        read: readReference("SavedFilter"),
+        read: readDanglingNull,
       },
     },
   },


### PR DESCRIPTION
Two simple fixes to issues after #3912:
- Fix the infinite loop after migrate issue from #3970, caused by the `systemStatus` query not being cached, and therefore not being refetched when the cache for that query is evicted after the migration mutation returns. For this reason we should probably avoid using "no-cache" in hooks, preferring "network-only" instead, unless the response specifically should not be stored in the cache (eg a large response, like the logs query)
- A "proper" fix for the default filter issue fixed in d48dbeb864612de4c636efb84842a368fb6b54ee. Caused by `readDanglingNull` returning `null` instead of `undefined` if the field is not in the cache. 

Fixes #3970