### PR TITLE
Fix login page favicon on Firefox

### DIFF
--- a/ui/login/login.html
+++ b/ui/login/login.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Login</title>
 
+    <link rel="shortcut icon" href="data:,">
     <link rel="stylesheet" href="login/login.css">
     <link rel="stylesheet" href="css">
 </head>


### PR DESCRIPTION
This fixes a small issue that has been annoying me for ages. On Firefox, if authentication is enabled in Stash, then the blank/absent favicon from the login page persists even after logging in. This doesn't appear to happen in Chrome - once you've logged in once, the normal Stash favicon is always displayed, even on the login page.

For whatever reason, Firefox caches favicons very aggressively: for a given website, the favicon request will basically only ever be made once. The response received from the first request is cached and is used whenever the favicon is needed again, even if that response was an error (e.g. a 404, or in this case, a 401). The favicon will never be requested from the server again, irrespective of the `Cache-Control` header - setting `no-store` has no effect.

For Stash, this means that because the login page is usually the first page loaded, its favicon is then cached and used even after logging in. The fix is to simply set a completely blank favicon with `href="data:,"` on the login page, preventing Firefox from requesting (and thus caching) `favicon.ico` before the user is logged in. It also has the nice side-effect of showing a fallback globe icon in the tab alongside "Login" - previously the tab would just say "Login" with no icon. Chrome also now shows a similar fallback globe icon on the login page, rather than the normal Stash favicon if that is cached.