### PR TITLE
Change drop location for dropdown menus

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -645,7 +645,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     );
 
     return (
-      <Dropdown drop="up" className="d-inline-block">
+      <Dropdown className="d-inline-block">
         <Dropdown.Toggle variant="secondary" className="mr-2">
           <FormattedMessage id="actions.scrape_with" />
         </Dropdown.Toggle>

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -280,7 +280,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
 
   function renderMergeButton() {
     return (
-      <Dropdown drop="up">
+      <Dropdown>
         <Dropdown.Toggle variant="secondary">
           <FormattedMessage id="actions.merge" />
           ...


### PR DESCRIPTION
Changes the drop location to the default below for the dropdown menus on the performer and tag pages.

Fixes #4033 