### PR TITLE
Fix SettingsContext error for Setup Component

### DIFF
--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -27,6 +27,7 @@ import {
   faQuestionCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { releaseNotes } from "src/docs/en/ReleaseNotes";
+import { SettingsContext } from "../Settings/context";
 
 export const Setup: React.FC = () => {
   const { configuration, loading: configLoading } =
@@ -549,10 +550,12 @@ export const Setup: React.FC = () => {
               <FormattedMessage id="setup.paths.where_is_your_porn_located_description" />
             </p>
             <Card>
-              <StashConfiguration
-                stashes={stashes}
-                setStashes={(s) => setStashes(s)}
-              />
+              <SettingsContext>
+                <StashConfiguration
+                  stashes={stashes}
+                  setStashes={(s) => setStashes(s)}
+                />
+              </SettingsContext>
             </Card>
           </Form.Group>
           {maybeRenderDatabase()}


### PR DESCRIPTION
When running Stash for the first time, after specifying the path in the Setup Component, the following error occurs:

```
Error: useSettings must be used within a SettingsContext
    at Object.apply (http://localhost:9999/assets/index-a9ae164e.js:49:1224987)
    at an (http://localhost:9999/assets/SettingSection-4086f50f.js:1:4927)
    at div
    at div
    at http://localhost:9999/assets/index-a9ae164e.js:44:25295
    at div
    at http://localhost:9999/assets/index-a9ae164e.js:44:104135
    at E (http://localhost:9999/assets/StashConfiguration-d485fcb1.js:1:707)
    at div
    at _ (http://localhost:9999/assets/StashConfiguration-d485fcb1.js:1:1806)
```

It seems like a problem that occurred in https://github.com/stashapp/stash/pull/4390
To fix this, I've added `SettingsContext` around `StashConfiguration`, but I'm not sure if it's in the right place.
If there's a better location, please let me know.