### PR TITLE
Log more when resolving Python

### DIFF
--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -96,7 +96,7 @@ func (t *rawPluginTask) Start() error {
 	go t.handlePluginStderr(t.plugin.Name, stderr)
 	t.cmd = cmd
 
-	logger.Infof("Plugin %s started: %s", t.plugin.Name, strings.Join(cmd.Args, " "))
+	logger.Debugf("Plugin %s started: %s", t.plugin.Name, strings.Join(cmd.Args, " "))
 
 	// send the stdout to the plugin output
 	go func() {
@@ -112,7 +112,7 @@ func (t *rawPluginTask) Start() error {
 			errStr := err.Error()
 			output.Error = &errStr
 		}
-		logger.Infof("Plugin %s finished", t.plugin.Name)
+		logger.Debugf("Plugin %s finished", t.plugin.Name)
 
 		t.result = &output
 	}()

--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync"
 
 	stashExec "github.com/stashapp/stash/pkg/exec"
@@ -45,21 +46,17 @@ func (t *rawPluginTask) Start() error {
 	var cmd *exec.Cmd
 	if python.IsPythonCommand(command[0]) {
 		pythonPath := t.serverConfig.GetPythonPath()
-		var p *python.Python
-		if pythonPath != "" {
-			p = python.New(pythonPath)
-		} else {
-			p, _ = python.Resolve()
-		}
+		p, err := python.Resolve(pythonPath)
 
-		if p != nil {
+		if err != nil {
+			logger.Warnf("%s", err)
+		} else {
 			cmd = p.Command(context.TODO(), command[1:])
 		}
-
-		// if could not find python, just use the command args as-is
 	}
 
 	if cmd == nil {
+		// if could not find python, just use the command args as-is
 		cmd = stashExec.Command(command[0], command[1:]...)
 	}
 
@@ -99,6 +96,8 @@ func (t *rawPluginTask) Start() error {
 	go t.handlePluginStderr(t.plugin.Name, stderr)
 	t.cmd = cmd
 
+	logger.Infof("Plugin %s started: %s", t.plugin.Name, strings.Join(cmd.Args, " "))
+
 	// send the stdout to the plugin output
 	go func() {
 		defer t.waitGroup.Done()
@@ -113,6 +112,7 @@ func (t *rawPluginTask) Start() error {
 			errStr := err.Error()
 			output.Error = &errStr
 		}
+		logger.Infof("Plugin %s finished", t.plugin.Name)
 
 		t.result = &output
 	}()

--- a/pkg/python/exec.go
+++ b/pkg/python/exec.go
@@ -23,19 +23,17 @@ func New(path string) *Python {
 // It first checks for python3, then python.
 // Returns nil and an exec.ErrNotFound error if not found.
 func Resolve() (*Python, error) {
-	_, err := exec.LookPath("python3")
-
-	if err != nil {
-		_, err = exec.LookPath("python")
-		if err != nil {
-			return nil, err
-		}
-		ret := Python("python")
-		return &ret, nil
+	python3, err := exec.LookPath("python3")
+	if err == nil {
+		return New(python3), nil
 	}
 
-	ret := Python("python3")
-	return &ret, nil
+	python, err := exec.LookPath("python")
+	if err == nil {
+		return New(python), nil
+	}
+
+	return nil, err
 }
 
 // IsPythonCommand returns true if arg is "python" or "python3"

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -84,7 +84,7 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 
 	go handleScraperStderr(s.config.Name, stderr)
 
-	logger.Infof("Scraper script <%s> started", strings.Join(cmd.Args, " "))
+	logger.Debugf("Scraper script <%s> started", strings.Join(cmd.Args, " "))
 
 	// TODO - add a timeout here
 	// Make a copy of stdout here. This allows us to decode it twice.
@@ -112,7 +112,7 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 	}
 
 	err = cmd.Wait()
-	logger.Infof("Scraper script finished")
+	logger.Debugf("Scraper script finished")
 
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrScraperScript, err)

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -43,13 +43,14 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 		if pythonPath != "" {
 			// Users commonly set the path to a folder instead of the executable
 			isFile, err := fsutil.FileExists(pythonPath)
-			if err != nil {
-				logger.Warnf("Unable to validate python path: %s", err)
-			} else if !isFile {
-				logger.Warnf("Python path is not a file: %s", pythonPath)
-			} else {
-				logger.Debugf("Using configured python path: %s", *p)
+			switch {
+			case err == nil && isFile:
+				logger.Debugf("Using configured python path: %s", pythonPath)
 				p = python.New(pythonPath)
+			case err == nil && !isFile:
+				logger.Warnf("Python path is not a file: %s", pythonPath)
+			case err != nil:
+				logger.Warnf("Unable to validate python path: %s", err)
 			}
 		} else {
 			p, _ = python.Resolve()


### PR DESCRIPTION
It's very common for users to struggle with configuring their Python environment for use with Stash and more verbose logging will help us when diagnosing the common issue of not knowing which (if any) Python executable they are using.

I also think the `Resolve` method could use the result of `LookPath` directly to use the absolute path for the Python executables it might find: this should make no difference to its usage, but allows us to log the absolute path.