### PR TITLE
Don't unset organized if tagger flag is false

### DIFF
--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -463,7 +463,8 @@ export const TaggerContext: React.FC = ({ children }) => {
         variables: {
           input: {
             ...sceneCreateInput,
-            organized: config?.markSceneAsOrganizedOnSave,
+            // only set organized if it is enabled in the config
+            organized: config?.markSceneAsOrganizedOnSave || undefined,
           },
         },
       });


### PR DESCRIPTION
Fixes issue where if `Mark as Organized on save` is false, then organized would be set to false when saving a scene.