### PR TITLE
Fix desktop notification duration formatting

### DIFF
--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -155,7 +155,16 @@ func initialisePackageManager(localPath string, srcPathGetter pkg.SourcePathGett
 }
 
 func formatDuration(t time.Duration) string {
-	return fmt.Sprintf("%02.f:%02.f:%02.f", t.Hours(), t.Minutes(), t.Seconds())
+	switch {
+	case t >= time.Minute: // 1m23s or 2h45m12s
+		t = t.Round(time.Second)
+	case t >= time.Second: // 45.36s
+		t = t.Round(10 * time.Millisecond)
+	default: // 51ms
+		t = t.Round(time.Millisecond)
+	}
+
+	return t.String()
 }
 
 func initJobManager(cfg *config.Config) *job.Manager {
@@ -177,7 +186,7 @@ func initJobManager(cfg *config.Config) *job.Manager {
 					}
 
 					timeElapsed := j.EndTime.Sub(*j.StartTime)
-					msg := fmt.Sprintf("Task \"%s\" is finished in %s.", cleanDesc, formatDuration(timeElapsed))
+					msg := fmt.Sprintf("Task \"%s\" finished in %s.", cleanDesc, formatDuration(timeElapsed))
 					desktop.SendNotification("Task Finished", msg)
 				}
 			case <-ctx.Done():


### PR DESCRIPTION
This is a simple fix for a bug with the duration formatting in desktop notifications.

As an example, a time of 2 hours 45 minutes and 12 seconds was being formatted as `3:165:9912` rather than `2:45:12`, which I believe was the original intention.

This happens because `Hours()`, `Minutes()` and `Seconds()` give the _total_ duration in that unit, rather than that specific "part" of the duration. The `%02.f` format string specifier adds rounding as well, which makes even the hours unit incorrect half of the time.

I've just fixed this by using `time.Duration`'s `String()` function, with some conditional rounding to prevent displaying tons of decimal places. This does change the output format, i.e. it's now `2h45m12s` rather than `2:45:12`, but I think the new format is clearer anyway, especially with times shorter than 1 second (it now shows `425ms`), and it means we don't have to manually do any math ourselves.