### PR TITLE
Errors for performer/studio non-unique names

### DIFF
--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -108,6 +108,10 @@ func (r *mutationResolver) PerformerCreate(ctx context.Context, input models.Per
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Performer
 
+		if err := performer.EnsureNameUnique(ctx, 0, newPerformer.Name, newPerformer.Disambiguation, qb); err != nil {
+			return err
+		}
+
 		err = qb.Create(ctx, &newPerformer)
 		if err != nil {
 			return err
@@ -213,6 +217,10 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 	// Start the transaction and save the performer
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Performer
+
+		if err := performer.EnsureNameUnique(ctx, 0, updatedPerformer.Name.Value, updatedPerformer.Disambiguation.Value, qb); err != nil {
+			return err
+		}
 
 		// need to get existing performer
 		existing, err := qb.Find(ctx, performerID)
@@ -326,6 +334,10 @@ func (r *mutationResolver) BulkPerformerUpdate(ctx context.Context, input BulkPe
 		qb := r.repository.Performer
 
 		for _, performerID := range performerIDs {
+			if err := performer.EnsureNameUnique(ctx, 0, updatedPerformer.Name.Value, updatedPerformer.Disambiguation.Value, qb); err != nil {
+				return err
+			}
+
 			// need to get existing performer
 			existing, err := qb.Find(ctx, performerID)
 			if err != nil {

--- a/internal/api/resolver_mutation_studio.go
+++ b/internal/api/resolver_mutation_studio.go
@@ -61,6 +61,10 @@ func (r *mutationResolver) StudioCreate(ctx context.Context, input models.Studio
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Studio
 
+		if err := studio.EnsureStudioNameUnique(ctx, 0, newStudio.Name, qb); err != nil {
+			return err
+		}
+
 		if len(input.Aliases) > 0 {
 			if err := studio.EnsureAliasesUnique(ctx, 0, input.Aliases, qb); err != nil {
 				return err

--- a/pkg/performer/update.go
+++ b/pkg/performer/update.go
@@ -1,0 +1,57 @@
+package performer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type NameExistsError struct {
+	Name           string
+	Disambiguation string
+}
+
+func (e *NameExistsError) Error() string {
+	if e.Disambiguation != "" {
+		return fmt.Sprintf("performer with name '%s' and disambiguation '%s' already exists", e.Name, e.Disambiguation)
+	}
+	return fmt.Sprintf("performer with name '%s' already exists", e.Name)
+}
+
+// EnsureNameUnique returns an error if the performer name and disambiguation provided
+// is used by another performer
+func EnsureNameUnique(ctx context.Context, id int, name string, disambig string, qb models.PerformerReaderWriter) error {
+	performerFilter := models.PerformerFilterType{
+		Name: &models.StringCriterionInput{
+			Value:    name,
+			Modifier: models.CriterionModifierEquals,
+		},
+	}
+
+	if disambig != "" {
+		performerFilter.Disambiguation = &models.StringCriterionInput{
+			Value:    disambig,
+			Modifier: models.CriterionModifierEquals,
+		}
+	}
+
+	pp := 1
+	findFilter := models.FindFilterType{
+		PerPage: &pp,
+	}
+
+	existing, _, err := qb.Query(ctx, &performerFilter, &findFilter)
+	if err != nil {
+		return err
+	}
+
+	if len(existing) > 0 && existing[0].ID != id {
+		return &NameExistsError{
+			Name:           name,
+			Disambiguation: disambig,
+		}
+	}
+
+	return nil
+}

--- a/pkg/studio/update.go
+++ b/pkg/studio/update.go
@@ -109,8 +109,10 @@ func ValidateModify(ctx context.Context, s models.StudioPartial, qb ValidateModi
 		}
 	}
 
-	if err := EnsureStudioNameUnique(ctx, 0, s.Name.Value, qb); err != nil {
-		return err
+	if s.Name.Set && s.Name.Value != existing.Name {
+		if err := EnsureStudioNameUnique(ctx, 0, s.Name.Value, qb); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/studio/update.go
+++ b/pkg/studio/update.go
@@ -80,6 +80,7 @@ type ValidateModifyReader interface {
 // 1. The studio exists locally
 // 2. The studio is not its own ancestor
 // 3. The studio's aliases are unique
+// 4. The name is unique
 func ValidateModify(ctx context.Context, s models.StudioPartial, qb ValidateModifyReader) error {
 	existing, err := qb.Find(ctx, s.ID)
 	if err != nil {
@@ -106,6 +107,10 @@ func ValidateModify(ctx context.Context, s models.StudioPartial, qb ValidateModi
 		if err := EnsureAliasesUnique(ctx, s.ID, effectiveAliases, qb); err != nil {
 			return err
 		}
+	}
+
+	if err := EnsureStudioNameUnique(ctx, 0, s.Name.Value, qb); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Resolves #4154 
Resolves #3072 

Returns friendly error messages when creating/updating performers/studios and the name or alias is not unique.