### PR TITLE
Move zip files while moving folders

### DIFF
--- a/pkg/file/move.go
+++ b/pkg/file/move.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/stashapp/stash/pkg/logger"
@@ -88,42 +87,8 @@ func (m *Mover) Move(ctx context.Context, f models.File, folder *models.Folder, 
 		return fmt.Errorf("file %s already exists", newPath)
 	}
 
-	if err := TransferZipFolderHierarchy(ctx, m.Folders, fBase.ID, oldPath, newPath); err != nil {
+	if err := transferZipHierarchy(ctx, m.Folders, m.Files, fBase.ID, oldPath, newPath); err != nil {
 		return fmt.Errorf("moving folder hierarchy for file %s: %w", fBase.Path, err)
-	}
-
-	// move contained files if file is a zip file
-	zipFiles, err := m.Files.FindByZipFileID(ctx, fBase.ID)
-	if err != nil {
-		return fmt.Errorf("finding contained files in file %s: %w", fBase.Path, err)
-	}
-	for _, zf := range zipFiles {
-		zfBase := zf.Base()
-		oldZfPath := zfBase.Path
-		oldZfDir := filepath.Dir(oldZfPath)
-
-		// sanity check - ignore files which aren't under oldPath
-		if !strings.HasPrefix(oldZfPath, oldPath) {
-			continue
-		}
-
-		relZfDir, err := filepath.Rel(oldPath, oldZfDir)
-		if err != nil {
-			return fmt.Errorf("moving contained file %s: %w", zfBase.ID, err)
-		}
-		newZfDir := filepath.Join(newPath, relZfDir)
-
-		// folder should have been created by moveZipFolderHierarchy
-		newZfFolder, err := GetOrCreateFolderHierarchy(ctx, m.Folders, newZfDir)
-		if err != nil {
-			return fmt.Errorf("getting or creating folder hierarchy: %w", err)
-		}
-
-		// update file parent folder
-		zfBase.ParentFolderID = newZfFolder.ID
-		if err := m.Files.Update(ctx, zf); err != nil {
-			return fmt.Errorf("updating file %s: %w", oldZfPath, err)
-		}
 	}
 
 	fBase.ParentFolderID = folder.ID

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -653,6 +653,7 @@ func (s *scanJob) handleFile(ctx context.Context, f scanFile) error {
 		}
 
 		if ff == nil {
+			// returns a file only if it is actually new
 			ff, err = s.onNewFile(ctx, f)
 			return err
 		}
@@ -740,7 +741,10 @@ func (s *scanJob) onNewFile(ctx context.Context, f scanFile) (models.File, error
 	}
 
 	if renamed != nil {
-		return renamed, nil
+		// handle rename should have already handled the contents of the zip file
+		// so shouldn't need to scan it again
+		// return nil so it doesn't
+		return nil, nil
 	}
 
 	// if not renamed, queue file for creation
@@ -901,8 +905,8 @@ func (s *scanJob) handleRename(ctx context.Context, f models.File, fp []models.F
 		}
 
 		if s.isZipFile(fBase.Basename) {
-			if err := TransferZipFolderHierarchy(ctx, s.Repository.Folder, fBase.ID, otherBase.Path, fBase.Path); err != nil {
-				return fmt.Errorf("moving folder hierarchy for renamed zip file %q: %w", fBase.Path, err)
+			if err := transferZipHierarchy(ctx, s.Repository.Folder, s.Repository.File, fBase.ID, otherBase.Path, fBase.Path); err != nil {
+				return fmt.Errorf("moving zip hierarchy for renamed zip file %q: %w", fBase.Path, err)
 			}
 		}
 


### PR DESCRIPTION
Resolves #1501 

If a zip file is renamed without modification to the contents, then the scan will now update the zip file locations as part of the move detection, instead of needing to rescan the entire zip file contents to update their location.