### PR TITLE
Don't bail on error when scraping all

### DIFF
--- a/ui/v2.5/src/hooks/Toast.tsx
+++ b/ui/v2.5/src/hooks/Toast.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
 } from "react";
 import { Toast } from "react-bootstrap";
+import { errorToString } from "src/utils";
 
 interface IToast {
   header?: string;
@@ -67,16 +68,7 @@ export const useToast = () => {
         });
       },
       error(error: unknown) {
-        let message;
-        if (error instanceof Error) {
-          message = error.message;
-        }
-        if (!message) {
-          message = String(error);
-        }
-        if (!message) {
-          message = "Unknown error";
-        }
+        const message = errorToString(error);
 
         console.error(error);
         addToast({

--- a/ui/v2.5/src/utils/errors.ts
+++ b/ui/v2.5/src/utils/errors.ts
@@ -2,3 +2,18 @@ import { ApolloError } from "@apollo/client";
 
 export const apolloError = (error: unknown) =>
   error instanceof ApolloError ? error.message : "";
+
+export function errorToString(error: unknown) {
+  let message;
+  if (error instanceof Error) {
+    message = error.message;
+  }
+  if (!message) {
+    message = String(error);
+  }
+  if (!message) {
+    message = "Unknown error";
+  }
+
+  return message;
+}


### PR DESCRIPTION
Fixes #4408 

Errors thrown during a scrape in the tagger are now output to the scene row, instead of as a Toast and stopping the scrape operation. 

![image](https://github.com/stashapp/stash/assets/53250216/f19444e0-c413-4a48-847e-37bee75899d6)
