### PR TITLE
Friendlier Scraper Error Message

### DIFF
--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -108,7 +108,7 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 		if lenientErr != nil {
 			// The error is genuine, so return it
 			logger.Errorf("could not unmarshal json from script output: %v", lenientErr)
-			return fmt.Errorf("could not unmarshal json from script output: %w", lenientErr)
+			return errors.New("Error running scraper script, check the logs for more information")
 		}
 
 		// Lenient decode succeeded, print a warning, but use the decode

--- a/ui/v2.5/src/hooks/Toast.tsx
+++ b/ui/v2.5/src/hooks/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext, createContext } from "react";
+import { Link } from "react-router-dom";
 import { Toast } from "react-bootstrap";
 
 interface IToast {
@@ -49,7 +50,7 @@ export const ToastProvider: React.FC = ({ children }) => {
 function createHookObject(toastFunc: (toast: IToast) => void) {
   return {
     success: toastFunc,
-    error: (error: unknown) => {
+    error: (error: unknown, delay: number = 10000) => {
       /* eslint-disable @typescript-eslint/no-explicit-any, no-console */
       let message: string;
       if (error instanceof Error) {
@@ -58,23 +59,35 @@ function createHookObject(toastFunc: (toast: IToast) => void) {
         message = (error as any).toString();
       } else {
         console.error(error);
-        toastFunc({
-          variant: "danger",
-          header: "Error",
-          content: "Unknown error",
-        });
-        return;
+        message = "Unknown error, check the logs for more information";
       }
 
       console.error(message);
+      let content = maybeAddLinkToErrMessage(message);
       toastFunc({
         variant: "danger",
         header: "Error",
-        content: message,
+        content: content,
+        delay: delay,
       });
       /* eslint-enable @typescript-eslint/no-explicit-any, no-console */
     },
   };
+
+  function maybeAddLinkToErrMessage(error: string): React.ReactNode | string {
+    // This function is a hack to enable the text to be a direct link in the Toast notification
+    if (error.includes("check the logs")) {
+      const msgParts = error.split("check the logs");
+      return (
+        <>
+          {msgParts[0]}
+          <Link to={`/settings?tab=logs`}>check the logs</Link>
+          {msgParts.length > 1 ? msgParts[1] : ""}
+        </>
+      );
+    }
+    return error;
+  }
 }
 
 export const useToast = () => {


### PR DESCRIPTION
A common help request in Discord is users coming with the error message `could not unmarshal json from script output: EOF` after they run a scraper and wondering what to do next.

This leaves that technical message writing to the log, but presents a more useful message to the user, telling them to go look at the logs to see what actual error happened with the scraper.
There's also a hack to linkify the `check the logs` text in the Toast notification to allow the user to go to the logs in case they aren't sure. This will break once server error messages become translatable.
![scraper_error](https://github.com/stashapp/stash/assets/90150289/c7734163-c38e-4b39-aca0-6c56e8ec9143)

It also defaults the error toasts to show for 10 seconds instead of 3. The assumption is that if an error did happen, you want a few seconds to be able to read what it was (or click the link to go to the logs).

I looked into copying the scraper `stderr` to display the actual error in the toast, but it didn't make sense since python can generate very large errors. I thought it better to make sure people are able to get to the logs page.
