### PR TITLE
Allow closing modals with the ESC key

### DIFF
--- a/ui/v2.5/src/components/Shared/Modal.tsx
+++ b/ui/v2.5/src/components/Shared/Modal.tsx
@@ -44,7 +44,7 @@ export const ModalComponent: React.FC<IModal> = ({
 }) => (
   <Modal
     className="ModalComponent"
-    keyboard={false}
+    keyboard={true}
     onHide={onHide ?? defaultOnHide}
     show={show}
     dialogClassName={dialogClassName}


### PR DESCRIPTION
It's a common pattern for users to press the ESC key to close modals. It is currently disabled, and that causes confusion (pressing ESC makes my browser go out of full screen instead) - and friction (for example after submitting to stash box)