### PR TITLE
Auto Tag Confirmation 

### DIFF
--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
@@ -26,6 +26,7 @@ import {
   faCogs,
   faFolderOpen,
   faQuestionCircle,
+  faTriangleExclamation,
 } from "@fortawesome/free-solid-svg-icons";
 
 interface IIdentifyDialogProps {
@@ -428,7 +429,8 @@ export const IdentifyDialog: React.FC<IIdentifyDialogProps> = ({
     >
       <div>
         <p>
-          <FormattedMessage id="config.tasks.identify.description" />
+          <Icon icon={faTriangleExclamation} size="xl" />
+          <FormattedMessage id="config.tasks.identify.warning" />
         </p>
       </div>
       <Form>

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
@@ -28,8 +28,6 @@ import {
   faQuestionCircle,
 } from "@fortawesome/free-solid-svg-icons";
 
-const autoTagScraperID = "builtin_autotag";
-
 interface IIdentifyDialogProps {
   selectedIds?: string[];
   onClose: () => void;

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
@@ -228,26 +228,9 @@ export const IdentifyDialog: React.FC<IIdentifyDialogProps> = ({
       // default to first stash-box instance only
       const stashBox = allSources.find((s) => s.stash_box_endpoint);
 
-      // add auto-tag as well
-      const autoTag = allSources.find(
-        (s) => s.id === `${SCRAPER_PREFIX}${autoTagScraperID}`
-      );
-
       const newSources: IScraperSource[] = [];
       if (stashBox) {
         newSources.push(stashBox);
-      }
-
-      // sanity check - this should always be true
-      if (autoTag) {
-        // don't set organised by default
-        const autoTagCopy = { ...autoTag };
-        autoTagCopy.options = {
-          setOrganized: false,
-          skipMultipleMatches: true,
-          skipSingleNamePerformers: true,
-        };
-        newSources.push(autoTagCopy);
       }
 
       setSources(newSources);
@@ -445,6 +428,11 @@ export const IdentifyDialog: React.FC<IIdentifyDialogProps> = ({
         </Button>
       }
     >
+      <div>
+        <p>
+          <FormattedMessage id="config.tasks.identify.description" />
+        </p>
+      </div>
       <Form>
         {selectionStatus}
         <SourcesList

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/Options.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/Options.tsx
@@ -170,6 +170,9 @@ export const OptionsEditor: React.FC<IOptionsEditor> = ({
             id: "config.tasks.identify.set_organized",
           })}
           defaultValue={defaultOptions?.setOrganized ?? undefined}
+          tooltip={intl.formatMessage({
+            id: "config.tasks.identify.organized",
+          })}
           {...checkboxProps}
         />
       </Form.Group>

--- a/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  IconDefinition,
   faMinus,
   faPencilAlt,
   faPlus,
@@ -15,12 +16,29 @@ interface IDirectorySelectionDialogProps {
   animation?: boolean;
   initialPaths?: string[];
   allowEmpty?: boolean;
+  allowPathSelection?: boolean;
+  message?: string;
+  header?: string;
+  icon?: IconDefinition;
+  acceptButtonText?: string;
+  acceptButtonVariant?: "danger" | "primary" | "secondary";
   onClose: (paths?: string[]) => void;
 }
 
 export const DirectorySelectionDialog: React.FC<
   IDirectorySelectionDialogProps
-> = ({ animation, allowEmpty = false, initialPaths = [], onClose }) => {
+> = ({
+  animation,
+  allowEmpty = false,
+  initialPaths = [],
+  allowPathSelection = true,
+  message,
+  header,
+  icon = faPencilAlt,
+  acceptButtonText,
+  acceptButtonVariant = "primary",
+  onClose,
+}) => {
   const intl = useIntl();
   const { configuration } = React.useContext(ConfigurationContext);
 
@@ -43,14 +61,15 @@ export const DirectorySelectionDialog: React.FC<
     <ModalComponent
       show
       modalProps={{ animation }}
-      disabled={!allowEmpty && paths.length === 0}
-      icon={faPencilAlt}
-      header={intl.formatMessage({ id: "actions.select_folders" })}
+      disabled={!allowEmpty && allowPathSelection && paths.length === 0}
+      icon={icon}
+      header={header ?? intl.formatMessage({ id: "actions.select_folders" })}
       accept={{
         onClick: () => {
           onClose(paths);
         },
-        text: intl.formatMessage({ id: "actions.confirm" }),
+        text: acceptButtonText ?? intl.formatMessage({ id: "actions.confirm" }),
+        variant: acceptButtonVariant,
       }}
       cancel={{
         onClick: () => onClose(),
@@ -78,19 +97,22 @@ export const DirectorySelectionDialog: React.FC<
           </Row>
         ))}
 
-        <FolderSelect
-          currentDirectory={currentDirectory}
-          setCurrentDirectory={(v) => setCurrentDirectory(v)}
-          defaultDirectories={libraryPaths}
-          appendButton={
-            <Button
-              variant="secondary"
-              onClick={() => addPath(currentDirectory)}
-            >
-              <Icon icon={faPlus} />
-            </Button>
-          }
-        />
+        {allowPathSelection ? (
+          <FolderSelect
+            currentDirectory={currentDirectory}
+            setCurrentDirectory={(v) => setCurrentDirectory(v)}
+            defaultDirectories={libraryPaths}
+            appendButton={
+              <Button
+                variant="secondary"
+                onClick={() => addPath(currentDirectory)}
+              >
+                <Icon icon={faPlus} />
+              </Button>
+            }
+          />
+        ) : undefined}
+        {message}
       </div>
     </ModalComponent>
   );

--- a/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
@@ -17,7 +17,7 @@ interface IDirectorySelectionDialogProps {
   initialPaths?: string[];
   allowEmpty?: boolean;
   allowPathSelection?: boolean;
-  message?: string;
+  message?: string | React.ReactNode;
   header?: string;
   icon?: IconDefinition;
   acceptButtonText?: string;

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -19,7 +19,10 @@ import { SettingSection } from "../SettingSection";
 import { BooleanSetting, Setting, SettingGroup } from "../Inputs";
 import { ManualLink } from "src/components/Help/context";
 import { Icon } from "src/components/Shared/Icon";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faQuestionCircle,
+  faTriangleExclamation,
+} from "@fortawesome/free-solid-svg-icons";
 
 interface IAutoTagOptions {
   options: GQL.AutoTagMetadataInput;
@@ -83,6 +86,8 @@ export const LibraryTasks: React.FC = () => {
   const [scanOptions, setScanOptions] = useState<GQL.ScanMetadataInput>({});
   const [autoTagOptions, setAutoTagOptions] =
     useState<GQL.AutoTagMetadataInput>({
+      // Updated per issue #3909 so that new users don't accidentally
+      // auto tag their entire library with performers and studios.
       performers: [],
       studios: [],
       tags: ["*"],
@@ -214,11 +219,20 @@ export const LibraryTasks: React.FC = () => {
       return (
         <DirectorySelectionDialog
           allowPathSelection={dialogOpen.autoTag}
-          message={intl.formatMessage({
-            id: "config.tasks.auto_tag_based_on_filenames",
-          })}
+          message={
+            <>
+              <p>
+                {intl.formatMessage({
+                  id: "config.tasks.auto_tag_based_on_filenames",
+                })}
+              </p>
+              <Icon icon={faTriangleExclamation} size="xl" />
+              {intl.formatMessage({ id: "config.tasks.auto_tag_warning" })}
+            </>
+          }
           header={intl.formatMessage({ id: "actions.auto_tag" })}
-          acceptButtonText={intl.formatMessage({ id: "actions.auto_tag" })}
+          icon={faTriangleExclamation}
+          acceptButtonText={intl.formatMessage({ id: "actions.continue" })}
           acceptButtonVariant="danger"
           onClose={(p) => {
             // undefined means cancelled
@@ -239,7 +253,6 @@ export const LibraryTasks: React.FC = () => {
         />
       );
     }
-    return;
   }
 
   async function runAutoTag(paths?: string[]) {
@@ -354,7 +367,14 @@ export const LibraryTasks: React.FC = () => {
               </ManualLink>
             </>
           }
-          subHeadingID="config.tasks.identify.description"
+          subHeading={
+            <>
+              {intl.formatMessage({ id: "config.tasks.identify.description" })}
+              <br />
+              <Icon icon={faTriangleExclamation} />
+              {intl.formatMessage({ id: "config.tasks.identify.warning" })}
+            </>
+          }
         >
           <Button
             variant="secondary"
@@ -377,7 +397,16 @@ export const LibraryTasks: React.FC = () => {
                 </ManualLink>
               </>
             ),
-            subHeadingID: "config.tasks.auto_tag_based_on_filenames",
+            subHeading: (
+              <>
+                {intl.formatMessage({
+                  id: "config.tasks.auto_tag_based_on_filenames",
+                })}
+                <br />
+                <Icon icon={faTriangleExclamation} />
+                {intl.formatMessage({ id: "config.tasks.auto_tag_warning" })}
+              </>
+            ),
           }}
           topLevel={
             <>

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ImageInput } from "./ImageInput";
 import cx from "classnames";
+import { Icon } from "./Icon";
+import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 
 interface IProps {
   objectName?: string;
@@ -28,6 +30,7 @@ interface IProps {
 export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
   const intl = useIntl();
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+  const [isAutoTagAlertOpen, setIsAutoTagAlertOpen] = useState<boolean>(false);
 
   function renderEditButton() {
     if (props.isNew) return;
@@ -89,22 +92,48 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
   function renderAutoTagButton() {
     if (props.isNew || props.isEditing) return;
 
-    if (props.onAutoTag) {
-      return (
-        <div>
+    return (
+      <div>
+        <Button variant="secondary" onClick={() => setIsAutoTagAlertOpen(true)}>
+          <FormattedMessage id="actions.auto_tag" />
+        </Button>
+      </div>
+    );
+  }
+
+  function renderAutoTagAlert() {
+    return (
+      <Modal show={isAutoTagAlertOpen}>
+        <Modal.Header>
+          <Icon icon={faTriangleExclamation} />
+          <span>
+            <FormattedMessage id="actions.confirm" />
+          </span>
+        </Modal.Header>
+        <Modal.Body>
+          <FormattedMessage id="config.tasks.auto_tag_based_on_filenames" />
+        </Modal.Body>
+        <Modal.Footer>
           <Button
-            variant="secondary"
+            variant="danger"
             onClick={() => {
               if (props.onAutoTag) {
                 props.onAutoTag();
               }
+              setIsAutoTagAlertOpen(false);
             }}
           >
             <FormattedMessage id="actions.auto_tag" />
           </Button>
-        </div>
-      );
-    }
+          <Button
+            variant="secondary"
+            onClick={() => setIsAutoTagAlertOpen(false)}
+          >
+            <FormattedMessage id="actions.cancel" />
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
   }
 
   function renderDeleteAlert() {
@@ -171,6 +200,7 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
         </div>
       ) : null}
       {renderAutoTagButton()}
+      {renderAutoTagAlert()}
       {props.customButtons}
       {renderSaveButton()}
       {renderDeleteButton()}

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -107,11 +107,15 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
         <Modal.Header>
           <Icon icon={faTriangleExclamation} />
           <span>
-            <FormattedMessage id="actions.confirm" />
+            <FormattedMessage id="actions.auto_tag" />
           </span>
         </Modal.Header>
         <Modal.Body>
-          <FormattedMessage id="config.tasks.auto_tag_based_on_filenames" />
+          <p>
+            <FormattedMessage id="config.tasks.auto_tag_based_on_filenames" />
+          </p>
+          <Icon icon={faTriangleExclamation} size="xl" />
+          <FormattedMessage id="config.tasks.auto_tag_warning" />
         </Modal.Body>
         <Modal.Footer>
           <Button
@@ -123,7 +127,7 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
               setIsAutoTagAlertOpen(false);
             }}
           >
-            <FormattedMessage id="actions.auto_tag" />
+            <FormattedMessage id="actions.continue" />
           </Button>
           <Button
             variant="secondary"

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -114,8 +114,14 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
           <p>
             <FormattedMessage id="config.tasks.auto_tag_based_on_filenames" />
           </p>
-          <Icon icon={faTriangleExclamation} size="xl" />
-          <FormattedMessage id="config.tasks.auto_tag_warning" />
+          <p>
+            <Icon icon={faTriangleExclamation} size="xl" />
+            <FormattedMessage id="config.tasks.auto_tag_warning" />
+          </p>
+          <FormattedMessage id="config.tasks.auto_tag.matching" />
+          <ul>
+            <li>{props.objectName}</li>
+          </ul>
         </Modal.Body>
         <Modal.Footer>
           <Button

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -100,8 +100,8 @@
 .folder-list {
   list-style-type: none;
   margin: 0;
-  padding-top: 1rem;
   padding-bottom: 1rem;
+  padding-top: 1rem;
 
   &-item {
     white-space: nowrap;

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -101,6 +101,7 @@
   list-style-type: none;
   margin: 0;
   padding-top: 1rem;
+  padding-bottom: 1rem;
 
   &-item {
     white-space: nowrap;
@@ -367,6 +368,7 @@ div.react-datepicker {
 
   .react-datepicker__day {
     color: $text-color;
+
     &.react-datepicker__day--disabled {
       color: $text-muted;
     }
@@ -436,6 +438,7 @@ div.react-datepicker {
     }
   }
 }
+
 /* stylelint-enable */
 
 #date-picker-portal .react-datepicker-popper {

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -202,7 +202,7 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
       );
     }
 
-    function renderAutoTagAlert(tag: any) {
+    function renderAutoTagAlert(tag: GQL.TagDataFragment) {
       return (
         <Modal show={isAutoTagAlertOpen}>
           <Modal.Header>

--- a/ui/v2.5/src/docs/en/Manual/Identify.md
+++ b/ui/v2.5/src/docs/en/Manual/Identify.md
@@ -1,10 +1,12 @@
 # Identify
 
-This task iterates through your Scenes and attempts to identify the scene using a selection of scraping sources.
+This task iterates through your Scenes and attempts to identify the scene using a selection of scraping sources. It will skip scenes marked as organized.
 
 This task accepts one or more scraper sources. Valid scraper sources for the Identify task are stash-box instances, and scene scrapers which support scraping via Scene Fragment. The order of the sources may be rearranged.
 
 For each Scene, the Identify task iterates through the scraper sources, in the order provided, and tries to identify the scene using each source. If a result is found in a source, then the Scene is updated, and no further sources are checked for that scene.
+
+Unexpected incorrect matches cannot be undone and it may be hard to figure out which ones they are.
 
 ## Options
 

--- a/ui/v2.5/src/docs/en/Manual/Identify.md
+++ b/ui/v2.5/src/docs/en/Manual/Identify.md
@@ -6,7 +6,7 @@ This task accepts one or more scraper sources. Valid scraper sources for the Ide
 
 For each Scene, the Identify task iterates through the scraper sources, in the order provided, and tries to identify the scene using each source. If a result is found in a source, then the Scene is updated, and no further sources are checked for that scene.
 
-Unexpected incorrect matches cannot be undone and it may be hard to figure out which ones they are.
+Some incorrect matches can be expected and they cannot be undone. It may also be hard to figure out which ones they are.
 
 ## Options
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -415,7 +415,8 @@
       "anonymising_database": "Anonymising database",
       "auto_tag": {
         "auto_tagging_all_paths": "Auto Tagging all paths",
-        "auto_tagging_paths": "Auto Tagging the following paths"
+        "auto_tagging_paths": "Auto Tagging the following paths",
+        "matching": "Matching:"
       },
       "auto_tag_based_on_filenames": "Auto Tag analyzes your file paths and attempts to find matches with your existing metadata (tags, studios, or performers).",
       "auto_tag_warning": "This process cannot be undone and may match incorrect false positives, particularly with non-unique tags and names.",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -417,7 +417,7 @@
         "auto_tagging_all_paths": "Auto Tagging all paths",
         "auto_tagging_paths": "Auto Tagging the following paths"
       },
-      "auto_tag_based_on_filenames": "Auto-tag content based on file paths.",
+      "auto_tag_based_on_filenames": "Auto Tag analyzes your file paths and attempts to find matches with your existing metadata (tags, studios, or performers). This process cannot be undone and may match incorrect false positives, particularly with non-unique tags and names.",
       "auto_tagging": "Auto Tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",
@@ -448,7 +448,7 @@
         "and_create_missing": "and create missing",
         "create_missing": "Create missing",
         "default_options": "Default Options",
-        "description": "Automatically set scene metadata using stash-box and scraper sources.",
+        "description": "Automatically set scene metadata using stash-box and scraper sources. Unexpected incorrect matches cannot be undone.",
         "explicit_set_description": "The following options will be used where not overridden in the source-specific options.",
         "field": "Field",
         "field_behaviour": "{strategy} {field}",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -417,7 +417,8 @@
         "auto_tagging_all_paths": "Auto Tagging all paths",
         "auto_tagging_paths": "Auto Tagging the following paths"
       },
-      "auto_tag_based_on_filenames": "Auto Tag analyzes your file paths and attempts to find matches with your existing metadata (tags, studios, or performers). This process cannot be undone and may match incorrect false positives, particularly with non-unique tags and names.",
+      "auto_tag_based_on_filenames": "Auto Tag analyzes your file paths and attempts to find matches with your existing metadata (tags, studios, or performers).",
+      "auto_tag_warning": "This process cannot be undone and may match incorrect false positives, particularly with non-unique tags and names.",
       "auto_tagging": "Auto Tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",
@@ -448,7 +449,7 @@
         "and_create_missing": "and create missing",
         "create_missing": "Create missing",
         "default_options": "Default Options",
-        "description": "Automatically set scene metadata using stash-box and scraper sources. Unexpected incorrect matches cannot be undone.",
+        "description": "Automatically set scene metadata using stash-box and scraper sources.",
         "explicit_set_description": "The following options will be used where not overridden in the source-specific options.",
         "field": "Field",
         "field_behaviour": "{strategy} {field}",
@@ -470,7 +471,8 @@
         "tag_skipped_matches": "Tag skipped matches with",
         "tag_skipped_matches_tooltip": "Create a tag like 'Identify: Multiple Matches' that you can filter for in the Scene Tagger view and choose the correct match by hand",
         "tag_skipped_performers": "Tag skipped performers with",
-        "tag_skipped_performer_tooltip": "Create a tag like 'Identify: Single Name Performer' that you can filter for in the Scene Tagger view and choose how you want to handle these performers"
+        "tag_skipped_performer_tooltip": "Create a tag like 'Identify: Single Name Performer' that you can filter for in the Scene Tagger view and choose how you want to handle these performers",
+        "warning": "Some incorrect matches can be expected and they cannot be undone."
       },
       "import_from_exported_json": "Import from exported JSON in the metadata directory. Wipes the existing database.",
       "incremental_import": "Incremental import from a supplied export zip file.",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -459,6 +459,7 @@
         "identifying_from_paths": "Identifying scenes from the following paths",
         "identifying_scenes": "Identifying {num} {scene}",
         "include_male_performers": "Include male performers",
+        "organized": "Scenes marked as organized will be skipped by Identify and Autotag",
         "set_cover_images": "Set cover images",
         "set_organized": "Set organised flag",
         "skip_multiple_matches": "Skip matches that have more than one result",


### PR DESCRIPTION
Resolves #3909 

Implements most of the suggestions from the ticket, except for a button to hide the dialogue in the future. I didn't see any similar functionality in Stash, and don't want to incorrectly build new features.

- Updated descriptions for Auto Tag and Identify with more explanation
- Auto Tag buttons should all have the confirmation dialog
- For new users, in the Settings their Performers and Studios will be disabled by default for Auto Tag
- For new users, removed Auto Tag as a default source from Identify

Other

- Refactored `DirectorySettingDialog.tsx` to allow customization and potentially hide the directory picker. This was copied from how the Clean task dialogs were doing their own directory picking, and the Clean task was refactored to use the updated `DirectorySettingDialog.tsx`. So now you can have a directory picking dialog that doesn't show you any directories, but all of the directory picking code is no longer duplicated for the Clean task.
- Added slight padding to the bottom of the directory listing to remove an inline scroll bar that was showing on my system

![autotag2](https://github.com/stashapp/stash/assets/90150289/f65ab8b5-dda1-4c80-93c9-73ac8c3feb8c)
![autotag4](https://github.com/stashapp/stash/assets/90150289/29d89a19-bc88-4625-b269-3d808c58ef40)
![autotag3](https://github.com/stashapp/stash/assets/90150289/6e108375-43ed-4b96-8dde-971f3b0c4333)
