### PR TITLE
Include image total O-Count on stats page

### DIFF
--- a/internal/api/resolver.go
+++ b/internal/api/resolver.go
@@ -168,27 +168,90 @@ func (r *queryResolver) Stats(ctx context.Context) (*StatsResultType, error) {
 	var ret StatsResultType
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 		repo := r.repository
-		scenesQB := repo.Scene
+		sceneQB := repo.Scene
 		imageQB := repo.Image
 		galleryQB := repo.Gallery
-		studiosQB := repo.Studio
-		performersQB := repo.Performer
-		moviesQB := repo.Movie
-		tagsQB := repo.Tag
-		scenesCount, _ := scenesQB.Count(ctx)
-		scenesSize, _ := scenesQB.Size(ctx)
-		scenesDuration, _ := scenesQB.Duration(ctx)
-		imageCount, _ := imageQB.Count(ctx)
-		imageSize, _ := imageQB.Size(ctx)
-		galleryCount, _ := galleryQB.Count(ctx)
-		performersCount, _ := performersQB.Count(ctx)
-		studiosCount, _ := studiosQB.Count(ctx)
-		moviesCount, _ := moviesQB.Count(ctx)
-		tagsCount, _ := tagsQB.Count(ctx)
-		totalOCount, _ := scenesQB.OCount(ctx)
-		totalPlayDuration, _ := scenesQB.PlayDuration(ctx)
-		totalPlayCount, _ := scenesQB.PlayCount(ctx)
-		uniqueScenePlayCount, _ := scenesQB.UniqueScenePlayCount(ctx)
+		studioQB := repo.Studio
+		performerQB := repo.Performer
+		movieQB := repo.Movie
+		tagQB := repo.Tag
+
+		// embrace the error
+
+		scenesCount, err := sceneQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		scenesSize, err := sceneQB.Size(ctx)
+		if err != nil {
+			return err
+		}
+
+		scenesDuration, err := sceneQB.Duration(ctx)
+		if err != nil {
+			return err
+		}
+
+		imageCount, err := imageQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		imageSize, err := imageQB.Size(ctx)
+		if err != nil {
+			return err
+		}
+
+		galleryCount, err := galleryQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		performersCount, err := performerQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		studiosCount, err := studioQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		moviesCount, err := movieQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		tagsCount, err := tagQB.Count(ctx)
+		if err != nil {
+			return err
+		}
+
+		scenesTotalOCount, err := sceneQB.OCount(ctx)
+		if err != nil {
+			return err
+		}
+		imagesTotalOCount, err := imageQB.OCount(ctx)
+		if err != nil {
+			return err
+		}
+		totalOCount := scenesTotalOCount + imagesTotalOCount
+
+		totalPlayDuration, err := sceneQB.PlayDuration(ctx)
+		if err != nil {
+			return err
+		}
+
+		totalPlayCount, err := sceneQB.PlayCount(ctx)
+		if err != nil {
+			return err
+		}
+
+		uniqueScenePlayCount, err := sceneQB.UniqueScenePlayCount(ctx)
+		if err != nil {
+			return err
+		}
 
 		ret = StatsResultType{
 			SceneCount:        scenesCount,

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -506,6 +506,27 @@ func (_m *ImageReaderWriter) IncrementOCounter(ctx context.Context, id int) (int
 	return r0, r1
 }
 
+// OCount provides a mock function with given fields: ctx
+func (_m *ImageReaderWriter) OCount(ctx context.Context) (int, error) {
+	ret := _m.Called(ctx)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // OCountByPerformerID provides a mock function with given fields: ctx, performerID
 func (_m *ImageReaderWriter) OCountByPerformerID(ctx context.Context, performerID int) (int, error) {
 	ret := _m.Called(ctx, performerID)

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -31,6 +31,7 @@ type ImageCounter interface {
 	Count(ctx context.Context) (int, error)
 	CountByFileID(ctx context.Context, fileID FileID) (int, error)
 	CountByGalleryID(ctx context.Context, galleryID int) (int, error)
+	OCount(ctx context.Context) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
 }
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -551,6 +551,18 @@ func (qb *ImageStore) OCountByPerformerID(ctx context.Context, performerID int) 
 	return ret, nil
 }
 
+func (qb *ImageStore) OCount(ctx context.Context) (int, error) {
+	table := qb.table()
+
+	q := dialect.Select(goqu.COALESCE(goqu.SUM("o_counter"), 0)).From(table)
+	var ret int
+	if err := querySimple(ctx, q, &ret); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
 func (qb *ImageStore) FindByFolderID(ctx context.Context, folderID models.FolderID) ([]*models.Image, error) {
 	table := qb.table()
 	fileTable := goqu.T(fileTable)


### PR DESCRIPTION
Fix for #4381 - the Total O-Count on the stats page only includes O-Counts from scenes.

Fixes #4381