### PR TITLE
Package manager UI-related tweaks

### DIFF
--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -9,6 +9,7 @@ fragment ConfigGeneralData on ConfigGeneralResult {
   generatedPath
   metadataPath
   scrapersPath
+  pluginsPath
   cachePath
   blobsPath
   blobsStorage

--- a/graphql/documents/queries/plugins.graphql
+++ b/graphql/documents/queries/plugins.graphql
@@ -55,7 +55,7 @@ query InstalledPluginPackages {
 query InstalledPluginPackagesStatus {
   installedPackages(type: Plugin) {
     ...PackageData
-    upgrade {
+    source_package {
       ...PackageData
     }
   }

--- a/graphql/documents/queries/scrapers/scrapers.graphql
+++ b/graphql/documents/queries/scrapers/scrapers.graphql
@@ -129,7 +129,7 @@ query InstalledScraperPackages {
 query InstalledScraperPackagesStatus {
   installedPackages(type: Scraper) {
     ...PackageData
-    upgrade {
+    source_package {
       ...PackageData
     }
   }

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -73,6 +73,8 @@ input ConfigGeneralInput {
   metadataPath: String
   "Path to scrapers"
   scrapersPath: String
+  "Path to plugins"
+  pluginsPath: String
   "Path to cache"
   cachePath: String
   "Path to blobs - required for filesystem blob storage"
@@ -189,6 +191,8 @@ type ConfigGeneralResult {
   configFilePath: String!
   "Path to scrapers"
   scrapersPath: String!
+  "Path to plugins"
+  pluginsPath: String!
   "Path to cache"
   cachePath: String!
   "Path to blobs - required for filesystem blob storage"

--- a/graphql/schema/types/package.graphql
+++ b/graphql/schema/types/package.graphql
@@ -12,8 +12,8 @@ type Package {
 
   sourceURL: String!
 
-  "The available upgraded version of this package"
-  upgrade: Package
+  "The version of this package currently available from the remote source"
+  source_package: Package
 
   metadata: Map!
 }

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -104,6 +104,7 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 	}
 
 	refreshScraperCache := false
+	refreshScraperSource := false
 	existingScrapersPath := c.GetScrapersPath()
 	if input.ScrapersPath != nil && existingScrapersPath != *input.ScrapersPath {
 		if err := validateDir(config.ScrapersPath, *input.ScrapersPath, false); err != nil {
@@ -111,7 +112,21 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 		}
 
 		refreshScraperCache = true
+		refreshScraperSource = true
 		c.Set(config.ScrapersPath, input.ScrapersPath)
+	}
+
+	refreshPluginCache := false
+	refreshPluginSource := false
+	existingPluginsPath := c.GetPluginsPath()
+	if input.PluginsPath != nil && existingPluginsPath != *input.PluginsPath {
+		if err := validateDir(config.PluginsPath, *input.PluginsPath, false); err != nil {
+			return makeConfigGeneralResult(), err
+		}
+
+		refreshPluginCache = true
+		refreshPluginSource = true
+		c.Set(config.PluginsPath, input.PluginsPath)
 	}
 
 	existingMetadataPath := c.GetMetadataPath()
@@ -347,13 +362,11 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 		c.Set(config.DrawFunscriptHeatmapRange, input.DrawFunscriptHeatmapRange)
 	}
 
-	refreshScraperSource := false
 	if input.ScraperPackageSources != nil {
 		c.Set(config.ScraperPackageSources, input.ScraperPackageSources)
 		refreshScraperSource = true
 	}
 
-	refreshPluginSource := false
 	if input.PluginPackageSources != nil {
 		c.Set(config.PluginPackageSources, input.PluginPackageSources)
 		refreshPluginSource = true
@@ -366,6 +379,9 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 	manager.GetInstance().RefreshConfig()
 	if refreshScraperCache {
 		manager.GetInstance().RefreshScraperCache()
+	}
+	if refreshPluginCache {
+		manager.GetInstance().RefreshPluginCache()
 	}
 	if refreshStreamManager {
 		manager.GetInstance().RefreshStreamManager()

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -87,6 +87,7 @@ func makeConfigGeneralResult() *ConfigGeneralResult {
 		MetadataPath:                  config.GetMetadataPath(),
 		ConfigFilePath:                config.GetConfigFile(),
 		ScrapersPath:                  config.GetScrapersPath(),
+		PluginsPath:                   config.GetPluginsPath(),
 		CachePath:                     config.GetCachePath(),
 		BlobsPath:                     config.GetBlobsPath(),
 		BlobsStorage:                  config.GetBlobsStorage(),

--- a/internal/api/resolver_query_package.go
+++ b/internal/api/resolver_query_package.go
@@ -98,11 +98,24 @@ func sortedPackageSpecKeys[V any](m map[models.PackageSpecInput]V) []models.Pack
 	}
 
 	sort.Slice(keys, func(i, j int) bool {
-		if strings.EqualFold(keys[i].ID, keys[j].ID) {
-			return keys[i].ID < keys[j].ID
+		a := keys[i]
+		b := keys[j]
+
+		aID := a.ID
+		bID := b.ID
+
+		if aID == bID {
+			return a.SourceURL < b.SourceURL
 		}
 
-		return strings.ToLower(keys[i].ID) < strings.ToLower(keys[j].ID)
+		aIDL := strings.ToLower(aID)
+		bIDL := strings.ToLower(bID)
+
+		if aIDL == bIDL {
+			return aID < bID
+		}
+
+		return aIDL < bIDL
 	})
 
 	return keys

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -138,7 +138,7 @@ const (
 	PluginsSettingPrefix = PluginsSetting + "."
 	DisabledPlugins      = "plugins.disabled"
 
-	sourceDefaultPath = "stable"
+	sourceDefaultPath = "community"
 	sourceDefaultName = "Community (stable)"
 
 	PluginPackageSources        = "plugins.package_sources"

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -1666,16 +1666,16 @@ func (i *Config) setDefaultValues() {
 	i.main.SetDefault(NoProxy, noProxyDefault)
 
 	// set default package sources
-	i.main.SetDefault(PluginPackageSources, map[string]string{
-		"name":       sourceDefaultName,
-		"url":        pluginPackageSourcesDefault,
-		"local_path": sourceDefaultPath,
-	})
-	i.main.SetDefault(ScraperPackageSources, map[string]string{
-		"name":       sourceDefaultName,
-		"url":        scraperPackageSourcesDefault,
-		"local_path": sourceDefaultPath,
-	})
+	i.main.SetDefault(PluginPackageSources, []map[string]string{{
+		"name":      sourceDefaultName,
+		"url":       pluginPackageSourcesDefault,
+		"localpath": sourceDefaultPath,
+	}})
+	i.main.SetDefault(ScraperPackageSources, []map[string]string{{
+		"name":      sourceDefaultName,
+		"url":       scraperPackageSourcesDefault,
+		"localpath": sourceDefaultPath,
+	}})
 }
 
 // setExistingSystemDefaults sets config options that are new and unset in an existing install,

--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -72,7 +72,7 @@ export const InstalledPluginPackages: React.FC = () => {
             onUpdatePackages(
               packages.map((p) => ({
                 id: p.package_id,
-                sourceURL: p.upgrade!.sourceURL,
+                sourceURL: p.sourceURL,
               }))
             )
           }

--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -26,15 +26,20 @@ export const InstalledPluginPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
-  const { data: installedPlugins, refetch: refetchPackages1 } =
-    useInstalledPluginPackages({
-      skip: loadUpgrades,
-    });
+  const {
+    data: installedPlugins,
+    refetch: refetchPackages1,
+    loading: loading1,
+    error: error1,
+  } = useInstalledPluginPackages({
+    skip: loadUpgrades,
+  });
 
   const {
     data: withStatus,
     refetch: refetchPackages2,
-    loading: statusLoading,
+    loading: loading2,
+    error: error2,
   } = useInstalledPluginPackagesStatus({
     skip: !loadUpgrades,
   });
@@ -78,13 +83,15 @@ export const InstalledPluginPackages: React.FC = () => {
     return installedPlugins?.installedPackages ?? [];
   }, [installedPlugins, withStatus]);
 
-  const loading = !!job || statusLoading;
+  const loading = !!job || loading1 || loading2;
+  const error = error1 || error2;
 
   return (
     <SettingSection headingID="config.plugins.installed_plugins">
       <div className="package-manager">
         <InstalledPackages
           loading={loading}
+          error={error?.message}
           packages={installedPackages}
           onCheckForUpdates={onCheckForUpdates}
           onUpdatePackages={(packages) =>

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import {
   evictQueries,
   getClient,
   queryAvailableScraperPackages,
   useInstalledScraperPackages,
-  useInstalledScraperPackagesStatus,
   mutateUpdateScraperPackages,
   mutateUninstallScraperPackages,
   mutateInstallScraperPackages,
@@ -26,24 +25,8 @@ export const InstalledScraperPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
-  const {
-    data: installedScrapers,
-    refetch: refetchPackages1,
-    loading: loading1,
-    error: error1,
-  } =
-    useInstalledScraperPackages({
-      skip: loadUpgrades,
-    });
-
-  const {
-    data: withStatus,
-    refetch: refetchPackages2,
-    loading: loading2,
-    error: error2,
-  } = useInstalledScraperPackagesStatus({
-    skip: !loadUpgrades,
-  });
+  const { data, previousData, refetch, loading, error } =
+    useInstalledScraperPackages(loadUpgrades);
 
   async function onUpdatePackages(packages: GQL.PackageSpecInput[]) {
     const r = await mutateUpdateScraperPackages(packages);
@@ -57,11 +40,6 @@ export const InstalledScraperPackages: React.FC = () => {
     setJobID(r.data?.uninstallPackages);
   }
 
-  function refetchPackages() {
-    refetchPackages1();
-    refetchPackages2();
-  }
-
   function onPackageChanges() {
     // job is complete, refresh all local data
     const ac = getClient();
@@ -72,26 +50,21 @@ export const InstalledScraperPackages: React.FC = () => {
     if (!loadUpgrades) {
       setLoadUpgrades(true);
     } else {
-      refetchPackages();
+      refetch();
     }
   }
 
-  const installedPackages = useMemo(() => {
-    if (withStatus?.installedPackages) {
-      return withStatus.installedPackages;
-    }
-
-    return installedScrapers?.installedPackages ?? [];
-  }, [installedScrapers, withStatus]);
-
-  const loading = !!job || loading1 || loading2;
-  const error = error1 || error2;
+  // when loadUpgrades changes from false to true, data is set to undefined while the request is loading
+  // so use previousData as a fallback, which will be the result when loadUpgrades was false,
+  // to prevent displaying a "No packages found" message
+  const installedPackages =
+    data?.installedPackages ?? previousData?.installedPackages ?? [];
 
   return (
     <SettingSection headingID="config.scraping.installed_scrapers">
       <div className="package-manager">
         <InstalledPackages
-          loading={loading}
+          loading={!!job || loading}
           error={error?.message}
           packages={installedPackages}
           onCheckForUpdates={onCheckForUpdates}
@@ -111,7 +84,7 @@ export const InstalledScraperPackages: React.FC = () => {
               }))
             )
           }
-          updatesLoaded={loadUpgrades}
+          updatesLoaded={loadUpgrades && !loading}
         />
       </div>
     </SettingSection>

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -72,7 +72,7 @@ export const InstalledScraperPackages: React.FC = () => {
             onUpdatePackages(
               packages.map((p) => ({
                 id: p.package_id,
-                sourceURL: p.upgrade!.sourceURL,
+                sourceURL: p.sourceURL,
               }))
             )
           }

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -136,6 +136,12 @@ export const AvailableScraperPackages: React.FC = () => {
     });
   }
 
+  function renderDescription(pkg: RemotePackage) {
+    if (pkg.metadata.description) {
+      return pkg.metadata.description;
+    }
+  }
+
   if (error) return <h1>{error.message}</h1>;
   if (configLoading) return <LoadingIndicator />;
 
@@ -149,6 +155,7 @@ export const AvailableScraperPackages: React.FC = () => {
         <AvailablePackages
           loading={loading}
           onInstallPackages={onInstallPackages}
+          renderDescription={renderDescription}
           loadSource={(source) => loadSource(source)}
           sources={sources}
           addSource={addSource}

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -26,7 +26,12 @@ export const InstalledScraperPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
-  const { data: installedScrapers, refetch: refetchPackages1 } =
+  const {
+    data: installedScrapers,
+    refetch: refetchPackages1,
+    loading: loading1,
+    error: error1,
+  } =
     useInstalledScraperPackages({
       skip: loadUpgrades,
     });
@@ -34,7 +39,8 @@ export const InstalledScraperPackages: React.FC = () => {
   const {
     data: withStatus,
     refetch: refetchPackages2,
-    loading: statusLoading,
+    loading: loading2,
+    error: error2,
   } = useInstalledScraperPackagesStatus({
     skip: !loadUpgrades,
   });
@@ -78,13 +84,15 @@ export const InstalledScraperPackages: React.FC = () => {
     return installedScrapers?.installedPackages ?? [];
   }, [installedScrapers, withStatus]);
 
-  const loading = !!job || statusLoading;
+  const loading = !!job || loading1 || loading2;
+  const error = error1 || error2;
 
   return (
     <SettingSection headingID="config.scraping.installed_scrapers">
       <div className="package-manager">
         <InstalledPackages
           loading={loading}
+          error={error?.message}
           packages={installedPackages}
           onCheckForUpdates={onCheckForUpdates}
           onUpdatePackages={(packages) =>

--- a/ui/v2.5/src/components/Settings/SettingsSystemPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsSystemPanel.tsx
@@ -138,6 +138,14 @@ export const SettingsConfigurationPanel: React.FC = () => {
         />
 
         <StringSetting
+          id="plugins-path"
+          headingID="config.general.plugins_path.heading"
+          subHeadingID="config.general.plugins_path.description"
+          value={general.pluginsPath ?? undefined}
+          onChange={(v) => saveGeneral({ pluginsPath: v })}
+        />
+
+        <StringSetting
           id="metadata-path"
           headingID="config.general.metadata_path.heading"
           subHeadingID="config.general.metadata_path.description"

--- a/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
+++ b/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
@@ -213,36 +213,33 @@ const InstalledPackagesToolbar: React.FC<{
   const intl = useIntl();
   return (
     <div className="package-manager-toolbar">
-      <div>
-        <ClearableInput
-          placeholder={`${intl.formatMessage({ id: "filter" })}...`}
-          value={filter}
-          setValue={(v) => setFilter(v)}
-        />
-      </div>
-      <div>
-        <Button
-          variant="primary"
-          onClick={() => onCheckForUpdates()}
-          disabled={loading}
-        >
-          <FormattedMessage id="package_manager.check_for_updates" />
-        </Button>
-        <Button
-          variant="primary"
-          disabled={!checkedPackages.length || loading}
-          onClick={() => onUpdatePackages()}
-        >
-          <FormattedMessage id="package_manager.update" />
-        </Button>
-        <Button
-          variant="danger"
-          disabled={!checkedPackages.length || loading}
-          onClick={() => onUninstallPackages()}
-        >
-          <FormattedMessage id="package_manager.uninstall" />
-        </Button>
-      </div>
+      <ClearableInput
+        placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+        value={filter}
+        setValue={(v) => setFilter(v)}
+      />
+      <div className="flex-grow-1" />
+      <Button
+        variant="primary"
+        onClick={() => onCheckForUpdates()}
+        disabled={loading}
+      >
+        <FormattedMessage id="package_manager.check_for_updates" />
+      </Button>
+      <Button
+        variant="primary"
+        disabled={!checkedPackages.length || loading}
+        onClick={() => onUpdatePackages()}
+      >
+        <FormattedMessage id="package_manager.update" />
+      </Button>
+      <Button
+        variant="danger"
+        disabled={!checkedPackages.length || loading}
+        onClick={() => onUninstallPackages()}
+      >
+        <FormattedMessage id="package_manager.uninstall" />
+      </Button>
     </div>
   );
 };
@@ -353,31 +350,28 @@ const AvailablePackagesToolbar: React.FC<{
 
   return (
     <div className="package-manager-toolbar">
-      <div>
-        <ClearableInput
-          placeholder={`${intl.formatMessage({ id: "filter" })}...`}
-          value={filter}
-          setValue={(v) => setFilter(v)}
-        />
-        {hasSelectedPackages && (
-          <Button
-            size="sm"
-            variant="primary"
-            onClick={() => setSelectedOnly(!selectedOnly)}
-          >
-            <FormattedMessage id={selectedOnlyId} />
-          </Button>
-        )}
-      </div>
-      <div>
+      <ClearableInput
+        placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+        value={filter}
+        setValue={(v) => setFilter(v)}
+      />
+      {hasSelectedPackages && (
         <Button
+          size="sm"
           variant="primary"
-          disabled={!hasSelectedPackages || loading}
-          onClick={() => onInstallPackages()}
+          onClick={() => setSelectedOnly(!selectedOnly)}
         >
-          <FormattedMessage id="package_manager.install" />
+          <FormattedMessage id={selectedOnlyId} />
         </Button>
-      </div>
+      )}
+      <div className="flex-grow-1" />
+      <Button
+        variant="primary"
+        disabled={!hasSelectedPackages || loading}
+        onClick={() => onInstallPackages()}
+      >
+        <FormattedMessage id="package_manager.install" />
+      </Button>
     </div>
   );
 };

--- a/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
+++ b/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
@@ -655,11 +655,15 @@ const SourcePackagesList: React.FC<{
   }
 
   function toggleSourceOpen() {
-    if (packages === undefined) {
-      loadPackages();
+    if (sourceOpen) {
+      setLoadError(undefined);
+      setSourceOpen(false);
+    } else {
+      if (packages === undefined) {
+        loadPackages();
+      }
+      setSourceOpen(true);
     }
-
-    setSourceOpen((prev) => !prev);
   }
 
   function renderCollapseButton() {

--- a/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
+++ b/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
@@ -17,7 +17,13 @@ import { LoadingIndicator } from "../LoadingIndicator";
 import { ApolloError } from "@apollo/client";
 import { ClearableInput } from "../ClearableInput";
 
-function formatDate(intl: IntlShape, date: string | undefined | null) {
+function displayVersion(intl: IntlShape, version: string | undefined | null) {
+  if (!version) return intl.formatMessage({ id: "package_manager.unknown" });
+
+  return version;
+}
+
+function displayDate(intl: IntlShape, date: string | undefined | null) {
   if (!date) return;
 
   const d = new Date(date);
@@ -79,17 +85,21 @@ const InstalledPackageRow: React.FC<{
         <span className="package-id">{pkg.package_id}</span>
       </td>
       <td>
-        <span className="package-version">{pkg.version}</span>
-        <span className="package-date">{formatDate(intl, pkg.date)}</span>
+        <span className="package-version">
+          {displayVersion(intl, pkg.version)}
+        </span>
+        <span className="package-date">{displayDate(intl, pkg.date)}</span>
       </td>
-      {updatesLoaded ? (
+      {updatesLoaded && pkg.upgrade && (
         <td>
-          <span className="package-version">{pkg.upgrade?.version}</span>
+          <span className="package-version">
+            {displayVersion(intl, pkg.upgrade.version)}
+          </span>
           <span className="package-date">
-            {formatDate(intl, pkg.upgrade?.date)}
+            {displayDate(intl, pkg.upgrade.date)}
           </span>
         </td>
-      ) : undefined}
+      )}
     </tr>
   );
 };
@@ -578,8 +588,10 @@ const AvailablePackageRow: React.FC<{
         <span className="package-id">{pkg.package_id}</span>
       </td>
       <td>
-        <span className="package-version">{pkg.version}</span>
-        <span className="package-date">{formatDate(intl, pkg.date)}</span>
+        <span className="package-version">
+          {displayVersion(intl, pkg.version)}
+        </span>
+        <span className="package-date">{displayDate(intl, pkg.date)}</span>
       </td>
       <td>
         {renderRequiredBy()}

--- a/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
+++ b/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
@@ -97,6 +97,7 @@ const InstalledPackageRow: React.FC<{
 const InstalledPackagesList: React.FC<{
   filter: string;
   loading?: boolean;
+  error?: string;
   updatesLoaded: boolean;
   packages: InstalledPackage[];
   checkedPackages: InstalledPackage[];
@@ -108,6 +109,7 @@ const InstalledPackagesList: React.FC<{
   setCheckedPackages,
   updatesLoaded,
   loading,
+  error,
 }) => {
   const checkedMap = useMemo(() => {
     const map: Record<string, boolean> = {};
@@ -141,6 +143,41 @@ const InstalledPackagesList: React.FC<{
     });
   }
 
+  function renderBody() {
+    if (error) {
+      return (
+        <tr>
+          <td />
+          <td colSpan={1000} className="source-error">
+            <Icon icon={faWarning} />
+            <span>{error}</span>
+          </td>
+        </tr>
+      );
+    }
+
+    if (filteredPackages.length === 0) {
+      return (
+        <tr className="package-manager-no-results">
+          <td colSpan={1000}>
+            <FormattedMessage id="package_manager.no_packages" />
+          </td>
+        </tr>
+      );
+    }
+
+    return filteredPackages.map((pkg) => (
+      <InstalledPackageRow
+        key={`${pkg.sourceURL}-${pkg.package_id}`}
+        loading={loading}
+        pkg={pkg}
+        selected={checkedMap[`${pkg.sourceURL}-${pkg.package_id}`] ?? false}
+        togglePackage={() => togglePackage(pkg)}
+        updatesLoaded={updatesLoaded}
+      />
+    ));
+  }
+
   return (
     <div className="package-manager-table-container">
       <Table>
@@ -166,28 +203,7 @@ const InstalledPackagesList: React.FC<{
             ) : undefined}
           </tr>
         </thead>
-        <tbody>
-          {filteredPackages.length === 0 ? (
-            <tr className="package-manager-no-results">
-              <td colSpan={updatesLoaded ? 4 : 3}>
-                <FormattedMessage id="package_manager.no_packages" />
-              </td>
-            </tr>
-          ) : (
-            filteredPackages.map((pkg) => (
-              <InstalledPackageRow
-                key={`${pkg.sourceURL}-${pkg.package_id}`}
-                loading={loading}
-                pkg={pkg}
-                selected={
-                  checkedMap[`${pkg.sourceURL}-${pkg.package_id}`] ?? false
-                }
-                togglePackage={() => togglePackage(pkg)}
-                updatesLoaded={updatesLoaded}
-              />
-            ))
-          )}
-        </tbody>
+        <tbody>{renderBody()}</tbody>
       </Table>
     </div>
   );
@@ -246,6 +262,7 @@ const InstalledPackagesToolbar: React.FC<{
 
 export const InstalledPackages: React.FC<{
   loading?: boolean;
+  error?: string;
   packages: InstalledPackage[];
   updatesLoaded: boolean;
   onCheckForUpdates: () => void;
@@ -258,6 +275,7 @@ export const InstalledPackages: React.FC<{
   onUpdatePackages,
   onUninstallPackages,
   loading,
+  error,
 }) => {
   const [checkedPackages, setCheckedPackages] = useState<InstalledPackage[]>(
     []
@@ -313,6 +331,7 @@ export const InstalledPackages: React.FC<{
         <InstalledPackagesList
           filter={filter}
           loading={loading}
+          error={error}
           packages={packages}
           // use original checked packages so that check boxes are not affected by filter
           checkedPackages={checkedPackages}

--- a/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
+++ b/ui/v2.5/src/components/Shared/PackageManager/PackageManager.tsx
@@ -19,6 +19,12 @@ import { LoadingIndicator } from "../LoadingIndicator";
 import { ApolloError } from "@apollo/client";
 import { ClearableInput } from "../ClearableInput";
 
+function packageKey(
+  pkg: Pick<GQL.Package, "package_id" | "sourceURL">
+): string {
+  return `${pkg.sourceURL}-${pkg.package_id}`;
+}
+
 function displayVersion(intl: IntlShape, version: string | undefined | null) {
   if (!version) return intl.formatMessage({ id: "package_manager.unknown" });
 
@@ -130,7 +136,7 @@ const InstalledPackagesList: React.FC<{
   const checkedMap = useMemo(() => {
     const map: Record<string, boolean> = {};
     for (const pkg of checkedPackages) {
-      map[`${pkg.sourceURL}-${pkg.package_id}`] = true;
+      map[packageKey(pkg)] = true;
     }
     return map;
   }, [checkedPackages]);
@@ -152,9 +158,9 @@ const InstalledPackagesList: React.FC<{
 
     setCheckedPackages((prev) => {
       if (prev.includes(pkg)) {
-        return prev.filter((n) => n.package_id !== pkg.package_id);
+        return prev.filter((n) => packageKey(n) !== packageKey(pkg));
       } else {
-        return prev.concat(pkg);
+        return [...prev, pkg];
       }
     });
   }
@@ -184,10 +190,10 @@ const InstalledPackagesList: React.FC<{
 
     return filteredPackages.map((pkg) => (
       <InstalledPackageRow
-        key={`${pkg.sourceURL}-${pkg.package_id}`}
+        key={packageKey(pkg)}
         loading={loading}
         pkg={pkg}
-        selected={checkedMap[`${pkg.sourceURL}-${pkg.package_id}`] ?? false}
+        selected={checkedMap[packageKey(pkg)] ?? false}
         togglePackage={() => togglePackage(pkg)}
         updatesLoaded={updatesLoaded}
       />
@@ -306,7 +312,7 @@ export const InstalledPackages: React.FC<{
   useEffect(() => {
     setCheckedPackages((prev) => {
       const newVal = prev.filter((pkg) =>
-        packages.find((p) => p.package_id === pkg.package_id)
+        packages.find((p) => packageKey(p) === packageKey(pkg))
       );
       if (newVal.length !== prev.length) {
         return newVal;

--- a/ui/v2.5/src/components/Shared/PackageManager/styles.scss
+++ b/ui/v2.5/src/components/Shared/PackageManager/styles.scss
@@ -4,6 +4,15 @@
   .package-source {
     font-weight: bold;
 
+    .source-collapse {
+      padding-left: 0;
+      padding-right: 0;
+
+      .btn {
+        color: $text-color;
+      }
+    }
+
     .source-controls {
       align-items: center;
       display: flex;
@@ -17,10 +26,6 @@
     cursor: pointer;
   }
 
-  .package-collapse-button {
-    color: $text-color;
-  }
-
   .package-manager-table-container {
     max-height: 300px;
     overflow-y: auto;
@@ -32,8 +37,12 @@
     top: 0;
     z-index: 1;
 
-    .button-cell {
+    .check-cell {
       width: 40px;
+    }
+
+    .collapse-cell {
+      width: 30px;
     }
   }
 

--- a/ui/v2.5/src/components/Shared/PackageManager/styles.scss
+++ b/ui/v2.5/src/components/Shared/PackageManager/styles.scss
@@ -7,6 +7,7 @@
     .source-controls {
       align-items: center;
       display: flex;
+      gap: 0.5rem;
       justify-content: end;
     }
   }
@@ -55,15 +56,8 @@
 
   .package-manager-toolbar {
     display: flex;
-    justify-content: space-between;
-
-    div {
-      display: flex;
-    }
-
-    .btn {
-      margin-left: 0.5em;
-    }
+    gap: 0.5rem;
+    padding-bottom: 0.25rem;
   }
 
   .package-required-by {

--- a/ui/v2.5/src/components/Shared/PackageManager/styles.scss
+++ b/ui/v2.5/src/components/Shared/PackageManager/styles.scss
@@ -41,17 +41,27 @@
     vertical-align: middle;
   }
 
+  .package-name,
+  .package-id,
   .package-version,
   .package-date,
-  .package-name,
-  .package-id {
+  .package-latest-version,
+  .package-latest-date {
     display: block;
   }
 
+  .package-id,
   .package-date,
-  .package-id {
+  .package-latest-date {
     color: $muted-gray;
     font-size: 0.8rem;
+  }
+
+  .package-update-available {
+    .package-latest-version,
+    .package-latest-date {
+      font-weight: 700;
+    }
   }
 
   .package-manager-toolbar {

--- a/ui/v2.5/src/components/Shared/PackageManager/styles.scss
+++ b/ui/v2.5/src/components/Shared/PackageManager/styles.scss
@@ -57,6 +57,14 @@
     font-size: 0.8rem;
   }
 
+  .package-id,
+  .package-version,
+  .package-date,
+  .package-latest-version,
+  .package-latest-date {
+    white-space: nowrap;
+  }
+
   .package-update-available {
     .package-latest-version,
     .package-latest-date {

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -1961,43 +1961,6 @@ export const mutateSubmitStashBoxPerformerDraft = (
     variables: { input },
   });
 
-/// Packages
-export const useInstalledScraperPackages = GQL.useInstalledScraperPackagesQuery;
-export const useInstalledScraperPackagesStatus =
-  GQL.useInstalledScraperPackagesStatusQuery;
-
-export const queryAvailableScraperPackages = (source: string) =>
-  client.query<GQL.AvailableScraperPackagesQuery>({
-    query: GQL.AvailableScraperPackagesDocument,
-    variables: {
-      source,
-    },
-    fetchPolicy: "network-only",
-  });
-
-export const useInstallScraperPackages = GQL.useInstallScraperPackagesMutation;
-export const useUpdateScraperPackages = GQL.useUpdateScraperPackagesMutation;
-export const useUninstallScraperPackages =
-  GQL.useUninstallScraperPackagesMutation;
-
-export const useInstalledPluginPackages = GQL.useInstalledPluginPackagesQuery;
-export const useInstalledPluginPackagesStatus =
-  GQL.useInstalledPluginPackagesStatusQuery;
-
-export const queryAvailablePluginPackages = (source: string) =>
-  client.query<GQL.AvailablePluginPackagesQuery>({
-    query: GQL.AvailablePluginPackagesDocument,
-    variables: {
-      source,
-    },
-    fetchPolicy: "network-only",
-  });
-
-export const useInstallPluginPackages = GQL.useInstallPluginPackagesMutation;
-export const useUpdatePluginPackages = GQL.useUpdatePluginPackagesMutation;
-export const useUninstallPluginPackages =
-  GQL.useUninstallPluginPackagesMutation;
-
 /// Configuration
 
 export const useConfiguration = () => GQL.useConfigurationQuery();
@@ -2043,6 +2006,65 @@ export const useJobsSubscribe = () => GQL.useJobsSubscribeSubscription();
 
 export const useLoggingSubscribe = () => GQL.useLoggingSubscribeSubscription();
 
+// all scraper-related queries
+export const scraperMutationImpactedQueries = [
+  GQL.ListMovieScrapersDocument,
+  GQL.ListPerformerScrapersDocument,
+  GQL.ListSceneScrapersDocument,
+  GQL.InstalledScraperPackagesDocument,
+  GQL.InstalledScraperPackagesStatusDocument,
+];
+
+export const mutateReloadScrapers = () =>
+  client.mutate<GQL.ReloadScrapersMutation>({
+    mutation: GQL.ReloadScrapersDocument,
+    update(cache, result) {
+      if (!result.data?.reloadScrapers) return;
+
+      evictQueries(cache, scraperMutationImpactedQueries);
+    },
+  });
+
+// all plugin-related queries
+export const pluginMutationImpactedQueries = [
+  GQL.PluginsDocument,
+  GQL.PluginTasksDocument,
+  GQL.InstalledPluginPackagesDocument,
+  GQL.InstalledPluginPackagesStatusDocument,
+];
+
+export const mutateReloadPlugins = () =>
+  client.mutate<GQL.ReloadPluginsMutation>({
+    mutation: GQL.ReloadPluginsDocument,
+    update(cache, result) {
+      if (!result.data?.reloadPlugins) return;
+
+      evictQueries(cache, pluginMutationImpactedQueries);
+    },
+  });
+
+type BoolMap = { [key: string]: boolean };
+
+export const mutateSetPluginsEnabled = (enabledMap: BoolMap) =>
+  client.mutate<GQL.SetPluginsEnabledMutation>({
+    mutation: GQL.SetPluginsEnabledDocument,
+    variables: { enabledMap },
+    update(cache, result) {
+      if (!result.data?.setPluginsEnabled) return;
+
+      for (const id in enabledMap) {
+        cache.modify({
+          id: cache.identify({ __typename: "Plugin", id }),
+          fields: {
+            enabled() {
+              return enabledMap[id];
+            },
+          },
+        });
+      }
+    },
+  });
+
 function updateConfiguration(cache: ApolloCache<unknown>, result: FetchResult) {
   if (!result.data) return;
 
@@ -2051,7 +2073,15 @@ function updateConfiguration(cache: ApolloCache<unknown>, result: FetchResult) {
 
 export const useConfigureGeneral = () =>
   GQL.useConfigureGeneralMutation({
-    update: updateConfiguration,
+    update(cache, result) {
+      if (!result.data?.configureGeneral) return;
+
+      evictQueries(cache, [
+        GQL.ConfigurationDocument,
+        ...scraperMutationImpactedQueries,
+        ...pluginMutationImpactedQueries,
+      ]);
+    },
   });
 
 export const useConfigureInterface = () =>
@@ -2097,48 +2127,6 @@ export const useAddTempDLNAIP = () => GQL.useAddTempDlnaipMutation();
 
 export const useRemoveTempDLNAIP = () => GQL.useRemoveTempDlnaipMutation();
 
-export const mutateReloadScrapers = () =>
-  client.mutate<GQL.ReloadScrapersMutation>({
-    mutation: GQL.ReloadScrapersDocument,
-    update(cache, result) {
-      if (!result.data?.reloadScrapers) return;
-
-      evictQueries(cache, [
-        GQL.ListMovieScrapersDocument,
-        GQL.ListPerformerScrapersDocument,
-        GQL.ListSceneScrapersDocument,
-      ]);
-    },
-  });
-
-const pluginMutationImpactedQueries = [
-  GQL.PluginsDocument,
-  GQL.PluginTasksDocument,
-];
-
-export const mutateReloadPlugins = () =>
-  client.mutate<GQL.ReloadPluginsMutation>({
-    mutation: GQL.ReloadPluginsDocument,
-    update(cache, result) {
-      if (!result.data?.reloadPlugins) return;
-
-      evictQueries(cache, pluginMutationImpactedQueries);
-    },
-  });
-
-type BoolMap = { [key: string]: boolean };
-
-export const mutateSetPluginsEnabled = (enabledMap: BoolMap) =>
-  client.mutate<GQL.SetPluginsEnabledMutation>({
-    mutation: GQL.SetPluginsEnabledDocument,
-    variables: { enabledMap },
-    update(cache, result) {
-      if (!result.data?.setPluginsEnabled) return;
-
-      evictQueries(cache, pluginMutationImpactedQueries);
-    },
-  });
-
 export const mutateStopJob = (jobID: string) =>
   client.mutate<GQL.StopJobMutation>({
     mutation: GQL.StopJobDocument,
@@ -2169,6 +2157,88 @@ export const mutateMigrate = (input: GQL.MigrateInput) =>
       if (!result.data?.migrate) return;
 
       evictQueries(cache, setupMutationImpactedQueries);
+    },
+  });
+
+/// Packages
+
+export const useInstalledScraperPackages = GQL.useInstalledScraperPackagesQuery;
+export const useInstalledScraperPackagesStatus =
+  GQL.useInstalledScraperPackagesStatusQuery;
+
+export const queryAvailableScraperPackages = (source: string) =>
+  client.query<GQL.AvailableScraperPackagesQuery>({
+    query: GQL.AvailableScraperPackagesDocument,
+    variables: {
+      source,
+    },
+    fetchPolicy: "network-only",
+  });
+
+export const mutateInstallScraperPackages = (
+  packages: GQL.PackageSpecInput[]
+) =>
+  client.mutate<GQL.InstallScraperPackagesMutation>({
+    mutation: GQL.InstallScraperPackagesDocument,
+    variables: {
+      packages,
+    },
+  });
+
+export const mutateUpdateScraperPackages = (packages: GQL.PackageSpecInput[]) =>
+  client.mutate<GQL.UpdateScraperPackagesMutation>({
+    mutation: GQL.UpdateScraperPackagesDocument,
+    variables: {
+      packages,
+    },
+  });
+
+export const mutateUninstallScraperPackages = (
+  packages: GQL.PackageSpecInput[]
+) =>
+  client.mutate<GQL.UninstallScraperPackagesMutation>({
+    mutation: GQL.UninstallScraperPackagesDocument,
+    variables: {
+      packages,
+    },
+  });
+
+export const useInstalledPluginPackages = GQL.useInstalledPluginPackagesQuery;
+export const useInstalledPluginPackagesStatus =
+  GQL.useInstalledPluginPackagesStatusQuery;
+
+export const queryAvailablePluginPackages = (source: string) =>
+  client.query<GQL.AvailablePluginPackagesQuery>({
+    query: GQL.AvailablePluginPackagesDocument,
+    variables: {
+      source,
+    },
+    fetchPolicy: "network-only",
+  });
+
+export const mutateInstallPluginPackages = (packages: GQL.PackageSpecInput[]) =>
+  client.mutate<GQL.InstallPluginPackagesMutation>({
+    mutation: GQL.InstallPluginPackagesDocument,
+    variables: {
+      packages,
+    },
+  });
+
+export const mutateUpdatePluginPackages = (packages: GQL.PackageSpecInput[]) =>
+  client.mutate<GQL.UpdatePluginPackagesMutation>({
+    mutation: GQL.UpdatePluginPackagesDocument,
+    variables: {
+      packages,
+    },
+  });
+
+export const mutateUninstallPluginPackages = (
+  packages: GQL.PackageSpecInput[]
+) =>
+  client.mutate<GQL.UninstallPluginPackagesMutation>({
+    mutation: GQL.UninstallPluginPackagesDocument,
+    variables: {
+      packages,
     },
   });
 

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -1,4 +1,9 @@
-import { ApolloCache, DocumentNode, FetchResult } from "@apollo/client";
+import {
+  ApolloCache,
+  DocumentNode,
+  FetchResult,
+  useQuery,
+} from "@apollo/client";
 import { Modifiers } from "@apollo/client/cache";
 import {
   isField,
@@ -2162,9 +2167,24 @@ export const mutateMigrate = (input: GQL.MigrateInput) =>
 
 /// Packages
 
-export const useInstalledScraperPackages = GQL.useInstalledScraperPackagesQuery;
-export const useInstalledScraperPackagesStatus =
-  GQL.useInstalledScraperPackagesStatusQuery;
+// Acts like GQL.useInstalledScraperPackagesStatusQuery if loadUpgrades is true,
+// and GQL.useInstalledScraperPackagesQuery if it is false
+export const useInstalledScraperPackages = <T extends boolean>(
+  loadUpgrades: T
+) => {
+  const query = loadUpgrades
+    ? GQL.InstalledScraperPackagesStatusDocument
+    : GQL.InstalledScraperPackagesDocument;
+
+  type TData = T extends true
+    ? GQL.InstalledScraperPackagesStatusQuery
+    : GQL.InstalledScraperPackagesQuery;
+  type TVariables = T extends true
+    ? GQL.InstalledScraperPackagesStatusQueryVariables
+    : GQL.InstalledScraperPackagesQueryVariables;
+
+  return useQuery<TData, TVariables>(query);
+};
 
 export const queryAvailableScraperPackages = (source: string) =>
   client.query<GQL.AvailableScraperPackagesQuery>({
@@ -2203,9 +2223,24 @@ export const mutateUninstallScraperPackages = (
     },
   });
 
-export const useInstalledPluginPackages = GQL.useInstalledPluginPackagesQuery;
-export const useInstalledPluginPackagesStatus =
-  GQL.useInstalledPluginPackagesStatusQuery;
+// Acts like GQL.useInstalledPluginPackagesStatusQuery if loadUpgrades is true,
+// and GQL.useInstalledPluginPackagesQuery if it is false
+export const useInstalledPluginPackages = <T extends boolean>(
+  loadUpgrades: T
+) => {
+  const query = loadUpgrades
+    ? GQL.InstalledPluginPackagesStatusDocument
+    : GQL.InstalledPluginPackagesDocument;
+
+  type TData = T extends true
+    ? GQL.InstalledPluginPackagesStatusQuery
+    : GQL.InstalledPluginPackagesQuery;
+  type TVariables = T extends true
+    ? GQL.InstalledPluginPackagesStatusQueryVariables
+    : GQL.InstalledPluginPackagesQueryVariables;
+
+  return useQuery<TData, TVariables>(query);
+};
 
 export const queryAvailablePluginPackages = (source: string) =>
   client.query<GQL.AvailablePluginPackagesQuery>({

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1102,6 +1102,7 @@
     "selected_only": "Selected only",
     "show_all": "Show all",
     "uninstall": "Uninstall",
+    "unknown": "<unknown>",
     "update": "Update",
     "version": "Version"
   },

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -360,6 +360,10 @@
       "number_of_parallel_task_for_scan_generation_desc": "Set to 0 for auto-detection. Warning running more tasks than is required to achieve 100% cpu utilisation will decrease performance and potentially cause other issues.",
       "number_of_parallel_task_for_scan_generation_head": "Number of parallel task for scan/generation",
       "parallel_scan_head": "Parallel Scan/Generation",
+      "plugins_path": {
+        "description": "Directory location of plugin configuration files",
+        "heading": "Plugins Path"
+      },
       "preview_generation": "Preview Generation",
       "python_path": {
         "description": "Path to the python executable (not just the folder). Used for script scrapers and plugins. If blank, python will be resolved from the environment",


### PR DESCRIPTION
These are a bunch of improvements and tweaks mostly related to the package manager UI.

- 07b2e78 is almost identical to #4377, the only difference being that it also refreshes the package managers when the plugin or scraper paths change, in addition to the plugin/scraper caches.
- 9e124de adds cache invalidation to refetch the plugin/scraper queries when the paths are changed, and improves the `SetPluginsEnabled` mutation to modify the cache client-side and avoid any refetching. I've also done some minor refactoring (the package manager mutations now use `client.mutate` rather than hooks), and I've removed the `sources` state which is no longer necessary since the cache is now being properly invalidated.
- 75e3dfc does what it says on the tin. Currently, if retrieving the available package list from a source fails, then the error message sticks around even after collapsing the source. Now the error will be cleared if you collapse the source, and it will retry the query if you expand the source again.
- 36bccb7 makes two style tweaks to the package manager UI. The first is to add some padding to the toolbar, which prevents the highlight on hover from being cut off at the bottom. The second is to add a gap between the "Edit" and "Delete" buttons - them being directly next to each other looks off to me. And then a minor refactor to the way the toolbar's flexbox works, to use a `flex-grow` spacer rather than `space-between`.
- 0db0840 also is fairly self-explanatory. Currently, if the installed packages query fails, then it just shows "No packages found" - so I've just made it display a simple error message instead.
- 704af96 prevents a "No packages found" message from showing while the installed package list loads after clicking "Check for Updates". 
- cabd147 makes the list display `<unknown>` if the package has no version specified, rather than showing nothing.
- a5d03b2 makes the "Latest Version" column always display the latest version info, rather than the current behaviour of just displaying it if the version is newer than the installed version. The `upgrade` GraphQL field is now `source_package`, and will always return a result if the package is available from the source. This change means that an upgrade needs to be highlighted in some other way, which I've done by making the text bold and adding an icon.
- efc8277 fixes two issues I came across when you have packages from different sources sharing the same ID (in my case, `py_common`). The first is that the `installedPackages` query doesn't return a stable sort order, which happens because `sortedPackageSpecKeys` only sorts by ID - it will now fall back to the source URL. The second issue happens when deselecting packages - if you select both `py_common` packages, and then deselect one of them, both of them will be deselected. This is again simply fixed by including the source URL in comparisons.

I've tried my best to demonstrate most of the changes in these two screenshots:

Before:
![before](https://github.com/stashapp/stash/assets/99329275/8a04e63d-617e-4ba8-9296-2c6b6d8e1ee3)

After:
![after](https://github.com/stashapp/stash/assets/99329275/6d38f15a-ce0b-4726-bfa4-2ef6eba167d1)

Closes #4377