### PR TITLE
Make x button on badges easier to click

### DIFF
--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -739,8 +739,9 @@ div.dropdown-menu {
     color: $dark-text;
     font-size: 12px;
     line-height: 1rem;
+    margin-right: -0.5rem;
     opacity: 0.5;
-    padding: 0 0 0 0.5rem;
+    padding: 0 0.5rem;
     position: relative;
 
     &:active,


### PR DESCRIPTION
Fixes #4027 

Makes the clickable area of the `x` button on badges extend to the right edge of the badge.