### PR TITLE
Fix unique folder migration error

### DIFF
--- a/pkg/sqlite/migrations/52_postmigrate.go
+++ b/pkg/sqlite/migrations/52_postmigrate.go
@@ -71,7 +71,7 @@ func (m *schema52Migrator) migrate(ctx context.Context) error {
 
 				if isEmptyErr == nil {
 					// correct path is not unique, log and skip
-					logger.Warnf("correct path %s is not unique, skipping...", correctPath)
+					logger.Warnf("correct path %s already exists, skipping...", correctPath)
 					continue
 				}
 

--- a/pkg/sqlite/migrations/52_postmigrate.go
+++ b/pkg/sqlite/migrations/52_postmigrate.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -64,7 +65,7 @@ func (m *schema52Migrator) migrate(ctx context.Context) error {
 				// ensure the correct path is unique
 				var v int
 				isEmptyErr := m.db.Get(&v, "SELECT 1 FROM folders WHERE path = ?", correctPath)
-				if isEmptyErr != nil && isEmptyErr != sql.ErrNoRows {
+				if isEmptyErr != nil && !errors.Is(isEmptyErr, sql.ErrNoRows) {
 					return fmt.Errorf("error checking if correct path %s is unique: %w", correctPath, isEmptyErr)
 				}
 


### PR DESCRIPTION
Fixes issue where the 52 post-migration was trying to rename folders to paths that already had a folder entry. Migration now logs that the folder can't be renamed and the folder is skipped.