### PR TITLE
Fix creating from non-stashbox sources in Scene Tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -563,7 +563,7 @@ export const TaggerContext: React.FC = ({ children }) => {
         return {
           ...r,
           performers: r.performers.map((p) => {
-            if (p.remote_site_id === performer.remote_site_id) {
+            if (p.name === performer.name) {
               return {
                 ...p,
                 stored_id: performerID,
@@ -658,8 +658,6 @@ export const TaggerContext: React.FC = ({ children }) => {
     studio: GQL.ScrapedStudio,
     toCreate: GQL.StudioCreateInput
   ) {
-    if (!currentSource?.stashboxEndpoint) return;
-
     try {
       const result = await createStudio({
         variables: {
@@ -678,7 +676,7 @@ export const TaggerContext: React.FC = ({ children }) => {
         return {
           ...r,
           studio:
-            r.studio.remote_site_id === studio.remote_site_id
+            r.studio.name === studio.name
               ? {
                   ...r.studio,
                   stored_id: studioID,

--- a/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
@@ -188,9 +188,7 @@ const StudioModal: React.FC<IStudioModalProps> = ({
       throw new Error("studio name must set");
     }
 
-    const studioData: GQL.StudioCreateInput & {
-      [index: string]: unknown;
-    } = {
+    const studioData: GQL.StudioCreateInput = {
       name: studio.name,
       url: studio.url,
       image: studio.image,
@@ -211,11 +209,7 @@ const StudioModal: React.FC<IStudioModalProps> = ({
     // handle exclusions
     excludeFields(studioData, excluded);
 
-    let parentData:
-      | (GQL.StudioCreateInput & {
-          [index: string]: unknown;
-        })
-      | undefined = undefined;
+    let parentData: GQL.StudioCreateInput | undefined = undefined;
 
     if (createParentStudio && sendParentStudio) {
       if (!studio.parent?.name) {

--- a/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
@@ -31,13 +31,38 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
   toggleField,
   isNew = false,
 }) => {
-  const renderField = (
+  function maybeRenderImage() {
+    if (!studio.image) return;
+
+    return (
+      <div className="row">
+        <div className="col-12 image-selection">
+          <div className="studio-image">
+            <Button
+              onClick={() => toggleField("image")}
+              variant="secondary"
+              className={cx(
+                "studio-image-exclude",
+                excluded.image ? "text-muted" : "text-success"
+              )}
+            >
+              <Icon icon={excluded.image ? faTimes : faCheck} />
+            </Button>
+            <img src={studio.image} alt="" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function maybeRenderField(
     id: string,
     text: string | null | undefined,
-    isSelectable: boolean = true,
-    truncate: boolean = true
-  ) =>
-    text && (
+    isSelectable: boolean = true
+  ) {
+    if (!text) return;
+
+    return (
       <div className="row no-gutters">
         <div className="col-5 studio-create-modal-field" key={id}>
           {isSelectable && (
@@ -53,47 +78,33 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
             <FormattedMessage id={id} />:
           </strong>
         </div>
-        {truncate ? (
-          <TruncatedText className="col-7" text={text} />
-        ) : (
-          <span className="col-7">{text}</span>
-        )}
+        <TruncatedText className="col-7" text={text} />
       </div>
     );
+  }
+
+  function maybeRenderLink() {
+    if (!link) return;
+
+    return (
+      <h6 className="mt-2">
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          <FormattedMessage id="stashbox.source" />
+          <Icon icon={faExternalLinkAlt} className="ml-2" />
+        </a>
+      </h6>
+    );
+  }
 
   return (
     <div>
-      <div className="row">
-        <div className="col-12 image-selection">
-          <div className="studio-image">
-            <Button
-              onClick={() => toggleField("image")}
-              variant="secondary"
-              className={cx(
-                "studio-image-exclude",
-                excluded.image ? "text-muted" : "text-success"
-              )}
-            >
-              <Icon icon={excluded.image ? faTimes : faCheck} />
-            </Button>
-            <img src={studio.image ?? ""} alt="" />
-          </div>
-        </div>
-      </div>
-
+      {maybeRenderImage()}
       <div className="row">
         <div className="col-12">
-          {renderField("name", studio.name, !isNew)}
-          {renderField("url", studio.url)}
-          {renderField("parent_studio", studio.parent?.name, false)}
-          {link && (
-            <h6 className="mt-2">
-              <a href={link} target="_blank" rel="noopener noreferrer">
-                <FormattedMessage id="stashbox.source" />
-                <Icon icon={faExternalLinkAlt} className="ml-2" />
-              </a>
-            </h6>
-          )}
+          {maybeRenderField("name", studio.name, !isNew)}
+          {maybeRenderField("url", studio.url)}
+          {maybeRenderField("parent_studio", studio.parent?.name, false)}
+          {maybeRenderLink()}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This fixes two bugs in #3912 that came up in Discord related to using non-stashbox scrapers in the Scene Tagger:

- When you create a new performer, the created performer replaces all performers that were previously about to be associated with a scene.
- And creating a studio does not work at all.

I also found a different bug while trying to reproduce the above issues, where the "Create Studio" dialog still shows the (blank) scraped image and its checkbox even if the scraper doesn't return an image. The simple fix is just to not render the image if the path is missing.