### PR TITLE
Fix identify nil dereference

### DIFF
--- a/internal/identify/identify.go
+++ b/internal/identify/identify.go
@@ -126,10 +126,14 @@ func (t *SceneIdentifier) scrapeScene(ctx context.Context, txnManager txn.Manage
 
 // Returns a MetadataOptions object with any default options overwritten by source specific options
 func (t *SceneIdentifier) getOptions(source ScraperSource) MetadataOptions {
-	options := *t.DefaultOptions
+	var options MetadataOptions
+	if t.DefaultOptions != nil {
+		options = *t.DefaultOptions
+	}
 	if source.Options == nil {
 		return options
 	}
+
 	if source.Options.SetCoverImage != nil {
 		options.SetCoverImage = source.Options.SetCoverImage
 	}
@@ -151,6 +155,7 @@ func (t *SceneIdentifier) getOptions(source ScraperSource) MetadataOptions {
 	if source.Options.SkipSingleNamePerformerTag != nil && len(*source.Options.SkipSingleNamePerformerTag) > 0 {
 		options.SkipSingleNamePerformerTag = source.Options.SkipSingleNamePerformerTag
 	}
+
 	return options
 }
 


### PR DESCRIPTION
This is a straightforward fix for a nil deference panic when identifying scenes, that came up in Discord.

If the `options` input to the `metadataIdentify` graphql mutation is not specified, then `t.DefaultOptions` is `nil`, which causes the panic in `getOptions`.