### PR TITLE
Fixed nesting anchor elements

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -271,7 +271,10 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
             alt={performer.name ?? ""}
             src={performer.image_path ?? ""}
           />
-
+        </>
+      }
+      overlays={
+        <>
           {renderFavoriteIcon()}
           {maybeRenderRatingBanner()}
           {maybeRenderFlag()}


### PR DESCRIPTION
Currently on the performers page, on dev tools throws the error react-dom.development.js:67 Warning: validateDOMNesting(...):  < a > cannot appear as a descendant of < a >.

I fixed this by separating renderFavoriteIcon, maybeRenderRatingBanner and maybeRenderFlag out from the GridCard image prop and into and utilising the overlays prop.

Now the dev tools doesn't throw the error and the nesting of <a> tags is gone and the now overlay elements still seem to be in their correct places and still clickable over the performer card.