### PR TITLE
Frontend fix media_err_decode on playback

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -145,7 +145,7 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
       if (!error) return;
 
       // Only try next source if media was unsupported
-      if (error.code !== MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) return;
+      if (error.code !== MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED && error.code !== MediaError.MEDIA_ERR_DECODE) return;
 
       const currentSource = player.currentSource() as ISource;
       console.log(`Source '${currentSource.label}' is unsupported`);

--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -145,7 +145,11 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
       if (!error) return;
 
       // Only try next source if media was unsupported
-      if (error.code !== MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED && error.code !== MediaError.MEDIA_ERR_DECODE) return;
+      if (
+        error.code !== MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED &&
+        error.code !== MediaError.MEDIA_ERR_DECODE
+      )
+        return;
 
       const currentSource = player.currentSource() as ISource;
       console.log(`Source '${currentSource.label}' is unsupported`);


### PR DESCRIPTION
Fixes #4046

Sometimes a MEDIA_ERR_DECODE signal is sent instead of MEDIA_ERR_SRC_NOT_SUPPORTED.
I can confirm this happens to HEVC on Firefox for me.

This patch simply adds MEDIA_ERR_DECODE to errors that should switch the source format.