### PR TITLE
Fix bulk tagger again

### DIFF
--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -383,8 +383,8 @@ func (s *Manager) StashBoxBatchPerformerTag(ctx context.Context, input StashBoxB
 							}
 
 							// Check if the user wants to refresh existing or new items
-							if (input.Refresh && len(performer.StashIDs.List()) > 0) ||
-								(!input.Refresh && len(performer.StashIDs.List()) == 0) {
+							hasStashID := performer.StashIDs.ForEndpoint(box.Endpoint) != nil
+							if (input.Refresh && hasStashID) || (!input.Refresh && !hasStashID) {
 								tasks = append(tasks, StashBoxBatchTagTask{
 									performer:      performer,
 									refresh:        input.Refresh,
@@ -516,8 +516,8 @@ func (s *Manager) StashBoxBatchStudioTag(ctx context.Context, input StashBoxBatc
 							}
 
 							// Check if the user wants to refresh existing or new items
-							if (input.Refresh && len(studio.StashIDs.List()) > 0) ||
-								(!input.Refresh && len(studio.StashIDs.List()) == 0) {
+							hasStashID := studio.StashIDs.ForEndpoint(box.Endpoint) != nil
+							if (input.Refresh && hasStashID) || (!input.Refresh && !hasStashID) {
 								tasks = append(tasks, StashBoxBatchTagTask{
 									studio:         studio,
 									refresh:        input.Refresh,

--- a/pkg/models/relationships.go
+++ b/pkg/models/relationships.go
@@ -208,6 +208,19 @@ func (r RelatedStashIDs) List() []StashID {
 	return r.list
 }
 
+// ForID returns the StashID object for the given endpoint. Returns nil if not found.
+func (r *RelatedStashIDs) ForEndpoint(endpoint string) *StashID {
+	r.mustLoaded()
+
+	for _, v := range r.list {
+		if v.Endpoint == endpoint {
+			return &v
+		}
+	}
+
+	return nil
+}
+
 func (r *RelatedStashIDs) load(fn func() ([]StashID, error)) error {
 	if r.Loaded() {
 		return nil

--- a/pkg/sqlite/migrations/48_premigrate.go
+++ b/pkg/sqlite/migrations/48_premigrate.go
@@ -130,7 +130,7 @@ func (m *schema48PreMigrator) fixStudioNames(ctx context.Context) error {
 					}
 				}
 
-				logger.Info("Renaming duplicate studio id %d to %s", id, newName)
+				logger.Infof("Renaming duplicate studio id %d to %s", id, newName)
 				_, err := m.db.Exec("UPDATE studios SET name = ? WHERE id = ?", newName, id)
 				if err != nil {
 					return err


### PR DESCRIPTION
This fixes another bug relating to the bulk tagger.

There is currently an error in the handling of `Untagged performers/studios` vs `Refresh tagged performers/studios` when bulk tagging these objects. The backend was not taking into account the fact that a performer/studio can have multiple StashIDs across different endpoints, and was instead treating "tagged" as meaning "has at least one StashID". This caused tagging for `Untagged performers/studios` to skip tagging items that already have a StashID, but for a different endpoint.

There exists another bulk tagging bug, but it was inadvertently fixed in 27016aa from #4092 (meaning it is still present in the v0.22.1 release): bulk scraping performers/studios for one stash-box endpoint would cause a matched performer/studio to lose all previous StashIDs. This happens because `getStashIDsForPerformer` and `getStashIDsForStudio` are not run inside a transaction, and since they ignore errors returned by `LoadStashIDs`, they always return `nil`. I bring this up because I found the first bug while investigating this one, and since it does cause data loss (albeit likely only for a very small number of people) another bugfix release might be needed.

And then 57d775d11d75c4e8453f5433f5b9714612948ffb just fixes a typo I made all the way back in #3839. No idea how I didn't spot it earlier.