### PR TITLE
Ensure plugin scripts are loaded in correct order

### DIFF
--- a/ui/v2.5/src/hooks/useScript.tsx
+++ b/ui/v2.5/src/hooks/useScript.tsx
@@ -14,6 +14,7 @@ const useScript = (urls: string | string[], condition?: boolean) => {
       const script = document.createElement("script");
 
       script.src = url;
+      script.async = false;
       script.defer = true;
       return script;
     });


### PR DESCRIPTION
Dynamically loaded `<script>` tags have `async` implicitly set to true. Sets the `async` property to false explicitly so that they are loaded in the order they are added.