### PR TITLE
Allow scene scrapers to return full movie data

### DIFF
--- a/graphql/documents/data/scrapers.graphql
+++ b/graphql/documents/data/scrapers.graphql
@@ -110,6 +110,12 @@ fragment ScrapedSceneMovieData on ScrapedMovie {
   director
   url
   synopsis
+  front_image
+  back_image
+
+  studio {
+    ...ScrapedMovieStudioData
+  }
 }
 
 fragment ScrapedSceneStudioData on ScrapedStudio {


### PR DESCRIPTION
Movies scraped from the scene scrape dialog can now create full movies just like the movie scrape dialog albeit without the helpful preview