### PR TITLE
Fix data corruption when moving folders

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -593,6 +593,11 @@ func (s *scanJob) handleFolderRename(ctx context.Context, file scanFile) (*model
 		return nil, fmt.Errorf("updating folder for rename %q: %w", renamedFrom.Path, err)
 	}
 
+	// #4146 - correct sub-folders to have the correct path
+	if err := correctSubFolderHierarchy(ctx, s.Repository.FolderStore, renamedFrom); err != nil {
+		return nil, fmt.Errorf("correcting sub folder hierarchy for %q: %w", renamedFrom.Path, err)
+	}
+
 	return renamedFrom, nil
 }
 

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -33,7 +33,7 @@ const (
 	dbConnTimeout = 30
 )
 
-var appSchemaVersion uint = 51
+var appSchemaVersion uint = 52
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/52_postmigrate.go
+++ b/pkg/sqlite/migrations/52_postmigrate.go
@@ -1,0 +1,79 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/sqlite"
+)
+
+type schema52Migrator struct {
+	migrator
+}
+
+func post52(ctx context.Context, db *sqlx.DB) error {
+	logger.Info("Running post-migration for schema version 52")
+
+	m := schema52Migrator{
+		migrator: migrator{
+			db: db,
+		},
+	}
+
+	return m.migrate(ctx)
+}
+
+func (m *schema52Migrator) migrate(ctx context.Context) error {
+	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
+		query := "SELECT `folders`.`id`, `folders`.`path`, `parent_folder`.`path` FROM `folders` " +
+			"INNER JOIN `folders` AS `parent_folder` ON `parent_folder`.`id` = `folders`.`parent_folder_id`"
+
+		rows, err := m.db.Query(query)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var (
+				id               int
+				folderPath       string
+				parentFolderPath string
+			)
+
+			err := rows.Scan(&id, &folderPath, &parentFolderPath)
+			if err != nil {
+				return err
+			}
+
+			// ensure folder path is correct
+			if !strings.HasPrefix(folderPath, parentFolderPath) {
+				logger.Debugf("folder path %s does not have prefix %s. Correcting...", folderPath, parentFolderPath)
+
+				// get the basename of the zip folder path and append it to the correct path
+				folderBasename := filepath.Base(folderPath)
+				correctPath := filepath.Join(parentFolderPath, folderBasename)
+
+				logger.Infof("correcting folder path %s to %s", folderPath, correctPath)
+
+				if _, err := m.db.Exec("UPDATE folders SET path = ? WHERE id = ?", correctPath, id); err != nil {
+					return fmt.Errorf("error updating folder path %s to %s: %w", folderPath, correctPath, err)
+				}
+			}
+		}
+
+		return rows.Err()
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	sqlite.RegisterPostMigration(52, post52)
+}

--- a/pkg/sqlite/migrations/52_zip_folder_data_correct.up.sql
+++ b/pkg/sqlite/migrations/52_zip_folder_data_correct.up.sql
@@ -1,0 +1,1 @@
+-- no schema changes


### PR DESCRIPTION
The folder rename detection code renamed the direct folder, but assumed that sub-folders would be handled during the scan. This left folders in zip files with incorrect paths, and could potentially impact other non-zip sub-folders as well.

The folder rename code now updates contained folders to have the correct sub-directory path. Also includes a data correction migration to correct any existing folders to be within their parent folder.