### PR TITLE
Fix gallery export panic

### DIFF
--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -779,6 +779,11 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 			continue
 		}
 
+		if err := g.LoadURLs(ctx, r.Gallery); err != nil {
+			logger.Errorf("[galleries] <%s> error getting gallery urls: %v", g.DisplayName(), err)
+			continue
+		}
+
 		galleryHash := g.PrimaryChecksum()
 
 		newGalleryJSON, err := gallery.ToBasicJSON(g)

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -124,14 +124,14 @@ func (t *ExportTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 		var err error
 		t.baseDir, err = instance.Paths.Generated.TempDir("export")
 		if err != nil {
-			logger.Errorf("error creating temporary directory for export: %s", err.Error())
+			logger.Errorf("error creating temporary directory for export: %v", err)
 			return
 		}
 
 		defer func() {
 			err := fsutil.RemoveDir(t.baseDir)
 			if err != nil {
-				logger.Errorf("error removing directory %s: %s", t.baseDir, err.Error())
+				logger.Errorf("error removing directory %s: %v", t.baseDir, err)
 			}
 		}()
 	}
@@ -179,7 +179,7 @@ func (t *ExportTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	if !t.full {
 		err := t.generateDownload()
 		if err != nil {
-			logger.Errorf("error generating download link: %s", err.Error())
+			logger.Errorf("error generating download link: %v", err)
 			return
 		}
 	}
@@ -258,18 +258,18 @@ func (t *ExportTask) zipFile(fn, outDir string, z *zip.Writer) error {
 
 	f, err := z.Create(p)
 	if err != nil {
-		return fmt.Errorf("error creating zip entry for %s: %s", fn, err.Error())
+		return fmt.Errorf("error creating zip entry for %s: %v", fn, err)
 	}
 
 	i, err := os.Open(fn)
 	if err != nil {
-		return fmt.Errorf("error opening %s: %s", fn, err.Error())
+		return fmt.Errorf("error opening %s: %v", fn, err)
 	}
 
 	defer i.Close()
 
 	if _, err := io.Copy(f, i); err != nil {
-		return fmt.Errorf("error writing %s to zip: %s", fn, err.Error())
+		return fmt.Errorf("error writing %s to zip: %v", fn, err)
 	}
 
 	return nil
@@ -321,18 +321,18 @@ func (t *ExportTask) populateGalleryImages(ctx context.Context) {
 	}
 
 	if err != nil {
-		logger.Errorf("[galleries] failed to fetch galleries: %s", err.Error())
+		logger.Errorf("[galleries] failed to fetch galleries: %v", err)
 	}
 
 	for _, g := range galleries {
 		if err := g.LoadFiles(ctx, reader); err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch files for gallery: %s", g.DisplayName(), err.Error())
+			logger.Errorf("[galleries] <%s> failed to fetch files for gallery: %v", g.DisplayName(), err)
 			continue
 		}
 
 		images, err := imageReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %s", g.PrimaryChecksum(), err.Error())
+			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %v", g.PrimaryChecksum(), err)
 			continue
 		}
 
@@ -357,7 +357,7 @@ func (t *ExportTask) ExportScenes(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[scenes] failed to fetch scenes: %s", err.Error())
+		logger.Errorf("[scenes] failed to fetch scenes: %v", err)
 	}
 
 	jobCh := make(chan *models.Scene, workers*2) // make a buffered channel to feed workers
@@ -391,7 +391,7 @@ func (t *ExportTask) exportFile(f models.File) {
 	fn := newFileJSON.Filename()
 
 	if err := t.json.saveFile(fn, newFileJSON); err != nil {
-		logger.Errorf("[files] <%s> failed to save json: %s", fn, err.Error())
+		logger.Errorf("[files] <%s> failed to save json: %v", fn, err)
 	}
 }
 
@@ -455,7 +455,7 @@ func (t *ExportTask) exportFolder(f models.Folder) {
 	fn := newFileJSON.Filename()
 
 	if err := t.json.saveFile(fn, newFileJSON); err != nil {
-		logger.Errorf("[files] <%s> failed to save json: %s", fn, err.Error())
+		logger.Errorf("[files] <%s> failed to save json: %v", fn, err)
 	}
 }
 
@@ -496,7 +496,7 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		newSceneJSON, err := scene.ToBasicJSON(ctx, sceneReader, s)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene JSON: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene JSON: %v", sceneHash, err)
 			continue
 		}
 
@@ -507,19 +507,19 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		newSceneJSON.Studio, err = scene.GetStudioName(ctx, studioReader, s)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene studio name: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene studio name: %v", sceneHash, err)
 			continue
 		}
 
 		galleries, err := galleryReader.FindBySceneID(ctx, s.ID)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene gallery checksums: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene gallery checksums: %v", sceneHash, err)
 			continue
 		}
 
 		for _, g := range galleries {
 			if err := g.LoadFiles(ctx, galleryReader); err != nil {
-				logger.Errorf("[scenes] <%s> error getting scene gallery files: %s", sceneHash, err.Error())
+				logger.Errorf("[scenes] <%s> error getting scene gallery files: %v", sceneHash, err)
 				continue
 			}
 		}
@@ -532,7 +532,7 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		performers, err := performerReader.FindBySceneID(ctx, s.ID)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene performer names: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene performer names: %v", sceneHash, err)
 			continue
 		}
 
@@ -540,19 +540,19 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		newSceneJSON.Tags, err = scene.GetTagNames(ctx, tagReader, s)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene tag names: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene tag names: %v", sceneHash, err)
 			continue
 		}
 
 		newSceneJSON.Markers, err = scene.GetSceneMarkersJSON(ctx, sceneMarkerReader, tagReader, s)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene markers JSON: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene markers JSON: %v", sceneHash, err)
 			continue
 		}
 
 		newSceneJSON.Movies, err = scene.GetSceneMoviesJSON(ctx, movieReader, s)
 		if err != nil {
-			logger.Errorf("[scenes] <%s> error getting scene movies JSON: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> error getting scene movies JSON: %v", sceneHash, err)
 			continue
 		}
 
@@ -565,14 +565,14 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 			tagIDs, err := scene.GetDependentTagIDs(ctx, tagReader, sceneMarkerReader, s)
 			if err != nil {
-				logger.Errorf("[scenes] <%s> error getting scene tags: %s", sceneHash, err.Error())
+				logger.Errorf("[scenes] <%s> error getting scene tags: %v", sceneHash, err)
 				continue
 			}
 			t.tags.IDs = sliceutil.AppendUniques(t.tags.IDs, tagIDs)
 
 			movieIDs, err := scene.GetDependentMovieIDs(ctx, s)
 			if err != nil {
-				logger.Errorf("[scenes] <%s> error getting scene movies: %s", sceneHash, err.Error())
+				logger.Errorf("[scenes] <%s> error getting scene movies: %v", sceneHash, err)
 				continue
 			}
 			t.movies.IDs = sliceutil.AppendUniques(t.movies.IDs, movieIDs)
@@ -586,7 +586,7 @@ func (t *ExportTask) exportScene(ctx context.Context, wg *sync.WaitGroup, jobCha
 		fn := newSceneJSON.Filename(s.ID, basename, hash)
 
 		if err := t.json.saveScene(fn, newSceneJSON); err != nil {
-			logger.Errorf("[scenes] <%s> failed to save json: %s", sceneHash, err.Error())
+			logger.Errorf("[scenes] <%s> failed to save json: %v", sceneHash, err)
 		}
 	}
 }
@@ -607,7 +607,7 @@ func (t *ExportTask) ExportImages(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[images] failed to fetch images: %s", err.Error())
+		logger.Errorf("[images] failed to fetch images: %v", err)
 	}
 
 	jobCh := make(chan *models.Image, workers*2) // make a buffered channel to feed workers
@@ -648,12 +648,12 @@ func (t *ExportTask) exportImage(ctx context.Context, wg *sync.WaitGroup, jobCha
 		imageHash := s.Checksum
 
 		if err := s.LoadFiles(ctx, r.Image); err != nil {
-			logger.Errorf("[images] <%s> error getting image files: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image files: %v", imageHash, err)
 			continue
 		}
 
 		if err := s.LoadURLs(ctx, r.Image); err != nil {
-			logger.Errorf("[images] <%s> error getting image urls: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image urls: %v", imageHash, err)
 			continue
 		}
 
@@ -667,19 +667,19 @@ func (t *ExportTask) exportImage(ctx context.Context, wg *sync.WaitGroup, jobCha
 		var err error
 		newImageJSON.Studio, err = image.GetStudioName(ctx, studioReader, s)
 		if err != nil {
-			logger.Errorf("[images] <%s> error getting image studio name: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image studio name: %v", imageHash, err)
 			continue
 		}
 
 		imageGalleries, err := galleryReader.FindByImageID(ctx, s.ID)
 		if err != nil {
-			logger.Errorf("[images] <%s> error getting image galleries: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image galleries: %v", imageHash, err)
 			continue
 		}
 
 		for _, g := range imageGalleries {
 			if err := g.LoadFiles(ctx, galleryReader); err != nil {
-				logger.Errorf("[images] <%s> error getting image gallery files: %s", imageHash, err.Error())
+				logger.Errorf("[images] <%s> error getting image gallery files: %v", imageHash, err)
 				continue
 			}
 		}
@@ -688,7 +688,7 @@ func (t *ExportTask) exportImage(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		performers, err := performerReader.FindByImageID(ctx, s.ID)
 		if err != nil {
-			logger.Errorf("[images] <%s> error getting image performer names: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image performer names: %v", imageHash, err)
 			continue
 		}
 
@@ -696,7 +696,7 @@ func (t *ExportTask) exportImage(ctx context.Context, wg *sync.WaitGroup, jobCha
 
 		tags, err := tagReader.FindByImageID(ctx, s.ID)
 		if err != nil {
-			logger.Errorf("[images] <%s> error getting image tag names: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> error getting image tag names: %v", imageHash, err)
 			continue
 		}
 
@@ -715,7 +715,7 @@ func (t *ExportTask) exportImage(ctx context.Context, wg *sync.WaitGroup, jobCha
 		fn := newImageJSON.Filename(filepath.Base(s.Path), s.Checksum)
 
 		if err := t.json.saveImage(fn, newImageJSON); err != nil {
-			logger.Errorf("[images] <%s> failed to save json: %s", imageHash, err.Error())
+			logger.Errorf("[images] <%s> failed to save json: %v", imageHash, err)
 		}
 	}
 }
@@ -735,7 +735,7 @@ func (t *ExportTask) ExportGalleries(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[galleries] failed to fetch galleries: %s", err.Error())
+		logger.Errorf("[galleries] failed to fetch galleries: %v", err)
 	}
 
 	jobCh := make(chan *models.Gallery, workers*2) // make a buffered channel to feed workers
@@ -775,7 +775,7 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 	for g := range jobChan {
 		if err := g.LoadFiles(ctx, r.Gallery); err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch files for gallery: %s", g.DisplayName(), err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery files: %v", g.DisplayName(), err)
 			continue
 		}
 
@@ -788,7 +788,7 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 		newGalleryJSON, err := gallery.ToBasicJSON(g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery JSON: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery JSON: %v", galleryHash, err)
 			continue
 		}
 
@@ -815,13 +815,13 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 		newGalleryJSON.Studio, err = gallery.GetStudioName(ctx, studioReader, g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery studio name: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery studio name: %v", galleryHash, err)
 			continue
 		}
 
 		performers, err := performerReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery performer names: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery performer names: %v", galleryHash, err)
 			continue
 		}
 
@@ -829,13 +829,13 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 		tags, err := tagReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery tag names: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery tag names: %v", galleryHash, err)
 			continue
 		}
 
 		newGalleryJSON.Chapters, err = gallery.GetGalleryChaptersJSON(ctx, galleryChapterReader, g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery chapters JSON: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> error getting gallery chapters JSON: %v", galleryHash, err)
 			continue
 		}
 
@@ -864,7 +864,7 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 		fn := newGalleryJSON.Filename(basename, hash)
 
 		if err := t.json.saveGallery(fn, newGalleryJSON); err != nil {
-			logger.Errorf("[galleries] <%s> failed to save json: %s", galleryHash, err.Error())
+			logger.Errorf("[galleries] <%s> failed to save json: %v", galleryHash, err)
 		}
 	}
 }
@@ -883,7 +883,7 @@ func (t *ExportTask) ExportPerformers(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[performers] failed to fetch performers: %s", err.Error())
+		logger.Errorf("[performers] failed to fetch performers: %v", err)
 	}
 	jobCh := make(chan *models.Performer, workers*2) // make a buffered channel to feed workers
 
@@ -918,13 +918,13 @@ func (t *ExportTask) exportPerformer(ctx context.Context, wg *sync.WaitGroup, jo
 		newPerformerJSON, err := performer.ToJSON(ctx, performerReader, p)
 
 		if err != nil {
-			logger.Errorf("[performers] <%s> error getting performer JSON: %s", p.Name, err.Error())
+			logger.Errorf("[performers] <%s> error getting performer JSON: %v", p.Name, err)
 			continue
 		}
 
 		tags, err := r.Tag.FindByPerformerID(ctx, p.ID)
 		if err != nil {
-			logger.Errorf("[performers] <%s> error getting performer tags: %s", p.Name, err.Error())
+			logger.Errorf("[performers] <%s> error getting performer tags: %v", p.Name, err)
 			continue
 		}
 
@@ -937,7 +937,7 @@ func (t *ExportTask) exportPerformer(ctx context.Context, wg *sync.WaitGroup, jo
 		fn := newPerformerJSON.Filename()
 
 		if err := t.json.savePerformer(fn, newPerformerJSON); err != nil {
-			logger.Errorf("[performers] <%s> failed to save json: %s", p.Name, err.Error())
+			logger.Errorf("[performers] <%s> failed to save json: %v", p.Name, err)
 		}
 	}
 }
@@ -956,7 +956,7 @@ func (t *ExportTask) ExportStudios(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[studios] failed to fetch studios: %s", err.Error())
+		logger.Errorf("[studios] failed to fetch studios: %v", err)
 	}
 
 	logger.Info("[studios] exporting")
@@ -1017,7 +1017,7 @@ func (t *ExportTask) ExportTags(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[tags] failed to fetch tags: %s", err.Error())
+		logger.Errorf("[tags] failed to fetch tags: %v", err)
 	}
 
 	logger.Info("[tags] exporting")
@@ -1052,14 +1052,14 @@ func (t *ExportTask) exportTag(ctx context.Context, wg *sync.WaitGroup, jobChan 
 		newTagJSON, err := tag.ToJSON(ctx, tagReader, thisTag)
 
 		if err != nil {
-			logger.Errorf("[tags] <%s> error getting tag JSON: %s", thisTag.Name, err.Error())
+			logger.Errorf("[tags] <%s> error getting tag JSON: %v", thisTag.Name, err)
 			continue
 		}
 
 		fn := newTagJSON.Filename()
 
 		if err := t.json.saveTag(fn, newTagJSON); err != nil {
-			logger.Errorf("[tags] <%s> failed to save json: %s", fn, err.Error())
+			logger.Errorf("[tags] <%s> failed to save json: %v", fn, err)
 		}
 	}
 }
@@ -1078,7 +1078,7 @@ func (t *ExportTask) ExportMovies(ctx context.Context, workers int) {
 	}
 
 	if err != nil {
-		logger.Errorf("[movies] failed to fetch movies: %s", err.Error())
+		logger.Errorf("[movies] failed to fetch movies: %v", err)
 	}
 
 	logger.Info("[movies] exporting")

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -332,7 +332,7 @@ func (t *ExportTask) populateGalleryImages(ctx context.Context) {
 
 		images, err := imageReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %v", g.PrimaryChecksum(), err)
+			logger.Errorf("[galleries] <%s> failed to fetch images for gallery: %v", g.DisplayName(), err)
 			continue
 		}
 
@@ -784,11 +784,9 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 			continue
 		}
 
-		galleryHash := g.PrimaryChecksum()
-
 		newGalleryJSON, err := gallery.ToBasicJSON(g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery JSON: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> error getting gallery JSON: %v", g.DisplayName(), err)
 			continue
 		}
 
@@ -801,12 +799,12 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 		if g.FolderID != nil {
 			folder, err := r.Folder.Find(ctx, *g.FolderID)
 			if err != nil {
-				logger.Errorf("[galleries] <%s> error getting gallery folder: %v", galleryHash, err)
+				logger.Errorf("[galleries] <%s> error getting gallery folder: %v", g.DisplayName(), err)
 				continue
 			}
 
 			if folder == nil {
-				logger.Errorf("[galleries] <%s> unable to find gallery folder", galleryHash)
+				logger.Errorf("[galleries] <%s> unable to find gallery folder", g.DisplayName())
 				continue
 			}
 
@@ -815,13 +813,13 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 		newGalleryJSON.Studio, err = gallery.GetStudioName(ctx, studioReader, g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery studio name: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> error getting gallery studio name: %v", g.DisplayName(), err)
 			continue
 		}
 
 		performers, err := performerReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery performer names: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> error getting gallery performer names: %v", g.DisplayName(), err)
 			continue
 		}
 
@@ -829,13 +827,13 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 
 		tags, err := tagReader.FindByGalleryID(ctx, g.ID)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery tag names: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> error getting gallery tag names: %v", g.DisplayName(), err)
 			continue
 		}
 
 		newGalleryJSON.Chapters, err = gallery.GetGalleryChaptersJSON(ctx, galleryChapterReader, g)
 		if err != nil {
-			logger.Errorf("[galleries] <%s> error getting gallery chapters JSON: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> error getting gallery chapters JSON: %v", g.DisplayName(), err)
 			continue
 		}
 
@@ -864,7 +862,7 @@ func (t *ExportTask) exportGallery(ctx context.Context, wg *sync.WaitGroup, jobC
 		fn := newGalleryJSON.Filename(basename, hash)
 
 		if err := t.json.saveGallery(fn, newGalleryJSON); err != nil {
-			logger.Errorf("[galleries] <%s> failed to save json: %v", galleryHash, err)
+			logger.Errorf("[galleries] <%s> failed to save json: %v", g.DisplayName(), err)
 		}
 	}
 }

--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -52,7 +52,7 @@ type ImportObjectsInput struct {
 func CreateImportTask(a models.HashAlgorithm, input ImportObjectsInput) (*ImportTask, error) {
 	baseDir, err := instance.Paths.Generated.TempDir("import")
 	if err != nil {
-		logger.Errorf("error creating temporary directory for import: %s", err.Error())
+		logger.Errorf("error creating temporary directory for import: %v", err)
 		return nil, err
 	}
 
@@ -93,12 +93,12 @@ func (t *ImportTask) Start(ctx context.Context) {
 		defer func() {
 			err := fsutil.RemoveDir(t.BaseDir)
 			if err != nil {
-				logger.Errorf("error removing directory %s: %s", t.BaseDir, err.Error())
+				logger.Errorf("error removing directory %s: %v", t.BaseDir, err)
 			}
 		}()
 
 		if err := t.unzipFile(); err != nil {
-			logger.Errorf("error unzipping provided file for import: %s", err.Error())
+			logger.Errorf("error unzipping provided file for import: %v", err)
 			return
 		}
 	}
@@ -119,7 +119,7 @@ func (t *ImportTask) Start(ctx context.Context) {
 		err := t.resetter.Reset()
 
 		if err != nil {
-			logger.Errorf("Error resetting database: %s", err.Error())
+			logger.Errorf("Error resetting database: %v", err)
 			return
 		}
 	}
@@ -139,7 +139,7 @@ func (t *ImportTask) unzipFile() error {
 	defer func() {
 		err := os.Remove(t.TmpZip)
 		if err != nil {
-			logger.Errorf("error removing temporary zip file %s: %s", t.TmpZip, err.Error())
+			logger.Errorf("error removing temporary zip file %s: %v", t.TmpZip, err)
 		}
 	}()
 
@@ -207,7 +207,7 @@ func (t *ImportTask) ImportPerformers(ctx context.Context) {
 		index := i + 1
 		performerJSON, err := jsonschema.LoadPerformerFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[performers] failed to read json: %s", err.Error())
+			logger.Errorf("[performers] failed to read json: %v", err)
 			continue
 		}
 
@@ -222,7 +222,7 @@ func (t *ImportTask) ImportPerformers(ctx context.Context) {
 
 			return performImport(ctx, importer, t.DuplicateBehaviour)
 		}); err != nil {
-			logger.Errorf("[performers] <%s> import failed: %s", fi.Name(), err.Error())
+			logger.Errorf("[performers] <%s> import failed: %v", fi.Name(), err)
 		}
 	}
 
@@ -250,7 +250,7 @@ func (t *ImportTask) ImportStudios(ctx context.Context) {
 		index := i + 1
 		studioJSON, err := jsonschema.LoadStudioFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[studios] failed to read json: %s", err.Error())
+			logger.Errorf("[studios] failed to read json: %v", err)
 			continue
 		}
 
@@ -267,7 +267,7 @@ func (t *ImportTask) ImportStudios(ctx context.Context) {
 				continue
 			}
 
-			logger.Errorf("[studios] <%s> failed to create: %s", fi.Name(), err.Error())
+			logger.Errorf("[studios] <%s> failed to create: %v", fi.Name(), err)
 			continue
 		}
 	}
@@ -281,7 +281,7 @@ func (t *ImportTask) ImportStudios(ctx context.Context) {
 				if err := r.WithTxn(ctx, func(ctx context.Context) error {
 					return t.importStudio(ctx, orphanStudioJSON, nil)
 				}); err != nil {
-					logger.Errorf("[studios] <%s> failed to create: %s", orphanStudioJSON.Name, err.Error())
+					logger.Errorf("[studios] <%s> failed to create: %v", orphanStudioJSON.Name, err)
 					continue
 				}
 			}
@@ -312,7 +312,7 @@ func (t *ImportTask) importStudio(ctx context.Context, studioJSON *jsonschema.St
 	for _, childStudioJSON := range s {
 		// map is nil since we're not checking parent studios at this point
 		if err := t.importStudio(ctx, childStudioJSON, nil); err != nil {
-			return fmt.Errorf("failed to create child studio <%s>: %s", childStudioJSON.Name, err.Error())
+			return fmt.Errorf("failed to create child studio <%s>: %v", childStudioJSON.Name, err)
 		}
 	}
 
@@ -341,7 +341,7 @@ func (t *ImportTask) ImportMovies(ctx context.Context) {
 		index := i + 1
 		movieJSON, err := jsonschema.LoadMovieFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[movies] failed to read json: %s", err.Error())
+			logger.Errorf("[movies] failed to read json: %v", err)
 			continue
 		}
 
@@ -357,7 +357,7 @@ func (t *ImportTask) ImportMovies(ctx context.Context) {
 
 			return performImport(ctx, movieImporter, t.DuplicateBehaviour)
 		}); err != nil {
-			logger.Errorf("[movies] <%s> import failed: %s", fi.Name(), err.Error())
+			logger.Errorf("[movies] <%s> import failed: %v", fi.Name(), err)
 			continue
 		}
 	}
@@ -386,7 +386,7 @@ func (t *ImportTask) ImportFiles(ctx context.Context) {
 		index := i + 1
 		fileJSON, err := jsonschema.LoadFileFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[files] failed to read json: %s", err.Error())
+			logger.Errorf("[files] failed to read json: %v", err)
 			continue
 		}
 
@@ -403,7 +403,7 @@ func (t *ImportTask) ImportFiles(ctx context.Context) {
 				continue
 			}
 
-			logger.Errorf("[files] <%s> failed to create: %s", fi.Name(), err.Error())
+			logger.Errorf("[files] <%s> failed to create: %v", fi.Name(), err)
 			continue
 		}
 	}
@@ -417,7 +417,7 @@ func (t *ImportTask) ImportFiles(ctx context.Context) {
 				if err := r.WithTxn(ctx, func(ctx context.Context) error {
 					return t.importFile(ctx, orphanFileJSON, nil)
 				}); err != nil {
-					logger.Errorf("[files] <%s> failed to create: %s", orphanFileJSON.DirEntry().Path, err.Error())
+					logger.Errorf("[files] <%s> failed to create: %v", orphanFileJSON.DirEntry().Path, err)
 					continue
 				}
 			}
@@ -446,7 +446,7 @@ func (t *ImportTask) importFile(ctx context.Context, fileJSON jsonschema.DirEntr
 	for _, childFileJSON := range s {
 		// map is nil since we're not checking parent studios at this point
 		if err := t.importFile(ctx, childFileJSON, nil); err != nil {
-			return fmt.Errorf("failed to create child file <%s>: %s", childFileJSON.DirEntry().Path, err.Error())
+			return fmt.Errorf("failed to create child file <%s>: %v", childFileJSON.DirEntry().Path, err)
 		}
 	}
 
@@ -475,7 +475,7 @@ func (t *ImportTask) ImportGalleries(ctx context.Context) {
 		index := i + 1
 		galleryJSON, err := jsonschema.LoadGalleryFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[galleries] failed to read json: %s", err.Error())
+			logger.Errorf("[galleries] failed to read json: %v", err)
 			continue
 		}
 
@@ -513,7 +513,7 @@ func (t *ImportTask) ImportGalleries(ctx context.Context) {
 
 			return nil
 		}); err != nil {
-			logger.Errorf("[galleries] <%s> import failed to commit: %s", fi.Name(), err.Error())
+			logger.Errorf("[galleries] <%s> import failed to commit: %v", fi.Name(), err)
 			continue
 		}
 	}
@@ -541,7 +541,7 @@ func (t *ImportTask) ImportTags(ctx context.Context) {
 		index := i + 1
 		tagJSON, err := jsonschema.LoadTagFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Errorf("[tags] failed to read json: %s", err.Error())
+			logger.Errorf("[tags] failed to read json: %v", err)
 			continue
 		}
 
@@ -556,7 +556,7 @@ func (t *ImportTask) ImportTags(ctx context.Context) {
 				continue
 			}
 
-			logger.Errorf("[tags] <%s> failed to import: %s", fi.Name(), err.Error())
+			logger.Errorf("[tags] <%s> failed to import: %v", fi.Name(), err)
 			continue
 		}
 	}
@@ -566,7 +566,7 @@ func (t *ImportTask) ImportTags(ctx context.Context) {
 			if err := r.WithTxn(ctx, func(ctx context.Context) error {
 				return t.importTag(ctx, orphanTagJSON, nil, true)
 			}); err != nil {
-				logger.Errorf("[tags] <%s> failed to create: %s", orphanTagJSON.Name, err.Error())
+				logger.Errorf("[tags] <%s> failed to create: %v", orphanTagJSON.Name, err)
 				continue
 			}
 		}
@@ -599,7 +599,7 @@ func (t *ImportTask) importTag(ctx context.Context, tagJSON *jsonschema.Tag, pen
 				continue
 			}
 
-			return fmt.Errorf("failed to create child tag <%s>: %s", childTagJSON.Name, err.Error())
+			return fmt.Errorf("failed to create child tag <%s>: %v", childTagJSON.Name, err)
 		}
 	}
 
@@ -630,7 +630,7 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 
 		sceneJSON, err := jsonschema.LoadSceneFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Infof("[scenes] <%s> json parse failure: %s", fi.Name(), err.Error())
+			logger.Infof("[scenes] <%s> json parse failure: %v", fi.Name(), err)
 			continue
 		}
 
@@ -671,7 +671,7 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 
 			return nil
 		}); err != nil {
-			logger.Errorf("[scenes] <%s> import failed: %s", fi.Name(), err.Error())
+			logger.Errorf("[scenes] <%s> import failed: %v", fi.Name(), err)
 		}
 	}
 
@@ -700,7 +700,7 @@ func (t *ImportTask) ImportImages(ctx context.Context) {
 
 		imageJSON, err := jsonschema.LoadImageFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			logger.Infof("[images] <%s> json parse failure: %s", fi.Name(), err.Error())
+			logger.Infof("[images] <%s> json parse failure: %v", fi.Name(), err)
 			continue
 		}
 
@@ -720,7 +720,7 @@ func (t *ImportTask) ImportImages(ctx context.Context) {
 
 			return performImport(ctx, imageImporter, t.DuplicateBehaviour)
 		}); err != nil {
-			logger.Errorf("[images] <%s> import failed: %s", fi.Name(), err.Error())
+			logger.Errorf("[images] <%s> import failed: %v", fi.Name(), err)
 		}
 	}
 


### PR DESCRIPTION
Similar fix to #4157, gallery URLs weren't being loaded resulting in a panic.

Also replaced `%s` and `err.Error()` with `%v` and `err`

And gallery export errors are now logged using `DisplayName()` rather than `PrimaryChecksum()` - galleries without any files have no primary checksum, so logging by name makes more sense.

Fixes #4310