### PR TITLE
Fixed: `CopyFile` not working

### DIFF
--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -20,7 +20,7 @@ func CopyFile(srcpath, dstpath string) (err error) {
 		return err
 	}
 
-	w, err := os.OpenFile(dstpath, os.O_CREATE|os.O_EXCL, 0666)
+	w, err := os.OpenFile(dstpath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0666)
 	if err != nil {
 		r.Close() // We need to close the input file as the defer below would not be called.
 		return err


### PR DESCRIPTION
The `CopyFile` method was failing for me with "bad file descriptor" (error was not visible until #4101)

Looks like this was due to missing the open file mode. Per the [docs](https://pkg.go.dev/os#O_RDONLY):

> Exactly one of O_RDONLY, O_WRONLY, or O_RDWR must be specified.

I have added O_WRONLY since the stream is only used for writing. This now fixes the method for me.

(In my setup, `CopyFile` is used because the `generated/transcoded` folder is in a different partition than `generated/tmp`, and both using symlinks or mounting a separate Docker volume in the `/generated/transcoded` folder causes stash to use `CopyFile` - and that's by design)