### PR TITLE
Filter migration fix

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -143,7 +143,10 @@ export abstract class Criterion<V extends CriterionValue> {
   }
 
   public setFromEncodedCriterion(encodedCriterion: IEncodedCriterion<V>) {
-    if (encodedCriterion.value !== undefined) {
+    if (
+      encodedCriterion.value !== undefined &&
+      encodedCriterion.value !== null
+    ) {
       this.value = encodedCriterion.value;
     }
     this.modifier = encodedCriterion.modifier;


### PR DESCRIPTION
Changes the 49 post-migration to exclude the `value` field for `is null` and `not null` modifiers. Also fixes the UI to handle `null` criterion values, in addition to `undefined`, to prevent a UI crash.