### PR TITLE
Use visual files to populate image file names

### DIFF
--- a/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
@@ -76,7 +76,7 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
     const deletedFiles: string[] = [];
 
     props.selected.forEach((s) => {
-      const paths = s.files.map((f) => f.path);
+      const paths = s.visual_files.map((f) => f.path);
       deletedFiles.push(...paths);
     });
 


### PR DESCRIPTION
Fixes bug where when deleting an clip image type and selecting to delete the file, it would not show the file paths being deleted.