### PR TITLE
Fix URL and aliases update nil dereference

### DIFF
--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -200,7 +200,7 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input PerformerU
 			Values: input.AliasList,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
-	} else if translator.hasField("aliases") {
+	} else if input.Aliases != nil {
 		updatedPerformer.Aliases = &models.UpdateStrings{
 			Values: stringslice.FromString(*input.Aliases, ","),
 			Mode:   models.RelationshipUpdateModeSet,
@@ -331,7 +331,7 @@ func (r *mutationResolver) BulkPerformerUpdate(ctx context.Context, input BulkPe
 			Values: input.AliasList.Values,
 			Mode:   input.AliasList.Mode,
 		}
-	} else if translator.hasField("aliases") {
+	} else if input.Aliases != nil {
 		updatedPerformer.Aliases = &models.UpdateStrings{
 			Values: stringslice.FromString(*input.Aliases, ","),
 			Mode:   models.RelationshipUpdateModeSet,

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -200,9 +200,13 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input PerformerU
 			Values: input.AliasList,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
-	} else if input.Aliases != nil {
+	} else if translator.hasField("aliases") {
+		var values []string
+		if input.Aliases != nil {
+			values = stringslice.FromString(*input.Aliases, ",")
+		}
 		updatedPerformer.Aliases = &models.UpdateStrings{
-			Values: stringslice.FromString(*input.Aliases, ","),
+			Values: values,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
 	}
@@ -331,9 +335,13 @@ func (r *mutationResolver) BulkPerformerUpdate(ctx context.Context, input BulkPe
 			Values: input.AliasList.Values,
 			Mode:   input.AliasList.Mode,
 		}
-	} else if input.Aliases != nil {
+	} else if translator.hasField("aliases") {
+		var values []string
+		if input.Aliases != nil {
+			values = stringslice.FromString(*input.Aliases, ",")
+		}
 		updatedPerformer.Aliases = &models.UpdateStrings{
-			Values: stringslice.FromString(*input.Aliases, ","),
+			Values: values,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
 	}

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -199,9 +199,13 @@ func scenePartialFromInput(input models.SceneUpdateInput, translator changesetTr
 			Values: input.Urls,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
-	} else if input.URL != nil {
+	} else if translator.hasField("url") {
+		var values []string
+		if input.URL != nil {
+			values = []string{*input.URL}
+		}
 		updatedScene.URLs = &models.UpdateStrings{
-			Values: []string{*input.URL},
+			Values: values,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
 	}
@@ -380,9 +384,13 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input BulkSceneU
 			Values: input.Urls.Values,
 			Mode:   input.Urls.Mode,
 		}
-	} else if input.URL != nil {
+	} else if translator.hasField("url") {
+		var values []string
+		if input.URL != nil {
+			values = []string{*input.URL}
+		}
 		updatedScene.URLs = &models.UpdateStrings{
-			Values: []string{*input.URL},
+			Values: values,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
 	}

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -199,7 +199,7 @@ func scenePartialFromInput(input models.SceneUpdateInput, translator changesetTr
 			Values: input.Urls,
 			Mode:   models.RelationshipUpdateModeSet,
 		}
-	} else if translator.hasField("url") {
+	} else if input.URL != nil {
 		updatedScene.URLs = &models.UpdateStrings{
 			Values: []string{*input.URL},
 			Mode:   models.RelationshipUpdateModeSet,
@@ -380,7 +380,7 @@ func (r *mutationResolver) BulkSceneUpdate(ctx context.Context, input BulkSceneU
 			Values: input.Urls.Values,
 			Mode:   input.Urls.Mode,
 		}
-	} else if translator.hasField("url") {
+	} else if input.URL != nil {
 		updatedScene.URLs = &models.UpdateStrings{
 			Values: []string{*input.URL},
 			Mode:   models.RelationshipUpdateModeSet,


### PR DESCRIPTION
Simple fix for #4072.

This will ignore a `null` value in `aliases` or `url`, to avoid unintentional data loss. Both these fields are deprecated anyway, `alias_list` or `urls` should be used instead which gives more control.

Fixes #4072 