### PR TITLE
Do not log ECONNRESET errors when serving transcoded video files

### DIFF
--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -266,7 +266,7 @@ func (sm *StreamManager) getTranscodeStream(ctx *fsutil.LockContext, options Tra
 		// process killing should be handled by command context
 
 		_, err := io.Copy(w, stdout)
-		if err != nil && !errors.Is(err, syscall.EPIPE) {
+		if err != nil && !errors.Is(err, syscall.EPIPE) && !errors.Is(err, syscall.ECONNRESET) {
 			logger.Errorf("[transcode] error serving transcoded video file: %v", err)
 		}
 


### PR DESCRIPTION
When I abort the playback of a video that's being transcoded, I see this in the logs:

> 23-09-10 12:07:00 Error   [transcode] error serving transcoded video file: write tcp xxx:8778->xxx:52719: write: connection reset by peer