### PR TITLE
Re-add to hide video player overflow

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -25,6 +25,7 @@ $sceneTabWidth: 450px;
 
 .video-wrapper {
   height: 56.25vw;
+  overflow: hidden;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Fixes #3977 

Fixes issue introduced by #3882. Re-adds the `overflow: hidden` directive on the video wrapper.

@NodudeWasTaken can you confirm that this does not cause a regression on iPad viewing?