### PR TITLE
Fix performer select not working correctly in scrape dialog

### DIFF
--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -151,7 +151,8 @@ export const ScrapedPerformersRow: React.FC<
         isDisabled={!isNew}
         onSelect={(items) => {
           if (onChangeFn) {
-            onChangeFn(items);
+            // map the id back to stored_id
+            onChangeFn(items.map((p) => ({ ...p, stored_id: p.id })));
           }
         }}
         values={selectValue}


### PR DESCRIPTION
Fixes issue where selecting performers in the scene scrape dialog would not fed back to the edit scene fields.