### PR TITLE
Fix thumbnail scrubber crash

### DIFF
--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -104,7 +104,7 @@ export const PreviewScrubber: React.FC<IScenePreviewProps> = ({
   const debounceSetActiveIndex = useDebounce(
     setActiveIndex,
     [setActiveIndex],
-    10
+    1
   );
 
   const spriteInfo = useSpriteInfo(vttPath);

--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -20,7 +20,7 @@ const HoverScrubber: React.FC<IHoverScrubber> = ({
     const { width } = e.currentTarget.getBoundingClientRect();
     const x = e.nativeEvent.offsetX;
 
-    return Math.floor((x / width) * totalSprites);
+    return Math.floor((x / width) * (totalSprites - 1));
   }
 
   function onMouseMove(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {


### PR DESCRIPTION
Fixes crash when mousing over the right-most pixel on the thumbnail scrubber. Also reduces the debounce time so that scrubbing is smoother.