### PR TITLE
Tagger match performer by alias

### DIFF
--- a/pkg/match/scraped.go
+++ b/pkg/match/scraped.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/performer"
 	"github.com/stashapp/stash/pkg/studio"
 	"github.com/stashapp/stash/pkg/tag"
 )
 
 type PerformerFinder interface {
+	models.PerformerQueryer
 	FindByNames(ctx context.Context, names []string, nocase bool) ([]*models.Performer, error)
 	FindByStashID(ctx context.Context, stashID models.StashID) ([]*models.Performer, error)
 }
@@ -47,9 +49,17 @@ func ScrapedPerformer(ctx context.Context, qb PerformerFinder, p *models.Scraped
 		return err
 	}
 
-	if len(performers) != 1 {
-		// ignore - cannot match
-		return nil
+	if performers == nil || len(performers) != 1 {
+		// try matching a single performer by exact alias
+		performers, err = performer.ByAlias(ctx, qb, *p.Name)
+		if err != nil {
+			return err
+		}
+
+		if performers == nil || len(performers) != 1 {
+			// ignore - cannot match
+			return nil
+		}
 	}
 
 	id := strconv.Itoa(performers[0].ID)

--- a/pkg/performer/query.go
+++ b/pkg/performer/query.go
@@ -41,3 +41,24 @@ func CountByAppearsWith(ctx context.Context, r models.PerformerQueryer, id int) 
 
 	return r.QueryCount(ctx, filter, nil)
 }
+
+func ByAlias(ctx context.Context, r models.PerformerQueryer, alias string) ([]*models.Performer, error) {
+	f := &models.PerformerFilterType{
+		Aliases: &models.StringCriterionInput{
+			Value:    alias,
+			Modifier: models.CriterionModifierEquals,
+		},
+	}
+
+	ret, count, err := r.Query(ctx, f, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if count > 0 {
+		return ret, nil
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
When using scene tagger, if a performer is returned with no StashID match, it will attempt to find a single performer based on exact name match. This adds another step if no performer is found, and attempts to match an exact alias.
It will only return a match if a single performer has that alias, so common first name aliases will not return a match, but it should help match performers with a social media alias, or JAV where first and last can be switched.

Resolves #3423 
Resolves #3224