### PR TITLE
Details redesign tweaks and refactoring

### DIFF
--- a/graphql/documents/data/gallery-slim.graphql
+++ b/graphql/documents/data/gallery-slim.graphql
@@ -14,10 +14,10 @@ fragment SlimGalleryData on Gallery {
   }
   image_count
   cover {
+    id
     files {
       ...ImageFileData
     }
-
     paths {
       thumbnail
     }

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -28,7 +28,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { MainNavbar } from "./components/MainNavbar";
 import { PageNotFound } from "./components/PageNotFound";
 import * as GQL from "./core/generated-graphql";
-import { TITLE_SUFFIX } from "./components/Shared/constants";
+import { makeTitleProps } from "./hooks/title";
 import { LoadingIndicator } from "./components/Shared/LoadingIndicator";
 
 import { ConfigurationProvider } from "./hooks/Config";
@@ -254,6 +254,8 @@ export const App: React.FC = () => {
     );
   }
 
+  const titleProps = makeTitleProps();
+
   return (
     <ErrorBoundary>
       {messages ? (
@@ -272,10 +274,7 @@ export const App: React.FC = () => {
                 <LightboxProvider>
                   <ManualProvider>
                     <InteractiveProvider>
-                      <Helmet
-                        titleTemplate={`%s ${TITLE_SUFFIX}`}
-                        defaultTitle="Stash"
-                      />
+                      <Helmet {...titleProps} />
                       {maybeRenderNavbar()}
                       <div
                         className={`main container-fluid ${

--- a/ui/v2.5/src/components/FrontPage/FrontPage.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPage.tsx
@@ -12,6 +12,7 @@ import {
   generateDefaultFrontPageContent,
   IUIConfig,
 } from "src/core/config";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const FrontPage: React.FC = () => {
   const intl = useIntl();
@@ -23,6 +24,8 @@ const FrontPage: React.FC = () => {
   const [saveUI] = useConfigureUI();
 
   const { configuration, loading } = React.useContext(ConfigurationContext);
+
+  useScrollToTopOnMount();
 
   async function onUpdateConfig(content?: FrontPageContent[]) {
     setIsEditing(false);

--- a/ui/v2.5/src/components/Galleries/Galleries.tsx
+++ b/ui/v2.5/src/components/Galleries/Galleries.tsx
@@ -1,25 +1,17 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "../Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import Gallery from "./GalleryDetails/Gallery";
 import GalleryCreate from "./GalleryDetails/GalleryCreate";
 import { GalleryList } from "./GalleryList";
 
 const Galleries: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "galleries",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "galleries" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route
           exact

--- a/ui/v2.5/src/components/Galleries/Galleries.tsx
+++ b/ui/v2.5/src/components/Galleries/Galleries.tsx
@@ -6,20 +6,21 @@ import { PersistanceLevel } from "../List/ItemList";
 import Gallery from "./GalleryDetails/Gallery";
 import GalleryCreate from "./GalleryDetails/GalleryCreate";
 import { GalleryList } from "./GalleryList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Galleries: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <GalleryList persistState={PersistanceLevel.ALL} />;
+};
+
+const GalleryRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "galleries" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route
-          exact
-          path="/galleries"
-          render={(props) => (
-            <GalleryList {...props} persistState={PersistanceLevel.ALL} />
-          )}
-        />
+        <Route exact path="/galleries" component={Galleries} />
         <Route exact path="/galleries/new" component={GalleryCreate} />
         <Route path="/galleries/:id/:tab?" component={Gallery} />
       </Switch>
@@ -27,4 +28,4 @@ const Galleries: React.FC = () => {
   );
 };
 
-export default Galleries;
+export default GalleryRoutes;

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -31,6 +31,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { galleryPath, galleryTitle } from "src/core/galleries";
 import { GalleryChapterPanel } from "./GalleryChaptersPanel";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   gallery: GQL.GalleryDataFragment;
@@ -375,6 +376,8 @@ export const GalleryPage: React.FC<IProps> = ({ gallery }) => {
 const GalleryLoader: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { data, loading, error } = useFindGallery(id ?? "");
+
+  useScrollToTopOnMount();
 
   if (loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -1,7 +1,7 @@
 import { Tab, Nav, Dropdown } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useParams, useHistory, Link } from "react-router-dom";
+import { useHistory, Link, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import {
   useFindImage,
@@ -27,22 +27,24 @@ import { DeleteImagesDialog } from "../DeleteImagesDialog";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
 import { objectPath, objectTitle } from "src/core/files";
 import { isVideo } from "src/utils/visualFile";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
-interface IImageParams {
-  id?: string;
+interface IProps {
+  image: GQL.ImageDataFragment;
 }
 
-export const Image: React.FC = () => {
-  const { id = "new" } = useParams<IImageParams>();
+interface IImageParams {
+  id: string;
+}
+
+const ImagePage: React.FC<IProps> = ({ image }) => {
   const history = useHistory();
   const Toast = useToast();
   const intl = useIntl();
 
-  const { data, error, loading } = useFindImage(id);
-  const image = data?.findImage;
-  const [incrementO] = useImageIncrementO(image?.id ?? "0");
-  const [decrementO] = useImageDecrementO(image?.id ?? "0");
-  const [resetO] = useImageResetO(image?.id ?? "0");
+  const [incrementO] = useImageIncrementO(image.id);
+  const [decrementO] = useImageDecrementO(image.id);
+  const [resetO] = useImageResetO(image.id);
 
   const [updateImage] = useImageUpdate();
 
@@ -90,8 +92,8 @@ export const Image: React.FC = () => {
       await updateImage({
         variables: {
           input: {
-            id: image?.id ?? "",
-            organized: !image?.organized,
+            id: image.id,
+            organized: !image.organized,
           },
         },
       });
@@ -262,16 +264,6 @@ export const Image: React.FC = () => {
     };
   });
 
-  if (loading) {
-    return <LoadingIndicator />;
-  }
-
-  if (error) return <ErrorMessage error={error.message} />;
-
-  if (!image) {
-    return <ErrorMessage error={`No image found with id ${id}.`} />;
-  }
-
   const title = objectTitle(image);
   const ImageView = isVideo(image.visual_files[0]) ? "video" : "img";
 
@@ -317,3 +309,21 @@ export const Image: React.FC = () => {
     </div>
   );
 };
+
+const ImageLoader: React.FC<RouteComponentProps<IImageParams>> = ({
+  match,
+}) => {
+  const { id } = match.params;
+  const { data, loading, error } = useFindImage(id);
+
+  useScrollToTopOnMount();
+
+  if (loading) return <LoadingIndicator />;
+  if (error) return <ErrorMessage error={error.message} />;
+  if (!data?.findImage)
+    return <ErrorMessage error={`No image found with id ${id}.`} />;
+
+  return <ImagePage image={data.findImage} />;
+};
+
+export default ImageLoader;

--- a/ui/v2.5/src/components/Images/Images.tsx
+++ b/ui/v2.5/src/components/Images/Images.tsx
@@ -1,24 +1,16 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "../Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import { Image } from "./ImageDetails/Image";
 import { ImageList } from "./ImageList";
 
 const Images: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "images",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "images" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route
           exact

--- a/ui/v2.5/src/components/Images/Images.tsx
+++ b/ui/v2.5/src/components/Images/Images.tsx
@@ -5,24 +5,25 @@ import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import { Image } from "./ImageDetails/Image";
 import { ImageList } from "./ImageList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Images: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <ImageList persistState={PersistanceLevel.ALL} />;
+};
+
+const ImageRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "images" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route
-          exact
-          path="/images"
-          render={(props) => (
-            <ImageList persistState={PersistanceLevel.ALL} {...props} />
-          )}
-        />
+        <Route exact path="/images" component={Images} />
         <Route path="/images/:id" component={Image} />
       </Switch>
     </>
   );
 };
 
-export default Images;
+export default ImageRoutes;

--- a/ui/v2.5/src/components/Images/Images.tsx
+++ b/ui/v2.5/src/components/Images/Images.tsx
@@ -3,7 +3,7 @@ import { Route, Switch } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
-import { Image } from "./ImageDetails/Image";
+import Image from "./ImageDetails/Image";
 import { ImageList } from "./ImageList";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -153,9 +153,7 @@ export function makeItemList<T extends QueryResult, E extends IDataItem>({
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [lastClickedId, setLastClickedId] = useState<string>();
 
-    const [editingCriterion, setEditingCriterion] = useState<
-      string | undefined
-    >();
+    const [editingCriterion, setEditingCriterion] = useState<string>();
     const [showEditFilter, setShowEditFilter] = useState(false);
 
     const result = useResult(filter);
@@ -701,7 +699,15 @@ export function makeItemList<T extends QueryResult, E extends IDataItem>({
         const newFilter = cloneDeep(filter);
         newFilter.currentPage = page;
         updateFilter(newFilter);
-        window.scrollTo(0, 0);
+
+        // if the current page has a detail-header, then
+        // scroll up relative to that rather than 0, 0
+        const detailHeader = document.querySelector(".detail-header");
+        if (detailHeader) {
+          window.scrollTo(0, detailHeader.scrollHeight - 50);
+        } else {
+          window.scrollTo(0, 0);
+        }
       },
       [filter, updateFilter]
     );

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -34,7 +34,7 @@ import { Icon } from "src/components/Shared/Icon";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
-import ImageUtils from "src/utils/image";
+import { DetailImage } from "src/components/Shared/DetailImage";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
@@ -232,11 +232,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     if (image && defaultImage) {
       return (
         <div className="movie-image-container">
-          <img
-            alt="Front Cover"
-            src={image}
-            onLoad={ImageUtils.verifyImageSize}
-          />
+          <DetailImage alt="Front Cover" src={image} />
         </div>
       );
     } else if (image) {
@@ -246,11 +242,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
           variant="link"
           onClick={() => showLightbox()}
         >
-          <img
-            alt="Front Cover"
-            src={image}
-            onLoad={ImageUtils.verifyImageSize}
-          />
+          <DetailImage alt="Front Cover" src={image} />
         </Button>
       );
     }
@@ -273,11 +265,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
           variant="link"
           onClick={() => showLightbox(index - 1)}
         >
-          <img
-            alt="Back Cover"
-            src={image}
-            onLoad={ImageUtils.verifyImageSize}
-          />
+          <DetailImage alt="Back Cover" src={image} />
         </Button>
       );
     }

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -36,6 +36,7 @@ import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -450,6 +451,8 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
 const MovieLoader: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { data, loading, error } = useFindMovie(id ?? "");
+
+  useScrollToTopOnMount();
 
   if (loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -35,6 +35,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -53,7 +54,7 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   const showAllDetails = uiConfig?.showAllDetails ?? true;
 
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
+  const loadStickyHeader = useLoadStickyHeader();
 
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -125,21 +126,6 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
     configuration?.ui?.ratingSystemOptions?.type,
     setRating
   );
-
-  useEffect(() => {
-    const f = () => {
-      if (document.documentElement.scrollTop <= 50) {
-        setLoadStickyHeader(false);
-      } else {
-        setLoadStickyHeader(true);
-      }
-    };
-
-    window.addEventListener("scroll", f);
-    return () => {
-      window.removeEventListener("scroll", f);
-    };
-  });
 
   async function onSave(input: GQL.MovieCreateInput) {
     await updateMovie({

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -9,7 +9,7 @@ import {
   useMovieUpdate,
   useMovieDestroy,
 } from "src/core/StashService";
-import { useParams, useHistory } from "react-router-dom";
+import { useHistory, RouteComponentProps } from "react-router-dom";
 import { DetailsEditNavbar } from "src/components/Shared/DetailsEditNavbar";
 import { ErrorMessage } from "src/components/Shared/ErrorMessage";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
@@ -40,6 +40,10 @@ import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
+}
+
+interface IMovieParams {
+  id: string;
 }
 
 const MoviePage: React.FC<IProps> = ({ movie }) => {
@@ -448,9 +452,11 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   );
 };
 
-const MovieLoader: React.FC = () => {
-  const { id } = useParams<{ id?: string }>();
-  const { data, loading, error } = useFindMovie(id ?? "");
+const MovieLoader: React.FC<RouteComponentProps<IMovieParams>> = ({
+  match,
+}) => {
+  const { id } = match.params;
+  const { data, loading, error } = useFindMovie(id);
 
   useScrollToTopOnMount();
 

--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Button } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
+import cx from "classnames";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import {
@@ -396,17 +397,19 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
 
   if (updating || deleting) return <LoadingIndicator />;
 
+  const headerClassName = cx("detail-header", {
+    edit: isEditing,
+    collapsed,
+    "full-width": !collapsed && !compactExpandedDetails,
+  });
+
   return (
     <div id="movie-page" className="row">
       <Helmet>
         <title>{movie?.name}</title>
       </Helmet>
 
-      <div
-        className={`detail-header ${isEditing ? "edit" : ""}  ${
-          collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
-      >
+      <div className={headerClassName}>
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">
           <div className="detail-header-image">

--- a/ui/v2.5/src/components/Movies/Movies.tsx
+++ b/ui/v2.5/src/components/Movies/Movies.tsx
@@ -5,14 +5,21 @@ import { useTitleProps } from "src/hooks/title";
 import Movie from "./MovieDetails/Movie";
 import MovieCreate from "./MovieDetails/MovieCreate";
 import { MovieList } from "./MovieList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Movies: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <MovieList />;
+};
+
+const MovieRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "movies" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route exact path="/movies" component={MovieList} />
+        <Route exact path="/movies" component={Movies} />
         <Route exact path="/movies/new" component={MovieCreate} />
         <Route path="/movies/:id/:tab?" component={Movie} />
       </Switch>
@@ -20,4 +27,4 @@ const Movies: React.FC = () => {
   );
 };
 
-export default Movies;
+export default MovieRoutes;

--- a/ui/v2.5/src/components/Movies/Movies.tsx
+++ b/ui/v2.5/src/components/Movies/Movies.tsx
@@ -1,24 +1,16 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import Movie from "./MovieDetails/Movie";
 import MovieCreate from "./MovieDetails/MovieCreate";
 import { MovieList } from "./MovieList";
 
 const Movies: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "movies",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "movies" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route exact path="/movies" component={MovieList} />
         <Route exact path="/movies/new" component={MovieCreate} />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Button, Tabs, Tab, Col, Row } from "react-bootstrap";
 import { useIntl } from "react-intl";
-import { useParams, useHistory } from "react-router-dom";
+import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import cx from "classnames";
 import Mousetrap from "mousetrap";
@@ -48,16 +48,33 @@ import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
+  tabKey: TabKey;
 }
+
 interface IPerformerParams {
+  id: string;
   tab?: string;
 }
 
-const PerformerPage: React.FC<IProps> = ({ performer }) => {
+const validTabs = [
+  "scenes",
+  "galleries",
+  "images",
+  "movies",
+  "appearswith",
+] as const;
+type TabKey = (typeof validTabs)[number];
+
+const defaultTab: TabKey = "scenes";
+
+function isTabKey(tab: string): tab is TabKey {
+  return validTabs.includes(tab as TabKey);
+}
+
+const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
   const Toast = useToast();
   const history = useHistory();
   const intl = useIntl();
-  const { tab = "details" } = useParams<IPerformerParams>();
 
   // Configuration settings
   const { configuration } = React.useContext(ConfigurationContext);
@@ -100,20 +117,16 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [updatePerformer] = usePerformerUpdate();
   const [deletePerformer, { loading: isDestroying }] = usePerformerDestroy();
 
-  const activeTabKey =
-    tab === "scenes" ||
-    tab === "galleries" ||
-    tab === "images" ||
-    tab === "movies" ||
-    tab == "appearswith"
-      ? tab
-      : "scenes";
-  const setActiveTabKey = (newTab: string | null) => {
-    if (tab !== newTab) {
-      const tabParam = newTab === "scenes" ? "" : `/${newTab}`;
-      history.replace(`/performers/${performer.id}${tabParam}`);
+  function setTabKey(newTabKey: string | null) {
+    if (!newTabKey) newTabKey = defaultTab;
+    if (newTabKey === tabKey) return;
+
+    if (newTabKey === defaultTab) {
+      history.replace(`/performers/${performer.id}`);
+    } else if (isTabKey(newTabKey)) {
+      history.replace(`/performers/${performer.id}/${newTabKey}`);
     }
-  };
+  }
 
   async function onAutoTag() {
     try {
@@ -135,18 +148,18 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   // set up hotkeys
   useEffect(() => {
     Mousetrap.bind("e", () => toggleEditing());
-    Mousetrap.bind("c", () => setActiveTabKey("scenes"));
-    Mousetrap.bind("g", () => setActiveTabKey("galleries"));
-    Mousetrap.bind("m", () => setActiveTabKey("movies"));
+    Mousetrap.bind("c", () => setTabKey("scenes"));
+    Mousetrap.bind("g", () => setTabKey("galleries"));
+    Mousetrap.bind("m", () => setTabKey("movies"));
     Mousetrap.bind("f", () => setFavorite(!performer.favorite));
     Mousetrap.bind(",", () => setCollapsed(!collapsed));
 
     return () => {
-      Mousetrap.unbind("a");
       Mousetrap.unbind("e");
       Mousetrap.unbind("c");
+      Mousetrap.unbind("g");
+      Mousetrap.unbind("m");
       Mousetrap.unbind("f");
-      Mousetrap.unbind("o");
       Mousetrap.unbind(",");
     };
   });
@@ -204,105 +217,104 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
     }
   }
   const renderTabs = () => (
-    <React.Fragment>
-      <Tabs
-        activeKey={activeTabKey}
-        onSelect={setActiveTabKey}
-        id="performer-details"
-        unmountOnExit
+    <Tabs
+      id="performer-tabs"
+      mountOnEnter
+      unmountOnExit
+      activeKey={tabKey}
+      onSelect={setTabKey}
+    >
+      <Tab
+        eventKey="scenes"
+        title={
+          <>
+            {intl.formatMessage({ id: "scenes" })}
+            <Counter
+              abbreviateCounter={abbreviateCounter}
+              count={performer.scene_count}
+              hideZero
+            />
+          </>
+        }
       >
-        <Tab
-          eventKey="scenes"
-          title={
-            <>
-              {intl.formatMessage({ id: "scenes" })}
-              <Counter
-                abbreviateCounter={abbreviateCounter}
-                count={performer.scene_count}
-                hideZero
-              />
-            </>
-          }
-        >
-          <PerformerScenesPanel
-            active={activeTabKey == "scenes"}
-            performer={performer}
-          />
-        </Tab>
-        <Tab
-          eventKey="galleries"
-          title={
-            <>
-              {intl.formatMessage({ id: "galleries" })}
-              <Counter
-                abbreviateCounter={abbreviateCounter}
-                count={performer.gallery_count}
-                hideZero
-              />
-            </>
-          }
-        >
-          <PerformerGalleriesPanel
-            active={activeTabKey == "galleries"}
-            performer={performer}
-          />
-        </Tab>
-        <Tab
-          eventKey="images"
-          title={
-            <>
-              {intl.formatMessage({ id: "images" })}
-              <Counter
-                abbreviateCounter={abbreviateCounter}
-                count={performer.image_count}
-                hideZero
-              />
-            </>
-          }
-        >
-          <PerformerImagesPanel
-            active={activeTabKey == "images"}
-            performer={performer}
-          />
-        </Tab>
-        <Tab
-          eventKey="movies"
-          title={
-            <>
-              {intl.formatMessage({ id: "movies" })}
-              <Counter
-                abbreviateCounter={abbreviateCounter}
-                count={performer.movie_count}
-                hideZero
-              />
-            </>
-          }
-        >
-          <PerformerMoviesPanel
-            active={activeTabKey == "movies"}
-            performer={performer}
-          />
-        </Tab>
-        <Tab
-          eventKey="appearswith"
-          title={
-            <>
-              {intl.formatMessage({ id: "appears_with" })}
-              <Counter
-                abbreviateCounter={abbreviateCounter}
-                count={performer.performer_count}
-                hideZero
-              />
-            </>
-          }
-        >
-          <PerformerAppearsWithPanel
-            active={activeTabKey == "appearswith"}
-            performer={performer}
-          />
-        </Tab>
-      </Tabs>
-    </React.Fragment>
+        <PerformerScenesPanel
+          active={tabKey === "scenes"}
+          performer={performer}
+        />
+      </Tab>
+      <Tab
+        eventKey="galleries"
+        title={
+          <>
+            {intl.formatMessage({ id: "galleries" })}
+            <Counter
+              abbreviateCounter={abbreviateCounter}
+              count={performer.gallery_count}
+              hideZero
+            />
+          </>
+        }
+      >
+        <PerformerGalleriesPanel
+          active={tabKey === "galleries"}
+          performer={performer}
+        />
+      </Tab>
+      <Tab
+        eventKey="images"
+        title={
+          <>
+            {intl.formatMessage({ id: "images" })}
+            <Counter
+              abbreviateCounter={abbreviateCounter}
+              count={performer.image_count}
+              hideZero
+            />
+          </>
+        }
+      >
+        <PerformerImagesPanel
+          active={tabKey === "images"}
+          performer={performer}
+        />
+      </Tab>
+      <Tab
+        eventKey="movies"
+        title={
+          <>
+            {intl.formatMessage({ id: "movies" })}
+            <Counter
+              abbreviateCounter={abbreviateCounter}
+              count={performer.movie_count}
+              hideZero
+            />
+          </>
+        }
+      >
+        <PerformerMoviesPanel
+          active={tabKey === "movies"}
+          performer={performer}
+        />
+      </Tab>
+      <Tab
+        eventKey="appearswith"
+        title={
+          <>
+            {intl.formatMessage({ id: "appears_with" })}
+            <Counter
+              abbreviateCounter={abbreviateCounter}
+              count={performer.performer_count}
+              hideZero
+            />
+          </>
+        }
+      >
+        <PerformerAppearsWithPanel
+          active={tabKey === "appearswith"}
+          performer={performer}
+        />
+      </Tab>
+    </Tabs>
   );
 
   function maybeRenderHeaderBackgroundImage() {
@@ -579,9 +591,12 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   );
 };
 
-const PerformerLoader: React.FC = () => {
-  const { id } = useParams<{ id?: string }>();
-  const { data, loading, error } = useFindPerformer(id ?? "");
+const PerformerLoader: React.FC<RouteComponentProps<IPerformerParams>> = ({
+  location,
+  match,
+}) => {
+  const { id, tab } = match.params;
+  const { data, loading, error } = useFindPerformer(id);
 
   useScrollToTopOnMount();
 
@@ -590,7 +605,22 @@ const PerformerLoader: React.FC = () => {
   if (!data?.findPerformer)
     return <ErrorMessage error={`No performer found with id ${id}.`} />;
 
-  return <PerformerPage performer={data.findPerformer} />;
+  if (!tab) {
+    return <PerformerPage performer={data.findPerformer} tabKey={defaultTab} />;
+  }
+
+  if (!isTabKey(tab)) {
+    return (
+      <Redirect
+        to={{
+          ...location,
+          pathname: `/performers/${id}`,
+        }}
+      />
+    );
+  }
+
+  return <PerformerPage performer={data.findPerformer} tabKey={tab} />;
 };
 
 export default PerformerLoader;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -42,7 +42,7 @@ import {
 import { faInstagram, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { IUIConfig } from "src/core/config";
 import { useRatingKeybinds } from "src/hooks/keybinds";
-import ImageUtils from "src/utils/image";
+import { DetailImage } from "src/components/Shared/DetailImage";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
@@ -206,11 +206,10 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
     if (activeImage) {
       return (
         <Button variant="link" onClick={() => showLightbox()}>
-          <img
+          <DetailImage
             className="performer"
             src={activeImage}
             alt={performer.name}
-            onLoad={ImageUtils.verifyImageSize}
           />
         </Button>
       );

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -43,6 +43,7 @@ import { faInstagram, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { IUIConfig } from "src/core/config";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import ImageUtils from "src/utils/image";
+import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -70,7 +71,7 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [image, setImage] = useState<string | null>();
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
-  const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
+  const loadStickyHeader = useLoadStickyHeader();
 
   const activeImage = useMemo(() => {
     const performerImage = performer.image_path;
@@ -364,21 +365,6 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
   function getCollapseButtonIcon() {
     return collapsed ? faChevronDown : faChevronUp;
   }
-
-  useEffect(() => {
-    const f = () => {
-      if (document.documentElement.scrollTop <= 50) {
-        setLoadStickyHeader(false);
-      } else {
-        setLoadStickyHeader(true);
-      }
-    };
-
-    window.addEventListener("scroll", f);
-    return () => {
-      window.removeEventListener("scroll", f);
-    };
-  });
 
   function maybeRenderDetails() {
     if (!isEditing) {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -536,17 +536,19 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
       />
     );
 
+  const headerClassName = cx("detail-header", {
+    edit: isEditing,
+    collapsed,
+    "full-width": !collapsed && !compactExpandedDetails,
+  });
+
   return (
     <div id="performer-page" className="row">
       <Helmet>
         <title>{performer.name}</title>
       </Helmet>
 
-      <div
-        className={`detail-header ${isEditing ? "edit" : ""}  ${
-          collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
-      >
+      <div className={headerClassName}>
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">
           <div className="detail-header-image">

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -44,6 +44,7 @@ import { IUIConfig } from "src/core/config";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import ImageUtils from "src/utils/image";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
@@ -581,6 +582,8 @@ const PerformerPage: React.FC<IProps> = ({ performer }) => {
 const PerformerLoader: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { data, loading, error } = useFindPerformer(id ?? "");
+
+  useScrollToTopOnMount();
 
   if (loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -213,7 +213,7 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> = ({
             fullWidth={fullWidth}
           />
           <DetailItem
-            id="StashIDs"
+            id="stash_ids"
             value={renderStashIDs()}
             fullWidth={fullWidth}
           />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -789,7 +789,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     return (
       <Row>
         <Form.Label column sm={labelXS} xl={labelXL}>
-          StashIDs
+          {intl.formatMessage({ id: "stash_ids" })}
         </Form.Label>
         <Col sm={fieldXS} xl={fieldXL}>
           <ul className="pl-0">

--- a/ui/v2.5/src/components/Performers/Performers.tsx
+++ b/ui/v2.5/src/components/Performers/Performers.tsx
@@ -6,24 +6,26 @@ import { PersistanceLevel } from "../List/ItemList";
 import Performer from "./PerformerDetails/Performer";
 import PerformerCreate from "./PerformerDetails/PerformerCreate";
 import { PerformerList } from "./PerformerList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Performers: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <PerformerList persistState={PersistanceLevel.ALL} />;
+};
+
+const PerformerRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "performers" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route
-          exact
-          path="/performers"
-          render={(props) => (
-            <PerformerList persistState={PersistanceLevel.ALL} {...props} />
-          )}
-        />
+        <Route exact path="/performers" component={Performers} />
         <Route path="/performers/new" component={PerformerCreate} />
         <Route path="/performers/:id/:tab?" component={Performer} />
       </Switch>
     </>
   );
 };
-export default Performers;
+
+export default PerformerRoutes;

--- a/ui/v2.5/src/components/Performers/Performers.tsx
+++ b/ui/v2.5/src/components/Performers/Performers.tsx
@@ -1,25 +1,17 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import Performer from "./PerformerDetails/Performer";
 import PerformerCreate from "./PerformerDetails/PerformerCreate";
 import { PerformerList } from "./PerformerList";
 
 const Performers: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "performers",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "performers" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route
           exact

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -8,7 +8,7 @@ import React, {
   useLayoutEffect,
 } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useParams, useLocation, useHistory, Link } from "react-router-dom";
+import { Link, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import * as GQL from "src/core/generated-graphql";
 import {
@@ -91,6 +91,10 @@ interface IProps {
   collapsed: boolean;
   setCollapsed: (state: boolean) => void;
   setContinuePlaylist: (value: boolean) => void;
+}
+
+interface ISceneParams {
+  id: string;
 }
 
 const ScenePage: React.FC<IProps> = ({
@@ -539,12 +543,14 @@ const ScenePage: React.FC<IProps> = ({
   );
 };
 
-const SceneLoader: React.FC = () => {
-  const { id } = useParams<{ id?: string }>();
-  const location = useLocation();
-  const history = useHistory();
+const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
+  location,
+  history,
+  match,
+}) => {
+  const { id } = match.params;
   const { configuration } = useContext(ConfigurationContext);
-  const { data, loading, error } = useFindScene(id ?? "");
+  const { data, loading, error } = useFindScene(id);
 
   const [scene, setScene] = useState<GQL.SceneDataFragment>();
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -191,7 +191,9 @@ export const SceneFileInfoPanel: React.FC<ISceneFileInfoPanelProps> = (
 
     return (
       <>
-        <dt>StashIDs</dt>
+        <dt>
+          <FormattedMessage id="stash_ids" />
+        </dt>
         <dd>
           <dl>
             {props.scene.stash_ids.map((stashID) => {

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import { lazyComponent } from "src/utils/lazyComponent";
 
@@ -12,21 +11,12 @@ const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
 const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));
 
 const Scenes: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "scenes",
-  })} ${TITLE_SUFFIX}`;
-  const marker_title_template = `${intl.formatMessage({
-    id: "markers",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "scenes" });
+  const markerTitleProps = useTitleProps({ id: "markers" });
 
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route
           exact
@@ -40,10 +30,7 @@ const Scenes: React.FC = () => {
           path="/scenes/markers"
           render={() => (
             <>
-              <Helmet
-                defaultTitle={marker_title_template}
-                titleTemplate={`%s | ${marker_title_template}`}
-              />
+              <Helmet {...markerTitleProps} />
               <SceneMarkerList />
             </>
           )}

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -4,6 +4,7 @@ import { Helmet } from "react-helmet";
 import { useTitleProps } from "src/hooks/title";
 import { PersistanceLevel } from "../List/ItemList";
 import { lazyComponent } from "src/utils/lazyComponent";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const SceneList = lazyComponent(() => import("./SceneList"));
 const SceneMarkerList = lazyComponent(() => import("./SceneMarkerList"));
@@ -11,34 +12,36 @@ const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
 const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));
 
 const Scenes: React.FC = () => {
-  const titleProps = useTitleProps({ id: "scenes" });
-  const markerTitleProps = useTitleProps({ id: "markers" });
+  useScrollToTopOnMount();
 
+  return <SceneList persistState={PersistanceLevel.ALL} />;
+};
+
+const SceneMarkers: React.FC = () => {
+  useScrollToTopOnMount();
+
+  const titleProps = useTitleProps({ id: "markers" });
+  return (
+    <>
+      <Helmet {...titleProps} />
+      <SceneMarkerList />
+    </>
+  );
+};
+
+const SceneRoutes: React.FC = () => {
+  const titleProps = useTitleProps({ id: "scenes" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route
-          exact
-          path="/scenes"
-          render={(props) => (
-            <SceneList persistState={PersistanceLevel.ALL} {...props} />
-          )}
-        />
-        <Route
-          exact
-          path="/scenes/markers"
-          render={() => (
-            <>
-              <Helmet {...markerTitleProps} />
-              <SceneMarkerList />
-            </>
-          )}
-        />
+        <Route exact path="/scenes" component={Scenes} />
+        <Route exact path="/scenes/markers" component={SceneMarkers} />
         <Route exact path="/scenes/new" component={SceneCreate} />
         <Route path="/scenes/:id" component={Scene} />
       </Switch>
     </>
   );
 };
-export default Scenes;
+
+export default SceneRoutes;

--- a/ui/v2.5/src/components/Settings/Settings.tsx
+++ b/ui/v2.5/src/components/Settings/Settings.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Tab, Nav, Row, Col } from "react-bootstrap";
 import { useHistory, useLocation } from "react-router-dom";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import { SettingsAboutPanel } from "./SettingsAboutPanel";
 import { SettingsConfigurationPanel } from "./SettingsSystemPanel";
 import { SettingsInterfacePanel } from "./SettingsInterfacePanel/SettingsInterfacePanel";
@@ -19,26 +19,20 @@ import { SettingsSecurityPanel } from "./SettingsSecurityPanel";
 import Changelog from "../Changelog/Changelog";
 
 export const Settings: React.FC = () => {
-  const intl = useIntl();
   const location = useLocation();
   const history = useHistory();
   const defaultTab = new URLSearchParams(location.search).get("tab") ?? "tasks";
 
   const onSelect = (val: string) => history.push(`?tab=${val}`);
 
-  const title_template = `${intl.formatMessage({
-    id: "settings",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "settings" });
   return (
     <Tab.Container
       activeKey={defaultTab}
       id="configuration-tabs"
       onSelect={(tab) => tab && onSelect(tab)}
     >
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Row>
         <Col id="settings-menu-container" sm={3} md={3} xl={2}>
           <Nav variant="pills" className="flex-column">

--- a/ui/v2.5/src/components/Shared/DetailImage.tsx
+++ b/ui/v2.5/src/components/Shared/DetailImage.tsx
@@ -1,0 +1,38 @@
+import { useLayoutEffect, useRef } from "react";
+
+const DEFAULT_WIDTH = "200";
+
+// Props used by the <img> element
+type IDetailImageProps = JSX.IntrinsicElements["img"];
+
+export const DetailImage = (props: IDetailImageProps) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  function fixWidth() {
+    const img = imgRef.current;
+    if (!img) return;
+
+    // prevent SVG's w/o intrinsic size from rendering as 0x0
+    if (img.naturalWidth === 0) {
+      // If the naturalWidth is zero, it means the image either hasn't loaded yet
+      // or we're on Firefox and it is an SVG w/o an intrinsic size.
+      // So set the width to our fallback width.
+      img.setAttribute("width", DEFAULT_WIDTH);
+    } else {
+      // If we have a `naturalWidth`, this could either be the actual intrinsic width
+      // of the image, or the image is an SVG w/o an intrinsic size and we're on Chrome or Safari,
+      // which seem to return a size calculated in some browser-specific way.
+      // Worse yet, once rendered, Safari will then return the value of `img.width` as `img.naturalWidth`,
+      // so we need to clone the image to disconnect it from the DOM, and then get the `naturalWidth` of the clone,
+      // in order to always return the same `naturalWidth` for a given src.
+      const i = img.cloneNode() as HTMLImageElement;
+      img.setAttribute("width", (i.naturalWidth || DEFAULT_WIDTH).toString());
+    }
+  }
+
+  useLayoutEffect(() => {
+    fixWidth();
+  }, [props.src]);
+
+  return <img ref={imgRef} onLoad={() => fixWidth()} {...props} />;
+};

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -34,8 +34,6 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
     if (props.selecting) {
       props.onSelectedChanged(!props.selected, shiftKey);
       event.preventDefault();
-    } else {
-      window.scrollTo(0, 0);
     }
   }
 

--- a/ui/v2.5/src/components/Shared/constants.ts
+++ b/ui/v2.5/src/components/Shared/constants.ts
@@ -1,1 +1,0 @@
-export const TITLE_SUFFIX = " | Stash";

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -42,6 +42,7 @@ import TextUtils from "src/utils/text";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
+import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -66,7 +67,7 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
   const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
+  const loadStickyHeader = useLoadStickyHeader();
 
   // Editing state
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -112,21 +113,6 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
     configuration?.ui?.ratingSystemOptions?.type,
     setRating
   );
-
-  useEffect(() => {
-    const f = () => {
-      if (document.documentElement.scrollTop <= 50) {
-        setLoadStickyHeader(false);
-      } else {
-        setLoadStickyHeader(true);
-      }
-    };
-
-    window.addEventListener("scroll", f);
-    return () => {
-      window.removeEventListener("scroll", f);
-    };
-  });
 
   async function onSave(input: GQL.StudioCreateInput) {
     await updateStudio({

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -43,6 +43,7 @@ import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import ImageUtils from "src/utils/image";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -535,6 +536,8 @@ const StudioPage: React.FC<IProps> = ({ studio }) => {
 const StudioLoader: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { data, loading, error } = useFindStudio(id ?? "");
+
+  useScrollToTopOnMount();
 
   if (loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -41,7 +41,7 @@ import {
 import { IUIConfig } from "src/core/config";
 import TextUtils from "src/utils/text";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
-import ImageUtils from "src/utils/image";
+import { DetailImage } from "src/components/Shared/DetailImage";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
@@ -237,12 +237,7 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
 
     if (studioImage) {
       return (
-        <img
-          className="logo"
-          alt={studio.name}
-          src={studioImage}
-          onLoad={ImageUtils.verifyImageSize}
-        />
+        <DetailImage className="logo" alt={studio.name} src={studioImage} />
       );
     }
   }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
+import cx from "classnames";
 import Mousetrap from "mousetrap";
 
 import * as GQL from "src/core/generated-graphql";
@@ -481,17 +482,19 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
     }
   }
 
+  const headerClassName = cx("detail-header", {
+    edit: isEditing,
+    collapsed,
+    "full-width": !collapsed && !compactExpandedDetails,
+  });
+
   return (
     <div id="studio-page" className="row">
       <Helmet>
         <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
       </Helmet>
 
-      <div
-        className={`detail-header ${isEditing ? "edit" : ""}  ${
-          collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
-      >
+      <div className={headerClassName}>
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">
           <div className="detail-header-image">

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioDetailsPanel.tsx
@@ -47,7 +47,7 @@ export const StudioDetailsPanel: React.FC<IStudioDetailsPanel> = ({
     if (!collapsed) {
       return (
         <DetailItem
-          id="StashIDs"
+          id="stash_ids"
           value={renderStashIDs()}
           fullWidth={fullWidth}
         />

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -160,7 +160,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     return (
       <Row>
         <Form.Label column xs={labelXS} xl={labelXL}>
-          StashIDs
+          {intl.formatMessage({ id: "stash_ids" })}
         </Form.Label>
         <Col xs={fieldXS} xl={fieldXL}>
           <ul className="pl-0">

--- a/ui/v2.5/src/components/Studios/Studios.tsx
+++ b/ui/v2.5/src/components/Studios/Studios.tsx
@@ -1,24 +1,16 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import Studio from "./StudioDetails/Studio";
 import StudioCreate from "./StudioDetails/StudioCreate";
 import { StudioList } from "./StudioList";
 
 const Studios: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "studios",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "studios" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
+      <Helmet {...titleProps} />
       <Switch>
         <Route exact path="/studios" component={StudioList} />
         <Route exact path="/studios/new" component={StudioCreate} />

--- a/ui/v2.5/src/components/Studios/Studios.tsx
+++ b/ui/v2.5/src/components/Studios/Studios.tsx
@@ -5,18 +5,26 @@ import { useTitleProps } from "src/hooks/title";
 import Studio from "./StudioDetails/Studio";
 import StudioCreate from "./StudioDetails/StudioCreate";
 import { StudioList } from "./StudioList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Studios: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <StudioList />;
+};
+
+const StudioRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "studios" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route exact path="/studios" component={StudioList} />
+        <Route exact path="/studios" component={Studios} />
         <Route exact path="/studios/new" component={StudioCreate} />
         <Route path="/studios/:id/:tab?" component={Studio} />
       </Switch>
     </>
   );
 };
-export default Studios;
+
+export default StudioRoutes;

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
+import cx from "classnames";
 import Mousetrap from "mousetrap";
 
 import * as GQL from "src/core/generated-graphql";
@@ -484,17 +485,19 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
     }
   }
 
+  const headerClassName = cx("detail-header", {
+    edit: isEditing,
+    collapsed,
+    "full-width": !collapsed && !compactExpandedDetails,
+  });
+
   return (
     <div id="tag-page" className="row">
       <Helmet>
         <title>{tag.name}</title>
       </Helmet>
 
-      <div
-        className={`detail-header ${isEditing ? "edit" : ""}  ${
-          collapsed ? "collapsed" : !compactExpandedDetails ? "full-width" : ""
-        }`}
-      >
+      <div className={headerClassName}>
         {maybeRenderHeaderBackgroundImage()}
         <div className="detail-container">
           <div className="detail-header-image">

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -38,6 +38,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
+import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -61,7 +62,7 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
   const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const [loadStickyHeader, setLoadStickyHeader] = useState<boolean>(false);
+  const loadStickyHeader = useLoadStickyHeader();
 
   const { tab = "scenes" } = useParams<ITabParams>();
 
@@ -119,21 +120,6 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
       Mousetrap.unbind(",");
-    };
-  });
-
-  useEffect(() => {
-    const f = () => {
-      if (document.documentElement.scrollTop <= 50) {
-        setLoadStickyHeader(false);
-      } else {
-        setLoadStickyHeader(true);
-      }
-    };
-
-    window.addEventListener("scroll", f);
-    return () => {
-      window.removeEventListener("scroll", f);
     };
   });
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -38,7 +38,7 @@ import {
   faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import { IUIConfig } from "src/core/config";
-import ImageUtils from "src/utils/image";
+import { DetailImage } from "src/components/Shared/DetailImage";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
@@ -274,14 +274,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
     }
 
     if (tagImage) {
-      return (
-        <img
-          className="logo"
-          alt={tag.name}
-          src={tagImage}
-          onLoad={ImageUtils.verifyImageSize}
-        />
-      );
+      return <DetailImage className="logo" alt={tag.name} src={tagImage} />;
     }
   }
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -39,6 +39,7 @@ import {
 import { IUIConfig } from "src/core/config";
 import ImageUtils from "src/utils/image";
 import { useLoadStickyHeader } from "src/hooks/detailsPanel";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -523,6 +524,8 @@ const TagPage: React.FC<IProps> = ({ tag }) => {
 const TagLoader: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { data, loading, error } = useFindTag(id ?? "");
+
+  useScrollToTopOnMount();
 
   if (loading) return <LoadingIndicator />;
   if (error) return <ErrorMessage error={error.message} />;

--- a/ui/v2.5/src/components/Tags/Tags.tsx
+++ b/ui/v2.5/src/components/Tags/Tags.tsx
@@ -5,18 +5,26 @@ import { useTitleProps } from "src/hooks/title";
 import Tag from "./TagDetails/Tag";
 import TagCreate from "./TagDetails/TagCreate";
 import { TagList } from "./TagList";
+import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Tags: React.FC = () => {
+  useScrollToTopOnMount();
+
+  return <TagList />;
+};
+
+const TagRoutes: React.FC = () => {
   const titleProps = useTitleProps({ id: "tags" });
   return (
     <>
       <Helmet {...titleProps} />
       <Switch>
-        <Route exact path="/tags" component={TagList} />
+        <Route exact path="/tags" component={Tags} />
         <Route exact path="/tags/new" component={TagCreate} />
         <Route path="/tags/:id/:tab?" component={Tag} />
       </Switch>
     </>
   );
 };
-export default Tags;
+
+export default TagRoutes;

--- a/ui/v2.5/src/components/Tags/Tags.tsx
+++ b/ui/v2.5/src/components/Tags/Tags.tsx
@@ -1,25 +1,16 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import { useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
-import { TITLE_SUFFIX } from "src/components/Shared/constants";
+import { useTitleProps } from "src/hooks/title";
 import Tag from "./TagDetails/Tag";
 import TagCreate from "./TagDetails/TagCreate";
 import { TagList } from "./TagList";
 
 const Tags: React.FC = () => {
-  const intl = useIntl();
-
-  const title_template = `${intl.formatMessage({
-    id: "tags",
-  })} ${TITLE_SUFFIX}`;
+  const titleProps = useTitleProps({ id: "tags" });
   return (
     <>
-      <Helmet
-        defaultTitle={title_template}
-        titleTemplate={`%s | ${title_template}`}
-      />
-
+      <Helmet {...titleProps} />
       <Switch>
         <Route exact path="/tags" component={TagList} />
         <Route exact path="/tags/new" component={TagCreate} />

--- a/ui/v2.5/src/core/createClient.ts
+++ b/ui/v2.5/src/core/createClient.ts
@@ -68,9 +68,6 @@ const typePolicies: TypePolicies = {
   },
   Scene: {
     fields: {
-      scene_markers: {
-        merge: false,
-      },
       studio: {
         read: readDanglingNull,
       },
@@ -80,6 +77,9 @@ const typePolicies: TypePolicies = {
     fields: {
       studio: {
         read: readDanglingNull,
+      },
+      paths: {
+        merge: false,
       },
     },
   },
@@ -101,16 +101,6 @@ const typePolicies: TypePolicies = {
     fields: {
       parent_studio: {
         read: readDanglingNull,
-      },
-    },
-  },
-  Tag: {
-    fields: {
-      parents: {
-        merge: false,
-      },
-      children: {
-        merge: false,
       },
     },
   },

--- a/ui/v2.5/src/hooks/detailsPanel.ts
+++ b/ui/v2.5/src/hooks/detailsPanel.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+function shouldLoadStickyHeader() {
+  return document.documentElement.scrollTop > 50;
+}
+
+export function useLoadStickyHeader() {
+  const [load, setLoad] = useState(shouldLoadStickyHeader());
+
+  useEffect(() => {
+    const onScroll = () => {
+      setLoad(shouldLoadStickyHeader());
+    };
+
+    window.addEventListener("scroll", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  return load;
+}

--- a/ui/v2.5/src/hooks/scrollToTop.ts
+++ b/ui/v2.5/src/hooks/scrollToTop.ts
@@ -1,0 +1,7 @@
+import { useEffect } from "react";
+
+export function useScrollToTopOnMount() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+}

--- a/ui/v2.5/src/hooks/title.ts
+++ b/ui/v2.5/src/hooks/title.ts
@@ -1,0 +1,26 @@
+import { MessageDescriptor, useIntl } from "react-intl";
+
+export const TITLE = "Stash";
+export const TITLE_SEPARATOR = " | ";
+
+export function useTitleProps(...messages: (string | MessageDescriptor)[]) {
+  const intl = useIntl();
+
+  const parts = messages.map((msg) => {
+    if (typeof msg === "object") {
+      return intl.formatMessage(msg);
+    } else {
+      return msg;
+    }
+  });
+
+  return makeTitleProps(...parts);
+}
+
+export function makeTitleProps(...parts: string[]) {
+  const title = [...parts, TITLE].join(TITLE_SEPARATOR);
+  return {
+    titleTemplate: `%s | ${title}`,
+    defaultTitle: title,
+  };
+}

--- a/ui/v2.5/src/utils/image.tsx
+++ b/ui/v2.5/src/utils/image.tsx
@@ -70,17 +70,6 @@ const ImageUtils = {
   onImageChange,
   usePasteImage,
   imageToDataURL,
-  verifyImageSize,
 };
-
-function verifyImageSize(e: React.UIEvent<HTMLImageElement>) {
-  const img = e.target as HTMLImageElement;
-  // set width = 200px if zero-sized image (SVG w/o intrinsic size)
-  if (img.width === 0 && img.height === 0) {
-    img.setAttribute("width", "200");
-  } else {
-    img.removeAttribute("width");
-  }
-}
 
 export default ImageUtils;


### PR DESCRIPTION
These are a few tweaks and changes related to the recent details redesign, with some refactoring thrown in as well.

- The state flag for the sticky header is now initialized to the correct value rather than waiting for an `onscroll` event. This fixes an issue I came across where the sticky header would flicker if the page's initial scroll position was such that the header should show.
- The intl ID for the StashID detail item label was incorrect, leading to a console error and the ID being directly displayed (ie without being translated). I've fixed this and also added i18n for a few other hardcoded "StashIDs" labels. This does bring up the question on whether it's "Stash IDs" or "StashIDs" - the `en-GB.json` translation file has "Stash IDs" but the hardcoded strings all were "StashIDs". All the labels are now consistently display "Stash IDs", but I feel like "StashIDs" looks better - although maybe that's simply because I've seen "StashIDs" more often.
- The main details redesign-related fix is removing the `window.scrollTo(0, 0)` in the `GridCard` `onclick` event and instead scrolling up to the top when a "long" component (studios, tags, etc pages, list pages) is mounted. The `scrollTo` in the `onclick` was causing the page to unconditionally scroll up when clicking on a card, even if the click doesn't actually navigate away to a new page (eg a middle click to open in a new tab).
- Added an `id` to the `cover` field of `SlimGalleryData`, thus allowing the field to be properly cached, which fixes a console warning complaining about the missing ID. I also set the merge function for the `paths` field of a `Scene` object to `false`, fixing another console warning, and removed a few unnecessary `false` merge functions on fields which return normalized objects and thus do not need them.
- Refactored the ugly page title string templating code out into `useTitleProps` and `makeTitleProps`, and made it more modular with support for multiple pipe-separated parts.
- Refactored the various loaders (`SceneLoader`, `PerformerLoader`, etc) and created an `ImageLoader` to directly use the `RouteComponentProps` passed to them by `react-router` instead of `useLocation` or `useParams`.
- ~~Refactored the handling of the "tab" URL parameter, adding a `TabKey` type. Now instead of having `/performer/11` display the performer's scenes, the page will be redirected to `/performer/11/scenes` first before showing the scenes. This allows for a possible future feature where you would be able to set the default tab instead of it being hardcoded. Existing URL query strings are retained by the redirection, retaining backwards-compatibility: `/performers/1?sortby=date` will redirect to `/performers/1/scenes?sortby=date` for example.~~
  Edit: This is now just a refactor of the tab handling - the behaviour should match how it was before. I'll leave that change for a subsequent PR implementing #3961.
- And lastly, refactor to use `classnames` to generate the class string for the `.detail-header` instead of doing it manually with a template string - it just looks a bit cleaner.

This ended up being a lot bigger than I had anticipated, because I kept stumbling across things to refactor and couldn't help myself. I'm happy to split anything out into separate PRs if necessary.