### PR TITLE
Fix urls disappearing when merging scenes

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -165,7 +165,11 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
       new ScrapeResult(dest.code, sources.find((s) => s.code)?.code, !dest.code)
     );
     setURL(
-      new ScrapeResult(dest.urls, sources.find((s) => s.urls)?.urls, !dest.urls?.length)
+      new ScrapeResult(
+        dest.urls,
+        sources.find((s) => s.urls)?.urls,
+        !dest.urls?.length
+      )
     );
     setDate(
       new ScrapeResult(dest.date, sources.find((s) => s.date)?.date, !dest.date)

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -165,7 +165,7 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
       new ScrapeResult(dest.code, sources.find((s) => s.code)?.code, !dest.code)
     );
     setURL(
-      new ScrapeResult(dest.urls, sources.find((s) => s.urls)?.urls, !dest.urls)
+      new ScrapeResult(dest.urls, sources.find((s) => s.urls)?.urls, !dest.urls?.length)
     );
     setDate(
       new ScrapeResult(dest.date, sources.find((s) => s.date)?.date, !dest.date)


### PR DESCRIPTION
URLs are removed during scene merge even though they are visible in the merge dialog.
This at happens when destination scene doesn't have URL set.

This small change fixes it