### PR TITLE
Fix hyphen symbol being used instead of the appropriate emdash

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -47,7 +47,7 @@ const SceneItemList = makeItemList({
       return;
     }
 
-    const separator = duration && size ? " - " : "";
+    const separator = duration && size ? "—" : "";
 
     return (
       <span className="scenes-stats">


### PR DESCRIPTION
The "-" symbol is a hyphen, it serves only a singular purpose: as a hyphen forming hyphenated words, i.e. "mother-in-law".

The correct grammatical symbol in this context is the emdash "—". Lazy folk will often substitute a hyphen with a space on either side into contexts where an emdash should be used.