### PR TITLE
Set PYTHONPATH environment variable for Python script scrapers

### DIFF
--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -52,6 +53,9 @@ func (t *rawPluginTask) Start() error {
 			logger.Warnf("%s", err)
 		} else {
 			cmd = p.Command(context.TODO(), command[1:])
+
+			envVariable, _ := filepath.Abs(filepath.Dir(filepath.Dir(t.plugin.path)))
+			python.AppendPythonPath(cmd, envVariable)
 		}
 	}
 

--- a/pkg/python/env.go
+++ b/pkg/python/env.go
@@ -1,0 +1,15 @@
+package python
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func AppendPythonPath(cmd *exec.Cmd, path string) {
+	// Respect the users PYTHONPATH if set
+	if currentValue, set := os.LookupEnv("PYTHONPATH"); set {
+		path = fmt.Sprintf("%s%c%s", currentValue, os.PathListSeparator, path)
+	}
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PYTHONPATH=%s", path))
+}

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,12 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 			logger.Warnf("%s", err)
 		} else {
 			cmd = p.Command(context.TODO(), command[1:])
+			envVariable := filepath.Dir(filepath.Dir(s.config.path))
+			// Respect the users PYTHONPATH if set
+			if currentValue, set := os.LookupEnv("PYTHONPATH"); set {
+				envVariable = fmt.Sprintf("%s%c%s", currentValue, os.PathListSeparator, envVariable)
+			}
+			cmd.Env = append(os.Environ(), fmt.Sprintf("PYTHONPATH=%s", envVariable))
 		}
 	}
 

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -45,7 +45,7 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 			logger.Warnf("%s", err)
 		} else {
 			cmd = p.Command(context.TODO(), command[1:])
-			envVariable := filepath.Dir(filepath.Dir(s.config.path))
+			envVariable, _ := filepath.Abs(filepath.Dir(filepath.Dir(s.config.path)))
 			// Respect the users PYTHONPATH if set
 			if currentValue, set := os.LookupEnv("PYTHONPATH"); set {
 				envVariable = fmt.Sprintf("%s%c%s", currentValue, os.PathListSeparator, envVariable)

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -46,11 +45,7 @@ func (s *scriptScraper) runScraperScript(ctx context.Context, inString string, o
 		} else {
 			cmd = p.Command(context.TODO(), command[1:])
 			envVariable, _ := filepath.Abs(filepath.Dir(filepath.Dir(s.config.path)))
-			// Respect the users PYTHONPATH if set
-			if currentValue, set := os.LookupEnv("PYTHONPATH"); set {
-				envVariable = fmt.Sprintf("%s%c%s", currentValue, os.PathListSeparator, envVariable)
-			}
-			cmd.Env = append(os.Environ(), fmt.Sprintf("PYTHONPATH=%s", envVariable))
+			python.AppendPythonPath(cmd, envVariable)
 		}
 	}
 


### PR DESCRIPTION
With the introduction of the new scraper and plugin management system in #4242 we've seen several scrapers failing because of their dependency on other packages such as `py_common`. Since the new management system puts these scrapers in separate folders they need to hack around this by [manually adding their parent to their `sys.path`](https://github.com/stashapp/CommunityScrapers/blob/a2a63ee79a4916b93b9e7bab7ffb2ccb6a0a66c8/scrapers/ManyVids/ManyVids.py#L8-L14)

To solve this in Stash itself we can set the [PYTHONPATH environment variable](https://docs.python.org/3/using/cmdline.html#environment-variables) when running Python scrapers to add the base scraper directory to the list of paths where Python will search for module imports

Notes:
- I know the variable names aren't great, but my imagination is lacking and they're entirely local.
- I would have loved to have had access to the local path configured for this scraper source, but I do not know the code base well enough to include it. Currently the scraper knows its absolute path so I simply used that to get the parent of its parent folder, but this will fail if scrapers have nested folder structures 🤷‍♂️
- I'm not familiar with any plugins that will need this so I have only added this to the scraper package