### PR TITLE
Minor UI tweaks

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -212,9 +212,6 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     setIsLoading(true);
     try {
       await mutateReloadScrapers();
-
-      // reload the performer scrapers
-      await Scrapers.refetch();
     } catch (e) {
       Toast.error(e);
     } finally {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -506,9 +506,6 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     setIsLoading(true);
     try {
       await mutateReloadScrapers();
-
-      // reload the performer scrapers
-      await Scrapers.refetch();
     } catch (e) {
       Toast.error(e);
     } finally {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -368,9 +368,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     setIsLoading(true);
     try {
       await mutateReloadScrapers();
-
-      // reload the performer scrapers
-      await Scrapers.refetch();
     } catch (e) {
       Toast.error(e);
     } finally {

--- a/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
@@ -75,14 +75,18 @@ export const SettingsPluginsPanel: React.FC = () => {
   const intl = useIntl();
 
   const { loading: configLoading, plugins, savePluginSettings } = useSettings();
-  const { data, loading, refetch } = usePlugins();
+  const { data, loading } = usePlugins();
 
   const [changedPluginID, setChangedPluginID] = React.useState<
     string | undefined
   >();
 
   async function onReloadPlugins() {
-    await mutateReloadPlugins().catch((e) => Toast.error(e));
+    try {
+      await mutateReloadPlugins();
+    } catch (e) {
+      Toast.error(e);
+    }
   }
 
   const pluginElements = useMemo(() => {
@@ -105,12 +109,13 @@ export const SettingsPluginsPanel: React.FC = () => {
 
     function renderEnableButton(pluginID: string, enabled: boolean) {
       async function onClick() {
-        await mutateSetPluginsEnabled({ [pluginID]: !enabled }).catch((e) =>
-          Toast.error(e)
-        );
+        try {
+          await mutateSetPluginsEnabled({ [pluginID]: !enabled });
+        } catch (e) {
+          Toast.error(e);
+        }
 
         setChangedPluginID(pluginID);
-        refetch();
       }
 
       return (
@@ -229,7 +234,6 @@ export const SettingsPluginsPanel: React.FC = () => {
     intl,
     Toast,
     changedPluginID,
-    refetch,
     plugins,
     savePluginSettings,
   ]);

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -90,7 +90,11 @@ export const SettingsScrapingPanel: React.FC = () => {
     useSettings();
 
   async function onReloadScrapers() {
-    await mutateReloadScrapers().catch((e) => Toast.error(e));
+    try {
+      await mutateReloadScrapers();
+    } catch (e) {
+      Toast.error(e);
+    }
   }
 
   function renderPerformerScrapeTypes(types: ScrapeType[]) {

--- a/ui/v2.5/src/components/Settings/Tasks/PluginTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/PluginTasks.tsx
@@ -16,46 +16,10 @@ export const PluginTasks: React.FC = () => {
 
   const plugins = usePlugins();
 
-  function renderPlugins() {
-    if (!plugins.data || !plugins.data.plugins) {
-      return;
-    }
-
-    const taskPlugins = plugins.data.plugins.filter(
-      (p) => p.enabled && p.tasks && p.tasks.length > 0
-    );
-
-    return (
-      <SettingSection headingID="config.tasks.plugin_tasks">
-        {taskPlugins.map((o) => {
-          return (
-            <SettingGroup
-              key={`${o.id}`}
-              settingProps={{
-                heading: o.name,
-              }}
-              collapsible
-            >
-              {renderPluginTasks(o, o.tasks ?? [])}
-            </SettingGroup>
-          );
-        })}
-      </SettingSection>
-    );
-  }
-
   function renderPluginTasks(plugin: Plugin, pluginTasks: PluginTask[]) {
-    if (!pluginTasks) {
-      return;
-    }
-
     return pluginTasks.map((o) => {
       return (
-        <Setting
-          heading={o.name}
-          subHeading={o.description ?? undefined}
-          key={o.name}
-        >
+        <Setting heading={o.name} subHeading={o.description} key={o.name}>
           <Button
             onClick={() => onPluginTaskClicked(plugin, o)}
             variant="secondary"
@@ -78,5 +42,35 @@ export const PluginTasks: React.FC = () => {
     });
   }
 
-  return <Form.Group>{renderPlugins()}</Form.Group>;
+  if (!plugins.data?.plugins) {
+    return null;
+  }
+
+  const taskPlugins = plugins.data.plugins.filter(
+    (p) => p.enabled && p.tasks && p.tasks.length > 0
+  );
+
+  if (!taskPlugins.length) {
+    return null;
+  }
+
+  return (
+    <Form.Group>
+      <SettingSection headingID="config.tasks.plugin_tasks">
+        {taskPlugins.map((o) => {
+          return (
+            <SettingGroup
+              key={o.id}
+              settingProps={{
+                heading: o.name,
+              }}
+              collapsible
+            >
+              {renderPluginTasks(o, o.tasks!)}
+            </SettingGroup>
+          );
+        })}
+      </SettingSection>
+    </Form.Group>
+  );
 };

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2047,17 +2047,43 @@ export const useRemoveTempDLNAIP = () => GQL.useRemoveTempDlnaipMutation();
 export const mutateReloadScrapers = () =>
   client.mutate<GQL.ReloadScrapersMutation>({
     mutation: GQL.ReloadScrapersDocument,
-    refetchQueries: [
-      GQL.refetchListMovieScrapersQuery(),
-      GQL.refetchListPerformerScrapersQuery(),
-      GQL.refetchListSceneScrapersQuery(),
-    ],
+    update(cache, result) {
+      if (!result.data?.reloadScrapers) return;
+
+      evictQueries(cache, [
+        GQL.ListMovieScrapersDocument,
+        GQL.ListPerformerScrapersDocument,
+        GQL.ListSceneScrapersDocument,
+      ]);
+    },
   });
+
+const pluginMutationImpactedQueries = [
+  GQL.PluginsDocument,
+  GQL.PluginTasksDocument,
+];
 
 export const mutateReloadPlugins = () =>
   client.mutate<GQL.ReloadPluginsMutation>({
     mutation: GQL.ReloadPluginsDocument,
-    refetchQueries: [GQL.refetchPluginsQuery(), GQL.refetchPluginTasksQuery()],
+    update(cache, result) {
+      if (!result.data?.reloadPlugins) return;
+
+      evictQueries(cache, pluginMutationImpactedQueries);
+    },
+  });
+
+type BoolMap = { [key: string]: boolean };
+
+export const mutateSetPluginsEnabled = (enabledMap: BoolMap) =>
+  client.mutate<GQL.SetPluginsEnabledMutation>({
+    mutation: GQL.SetPluginsEnabledDocument,
+    variables: { enabledMap },
+    update(cache, result) {
+      if (!result.data?.setPluginsEnabled) return;
+
+      evictQueries(cache, pluginMutationImpactedQueries);
+    },
   });
 
 export const mutateStopJob = (jobID: string) =>
@@ -2091,14 +2117,6 @@ export const mutateMigrate = (input: GQL.MigrateInput) =>
 
       evictQueries(cache, setupMutationImpactedQueries);
     },
-  });
-
-type BoolMap = { [key: string]: boolean };
-
-export const mutateSetPluginsEnabled = (enabledMap: BoolMap) =>
-  client.mutate<GQL.SetPluginsEnabledMutation>({
-    mutation: GQL.SetPluginsEnabledDocument,
-    variables: { enabledMap },
   });
 
 /// Tasks


### PR DESCRIPTION
Per title, two minor UI changes:
- If you have plugins installed, but none of them define any tasks, the "Plugin Tasks" section will appear but it will be empty. It is now hidden in this scenario, matching the behaviour when no plugins are installed at all.
- Minor tweaks to cache invalidation after running `mutateReloadScrapers`, `mutateReloadPlugins` or `mutateSetPluginsEnabled` - manually calling `.refetch()` is no longer necessary.