### PR TITLE
Fix error when creating/updating performer with alias == name

### DIFF
--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/performer"
 	"github.com/stashapp/stash/pkg/scraper/stashbox"
 	"github.com/stashapp/stash/pkg/studio"
 )
@@ -155,6 +156,10 @@ func (t *StashBoxBatchTagTask) processMatchedPerformer(ctx context.Context, p *m
 
 			partial := p.ToPartial(t.box.Endpoint, excluded, existingStashIDs)
 
+			if err := performer.ValidateUpdate(ctx, t.performer.ID, partial, qb); err != nil {
+				return err
+			}
+
 			if _, err := qb.UpdatePartial(ctx, t.performer.ID, partial); err != nil {
 				return err
 			}
@@ -184,6 +189,10 @@ func (t *StashBoxBatchTagTask) processMatchedPerformer(ctx context.Context, p *m
 		r := instance.Repository
 		err = r.WithTxn(ctx, func(ctx context.Context) error {
 			qb := r.Performer
+
+			if err := performer.ValidateCreate(ctx, *newPerformer, qb); err != nil {
+				return err
+			}
 
 			if err := qb.Create(ctx, newPerformer); err != nil {
 				return err

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scraper"
 	"github.com/stashapp/stash/pkg/scraper/stashbox/graphql"
+	"github.com/stashapp/stash/pkg/sliceutil"
 	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 	"github.com/stashapp/stash/pkg/txn"
 	"github.com/stashapp/stash/pkg/utils"
@@ -669,6 +670,10 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 	}
 
 	if len(p.Aliases) > 0 {
+		// #4437 - stash-box may return aliases that are equal to the performer name
+		// filter these out
+		p.Aliases = sliceutil.Exclude(p.Aliases, []string{p.Name})
+
 		alias := strings.Join(p.Aliases, ", ")
 		sp.Aliases = &alias
 	}

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -672,7 +672,9 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 	if len(p.Aliases) > 0 {
 		// #4437 - stash-box may return aliases that are equal to the performer name
 		// filter these out
-		p.Aliases = sliceutil.Exclude(p.Aliases, []string{p.Name})
+		p.Aliases = sliceutil.Filter(p.Aliases, func(s string) bool {
+			return !strings.EqualFold(s, p.Name)
+		})
 
 		alias := strings.Join(p.Aliases, ", ")
 		sp.Aliases = &alias


### PR DESCRIPTION
Fixes #4437 

Filters out aliases that match the performer name when returning performer data from stash-box. Also patches a hole in the stash-box performer add/update task where the performer data would not be validated before creating/updating.