### PR TITLE
Import video rotation from side_data_list as well

### DIFF
--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -176,7 +176,12 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 			framerate = 0
 		}
 		result.FrameRate = math.Round(framerate*100) / 100
-		if rotate, err := strconv.ParseInt(videoStream.Tags.Rotate, 10, 64); err == nil && rotate != 180 {
+		rotate, err := strconv.ParseInt(videoStream.Tags.Rotate, 10, 64)
+		if err != nil && len(videoStream.SideDataList) > 0 {
+			err = nil
+			rotate = videoStream.SideDataList[0].Rotation
+		}
+		if err == nil && rotate != 180 {
 			result.Width = videoStream.Height
 			result.Height = videoStream.Width
 		} else {

--- a/pkg/ffmpeg/types.go
+++ b/pkg/ffmpeg/types.go
@@ -86,12 +86,20 @@ type FFProbeStream struct {
 		Language     string        `json:"language"`
 		Rotate       string        `json:"rotate"`
 	} `json:"tags"`
-	TimeBase      string `json:"time_base"`
-	Width         int    `json:"width,omitempty"`
-	BitsPerSample int    `json:"bits_per_sample,omitempty"`
-	ChannelLayout string `json:"channel_layout,omitempty"`
-	Channels      int    `json:"channels,omitempty"`
-	MaxBitRate    string `json:"max_bit_rate,omitempty"`
-	SampleFmt     string `json:"sample_fmt,omitempty"`
-	SampleRate    string `json:"sample_rate,omitempty"`
+	SideDataList  []FFProbeSideData `json:"side_data_list"`
+	TimeBase      string            `json:"time_base"`
+	Width         int               `json:"width,omitempty"`
+	BitsPerSample int               `json:"bits_per_sample,omitempty"`
+	ChannelLayout string            `json:"channel_layout,omitempty"`
+	Channels      int               `json:"channels,omitempty"`
+	MaxBitRate    string            `json:"max_bit_rate,omitempty"`
+	SampleFmt     string            `json:"sample_fmt,omitempty"`
+	SampleRate    string            `json:"sample_rate,omitempty"`
+}
+
+// FFProbeSideData is a JSON representation of an item in the side_data_list array of ffprobe output.
+type FFProbeSideData struct {
+	SideDataType  string `json:"side_data_type"`
+	DisplayMatrix string `json:"displaymatrix"`
+	Rotation      int64  `json:"rotation"`
 }


### PR DESCRIPTION
Imports rotation info for a video out of the first side_data_list structure if available and if rotate tag is not present.

Fixes #4233 but I'm not sure if the fix is robust enough. It works on all my affected files.

One issue left unsolved is that once a file has been added to the DB with the wrong rotation info then it is impossible to fix it short of directly editing the DB.

If I remove the scene without deleting the scene file then the file row in the DB is not removed so the rotation information is not removed either.
Ideally a rescan should reimport the rotation info but I couldn't figure out how to do that.