### PR TITLE
Fix batch performer tag panic

### DIFF
--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -825,6 +825,10 @@ func (c Client) FindStashBoxPerformerByID(ctx context.Context, id string) (*mode
 		return nil, err
 	}
 
+	if performer.FindPerformer == nil {
+		return nil, nil
+	}
+
 	ret := performerFragmentToScrapedPerformer(*performer.FindPerformer)
 
 	r := c.repository


### PR DESCRIPTION
A nil deference panic can occur when batch performer tagging, if a performer has an invalid Stash ID - i.e. the stash-box `findPerformer` endpoint returns `null`. Ordinarily this is never the case, because even if performers are deleted on the stash-box, finding them directly by ID still works - the `deleted` field is simply set to `true`.

Fixes #4280