### PR TITLE
Change styling of FolderSelect 

### DIFF
--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -110,6 +110,8 @@
       color: white;
       font-weight: 400;
       padding: 0;
+      position: relative;
+      z-index: 1;
     }
 
     &:last-child::before {


### PR DESCRIPTION
This PR (my first 🎉) should fix #4003 where the .folder-list-item::before padding made the leftmost side of the folder button unclickable, which was a problem with very short paths.