### PR TITLE
OS Sandbox the Phasher Binary

### DIFF
--- a/cmd/phasher/main.go
+++ b/cmd/phasher/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/stashapp/stash/cmd/phasher/sandbox"
 	"os"
 
 	flag "github.com/spf13/pflag"
@@ -50,6 +51,7 @@ func main() {
 	flag.Usage = customUsage
 	quiet := flag.BoolP("quiet", "q", false, "print only the phash")
 	help := flag.BoolP("help", "h", false, "print this help output")
+	sbox := flag.BoolP("sandbox", "s", false, "sandbox while running")
 	flag.Parse()
 
 	if *help {
@@ -74,6 +76,10 @@ func main() {
 	encoder := ffmpeg.NewEncoder(ffmpegPath)
 	encoder.InitHWSupport(context.TODO())
 	ffprobe := ffmpeg.FFProbe(ffprobePath)
+
+	if *sbox {
+		sandbox.SandboxPHasher(ffmpegPath, ffprobePath, args)
+	}
 
 	for _, item := range args {
 		if err := printPhash(encoder, ffprobe, item, quiet); err != nil {

--- a/cmd/phasher/sandbox/sandbox.go
+++ b/cmd/phasher/sandbox/sandbox.go
@@ -1,0 +1,10 @@
+//go:build !openbsd && !linux
+// +build !openbsd,!linux
+
+package sandbox
+
+import "fmt"
+
+func SandboxPHasher(ffmpegPath string, ffprobePath string, args []string) {
+	fmt.Printf("Sandboxing is not yet implemented for your platform")
+}

--- a/cmd/phasher/sandbox/sandbox_linux.go
+++ b/cmd/phasher/sandbox/sandbox_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+// +build linux
+
+package sandbox
+
+import "fmt"
+
+func SandboxPHasher(ffmpegPath string, ffprobePath string, args []string) {
+	// TODO: SECCOMP and Landlock
+	fmt.Printf("Sandboxing is not yet implemented for your platform")
+}

--- a/cmd/phasher/sandbox/sandbox_linux.go
+++ b/cmd/phasher/sandbox/sandbox_linux.go
@@ -3,9 +3,22 @@
 
 package sandbox
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/landlock-lsm/go-landlock/landlock"
+	"os"
+)
 
 func SandboxPHasher(ffmpegPath string, ffprobePath string, args []string) {
-	// TODO: SECCOMP and Landlock
-	fmt.Printf("Sandboxing is not yet implemented for your platform")
+	err := landlock.V3.BestEffort().RestrictPaths(
+		landlock.ROFiles("/dev/null"),
+		landlock.ROFiles("/usr/lib"),
+		landlock.ROFiles(args...),
+		landlock.ROFiles(ffmpegPath),
+		landlock.ROFiles(ffprobePath),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ffmpeg landlock failed with %s\n", err.Error())
+	}
+
 }

--- a/cmd/phasher/sandbox/sandbox_openbsd.go
+++ b/cmd/phasher/sandbox/sandbox_openbsd.go
@@ -1,0 +1,38 @@
+//go:build openbsd
+// +build openbsd
+
+package sandbox
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func SandboxPHasher(ffmpegPath string, ffprobePath string, args []string) {
+	err := unix.Unveil("/dev/null", "rw")
+	err = unix.Unveil(ffmpegPath, "x")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ffmpeg unveil failed with %s\n", err.Error())
+		os.Exit(2)
+	}
+	err = unix.Unveil(ffprobePath, "x")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ffprobe unveil failed with %s\n", err.Error())
+		os.Exit(2)
+	}
+	for _, item := range args {
+		err = unix.Unveil(item, "r")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s unveil failed with %s\n", item, err.Error())
+			os.Exit(2)
+		}
+	}
+	err = unix.UnveilBlock()
+
+	err = unix.PledgePromises("stdio rpath exec proc error")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pledge failed with %s\n", err.Error())
+		os.Exit(2)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/kermieisinthehouse/gosx-notifier v0.1.2
 	github.com/kermieisinthehouse/systray v1.2.4
+	github.com/landlock-lsm/go-landlock v0.0.0-20230607164353-b03374193cb2
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/natefinch/pie v0.0.0-20170715172608-9a0d72014007
@@ -109,4 +110,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.66 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/landlock-lsm/go-landlock v0.0.0-20230607164353-b03374193cb2 h1:urvYVFXXrgiZWCYCQ6LWEE98QdU4Mvd5zwXuTllWMTg=
+github.com/landlock-lsm/go-landlock v0.0.0-20230607164353-b03374193cb2/go.mod h1:D25+lEYNcoxH7SgM/VOvWNrF3ZNAfRdydDuVbQBe6yE=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1100,6 +1102,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.66 h1:ikIhPzfkSSAEwBOU+2DWhoF+xnGUhvlMTfQjBVhvzQY=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.66/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
An example of how operating system sandboxing can be used to harden the system without performance impact. This is accomplished with Landlock on Linux, and pledge/unveil on OpenBSD. This was tested on OpenBSD 7.4 and Ubuntu 22.04 LTS, and serves as an example for [my RFC](https://github.com/stashapp/stash/issues/4292). 
A [new dependency](https://pkg.go.dev/github.com/landlock-lsm/go-landlock/landlock) is introduced for Linux's Landlock, but no new dependencies are needed for OpenBSD's sandboxing, only the built-in sys/unix. 