### PR TITLE
Details redesign bug fixes

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -35,6 +35,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -64,9 +65,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const [backImage, setBackImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const appleRendering =
-    /(ipad)/i.test(navigator.userAgent) ||
-    /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering = isPlatfornUniquelyRenderByApple();
 
   const defaultImage =
     movie.front_image_path && movie.front_image_path.includes("default=true")

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -35,7 +35,6 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
-import UAParser from "ua-parser-js";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -65,7 +64,9 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const [backImage, setBackImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering =
+    /(ipad)/i.test(navigator.userAgent) ||
+    /(macintosh.*safari)/i.test(navigator.userAgent);
 
   const defaultImage =
     movie.front_image_path && movie.front_image_path.includes("default=true")

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -35,7 +35,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
-import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
+import { isPlatformUniquelyRenderedByApple } from "src/utils/apple";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -65,7 +65,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const [backImage, setBackImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const appleRendering = isPlatfornUniquelyRenderByApple();
+  const appleRendering = isPlatformUniquelyRenderedByApple();
 
   const defaultImage =
     movie.front_image_path && movie.front_image_path.includes("default=true")
@@ -424,7 +424,9 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
           <div className="detail-header-image">
             <div className="logo w-100">
               {encodingImage ? (
-                <LoadingIndicator message="Encoding image..." />
+                <LoadingIndicator
+                  message={`${intl.formatMessage({ id: "encoding_image" })}...`}
+                />
               ) : (
                 <div className="movie-images">
                   {renderFrontImage()}

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -35,6 +35,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import UAParser from "ua-parser-js";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -63,6 +64,8 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const [frontImage, setFrontImage] = useState<string | null>();
   const [backImage, setBackImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
+
+  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
 
   const defaultImage =
     movie.front_image_path && movie.front_image_path.includes("default=true")
@@ -414,16 +417,14 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
       <div
         className={`detail-header ${isEditing ? "edit" : ""}  ${
           collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
+        } ${appleRendering ? "apple" : ""}`}
       >
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">
           <div className="detail-header-image">
             <div className="logo w-100">
               {encodingImage ? (
-                <LoadingIndicator
-                  message={`${intl.formatMessage({ id: "encoding_image" })}...`}
-                />
+                <LoadingIndicator message="Encoding image..." />
               ) : (
                 <div className="movie-images">
                   {renderFrontImage()}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -72,7 +72,9 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering =
+    /(ipad)/i.test(navigator.userAgent) ||
+    /(macintosh.*safari)/i.test(navigator.userAgent);
 
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -72,6 +72,8 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
+  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;
     if (isEditing) {
@@ -546,7 +548,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
       <div
         className={`detail-header ${isEditing ? "edit" : ""}  ${
           collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
+        } ${appleRendering ? "apple" : ""}`}
       >
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -43,6 +43,7 @@ import { faInstagram, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { IUIConfig } from "src/core/config";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import ImageUtils from "src/utils/image";
+import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -72,9 +73,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering =
-    /(ipad)/i.test(navigator.userAgent) ||
-    /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering = isPlatfornUniquelyRenderByApple();
 
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -43,7 +43,7 @@ import { faInstagram, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { IUIConfig } from "src/core/config";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import ImageUtils from "src/utils/image";
-import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
+import { isPlatformUniquelyRenderedByApple } from "src/utils/apple";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -73,7 +73,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = isPlatfornUniquelyRenderByApple();
+  const appleRendering = isPlatformUniquelyRenderedByApple();
 
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -186,6 +186,11 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
             value={performer?.piercings}
             fullWidth={fullWidth}
           />
+          <DetailItem
+            id="career_length"
+            value={performer?.career_length}
+            fullWidth={fullWidth}
+          />
           <DetailItem id="details" value={details} fullWidth={fullWidth} />
           <DetailItem
             id="tags"

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -1,16 +1,11 @@
 @include media-breakpoint-up(sm) {
   #settings-menu-container {
-    margin-top: 0.5rem;
     position: fixed;
   }
 }
 
-#settings-container {
-  margin-top: 0.5rem;
-
-  .tab-content {
-    max-width: 780px;
-  }
+#settings-container .tab-content {
+  max-width: 780px;
 }
 
 .setting-section {

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -1,11 +1,16 @@
 @include media-breakpoint-up(sm) {
   #settings-menu-container {
+    margin-top: 0.5rem;
     position: fixed;
   }
 }
 
-#settings-container .tab-content {
-  max-width: 780px;
+#settings-container {
+  margin-top: 0.5rem;
+
+  .tab-content {
+    max-width: 780px;
+  }
 }
 
 .setting-section {

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -34,8 +34,9 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
     if (props.selecting) {
       props.onSelectedChanged(!props.selected, shiftKey);
       event.preventDefault();
+    } else {
+      window.scrollTo(0, 0);
     }
-    window.scrollTo(0, 0);
   }
 
   function handleDrag(event: React.DragEvent<HTMLElement>) {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -68,6 +68,8 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
+  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
@@ -504,7 +506,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
       <div
         className={`detail-header ${isEditing ? "edit" : ""}  ${
           collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
+        }  ${appleRendering ? "apple" : ""}`}
       >
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -42,6 +42,7 @@ import TextUtils from "src/utils/text";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -68,9 +69,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering =
-    /(ipad)/i.test(navigator.userAgent) ||
-    /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering = isPlatfornUniquelyRenderByApple();
 
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -42,7 +42,7 @@ import TextUtils from "src/utils/text";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
-import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
+import { isPlatformUniquelyRenderedByApple } from "src/utils/apple";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -69,7 +69,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = isPlatfornUniquelyRenderByApple();
+  const appleRendering = isPlatformUniquelyRenderedByApple();
 
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -68,7 +68,9 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering =
+    /(ipad)/i.test(navigator.userAgent) ||
+    /(macintosh.*safari)/i.test(navigator.userAgent);
 
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -38,6 +38,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
+import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -63,9 +64,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering =
-    /(ipad)/i.test(navigator.userAgent) ||
-    /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering = isPlatfornUniquelyRenderByApple();
 
   const { tab = "scenes" } = useParams<ITabParams>();
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -38,7 +38,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
-import { isPlatfornUniquelyRenderByApple } from "src/utils/apple";
+import { isPlatformUniquelyRenderedByApple } from "src/utils/apple";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -64,7 +64,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = isPlatfornUniquelyRenderByApple();
+  const appleRendering = isPlatformUniquelyRenderedByApple();
 
   const { tab = "scenes" } = useParams<ITabParams>();
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -63,6 +63,8 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
+  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+
   const { tab = "scenes" } = useParams<ITabParams>();
 
   // Editing state
@@ -496,7 +498,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
       <div
         className={`detail-header ${isEditing ? "edit" : ""}  ${
           collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
+        } ${appleRendering ? "apple" : ""}`}
       >
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -63,7 +63,9 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
 
-  const appleRendering = /(ipad)/i.test(navigator.userAgent) || /(macintosh.*safari)/i.test(navigator.userAgent);
+  const appleRendering =
+    /(ipad)/i.test(navigator.userAgent) ||
+    /(macintosh.*safari)/i.test(navigator.userAgent);
 
   const { tab = "scenes" } = useParams<ITabParams>();
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -43,13 +43,20 @@ body {
   -webkit-font-smoothing: antialiased;
   margin: 0;
   overflow-x: hidden;
-  padding: 3.5rem 0 0 0;
+  padding: 4rem 0 0 0;
 
   @include media-breakpoint-down(xs) {
     @media (orientation: portrait) {
       padding: 1rem 0 5rem;
     }
   }
+}
+
+#movie-page,
+#performer-page,
+#studio-page,
+#tag-page {
+  margin-top: -0.5rem;
 }
 
 code,

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -263,7 +263,7 @@ dd {
     }
 
     .detail-item-value.age {
-      width: 1.13rem;
+      width: fit-content;
     }
   }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -351,6 +351,8 @@ dd {
   }
 }
 
+/* the .apple class denotes areas where rendering on some apple platforms has been inconsistent with other platforms
+   these rules aim to address those inconsistences */
 .detail-header.apple .detail-container {
   display: flex;
 }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -188,6 +188,7 @@ dd {
 
 .detail-header.edit {
   background-color: unset;
+  overflow: auto;
 
   form {
     padding-top: 0.5rem;
@@ -241,7 +242,7 @@ dd {
   }
 
   .detail-item {
-    flex-direction: unset;
+    display: table;
     padding-right: 0;
     width: 100%;
 
@@ -251,7 +252,11 @@ dd {
     }
 
     .detail-item-value {
-      padding-left: 0.5rem;
+      margin-left: 1.5rem;
+    }
+
+    .detail-item-value.age {
+      width: 1.13rem;
     }
   }
 
@@ -336,7 +341,6 @@ dd {
 }
 
 .detail-item {
-  align-items: left;
   display: inline-flex;
   flex-direction: column;
   padding-bottom: 0.5rem;
@@ -345,6 +349,15 @@ dd {
   @media (max-width: 576px) {
     padding-right: 2rem;
   }
+}
+
+.detail-header.apple .detail-container {
+  display: flex;
+}
+
+.detail-header.full-width.apple .detail-header-image,
+.detail-header.edit.apple .detail-header-image {
+  display: unset;
 }
 
 .detail-item-title {

--- a/ui/v2.5/src/utils/apple.ts
+++ b/ui/v2.5/src/utils/apple.ts
@@ -1,0 +1,6 @@
+export function isPlatfornUniquelyRenderByApple() {
+  return (
+    /(ipad)/i.test(navigator.userAgent) ||
+    /(macintosh.*safari)/i.test(navigator.userAgent)
+  );
+}

--- a/ui/v2.5/src/utils/apple.ts
+++ b/ui/v2.5/src/utils/apple.ts
@@ -1,4 +1,4 @@
-export function isPlatfornUniquelyRenderByApple() {
+export function isPlatformUniquelyRenderedByApple() {
   return (
     /(ipad)/i.test(navigator.userAgent) ||
     /(macintosh.*safari)/i.test(navigator.userAgent)


### PR DESCRIPTION
- Fixes broken details header on iPads or Macs browsing via Safari
- Fixes overflow issue when selecting tags on the edit page
- Fixes scroll to the top issue when selecting items (Fixes #3972)
- Fixes visible spacing before the age field when full-width details are displayed
- Improved expanded full-width details 
- Fixes career length missing in performer details
- Fixes measurements field cutting off Mac due to font discrepancy