### PR TITLE
Make folder select easier to click

### DIFF
--- a/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
@@ -78,7 +78,9 @@ export const FolderSelect: React.FC<IProps> = ({
     currentDirectory && data?.directory?.parent ? (
       <li className="folder-list-parent folder-list-item">
         <Button variant="link" onClick={() => goUp()}>
-          <FormattedMessage id="setup.folder.up_dir" />
+          <span>
+            <FormattedMessage id="setup.folder.up_dir" />
+          </span>
         </Button>
       </li>
     ) : null;
@@ -128,7 +130,7 @@ export const FolderSelect: React.FC<IProps> = ({
             return (
               <li key={path} className="folder-list-item">
                 <Button variant="link" onClick={() => setInstant(path)}>
-                  {path}
+                  <span>{path}</span>
                 </Button>
               </li>
             );

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -105,18 +105,20 @@
   &-item {
     white-space: nowrap;
 
-    .btn-link {
+    .btn {
       border: none;
       color: white;
       font-weight: 400;
       padding: 0;
+      text-align: left;
+      width: 100%;
     }
 
-    &:last-child::before {
+    &:last-child .btn span::before {
       content: "└ \1F4C1";
     }
 
-    &::before {
+    .btn span::before {
       content: "├ \1F4C1";
       display: inline-block;
       padding-right: 1rem;
@@ -125,7 +127,7 @@
   }
 
   &-parent {
-    &::before {
+    .btn span::before {
       visibility: hidden;
     }
 


### PR DESCRIPTION
Fixes #4003 

Obsoletes #4015 

Moves the folder select icon into the button and makes the button use the entire width so that the option can be clicked anywhere along the row.