### PR TITLE
Fix build flags to be friendly to niche operating systems

### DIFF
--- a/internal/desktop/desktop_platform_nixes.go
+++ b/internal/desktop/desktop_platform_nixes.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd
-// +build linux freebsd
+//go:build unix && !darwin
+// +build unix,!darwin
 
 package desktop
 

--- a/internal/desktop/systray_nixes.go
+++ b/internal/desktop/systray_nixes.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd
-// +build linux freebsd
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package desktop
 


### PR DESCRIPTION
In `desktop_platform_nixes.go`, move from "linux or freebsd", to "unix and not darwin", I think it's a reasonable assumption that all non-MacOS UNIX-like OS's will at least have the option to install notify-send.

In `systray_nixes.go`, the no-op systray, move from "linux or freebsd" to "not-windows and not-darwin", so all operating systems except windows and MacOS have a no-op systray.