### PR TITLE
PerformerSelect Tagger bugfixes

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -5,6 +5,7 @@ import {
   MultiValueGenericProps,
   SingleValueProps,
 } from "react-select";
+import cx from "classnames";
 
 import * as GQL from "src/core/generated-graphql";
 import {
@@ -170,6 +171,13 @@ export const PerformerSelect: React.FC<
   return (
     <FilterSelectComponent<Performer, boolean>
       {...props}
+      className={cx(
+        "performer-select",
+        {
+          "performer-select-active": props.active,
+        },
+        props.className
+      )}
       loadOptions={loadPerformers}
       getNamedObject={getNamedObject}
       isValidNewOption={isValidNewOption}

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -224,6 +224,6 @@
   }
 }
 
-.react-select .alias {
+.performer-select .alias {
   font-weight: bold;
 }

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -10,6 +10,7 @@ import AsyncSelect from "react-select/async";
 import AsyncCreatableSelect, {
   AsyncCreatableProps,
 } from "react-select/async-creatable";
+import cx from "classnames";
 
 import { useToast } from "src/hooks/Toast";
 import { useDebounce } from "src/hooks/debounce";
@@ -89,6 +90,7 @@ const SelectComponent = <T, IsMulti extends boolean>(
     styles,
     defaultOptions: true,
     value: selectedOptions,
+    className: cx("react-select", props.className),
     classNamePrefix: "react-select",
     noOptionsMessage: () => noOptionsMessage,
     placeholder: isDisabled ? "" : placeholder,

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -89,7 +89,6 @@ const SelectComponent = <T, IsMulti extends boolean>(
     styles,
     defaultOptions: true,
     value: selectedOptions,
-    className: "react-select",
     classNamePrefix: "react-select",
     noOptionsMessage: () => noOptionsMessage,
     placeholder: isDisabled ? "" : placeholder,
@@ -119,6 +118,7 @@ export interface IFilterValueProps<T> {
 export interface IFilterProps {
   noSelectionString?: string;
   className?: string;
+  active?: boolean;
   isMulti?: boolean;
   isClearable?: boolean;
   isDisabled?: boolean;

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -89,7 +89,7 @@ const SelectComponent = <T, IsMulti extends boolean>(
     ...props,
     styles,
     defaultOptions: true,
-    value: selectedOptions,
+    value: selectedOptions ?? null,
     className: cx("react-select", props.className),
     classNamePrefix: "react-select",
     noOptionsMessage: () => noOptionsMessage,

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -147,7 +147,7 @@ export const ScrapedPerformersRow: React.FC<
     return (
       <PerformerSelect
         isMulti
-        className="form-control react-select"
+        className="form-control"
         isDisabled={!isNew}
         onSelect={(items) => {
           if (onChangeFn) {

--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
-import cx from "classnames";
 
 import * as GQL from "src/core/generated-graphql";
 import { Icon } from "src/components/Shared/Icon";
@@ -134,9 +133,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
         <PerformerSelect
           values={selectedPerformer ? [selectedPerformer] : []}
           onSelect={handlePerformerSelect}
-          className={cx("performer-select", {
-            "performer-select-active": selectedSource === "existing",
-          })}
+          active={selectedSource === "existing"}
           isClearable={false}
         />
         {maybeRenderLinkButton()}

--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -44,6 +44,11 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
 
   const [selectedPerformer, setSelectedPerformer] = useState<Performer>();
 
+  function selectPerformer(selected: Performer | undefined) {
+    setSelectedPerformer(selected);
+    setSelectedID(selected?.id);
+  }
+
   useEffect(() => {
     if (
       performerData?.findPerformer &&
@@ -55,17 +60,14 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
 
   const handleSelect = (performers: Performer[]) => {
     if (performers.length) {
-      setSelectedPerformer(performers[0]);
-      setSelectedID(performers[0].id);
+      selectPerformer(performers[0]);
     } else {
-      setSelectedPerformer(undefined);
-      setSelectedID(undefined);
+      selectPerformer(undefined);
     }
   };
 
   const handleSkip = () => {
-    setSelectedPerformer(undefined);
-    setSelectedID(undefined);
+    selectPerformer(undefined);
   };
 
   if (stashLoading) return <div>Loading performer</div>;

--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -42,9 +42,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
       stashID.stash_id === performer.remote_site_id
   );
 
-  const [selectedPerformer, setSelectedPerformer] = useState<
-    Performer | undefined
-  >();
+  const [selectedPerformer, setSelectedPerformer] = useState<Performer>();
 
   useEffect(() => {
     if (
@@ -55,7 +53,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     }
   }, [performerData?.findPerformer, selectedID]);
 
-  const handlePerformerSelect = (performers: Performer[]) => {
+  const handleSelect = (performers: Performer[]) => {
     if (performers.length) {
       setSelectedPerformer(performers[0]);
       setSelectedID(performers[0].id);
@@ -65,7 +63,8 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     }
   };
 
-  const handlePerformerSkip = () => {
+  const handleSkip = () => {
+    setSelectedPerformer(undefined);
     setSelectedID(undefined);
   };
 
@@ -82,7 +81,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
           <OptionalField
             exclude={selectedID === undefined}
             setExclude={(v) =>
-              v ? handlePerformerSkip() : setSelectedID(matchedPerformer.id)
+              v ? handleSkip() : setSelectedID(matchedPerformer.id)
             }
           >
             <div>
@@ -126,13 +125,13 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
         </Button>
         <Button
           variant={selectedSource === "skip" ? "primary" : "secondary"}
-          onClick={() => handlePerformerSkip()}
+          onClick={() => handleSkip()}
         >
           <FormattedMessage id="actions.skip" />
         </Button>
         <PerformerSelect
           values={selectedPerformer ? [selectedPerformer] : []}
-          onSelect={handlePerformerSelect}
+          onSelect={handleSelect}
           active={selectedSource === "existing"}
           isClearable={false}
         />

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -66,6 +66,16 @@
     background-color: hsl(204, 20%, 30%);
     cursor: pointer;
   }
+
+  .performer-select,
+  .studio-select {
+    width: 14rem;
+
+    // stylelint-disable-next-line selector-class-pattern
+    &-active .react-select__control {
+      background-color: #137cbd;
+    }
+  }
 }
 
 .selected-result {
@@ -96,16 +106,6 @@
 
 .select-existing {
   width: 2rem;
-}
-
-.performer-select,
-.studio-select {
-  width: 14rem;
-
-  // stylelint-disable-next-line selector-class-pattern
-  &-active .react-select__control {
-    background-color: #137cbd;
-  }
 }
 
 .entity-name {


### PR DESCRIPTION
This fixes two bugs which I believe were introduced by the PerformerScene refactoring in #4013.

- When using the Tagger with a non-stashbox scraper, and a scraped performer matches one already in the database, the selection box is no longer highlighted in blue. It also no longer has fixed width, so the control changes size based on how long the performer's name is. This is due to the `performer-select` and `performer-select-active` classes not being properly passed down to the underlying `react-select` component.
- When "Skip" is clicked, the performer select box is not properly cleared anymore - the name still remains. This was just due to a missing `setSelectedPerformer(undefined)`.

Before:
![before](https://github.com/stashapp/stash/assets/99329275/a7d19a60-fd84-4d4d-af54-303a87e0574a)
After:
![after](https://github.com/stashapp/stash/assets/99329275/553ecc57-0c23-459a-bdda-9b2a6bcd0f34)
