### PR TITLE
Use int64 for sample-related FFProbeStream fields

### DIFF
--- a/pkg/ffmpeg/types.go
+++ b/pkg/ffmpeg/types.go
@@ -64,7 +64,7 @@ type FFProbeStream struct {
 		VisualImpaired  int `json:"visual_impaired"`
 	} `json:"disposition"`
 	Duration          string `json:"duration"`
-	DurationTs        int    `json:"duration_ts"`
+	DurationTs        int64  `json:"duration_ts"`
 	HasBFrames        int    `json:"has_b_frames,omitempty"`
 	Height            int    `json:"height,omitempty"`
 	Index             int    `json:"index"`
@@ -78,7 +78,7 @@ type FFProbeStream struct {
 	RFrameRate        string `json:"r_frame_rate"`
 	Refs              int    `json:"refs,omitempty"`
 	SampleAspectRatio string `json:"sample_aspect_ratio,omitempty"`
-	StartPts          int    `json:"start_pts"`
+	StartPts          int64  `json:"start_pts"`
 	StartTime         string `json:"start_time"`
 	Tags              struct {
 		CreationTime json.JSONTime `json:"creation_time"`


### PR DESCRIPTION
This is a simple fix for an bug that came up in Discord, where scanning throws an ffprobe unmarshal error if you scan really long files on a 32-bit system. This is because `duration_ts` can sometimes, for really long files, be too large for a signed 32-bit integer, which is what the `int` type is an alias for on 32-bit systems.

I've thus just replaced the `int` with `int64` on the `DurationTs` field to solve the issue. I've also made the same change on `StartPts`, just to be safe, since that is a value that is also measured in samples. Neither of these values are actually ever used anyway.