### PR TITLE
Fix performer tag sort

### DIFF
--- a/internal/identify/scene_test.go
+++ b/internal/identify/scene_test.go
@@ -1,7 +1,6 @@
 package identify
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"strconv"
@@ -770,7 +769,7 @@ func Test_sceneRelationships_cover(t *testing.T) {
 				},
 			}
 
-			got, err := tr.cover(context.TODO())
+			got, err := tr.cover(testCtx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sceneRelationships.cover() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -1034,7 +1034,9 @@ func (qb *PerformerStore) tagsRepository() *joinRepository {
 			tableName: performersTagsTable,
 			idColumn:  performerIDColumn,
 		},
-		fkColumn: tagIDColumn,
+		fkColumn:     tagIDColumn,
+		foreignTable: tagTable,
+		orderBy:      "tags.name ASC",
 	}
 }
 


### PR DESCRIPTION
This is a straightforward fix for a bug that came up in Discord, where the performer tag list is not sorted correctly (sorted by tag ID). This simply adds an `orderBy` to the `joinRepository` to sort the list by name, which is in line with the other tag lists (scenes, galleries, images).

I also had a completely unrelated test fail when running `make validate`, which I've fixed - not sure how that slipped through.