### PR TITLE
Fix width of image selection arrow div

### DIFF
--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapeDialog.tsx
@@ -402,7 +402,7 @@ export const ScrapedImagesRow: React.FC<IScrapedImagesRowProps> = (props) => {
         />
       )}
       renderNewField={() => (
-        <div>
+        <div className="image-selection-parent">
           <ImageSelector
             imageClassName={props.className}
             images={props.images}

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -144,6 +144,10 @@
     padding-right: 15px;
   }
 
+  .image-selection-parent {
+    min-width: 100%;
+  }
+
   .image-selection {
     .select-buttons {
       align-items: center;
@@ -369,6 +373,7 @@ div.react-datepicker {
 
   .react-datepicker__day {
     color: $text-color;
+
     &.react-datepicker__day--disabled {
       color: $text-muted;
     }
@@ -438,6 +443,7 @@ div.react-datepicker {
     }
   }
 }
+
 /* stylelint-enable */
 
 #date-picker-portal .react-datepicker-popper {


### PR DESCRIPTION
When selecting an image for a performer, the arrows no longer move around depending on the size of the image.