### PR TITLE
Clarify session setting description

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -271,7 +271,7 @@
         "log_to_terminal": "Log to terminal",
         "log_to_terminal_desc": "Logs to the terminal in addition to a file. Always true if file logging is disabled. Requires restart.",
         "maximum_session_age": "Maximum Session Age",
-        "maximum_session_age_desc": "Maximum idle time before a login session is expired, in seconds.",
+        "maximum_session_age_desc": "Maximum idle time before a login session is expired, in seconds. Requires restart.",
         "password": "Password",
         "password_desc": "Password to access Stash. Leave blank to disable user authentication",
         "stash-box_integration": "Stash-box integration",


### PR DESCRIPTION
The setting requires a restart to take effect, but the description omits that information. 

Resolves https://github.com/stashapp/stash/issues/4312