### PR TITLE
Default Filter for Links & Details

### DIFF
--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -39,6 +39,8 @@ export enum PersistanceLevel {
   NONE,
   // load default query, don't load or persist display mode
   ALL,
+  // load default view without the query
+  SAVEDVIEW,
   // load and persist display mode only
   VIEW,
 }
@@ -622,6 +624,29 @@ export function makeItemList<T extends QueryResult, E extends IDataItem>({
               newFilter.configureFromJSON(
                 defaultFilter.findDefaultFilter.filter
               );
+            } catch (err) {
+              console.log(err);
+              // ignore
+            }
+            // #1507 - reset random seed when loaded
+            newFilter.randomSeed = -1;
+          }
+        }
+      } else if (persistState === PersistanceLevel.SAVEDVIEW) {
+        // only set default filter if uninitialised
+        if (loadDefault) {
+          // wait until default filter is loaded
+          if (defaultFilterLoading) return;
+
+          if (defaultFilter?.findDefaultFilter) {
+            newFilter.currentPage = 1;
+            try {
+              let { criteria: criteria } = newFilter;
+              newFilter.configureFromJSON(
+                defaultFilter.findDefaultFilter.filter
+              );
+              newFilter.criteria = criteria;
+              newFilter.searchTerm = "";
             } catch (err) {
               console.log(err);
               // ignore

--- a/ui/v2.5/src/components/Movies/MovieList.tsx
+++ b/ui/v2.5/src/components/Movies/MovieList.tsx
@@ -34,6 +34,7 @@ const MovieItemList = makeItemList({
 
 interface IMovieList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
+  persistState?: PersistanceLevel;
   alterQuery?: boolean;
 }
 

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -22,6 +22,10 @@ import { RatingBanner } from "../Shared/RatingBanner";
 import cx from "classnames";
 import { usePerformerUpdate } from "src/core/StashService";
 import { ILabeledId } from "src/models/list-filter/types";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 export interface IPerformerCardExtraCriteria {
   scenes?: Criterion<CriterionValue>[];
@@ -63,6 +67,22 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   const ageString = intl.formatMessage(
     { id: ageL10nId },
     { age, years_old: ageL10String }
+  );
+
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
+  const imageDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Images
+  );
+  const galleryDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Galleries
+  );
+  const movieDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Movies
+  );
+  const performerDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Performers
   );
 
   const [updatePerformer] = usePerformerUpdate();
@@ -109,7 +129,8 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
         url={NavUtils.makePerformerScenesUrl(
           performer,
           extraCriteria?.performer,
-          extraCriteria?.scenes
+          extraCriteria?.scenes,
+          sceneDefaultFilter
         )}
       />
     );
@@ -126,7 +147,8 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
         url={NavUtils.makePerformerImagesUrl(
           performer,
           extraCriteria?.performer,
-          extraCriteria?.images
+          extraCriteria?.images,
+          imageDefaultFilter
         )}
       />
     );
@@ -143,7 +165,8 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
         url={NavUtils.makePerformerGalleriesUrl(
           performer,
           extraCriteria?.performer,
-          extraCriteria?.galleries
+          extraCriteria?.galleries,
+          galleryDefaultFilter
         )}
       />
     );
@@ -192,7 +215,8 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
         url={NavUtils.makePerformerMoviesUrl(
           performer,
           extraCriteria?.performer,
-          extraCriteria?.movies
+          extraCriteria?.movies,
+          movieDefaultFilter
         )}
       />
     );
@@ -233,7 +257,12 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   function maybeRenderFlag() {
     if (performer.country) {
       return (
-        <Link to={NavUtils.makePerformersCountryUrl(performer)}>
+        <Link
+          to={NavUtils.makePerformersCountryUrl(
+            performer,
+            performerDefaultFilter
+          )}
+        >
           <CountryFlag
             className="performer-card__country-flag"
             country={performer.country}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerGalleriesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GalleryList } from "src/components/Galleries/GalleryList";
 import { usePerformerFilterHook } from "src/core/performers";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IPerformerDetailsProps {
   active: boolean;
@@ -13,5 +14,11 @@ export const PerformerGalleriesPanel: React.FC<IPerformerDetailsProps> = ({
   performer,
 }) => {
   const filterHook = usePerformerFilterHook(performer);
-  return <GalleryList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <GalleryList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerImagesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerImagesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { ImageList } from "src/components/Images/ImageList";
 import { usePerformerFilterHook } from "src/core/performers";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IPerformerImagesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const PerformerImagesPanel: React.FC<IPerformerImagesPanel> = ({
   performer,
 }) => {
   const filterHook = usePerformerFilterHook(performer);
-  return <ImageList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <ImageList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerMoviesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerMoviesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { MovieList } from "src/components/Movies/MovieList";
 import { usePerformerFilterHook } from "src/core/performers";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IPerformerDetailsProps {
   active: boolean;
@@ -13,5 +14,11 @@ export const PerformerMoviesPanel: React.FC<IPerformerDetailsProps> = ({
   performer,
 }) => {
   const filterHook = usePerformerFilterHook(performer);
-  return <MovieList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <MovieList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { SceneList } from "src/components/Scenes/SceneList";
 import { usePerformerFilterHook } from "src/core/performers";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IPerformerDetailsProps {
   active: boolean;
@@ -13,5 +14,11 @@ export const PerformerScenesPanel: React.FC<IPerformerDetailsProps> = ({
   performer,
 }) => {
   const filterHook = usePerformerFilterHook(performer);
-  return <SceneList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <SceneList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Performers/PerformerDetails/performerAppearsWithPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/performerAppearsWithPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { PerformerList } from "src/components/Performers/PerformerList";
 import { usePerformerFilterHook } from "src/core/performers";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IPerformerDetailsProps {
   active: boolean;
@@ -28,6 +29,7 @@ export const PerformerAppearsWithPanel: React.FC<IPerformerDetailsProps> = ({
       filterHook={filterHook}
       extraCriteria={extraCriteria}
       alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
     />
   );
 };

--- a/ui/v2.5/src/components/Performers/PerformerListTable.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerListTable.tsx
@@ -9,6 +9,10 @@ import { Icon } from "../Shared/Icon";
 import NavUtils from "src/utils/navigation";
 import { faHeart } from "@fortawesome/free-solid-svg-icons";
 import { cmToImperial } from "src/utils/units";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface IPerformerListTableProps {
   performers: GQL.PerformerDataFragment[];
@@ -18,6 +22,15 @@ export const PerformerListTable: React.FC<IPerformerListTableProps> = (
   props: IPerformerListTableProps
 ) => {
   const intl = useIntl();
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
+  const imageDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Images
+  );
+  const galleryDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Galleries
+  );
 
   const formatHeight = (height?: number | null) => {
     if (!height) {
@@ -83,17 +96,38 @@ export const PerformerListTable: React.FC<IPerformerListTableProps> = (
         )}
       </td>
       <td>
-        <Link to={NavUtils.makePerformerScenesUrl(performer)}>
+        <Link
+          to={NavUtils.makePerformerScenesUrl(
+            performer,
+            undefined,
+            undefined,
+            sceneDefaultFilter
+          )}
+        >
           <h6>{performer.scene_count}</h6>
         </Link>
       </td>
       <td>
-        <Link to={NavUtils.makePerformerImagesUrl(performer)}>
+        <Link
+          to={NavUtils.makePerformerImagesUrl(
+            performer,
+            undefined,
+            undefined,
+            imageDefaultFilter
+          )}
+        >
           <h6>{performer.image_count}</h6>
         </Link>
       </td>
       <td>
-        <Link to={NavUtils.makePerformerGalleriesUrl(performer)}>
+        <Link
+          to={NavUtils.makePerformerGalleriesUrl(
+            performer,
+            undefined,
+            undefined,
+            galleryDefaultFilter
+          )}
+        >
           <h6>{performer.gallery_count}</h6>
         </Link>
       </td>

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -25,6 +25,10 @@ import {
   faTag,
 } from "@fortawesome/free-solid-svg-icons";
 import { objectPath, objectTitle } from "src/core/files";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface IScenePreviewProps {
   isPortrait: boolean;
@@ -91,6 +95,9 @@ export const SceneCard: React.FC<ISceneCardProps> = (
   props: ISceneCardProps
 ) => {
   const { configuration } = React.useContext(ConfigurationContext);
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
 
   const file = useMemo(
     () => (props.scene.files.length > 0 ? props.scene.files[0] : undefined),
@@ -313,7 +320,10 @@ export const SceneCard: React.FC<ISceneCardProps> = (
       return (
         <div className="other-copies extra-scene-info">
           <Button
-            href={NavUtils.makeScenesPHashMatchUrl(phash.value)}
+            href={NavUtils.makeScenesPHashMatchUrl(
+              phash.value,
+              sceneDefaultFilter
+            )}
             className="minimal"
           >
             <Icon icon={faCopy} />

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -17,6 +17,10 @@ import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
 import { getStashboxBase } from "src/utils/stashbox";
 import { TextField, URLField, URLsField } from "src/utils/field";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface IFileInfoPanelProps {
   sceneID: string;
@@ -34,6 +38,9 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
 ) => {
   const intl = useIntl();
   const history = useHistory();
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
 
   function renderFileSize() {
     const { size, unit } = TextUtils.fileSize(props.file.size);
@@ -82,7 +89,10 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
           id="media_info.phash"
           abbr="Perceptual hash"
           value={phash?.value}
-          url={NavUtils.makeScenesPHashMatchUrl(phash?.value)}
+          url={NavUtils.makeScenesPHashMatchUrl(
+            phash?.value,
+            sceneDefaultFilter
+          )}
           target="_self"
           truncate
           trusted

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -8,6 +8,10 @@ import { FormattedMessage } from "react-intl";
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import SceneQueue from "src/models/sceneQueue";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface ISceneListTableProps {
   scenes: GQL.SlimSceneDataFragment[];
@@ -19,16 +23,30 @@ interface ISceneListTableProps {
 export const SceneListTable: React.FC<ISceneListTableProps> = (
   props: ISceneListTableProps
 ) => {
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
   const renderTags = (tags: Partial<GQL.TagDataFragment>[]) =>
     tags.map((tag) => (
-      <Link key={tag.id} to={NavUtils.makeTagScenesUrl(tag)}>
+      <Link
+        key={tag.id}
+        to={NavUtils.makeTagScenesUrl(tag, sceneDefaultFilter)}
+      >
         <h6>{tag.name}</h6>
       </Link>
     ));
 
   const renderPerformers = (performers: Partial<GQL.PerformerDataFragment>[]) =>
     performers.map((performer) => (
-      <Link key={performer.id} to={NavUtils.makePerformerScenesUrl(performer)}>
+      <Link
+        key={performer.id}
+        to={NavUtils.makePerformerScenesUrl(
+          performer,
+          undefined,
+          undefined,
+          sceneDefaultFilter
+        )}
+      >
         <h6>{performer.name}</h6>
       </Link>
     ));
@@ -37,7 +55,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
     scene.movies.map((sceneMovie) => (
       <Link
         key={sceneMovie.movie.id}
-        to={NavUtils.makeMovieScenesUrl(sceneMovie.movie)}
+        to={NavUtils.makeMovieScenesUrl(sceneMovie.movie, sceneDefaultFilter)}
       >
         <h6>{sceneMovie.movie.name}</h6>
       </Link>
@@ -104,7 +122,12 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
         <td>{renderPerformers(scene.performers)}</td>
         <td>
           {scene.studio && (
-            <Link to={NavUtils.makeStudioScenesUrl(scene.studio)}>
+            <Link
+              to={NavUtils.makeStudioScenesUrl(
+                scene.studio,
+                sceneDefaultFilter
+              )}
+            >
               <h6>{scene.studio.name}</h6>
             </Link>
           )}

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -27,6 +27,7 @@ const SceneMarkerItemList = makeItemList({
 
 interface ISceneMarkerList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
+  persistState?: PersistanceLevel;
   alterQuery?: boolean;
 }
 

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -7,6 +7,10 @@ import { ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import { RatingBanner } from "../Shared/RatingBanner";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -38,7 +42,10 @@ function maybeRenderParent(
   }
 }
 
-function maybeRenderChildren(studio: GQL.StudioDataFragment) {
+function maybeRenderChildren(
+  studio: GQL.StudioDataFragment,
+  defaultFilter: ListFilterModel
+) {
   if (studio.child_studios.length > 0) {
     return (
       <div className="studio-child-studios">
@@ -46,7 +53,7 @@ function maybeRenderChildren(studio: GQL.StudioDataFragment) {
           id="parent_of"
           values={{
             children: (
-              <Link to={NavUtils.makeChildStudiosUrl(studio)}>
+              <Link to={NavUtils.makeChildStudiosUrl(studio, defaultFilter)}>
                 {studio.child_studios.length} studios
               </Link>
             ),
@@ -64,6 +71,25 @@ export const StudioCard: React.FC<IProps> = ({
   selected,
   onSelectedChanged,
 }) => {
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
+  const imageDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Images
+  );
+  const galleryDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Galleries
+  );
+  const movieDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Movies
+  );
+  const performerDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Performers
+  );
+  const studioDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Studios
+  );
+
   function maybeRenderScenesPopoverButton() {
     if (!studio.scene_count) return;
 
@@ -72,7 +98,7 @@ export const StudioCard: React.FC<IProps> = ({
         className="scene-count"
         type="scene"
         count={studio.scene_count}
-        url={NavUtils.makeStudioScenesUrl(studio)}
+        url={NavUtils.makeStudioScenesUrl(studio, sceneDefaultFilter)}
       />
     );
   }
@@ -85,7 +111,7 @@ export const StudioCard: React.FC<IProps> = ({
         className="image-count"
         type="image"
         count={studio.image_count}
-        url={NavUtils.makeStudioImagesUrl(studio)}
+        url={NavUtils.makeStudioImagesUrl(studio, imageDefaultFilter)}
       />
     );
   }
@@ -98,7 +124,7 @@ export const StudioCard: React.FC<IProps> = ({
         className="gallery-count"
         type="gallery"
         count={studio.gallery_count}
-        url={NavUtils.makeStudioGalleriesUrl(studio)}
+        url={NavUtils.makeStudioGalleriesUrl(studio, galleryDefaultFilter)}
       />
     );
   }
@@ -111,7 +137,7 @@ export const StudioCard: React.FC<IProps> = ({
         className="movie-count"
         type="movie"
         count={studio.movie_count}
-        url={NavUtils.makeStudioMoviesUrl(studio)}
+        url={NavUtils.makeStudioMoviesUrl(studio, movieDefaultFilter)}
       />
     );
   }
@@ -124,7 +150,7 @@ export const StudioCard: React.FC<IProps> = ({
         className="performer-count"
         type="performer"
         count={studio.performer_count}
-        url={NavUtils.makeStudioPerformersUrl(studio)}
+        url={NavUtils.makeStudioPerformersUrl(studio, performerDefaultFilter)}
       />
     );
   }
@@ -168,7 +194,7 @@ export const StudioCard: React.FC<IProps> = ({
       details={
         <div className="studio-card__details">
           {maybeRenderParent(studio, hideParent)}
-          {maybeRenderChildren(studio)}
+          {maybeRenderChildren(studio, studioDefaultFilter)}
           <RatingBanner rating={studio.rating100} />
         </div>
       }

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioChildrenPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioChildrenPanel.tsx
@@ -3,6 +3,7 @@ import * as GQL from "src/core/generated-graphql";
 import { ParentStudiosCriterion } from "src/models/list-filter/criteria/studios";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { StudioList } from "../StudioList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioChildrenPanel {
   active: boolean;
@@ -45,5 +46,12 @@ export const StudioChildrenPanel: React.FC<IStudioChildrenPanel> = ({
     return filter;
   }
 
-  return <StudioList fromParent filterHook={filterHook} alterQuery={active} />;
+  return (
+    <StudioList
+      fromParent
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GalleryList } from "src/components/Galleries/GalleryList";
 import { useStudioFilterHook } from "src/core/studios";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioGalleriesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const StudioGalleriesPanel: React.FC<IStudioGalleriesPanel> = ({
   studio,
 }) => {
   const filterHook = useStudioFilterHook(studio);
-  return <GalleryList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <GalleryList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useStudioFilterHook } from "src/core/studios";
 import { ImageList } from "src/components/Images/ImageList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioImagesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const StudioImagesPanel: React.FC<IStudioImagesPanel> = ({
   studio,
 }) => {
   const filterHook = useStudioFilterHook(studio);
-  return <ImageList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <ImageList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioMoviesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioMoviesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { MovieList } from "src/components/Movies/MovieList";
 import { useStudioFilterHook } from "src/core/studios";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioMoviesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const StudioMoviesPanel: React.FC<IStudioMoviesPanel> = ({
   studio,
 }) => {
   const filterHook = useStudioFilterHook(studio);
-  return <MovieList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <MovieList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
@@ -3,6 +3,7 @@ import * as GQL from "src/core/generated-graphql";
 import { useStudioFilterHook } from "src/core/studios";
 import { PerformerList } from "src/components/Performers/PerformerList";
 import { StudiosCriterion } from "src/models/list-filter/criteria/studios";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioPerformersPanel {
   active: boolean;
@@ -34,6 +35,7 @@ export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
       filterHook={filterHook}
       extraCriteria={extraCriteria}
       alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { SceneList } from "src/components/Scenes/SceneList";
 import { useStudioFilterHook } from "src/core/studios";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface IStudioScenesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const StudioScenesPanel: React.FC<IStudioScenesPanel> = ({
   studio,
 }) => {
   const filterHook = useStudioFilterHook(studio);
-  return <SceneList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <SceneList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -35,6 +35,7 @@ const StudioItemList = makeItemList({
 interface IStudioList {
   fromParent?: boolean;
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
+  persistState?: PersistanceLevel;
   alterQuery?: boolean;
 }
 

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -9,6 +9,10 @@ import { TruncatedText } from "../Shared/TruncatedText";
 import { GridCard } from "../Shared/GridCard";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import { faMapMarkerAlt, faUser } from "@fortawesome/free-solid-svg-icons";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -25,6 +29,25 @@ export const TagCard: React.FC<IProps> = ({
   selected,
   onSelectedChanged,
 }) => {
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
+  const imageDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Images
+  );
+  const galleryDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Galleries
+  );
+  const markerDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.SceneMarkers
+  );
+  const performerDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Performers
+  );
+  const tagDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Tags
+  );
+
   function maybeRenderDescription() {
     if (tag.description) {
       return (
@@ -59,7 +82,7 @@ export const TagCard: React.FC<IProps> = ({
             id="sub_tag_of"
             values={{
               parent: (
-                <Link to={NavUtils.makeParentTagsUrl(tag)}>
+                <Link to={NavUtils.makeParentTagsUrl(tag, tagDefaultFilter)}>
                   {tag.parents.length}&nbsp;
                   <FormattedMessage
                     id="countables.tags"
@@ -82,7 +105,7 @@ export const TagCard: React.FC<IProps> = ({
             id="parent_of"
             values={{
               children: (
-                <Link to={NavUtils.makeChildTagsUrl(tag)}>
+                <Link to={NavUtils.makeChildTagsUrl(tag, tagDefaultFilter)}>
                   {tag.children.length}&nbsp;
                   <FormattedMessage
                     id="countables.tags"
@@ -105,7 +128,7 @@ export const TagCard: React.FC<IProps> = ({
         className="scene-count"
         type="scene"
         count={tag.scene_count}
-        url={NavUtils.makeTagScenesUrl(tag)}
+        url={NavUtils.makeTagScenesUrl(tag, sceneDefaultFilter)}
       />
     );
   }
@@ -114,7 +137,10 @@ export const TagCard: React.FC<IProps> = ({
     if (!tag.scene_marker_count) return;
 
     return (
-      <Link className="marker-count" to={NavUtils.makeTagSceneMarkersUrl(tag)}>
+      <Link
+        className="marker-count"
+        to={NavUtils.makeTagSceneMarkersUrl(tag, markerDefaultFilter)}
+      >
         <Button className="minimal">
           <Icon icon={faMapMarkerAlt} />
           <span>{tag.scene_marker_count}</span>
@@ -131,7 +157,7 @@ export const TagCard: React.FC<IProps> = ({
         className="image-count"
         type="image"
         count={tag.image_count}
-        url={NavUtils.makeTagImagesUrl(tag)}
+        url={NavUtils.makeTagImagesUrl(tag, imageDefaultFilter)}
       />
     );
   }
@@ -144,7 +170,7 @@ export const TagCard: React.FC<IProps> = ({
         className="gallery-count"
         type="gallery"
         count={tag.gallery_count}
-        url={NavUtils.makeTagGalleriesUrl(tag)}
+        url={NavUtils.makeTagGalleriesUrl(tag, galleryDefaultFilter)}
       />
     );
   }
@@ -153,7 +179,10 @@ export const TagCard: React.FC<IProps> = ({
     if (!tag.performer_count) return;
 
     return (
-      <Link className="performer-count" to={NavUtils.makeTagPerformersUrl(tag)}>
+      <Link
+        className="performer-count"
+        to={NavUtils.makeTagPerformersUrl(tag, performerDefaultFilter)}
+      >
         <Button className="minimal">
           <Icon icon={faUser} />
           <span>{tag.performer_count}</span>

--- a/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useTagFilterHook } from "src/core/tags";
 import { GalleryList } from "src/components/Galleries/GalleryList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface ITagGalleriesPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const TagGalleriesPanel: React.FC<ITagGalleriesPanel> = ({
   tag,
 }) => {
   const filterHook = useTagFilterHook(tag);
-  return <GalleryList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <GalleryList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useTagFilterHook } from "src/core/tags";
 import { ImageList } from "src/components/Images/ImageList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface ITagImagesPanel {
   active: boolean;
@@ -10,5 +11,11 @@ interface ITagImagesPanel {
 
 export const TagImagesPanel: React.FC<ITagImagesPanel> = ({ active, tag }) => {
   const filterHook = useTagFilterHook(tag);
-  return <ImageList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <ImageList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
@@ -6,6 +6,7 @@ import {
   TagsCriterionOption,
 } from "src/models/list-filter/criteria/tags";
 import { SceneMarkerList } from "src/components/Scenes/SceneMarkerList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface ITagMarkersPanel {
   active: boolean;
@@ -52,5 +53,11 @@ export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({
     return filter;
   }
 
-  return <SceneMarkerList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <SceneMarkerList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useTagFilterHook } from "src/core/tags";
 import { PerformerList } from "src/components/Performers/PerformerList";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface ITagPerformersPanel {
   active: boolean;
@@ -13,5 +14,11 @@ export const TagPerformersPanel: React.FC<ITagPerformersPanel> = ({
   tag,
 }) => {
   const filterHook = useTagFilterHook(tag);
-  return <PerformerList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <PerformerList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { SceneList } from "src/components/Scenes/SceneList";
 import { useTagFilterHook } from "src/core/tags";
+import { PersistanceLevel } from "src/components/List/ItemList";
 
 interface ITagScenesPanel {
   active: boolean;
@@ -10,5 +11,11 @@ interface ITagScenesPanel {
 
 export const TagScenesPanel: React.FC<ITagScenesPanel> = ({ active, tag }) => {
   const filterHook = useTagFilterHook(tag);
-  return <SceneList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <SceneList
+      filterHook={filterHook}
+      alterQuery={active}
+      persistState={PersistanceLevel.SAVEDVIEW}
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from "react";
 import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
-import { ListFilterModel } from "src/models/list-filter/filter";
+import {
+  ListFilterModel,
+  useDefaultFilter,
+} from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import {
   makeItemList,
@@ -49,6 +52,18 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
   const Toast = useToast();
   const [deletingTag, setDeletingTag] =
     useState<Partial<GQL.TagDataFragment> | null>(null);
+  const sceneDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Scenes
+  );
+  const imageDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Images
+  );
+  const galleryDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.Galleries
+  );
+  const markerDefaultFilter: ListFilterModel = useDefaultFilter(
+    GQL.FilterMode.SceneMarkers
+  );
 
   function getDeleteTagInput() {
     const tagInput: Partial<GQL.TagDestroyInput> = {};
@@ -243,7 +258,7 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
                 </Button>
                 <Button variant="secondary" className="tag-list-button">
                   <Link
-                    to={NavUtils.makeTagScenesUrl(tag)}
+                    to={NavUtils.makeTagScenesUrl(tag, sceneDefaultFilter)}
                     className="tag-list-anchor"
                   >
                     <FormattedMessage
@@ -257,7 +272,7 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
                 </Button>
                 <Button variant="secondary" className="tag-list-button">
                   <Link
-                    to={NavUtils.makeTagImagesUrl(tag)}
+                    to={NavUtils.makeTagImagesUrl(tag, imageDefaultFilter)}
                     className="tag-list-anchor"
                   >
                     <FormattedMessage
@@ -271,7 +286,7 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
                 </Button>
                 <Button variant="secondary" className="tag-list-button">
                   <Link
-                    to={NavUtils.makeTagGalleriesUrl(tag)}
+                    to={NavUtils.makeTagGalleriesUrl(tag, galleryDefaultFilter)}
                     className="tag-list-anchor"
                   >
                     <FormattedMessage
@@ -285,7 +300,10 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
                 </Button>
                 <Button variant="secondary" className="tag-list-button">
                   <Link
-                    to={NavUtils.makeTagSceneMarkersUrl(tag)}
+                    to={NavUtils.makeTagSceneMarkersUrl(
+                      tag,
+                      markerDefaultFilter
+                    )}
                     className="tag-list-anchor"
                   >
                     <FormattedMessage

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -34,10 +34,15 @@ function addExtraCriteria(
 const makePerformerScenesUrl = (
   performer: Partial<GQL.PerformerDataFragment>,
   extraPerformer?: ILabeledId,
-  extraCriteria?: Criterion<CriterionValue>[]
+  extraCriteria?: Criterion<CriterionValue>[],
+  defaultFilter?: ListFilterModel
 ) => {
   if (!performer.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new PerformersCriterion();
   criterion.value.items = [
     { id: performer.id, label: performer.name || `Performer ${performer.id}` },
@@ -55,10 +60,15 @@ const makePerformerScenesUrl = (
 const makePerformerImagesUrl = (
   performer: Partial<GQL.PerformerDataFragment>,
   extraPerformer?: ILabeledId,
-  extraCriteria?: Criterion<CriterionValue>[]
+  extraCriteria?: Criterion<CriterionValue>[],
+  defaultFilter?: ListFilterModel
 ) => {
   if (!performer.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Images, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new PerformersCriterion();
   criterion.value.items = [
     { id: performer.id, label: performer.name || `Performer ${performer.id}` },
@@ -76,10 +86,15 @@ const makePerformerImagesUrl = (
 const makePerformerGalleriesUrl = (
   performer: Partial<GQL.PerformerDataFragment>,
   extraPerformer?: ILabeledId,
-  extraCriteria?: Criterion<CriterionValue>[]
+  extraCriteria?: Criterion<CriterionValue>[],
+  defaultFilter?: ListFilterModel
 ) => {
   if (!performer.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new PerformersCriterion();
   criterion.value.items = [
     { id: performer.id, label: performer.name || `Performer ${performer.id}` },
@@ -97,10 +112,15 @@ const makePerformerGalleriesUrl = (
 const makePerformerMoviesUrl = (
   performer: Partial<GQL.PerformerDataFragment>,
   extraPerformer?: ILabeledId,
-  extraCriteria?: Criterion<CriterionValue>[]
+  extraCriteria?: Criterion<CriterionValue>[],
+  defaultFilter?: ListFilterModel
 ) => {
   if (!performer.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Movies, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Movies, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new PerformersCriterion();
   criterion.value.items = [
     { id: performer.id, label: performer.name || `Performer ${performer.id}` },
@@ -116,19 +136,31 @@ const makePerformerMoviesUrl = (
 };
 
 const makePerformersCountryUrl = (
-  performer: Partial<GQL.PerformerDataFragment>
+  performer: Partial<GQL.PerformerDataFragment>,
+  defaultFilter?: ListFilterModel
 ) => {
   if (!performer.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new CountryCriterion();
   criterion.value = `${performer.country}`;
   filter.criteria.push(criterion);
   return `/performers?${filter.makeQueryParameters()}`;
 };
 
-const makeStudioScenesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeStudioScenesUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Studios, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new StudiosCriterion();
   criterion.value = {
     items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
@@ -139,9 +171,16 @@ const makeStudioScenesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/scenes?${filter.makeQueryParameters()}`;
 };
 
-const makeStudioImagesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeStudioImagesUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Images, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new StudiosCriterion();
   criterion.value = {
     items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
@@ -152,9 +191,16 @@ const makeStudioImagesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/images?${filter.makeQueryParameters()}`;
 };
 
-const makeStudioGalleriesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeStudioGalleriesUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new StudiosCriterion();
   criterion.value = {
     items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
@@ -165,9 +211,16 @@ const makeStudioGalleriesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/galleries?${filter.makeQueryParameters()}`;
 };
 
-const makeStudioMoviesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeStudioMoviesUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Movies, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Movies, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new StudiosCriterion();
   criterion.value = {
     items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
@@ -178,9 +231,16 @@ const makeStudioMoviesUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/movies?${filter.makeQueryParameters()}`;
 };
 
-const makeStudioPerformersUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeStudioPerformersUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new StudiosCriterion();
   criterion.value = {
     items: [{ id: studio.id, label: studio.name || `Studio ${studio.id}` }],
@@ -191,9 +251,16 @@ const makeStudioPerformersUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/performers?${filter.makeQueryParameters()}`;
 };
 
-const makeChildStudiosUrl = (studio: Partial<GQL.StudioDataFragment>) => {
+const makeChildStudiosUrl = (
+  studio: Partial<GQL.StudioDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!studio.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Studios, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Studios, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new ParentStudiosCriterion();
   criterion.value = [
     { id: studio.id, label: studio.name || `Studio ${studio.id}` },
@@ -202,9 +269,16 @@ const makeChildStudiosUrl = (studio: Partial<GQL.StudioDataFragment>) => {
   return `/studios?${filter.makeQueryParameters()}`;
 };
 
-const makeMovieScenesUrl = (movie: Partial<GQL.MovieDataFragment>) => {
+const makeMovieScenesUrl = (
+  movie: Partial<GQL.MovieDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!movie.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new MoviesCriterion();
   criterion.value = [
     { id: movie.id, label: movie.name || `Movie ${movie.id}` },
@@ -217,9 +291,16 @@ const makeTagUrl = (id: string) => {
   return `/tags/${id}`;
 };
 
-const makeParentTagsUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeParentTagsUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Tags, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Tags, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(ChildTagsCriterionOption);
   criterion.value = {
     items: [
@@ -235,9 +316,16 @@ const makeParentTagsUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/tags?${filter.makeQueryParameters()}`;
 };
 
-const makeChildTagsUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeChildTagsUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Tags, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Tags, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(ParentTagsCriterionOption);
   criterion.value = {
     items: [
@@ -253,9 +341,16 @@ const makeChildTagsUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/tags?${filter.makeQueryParameters()}`;
 };
 
-const makeTagScenesUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeTagScenesUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(TagsCriterionOption);
   criterion.value = {
     items: [{ id: tag.id, label: tag.name || `Tag ${tag.id}` }],
@@ -266,9 +361,16 @@ const makeTagScenesUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/scenes?${filter.makeQueryParameters()}`;
 };
 
-const makeTagPerformersUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeTagPerformersUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Performers, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(TagsCriterionOption);
   criterion.value = {
     items: [{ id: tag.id, label: tag.name || `Tag ${tag.id}` }],
@@ -279,9 +381,16 @@ const makeTagPerformersUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/performers?${filter.makeQueryParameters()}`;
 };
 
-const makeTagSceneMarkersUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeTagSceneMarkersUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.SceneMarkers, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.SceneMarkers, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(TagsCriterionOption);
   criterion.value = {
     items: [{ id: tag.id, label: tag.name || `Tag ${tag.id}` }],
@@ -292,9 +401,16 @@ const makeTagSceneMarkersUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/scenes/markers?${filter.makeQueryParameters()}`;
 };
 
-const makeTagGalleriesUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeTagGalleriesUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(TagsCriterionOption);
   criterion.value = {
     items: [{ id: tag.id, label: tag.name || `Tag ${tag.id}` }],
@@ -305,9 +421,16 @@ const makeTagGalleriesUrl = (tag: Partial<GQL.TagDataFragment>) => {
   return `/galleries?${filter.makeQueryParameters()}`;
 };
 
-const makeTagImagesUrl = (tag: Partial<GQL.TagDataFragment>) => {
+const makeTagImagesUrl = (
+  tag: Partial<GQL.TagDataFragment>,
+  defaultFilter?: ListFilterModel
+) => {
   if (!tag.id) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Images, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new TagsCriterion(TagsCriterionOption);
   criterion.value = {
     items: [{ id: tag.id, label: tag.name || `Tag ${tag.id}` }],
@@ -327,9 +450,16 @@ const makeSceneMarkerUrl = (sceneMarker: SceneMarkerDataFragment) => {
   return `/scenes/${sceneMarker.scene.id}?t=${sceneMarker.seconds}`;
 };
 
-const makeScenesPHashMatchUrl = (phash: GQL.Maybe<string> | undefined) => {
+const makeScenesPHashMatchUrl = (
+  phash: GQL.Maybe<string> | undefined,
+  defaultFilter?: ListFilterModel
+) => {
   if (!phash) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  var filter = defaultFilter
+    ? defaultFilter
+    : new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  filter.searchTerm = "";
+  filter.criteria = [];
   const criterion = new PhashCriterion();
   criterion.value = { value: phash };
   filter.criteria.push(criterion);


### PR DESCRIPTION
This Commit is aiming at the fact that the saved default filter is not taken into consideration outside of the main page its associated with. This is specifically relevant for two types of scenarios, and both are adressed in this commit:

The details page of Performer, Tag or Studio
Links provided from Cards of all kinds in all places, as well as clickable tags

Both right now will give you the view stash delivers as default, combined with the associated filter. This commit reads the default filter of the according type and applies all view-related settings (this means further filters from default as well as searchterms are ignored).
This seems to me much more intuitive, and it has been requested in several ways multiple times from what I can tell:
#4010 #3079 #2573 #1938 

However, it was far more complicated than anticipated, if someone more adapt with react sees a way to streamline this more I would be open for that, although I think this solution is not really bad, its just a bit widespread in the code...

I have tested several scenarios and they all work, however we are talking about dozends of scenarios so anyone willing to test it further is welcomed. 

Lastly, this commit changes the behavior of stash in a not insignificant way. This raises the question whether it should be made optional. I personally don't think this is necessary, as I cannot think of a user that would not expect the sorting and viewtype (grid/wall) to be identical in details pages, the default main page and when clicking on a tag or other link to a filtered view. But maybe I'm just lacking imagination here.