### PR TITLE
Duplicate checker option for highest resolution

### DIFF
--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -177,6 +177,20 @@ export const SceneDuplicateChecker: React.FC = () => {
     });
   };
 
+  const findLargestResolutionScene = (group: GQL.SlimSceneDataFragment[]) => {
+    // Get resolution of a scene
+    const sceneResolution = (scene: GQL.SlimSceneDataFragment) => {
+      return scene.files.reduce((sum: number, f) => sum + (f.height * f.width|| 0), 0);
+    };
+    // Find scene object with maximum resolution
+    return group.reduce((largest, scene) => {
+      const largestSize = sceneResolution(largest);
+      const currentSize = sceneResolution(scene);
+      return currentSize > largestSize ? scene : largest;
+    });
+  };
+
+
   // Helper to get file date
 
   const findFirstFileByAge = (
@@ -216,6 +230,11 @@ export const SceneDuplicateChecker: React.FC = () => {
     return new Set(codecs).size === 1;
   }
 
+  function checkSameResolution(dataGroup: GQL.SlimSceneDataFragment[]) {
+    const resolutions = dataGroup.map((s) => s.files[0]?.width * s.files[0]?.height);
+    return new Set(resolutions).size === 1;
+  }
+
   const onSelectLargestClick = () => {
     setSelectedScenes([]);
     const checkedArray: Record<string, boolean> = {};
@@ -228,6 +247,31 @@ export const SceneDuplicateChecker: React.FC = () => {
       const largest = findLargestScene(group);
       group.forEach((scene) => {
         if (scene !== largest) {
+          checkedArray[scene.id] = true;
+        }
+      });
+    });
+
+    setCheckedScenes(checkedArray);
+  };
+
+
+  const onSelectLargestResolutionClick = () => {
+    setSelectedScenes([]);
+    const checkedArray: Record<string, boolean> = {};
+
+    filteredScenes.forEach((group) => {
+      if (chkSafeSelect && !checkSameCodec(group)) {
+        return;
+      }
+      // Don't select scenes where resolution is identical.
+      if (checkSameResolution(group)) {
+        return;
+      }
+      // Find the highest resolution scene in group.
+      const highest = findLargestResolutionScene(group);
+      group.forEach((scene) => {
+        if (scene !== highest) {
           checkedArray[scene.id] = true;
         }
       });
@@ -713,6 +757,12 @@ export const SceneDuplicateChecker: React.FC = () => {
                   <Dropdown.Menu className="bg-secondary text-white">
                     <Dropdown.Item onClick={() => resetCheckboxSelection()}>
                       {intl.formatMessage({ id: "dupe_check.select_none" })}
+                    </Dropdown.Item>
+
+                    <Dropdown.Item onClick={() => onSelectLargestResolutionClick()}>
+                      {intl.formatMessage({
+                        id: "dupe_check.select_all_but_largest_resolution",
+                      })}
                     </Dropdown.Item>
 
                     <Dropdown.Item onClick={() => onSelectLargestClick()}>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -932,6 +932,7 @@
     "search_accuracy_label": "Search Accuracy",
     "select_options": "Select Options…",
     "select_all_but_largest_file": "Select every file in each duplicated group, except the largest file",
+    "select_all_but_largest_resolution": "Select every file in each duplicated group, except the file with highest resolution",
     "select_none": "Select None",
     "select_oldest": "Select the oldest file in the duplicate group",
     "select_youngest": "Select the youngest file in the duplicate group",


### PR DESCRIPTION
A much needed addition to the duplicate checker dropdown menu options to allow selecting all except highest resolution.
I just added two small functions in SceneDuplicateChecker.tsx and a descriptive label in en-GB.json.
Built a release build of the project and verified everything is 100% working as intended. 
Be kind its my first pull request. thanks.
