### PR TITLE
Fix Docker compiler: Upgrade to gcc-12-multilib

### DIFF
--- a/docker/compiler/Dockerfile
+++ b/docker/compiler/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     apt-get install -y automake autogen cmake \
     libtool libxml2-dev uuid-dev libssl-dev bash \
     patch make tar xz-utils bzip2 gzip zlib1g-dev sed cpio \
-	gcc-10-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
+	gcc-12-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
 	gcc-arm-linux-gnueabi libc-dev-armel-cross linux-libc-dev-armel-cross \
     gcc-arm-linux-gnueabihf libc-dev-armhf-cross \
     gcc-aarch64-linux-gnu libc-dev-arm64-cross \


### PR DESCRIPTION
Building the Dockerfile for the compiler currently fails with `Unable to locate package gcc-10-multilib`. Looks like this is because the underlying image `golang:1.19` recently updated to Debian 12 "Bookworm". Debian 12 does not have gcc-10-multilib, but [does have gcc-12-multilib](https://packages.debian.org/bookworm/gcc-12-multilib). So this one-character change fixes the Dockerfile for newly built containers. 

Tested by running cross compiles and it seems to build successfully with the newly built container. 