### PR TITLE
move item-list-container in detail-body

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -359,11 +359,3 @@ input[type="range"].zoom-slider {
 .tilted {
   transform: rotate(45deg);
 }
-
-.item-list-container {
-  padding-top: 15px;
-
-  @media (max-width: 576px) {
-    overflow-x: hidden;
-  }
-}

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -246,6 +246,14 @@ dd {
     margin: 0;
     padding: 5px 0;
   }
+
+  .item-list-container {
+    padding-top: 15px;
+  
+    @media (max-width: 576px) {
+      overflow-x: hidden;
+    }
+  }
 }
 
 .collapsed .detail-item-value {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -249,7 +249,7 @@ dd {
 
   .item-list-container {
     padding-top: 15px;
-  
+
     @media (max-width: 576px) {
       overflow-x: hidden;
     }


### PR DESCRIPTION
This pull request moves the new .item-list-container style rule into the detail-body SCSS block so it is only applied on the detail pages.