### PR TITLE
Fix false positive mismatch in Movie Scrape dialog

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
@@ -84,9 +84,10 @@ export const MovieScrapeDialog: React.FC<IMovieScrapeDialogProps> = (
   const [duration, setDuration] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(
       DurationUtils.secondsToString(props.movie.duration || 0),
+      // convert seconds to string if it's a number
       props.scraped.duration && !isNaN(+props.scraped.duration)
         ? DurationUtils.secondsToString(parseInt(props.scraped.duration, 10))
-        : undefined
+        : props.scraped.duration
     )
   );
   const [date, setDate] = useState<ScrapeResult<string>>(

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieScrapeDialog.tsx
@@ -84,7 +84,9 @@ export const MovieScrapeDialog: React.FC<IMovieScrapeDialogProps> = (
   const [duration, setDuration] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(
       DurationUtils.secondsToString(props.movie.duration || 0),
-      props.scraped.duration
+      props.scraped.duration && !isNaN(+props.scraped.duration)
+        ? DurationUtils.secondsToString(parseInt(props.scraped.duration, 10))
+        : undefined
     )
   );
   const [date, setDate] = useState<ScrapeResult<string>>(


### PR DESCRIPTION
Scraping a movie by URL would show a difference in duration because the persisted value of duration was converted to HH:MM:SS while the newly scraped value was displayed without formatting: this makes sense because the newly scraped value is just a string and so could be anything

![Scraping the same movie](https://cdn.discordapp.com/attachments/651418567475986432/1154751683944005652/image.png)

This adds a check to see if the string is a number and converts it to HH:MM:SS format if possible