### PR TITLE
Add OpenBSD development instructions

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,23 @@ NOTE: The `make` command in Windows will be `mingw32-make` with MinGW. For examp
 2. Enable corepack in Node.js: `corepack enable`
 3. Install yarn: `corepack prepare yarn@stable --activate`
 
+### OpenBSD
+
+1. Install dependencies `doas pkg_add gmake go git yarn node cmake`
+2. Compile a custom ffmpeg from ports. The default ffmpeg in OpenBSD's packages is not compiled with WebP support, which is required by Stash.
+   - If you've already installed ffmpeg, uninstall it: `doas pkg_delete ffmpeg`
+   - If you haven't already, [fetch the ports tree and verify](https://www.openbsd.org/faq/ports/ports.html#PortsFetch).
+   - Find the ffmpeg port in `/usr/ports/graphics/ffmpeg`, and patch the Makefile to include libwebp
+     - Add `webp` to `WANTLIB`
+     - Add `graphics/libwebp` to the list in `LIB_DEPENDS`
+     - Add `-lwebp -lwebpdecoder -lwebpdemux -lwebpmux` to `LIBavcodec_EXTRALIBS`
+     - Add `--enable-libweb` to the list in `CONFIGURE_ARGS`
+     - If you've already built ffmpeg from ports before, you may need to also increment `REVISION`
+     - Run `doas make install`
+   - Follow the instructions below to build a release, but replace the final step `make build-release` with `gmake flags-release stash`, to [avoid the PIE buildmode](https://github.com/golang/go/issues/59866). 
+
+NOTE: The `make` command in OpenBSD will be `gmake`. For example, `make pre-ui` will be `gmake pre-ui`.
+
 ## Commands
 
 * `make pre-ui` - Installs the UI dependencies. This only needs to be run once after cloning the repository, or if the dependencies are updated.


### PR DESCRIPTION
Tested working on my laptop and also on a fresh OpenBSD 7.4 VM running from vmd(8). The dependencies are largely the same as other operating systems, with the addition of `cmake` which is only required for the compilation of the custom ffmpeg. For now I thought it was easier to include instructions for compiling the custom ffmpeg from ports rather than create a custom (and redistributable) binary, figure out hosting, and then patch the download code to point to the new binary, and test that works on OpenBSD. Getting that to work can be a follow-up pull request if the maintainers want that. 