### PR TITLE
UI plugin dependencies

### DIFF
--- a/graphql/documents/queries/plugins.graphql
+++ b/graphql/documents/queries/plugins.graphql
@@ -25,6 +25,8 @@ query Plugins {
       type
     }
 
+    requires
+
     paths {
       css
       javascript

--- a/graphql/schema/types/plugin.graphql
+++ b/graphql/schema/types/plugin.graphql
@@ -18,6 +18,12 @@ type Plugin {
   hooks: [PluginHook!]
   settings: [PluginSetting!]
 
+  """
+  Plugin IDs of plugins that this plugin depends on.
+  Applies only for UI plugins to indicate css/javascript load order.
+  """
+  requires: [ID!]
+
   paths: PluginPaths!
 }
 

--- a/internal/api/resolver_model_plugin.go
+++ b/internal/api/resolver_model_plugin.go
@@ -55,3 +55,7 @@ func (r *pluginResolver) Paths(ctx context.Context, obj *plugin.Plugin) (*Plugin
 
 	return b.paths(), nil
 }
+
+func (r *pluginResolver) Requires(ctx context.Context, obj *plugin.Plugin) ([]string, error) {
+	return obj.UI.Requires, nil
+}

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -72,6 +72,10 @@ type PluginCSP struct {
 }
 
 type UIConfig struct {
+	// Requires is a list of plugin IDs that this plugin depends on.
+	// These plugins will be loaded before this plugin.
+	Requires []string `yaml:"requires"`
+
 	// Content Security Policy configuration for the plugin.
 	CSP PluginCSP `yaml:"csp"`
 
@@ -239,6 +243,7 @@ func (c Config) toPlugin() *Plugin {
 		Tasks:       c.getPluginTasks(false),
 		Hooks:       c.getPluginHooks(false),
 		UI: PluginUI{
+			Requires:       c.UI.Requires,
 			ExternalScript: c.UI.getExternalScripts(),
 			ExternalCSS:    c.UI.getExternalCSS(),
 			Javascript:     c.UI.getJavascriptFiles(c),

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -42,6 +42,10 @@ type Plugin struct {
 }
 
 type PluginUI struct {
+	// Requires is a list of plugin IDs that this plugin depends on.
+	// These plugins will be loaded before this plugin.
+	Requires []string `json:"requires"`
+
 	// Content Security Policy configuration for the plugin.
 	CSP PluginCSP `json:"csp"`
 

--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -43,6 +43,10 @@ ui:
   javascript:
     - <path to javascript file>
 
+  # optional list of plugin IDs to load prior to this plugin
+  requires:
+    - <plugin ID>
+
   # optional list of assets 
   assets:
     urlPrefix: fsLocation
@@ -76,6 +80,9 @@ The `exec`, `interface`, `errLog` and `tasks` fields are used only for plugins w
 
 The `css` and `javascript` field values may be relative paths to the plugin configuration file, or
 may be full external URLs.
+
+The `requires` field is a list of plugin IDs which must have their javascript/css files loaded
+before this plugins javascript/css files.
 
 The `assets` field is a map of URL prefixes to filesystem paths relative to the plugin configuration file.
 Assets are mounted to the `/plugin/{pluginID}/assets` path. 

--- a/ui/v2.5/src/hooks/useScript.tsx
+++ b/ui/v2.5/src/hooks/useScript.tsx
@@ -14,7 +14,7 @@ const useScript = (urls: string | string[], condition?: boolean) => {
       const script = document.createElement("script");
 
       script.src = url;
-      script.async = true;
+      script.defer = true;
       return script;
     });
 


### PR DESCRIPTION
Adds a `requires` fields to the UI config in the plugin config. This is used for UI plugins only and is used to determine the load order for javascript and css files.

TODO: documentation