### PR TITLE
Show performer image in select

### DIFF
--- a/graphql/documents/data/performer-slim.graphql
+++ b/graphql/documents/data/performer-slim.graphql
@@ -40,4 +40,5 @@ fragment SelectPerformerData on Performer {
   name
   disambiguation
   alias_list
+  image_path
 }

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -34,7 +34,7 @@ export type SelectObject = {
 
 export type Performer = Pick<
   GQL.Performer,
-  "id" | "name" | "alias_list" | "disambiguation"
+  "id" | "name" | "alias_list" | "disambiguation" | "image_path"
 >;
 type Option = SelectOption<Performer>;
 
@@ -86,6 +86,18 @@ export const PerformerSelect: React.FC<
       ...optionProps,
       children: (
         <span>
+          <a
+            href={`/performers/${object.id}`}
+            target="_blank"
+            rel="noreferrer"
+            className="performer-select-image-link"
+          >
+            <img
+              className="performer-select-image"
+              src={object.image_path ?? ""}
+              loading="lazy"
+            />
+          </a>
           <span>{name}</span>
           {object.disambiguation && (
             <span className="performer-disambiguation">{` (${object.disambiguation})`}</span>

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -224,6 +224,14 @@
   }
 }
 
-.performer-select .alias {
-  font-weight: bold;
+.performer-select {
+  .alias {
+    font-weight: bold;
+  }
+
+  .performer-select-image {
+    margin-right: 0.5em;
+    max-height: 50px;
+    max-width: 50px;
+  }
 }


### PR DESCRIPTION
Shows a thumbnail of the performer in the performer select dropdown. Clicking on the image opens the performer detail page in a new tab. Images are loaded lazily. 

![image](https://github.com/stashapp/stash/assets/53250216/c199a3d9-ac48-4908-ab1a-8a57a396c926)

Proposed as an alternative to #4193 (ping @elkorol)
