### PR TITLE
Fix nil deference when generating markers by ID

### DIFF
--- a/internal/manager/task_generate_markers.go
+++ b/internal/manager/task_generate_markers.go
@@ -104,7 +104,7 @@ func (t *GenerateMarkersTask) generateSceneMarkers(ctx context.Context) {
 }
 
 func (t *GenerateMarkersTask) generateMarker(videoFile *models.VideoFile, scene *models.Scene, sceneMarker *models.SceneMarker) {
-	sceneHash := t.Scene.GetHash(t.fileNamingAlgorithm)
+	sceneHash := scene.GetHash(t.fileNamingAlgorithm)
 	seconds := int(sceneMarker.Seconds)
 
 	g := t.generator


### PR DESCRIPTION
Very simple fix for a nil deference when generating markers by ID.

I believe this bug was introduced all the way back in #667 :open_mouth: 

Fixes #4334