### PR TITLE
Fix Scene Tagger config blacklist 

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/Config.tsx
@@ -29,10 +29,14 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
     const input = blacklistRef.current.value;
     if (!input) return;
 
-    setConfig({
-      ...config,
-      blacklist: [...config.blacklist, input],
-    });
+    // don't add duplicate items
+    if (!config.blacklist.includes(input)) {
+      setConfig({
+        ...config,
+        blacklist: [...config.blacklist, input],
+      });
+    }
+
     blacklistRef.current.value = "";
   }
 

--- a/ui/v2.5/src/components/Tagger/scenes/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/Config.tsx
@@ -198,7 +198,16 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
               <FormattedMessage id="component_tagger.config.blacklist_label" />
             </h5>
             <InputGroup>
-              <Form.Control className="text-input" ref={blacklistRef} />
+              <Form.Control
+                className="text-input"
+                ref={blacklistRef}
+                onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Enter") {
+                    addBlacklistItem();
+                    e.preventDefault();
+                  }
+                }}
+              />
               <InputGroup.Append>
                 <Button onClick={() => addBlacklistItem()}>
                   <FormattedMessage id="actions.add" />

--- a/ui/v2.5/src/components/Tagger/scenes/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/Config.tsx
@@ -23,28 +23,27 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
   const intl = useIntl();
   const blacklistRef = useRef<HTMLInputElement | null>(null);
 
-  const removeBlacklist = (index: number) => {
-    setConfig({
-      ...config,
-      blacklist: [
-        ...config.blacklist.slice(0, index),
-        ...config.blacklist.slice(index + 1),
-      ],
-    });
-  };
-
-  const handleBlacklistAddition = () => {
+  function addBlacklistItem() {
     if (!blacklistRef.current) return;
 
     const input = blacklistRef.current.value;
-    if (input.length === 0) return;
+    if (!input) return;
 
     setConfig({
       ...config,
       blacklist: [...config.blacklist, input],
     });
     blacklistRef.current.value = "";
-  };
+  }
+
+  function removeBlacklistItem(index: number) {
+    const newBlacklist = [...config.blacklist];
+    newBlacklist.splice(index, 1);
+    setConfig({
+      ...config,
+      blacklist: newBlacklist,
+    });
+  }
 
   return (
     <Collapse in={show}>
@@ -61,7 +60,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   <FormattedMessage id="component_tagger.config.show_male_label" />
                 }
                 checked={config.showMales}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onChange={(e) =>
                   setConfig({ ...config, showMales: e.currentTarget.checked })
                 }
               />
@@ -75,7 +74,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   <FormattedMessage id="component_tagger.config.set_cover_label" />
                 }
                 checked={config.setCoverImage}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onChange={(e) =>
                   setConfig({
                     ...config,
                     setCoverImage: e.currentTarget.checked,
@@ -95,7 +94,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   }
                   className="mr-4"
                   checked={config.setTags}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onChange={(e) =>
                     setConfig({ ...config, setTags: e.currentTarget.checked })
                   }
                 />
@@ -104,7 +103,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   className="col-md-2 col-3 input-control"
                   as="select"
                   value={config.tagOperation}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  onChange={(e) =>
                     setConfig({
                       ...config,
                       tagOperation: e.currentTarget.value as TagOperation,
@@ -135,7 +134,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   as="select"
                   className="col-md-2 col-3 input-control"
                   value={config.mode}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  onChange={(e) =>
                     setConfig({
                       ...config,
                       mode: e.currentTarget.value as ParseMode,
@@ -182,7 +181,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                   <FormattedMessage id="component_tagger.config.mark_organized_label" />
                 }
                 checked={config.markSceneAsOrganizedOnSave}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onChange={(e) =>
                   setConfig({
                     ...config,
                     markSceneAsOrganizedOnSave: e.currentTarget.checked,
@@ -201,7 +200,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
             <InputGroup>
               <Form.Control className="text-input" ref={blacklistRef} />
               <InputGroup.Append>
-                <Button onClick={handleBlacklistAddition}>
+                <Button onClick={() => addBlacklistItem()}>
                   <FormattedMessage id="actions.add" />
                 </Button>
               </InputGroup.Append>
@@ -221,7 +220,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
                 {item.toString()}
                 <Button
                   className="minimal ml-2"
-                  onClick={() => removeBlacklist(index)}
+                  onClick={() => removeBlacklistItem(index)}
                 >
                   <Icon icon={faTimes} />
                 </Button>


### PR DESCRIPTION
This fixes a bug with the Scene Tagger config blacklist where if you have duplicate items, deleting an item from the list could seemingly cause new items to be added to the list. This happens because the React `key` prop, which must always be unique, is set to the item's now non-unique name.

Duplicate items don't really make sense anyway, so the fix is to just not allow adding them in the first place.

While at it I also added an `onKeyPress` event listener so that hitting Enter on the input field does the same as clicking the "Add" button. And some very minor refactoring because I can't help myself.