### PR TITLE
Fix saved filter UI bugs

### DIFF
--- a/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
@@ -3,11 +3,7 @@ import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { useFindSavedFilters } from "src/core/StashService";
 import { LoadingIndicator } from "../Shared/LoadingIndicator";
 import { Button, Form, Modal } from "react-bootstrap";
-import {
-  FilterMode,
-  FindSavedFiltersQuery,
-  SavedFilter,
-} from "src/core/generated-graphql";
+import * as GQL from "src/core/generated-graphql";
 import { ConfigurationContext } from "src/hooks/Config";
 import {
   IUIConfig,
@@ -21,24 +17,25 @@ import {
 interface IAddSavedFilterModalProps {
   onClose: (content?: FrontPageContent) => void;
   existingSavedFilterIDs: string[];
-  candidates: FindSavedFiltersQuery;
+  candidates: GQL.FindSavedFiltersQuery;
 }
 
 const FilterModeToMessageID = {
-  [FilterMode.Galleries]: "galleries",
-  [FilterMode.Images]: "images",
-  [FilterMode.Movies]: "movies",
-  [FilterMode.Performers]: "performers",
-  [FilterMode.SceneMarkers]: "markers",
-  [FilterMode.Scenes]: "scenes",
-  [FilterMode.Studios]: "studios",
-  [FilterMode.Tags]: "tags",
+  [GQL.FilterMode.Galleries]: "galleries",
+  [GQL.FilterMode.Images]: "images",
+  [GQL.FilterMode.Movies]: "movies",
+  [GQL.FilterMode.Performers]: "performers",
+  [GQL.FilterMode.SceneMarkers]: "markers",
+  [GQL.FilterMode.Scenes]: "scenes",
+  [GQL.FilterMode.Studios]: "studios",
+  [GQL.FilterMode.Tags]: "tags",
 };
 
-function filterTitle(intl: IntlShape, f: Pick<SavedFilter, "mode" | "name">) {
-  return `${intl.formatMessage({ id: FilterModeToMessageID[f.mode] })}: ${
-    f.name
-  }`;
+type SavedFilter = Pick<GQL.SavedFilter, "id" | "mode" | "name">;
+
+function filterTitle(intl: IntlShape, f: SavedFilter) {
+  const typeMessage = intl.formatMessage({ id: FilterModeToMessageID[f.mode] });
+  return `${typeMessage}: ${f.name}`;
 }
 
 const AddContentModal: React.FC<IAddSavedFilterModalProps> = ({
@@ -98,7 +95,7 @@ const AddContentModal: React.FC<IAddSavedFilterModalProps> = ({
         .filter((f) => {
           // markers not currently supported
           return (
-            f.mode !== FilterMode.SceneMarkers &&
+            f.mode !== GQL.FilterMode.SceneMarkers &&
             !existingSavedFilterIDs.includes(f.id)
           );
         })
@@ -232,7 +229,7 @@ const AddContentModal: React.FC<IAddSavedFilterModalProps> = ({
 
 interface IFilterRowProps {
   content: FrontPageContent;
-  allSavedFilters: Pick<SavedFilter, "id" | "mode" | "name">[];
+  allSavedFilters: SavedFilter[];
   onDelete: () => void;
 }
 
@@ -242,10 +239,9 @@ const ContentRow: React.FC<IFilterRowProps> = (props: IFilterRowProps) => {
   function title() {
     switch (props.content.__typename) {
       case "SavedFilter":
+        const savedFilterId = String(props.content.savedFilterId);
         const savedFilter = props.allSavedFilters.find(
-          (f) =>
-            f.id ===
-            (props.content as ISavedFilterRow).savedFilterId?.toString()
+          (f) => f.id === savedFilterId
         );
         if (!savedFilter) return "";
         return filterTitle(intl, savedFilter);
@@ -302,7 +298,18 @@ export const FrontPageConfig: React.FC<IFrontPageConfigProps> = ({
 
     const frontPageContent = getFrontPageContent(ui);
     if (frontPageContent) {
-      setCurrentContent(frontPageContent);
+      setCurrentContent(
+        // filter out rows where the saved filter no longer exists
+        frontPageContent.filter((r) => {
+          if (r.__typename === "SavedFilter") {
+            const savedFilterId = String(r.savedFilterId);
+            return allFilters.findSavedFilters.some(
+              (f) => f.id === savedFilterId
+            );
+          }
+          return true;
+        })
+      );
     }
   }, [allFilters, ui]);
 

--- a/ui/v2.5/src/components/List/Filters/PhashFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/PhashFilter.tsx
@@ -43,7 +43,7 @@ export const PhashFilter: React.FC<IPhashFilterProps> = ({
           className="btn-secondary"
           onChange={valueChanged}
           value={value ? value.value : ""}
-          placeholder={intl.formatMessage({ id: "phash" })}
+          placeholder={intl.formatMessage({ id: "media_info.phash" })}
         />
       </Form.Group>
       {criterion.modifier !== CriterionModifier.IsNull &&

--- a/ui/v2.5/src/components/List/SavedFilterList.tsx
+++ b/ui/v2.5/src/components/List/SavedFilterList.tsx
@@ -311,20 +311,22 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
   function maybeRenderSetDefaultButton() {
     if (persistState === PersistanceLevel.ALL) {
       return (
-        <Button
-          className="set-as-default-button"
-          variant="secondary"
-          size="sm"
-          onClick={() => onSetDefaultFilter()}
-        >
-          {intl.formatMessage({ id: "actions.set_as_default" })}
-        </Button>
+        <div className="mt-1">
+          <Button
+            className="set-as-default-button"
+            variant="secondary"
+            size="sm"
+            onClick={() => onSetDefaultFilter()}
+          >
+            {intl.formatMessage({ id: "actions.set_as_default" })}
+          </Button>
+        </div>
       );
     }
   }
 
   return (
-    <div>
+    <>
       {maybeRenderDeleteAlert()}
       {maybeRenderOverwriteAlert()}
       <InputGroup>
@@ -359,6 +361,6 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
       </InputGroup>
       {renderSavedFilters()}
       {maybeRenderSetDefaultButton()}
-    </div>
+    </>
   );
 };

--- a/ui/v2.5/src/components/List/SavedFilterList.tsx
+++ b/ui/v2.5/src/components/List/SavedFilterList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import {
   Button,
   ButtonGroup,
@@ -39,7 +39,6 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
   const intl = useIntl();
 
   const { data, error, loading, refetch } = useFindSavedFilters(filter.mode);
-  const oldError = useRef(error);
 
   const [filterName, setFilterName] = useState("");
   const [saving, setSaving] = useState(false);
@@ -55,14 +54,6 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
   const [setDefaultFilter] = useSetDefaultFilter();
 
   const savedFilters = data?.findSavedFilters ?? [];
-
-  useEffect(() => {
-    if (error && error !== oldError.current) {
-      Toast.error(error);
-    }
-
-    oldError.current = error;
-  }, [error, Toast, oldError]);
 
   async function onSaveFilter(name: string, id?: string) {
     const filterCopy = filter.clone();
@@ -285,6 +276,8 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
   }
 
   function renderSavedFilters() {
+    if (error) return <h6 className="text-center">{error.message}</h6>;
+
     if (loading || saving) {
       return (
         <div className="loading">

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -65,8 +65,14 @@ input[type="range"].zoom-slider {
 .saved-filter-list-menu {
   width: 300px;
 
+  &.dropdown-menu.show {
+    display: flex;
+    flex-direction: column;
+  }
+
   .set-as-default-button {
     float: right;
+    margin-right: 0.5rem;
   }
 
   .LoadingIndicator {
@@ -94,12 +100,17 @@ input[type="range"].zoom-slider {
       align-items: center;
       display: inline;
       overflow-x: hidden;
+      padding-left: 1.25rem;
       padding-right: 0.25rem;
       text-overflow: ellipsis;
     }
 
     .btn-group {
       margin-left: auto;
+
+      .btn {
+        border-radius: 0;
+      }
     }
 
     .delete-button {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -660,7 +660,6 @@ div.react-select__menu,
 div.dropdown-menu {
   background-color: $secondary;
   color: $text-color;
-  z-index: 1600;
 
   .react-select__option,
   .dropdown-item {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -921,6 +921,7 @@
     "unknown": "Unknown",
     "wall": "Wall"
   },
+  "distance": "Distance",
   "donate": "Donate",
   "dupe_check": {
     "description": "Levels below 'Exact' can take longer to calculate. False positives might also be returned on lower accuracy levels.",


### PR DESCRIPTION
These are some UI bugfixes, mainly relating to saved filters. (The first is just a bug I happened to come across while fixing the other issues)

- 97b7cebc43e3cd99798233cd85d9b18e4a4d74ed fixes two invalid intl string ids.
- 07b4c401c65dc94152bdd8235102a8eaed8495ef fixes a z-index issue when deleting a saved filter: the delete dialog was appearing "underneath" the saved filter dropdown, which looks weird and also makes it difficult to click the "Delete" button. To fix it, I've just removed the `z-index: 1600;` line entirely. I couldn't find a place where setting the `z-index` on `div.react-select__menu` and `div.dropdown-menu` was actually required - removing the line doesn't seem to have broken anything, although I could potentially have missed something.
- 2324c56e5b98a676af28ec4e70813fd96eec48ab fixes what appears to be a Firefox-specific issue, where the saved filter dropdown would display two overlapping scrollbars - one for the actual inner filter list, and another for the entire dropdown, including the filter input and the "Set as default" button. I've also made some minor style changes, tweaking some padding and removing the rounded corners on the save and delete buttons.
- d71826144ad58da832b75be058a681c1b5676bca displays a potential load error inside the saved filter dropdown, rather than showing a toast. This is more in line with all the other components, where load errors are shown in the component itself with toast errors being used for actions directly triggered by a button press (i.e. mutations).
- ae46db4f22874806e0218882a5f463c9a5ac79ae fixes a bug relating to the front page configuration UI, where saved filter rows which refer to nonexistent saved filters display as blank rows. This kind of "invalid" row is already hidden on the front page itself, so no changes are needed there.