### PR TITLE
Minor UI fixes

### DIFF
--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -233,6 +233,10 @@
 }
 
 .performer-select {
+  .performer-disambiguation {
+    white-space: pre;
+  }
+
   .alias {
     font-weight: bold;
     white-space: pre;

--- a/ui/v2.5/src/components/Settings/Inputs.tsx
+++ b/ui/v2.5/src/components/Settings/Inputs.tsx
@@ -322,7 +322,10 @@ export const SettingModal = <T extends {}>(props: ISettingModal<T>) => {
             type="submit"
             variant="primary"
             onClick={() => close(currentValue)}
-            disabled={!currentValue || (validate && !validate(currentValue))}
+            disabled={
+              currentValue === undefined ||
+              (validate && !validate(currentValue))
+            }
           >
             <FormattedMessage id="actions.confirm" />
           </Button>

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -518,6 +518,6 @@ div.react-datepicker {
 }
 
 .react-select-image-option {
-  align-items: center;
+  align-items: baseline;
   display: flex;
 }

--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -356,7 +356,7 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
       [performerID]: {
         message: intl.formatMessage(
           { id: "performer_tagger.failed_to_save_performer" },
-          { studio: modalPerformer?.name }
+          { performer: modalPerformer?.name }
         ),
         details:
           message === "UNIQUE constraint failed: performers.name"


### PR DESCRIPTION
Three minor UI fixes:
- Fixes alignment of the performer disambiguation text in the `PerformerSelect` component
- Fixes numeric modal setting dialogs preventing a zero input
- Fixes a copy-paste typo I made in #4024 causing the `failed_to_save_performer` error message to display as "Failed to save {performer}".