### PR TITLE
Scene framerate filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -225,6 +225,8 @@ input SceneFilterType {
   duplicated: PHashDuplicationCriterionInput
   "Filter by resolution"
   resolution: ResolutionCriterionInput
+  "Filter by frame rate"
+  framerate: IntCriterionInput
   "Filter by video codec"
   video_codec: StringCriterionInput
   "Filter by audio codec"

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -41,6 +41,8 @@ type SceneFilterType struct {
 	Duplicated *PHashDuplicationCriterionInput `json:"duplicated"`
 	// Filter by resolution
 	Resolution *ResolutionCriterionInput `json:"resolution"`
+	// Filter by framerate
+	Framerate *IntCriterionInput `json:"framerate"`
 	// Filter by video codec
 	VideoCodec *StringCriterionInput `json:"video_codec"`
 	// Filter by audio codec

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -983,7 +983,7 @@ func (qb *SceneStore) makeFilter(ctx context.Context, sceneFilter *models.SceneF
 
 	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.Duration, "video_files.duration", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, resolutionCriterionHandler(sceneFilter.Resolution, "video_files.height", "video_files.width", qb.addVideoFilesTable))
-
+	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.Framerate, "ROUND(video_files.frame_rate)", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, codecCriterionHandler(sceneFilter.VideoCodec, "video_files.video_codec", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, codecCriterionHandler(sceneFilter.AudioCodec, "video_files.audio_codec", qb.addVideoFilesTable))
 

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -72,6 +72,7 @@ const criterionOptions = [
   RatingCriterionOption,
   createMandatoryNumberCriterionOption("o_counter"),
   ResolutionCriterionOption,
+  createMandatoryNumberCriterionOption("framerate"),
   createStringCriterionOption("video_codec"),
   createStringCriterionOption("audio_codec"),
   createDurationCriterionOption("duration"),

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -120,6 +120,7 @@ export type CriterionType =
   | "o_counter"
   | "resolution"
   | "average_resolution"
+  | "framerate"
   | "video_codec"
   | "audio_codec"
   | "duration"


### PR DESCRIPTION
Adds the ability to filter scenes by framerate.

I've opted for a number filter and rounding the stored framerates to the nearest number so 29.97 = 30, 23.98 = 24 and 59.94 = 60.

Resolves #2559