### PR TITLE
Fix scraped performer alias matching

### DIFF
--- a/pkg/match/scraped.go
+++ b/pkg/match/scraped.go
@@ -44,22 +44,21 @@ func ScrapedPerformer(ctx context.Context, qb PerformerFinder, p *models.Scraped
 	}
 
 	performers, err := qb.FindByNames(ctx, []string{*p.Name}, true)
-
 	if err != nil {
 		return err
 	}
 
-	if performers == nil || len(performers) != 1 {
-		// try matching a single performer by exact alias
+	if len(performers) == 0 {
+		// if no names matched, try match an exact alias
 		performers, err = performer.ByAlias(ctx, qb, *p.Name)
 		if err != nil {
 			return err
 		}
+	}
 
-		if performers == nil || len(performers) != 1 {
-			// ignore - cannot match
-			return nil
-		}
+	if len(performers) != 1 {
+		// ignore - cannot match
+		return nil
 	}
 
 	id := strconv.Itoa(performers[0].ID)


### PR DESCRIPTION
This fixes an issue caused by #4182, where if a scraped performer matches multiple database performers by name, then it would try to match by alias rather than just failing to match. This can cause an issue where if there exist multiple performers with the same name, but only one performer with that name as an alias: scraping that performer would match to the performer with the alias, rather than failing to match and forcing the user to manually pick which performer is correct.

The fix is simply to _only_ try matching by alias if no name matches were found, rather than if either no matches or if more than one match was found.