### PR TITLE
Frontpage Mobile Fix

### DIFF
--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -494,6 +494,7 @@ textarea.text-input {
     margin-right: 0;
   }
 }
+
 .zoom-0 {
   width: 240px;
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -494,85 +494,83 @@ textarea.text-input {
     margin-right: 0;
   }
 }
-@media (min-width: 576px) {
-  .zoom-0 {
-    width: 240px;
+.zoom-0 {
+  width: 240px;
 
-    .scene-card-preview {
-      height: 135px;
-    }
-
-    .portrait {
-      height: 180px;
-    }
-
-    .gallery-card-image,
-    .tag-card-image {
-      max-height: 180px;
-    }
+  .scene-card-preview {
+    height: 135px;
   }
 
-  .zoom-1 {
-    width: 320px;
-
-    .scene-card-preview {
-      height: 180px;
-    }
-
-    .portrait {
-      height: 240px;
-    }
-
-    .gallery-card-image,
-    .tag-card-image {
-      max-height: 240px;
-    }
-
-    .image-card-preview {
-      height: 240px;
-    }
+  .portrait {
+    height: 180px;
   }
 
-  .zoom-2 {
-    width: 480px;
+  .gallery-card-image,
+  .tag-card-image {
+    max-height: 180px;
+  }
+}
 
-    .scene-card-preview {
-      height: 270px;
-    }
+.zoom-1 {
+  width: 320px;
 
-    .portrait {
-      height: 360px;
-    }
-
-    .gallery-card-image,
-    .tag-card-image {
-      max-height: 360px;
-    }
-
-    .image-card-preview {
-      height: 360px;
-    }
+  .scene-card-preview {
+    height: 180px;
   }
 
-  .zoom-3 {
-    width: 640px;
+  .portrait {
+    height: 240px;
+  }
 
-    .scene-card-preview {
-      height: 360px;
-    }
+  .gallery-card-image,
+  .tag-card-image {
+    max-height: 240px;
+  }
 
-    .portrait {
-      height: 480px;
-    }
+  .image-card-preview {
+    height: 240px;
+  }
+}
 
-    .tag-card-image,
-    .gallery-card-image {
-      max-height: 480px;
-    }
+.zoom-2 {
+  width: 480px;
 
-    .image-card-preview {
-      height: 480px;
-    }
+  .scene-card-preview {
+    height: 270px;
+  }
+
+  .portrait {
+    height: 360px;
+  }
+
+  .gallery-card-image,
+  .tag-card-image {
+    max-height: 360px;
+  }
+
+  .image-card-preview {
+    height: 360px;
+  }
+}
+
+.zoom-3 {
+  width: 640px;
+
+  .scene-card-preview {
+    height: 360px;
+  }
+
+  .portrait {
+    height: 480px;
+  }
+
+  .tag-card-image,
+  .gallery-card-image {
+    max-height: 480px;
+  }
+
+  .image-card-preview {
+    height: 480px;
   }
 }
 


### PR DESCRIPTION
Right now, I get really elongated and inconsistent cards on the frontpage when switching to a mobile view (width below x), but also on mobile devices in general.
This seems to be due to the image sizes not being restricted, meaning that the width and height are both determined by the pixel size of the largest image, while the smallest images drown in comparision in otherwise empty elements. 
This is a fix for behavior I recognized in performer, tag, studio and to a certain degree also scenecards.

I did this by simply applying the css rules of desktop view to mobile as well. I couldn't find any side effects, but someone more into CSS may want to check whether this could have unforseen consequences.