### PR TITLE
Handle equality when scraping scene performers

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryScrapeDialog.tsx
@@ -7,7 +7,10 @@ import {
   ScrapedTextAreaRow,
 } from "src/components/Shared/ScrapeDialog/ScrapeDialog";
 import clone from "lodash-es/clone";
-import { ScrapeResult } from "src/components/Shared/ScrapeDialog/scrapeResult";
+import {
+  ObjectListScrapeResult,
+  ScrapeResult,
+} from "src/components/Shared/ScrapeDialog/scrapeResult";
 import {
   ScrapedPerformersRow,
   ScrapedStudioRow,
@@ -97,9 +100,9 @@ export const GalleryScrapeDialog: React.FC<IGalleryScrapeDialogProps> = (
   }
 
   const [performers, setPerformers] = useState<
-    ScrapeResult<GQL.ScrapedPerformer[]>
+    ObjectListScrapeResult<GQL.ScrapedPerformer>
   >(
-    new ScrapeResult<GQL.ScrapedPerformer[]>(
+    new ObjectListScrapeResult<GQL.ScrapedPerformer>(
       sortStoredIdObjects(
         props.galleryPerformers.map((p) => ({
           stored_id: p.id,

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneScrapeDialog.tsx
@@ -12,7 +12,10 @@ import { useIntl } from "react-intl";
 import { uniq } from "lodash-es";
 import { Performer } from "src/components/Performers/PerformerSelect";
 import { IHasStoredID, sortStoredIdObjects } from "src/utils/data";
-import { ScrapeResult } from "src/components/Shared/ScrapeDialog/scrapeResult";
+import {
+  ObjectListScrapeResult,
+  ScrapeResult,
+} from "src/components/Shared/ScrapeDialog/scrapeResult";
 import {
   ScrapedMoviesRow,
   ScrapedPerformersRow,
@@ -117,9 +120,9 @@ export const SceneScrapeDialog: React.FC<ISceneScrapeDialogProps> = ({
   }
 
   const [performers, setPerformers] = useState<
-    ScrapeResult<GQL.ScrapedPerformer[]>
+    ObjectListScrapeResult<GQL.ScrapedPerformer>
   >(
-    new ScrapeResult<GQL.ScrapedPerformer[]>(
+    new ObjectListScrapeResult<GQL.ScrapedPerformer>(
       sortStoredIdObjects(
         scenePerformers.map((p) => ({
           stored_id: p.id,

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -25,6 +25,7 @@ import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { ModalComponent } from "../Shared/Modal";
 import { IHasStoredID, sortStoredIdObjects } from "src/utils/data";
 import {
+  ObjectListScrapeResult,
   ScrapeResult,
   ZeroableScrapeResult,
   hasScrapedValues,
@@ -118,9 +119,9 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
   }
 
   const [performers, setPerformers] = useState<
-    ScrapeResult<GQL.ScrapedPerformer[]>
+    ObjectListScrapeResult<GQL.ScrapedPerformer>
   >(
-    new ScrapeResult<GQL.ScrapedPerformer[]>(
+    new ObjectListScrapeResult<GQL.ScrapedPerformer>(
       sortStoredIdObjects(dest.performers.map(idToStoredID))
     )
   );
@@ -203,8 +204,8 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
     );
 
     setPerformers(
-      new ScrapeResult(
-        dest.performers.map(idToStoredID),
+      new ObjectListScrapeResult<GQL.ScrapedPerformer>(
+        sortStoredIdObjects(dest.performers.map(idToStoredID)),
         uniqIDStoredIDs(all.map((s) => s.performers.map(idToStoredID)).flat())
       )
     );


### PR DESCRIPTION
Resolves issue where performers would be shown in the scrape dialog despite them being the same as the current value.