### PR TITLE
Fix CI pip externally-managed-environment error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ stash-macapp: flags-release flags-pie stash
 
 # build-cc- targets should be run within the compiler docker container
 
+.PHONY: build-cc-windows
 build-cc-windows: export GOOS := windows
 build-cc-windows: export GOARCH := amd64
 build-cc-windows: export CC := x86_64-w64-mingw32-gcc

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -48,3 +48,5 @@ ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999
 ENTRYPOINT ["docker-entrypoint.sh", "stash"]
+
+# vim: ft=dockerfile

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 RUN apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev \
     && apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg vips-tools ruby tzdata \
-    && pip install mechanicalsoup cloudscraper bencoder.pyx \
+    && pip install --user --break-system-packages mechanicalsoup cloudscraper bencoder.pyx \
     && gem install faraday \
     && apk del .build-deps
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml


### PR DESCRIPTION
Alpine seems to have finally enabled Python's externally managed environment warning as specified in [PEP 668](https://peps.python.org/pep-0668/), which is now causing the CI docker build to fail.

The fix here is to simply use `--break-system-packages`, which ignores the warning. Given that this is a Docker container, I don't think we really need to worry about breaking anything, and it's been fine up to now anyway. I've added `--user` as well just to be on the safe side, so it will install packages to `~/.local/lib/python3.11/site-packages` rather than `/usr/lib/python3.11/site-packages`.

And then I've just added a missing PHONY target to the Makefile and added a vim modeline to `Dockerfile-CUDA` to enable syntax highlighting.