### PR TITLE
Fix Ubuntu dependencies

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -32,9 +32,7 @@ NOTE: The `make` command in Windows will be `mingw32-make` with MinGW. For examp
 
 #### Ubuntu
 
-1. Install dependencies: `sudo apt-get install golang git gcc nodejs ffmpeg -y`
-2. Enable corepack in Node.js: `corepack enable`
-3. Install yarn: `corepack prepare yarn@stable --activate`
+1. Install dependencies: `sudo apt-get install golang git yarnpkg gcc nodejs ffmpeg -y`
 
 ### OpenBSD
 


### PR DESCRIPTION
Installing Yarn using `corepack` gives Yarn v4, which tries to update the lockfile when installing dependencies, and thus errors due to the `--frozen-lockfile` flag.

Ubuntu has Yarn v1.22 (as `yarnpkg`) in its "universe" repository for 20.04LTS, 22.04LTS, 23.04 and the latest 23.10. We should just recommend installing that instead of installing through `corepack`.