### PR TITLE
Improve error reporting when moving a transcoded file fails

### DIFF
--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -61,7 +61,7 @@ func SafeMove(src, dst string) error {
 	if err != nil {
 		copyErr := CopyFile(src, dst)
 		if copyErr != nil {
-			return fmt.Errorf("copying file failed during SaveMove with %w; renaming file failed previously with %w", copyErr, err)
+			return fmt.Errorf("copying file during SaveMove failed with: '%w'; renaming file failed previously with: '%w'", copyErr, err)
 		}
 
 		err = os.Remove(src)

--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -61,7 +61,7 @@ func SafeMove(src, dst string) error {
 	if err != nil {
 		copyErr := CopyFile(src, dst)
 		if copyErr != nil {
-			return fmt.Errorf("copying file during SaveMove failed with: '%w'; renaming file failed previously with: '%w'", copyErr, err)
+			return fmt.Errorf("copying file during SaveMove failed with: '%w'; renaming file failed previously with: '%v'", copyErr, err)
 		}
 
 		err = os.Remove(src)

--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -59,9 +59,9 @@ func SafeMove(src, dst string) error {
 	err := os.Rename(src, dst)
 
 	if err != nil {
-		err = CopyFile(src, dst)
-		if err != nil {
-			return err
+		copyErr := CopyFile(src, dst)
+		if copyErr != nil {
+			return fmt.Errorf("copying file failed during SaveMove with %w; renaming file failed previously with %w", copyErr, err)
 		}
 
 		err = os.Remove(src)

--- a/pkg/scene/generate/generator.go
+++ b/pkg/scene/generate/generator.go
@@ -97,7 +97,7 @@ func (g Generator) generateFile(lockCtx *fsutil.LockContext, p Paths, pattern st
 	}
 
 	if err := fsutil.SafeMove(tmpFn, output); err != nil {
-		return fmt.Errorf("moving %s to %s", tmpFn, output)
+		return fmt.Errorf("moving %s to %s failed: %w", tmpFn, output, err)
 	}
 
 	return nil


### PR DESCRIPTION
After changing some stuff in my system (and still debugging what the error is, but it's not like a bug with stash itself), transcoded files are not getting moved to the "transcoded" folder. They are failing with:

> [transcode] error generating transcode: moving /generated/tmp/xxx.mp4 to /generated/transcodes/xxx.mp4

The logs do not include the actual error. This PR makes sure that the error message is preserved.