### PR TITLE
Add disambiguation and links to tagger results

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -122,7 +122,14 @@ export const PerformerSelect: React.FC<
 
     thisOptionProps = {
       ...optionProps,
-      children: object.name,
+      children: (
+        <>
+          {object.name}
+          {object.disambiguation && (
+            <span className="performer-disambiguation">{` (${object.disambiguation})`}</span>
+          )}
+        </>
+      ),
     };
 
     return <reactSelectComponents.SingleValue {...thisOptionProps} />;

--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -19,6 +19,7 @@ interface IPerformerResultProps {
   onCreate: () => void;
   onLink?: () => Promise<void>;
   endpoint?: string;
+  stashBoxBaseURL?: string;
 }
 
 const PerformerResult: React.FC<IPerformerResultProps> = ({
@@ -28,6 +29,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
   onCreate,
   onLink,
   endpoint,
+  stashBoxBaseURL,
 }) => {
   const { data: performerData, loading: stashLoading } =
     GQL.useFindPerformerQuery({
@@ -70,6 +72,33 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     selectPerformer(undefined);
   };
 
+  function renderPerformerName(
+    p: GQL.ScrapedPerformer | Performer,
+    className: string,
+    url: string | undefined,
+    id: string | undefined | null
+  ) {
+    const name =
+      url && id ? (
+        <a href={url + "performers/" + id} target="_blank" rel="noreferrer">
+          {p.name}
+        </a>
+      ) : (
+        p.name
+      );
+
+    return (
+      <>
+        <b className={className}>{name}</b>
+        {p.disambiguation && (
+          <span className="performer-disambiguation">
+            {` (${p.disambiguation})`}
+          </span>
+        )}
+      </>
+    );
+  }
+
   if (stashLoading) return <div>Loading performer</div>;
 
   if (matchedPerformer && matchedStashID) {
@@ -77,7 +106,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
       <div className="row no-gutters my-2">
         <div className="entity-name">
           <FormattedMessage id="countables.performers" values={{ count: 1 }} />:
-          <b className="ml-2">{performer.name}</b>
+          {renderPerformerName(
+            performer,
+            "ml-2",
+            stashBoxBaseURL,
+            performer.remote_site_id
+          )}
         </div>
         <span className="ml-auto">
           <OptionalField
@@ -90,7 +124,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
               <span className="mr-2">
                 <FormattedMessage id="component_tagger.verb_matched" />:
               </span>
-              <b className="col-3 text-right">{matchedPerformer.name}</b>
+              {renderPerformerName(
+                matchedPerformer,
+                "ml-3 text-right",
+                "/",
+                matchedPerformer.id
+              )}
             </div>
           </OptionalField>
         </span>
@@ -119,7 +158,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     <div className="row no-gutters align-items-center mt-2">
       <div className="entity-name">
         <FormattedMessage id="countables.performers" values={{ count: 1 }} />:
-        <b className="ml-2">{performer.name}</b>
+        {renderPerformerName(
+          performer,
+          "ml-2",
+          stashBoxBaseURL,
+          performer.remote_site_id
+        )}
       </div>
       <ButtonGroup>
         <Button variant="secondary" onClick={() => onCreate()}>

--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -11,6 +11,41 @@ import {
   Performer,
   PerformerSelect,
 } from "src/components/Performers/PerformerSelect";
+import { getStashboxBase } from "src/utils/stashbox";
+
+interface IPerformerName {
+  performer: GQL.ScrapedPerformer | Performer;
+  className?: string;
+  baseURL: string | undefined;
+  id: string | undefined | null;
+}
+
+const PerformerName: React.FC<IPerformerName> = ({
+  performer,
+  className,
+  baseURL,
+  id,
+}) => {
+  const name =
+    baseURL && id ? (
+      <a href={`${baseURL}${id}`} target="_blank" rel="noreferrer">
+        {performer.name}
+      </a>
+    ) : (
+      performer.name
+    );
+
+  return (
+    <span className={className}>
+      <span>{name}</span>
+      {performer.disambiguation && (
+        <span className="performer-disambiguation">
+          {` (${performer.disambiguation})`}
+        </span>
+      )}
+    </span>
+  );
+};
 
 interface IPerformerResultProps {
   performer: GQL.ScrapedPerformer;
@@ -19,7 +54,6 @@ interface IPerformerResultProps {
   onCreate: () => void;
   onLink?: () => Promise<void>;
   endpoint?: string;
-  stashBoxBaseURL?: string;
 }
 
 const PerformerResult: React.FC<IPerformerResultProps> = ({
@@ -29,7 +63,6 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
   onCreate,
   onLink,
   endpoint,
-  stashBoxBaseURL,
 }) => {
   const { data: performerData, loading: stashLoading } =
     GQL.useFindPerformerQuery({
@@ -45,6 +78,11 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
   );
 
   const [selectedPerformer, setSelectedPerformer] = useState<Performer>();
+
+  const stashboxPerformerPrefix = endpoint
+    ? `${getStashboxBase(endpoint)}performers/`
+    : undefined;
+  const performerURLPrefix = "/performers/";
 
   function selectPerformer(selected: Performer | undefined) {
     setSelectedPerformer(selected);
@@ -72,33 +110,6 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     selectPerformer(undefined);
   };
 
-  function renderPerformerName(
-    p: GQL.ScrapedPerformer | Performer,
-    className: string,
-    url: string | undefined,
-    id: string | undefined | null
-  ) {
-    const name =
-      url && id ? (
-        <a href={url + "performers/" + id} target="_blank" rel="noreferrer">
-          {p.name}
-        </a>
-      ) : (
-        p.name
-      );
-
-    return (
-      <>
-        <b className={className}>{name}</b>
-        {p.disambiguation && (
-          <span className="performer-disambiguation">
-            {` (${p.disambiguation})`}
-          </span>
-        )}
-      </>
-    );
-  }
-
   if (stashLoading) return <div>Loading performer</div>;
 
   if (matchedPerformer && matchedStashID) {
@@ -106,12 +117,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
       <div className="row no-gutters my-2">
         <div className="entity-name">
           <FormattedMessage id="countables.performers" values={{ count: 1 }} />:
-          {renderPerformerName(
-            performer,
-            "ml-2",
-            stashBoxBaseURL,
-            performer.remote_site_id
-          )}
+          <PerformerName
+            performer={performer}
+            className="ml-2"
+            id={performer.remote_site_id}
+            baseURL={stashboxPerformerPrefix}
+          />
         </div>
         <span className="ml-auto">
           <OptionalField
@@ -124,12 +135,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
               <span className="mr-2">
                 <FormattedMessage id="component_tagger.verb_matched" />:
               </span>
-              {renderPerformerName(
-                matchedPerformer,
-                "ml-3 text-right",
-                "/",
-                matchedPerformer.id
-              )}
+              <PerformerName
+                performer={matchedPerformer}
+                className="ml-3 text-right"
+                id={matchedPerformer.id}
+                baseURL={performerURLPrefix}
+              />
             </div>
           </OptionalField>
         </span>
@@ -158,12 +169,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
     <div className="row no-gutters align-items-center mt-2">
       <div className="entity-name">
         <FormattedMessage id="countables.performers" values={{ count: 1 }} />:
-        {renderPerformerName(
-          performer,
-          "ml-2",
-          stashBoxBaseURL,
-          performer.remote_site_id
-        )}
+        <PerformerName
+          performer={performer}
+          className="ml-2"
+          id={performer.remote_site_id}
+          baseURL={stashboxPerformerPrefix}
+        />
       </div>
       <ButtonGroup>
         <Button variant="secondary" onClick={() => onCreate()}>

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -23,6 +23,7 @@ import PerformerResult from "./PerformerResult";
 import StudioResult from "./StudioResult";
 import { useInitialState } from "src/hooks/state";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { getStashboxBase } from "src/utils/stashbox";
 
 const getDurationStatus = (
   scene: IScrapedScene,
@@ -302,7 +303,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   }, [isActive, loading, stashScene, index, resolveScene, scene]);
 
   const stashBoxBaseURL = currentSource?.stashboxEndpoint
-    ? currentSource.stashboxEndpoint.match(/https?:\/\/.*?\//)?.[0]
+    ? getStashboxBase(currentSource.stashboxEndpoint)
     : undefined;
   const stashBoxURL = useMemo(() => {
     if (stashBoxBaseURL) {
@@ -669,7 +670,6 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
                 await linkPerformer(performer, performerIDs[performerIndex]!);
               }}
               endpoint={currentSource?.stashboxEndpoint}
-              stashBoxBaseURL={stashBoxBaseURL}
               key={`${performer.name ?? performer.remote_site_id ?? ""}`}
             />
           ))}

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -301,13 +301,14 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     }
   }, [isActive, loading, stashScene, index, resolveScene, scene]);
 
+  const stashBoxBaseURL = currentSource?.stashboxEndpoint
+    ? currentSource.stashboxEndpoint.match(/https?:\/\/.*?\//)?.[0]
+    : undefined;
   const stashBoxURL = useMemo(() => {
-    if (currentSource?.stashboxEndpoint && scene.remote_site_id) {
-      const endpoint = currentSource.stashboxEndpoint;
-      const endpointBase = endpoint.match(/https?:\/\/.*?\//)?.[0];
-      return `${endpointBase}scenes/${scene.remote_site_id}`;
+    if (stashBoxBaseURL) {
+      return `${stashBoxBaseURL}scenes/${scene.remote_site_id}`;
     }
-  }, [currentSource, scene]);
+  }, [scene, stashBoxBaseURL]);
 
   const setExcludedField = (name: string, value: boolean) =>
     setExcludedFields({
@@ -638,6 +639,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             setSelectedID={(id) => setStudioID(id)}
             onCreate={() => showStudioModal(scene.studio!)}
             endpoint={currentSource?.stashboxEndpoint}
+            stashBoxBaseURL={stashBoxBaseURL}
             onLink={async () => {
               await linkStudio(scene.studio!, studioID!);
             }}
@@ -667,6 +669,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
                 await linkPerformer(performer, performerIDs[performerIndex]!);
               }}
               endpoint={currentSource?.stashboxEndpoint}
+              stashBoxBaseURL={stashBoxBaseURL}
               key={`${performer.name ?? performer.remote_site_id ?? ""}`}
             />
           ))}

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -640,7 +640,6 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             setSelectedID={(id) => setStudioID(id)}
             onCreate={() => showStudioModal(scene.studio!)}
             endpoint={currentSource?.stashboxEndpoint}
-            stashBoxBaseURL={stashBoxBaseURL}
             onLink={async () => {
               await linkStudio(scene.studio!, studioID!);
             }}

--- a/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
@@ -18,6 +18,7 @@ interface IStudioResultProps {
   onCreate: () => void;
   onLink?: () => Promise<void>;
   endpoint?: string;
+  stashBoxBaseURL?: string;
 }
 
 const StudioResult: React.FC<IStudioResultProps> = ({
@@ -27,6 +28,7 @@ const StudioResult: React.FC<IStudioResultProps> = ({
   onCreate,
   onLink,
   endpoint,
+  stashBoxBaseURL,
 }) => {
   const { data: studioData, loading: stashLoading } = GQL.useFindStudioQuery({
     variables: { id: studio.stored_id ?? "" },
@@ -52,12 +54,32 @@ const StudioResult: React.FC<IStudioResultProps> = ({
 
   if (stashLoading) return <div>Loading studio</div>;
 
+  function renderStudioName(
+    name: string,
+    url: string | undefined,
+    id: string | undefined | null
+  ) {
+    return url && id ? (
+      <a href={url + "studios/" + id} target="_blank" rel="noreferrer">
+        {name}
+      </a>
+    ) : (
+      name
+    );
+  }
+
   if (matchedStudio && matchedStashID) {
     return (
       <div className="row no-gutters my-2">
         <div className="entity-name">
           <FormattedMessage id="countables.studios" values={{ count: 1 }} />:
-          <b className="ml-2">{studio.name}</b>
+          <b className="ml-2">
+            {renderStudioName(
+              studio.name,
+              stashBoxBaseURL,
+              studio.remote_site_id
+            )}
+          </b>
         </div>
         <span className="ml-auto">
           <OptionalField
@@ -70,7 +92,9 @@ const StudioResult: React.FC<IStudioResultProps> = ({
               <span className="mr-2">
                 <FormattedMessage id="component_tagger.verb_matched" />:
               </span>
-              <b className="col-3 text-right">{matchedStudio.name}</b>
+              <b className="col-3 text-right">
+                {renderStudioName(matchedStudio.name, "/", matchedStudio.id)}
+              </b>
             </div>
           </OptionalField>
         </span>
@@ -99,7 +123,13 @@ const StudioResult: React.FC<IStudioResultProps> = ({
     <div className="row no-gutters align-items-center mt-2">
       <div className="entity-name">
         <FormattedMessage id="countables.studios" values={{ count: 1 }} />:
-        <b className="ml-2">{studio.name}</b>
+        <b className="ml-2">
+          {renderStudioName(
+            studio.name,
+            stashBoxBaseURL,
+            studio.remote_site_id
+          )}
+        </b>
       </div>
       <ButtonGroup>
         <Button variant="secondary" onClick={() => onCreate()}>

--- a/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
@@ -10,6 +10,7 @@ import * as GQL from "src/core/generated-graphql";
 
 import { OptionalField } from "../IncludeButton";
 import { faSave } from "@fortawesome/free-solid-svg-icons";
+import { getStashboxBase } from "src/utils/stashbox";
 
 interface IStudioResultProps {
   studio: GQL.ScrapedStudio;
@@ -18,7 +19,6 @@ interface IStudioResultProps {
   onCreate: () => void;
   onLink?: () => Promise<void>;
   endpoint?: string;
-  stashBoxBaseURL?: string;
 }
 
 const StudioResult: React.FC<IStudioResultProps> = ({
@@ -28,7 +28,6 @@ const StudioResult: React.FC<IStudioResultProps> = ({
   onCreate,
   onLink,
   endpoint,
-  stashBoxBaseURL,
 }) => {
   const { data: studioData, loading: stashLoading } = GQL.useFindStudioQuery({
     variables: { id: studio.stored_id ?? "" },
@@ -39,6 +38,11 @@ const StudioResult: React.FC<IStudioResultProps> = ({
   const matchedStashID = matchedStudio?.stash_ids.some(
     (stashID) => stashID.endpoint === endpoint && stashID.stash_id
   );
+
+  const stashboxStudioPrefix = endpoint
+    ? `${getStashboxBase(endpoint)}studios/`
+    : undefined;
+    const studioURLPrefix = "/studios/";
 
   const handleSelect = (studios: SelectObject[]) => {
     if (studios.length) {
@@ -54,19 +58,23 @@ const StudioResult: React.FC<IStudioResultProps> = ({
 
   if (stashLoading) return <div>Loading studio</div>;
 
-  function renderStudioName(
-    name: string,
-    url: string | undefined,
-    id: string | undefined | null
-  ) {
-    return url && id ? (
-      <a href={url + "studios/" + id} target="_blank" rel="noreferrer">
+  const StudioName = ({
+    name,
+    baseURL,
+    id,
+  }: {
+    name: string;
+    baseURL: string | undefined;
+    id: string | undefined | null;
+  }) => {
+    return baseURL && id ? (
+      <a href={`${baseURL}${id}`} target="_blank" rel="noreferrer">
         {name}
       </a>
     ) : (
-      name
+      <span>name</span>
     );
-  }
+  };
 
   if (matchedStudio && matchedStashID) {
     return (
@@ -74,11 +82,11 @@ const StudioResult: React.FC<IStudioResultProps> = ({
         <div className="entity-name">
           <FormattedMessage id="countables.studios" values={{ count: 1 }} />:
           <b className="ml-2">
-            {renderStudioName(
-              studio.name,
-              stashBoxBaseURL,
-              studio.remote_site_id
-            )}
+            <StudioName
+              name={studio.name}
+              baseURL={stashboxStudioPrefix}
+              id={studio.remote_site_id}
+            />
           </b>
         </div>
         <span className="ml-auto">
@@ -93,7 +101,11 @@ const StudioResult: React.FC<IStudioResultProps> = ({
                 <FormattedMessage id="component_tagger.verb_matched" />:
               </span>
               <b className="col-3 text-right">
-                {renderStudioName(matchedStudio.name, "/", matchedStudio.id)}
+                <StudioName
+                  name={matchedStudio.name}
+                  baseURL={studioURLPrefix}
+                  id={matchedStudio.id}
+                />
               </b>
             </div>
           </OptionalField>
@@ -124,11 +136,11 @@ const StudioResult: React.FC<IStudioResultProps> = ({
       <div className="entity-name">
         <FormattedMessage id="countables.studios" values={{ count: 1 }} />:
         <b className="ml-2">
-          {renderStudioName(
-            studio.name,
-            stashBoxBaseURL,
-            studio.remote_site_id
-          )}
+          <StudioName
+            name={studio.name}
+            baseURL={stashboxStudioPrefix}
+            id={studio.remote_site_id}
+          />
         </b>
       </div>
       <ButtonGroup>

--- a/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
@@ -42,7 +42,7 @@ const StudioResult: React.FC<IStudioResultProps> = ({
   const stashboxStudioPrefix = endpoint
     ? `${getStashboxBase(endpoint)}studios/`
     : undefined;
-    const studioURLPrefix = "/studios/";
+  const studioURLPrefix = "/studios/";
 
   const handleSelect = (studios: SelectObject[]) => {
     if (studios.length) {


### PR DESCRIPTION
In the scene tagger results list, disambiguations are now shown beside a performers name. It's added to the Stashbox name, the matched local name and the local name currently selected in the dropdown.
This helps ensuring the matches are correct without having to go to the individual performer pages to confirm.

Those same performer names, as well as studio names are now links. Stashbox links open a new tab to the Stashbox they came from, and local names open a new tab to the local instance.
This removes the need for https://docs.stashapp.cc/add-ons/userscripts/#stash-scene-tagger-linkify (which no longer works correctly with the disambiguations added).