### PR TITLE
Add join to intCriterionHandler

### DIFF
--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -542,6 +542,9 @@ func getPathSearchClauseMany(pathColumn, basenameColumn, p string, addWildcards,
 func intCriterionHandler(c *models.IntCriterionInput, column string, addJoinFn func(f *filterBuilder)) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if c != nil {
+			if addJoinFn != nil {
+				addJoinFn(f)
+			}
 			clause, args := getIntCriterionWhereClause(column, *c)
 			f.addWhere(clause, args...)
 		}

--- a/pkg/sqlite/filter.go
+++ b/pkg/sqlite/filter.go
@@ -554,6 +554,9 @@ func intCriterionHandler(c *models.IntCriterionInput, column string, addJoinFn f
 func floatCriterionHandler(c *models.FloatCriterionInput, column string, addJoinFn func(f *filterBuilder)) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if c != nil {
+			if addJoinFn != nil {
+				addJoinFn(f)
+			}
 			clause, args := getFloatCriterionWhereClause(column, *c)
 			f.addWhere(clause, args...)
 		}


### PR DESCRIPTION
Fixes #4413

Allow intCriterionHandler to add a join to the query if required like other handlers. Not sure if floatCriterionHandler need the same done, I don't think any filter that uses it is broken at the moment.