### PR TITLE
Vite dev server authentication tweaks

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,7 +57,7 @@ NOTE: The `make` command in Windows will be `mingw32-make` with MinGW. For examp
 * `make fmt-ui` - Formats the UI source code
 * `make server-start` - Runs a development stash server in the `.local` directory
 * `make server-clean` - Removes the `.local` directory and all of its contents
-* `make ui-start` - Runs the UI in development mode. Requires a running Stash server to connect to. The server port can be changed from the default of `9999` using the environment variable `VITE_APP_PLATFORM_PORT`. The UI runs on port `3000` or the next available port.
+* `make ui-start` - Runs the UI in development mode. Requires a running Stash server to connect to - the server URL can be changed from the default of `http://localhost:9999` using the environment variable `VITE_APP_PLATFORM_URL`, but keep in mind that authentication cannot be used since the session authorization cookie cannot be sent cross-origin. The UI runs on port `3000` or the next available port.
 
 ## Local development quickstart
 

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -102,7 +102,7 @@ export const App: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch(getPlatformURL() + "customlocales");
+        const res = await fetch(getPlatformURL("customlocales"));
         if (res.ok) {
           setCustomMessages(await res.json());
         }

--- a/ui/v2.5/src/globals.d.ts
+++ b/ui/v2.5/src/globals.d.ts
@@ -5,11 +5,10 @@ declare module "*.md" {
   export default src;
 }
 
-/* eslint-disable-next-line  @typescript-eslint/naming-convention */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 interface ImportMetaEnv {
   readonly VITE_APP_GITHASH?: string;
   readonly VITE_APP_STASH_VERSION?: string;
   readonly VITE_APP_DATE?: string;
-  readonly VITE_APP_PLATFORM_PORT?: string;
-  readonly VITE_APP_HTTPS?: string;
+  readonly VITE_APP_PLATFORM_URL?: string;
 }

--- a/ui/v2.5/src/index.tsx
+++ b/ui/v2.5/src/index.tsx
@@ -9,7 +9,11 @@ import * as serviceWorker from "./serviceWorker";
 
 ReactDOM.render(
   <>
-    <link rel="stylesheet" type="text/css" href={`${getPlatformURL()}css`} />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href={getPlatformURL("css").toString()}
+    />
     <BrowserRouter basename={baseURL}>
       <ApolloProvider client={getClient()}>
         <App />
@@ -20,7 +24,7 @@ ReactDOM.render(
 );
 
 const script = document.createElement("script");
-script.src = `${getPlatformURL()}javascript`;
+script.src = getPlatformURL("javascript").toString();
 document.body.appendChild(script);
 
 // If you want your app to work offline and load faster, you can change

--- a/ui/v2.5/vite.config.js
+++ b/ui/v2.5/vite.config.js
@@ -34,11 +34,6 @@ export default defineConfig(() => {
       outDir: "build",
       sourcemap: sourcemap,
       reportCompressedSize: false,
-      rollupOptions: {
-        output: {
-          experimentalDeepDynamicChunkOptimization: true,
-        },
-      },
     },
     optimizeDeps: {
       entries: "src/index.tsx",


### PR DESCRIPTION
These are two simple tweaks to the UI behaviour when running the vite dev server:
- Add a `VITE_APP_PLATFORM_URL` environment variable, replacing the previous `VITE_APP_PLATFORM_PORT` and `VITE_APP_PLATFORM_HTTPS` variables, to allow the full backend server URL to be specified.
- Show an `alert()` when the graphql server returns a 401 instead of redirecting to the non-existent login page (which was causing a redirect loop). The session cookie cannot be sent since it is a cross-origin request, so authentication will never work with the dev server.

And then I've also removed the `experimentalDeepDynamicChunkOptimization` option, which now gives a `The "output.experimentalDeepDynamicChunkOptimization" option is deprecated as Rollup always runs the full chunking algorithm now` message when building the UI since vite was upgraded in #4225.