### PR TITLE
Add a setting to show file path on scene list table view (#2948)

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -71,6 +71,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   autostartVideoOnPlaySelected
   continuePlaylistDefault
   showStudioAsText
+  showFilePathInSceneList
   css
   cssEnabled
   javascript

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -373,6 +373,9 @@ input ConfigInterfaceInput {
   "If true, studio overlays will be shown as text instead of logo images"
   showStudioAsText: Boolean
 
+  "If true, file path will show below the title in the scene list"
+  showFilePathInSceneList: Boolean
+
   "Custom CSS"
   css: String
   cssEnabled: Boolean
@@ -445,6 +448,9 @@ type ConfigInterfaceResult {
 
   "If true, studio overlays will be shown as text instead of logo images"
   showStudioAsText: Boolean
+
+  "If true, file path will show below the title in the scene list"
+  showFilePathInSceneList: Boolean
 
   "Custom CSS"
   css: String

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -417,6 +417,7 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 
 	setBool(config.AutostartVideo, input.AutostartVideo)
 	setBool(config.ShowStudioAsText, input.ShowStudioAsText)
+	setBool(config.ShowFilePathInSceneList, input.ShowFilePathInSceneList)
 	setBool(config.AutostartVideoOnPlaySelected, input.AutostartVideoOnPlaySelected)
 	setBool(config.ContinuePlaylistDefault, input.ContinuePlaylistDefault)
 

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -150,6 +150,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 	autostartVideoOnPlaySelected := config.GetAutostartVideoOnPlaySelected()
 	continuePlaylistDefault := config.GetContinuePlaylistDefault()
 	showStudioAsText := config.GetShowStudioAsText()
+	showFilePathInSceneList := config.GetShowFilePathInSceneList()
 	css := config.GetCSS()
 	cssEnabled := config.GetCSSEnabled()
 	javascript := config.GetJavascript()
@@ -175,6 +176,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 		NotificationsEnabled:         &notificationsEnabled,
 		AutostartVideo:               &autostartVideo,
 		ShowStudioAsText:             &showStudioAsText,
+		ShowFilePathInSceneList:      &showFilePathInSceneList,
 		AutostartVideoOnPlaySelected: &autostartVideoOnPlaySelected,
 		ContinuePlaylistDefault:      &continuePlaylistDefault,
 		CSS:                          &css,

--- a/internal/autotag/integration_test.go
+++ b/internal/autotag/integration_test.go
@@ -99,7 +99,7 @@ func createPerformer(ctx context.Context, pqb models.PerformerWriter) error {
 func createStudio(ctx context.Context, qb models.StudioWriter, name string) (*models.Studio, error) {
 	// create the studio
 	studio := models.Studio{
-		Name:     name,
+		Name: name,
 	}
 
 	err := qb.Create(ctx, &studio)

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -163,6 +163,7 @@ const (
 	autostartVideoOnPlaySelectedDefault = true
 	ContinuePlaylistDefault             = "continue_playlist_default"
 	ShowStudioAsText                    = "show_studio_as_text"
+	ShowFilePathInSceneList             = "show_file_path_in_scene_list"
 	CSSEnabled                          = "cssEnabled"
 	JavascriptEnabled                   = "javascriptEnabled"
 	CustomLocalesEnabled                = "customLocalesEnabled"
@@ -1039,6 +1040,10 @@ func (i *Instance) GetContinuePlaylistDefault() bool {
 
 func (i *Instance) GetShowStudioAsText() bool {
 	return i.getBool(ShowStudioAsText)
+}
+
+func (i *Instance) GetShowFilePathInSceneList() bool {
+	return i.getBool(ShowFilePathInSceneList)
 }
 
 func (i *Instance) getSlideshowDelay() int {

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -82,6 +82,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.Set(MaximumLoopDuration, i.GetMaximumLoopDuration())
 				i.Set(AutostartVideo, i.GetAutostartVideo())
 				i.Set(ShowStudioAsText, i.GetShowStudioAsText())
+				i.Set(ShowFilePathInSceneList, i.GetShowFilePathInSceneList())
 				i.Set(legacyImageLightboxSlideshowDelay, *i.GetImageLightboxOptions().SlideshowDelay)
 				i.Set(ImageLightboxSlideshowDelay, *i.GetImageLightboxOptions().SlideshowDelay)
 				i.GetCSSPath()

--- a/pkg/sqlite/movies_test.go
+++ b/pkg/sqlite/movies_test.go
@@ -291,7 +291,7 @@ func TestMovieUpdateFrontImage(t *testing.T) {
 		// create movie to test against
 		const name = "TestMovieUpdateMovieImages"
 		movie := models.Movie{
-			Name:     name,
+			Name: name,
 		}
 		err := qb.Create(ctx, &movie)
 		if err != nil {
@@ -311,7 +311,7 @@ func TestMovieUpdateBackImage(t *testing.T) {
 		// create movie to test against
 		const name = "TestMovieUpdateMovieImages"
 		movie := models.Movie{
-			Name:     name,
+			Name: name,
 		}
 		err := qb.Create(ctx, &movie)
 		if err != nil {

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage } from "react-intl";
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import SceneQueue from "src/models/sceneQueue";
+import { ConfigurationContext } from "src/hooks/Config";
 
 interface ISceneListTableProps {
   scenes: GQL.SlimSceneDataFragment[];
@@ -19,6 +20,8 @@ interface ISceneListTableProps {
 export const SceneListTable: React.FC<ISceneListTableProps> = (
   props: ISceneListTableProps
 ) => {
+  const { configuration } = React.useContext(ConfigurationContext);
+
   const renderTags = (tags: Partial<GQL.TagDataFragment>[]) =>
     tags.map((tag) => (
       <Link key={tag.id} to={NavUtils.makeTagScenesUrl(tag)}>
@@ -59,6 +62,9 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
 
     const file = scene.files.length > 0 ? scene.files[0] : undefined;
 
+    const showFilePath =
+      configuration?.interface.showFilePathInSceneList && file?.path;
+
     const title = objectTitle(scene);
     return (
       <tr key={scene.id}>
@@ -97,6 +103,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
           <Link to={sceneLink}>
             <h5>{title}</h5>
           </Link>
+          {showFilePath && <small>{file.path}</small>}
         </td>
         <td>{scene.rating100 ? scene.rating100 : ""}</td>
         <td>{file?.duration && TextUtils.secondsToTimestamp(file.duration)}</td>

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -271,6 +271,15 @@ export const SettingsInterfacePanel: React.FC = () => {
         />
       </SettingSection>
 
+      <SettingSection headingID="config.ui.scene_list_table.heading">
+        <BooleanSetting
+          id="show-file-path"
+          headingID="config.ui.scene_list_table.options.show_file_path_in_scene_list"
+          checked={iface.showFilePathInSceneList ?? undefined}
+          onChange={(v) => saveInterface({ showFilePathInSceneList: v })}
+        />
+      </SettingSection>
+
       <SettingSection headingID="config.ui.scene_player.heading">
         <BooleanSetting
           id="enable-chromecast"

--- a/ui/v2.5/src/docs/en/Manual/Interface.md
+++ b/ui/v2.5/src/docs/en/Manual/Interface.md
@@ -14,6 +14,10 @@ The Scene Wall and Marker pages display scene preview videos by default. This ca
 
 By default, a scene's studio will be shown as an image overlay. Checking this option changes this to display studios as a text name instead.
 
+## Show File Path
+
+By default, no file path will be shown in the scene list. Checking this option changes this to display the file path below the title.
+
 ## Scene Player options
 
 By default, scene videos do not automatically start when navigating to the scenes page. Checking the "Auto-start video" option changes this to auto play scene videos.

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -676,6 +676,12 @@
           "show_studio_as_text": "Show Studios as text"
         }
       },
+      "scene_list_table": {
+        "heading": "Scene List Table",
+        "options": {
+          "show_file_path_in_scene_list": "Show File Path"
+        }
+      },
       "scene_player": {
         "heading": "Scene Player",
         "options": {


### PR DESCRIPTION
This code adds a new setting in the Interface section to allow users to toggle on/off showing the File Path on the Scene list table view. The default remains False, meaning the file path does not show. Toggling on this setting will show the full file path under the scene title. This attempts to fix issue #2948.