### PR TITLE
Fix parent/child links on tag pages

### DIFF
--- a/ui/v2.5/src/components/Shared/TagLink.tsx
+++ b/ui/v2.5/src/components/Shared/TagLink.tsx
@@ -34,7 +34,7 @@ type SceneMarkerFragment = Pick<GQL.SceneMarker, "id" | "title" | "seconds"> & {
 
 interface IProps {
   tag?: Partial<TagDataFragment>;
-  tagType?: "performer" | "scene" | "gallery" | "image";
+  tagType?: "performer" | "scene" | "gallery" | "image" | "details";
   performer?: Partial<PerformerDataFragment>;
   marker?: SceneMarkerFragment;
   movie?: Partial<MovieDataFragment>;
@@ -49,6 +49,7 @@ export const TagLink: React.FC<IProps> = (props: IProps) => {
   let link: string = "#";
   let title: string = "";
   if (props.tag) {
+    id = props.tag.id || "";
     switch (props.tagType) {
       case "scene":
       case undefined:
@@ -63,8 +64,10 @@ export const TagLink: React.FC<IProps> = (props: IProps) => {
       case "image":
         link = NavUtils.makeTagImagesUrl(props.tag);
         break;
+      case "details":
+        link = NavUtils.makeTagUrl(id);
+        break;
     }
-    id = props.tag.id || "";
     title = props.tag.name || "";
   } else if (props.performer) {
     link = NavUtils.makePerformerScenesUrl(props.performer);

--- a/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
@@ -17,7 +17,12 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
     return (
       <>
         {tag.parents.map((p) => (
-          <TagLink key={p.id} tag={p} hoverPlacement="bottom" />
+          <TagLink
+            key={p.id}
+            tag={p}
+            hoverPlacement="bottom"
+            tagType="details"
+          />
         ))}
       </>
     );
@@ -31,7 +36,12 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
     return (
       <>
         {tag.children.map((c) => (
-          <TagLink key={c.id} tag={c} hoverPlacement="bottom" />
+          <TagLink
+            key={c.id}
+            tag={c}
+            hoverPlacement="bottom"
+            tagType="details"
+          />
         ))}
       </>
     );

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -213,6 +213,10 @@ const makeMovieScenesUrl = (movie: Partial<GQL.MovieDataFragment>) => {
   return `/scenes?${filter.makeQueryParameters()}`;
 };
 
+const makeTagUrl = (id: string) => {
+  return `/tags/${id}`;
+};
+
 const makeParentTagsUrl = (tag: Partial<GQL.TagDataFragment>) => {
   if (!tag.id) return "#";
   const filter = new ListFilterModel(GQL.FilterMode.Tags, undefined);
@@ -373,6 +377,7 @@ const NavUtils = {
   makeStudioGalleriesUrl,
   makeStudioMoviesUrl,
   makeStudioPerformersUrl,
+  makeTagUrl,
   makeParentTagsUrl,
   makeChildTagsUrl,
   makeTagSceneMarkersUrl,


### PR DESCRIPTION
Fixes bug introduced by #3968 where parent/child tag links would go to the scenes page instead of the tag page.