### PR TITLE
Github action to publish a CUDA build alongside the alpine one

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -47,10 +47,10 @@ ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 # NVENC Patch
-RUN mkdir -p /usr/local/bin /patched-lib
-RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh
-RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
+RUN mkdir -p /usr/local/bin /patched-lib \
+    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh \
+    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh \
+    && chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
 
 # Clean
 RUN apt-get remove -y build-essential wget && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -20,3 +20,40 @@ ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 EXPOSE 9999
 CMD ["stash"]
+
+FROM --platform=$TARGETPLATFORM nvidia/cuda:12.2.0-base-ubuntu22.04 AS cuda_app
+COPY --from=binary /stash /usr/bin/
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    gcc \
+    python3-dev \
+    python3 \
+    python3-pip \
+    python3-requests \
+    python3-requests-toolbelt \
+    python3-lxml \
+    ffmpeg \
+    libvips-tools \
+    ruby \
+    gem \
+    tzdata \
+    build-essential \
+    wget \
+    && pip3 install mechanicalsoup cloudscraper bencoder.pyx \
+    && gem install faraday
+ENV LANG C.UTF-8
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
+ENV STASH_CONFIG_FILE=/root/.stash/config.yml
+
+# NVENC Patch
+RUN mkdir -p /usr/local/bin /patched-lib
+RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh
+RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
+
+# Clean
+RUN apt-get remove -y build-essential wget && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 9999
+ENTRYPOINT ["docker-entrypoint.sh", "stash"]

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -21,7 +21,7 @@ ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999
 CMD ["stash"]
 
-FROM --platform=$TARGETPLATFORM nvidia/cuda:12.2.0-base-ubuntu22.04 AS cuda_app
+FROM --platform=$TARGETPLATFORM nvidia/cuda:12.0.1-base-ubuntu22.04 AS cuda_app
 COPY --from=binary /stash /usr/bin/
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -26,14 +26,10 @@ COPY --from=binary /stash /usr/bin/
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     gcc \
-    python3-dev \
-    python3 \
-    python3-pip \
-    python3-requests \
-    python3-requests-toolbelt \
-    python3-lxml \
+    python3-dev python3 python3-pip python3-requests python3-requests-toolbelt python3-lxml \
     ffmpeg \
     libvips-tools \
+    intel-media-va-driver-non-free vainfo \
     ruby \
     gem \
     tzdata \


### PR DESCRIPTION
For some time people complained that there was no official cuda build.
So i changed the build a little bit and now there could be.

Comments? Do we want to do this? Did i use too many newlines? Is anyone actually gonna use the NVidia arm64 build?
There are also some people who have a jellyfin-ffmpeg build which could be interesting, but for now i just made it similar to the old one.
