### PR TITLE
Preview scrubber

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -32,7 +32,6 @@
     "@silvermine/videojs-airplay": "^1.2.0",
     "@silvermine/videojs-chromecast": "^1.4.1",
     "apollo-upload-client": "^17.0.0",
-    "axios": "^1.3.3",
     "base64-blob": "^1.4.1",
     "bootstrap": "^4.6.2",
     "classnames": "^2.3.2",

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayerScrubber.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayerScrubber.tsx
@@ -6,15 +6,14 @@ import React, {
   useCallback,
 } from "react";
 import { Button } from "react-bootstrap";
-import axios from "axios";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { WebVTT } from "videojs-vtt.js";
 import { Icon } from "src/components/Shared/Icon";
 import {
   faChevronRight,
   faChevronLeft,
 } from "@fortawesome/free-solid-svg-icons";
+import { useSpriteInfo } from "src/hooks/sprite";
 
 interface IScenePlayerScrubberProps {
   file: GQL.VideoFileDataFragment;
@@ -27,42 +26,6 @@ interface IScenePlayerScrubberProps {
 interface ISceneSpriteItem {
   style: CSSProperties;
   time: string;
-}
-
-interface ISceneSpriteInfo {
-  url: string;
-  start: number;
-  end: number;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
-
-async function fetchSpriteInfo(vttPath: string) {
-  const response = await axios.get<string>(vttPath, { responseType: "text" });
-
-  const sprites: ISceneSpriteInfo[] = [];
-
-  const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
-  parser.oncue = (cue: VTTCue) => {
-    const match = cue.text.match(/^([^#]*)#xywh=(\d+),(\d+),(\d+),(\d+)$/i);
-    if (!match) return;
-
-    sprites.push({
-      url: new URL(match[1], vttPath).href,
-      start: cue.startTime,
-      end: cue.endTime,
-      x: Number(match[2]),
-      y: Number(match[3]),
-      w: Number(match[4]),
-      h: Number(match[5]),
-    });
-  };
-  parser.parse(response.data);
-  parser.flush();
-
-  return sprites;
 }
 
 export const ScenePlayerScrubber: React.FC<IScenePlayerScrubberProps> = ({
@@ -119,34 +82,32 @@ export const ScenePlayerScrubber: React.FC<IScenePlayerScrubberProps> = ({
     [onSeek, file.duration, scrubWidth]
   );
 
+  const spriteInfo = useSpriteInfo(scene.paths.vtt ?? undefined);
   const [spriteItems, setSpriteItems] = useState<ISceneSpriteItem[]>();
 
   useEffect(() => {
-    if (!scene.paths.vtt) return;
-    fetchSpriteInfo(scene.paths.vtt).then((sprites) => {
-      if (!sprites) return;
-      let totalWidth = 0;
-      const newSprites = sprites?.map((sprite, index) => {
-        totalWidth += sprite.w;
-        const left = sprite.w * index;
-        const style = {
-          width: `${sprite.w}px`,
-          height: `${sprite.h}px`,
-          backgroundPosition: `${-sprite.x}px ${-sprite.y}px`,
-          backgroundImage: `url(${sprite.url})`,
-          left: `${left}px`,
-        };
-        const start = TextUtils.secondsToTimestamp(sprite.start);
-        const end = TextUtils.secondsToTimestamp(sprite.end);
-        return {
-          style,
-          time: `${start} - ${end}`,
-        };
-      });
-      setScrubWidth(totalWidth);
-      setSpriteItems(newSprites);
+    if (!spriteInfo) return;
+    let totalWidth = 0;
+    const newSprites = spriteInfo?.map((sprite, index) => {
+      totalWidth += sprite.w;
+      const left = sprite.w * index;
+      const style = {
+        width: `${sprite.w}px`,
+        height: `${sprite.h}px`,
+        backgroundPosition: `${-sprite.x}px ${-sprite.y}px`,
+        backgroundImage: `url(${sprite.url})`,
+        left: `${left}px`,
+      };
+      const start = TextUtils.secondsToTimestamp(sprite.start);
+      const end = TextUtils.secondsToTimestamp(sprite.end);
+      return {
+        style,
+        time: `${start} - ${end}`,
+      };
     });
-  }, [scene]);
+    setScrubWidth(totalWidth);
+    setSpriteItems(newSprites);
+  }, [spriteInfo]);
 
   useEffect(() => {
     const onResize = (entries: ResizeObserverEntry[]) => {

--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -32,11 +32,9 @@ const HoverScrubber: React.FC<IHoverScrubber> = ({
   const indicatorStyle = useMemo(() => {
     if (activeIndex === undefined) return {};
 
-    const left = (activeIndex / totalSprites) * 100;
-    const width = 100 / totalSprites;
+    const width = (activeIndex / totalSprites) * 100;
 
     return {
-      left: `${left}%`,
       width: `${width}%`,
     };
   }, [activeIndex, totalSprites]);
@@ -44,10 +42,11 @@ const HoverScrubber: React.FC<IHoverScrubber> = ({
   return (
     <div className="hover-scrubber">
       <div
-        className="hover-scrubber-indicator"
+        className="hover-scrubber-area"
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
-      >
+      ></div>
+      <div className="hover-scrubber-indicator">
         {activeIndex !== undefined && (
           <div
             className="hover-scrubber-indicator-marker"

--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { useDebounce } from "src/hooks/debounce";
 import { useSpriteInfo } from "src/hooks/sprite";
+import TextUtils from "src/utils/text";
 
 interface IHoverScrubber {
   totalSprites: number;
@@ -45,7 +46,7 @@ const HoverScrubber: React.FC<IHoverScrubber> = ({
         className="hover-scrubber-area"
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
-      ></div>
+      />
       <div className="hover-scrubber-indicator">
         {activeIndex !== undefined && (
           <div
@@ -101,6 +102,18 @@ export const PreviewScrubber: React.FC<IScenePreviewProps> = ({ vttPath }) => {
     };
   }, [spriteInfo, activeIndex]);
 
+  const currentTime = useMemo(() => {
+    if (!spriteInfo || activeIndex === undefined) {
+      return undefined;
+    }
+
+    const sprite = spriteInfo[activeIndex];
+
+    const start = TextUtils.secondsToTimestamp(sprite.start);
+
+    return start;
+  }, [activeIndex, spriteInfo]);
+
   if (!spriteInfo) return null;
 
   return (
@@ -108,6 +121,9 @@ export const PreviewScrubber: React.FC<IScenePreviewProps> = ({ vttPath }) => {
       {activeIndex !== undefined && spriteInfo && (
         <div className="scene-card-preview-image">
           <div className="scrubber-image" style={style}></div>
+          {currentTime !== undefined && (
+            <div className="scrubber-timestamp">{currentTime}</div>
+          )}
         </div>
       )}
       <HoverScrubber

--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo } from "react";
+import { useDebounce } from "src/hooks/debounce";
+import { useSpriteInfo } from "src/hooks/sprite";
+
+interface IHoverScrubber {
+  totalSprites: number;
+  activeIndex: number | undefined;
+  setActiveIndex: (index: number | undefined) => void;
+}
+
+const HoverScrubber: React.FC<IHoverScrubber> = ({
+  totalSprites,
+  activeIndex,
+  setActiveIndex,
+}) => {
+  function onMouseMove(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+    const relatedTarget = e.currentTarget;
+
+    if (relatedTarget !== e.target) return;
+
+    const { width } = relatedTarget.getBoundingClientRect();
+    const x = e.nativeEvent.offsetX;
+
+    const index = Math.floor((x / width) * totalSprites);
+    setActiveIndex(index);
+  }
+
+  function onMouseLeave() {
+    setActiveIndex(undefined);
+  }
+
+  const indicatorStyle = useMemo(() => {
+    if (activeIndex === undefined) return {};
+
+    const left = (activeIndex / totalSprites) * 100;
+    const width = 100 / totalSprites;
+
+    return {
+      left: `${left}%`,
+      width: `${width}%`,
+    };
+  }, [activeIndex, totalSprites]);
+
+  return (
+    <div className="hover-scrubber">
+      <div
+        className="hover-scrubber-indicator"
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+      >
+        {activeIndex !== undefined && (
+          <div
+            className="hover-scrubber-indicator-marker"
+            style={indicatorStyle}
+          ></div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface IScenePreviewProps {
+  vttPath: string | undefined;
+}
+
+export const PreviewScrubber: React.FC<IScenePreviewProps> = ({ vttPath }) => {
+  const [activeIndex, setActiveIndex] = React.useState<number | undefined>();
+
+  const debounceSetActiveIndex = useDebounce(
+    setActiveIndex,
+    [setActiveIndex],
+    10
+  );
+
+  const spriteInfo = useSpriteInfo(vttPath);
+
+  const style = useMemo(() => {
+    if (!spriteInfo || activeIndex === undefined) {
+      return {};
+    }
+
+    const sprite = spriteInfo[activeIndex];
+    const totalWidth = spriteInfo.reduce(
+      (acc, cur) => Math.max(acc, cur.x + cur.w),
+      0
+    );
+    const totalHeight = spriteInfo.reduce(
+      (acc, cur) => Math.max(acc, cur.y + cur.h),
+      0
+    );
+
+    const spriteX = sprite.x / totalWidth;
+    const spriteY = sprite.y / totalHeight;
+
+    const spritesX = Math.floor(totalWidth / sprite.w);
+    const spritesY = Math.floor(totalHeight / sprite.h);
+
+    return {
+      "background-size": `calc(100% * ${spritesX}) calc(100% * ${spritesY})`,
+      backgroundPosition: `calc(${-spriteX} * 100% * ${spritesX}) calc(${-spriteY} * 100% * ${spritesY})`,
+      backgroundImage: `url(${sprite.url})`,
+    };
+  }, [spriteInfo, activeIndex]);
+
+  if (!spriteInfo) return null;
+
+  return (
+    <div className="preview-scrubber">
+      {activeIndex !== undefined && spriteInfo && (
+        <div className="scene-card-preview-image">
+          <div className="scrubber-image" style={style}></div>
+        </div>
+      )}
+      <HoverScrubber
+        totalSprites={81}
+        activeIndex={activeIndex}
+        setActiveIndex={(i) => debounceSetActiveIndex(i)}
+      />
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -25,12 +25,14 @@ import {
   faTag,
 } from "@fortawesome/free-solid-svg-icons";
 import { objectPath, objectTitle } from "src/core/files";
+import { PreviewScrubber } from "./PreviewScrubber";
 
 interface IScenePreviewProps {
   isPortrait: boolean;
   image?: string;
   video?: string;
   soundActive: boolean;
+  vttPath?: string;
 }
 
 export const ScenePreview: React.FC<IScenePreviewProps> = ({
@@ -38,6 +40,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
   video,
   isPortrait,
   soundActive,
+  vttPath,
 }) => {
   const videoEl = useRef<HTMLVideoElement>(null);
 
@@ -72,6 +75,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
         ref={videoEl}
         src={video}
       />
+      <PreviewScrubber vttPath={vttPath} />
     </div>
   );
 };
@@ -404,6 +408,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
             video={props.scene.paths.preview ?? undefined}
             isPortrait={isPortrait()}
             soundActive={configuration?.interface?.soundOnPreview ?? false}
+            vttPath={props.scene.paths.vtt ?? undefined}
           />
           <RatingBanner rating={props.scene.rating100} />
           {maybeRenderSceneSpecsOverlay()}

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import cx from "classnames";
 import * as GQL from "src/core/generated-graphql";
 import { Icon } from "../Shared/Icon";
@@ -33,6 +33,7 @@ interface IScenePreviewProps {
   video?: string;
   soundActive: boolean;
   vttPath?: string;
+  onScrubberClick?: (timestamp: number) => void;
 }
 
 export const ScenePreview: React.FC<IScenePreviewProps> = ({
@@ -41,6 +42,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
   isPortrait,
   soundActive,
   vttPath,
+  onScrubberClick,
 }) => {
   const videoEl = useRef<HTMLVideoElement>(null);
 
@@ -75,7 +77,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
         ref={videoEl}
         src={video}
       />
-      <PreviewScrubber vttPath={vttPath} />
+      <PreviewScrubber vttPath={vttPath} onClick={onScrubberClick} />
     </div>
   );
 };
@@ -94,6 +96,7 @@ interface ISceneCardProps {
 export const SceneCard: React.FC<ISceneCardProps> = (
   props: ISceneCardProps
 ) => {
+  const history = useHistory();
   const { configuration } = React.useContext(ConfigurationContext);
 
   const file = useMemo(
@@ -387,6 +390,18 @@ export const SceneCard: React.FC<ISceneCardProps> = (
       })
     : `/scenes/${props.scene.id}`;
 
+  function onScrubberClick(timestamp: number) {
+    const link = props.queue
+      ? props.queue.makeLink(props.scene.id, {
+          sceneIndex: props.index,
+          continue: cont,
+          start: timestamp,
+        })
+      : `/scenes/${props.scene.id}?t=${timestamp}`;
+
+    history.push(link);
+  }
+
   return (
     <GridCard
       className={`scene-card ${zoomIndex()} ${filelessClass()}`}
@@ -409,6 +424,7 @@ export const SceneCard: React.FC<ISceneCardProps> = (
             isPortrait={isPortrait()}
             soundActive={configuration?.interface?.soundOnPreview ?? false}
             vttPath={props.scene.paths.vtt ?? undefined}
+            onScrubberClick={onScrubberClick}
           />
           <RatingBanner rating={props.scene.rating100} />
           {maybeRenderSceneSpecsOverlay()}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -643,3 +643,34 @@ input[type="range"].blue-slider {
 .scrape-dialog .rating-number.disabled {
   padding-left: 0.5em;
 }
+
+.preview-scrubber {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+
+  .scrubber-image {
+    height: 100%;
+    width: 100%;
+  }
+}
+
+.hover-scrubber {
+  bottom: 0;
+  height: 20px;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+
+  .hover-scrubber-indicator {
+    height: 100%;
+    position: absolute;
+    width: 100%;
+
+    .hover-scrubber-indicator-marker {
+      background-color: rgba(255, 0, 0, 0.5);
+      height: 100%;
+      position: absolute;
+    }
+  }
+}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -649,6 +649,13 @@ input[type="range"].blue-slider {
   position: absolute;
   width: 100%;
 
+  .scene-card-preview-image {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+  }
+
   .scrubber-image {
     height: 100%;
     width: 100%;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -653,6 +653,15 @@ input[type="range"].blue-slider {
     height: 100%;
     width: 100%;
   }
+
+  .scrubber-timestamp {
+    bottom: calc(20px + 0.25rem);
+    font-weight: 400;
+    opacity: 0.75;
+    position: absolute;
+    right: 0.7rem;
+    text-shadow: 0 0 3px #000;
+  }
 }
 
 .hover-scrubber {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -658,19 +658,35 @@ input[type="range"].blue-slider {
 .hover-scrubber {
   bottom: 0;
   height: 20px;
+  overflow: hidden;
   position: absolute;
   width: 100%;
-  z-index: 1;
 
-  .hover-scrubber-indicator {
+  .hover-scrubber-area {
+    cursor: col-resize;
     height: 100%;
     position: absolute;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .hover-scrubber-indicator {
+    background-color: rgba(255, 255, 255, 0.1);
+    bottom: -100%;
+    height: 100%;
+    position: absolute;
+    transition: bottom 0.2s ease-in-out;
     width: 100%;
 
     .hover-scrubber-indicator-marker {
       background-color: rgba(255, 0, 0, 0.5);
-      height: 100%;
+      bottom: 0;
+      height: 5px;
       position: absolute;
     }
+  }
+
+  &:hover .hover-scrubber-indicator {
+    bottom: 0;
   }
 }

--- a/ui/v2.5/src/hooks/sprite.ts
+++ b/ui/v2.5/src/hooks/sprite.ts
@@ -47,6 +47,11 @@ export function useSpriteInfo(vttPath: string | undefined) {
     }
 
     fetch(vttPath).then((response) => {
+      if (!response.ok) {
+        setSpriteInfo(undefined);
+        return;
+      }
+
       response.text().then((text) => {
         setSpriteInfo(getSpriteInfo(vttPath, text));
       });

--- a/ui/v2.5/src/hooks/sprite.ts
+++ b/ui/v2.5/src/hooks/sprite.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { WebVTT } from "videojs-vtt.js";
+
+export interface ISceneSpriteInfo {
+  url: string;
+  start: number;
+  end: number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function getSpriteInfo(vttPath: string, response: string) {
+  const sprites: ISceneSpriteInfo[] = [];
+
+  const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
+  parser.oncue = (cue: VTTCue) => {
+    const match = cue.text.match(/^([^#]*)#xywh=(\d+),(\d+),(\d+),(\d+)$/i);
+    if (!match) return;
+
+    sprites.push({
+      url: new URL(match[1], vttPath).href,
+      start: cue.startTime,
+      end: cue.endTime,
+      x: Number(match[2]),
+      y: Number(match[3]),
+      w: Number(match[4]),
+      h: Number(match[5]),
+    });
+  };
+  parser.parse(response);
+  parser.flush();
+
+  return sprites;
+}
+
+export function useSpriteInfo(vttPath: string | undefined) {
+  const [spriteInfo, setSpriteInfo] = useState<
+    ISceneSpriteInfo[] | undefined
+  >();
+
+  useEffect(() => {
+    if (!vttPath) {
+      setSpriteInfo(undefined);
+      return;
+    }
+
+    fetch(vttPath).then((response) => {
+      response.text().then((text) => {
+        setSpriteInfo(getSpriteInfo(vttPath, text));
+      });
+    });
+  }, [vttPath]);
+
+  return spriteInfo;
+}

--- a/ui/v2.5/src/models/sceneQueue.ts
+++ b/ui/v2.5/src/models/sceneQueue.ts
@@ -9,6 +9,7 @@ export interface IPlaySceneOptions {
   newPage?: number;
   autoPlay?: boolean;
   continue?: boolean;
+  start?: number;
 }
 
 export class SceneQueue {
@@ -116,6 +117,9 @@ export class SceneQueue {
     }
     if (options.continue !== undefined) {
       params.push("continue=" + options.continue);
+    }
+    if (options.start !== undefined) {
+      params.push("t=" + options.start);
     }
     return `/scenes/${sceneID}${params.length ? "?" + params.join("&") : ""}`;
   }


### PR DESCRIPTION
Adds a hoverable control on the bottom edge of the scene preview to allow scrubbing through the scene, using the scene sprite image:

![chrome_QytgLb4DVH](https://github.com/stashapp/stash/assets/53250216/eaac7e3d-25d9-46bd-9de9-429c2001f3e3)

~~TODO - portrait videos are not currently displaying correctly~~
