### PR TITLE
Fix performer stash ids being overwritten in performer tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -25,6 +25,7 @@ import { LOCAL_FORAGE_KEY, ITaggerConfig, initialConfig } from "../constants";
 import PerformerModal from "../PerformerModal";
 import { useUpdatePerformer } from "../queries";
 import { faStar, faTags } from "@fortawesome/free-solid-svg-icons";
+import { mergeStashIDs } from "src/utils/stashbox";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -367,10 +368,18 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
     });
   }
 
-  const handlePerformerUpdate = async (input: GQL.PerformerCreateInput) => {
+  const handlePerformerUpdate = async (
+    existing: GQL.PerformerDataFragment,
+    input: GQL.PerformerCreateInput
+  ) => {
     setModalPerformer(undefined);
     const performerID = modalPerformer?.stored_id;
     if (performerID) {
+      // handle stash ids - we want to add, not set them
+      if (input.stash_ids?.length) {
+        input.stash_ids = mergeStashIDs(existing.stash_ids, input.stash_ids);
+      }
+
       const updateData: GQL.PerformerUpdateInput = {
         ...input,
         id: performerID,
@@ -540,7 +549,9 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
               closeModal={() => setModalPerformer(undefined)}
               modalVisible={modalPerformer.stored_id === performer.id}
               performer={modalPerformer}
-              onSave={handlePerformerUpdate}
+              onSave={(input) => {
+                handlePerformerUpdate(performer, input);
+              }}
               excludedPerformerFields={config.excludedPerformerFields}
               icon={faTags}
               header={intl.formatMessage({

--- a/ui/v2.5/src/components/Tagger/performers/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/StashSearchResult.tsx
@@ -5,6 +5,7 @@ import * as GQL from "src/core/generated-graphql";
 import { useUpdatePerformer } from "../queries";
 import PerformerModal from "../PerformerModal";
 import { faTags } from "@fortawesome/free-solid-svg-icons";
+import { mergeStashIDs } from "src/utils/stashbox";
 
 interface IStashSearchResultProps {
   performer: GQL.SlimPerformerDataFragment;
@@ -37,6 +38,10 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     setError({});
     setSaveState("Saving performer");
     setModalPerformer(undefined);
+
+    if (input.stash_ids?.length) {
+      input.stash_ids = mergeStashIDs(performer.stash_ids, input.stash_ids);
+    }
 
     const updateData: GQL.PerformerUpdateInput = {
       ...input,

--- a/ui/v2.5/src/utils/stashbox.ts
+++ b/ui/v2.5/src/utils/stashbox.ts
@@ -1,6 +1,16 @@
+import { StashIdInput } from "src/core/generated-graphql";
+
 export function stashboxDisplayName(name: string, index: number) {
   return name || `Stash-Box #${index + 1}`;
 }
 
 export const getStashboxBase = (endpoint: string) =>
   endpoint.match(/(https?:\/\/.*?\/)graphql/)?.[1];
+
+// mergeStashIDs merges the src stash ID into the dest stash IDs.
+// If the src stash ID is already in dest, the src stash ID overwrites the dest stash ID.
+export function mergeStashIDs(dest: StashIdInput[], src: StashIdInput[]) {
+  return dest
+    .filter((i) => !src.find((j) => i.endpoint === j.endpoint))
+    .concat(src);
+}


### PR DESCRIPTION
Changes the performer tagger to merge stash ids instead of overwriting them.

Fixes #4212 