### PR TITLE
Refresh package managers after setup

### DIFF
--- a/internal/api/resolver_query_package.go
+++ b/internal/api/resolver_query_package.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -24,6 +25,10 @@ func getPackageManager(typeArg PackageType) (*pkg.Manager, error) {
 		pm = manager.GetInstance().PluginPackageManager
 	default:
 		return nil, ErrInvalidPackageType
+	}
+
+	if pm == nil {
+		return nil, fmt.Errorf("%s package manager not initialized", typeArg)
 	}
 
 	return pm, nil

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -200,10 +200,6 @@ func (s *Manager) Setup(ctx context.Context, input SetupInput) error {
 	setSetupDefaults(&input)
 	cfg := s.Config
 
-	if err := cfg.SetInitialConfig(); err != nil {
-		return fmt.Errorf("error setting initial configuration: %v", err)
-	}
-
 	// create the config directory if it does not exist
 	// don't do anything if config is already set in the environment
 	if !config.FileEnvSet() {
@@ -226,6 +222,10 @@ func (s *Manager) Setup(ctx context.Context, input SetupInput) error {
 		}
 
 		s.Config.SetConfigFile(configFile)
+	}
+
+	if err := cfg.SetInitialConfig(); err != nil {
+		return fmt.Errorf("error setting initial configuration: %v", err)
 	}
 
 	// create the generated directory if it does not exist


### PR DESCRIPTION
The package managers were not being refreshed after initial setup, causing them both to install packages into the current directory.

Also fixed a bug caused by #4298 where if you start a new instance in `$HOME/.stash` then the default scrapers and plugins paths become `scrapers` and `plugins` respectively, rather than `$HOME/.stash/scrapers` and `$HOME/.stash/plugins`.

Fixes #4395