### PR TITLE
Tag select refactor

### DIFF
--- a/graphql/documents/data/tag.graphql
+++ b/graphql/documents/data/tag.graphql
@@ -24,3 +24,16 @@ fragment TagData on Tag {
     ...SlimTagData
   }
 }
+
+fragment SelectTagData on Tag {
+  id
+  name
+  description
+  aliases
+  image_path
+
+  parents {
+    id
+    name
+  }
+}

--- a/graphql/documents/queries/misc.graphql
+++ b/graphql/documents/queries/misc.graphql
@@ -21,14 +21,6 @@ query AllMoviesForFilter {
   }
 }
 
-query AllTagsForFilter {
-  allTags {
-    id
-    name
-    aliases
-  }
-}
-
 query Stats {
   stats {
     scene_count

--- a/graphql/documents/queries/tag.graphql
+++ b/graphql/documents/queries/tag.graphql
@@ -12,3 +12,16 @@ query FindTag($id: ID!) {
     ...TagData
   }
 }
+
+query FindTagsForSelect(
+  $filter: FindFilterType
+  $tag_filter: TagFilterType
+  $ids: [Int!]
+) {
+  findTags(filter: $filter, tag_filter: $tag_filter, ids: $ids) {
+    count
+    tags {
+      ...SelectTagData
+    }
+  }
+}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -89,6 +89,7 @@ type Query {
   findTags(
     tag_filter: TagFilterType
     filter: FindFilterType
+    ids: [Int!]
   ): FindTagsResultType!
 
   "Retrieve random scene markers for the wall"

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -204,9 +204,9 @@ type Query {
   allGalleries: [Gallery!]!
   allStudios: [Studio!]!
   allMovies: [Movie!]!
-  allTags: [Tag!]!
 
   allPerformers: [Performer!]! @deprecated(reason: "Use findPerformers instead")
+  allTags: [Tag!]! @deprecated(reason: "Use findTags instead")
 
   # Get everything with minimal metadata
 

--- a/internal/api/resolver_query_find_tag.go
+++ b/internal/api/resolver_query_find_tag.go
@@ -23,9 +23,19 @@ func (r *queryResolver) FindTag(ctx context.Context, id string) (ret *models.Tag
 	return ret, nil
 }
 
-func (r *queryResolver) FindTags(ctx context.Context, tagFilter *models.TagFilterType, filter *models.FindFilterType) (ret *FindTagsResultType, err error) {
+func (r *queryResolver) FindTags(ctx context.Context, tagFilter *models.TagFilterType, filter *models.FindFilterType, ids []int) (ret *FindTagsResultType, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		tags, total, err := r.repository.Tag.Query(ctx, tagFilter, filter)
+		var tags []*models.Tag
+		var err error
+		var total int
+
+		if len(ids) > 0 {
+			tags, err = r.repository.Tag.FindMany(ctx, ids)
+			total = len(tags)
+		} else {
+			tags, total, err = r.repository.Tag.Query(ctx, tagFilter, filter)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -18,11 +18,7 @@ import {
   useListGalleryScrapers,
   mutateReloadScrapers,
 } from "src/core/StashService";
-import {
-  TagSelect,
-  SceneSelect,
-  StudioSelect,
-} from "src/components/Shared/Select";
+import { SceneSelect, StudioSelect } from "src/components/Shared/Select";
 import { Icon } from "src/components/Shared/Icon";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { useToast } from "src/hooks/Toast";
@@ -44,6 +40,7 @@ import {
   yupUniqueStringList,
 } from "src/utils/yup";
 import { formikUtils } from "src/utils/form";
+import { Tag, TagSelect } from "src/components/Tags/TagSelect";
 
 interface IProps {
   gallery: Partial<GQL.GalleryDataFragment>;
@@ -68,6 +65,7 @@ export const GalleryEditPanel: React.FC<IProps> = ({
   );
 
   const [performers, setPerformers] = useState<Performer[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
 
   const isNew = gallery.id === undefined;
   const { configuration: stashConfig } = React.useContext(ConfigurationContext);
@@ -146,6 +144,14 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     );
   }
 
+  function onSetTags(items: Tag[]) {
+    setTags(items);
+    formik.setFieldValue(
+      "tag_ids",
+      items.map((item) => item.id)
+    );
+  }
+
   useRatingKeybinds(
     isVisible,
     stashConfig?.ui?.ratingSystemOptions?.type,
@@ -155,6 +161,10 @@ export const GalleryEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     setPerformers(gallery.performers ?? []);
   }, [gallery.performers]);
+
+  useEffect(() => {
+    setTags(gallery.tags ?? []);
+  }, [gallery.tags]);
 
   useEffect(() => {
     if (isVisible) {
@@ -340,8 +350,15 @@ export const GalleryEditPanel: React.FC<IProps> = ({
       });
 
       if (idTags.length > 0) {
-        const newIds = idTags.map((t) => t.stored_id);
-        formik.setFieldValue("tag_ids", newIds as string[]);
+        onSetTags(
+          idTags.map((p) => {
+            return {
+              id: p.stored_id!,
+              name: p.name ?? "",
+              aliases: [],
+            };
+          })
+        );
       }
     }
   }
@@ -438,13 +455,8 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     const control = (
       <TagSelect
         isMulti
-        onSelect={(items) =>
-          formik.setFieldValue(
-            "tag_ids",
-            items.map((item) => item.id)
-          )
-        }
-        ids={formik.values.tag_ids}
+        onSelect={onSetTags}
+        values={tags}
         hoverPlacement="right"
       />
     );

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
-import { TagSelect, StudioSelect } from "src/components/Shared/Select";
+import { StudioSelect } from "src/components/Shared/Select";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { useToast } from "src/hooks/Toast";
 import { useFormik } from "formik";
@@ -22,6 +22,7 @@ import {
   PerformerSelect,
 } from "src/components/Performers/PerformerSelect";
 import { formikUtils } from "src/utils/form";
+import { Tag, TagSelect } from "src/components/Tags/TagSelect";
 
 interface IProps {
   image: GQL.ImageDataFragment;
@@ -45,6 +46,7 @@ export const ImageEditPanel: React.FC<IProps> = ({
   const { configuration } = React.useContext(ConfigurationContext);
 
   const [performers, setPerformers] = useState<Performer[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
 
   const schema = yup.object({
     title: yup.string().ensure(),
@@ -93,6 +95,14 @@ export const ImageEditPanel: React.FC<IProps> = ({
     );
   }
 
+  function onSetTags(items: Tag[]) {
+    setTags(items);
+    formik.setFieldValue(
+      "tag_ids",
+      items.map((item) => item.id)
+    );
+  }
+
   useRatingKeybinds(
     true,
     configuration?.ui?.ratingSystemOptions?.type,
@@ -102,6 +112,10 @@ export const ImageEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     setPerformers(image.performers ?? []);
   }, [image.performers]);
+
+  useEffect(() => {
+    setTags(image.tags ?? []);
+  }, [image.tags]);
 
   useEffect(() => {
     if (isVisible) {
@@ -196,13 +210,8 @@ export const ImageEditPanel: React.FC<IProps> = ({
     const control = (
       <TagSelect
         isMulti
-        onSelect={(items) =>
-          formik.setFieldValue(
-            "tag_ids",
-            items.map((item) => item.id)
-          )
-        }
-        ids={formik.values.tag_ids}
+        onSelect={onSetTags}
+        values={tags}
         hoverPlacement="right"
       />
     );

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -85,7 +85,7 @@ export const PerformerSelect: React.FC<
     thisOptionProps = {
       ...optionProps,
       children: (
-        <span>
+        <span className="react-select-image-option">
           <a
             href={`/performers/${object.id}`}
             target="_blank"

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -235,6 +235,7 @@
 .performer-select {
   .alias {
     font-weight: bold;
+    white-space: pre;
   }
 
   .performer-select-image {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -20,7 +20,6 @@ import {
   queryScrapeSceneQueryFragment,
 } from "src/core/StashService";
 import {
-  TagSelect,
   StudioSelect,
   GallerySelect,
   MovieSelect,
@@ -52,6 +51,7 @@ import {
   PerformerSelect,
 } from "src/components/Performers/PerformerSelect";
 import { formikUtils } from "src/utils/form";
+import { Tag, TagSelect } from "src/components/Tags/TagSelect";
 
 const SceneScrapeDialog = lazyComponent(() => import("./SceneScrapeDialog"));
 const SceneQueryModal = lazyComponent(() => import("./SceneQueryModal"));
@@ -80,6 +80,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     []
   );
   const [performers, setPerformers] = useState<Performer[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
 
   const Scrapers = useListSceneScrapers();
   const [fragmentScrapers, setFragmentScrapers] = useState<GQL.Scraper[]>([]);
@@ -103,6 +104,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
   useEffect(() => {
     setPerformers(scene.performers ?? []);
   }, [scene.performers]);
+
+  useEffect(() => {
+    setTags(scene.tags ?? []);
+  }, [scene.tags]);
 
   const { configuration: stashConfig } = React.useContext(ConfigurationContext);
 
@@ -198,6 +203,14 @@ export const SceneEditPanel: React.FC<IProps> = ({
     setPerformers(items);
     formik.setFieldValue(
       "performer_ids",
+      items.map((item) => item.id)
+    );
+  }
+
+  function onSetTags(items: Tag[]) {
+    setTags(items);
+    formik.setFieldValue(
+      "tag_ids",
       items.map((item) => item.id)
     );
   }
@@ -578,8 +591,15 @@ export const SceneEditPanel: React.FC<IProps> = ({
       });
 
       if (idTags.length > 0) {
-        const newIds = idTags.map((p) => p.stored_id);
-        formik.setFieldValue("tag_ids", newIds as string[]);
+        onSetTags(
+          idTags.map((p) => {
+            return {
+              id: p.stored_id!,
+              name: p.name ?? "",
+              aliases: [],
+            };
+          })
+        );
       }
     }
 
@@ -748,13 +768,8 @@ export const SceneEditPanel: React.FC<IProps> = ({
     const control = (
       <TagSelect
         isMulti
-        onSelect={(items) =>
-          formik.setFieldValue(
-            "tag_ids",
-            items.map((item) => item.id)
-          )
-        }
-        ids={formik.values.tag_ids}
+        onSelect={onSetTags}
+        values={tags}
         hoverPlacement="right"
       />
     );

--- a/ui/v2.5/src/components/Shared/HoverPopover.tsx
+++ b/ui/v2.5/src/components/Shared/HoverPopover.tsx
@@ -9,6 +9,7 @@ interface IHoverPopover {
   placement?: OverlayProps["placement"];
   onOpen?: () => void;
   onClose?: () => void;
+  target?: React.RefObject<HTMLElement>;
 }
 
 export const HoverPopover: React.FC<IHoverPopover> = ({
@@ -20,6 +21,7 @@ export const HoverPopover: React.FC<IHoverPopover> = ({
   placement = "top",
   onOpen,
   onClose,
+  target,
 }) => {
   const [show, setShow] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -61,7 +63,11 @@ export const HoverPopover: React.FC<IHoverPopover> = ({
         {children}
       </div>
       {triggerRef.current && (
-        <Overlay show={show} placement={placement} target={triggerRef.current}>
+        <Overlay
+          show={show}
+          placement={placement}
+          target={target?.current ?? triggerRef.current}
+        >
           <Popover
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}

--- a/ui/v2.5/src/components/Shared/Select.tsx
+++ b/ui/v2.5/src/components/Shared/Select.tsx
@@ -14,11 +14,9 @@ import CreatableSelect from "react-select/creatable";
 
 import * as GQL from "src/core/generated-graphql";
 import {
-  useAllTagsForFilter,
   useAllMoviesForFilter,
   useAllStudiosForFilter,
   useMarkerStrings,
-  useTagCreate,
   useStudioCreate,
   useMovieCreate,
 } from "src/core/StashService";
@@ -28,13 +26,13 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { useIntl } from "react-intl";
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
-import { TagPopover } from "../Tags/TagPopover";
 import { defaultMaxOptionsShown, IUIConfig } from "src/core/config";
 import { useDebounce } from "src/hooks/debounce";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { PerformerIDSelect } from "../Performers/PerformerSelect";
 import { Icon } from "./Icon";
 import { faTableColumns } from "@fortawesome/free-solid-svg-icons";
+import { TagIDSelect } from "../Tags/TagSelect";
 
 export type SelectObject = {
   id: string;
@@ -726,146 +724,7 @@ export const MovieSelect: React.FC<IFilterProps> = (props) => {
 export const TagSelect: React.FC<
   IFilterProps & { excludeIds?: string[]; hoverPlacement?: Placement }
 > = (props) => {
-  const [tagAliases, setTagAliases] = useState<Record<string, string[]>>({});
-  const [allAliases, setAllAliases] = useState<string[]>([]);
-  const { data, loading } = useAllTagsForFilter();
-  const [createTag] = useTagCreate();
-  const intl = useIntl();
-  const placeholder =
-    props.noSelectionString ??
-    intl.formatMessage(
-      { id: "actions.select_entity" },
-      { entityType: intl.formatMessage({ id: props.isMulti ? "tags" : "tag" }) }
-    );
-
-  const { configuration } = React.useContext(ConfigurationContext);
-  const defaultCreatable =
-    !configuration?.interface.disableDropdownCreate.tag ?? true;
-
-  const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
-  const tags = useMemo(
-    () => (data?.allTags ?? []).filter((tag) => !exclude.includes(tag.id)),
-    [data?.allTags, exclude]
-  );
-
-  useEffect(() => {
-    // build the tag aliases map
-    const newAliases: Record<string, string[]> = {};
-    const newAll: string[] = [];
-    tags.forEach((t) => {
-      newAliases[t.id] = t.aliases;
-      newAll.push(...t.aliases);
-    });
-    setTagAliases(newAliases);
-    setAllAliases(newAll);
-  }, [tags]);
-
-  const TagOption: React.FC<OptionProps<Option, boolean>> = (optionProps) => {
-    const { inputValue } = optionProps.selectProps;
-
-    let thisOptionProps = optionProps;
-    if (
-      inputValue &&
-      !optionProps.label.toLowerCase().includes(inputValue.toLowerCase())
-    ) {
-      // must be alias
-      const newLabel = `${optionProps.data.label} (alias)`;
-      thisOptionProps = {
-        ...optionProps,
-        children: newLabel,
-      };
-    }
-
-    const id = optionProps.data.value;
-    const hide = (optionProps.data as Option & { __isNew__: boolean })
-      .__isNew__;
-
-    return (
-      <TagPopover id={id} hide={hide} placement={props.hoverPlacement}>
-        <reactSelectComponents.Option {...thisOptionProps} />
-      </TagPopover>
-    );
-  };
-
-  const filterOption = (option: Option, rawInput: string): boolean => {
-    if (!rawInput) {
-      return true;
-    }
-
-    const input = rawInput.toLowerCase();
-    const optionVal = option.label.toLowerCase();
-
-    if (optionVal.includes(input)) {
-      return true;
-    }
-
-    // search for tag aliases
-    const aliases = tagAliases[option.value];
-    // only match on alias if exact
-    if (aliases && aliases.some((a) => a.toLowerCase() === input)) {
-      return true;
-    }
-
-    return false;
-  };
-
-  const onCreate = async (name: string) => {
-    const result = await createTag({
-      variables: {
-        input: {
-          name,
-        },
-      },
-    });
-    return {
-      item: result.data!.tagCreate!,
-      message: intl.formatMessage(
-        { id: "toast.created_entity" },
-        { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
-      ),
-    };
-  };
-
-  const isValidNewOption = (
-    inputValue: string,
-    value: OnChangeValue<Option, boolean>,
-    options: OptionsOrGroups<Option, GroupBase<Option>>
-  ) => {
-    if (!inputValue) {
-      return false;
-    }
-
-    if (
-      (options as Options<Option>).some((o: Option) => {
-        return o.label.toLowerCase() === inputValue.toLowerCase();
-      })
-    ) {
-      return false;
-    }
-
-    if (allAliases.some((a) => a.toLowerCase() === inputValue.toLowerCase())) {
-      return false;
-    }
-
-    return true;
-  };
-
-  return (
-    <FilterSelectComponent
-      {...props}
-      filterOption={filterOption}
-      isValidNewOption={isValidNewOption}
-      components={{ Option: TagOption }}
-      isMulti={props.isMulti ?? false}
-      items={tags}
-      creatable={props.creatable ?? defaultCreatable}
-      type="tags"
-      placeholder={placeholder}
-      isLoading={loading}
-      onCreate={onCreate}
-      closeMenuOnSelect={!props.isMulti}
-    />
-  );
+  return <TagIDSelect {...props} />;
 };
 
 export const FilterSelect: React.FC<IFilterProps & ITypeProps> = (props) => {

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -516,3 +516,8 @@ div.react-datepicker {
     border-radius: 0 0.25rem 0.25rem 0;
   }
 }
+
+.react-select-image-option {
+  align-items: center;
+  display: flex;
+}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMergeDialog.tsx
@@ -2,13 +2,13 @@ import { Form, Col, Row } from "react-bootstrap";
 import React, { useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { ModalComponent } from "src/components/Shared/Modal";
-import { TagSelect } from "src/components/Shared/Select";
 import * as FormUtils from "src/utils/form";
 import { useTagsMerge } from "src/core/StashService";
 import { useIntl } from "react-intl";
 import { useToast } from "src/hooks/Toast";
 import { useHistory } from "react-router-dom";
 import { faSignInAlt, faSignOutAlt } from "@fortawesome/free-solid-svg-icons";
+import { Tag, TagSelect } from "../TagSelect";
 
 interface ITagMergeModalProps {
   show: boolean;
@@ -23,8 +23,9 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
   tag,
   mergeType,
 }) => {
-  const [srcIds, setSrcIds] = useState<string[]>([]);
-  const [destId, setDestId] = useState<string | null>(null);
+  const [src, setSrc] = useState<Tag[]>([]);
+  const [dest, setDest] = useState<Tag | null>(null);
+
   const [running, setRunning] = useState(false);
 
   const [mergeTags] = useTagsMerge();
@@ -38,8 +39,8 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
   });
 
   async function onMerge() {
-    const source = mergeType === "from" ? srcIds : [tag.id];
-    const destination = mergeType === "from" ? tag.id : destId;
+    const source = mergeType === "from" ? src.map((s) => s.id) : [tag.id];
+    const destination = mergeType === "from" ? tag.id : dest?.id ?? null;
 
     if (!destination) return;
 
@@ -65,8 +66,8 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
 
   function canMerge() {
     return (
-      (mergeType === "from" && srcIds.length > 0) ||
-      (mergeType === "into" && destId)
+      (mergeType === "from" && src.length > 0) ||
+      (mergeType === "into" && dest !== null)
     );
   }
 
@@ -102,8 +103,8 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
                 <TagSelect
                   isMulti
                   creatable={false}
-                  onSelect={(items) => setSrcIds(items.map((item) => item.id))}
-                  ids={srcIds}
+                  onSelect={(items) => setSrc(items)}
+                  values={src}
                   excludeIds={tag?.id ? [tag.id] : []}
                 />
               </Col>
@@ -125,8 +126,8 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
                 <TagSelect
                   isMulti={false}
                   creatable={false}
-                  onSelect={(items) => setDestId(items[0]?.id)}
-                  ids={destId ? [destId] : undefined}
+                  onSelect={(items) => setDest(items[0])}
+                  values={dest ? [dest] : undefined}
                   excludeIds={tag?.id ? [tag.id] : []}
                 />
               </Col>

--- a/ui/v2.5/src/components/Tags/TagPopover.tsx
+++ b/ui/v2.5/src/components/Tags/TagPopover.tsx
@@ -38,6 +38,7 @@ interface ITagPopoverProps {
   id: string;
   hide?: boolean;
   placement?: Placement;
+  target?: React.RefObject<HTMLElement>;
 }
 
 export const TagPopover: React.FC<ITagPopoverProps> = ({
@@ -45,6 +46,7 @@ export const TagPopover: React.FC<ITagPopoverProps> = ({
   hide,
   children,
   placement = "top",
+  target,
 }) => {
   const { configuration: config } = React.useContext(ConfigurationContext);
 
@@ -57,6 +59,7 @@ export const TagPopover: React.FC<ITagPopoverProps> = ({
 
   return (
     <HoverPopover
+      target={target}
       placement={placement}
       enterDelay={500}
       leaveDelay={100}

--- a/ui/v2.5/src/components/Tags/TagSelect.tsx
+++ b/ui/v2.5/src/components/Tags/TagSelect.tsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  OptionProps,
+  components as reactSelectComponents,
+  MultiValueGenericProps,
+  SingleValueProps,
+} from "react-select";
+import cx from "classnames";
+
+import * as GQL from "src/core/generated-graphql";
+import {
+  useTagCreate,
+  queryFindTagsByIDForSelect,
+  queryFindTagsForSelect,
+} from "src/core/StashService";
+import { ConfigurationContext } from "src/hooks/Config";
+import { useIntl } from "react-intl";
+import { defaultMaxOptionsShown, IUIConfig } from "src/core/config";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import {
+  FilterSelectComponent,
+  IFilterIDProps,
+  IFilterProps,
+  IFilterValueProps,
+  Option as SelectOption,
+} from "../Shared/FilterSelect";
+import { useCompare } from "src/hooks/state";
+import { TagPopover } from "./TagPopover";
+import { Placement } from "react-bootstrap/esm/Overlay";
+
+export type SelectObject = {
+  id: string;
+  name?: string | null;
+  title?: string | null;
+};
+
+export type Tag = Pick<GQL.Tag, "id" | "name" | "aliases" | "image_path">;
+type Option = SelectOption<Tag>;
+
+export const TagSelect: React.FC<
+  IFilterProps &
+    IFilterValueProps<Tag> & {
+      hoverPlacement?: Placement;
+    }
+> = (props) => {
+  const [createTag] = useTagCreate();
+
+  const { configuration } = React.useContext(ConfigurationContext);
+  const intl = useIntl();
+  const maxOptionsShown =
+    (configuration?.ui as IUIConfig).maxOptionsShown ?? defaultMaxOptionsShown;
+  const defaultCreatable =
+    !configuration?.interface.disableDropdownCreate.tag ?? true;
+
+  async function loadTags(input: string): Promise<Option[]> {
+    const filter = new ListFilterModel(GQL.FilterMode.Tags);
+    filter.searchTerm = input;
+    filter.currentPage = 1;
+    filter.itemsPerPage = maxOptionsShown;
+    filter.sortBy = "name";
+    filter.sortDirection = GQL.SortDirectionEnum.Asc;
+    const query = await queryFindTagsForSelect(filter);
+    return query.data.findTags.tags.map((tag) => ({
+      value: tag.id,
+      object: tag,
+    }));
+  }
+
+  const TagOption: React.FC<OptionProps<Option, boolean>> = (optionProps) => {
+    let thisOptionProps = optionProps;
+
+    const targetRef = useRef<HTMLDivElement>(null);
+
+    const { object } = optionProps.data;
+
+    let { name } = object;
+
+    // if name does not match the input value but an alias does, show the alias
+    const { inputValue } = optionProps.selectProps;
+    let alias: string | undefined = "";
+    if (!name.toLowerCase().includes(inputValue.toLowerCase())) {
+      alias = object.aliases?.find((a) =>
+        a.toLowerCase().includes(inputValue.toLowerCase())
+      );
+    }
+
+    thisOptionProps = {
+      ...optionProps,
+      children: (
+        <span className="react-select-image-option" ref={targetRef}>
+          <TagPopover
+            id={object.id}
+            placement={props.hoverPlacement}
+            target={targetRef}
+          >
+            <a
+              href={`/tags/${object.id}`}
+              target="_blank"
+              rel="noreferrer"
+              className="tag-select-image-link"
+            >
+              <img
+                className="tag-select-image"
+                src={object.image_path ?? ""}
+                loading="lazy"
+              />
+            </a>
+          </TagPopover>
+          <span>{name}</span>
+          {alias && <span className="alias">{` (${alias})`}</span>}
+        </span>
+      ),
+    };
+
+    // const hide = (optionProps.data as Option & { __isNew__: boolean })
+    //   .__isNew__;
+
+    return <reactSelectComponents.Option {...thisOptionProps} />;
+  };
+
+  const TagMultiValueLabel: React.FC<
+    MultiValueGenericProps<Option, boolean>
+  > = (optionProps) => {
+    let thisOptionProps = optionProps;
+
+    const { object } = optionProps.data;
+
+    thisOptionProps = {
+      ...optionProps,
+      children: object.name,
+    };
+
+    return <reactSelectComponents.MultiValueLabel {...thisOptionProps} />;
+  };
+
+  const TagValueLabel: React.FC<SingleValueProps<Option, boolean>> = (
+    optionProps
+  ) => {
+    let thisOptionProps = optionProps;
+
+    const { object } = optionProps.data;
+
+    thisOptionProps = {
+      ...optionProps,
+      children: <>{object.name}</>,
+    };
+
+    return <reactSelectComponents.SingleValue {...thisOptionProps} />;
+  };
+
+  const onCreate = async (name: string) => {
+    const result = await createTag({
+      variables: { input: { name } },
+    });
+    return {
+      value: result.data!.tagCreate!.id,
+      item: result.data!.tagCreate!,
+      message: "Created tag",
+    };
+  };
+
+  const getNamedObject = (id: string, name: string) => {
+    return {
+      id,
+      name,
+      aliases: [],
+    };
+  };
+
+  const isValidNewOption = (inputValue: string, options: Tag[]) => {
+    if (!inputValue) {
+      return false;
+    }
+
+    if (
+      options.some((o) => {
+        return (
+          o.name.toLowerCase() === inputValue.toLowerCase() ||
+          o.aliases?.some((a) => a.toLowerCase() === inputValue.toLowerCase())
+        );
+      })
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+
+  return (
+    <FilterSelectComponent<Tag, boolean>
+      {...props}
+      className={cx(
+        "tag-select",
+        {
+          "tag-select-active": props.active,
+        },
+        props.className
+      )}
+      loadOptions={loadTags}
+      getNamedObject={getNamedObject}
+      isValidNewOption={isValidNewOption}
+      components={{
+        Option: TagOption,
+        MultiValueLabel: TagMultiValueLabel,
+        SingleValue: TagValueLabel,
+      }}
+      isMulti={props.isMulti ?? false}
+      creatable={props.creatable ?? defaultCreatable}
+      onCreate={onCreate}
+      placeholder={
+        props.noSelectionString ??
+        intl.formatMessage(
+          { id: "actions.select_entity" },
+          {
+            entityType: intl.formatMessage({
+              id: props.isMulti ? "tags" : "tag",
+            }),
+          }
+        )
+      }
+    />
+  );
+};
+
+export const TagIDSelect: React.FC<IFilterProps & IFilterIDProps<Tag>> = (
+  props
+) => {
+  const { ids, onSelect: onSelectValues } = props;
+
+  const [values, setValues] = useState<Tag[]>([]);
+  const idsChanged = useCompare(ids);
+
+  function onSelect(items: Tag[]) {
+    setValues(items);
+    onSelectValues?.(items);
+  }
+
+  async function loadObjectsByID(idsToLoad: string[]): Promise<Tag[]> {
+    const tagIDs = idsToLoad.map((id) => parseInt(id));
+    const query = await queryFindTagsByIDForSelect(tagIDs);
+    const { tags: loadedTags } = query.data.findTags;
+
+    return loadedTags;
+  }
+
+  useEffect(() => {
+    if (!idsChanged) {
+      return;
+    }
+
+    if (!ids || ids?.length === 0) {
+      setValues([]);
+      return;
+    }
+
+    // load the values if we have ids and they haven't been loaded yet
+    const filteredValues = values.filter((v) => ids.includes(v.id.toString()));
+    if (filteredValues.length === ids.length) {
+      return;
+    }
+
+    const load = async () => {
+      const items = await loadObjectsByID(ids);
+      setValues(items);
+    };
+
+    load();
+  }, [ids, idsChanged, values]);
+
+  return <TagSelect {...props} values={values} onSelect={onSelect} />;
+};

--- a/ui/v2.5/src/components/Tags/styles.scss
+++ b/ui/v2.5/src/components/Tags/styles.scss
@@ -94,6 +94,7 @@
 .tag-select {
   .alias {
     font-weight: bold;
+    white-space: pre;
   }
 }
 

--- a/ui/v2.5/src/components/Tags/styles.scss
+++ b/ui/v2.5/src/components/Tags/styles.scss
@@ -95,10 +95,10 @@
   .alias {
     font-weight: bold;
   }
+}
 
-  .tag-select-image {
-    margin-right: 0.5em;
-    max-height: 25px;
-    max-width: 25px;
-  }
+.tag-select-image {
+  height: 25px;
+  margin-right: 0.5em;
+  width: 25px;
 }

--- a/ui/v2.5/src/components/Tags/styles.scss
+++ b/ui/v2.5/src/components/Tags/styles.scss
@@ -90,3 +90,15 @@
     transform: scale(0.7);
   }
 }
+
+.tag-select {
+  .alias {
+    font-weight: bold;
+  }
+
+  .tag-select-image {
+    margin-right: 0.5em;
+    max-height: 25px;
+    max-width: 25px;
+  }
+}

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -361,8 +361,6 @@ export const queryFindTagsForSelect = (filter: ListFilterModel) =>
     },
   });
 
-export const useAllTagsForFilter = () => GQL.useAllTagsForFilterQuery();
-
 export const useFindSavedFilter = (id: string) =>
   GQL.useFindSavedFilterQuery({
     variables: { id },
@@ -1614,8 +1612,6 @@ export const useTagCreate = () =>
     update(cache, result) {
       const tag = result.data?.tagCreate;
       if (!tag) return;
-
-      appendObject(cache, tag, GQL.AllTagsForFilterDocument);
 
       // update stats
       updateStats(cache, "tag_count", 1);

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -344,6 +344,23 @@ export const queryFindTags = (filter: ListFilterModel) =>
     },
   });
 
+export const queryFindTagsByIDForSelect = (tagIDs: number[]) =>
+  client.query<GQL.FindTagsForSelectQuery>({
+    query: GQL.FindTagsForSelectDocument,
+    variables: {
+      tag_ids: tagIDs,
+    },
+  });
+
+export const queryFindTagsForSelect = (filter: ListFilterModel) =>
+  client.query<GQL.FindTagsForSelectQuery>({
+    query: GQL.FindTagsForSelectDocument,
+    variables: {
+      filter: filter.makeFindFilter(),
+      tag_filter: filter.makeFilter(),
+    },
+  });
+
 export const useAllTagsForFilter = () => GQL.useAllTagsForFilterQuery();
 
 export const useFindSavedFilter = (id: string) =>

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -348,7 +348,7 @@ export const queryFindTagsByIDForSelect = (tagIDs: number[]) =>
   client.query<GQL.FindTagsForSelectQuery>({
     query: GQL.FindTagsForSelectDocument,
     variables: {
-      tag_ids: tagIDs,
+      ids: tagIDs,
     },
   });
 


### PR DESCRIPTION
Similar to #4013. Prerequisite for #4342.

This is the part of the work to remove the select controls which load entire datasets into the client (only studios remains). This addresses the tag select specifically.

The new select control no longer uses `allTags` (and this interface has been marked as deprecated). The main select control now stores tags objects instead of ids. For ease of compatibility, a `TagIDSelect` control is added where it's not easy to use objects. This control will load tags by id as needed, and a modification to `findTags` was made to accept a list of tag ids.

The presentation of the tag results is tweaked to show the actual matching tag alias (instead of a hardcoded `(alias)` string), and it only shows this if the search string matches an alias.

![image](https://github.com/stashapp/stash/assets/53250216/fa312f23-c4a1-43e4-8c1d-01328e195f10)

I expect this to improve performance for users with a significant amount of tags in their database.

