### PR TITLE
Details pages start with populated content tab

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -118,16 +118,21 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
   const [updatePerformer] = usePerformerUpdate();
   const [deletePerformer, { loading: isDestroying }] = usePerformerDestroy();
 
-  var populatedDefaultTab: TabKey = "scenes";
-  if (performer.scene_count == 0) {
-    if (performer.gallery_count != 0) {
-      populatedDefaultTab = "galleries";
-    } else if (performer.image_count != 0) {
-      populatedDefaultTab = "images";
-    } else if (performer.movie_count != 0) {
-      populatedDefaultTab = "movies";
+  const populatedDefaultTab = useMemo(() => {
+    let ret: TabKey = "scenes";
+    if (performer.scene_count == 0) {
+      if (performer.gallery_count != 0) {
+        ret = "galleries";
+      } else if (performer.image_count != 0) {
+        ret = "images";
+      } else if (performer.movie_count != 0) {
+        ret = "movies";
+      }
     }
-  }
+
+    return ret;
+  }, [performer]);
+
   if (tabKey === defaultTab) {
     tabKey = populatedDefaultTab;
   }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -57,6 +57,7 @@ interface IPerformerParams {
 }
 
 const validTabs = [
+  "default",
   "scenes",
   "galleries",
   "images",
@@ -65,7 +66,7 @@ const validTabs = [
 ] as const;
 type TabKey = (typeof validTabs)[number];
 
-const defaultTab: TabKey = "scenes";
+const defaultTab: TabKey = "default";
 
 function isTabKey(tab: string): tab is TabKey {
   return validTabs.includes(tab as TabKey);
@@ -117,11 +118,25 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
   const [updatePerformer] = usePerformerUpdate();
   const [deletePerformer, { loading: isDestroying }] = usePerformerDestroy();
 
+  var populatedDefaultTab: TabKey = "scenes";
+  if (performer.scene_count == 0) {
+    if (performer.gallery_count != 0) {
+      populatedDefaultTab = "galleries";
+    } else if (performer.image_count != 0) {
+      populatedDefaultTab = "images";
+    } else if (performer.movie_count != 0) {
+      populatedDefaultTab = "movies";
+    }
+  }
+  if (tabKey === defaultTab) {
+    tabKey = populatedDefaultTab;
+  }
+
   function setTabKey(newTabKey: string | null) {
-    if (!newTabKey) newTabKey = defaultTab;
+    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
     if (newTabKey === tabKey) return;
 
-    if (newTabKey === defaultTab) {
+    if (newTabKey === populatedDefaultTab) {
       history.replace(`/performers/${performer.id}`);
     } else if (isTabKey(newTabKey)) {
       history.replace(`/performers/${performer.id}/${newTabKey}`);

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -1,5 +1,5 @@
 import { Button, Tabs, Tab } from "react-bootstrap";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -113,20 +113,32 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
   const movieCount =
     (showAllCounts ? studio.movie_count_all : studio.movie_count) ?? 0;
 
-  var populatedDefaultTab: TabKey = "scenes";
-  if (sceneCount == 0) {
-    if (galleryCount != 0) {
-      populatedDefaultTab = "galleries";
-    } else if (imageCount != 0) {
-      populatedDefaultTab = "images";
-    } else if (performerCount != 0) {
-      populatedDefaultTab = "performers";
-    } else if (movieCount != 0) {
-      populatedDefaultTab = "movies";
-    } else if (studio.child_studios.length != 0) {
-      populatedDefaultTab = "childstudios";
+  const populatedDefaultTab = useMemo(() => {
+    let ret: TabKey = "scenes";
+    if (sceneCount == 0) {
+      if (galleryCount != 0) {
+        ret = "galleries";
+      } else if (imageCount != 0) {
+        ret = "images";
+      } else if (performerCount != 0) {
+        ret = "performers";
+      } else if (movieCount != 0) {
+        ret = "movies";
+      } else if (studio.child_studios.length != 0) {
+        ret = "childstudios";
+      }
     }
-  }
+
+    return ret;
+  }, [
+    sceneCount,
+    galleryCount,
+    imageCount,
+    performerCount,
+    movieCount,
+    studio,
+  ]);
+
   if (tabKey === defaultTab) {
     tabKey = populatedDefaultTab;
   }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -57,6 +57,7 @@ interface IStudioParams {
 }
 
 const validTabs = [
+  "default",
   "scenes",
   "galleries",
   "images",
@@ -66,7 +67,7 @@ const validTabs = [
 ] as const;
 type TabKey = (typeof validTabs)[number];
 
-const defaultTab: TabKey = "scenes";
+const defaultTab: TabKey = "default";
 
 function isTabKey(tab: string): tab is TabKey {
   return validTabs.includes(tab as TabKey);
@@ -111,6 +112,24 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
     (showAllCounts ? studio.performer_count_all : studio.performer_count) ?? 0;
   const movieCount =
     (showAllCounts ? studio.movie_count_all : studio.movie_count) ?? 0;
+
+  var populatedDefaultTab: TabKey = "scenes";
+  if (sceneCount == 0) {
+    if (galleryCount != 0) {
+      populatedDefaultTab = "galleries";
+    } else if (imageCount != 0) {
+      populatedDefaultTab = "images";
+    } else if (performerCount != 0) {
+      populatedDefaultTab = "performers";
+    } else if (movieCount != 0) {
+      populatedDefaultTab = "movies";
+    } else if (studio.child_studios.length != 0) {
+      populatedDefaultTab = "childstudios";
+    }
+  }
+  if (tabKey === defaultTab) {
+    tabKey = populatedDefaultTab;
+  }
 
   // set up hotkeys
   useEffect(() => {
@@ -243,10 +262,10 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
   }
 
   function setTabKey(newTabKey: string | null) {
-    if (!newTabKey) newTabKey = defaultTab;
+    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
     if (newTabKey === tabKey) return;
 
-    if (newTabKey === defaultTab) {
+    if (newTabKey === populatedDefaultTab) {
       history.replace(`/studios/${studio.id}`);
     } else if (isTabKey(newTabKey)) {
       history.replace(`/studios/${studio.id}/${newTabKey}`);

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -53,6 +53,7 @@ interface ITagParams {
 }
 
 const validTabs = [
+  "default",
   "scenes",
   "images",
   "galleries",
@@ -61,7 +62,7 @@ const validTabs = [
 ] as const;
 type TabKey = (typeof validTabs)[number];
 
-const defaultTab: TabKey = "scenes";
+const defaultTab: TabKey = "default";
 
 function isTabKey(tab: string): tab is TabKey {
   return validTabs.includes(tab as TabKey);
@@ -107,11 +108,27 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
   const performerCount =
     (showAllCounts ? tag.performer_count_all : tag.performer_count) ?? 0;
 
+  var populatedDefaultTab: TabKey = "scenes";
+  if (sceneCount == 0) {
+    if (imageCount != 0) {
+      populatedDefaultTab = "images";
+    } else if (galleryCount != 0) {
+      populatedDefaultTab = "galleries";
+    } else if (sceneMarkerCount != 0) {
+      populatedDefaultTab = "markers";
+    } else if (performerCount != 0) {
+      populatedDefaultTab = "performers";
+    }
+  }
+  if (tabKey === defaultTab) {
+    tabKey = populatedDefaultTab;
+  }
+
   function setTabKey(newTabKey: string | null) {
-    if (!newTabKey) newTabKey = defaultTab;
+    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
     if (newTabKey === tabKey) return;
 
-    if (newTabKey === defaultTab) {
+    if (newTabKey === populatedDefaultTab) {
       history.replace(`/tags/${tag.id}`);
     } else if (isTabKey(newTabKey)) {
       history.replace(`/tags/${tag.id}/${newTabKey}`);

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -1,5 +1,5 @@
 import { Tabs, Tab, Dropdown, Button } from "react-bootstrap";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -108,18 +108,23 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
   const performerCount =
     (showAllCounts ? tag.performer_count_all : tag.performer_count) ?? 0;
 
-  var populatedDefaultTab: TabKey = "scenes";
-  if (sceneCount == 0) {
-    if (imageCount != 0) {
-      populatedDefaultTab = "images";
-    } else if (galleryCount != 0) {
-      populatedDefaultTab = "galleries";
-    } else if (sceneMarkerCount != 0) {
-      populatedDefaultTab = "markers";
-    } else if (performerCount != 0) {
-      populatedDefaultTab = "performers";
+  const populatedDefaultTab = useMemo(() => {
+    let ret: TabKey = "scenes";
+    if (sceneCount == 0) {
+      if (imageCount != 0) {
+        ret = "images";
+      } else if (galleryCount != 0) {
+        ret = "galleries";
+      } else if (sceneMarkerCount != 0) {
+        ret = "markers";
+      } else if (performerCount != 0) {
+        ret = "performers";
+      }
     }
-  }
+
+    return ret;
+  }, [sceneCount, imageCount, galleryCount, sceneMarkerCount, performerCount]);
+
   if (tabKey === defaultTab) {
     tabKey = populatedDefaultTab;
   }


### PR DESCRIPTION
This has bothered me for a while, and I think there was also a ticket once, but not by me and I was not able to find it.

This Commit simply makes it that if you open the details page of a tag, a studio or a performer, instead of always showing the scenes of this organization unit, it will check whether it even has a scene to begin with. If there isn't one, it will show the first thing it has, going through the available media types from left to right (so for example performer will default to scene->gallery->image->movie). If there is simply no media associated with this organization unit, it defaults to scene again to minimize impact in general.
The only exceptional thing here would be the studio details page, which has the childrens as a tab. These are handled as if they were a media type, and will become the default tab if no other media is associated with the studio.

I think this is a pretty uncontroversial commit, but if there are questions don't hesitate to ask. 

It will (hopefully) make life easier for people managing more diverse kinds of media types with stash.