### PR TITLE
Refactor and fix stash-box submit dialog

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerSubmitButton.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerSubmitButton.tsx
@@ -24,9 +24,9 @@ export const PerformerSubmitButton: React.FC<IPerformerOperationsProps> = ({
         <FormattedMessage id="actions.submit_stash_box" />
       </Button>
       <SubmitStashBoxDraft
+        type="performer"
         boxes={boxes}
         entity={performer}
-        query={GQL.SubmitStashBoxPerformerDraftDocument}
         show={showDraftModal}
         onHide={() => setShowDraftModal(false)}
       />

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -531,9 +531,9 @@ const ScenePage: React.FC<IProps> = ({
         </Button>
       </div>
       <SubmitStashBoxDraft
+        type="scene"
         boxes={boxes}
         entity={scene}
-        query={GQL.SubmitStashBoxSceneDraftDocument}
         show={showDraftModal}
         onHide={() => setShowDraftModal(false)}
       />

--- a/ui/v2.5/src/components/Shared/Modal.tsx
+++ b/ui/v2.5/src/components/Shared/Modal.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Button, Modal, Spinner, ModalProps } from "react-bootstrap";
+import { ButtonVariant } from "react-bootstrap/types";
 import { Icon } from "./Icon";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FormattedMessage } from "react-intl";
 
 interface IButton {
   text?: string;
-  variant?: "danger" | "primary" | "secondary";
+  variant?: ButtonVariant;
   onClick?: () => void;
 }
 

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -1945,6 +1945,22 @@ export const queryScrapeGalleryURL = (url: string) =>
     fetchPolicy: "network-only",
   });
 
+export const mutateSubmitStashBoxSceneDraft = (
+  input: GQL.StashBoxDraftSubmissionInput
+) =>
+  client.mutate<GQL.SubmitStashBoxSceneDraftMutation>({
+    mutation: GQL.SubmitStashBoxSceneDraftDocument,
+    variables: { input },
+  });
+
+export const mutateSubmitStashBoxPerformerDraft = (
+  input: GQL.StashBoxDraftSubmissionInput
+) =>
+  client.mutate<GQL.SubmitStashBoxPerformerDraftMutation>({
+    mutation: GQL.SubmitStashBoxPerformerDraftDocument,
+    variables: { input },
+  });
+
 /// Packages
 export const useInstalledScraperPackages = GQL.useInstalledScraperPackagesQuery;
 export const useInstalledScraperPackagesStatus =


### PR DESCRIPTION
This refactors the `SubmitDraft` dialog to simplify it a bit and to fix #4354.

The dialog's state will now be reset every time it is opened, which also allows to submit the same scene to multiple stashboxes (or to the same stash-box multiple times, if you wanted to).

Besides that bugfix, I've also moved the "Submit" button and the "Already exists in stash-box" message to the dialog's footer. This means that the loading spinner can now be inside the "Submit" button - previously it would show inside the "Cancel" button, which is a bit odd.

Fixes #4354