### PR TITLE
Accept incorrectly insensitivised frontpage config keys

### DIFF
--- a/ui/v2.5/src/components/FrontPage/Control.tsx
+++ b/ui/v2.5/src/components/FrontPage/Control.tsx
@@ -1,10 +1,6 @@
 import React, { useContext, useMemo } from "react";
 import { useIntl } from "react-intl";
-import {
-  FrontPageContent,
-  ICustomFilter,
-  ISavedFilterRow,
-} from "src/core/config";
+import { FrontPageContent, ICustomFilter } from "src/core/config";
 import * as GQL from "src/core/generated-graphql";
 import { useFindSavedFilter } from "src/core/StashService";
 import { ConfigurationContext } from "src/hooks/Config";
@@ -167,17 +163,15 @@ interface IProps {
 export const Control: React.FC<IProps> = ({ content }) => {
   switch (content.__typename) {
     case "SavedFilter":
-      if (!(content as ISavedFilterRow).savedFilterId) {
+      if (!content.savedFilterId) {
         return <div>Error: missing savedFilterId</div>;
       }
 
       return (
-        <SavedFilterResults
-          savedFilterID={(content as ISavedFilterRow).savedFilterId.toString()}
-        />
+        <SavedFilterResults savedFilterID={content.savedFilterId.toString()} />
       );
     case "CustomFilter":
-      return <CustomFilterResults customFilter={content as ICustomFilter} />;
+      return <CustomFilterResults customFilter={content} />;
     default:
       return <></>;
   }

--- a/ui/v2.5/src/components/FrontPage/FrontPage.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPage.tsx
@@ -10,6 +10,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import {
   FrontPageContent,
   generateDefaultFrontPageContent,
+  getFrontPageContent,
   IUIConfig,
 } from "src/core/config";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
@@ -65,12 +66,12 @@ const FrontPage: React.FC = () => {
     onUpdateConfig(defaultContent);
   }
 
-  const { frontPageContent } = ui;
+  const frontPageContent = getFrontPageContent(ui);
 
   return (
     <div className="recommendations-container">
       <div>
-        {frontPageContent?.map((content: FrontPageContent, i) => (
+        {frontPageContent?.map((content, i) => (
           <Control key={i} content={content} />
         ))}
       </div>

--- a/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
@@ -15,6 +15,7 @@ import {
   ICustomFilter,
   FrontPageContent,
   generatePremadeFrontPageContent,
+  getFrontPageContent,
 } from "src/core/config";
 
 interface IAddSavedFilterModalProps {
@@ -299,8 +300,9 @@ export const FrontPageConfig: React.FC<IFrontPageConfigProps> = ({
       return;
     }
 
-    if (ui?.frontPageContent) {
-      setCurrentContent(ui.frontPageContent);
+    const frontPageContent = getFrontPageContent(ui);
+    if (frontPageContent) {
+      setCurrentContent(frontPageContent);
     }
   }, [allFilters, ui]);
 


### PR DESCRIPTION
This is a fix to deal with the after effects of the bug that was fixed in #4128, specifically the incorrect saving of the `sortBy` and `savedFilterId` keys in the front page UI configuration. The viper update in #4107 thoroughly converts all keys in the config file to lowercase, so the UI will need to deal with `sortby` and `savedfilterid` keys in existing systems.