### PR TITLE
Adjust compact details

### DIFF
--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -346,7 +346,7 @@ dd {
     max-width: 22rem;
   }
 
-  .detail-header.collapsed .detail-header-image img{
+  .detail-header.collapsed .detail-header-image img {
     max-width: 18rem;
   }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -341,19 +341,21 @@ dd {
   border-radius: 0.5rem;
 }
 
-#tag-page .full-width .detail-header-image img {
-  max-width: 22rem;
-
-  @media (max-width: 576px) {
-    max-width: 100%;
+#tag-page {
+  .full-width .detail-header-image img {
+    max-width: 22rem;
   }
-}
 
-#tag-page .detail-header-image img {
-  max-width: 18rem;
+  .detail-header.collapsed .detail-header-image img{
+    max-width: 18rem;
+  }
 
-  @media (max-width: 576px) {
-    max-width: 100%;
+  .detail-header-image img {
+    max-width: 20rem;
+
+    @media (max-width: 576px) {
+      max-width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
This pull request intends to reduce confusion with the `Compact expanded details` option. The initial purpose of that option was to show more details while taking up as little vertical space as possible. In order to do this, the remaining details are shown without presenting everything as a table, which takes up a lot of vertical space and leaves a lot of unused horizontal space. The tag and studio pages typically contain few details requiring more vertical space to fit. For that reason, enlarging the images to use any extra added space was unnecessary. As things currently stand, the expand/collapse buttons don't have as much value on these pages for the same reason when `Compact expanded details` is enabled. The Studio page unintentionally increases the image size when details are expanded, which at least gives the impression that something happened when few details are provided and the button is hit. I inevitably opted to do the same for the Tag image in the pull request to give that button more value on the page.