### PR TITLE
Help text for animated image previews

### DIFF
--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -133,6 +133,7 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
         id="phash-task"
         checked={options.phashes ?? false}
         headingID="dialogs.scene_gen.phash"
+        tooltipID="dialogs.scene_gen.phash_tooltip"
         onChange={(v) => setOptions({ phashes: v })}
       />
 

--- a/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
@@ -53,6 +53,7 @@ export const ScanOptions: React.FC<IScanOptions> = ({
       <BooleanSetting
         id="scan-generate-sprites"
         headingID="config.tasks.generate_sprites_during_scan"
+        tooltipID="config.tasks.generate_sprites_during_scan_tooltip"
         checked={scanGenerateSprites ?? false}
         onChange={(v) => setOptions({ scanGenerateSprites: v })}
       />

--- a/ui/v2.5/src/docs/en/Manual/Interface.md
+++ b/ui/v2.5/src/docs/en/Manual/Interface.md
@@ -6,7 +6,7 @@ Setting the language affects the formatting of numbers and dates.
 
 ## Scene/Marker Wall Preview Type
 
-The Scene Wall and Marker pages display scene preview videos by default. This can be changed to animated image (webp) or static image. 
+The Scene Wall and Marker pages display scene preview videos (mp4) by default. This can be changed to animated image (webp) or static image. 
 
 > **⚠️ Note:** scene/marker preview videos must be generated to see them in the applicable wall page if Video preview type is selected. Likewise, if Animated Image is selected, then Image Previews must be generated.
 

--- a/ui/v2.5/src/docs/en/Manual/Tasks.md
+++ b/ui/v2.5/src/docs/en/Manual/Tasks.md
@@ -15,9 +15,9 @@ The scan task accepts the following options:
 | Option | Description |
 |--------|-------------|
 | Generate scene covers | Generates scene covers for video files. |
-| Generate previews | Generates video previews which play when hovering over a scene. |
-| Generate animated image previews | Generates animated webp previews. Only required if the Preview Type is set to Animated Image. Requires Generate previews to be enabled. |
-| Generate scrubber sprites | Generates sprites for the scene scrubber. |
+| Generate previews | Generates video previews (mp4) which play when hovering over a scene. |
+| Generate animated image previews | Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files. |
+| Generate scrubber sprites | The set of images displayed below the video player for easy navigation. |
 | Generate perceptual hashes | Generates perceptual hashes for scene deduplication and identification. |
 | Generate thumbnails for images | Generates thumbnails for image files. | 
 | Generate previews for image clips | Generates a gif/looping video as thumbnail for image clips/gifs. |
@@ -43,11 +43,11 @@ The generate task accepts the following options:
 | Option | Description |
 |--------|-------------|
 | Scene covers | Generates scene covers for video files. |
-| Previews | Generates video previews which play when hovering over a scene. |
-| Animated image previews | Generates animated webp previews. Only required if the Preview Type is set to Animated Image. Requires Generate previews to be enabled. |
-| Scene Scrubber Sprites | Generates sprites for the scene scrubber. |
-| Markers Previews | Generates 20 second videos which begin at the marker timecode. |
-| Marker Animated Image Previews | Generates animated webp previews for markers. Only required if the Preview Type is set to Animated Image. Requires Markers to be enabled. |
+| Previews | Generates video previews (mp4) which play when hovering over a scene. |
+| Animated image previews | Generates animated previews (webp). Only required if the Preview Type is set to Animated Image. Requires Generate previews to be enabled. |
+| Scene Scrubber Sprites | The set of images displayed below the video player for easy navigation. |
+| Markers Previews | Generates 20 second video previews (mp4) which begin at the marker timecode. |
+| Marker Animated Image Previews | Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files. |
 | Marker Screenshots | Generates static JPG images for markers. Only required if Preview Type is set to Static Image. Requires Marker Previews to be enabled. | 
 | Transcodes | MP4 conversions of unsupported video formats. Allows direct streaming instead of live transcoding. |
 | Perceptual hashes (for deduplication) | Generates perceptual hashes for scene deduplication and identification. |

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -360,8 +360,8 @@
       "parallel_scan_head": "Parallel Scan/Generation",
       "preview_generation": "Preview Generation",
       "python_path": {
-        "description": "Location of python executable. Used for script scrapers and plugins. If blank, python will be resolved from the environment",
-        "heading": "Python Path"
+        "description": "Path to the python executable (not just the folder). Used for script scrapers and plugins. If blank, python will be resolved from the environment",
+        "heading": "Python Executable Path"
       },
       "scraper_user_agent": "Scraper User Agent",
       "scraper_user_agent_desc": "User-Agent string used during scrape http requests",
@@ -439,8 +439,9 @@
       "generate_phashes_during_scan": "Generate perceptual hashes",
       "generate_phashes_during_scan_tooltip": "For deduplication and scene identification.",
       "generate_previews_during_scan": "Generate animated image previews",
-      "generate_previews_during_scan_tooltip": "Generate animated WebP previews, only required if Preview Type is set to Animated Image.",
+      "generate_previews_during_scan_tooltip": "Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files.",
       "generate_sprites_during_scan": "Generate scrubber sprites",
+      "generate_sprites_during_scan_tooltip": "The set of images displayed below the video player for easy navigation.",
       "generate_thumbnails_during_scan": "Generate thumbnails for images",
       "generate_video_covers_during_scan": "Generate scene covers",
       "generate_video_previews_during_scan": "Generate previews",
@@ -662,7 +663,7 @@
         }
       },
       "preview_type": {
-        "description": "Configuration for wall items",
+        "description": "The default option is video (mp4) previews. For less CPU usage when browsing, you can use the animated image (webp) previews. However they must be generated in addition to the video previews and are larger files.",
         "heading": "Preview Type",
         "options": {
           "animated": "Animated Image",
@@ -859,10 +860,10 @@
       "force_transcodes": "Force Transcode generation",
       "force_transcodes_tooltip": "By default, transcodes are only generated when the video file is not supported in the browser. When enabled, transcodes will be generated even when the video file appears to be supported in the browser.",
       "image_previews": "Animated Image Previews",
-      "image_previews_tooltip": "Animated WebP previews, only required if Preview Type is set to Animated Image.",
+      "image_previews_tooltip": "Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files.",
       "interactive_heatmap_speed": "Generate heatmaps and speeds for interactive scenes",
       "marker_image_previews": "Marker Animated Image Previews",
-      "marker_image_previews_tooltip": "Animated marker WebP previews, only required if Preview Type is set to Animated Image.",
+      "marker_image_previews_tooltip": "Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files.",
       "marker_screenshots": "Marker Screenshots",
       "marker_screenshots_tooltip": "Marker static JPG images, only required if Preview Type is set to Static Image.",
       "markers": "Marker Previews",
@@ -870,7 +871,8 @@
       "override_preview_generation_options": "Override Preview Generation Options",
       "override_preview_generation_options_desc": "Override Preview Generation Options for this operation. Defaults are set in System -> Preview Generation.",
       "overwrite": "Overwrite existing files",
-      "phash": "Perceptual hashes (for deduplication)",
+      "phash": "Perceptual hashes",
+      "phash_tooltip": "For deduplication and scene identification",
       "preview_exclude_end_time_desc": "Exclude the last x seconds from scene previews. This can be a value in seconds, or a percentage (eg 2%) of the total scene duration.",
       "preview_exclude_end_time_head": "Exclude end time",
       "preview_exclude_start_time_desc": "Exclude the first x seconds from scene previews. This can be a value in seconds, or a percentage (eg 2%) of the total scene duration.",
@@ -884,7 +886,7 @@
       "preview_seg_duration_desc": "Duration of each preview segment, in seconds.",
       "preview_seg_duration_head": "Preview segment duration",
       "sprites": "Scene Scrubber Sprites",
-      "sprites_tooltip": "Sprites (for the scene scrubber)",
+      "sprites_tooltip": "The set of images displayed below the video player for easy navigation.",
       "transcodes": "Transcodes",
       "transcodes_tooltip": "MP4 conversions of unsupported video formats",
       "video_previews": "Previews",
@@ -926,7 +928,7 @@
       "medium": "Medium"
     },
     "search_accuracy_label": "Search Accuracy",
-    "select_options" : "Select Options…",
+    "select_options": "Select Options…",
     "select_all_but_largest_file": "Select every file in each duplicated group, except the largest file",
     "select_none": "Select None",
     "select_oldest": "Select the oldest file in the duplicate group",


### PR DESCRIPTION
- Added text to help folks understand what animated image previews are and why they might use them, but the downsides that come with.
- Explanation on what a scrubber sprite is.
- Added text to the Python path to hopefully stop folks from entering the folder where their python executable is.