### PR TITLE
Allow Autoplay when loading the site first time

### DIFF
--- a/ui/v2.5/src/components/Images/ImageWallItem.tsx
+++ b/ui/v2.5/src/components/Images/ImageWallItem.tsx
@@ -44,6 +44,7 @@ export const ImageWallItem: React.FC<RenderImageProps> = (
   return (
     <ImagePreview
       loop={video}
+      muted={video}
       autoPlay={video}
       key={props.photo.key}
       style={imgStyle}


### PR DESCRIPTION
Right now, when an image clip is in the image wall and the site is loaded/reloaded, videos won't autoplay. The browser ignores the autoplay because the play is not started by user interaction and the video is not muted, so I added the muted attribute, as those previews have no audio anyway.