### PR TITLE
Fit cards properly within their containers

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -319,10 +319,6 @@
   .slick-list .performer-card.card {
     width: 16rem;
   }
-
-  .slick-list .performer-card-image {
-    height: 24rem;
-  }
 }
 
 /* Icons */

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
+import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink, TagLink } from "../Shared/TagLink";
@@ -55,7 +55,7 @@ export const GalleryCard: React.FC<IProps> = (props) => {
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard } from "../Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink, TagLink } from "../Shared/TagLink";
@@ -38,11 +38,9 @@ export const GalleryCard: React.FC<IProps> = (props) => {
     )
       return;
 
-    let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
     let preferredCardWidth: number;
-    let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
         preferredCardWidth = 240;
@@ -57,7 +55,7 @@ export const GalleryCard: React.FC<IProps> = (props) => {
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import { GridCard } from "../Shared/GridCard";
@@ -17,6 +17,7 @@ import { galleryTitle } from "src/core/galleries";
 
 interface IProps {
   gallery: GQL.SlimGalleryDataFragment;
+  containerWidth?: number;
   selecting?: boolean;
   selected?: boolean | undefined;
   zoomIndex?: number;
@@ -26,6 +27,33 @@ interface IProps {
 export const GalleryCard: React.FC<IProps> = (props) => {
   const { configuration } = React.useContext(ConfigurationContext);
   const showStudioAsText = configuration?.interface.showStudioAsText ?? false;
+  const [cardWidth, setCardWidth] = useState<number>();
+
+  useEffect(() => {
+    if (!props.containerWidth || props.zoomIndex === undefined) return;
+
+    let containerPadding = 30;
+    let containerWidth = props.containerWidth - containerPadding;
+    let zoomValue = props.zoomIndex;
+    let maxCardWidth: number;
+    let paddingOffset = 10;
+    switch (zoomValue) {
+      case 0:
+        maxCardWidth = 240;
+        break;
+      case 1:
+        maxCardWidth = 340;
+        break;
+      case 2:
+        maxCardWidth = 480;
+        break;
+      case 3:
+        maxCardWidth = 640;
+    }
+    let maxElementsOnRow = Math.ceil(containerWidth / maxCardWidth!);
+    let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
+    setCardWidth(fittedCardWidth);
+  }, [props, props.containerWidth, props.zoomIndex]);
 
   function maybeRenderScenePopoverButton() {
     if (props.gallery.scenes.length === 0) return;
@@ -153,6 +181,7 @@ export const GalleryCard: React.FC<IProps> = (props) => {
     <GridCard
       className={`gallery-card zoom-${props.zoomIndex}`}
       url={`/galleries/${props.gallery.id}`}
+      width={cardWidth}
       title={galleryTitle(props.gallery)}
       linkClassName="gallery-card-header"
       image={

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
+import { GridCard, calculateCardWidth } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink, TagLink } from "../Shared/TagLink";
@@ -38,7 +38,6 @@ export const GalleryCard: React.FC<IProps> = (props) => {
     )
       return;
 
-    let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
     let preferredCardWidth: number;
     switch (zoomValue) {
@@ -54,8 +53,10 @@ export const GalleryCard: React.FC<IProps> = (props) => {
       case 3:
         preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      props.containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -31,7 +31,12 @@ export const GalleryCard: React.FC<IProps> = (props) => {
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!props.containerWidth || props.zoomIndex === undefined || ScreenUtils.isMobile()) return;
+    if (
+      !props.containerWidth ||
+      props.zoomIndex === undefined ||
+      ScreenUtils.isMobile()
+    )
+      return;
 
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -36,22 +36,22 @@ export const GalleryCard: React.FC<IProps> = (props) => {
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
-    let maxCardWidth: number;
+    let preferredCardWidth: number;
     let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
-        maxCardWidth = 240;
+        preferredCardWidth = 240;
         break;
       case 1:
-        maxCardWidth = 340;
+        preferredCardWidth = 340;
         break;
       case 2:
-        maxCardWidth = 480;
+        preferredCardWidth = 480;
         break;
       case 3:
-        maxCardWidth = 640;
+        preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(containerWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
     let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -14,6 +14,7 @@ import { ConfigurationContext } from "src/hooks/Config";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { faBox, faPlayCircle, faTag } from "@fortawesome/free-solid-svg-icons";
 import { galleryTitle } from "src/core/galleries";
+import ScreenUtils from "src/utils/screen";
 
 interface IProps {
   gallery: GQL.SlimGalleryDataFragment;
@@ -30,7 +31,7 @@ export const GalleryCard: React.FC<IProps> = (props) => {
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!props.containerWidth || props.zoomIndex === undefined) return;
+    if (!props.containerWidth || props.zoomIndex === undefined || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
 import { useHistory } from "react-router-dom";
@@ -18,6 +18,7 @@ import { EditGalleriesDialog } from "./EditGalleriesDialog";
 import { DeleteGalleriesDialog } from "./DeleteGalleriesDialog";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { GalleryListTable } from "./GalleryListTable";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 const GalleryItemList = makeItemList({
   filterMode: GQL.FilterMode.Galleries,
@@ -106,6 +107,9 @@ export const GalleryList: React.FC<IGalleryList> = ({
     setIsExportDialogOpen(true);
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderContent(
     result: GQL.FindGalleriesQueryResult,
     filter: ListFilterModel,
@@ -133,10 +137,11 @@ export const GalleryList: React.FC<IGalleryList> = ({
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center">
+          <div className="row justify-content-center" ref={componentRef}>
             {result.data.findGalleries.galleries.map((gallery) => (
               <GalleryCard
                 key={gallery.id}
+                containerWidth={width}
                 gallery={gallery}
                 zoomIndex={filter.zoomIndex}
                 selecting={selectedIds.size > 0}

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -7,7 +7,11 @@ import { GalleryLink, TagLink } from "src/components/Shared/TagLink";
 import { HoverPopover } from "src/components/Shared/HoverPopover";
 import { SweatDrops } from "src/components/Shared/SweatDrops";
 import { PerformerPopoverButton } from "src/components/Shared/PerformerPopoverButton";
-import { GridCard, cardPadding, containerPadding } from "src/components/Shared/GridCard";
+import {
+  GridCard,
+  cardPadding,
+  containerPadding,
+} from "src/components/Shared/GridCard";
 import { RatingBanner } from "src/components/Shared/RatingBanner";
 import {
   faBox,

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -7,11 +7,7 @@ import { GalleryLink, TagLink } from "src/components/Shared/TagLink";
 import { HoverPopover } from "src/components/Shared/HoverPopover";
 import { SweatDrops } from "src/components/Shared/SweatDrops";
 import { PerformerPopoverButton } from "src/components/Shared/PerformerPopoverButton";
-import {
-  GridCard,
-  cardMargin,
-  containerPadding,
-} from "src/components/Shared/GridCard";
+import { GridCard, calculateCardWidth } from "src/components/Shared/GridCard";
 import { RatingBanner } from "src/components/Shared/RatingBanner";
 import {
   faBox,
@@ -46,7 +42,6 @@ export const ImageCard: React.FC<IImageCardProps> = (
     )
       return;
 
-    let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
     let preferredCardWidth: number;
     switch (zoomValue) {
@@ -62,8 +57,10 @@ export const ImageCard: React.FC<IImageCardProps> = (
       case 3:
         preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      props.containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useMemo } from "react";
+import React, { MouseEvent, useEffect, useMemo, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import cx from "classnames";
 import * as GQL from "src/core/generated-graphql";
@@ -20,6 +20,7 @@ import { TruncatedText } from "../Shared/TruncatedText";
 
 interface IImageCardProps {
   image: GQL.SlimImageDataFragment;
+  containerWidth?: number;
   selecting?: boolean;
   selected?: boolean | undefined;
   zoomIndex: number;
@@ -30,6 +31,34 @@ interface IImageCardProps {
 export const ImageCard: React.FC<IImageCardProps> = (
   props: IImageCardProps
 ) => {
+  const [cardWidth, setCardWidth] = useState<number>();
+
+  useEffect(() => {
+    if (!props.containerWidth || props.zoomIndex === undefined) return;
+
+    let containerPadding = 30;
+    let containerWidth = props.containerWidth - containerPadding;
+    let zoomValue = props.zoomIndex;
+    let maxCardWidth: number;
+    let paddingOffset = 10;
+    switch (zoomValue) {
+      case 0:
+        maxCardWidth = 240;
+        break;
+      case 1:
+        maxCardWidth = 340;
+        break;
+      case 2:
+        maxCardWidth = 480;
+        break;
+      case 3:
+        maxCardWidth = 640;
+    }
+    let maxElementsOnRow = Math.ceil(containerWidth / maxCardWidth!);
+    let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
+    setCardWidth(fittedCardWidth);
+  }, [props, props.containerWidth, props.zoomIndex]);
+
   const file = useMemo(
     () =>
       props.image.visual_files.length > 0
@@ -153,6 +182,7 @@ export const ImageCard: React.FC<IImageCardProps> = (
     <GridCard
       className={`image-card zoom-${props.zoomIndex}`}
       url={`/images/${props.image.id}`}
+      width={cardWidth}
       title={objectTitle(props.image)}
       linkClassName="image-card-link"
       image={

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -7,7 +7,7 @@ import { GalleryLink, TagLink } from "src/components/Shared/TagLink";
 import { HoverPopover } from "src/components/Shared/HoverPopover";
 import { SweatDrops } from "src/components/Shared/SweatDrops";
 import { PerformerPopoverButton } from "src/components/Shared/PerformerPopoverButton";
-import { GridCard } from "src/components/Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "src/components/Shared/GridCard";
 import { RatingBanner } from "src/components/Shared/RatingBanner";
 import {
   faBox,
@@ -42,11 +42,9 @@ export const ImageCard: React.FC<IImageCardProps> = (
     )
       return;
 
-    let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
     let preferredCardWidth: number;
-    let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
         preferredCardWidth = 240;
@@ -61,7 +59,7 @@ export const ImageCard: React.FC<IImageCardProps> = (
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -17,6 +17,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { objectTitle } from "src/core/files";
 import { TruncatedText } from "../Shared/TruncatedText";
+import ScreenUtils from "src/utils/screen";
 
 interface IImageCardProps {
   image: GQL.SlimImageDataFragment;
@@ -34,7 +35,7 @@ export const ImageCard: React.FC<IImageCardProps> = (
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!props.containerWidth || props.zoomIndex === undefined) return;
+    if (!props.containerWidth || props.zoomIndex === undefined || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -35,7 +35,12 @@ export const ImageCard: React.FC<IImageCardProps> = (
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!props.containerWidth || props.zoomIndex === undefined || ScreenUtils.isMobile()) return;
+    if (
+      !props.containerWidth ||
+      props.zoomIndex === undefined ||
+      ScreenUtils.isMobile()
+    )
+      return;
 
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -9,7 +9,7 @@ import { SweatDrops } from "src/components/Shared/SweatDrops";
 import { PerformerPopoverButton } from "src/components/Shared/PerformerPopoverButton";
 import {
   GridCard,
-  cardPadding,
+  cardMargin,
   containerPadding,
 } from "src/components/Shared/GridCard";
 import { RatingBanner } from "src/components/Shared/RatingBanner";
@@ -63,7 +63,7 @@ export const ImageCard: React.FC<IImageCardProps> = (
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-    let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -40,22 +40,22 @@ export const ImageCard: React.FC<IImageCardProps> = (
     let containerPadding = 30;
     let containerWidth = props.containerWidth - containerPadding;
     let zoomValue = props.zoomIndex;
-    let maxCardWidth: number;
+    let preferredCardWidth: number;
     let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
-        maxCardWidth = 240;
+        preferredCardWidth = 240;
         break;
       case 1:
-        maxCardWidth = 340;
+        preferredCardWidth = 340;
         break;
       case 2:
-        maxCardWidth = 480;
+        preferredCardWidth = 480;
         break;
       case 3:
-        maxCardWidth = 640;
+        preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(containerWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
     let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth, props.zoomIndex]);

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   MouseEvent,
   useContext,
+  useRef,
 } from "react";
 import { FormattedNumber, useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
@@ -32,6 +33,7 @@ import { objectTitle } from "src/core/files";
 import TextUtils from "src/utils/text";
 import { ConfigurationContext } from "src/hooks/Config";
 import { IUIConfig } from "src/core/config";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 interface IImageWallProps {
   images: GQL.SlimImageDataFragment[];
@@ -196,6 +198,9 @@ const ImageListImages: React.FC<IImageListImages> = ({
     ev.preventDefault();
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderImageCard(
     index: number,
     image: GQL.SlimImageDataFragment,
@@ -204,6 +209,7 @@ const ImageListImages: React.FC<IImageListImages> = ({
     return (
       <ImageCard
         key={image.id}
+        containerWidth={width}
         image={image}
         zoomIndex={zoomIndex}
         selecting={selectedIds.size > 0}
@@ -220,7 +226,7 @@ const ImageListImages: React.FC<IImageListImages> = ({
 
   if (filter.displayMode === DisplayMode.Grid) {
     return (
-      <div className="row justify-content-center">
+      <div className="row justify-content-center" ref={componentRef}>
         {images.map((image, index) =>
           renderImageCard(index, image, filter.zoomIndex)
         )}

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard } from "../Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink } from "../Shared/TagLink";
@@ -26,13 +26,11 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
   useEffect(() => {
     if (!props.containerWidth || ScreenUtils.isMobile()) return;
 
-    let containerPadding = 30;
     let maxUsableWidth = props.containerWidth - containerPadding;
     let preferredCardWidth = 250;
-    let paddingOffset = 10;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth]);
 

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
+import { GridCard, calculateCardWidth } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink } from "../Shared/TagLink";
@@ -26,11 +26,11 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
   useEffect(() => {
     if (!props.containerWidth || ScreenUtils.isMobile()) return;
 
-    let maxUsableWidth = props.containerWidth - containerPadding;
     let preferredCardWidth = 250;
-
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      props.containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth]);
 

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
 import { GridCard } from "../Shared/GridCard";
@@ -12,6 +12,7 @@ import { faPlayCircle } from "@fortawesome/free-solid-svg-icons";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
+  containerWidth?: number;
   sceneIndex?: number;
   selecting?: boolean;
   selected?: boolean;
@@ -19,6 +20,21 @@ interface IProps {
 }
 
 export const MovieCard: React.FC<IProps> = (props: IProps) => {
+  const [cardWidth, setCardWidth] = useState<number>();
+
+  useEffect(() => {
+    if (!props.containerWidth) return;
+
+    let containerPadding = 30;
+    let maxUsableWidth = props.containerWidth - containerPadding;
+    let maxCardWidth = 250;
+    let paddingOffset = 10;
+
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    setCardWidth(fittedCardWidth);
+  }, [props, props.containerWidth]);
+
   function maybeRenderSceneNumber() {
     if (!props.sceneIndex) return;
 
@@ -71,6 +87,7 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
     <GridCard
       className="movie-card"
       url={`/movies/${props.movie.id}`}
+      width={cardWidth}
       title={props.movie.name}
       linkClassName="movie-card-header"
       image={

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -28,10 +28,10 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
 
     let containerPadding = 30;
     let maxUsableWidth = props.containerWidth - containerPadding;
-    let maxCardWidth = 250;
+    let preferredCardWidth = 250;
     let paddingOffset = 10;
 
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
     let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth]);

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -9,6 +9,7 @@ import { TruncatedText } from "../Shared/TruncatedText";
 import { FormattedMessage } from "react-intl";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { faPlayCircle } from "@fortawesome/free-solid-svg-icons";
+import ScreenUtils from "src/utils/screen";
 
 interface IProps {
   movie: GQL.MovieDataFragment;
@@ -23,7 +24,7 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!props.containerWidth) return;
+    if (!props.containerWidth || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let maxUsableWidth = props.containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Movies/MovieCard.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Button, ButtonGroup } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
-import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
+import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
 import { Icon } from "../Shared/Icon";
 import { SceneLink } from "../Shared/TagLink";
@@ -30,7 +30,7 @@ export const MovieCard: React.FC<IProps> = (props: IProps) => {
     let preferredCardWidth = 250;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [props, props.containerWidth]);
 

--- a/ui/v2.5/src/components/Movies/MovieCardGrid.tsx
+++ b/ui/v2.5/src/components/Movies/MovieCardGrid.tsx
@@ -1,0 +1,35 @@
+import React, { useRef } from "react";
+import * as GQL from "src/core/generated-graphql";
+import { MovieCard } from "./MovieCard";
+import { useContainerDimensions } from "../Shared/GridCard";
+
+interface IMovieCardGrid {
+  movies: GQL.MovieDataFragment[];
+  selectedIds: Set<string>;
+  onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+}
+
+export const MovieCardGrid: React.FC<IMovieCardGrid> = ({
+  movies,
+  selectedIds,
+  onSelectChange,
+}) => {
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+  return (
+    <div className="row justify-content-center" ref={componentRef}>
+      {movies.map((p) => (
+        <MovieCard
+          key={p.id}
+          containerWidth={width}
+          movie={p}
+          selecting={selectedIds.size > 0}
+          selected={selectedIds.has(p.id)}
+          onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
+            onSelectChange(p.id, selected, shiftKey)
+          }
+        />
+      ))}
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Movies/MovieList.tsx
+++ b/ui/v2.5/src/components/Movies/MovieList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
@@ -20,6 +20,7 @@ import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
 import { MovieCard } from "./MovieCard";
 import { EditMoviesDialog } from "./EditMoviesDialog";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 const MovieItemList = makeItemList({
   filterMode: GQL.FilterMode.Movies,
@@ -103,6 +104,9 @@ export const MovieList: React.FC<IMovieList> = ({ filterHook, alterQuery }) => {
     setIsExportDialogOpen(true);
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderContent(
     result: GQL.FindMoviesQueryResult,
     filter: ListFilterModel,
@@ -130,10 +134,11 @@ export const MovieList: React.FC<IMovieList> = ({ filterHook, alterQuery }) => {
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center">
+          <div className="row justify-content-center" ref={componentRef}>
             {result.data.findMovies.movies.map((p) => (
               <MovieCard
                 key={p.id}
+                containerWidth={width}
                 movie={p}
                 selecting={selectedIds.size > 0}
                 selected={selectedIds.has(p.id)}

--- a/ui/v2.5/src/components/Movies/MovieList.tsx
+++ b/ui/v2.5/src/components/Movies/MovieList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
@@ -18,9 +18,8 @@ import {
 } from "../List/ItemList";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
-import { MovieCard } from "./MovieCard";
+import { MovieCardGrid } from "./MovieCardGrid";
 import { EditMoviesDialog } from "./EditMoviesDialog";
-import { useContainerDimensions } from "../Shared/GridCard";
 
 const MovieItemList = makeItemList({
   filterMode: GQL.FilterMode.Movies,
@@ -104,9 +103,6 @@ export const MovieList: React.FC<IMovieList> = ({ filterHook, alterQuery }) => {
     setIsExportDialogOpen(true);
   }
 
-  const componentRef = useRef<HTMLDivElement>(null);
-  const { width } = useContainerDimensions(componentRef);
-
   function renderContent(
     result: GQL.FindMoviesQueryResult,
     filter: ListFilterModel,
@@ -134,20 +130,11 @@ export const MovieList: React.FC<IMovieList> = ({ filterHook, alterQuery }) => {
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center" ref={componentRef}>
-            {result.data.findMovies.movies.map((p) => (
-              <MovieCard
-                key={p.id}
-                containerWidth={width}
-                movie={p}
-                selecting={selectedIds.size > 0}
-                selected={selectedIds.has(p.id)}
-                onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
-                  onSelectChange(p.id, selected, shiftKey)
-                }
-              />
-            ))}
-          </div>
+          <MovieCardGrid
+            movies={result.data.findMovies.movies}
+            selectedIds={selectedIds}
+            onSelectChange={onSelectChange}
+          />
         );
       }
       if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
-import { GridCard } from "../Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
 import { CountryFlag } from "../Shared/CountryFlag";
 import { SweatDrops } from "../Shared/SweatDrops";
 import { HoverPopover } from "../Shared/HoverPopover";
@@ -74,13 +74,11 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
-    let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
     let preferredCardWidth = 300;
-    let paddingOffset = 10;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -34,8 +34,6 @@ export interface IPerformerCardExtraCriteria {
 interface IPerformerCardProps {
   performer: GQL.PerformerDataFragment;
   containerWidth?: number;
-  previewHeight?: number;
-  setPreviewHeight?: React.Dispatch<React.SetStateAction<number | undefined>>;
   ageFromDate?: string;
   selecting?: boolean;
   selected?: boolean;
@@ -68,14 +66,13 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     { id: ageL10nId },
     { age, years_old: ageL10String }
   );
-  
+
   const [updatePerformer] = usePerformerUpdate();
   const [cardWidth, setCardWidth] = useState<number>();
   const [imageHeight, setImageHeight] = useState<number>();
 
   useEffect(() => {
-    if (!containerWidth)
-      return;
+    if (!containerWidth) return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
@@ -83,7 +80,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     let paddingOffset = 10;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
-    let fittedCardWidth = (maxUsableWidth / maxElementsOnRow) - paddingOffset;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
     let fittedimageHeight = (fittedCardWidth / 2) * 3;
     setCardWidth(fittedCardWidth);
     setImageHeight(fittedimageHeight);

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
@@ -33,6 +33,9 @@ export interface IPerformerCardExtraCriteria {
 
 interface IPerformerCardProps {
   performer: GQL.PerformerDataFragment;
+  containerWidth?: number;
+  previewHeight?: number;
+  setPreviewHeight?: React.Dispatch<React.SetStateAction<number | undefined>>;
   ageFromDate?: string;
   selecting?: boolean;
   selected?: boolean;
@@ -42,6 +45,7 @@ interface IPerformerCardProps {
 
 export const PerformerCard: React.FC<IPerformerCardProps> = ({
   performer,
+  containerWidth,
   ageFromDate,
   selecting,
   selected,
@@ -64,8 +68,26 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     { id: ageL10nId },
     { age, years_old: ageL10String }
   );
-
+  
   const [updatePerformer] = usePerformerUpdate();
+  const [cardWidth, setCardWidth] = useState<number>();
+  const [imageHeight, setImageHeight] = useState<number>();
+
+  useEffect(() => {
+    if (!containerWidth)
+      return;
+
+    let containerPadding = 30;
+    let maxUsableWidth = containerWidth - containerPadding;
+    let maxCardWidth = 300;
+    let paddingOffset = 10;
+
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let fittedCardWidth = (maxUsableWidth / maxElementsOnRow) - paddingOffset;
+    let fittedimageHeight = (fittedCardWidth / 2) * 3;
+    setCardWidth(fittedCardWidth);
+    setImageHeight(fittedimageHeight);
+  }, [containerWidth]);
 
   function renderFavoriteIcon() {
     return (
@@ -251,6 +273,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     <GridCard
       className="performer-card"
       url={`/performers/${performer.id}`}
+      width={cardWidth}
       pretitleIcon={
         <GenderIcon className="gender-icon" gender={performer.gender} />
       }
@@ -267,6 +290,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
       image={
         <>
           <img
+            style={imageHeight ? { height: `${imageHeight}px` } : {}}
             loading="lazy"
             className="performer-card-image"
             alt={performer.name ?? ""}

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
-import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
+import { GridCard, calculateCardWidth } from "../Shared/GridCard";
 import { CountryFlag } from "../Shared/CountryFlag";
 import { SweatDrops } from "../Shared/SweatDrops";
 import { HoverPopover } from "../Shared/HoverPopover";
@@ -74,11 +74,11 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
-    let maxUsableWidth = containerWidth - containerPadding;
     let preferredCardWidth = 300;
-
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -70,21 +70,18 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
 
   const [updatePerformer] = usePerformerUpdate();
   const [cardWidth, setCardWidth] = useState<number>();
-  const [imageHeight, setImageHeight] = useState<number>();
 
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
-    let maxCardWidth = 300;
+    let preferredCardWidth = 300;
     let paddingOffset = 10;
 
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
     let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
-    let fittedimageHeight = (fittedCardWidth / 2) * 3;
     setCardWidth(fittedCardWidth);
-    setImageHeight(fittedimageHeight);
   }, [containerWidth]);
 
   function renderFavoriteIcon() {
@@ -288,7 +285,6 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
       image={
         <>
           <img
-            style={imageHeight ? { height: `${imageHeight}px` } : {}}
             loading="lazy"
             className="performer-card-image"
             alt={performer.name ?? ""}

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -4,7 +4,7 @@ import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
-import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
+import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
 import { CountryFlag } from "../Shared/CountryFlag";
 import { SweatDrops } from "../Shared/SweatDrops";
 import { HoverPopover } from "../Shared/HoverPopover";
@@ -78,7 +78,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
     let preferredCardWidth = 300;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -22,6 +22,7 @@ import { RatingBanner } from "../Shared/RatingBanner";
 import cx from "classnames";
 import { usePerformerUpdate } from "src/core/StashService";
 import { ILabeledId } from "src/models/list-filter/types";
+import ScreenUtils from "src/utils/screen";
 
 export interface IPerformerCardExtraCriteria {
   scenes?: Criterion<CriterionValue>[];
@@ -72,7 +73,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   const [imageHeight, setImageHeight] = useState<number>();
 
   useEffect(() => {
-    if (!containerWidth) return;
+    if (!containerWidth || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Performers/PerformerCardGrid.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCardGrid.tsx
@@ -1,0 +1,39 @@
+import React, { useRef } from "react";
+import * as GQL from "src/core/generated-graphql";
+import { IPerformerCardExtraCriteria, PerformerCard } from "./PerformerCard";
+import { useContainerDimensions } from "../Shared/GridCard";
+
+interface IPerformerCardGrid {
+  performers: GQL.PerformerDataFragment[];
+  selectedIds: Set<string>;
+  zoomIndex: number;
+  onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+  extraCriteria?: IPerformerCardExtraCriteria;
+}
+
+export const PerformerCardGrid: React.FC<IPerformerCardGrid> = ({
+  performers,
+  selectedIds,
+  onSelectChange,
+  extraCriteria,
+}) => {
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+  return (
+    <div className="row justify-content-center" ref={componentRef}>
+      {performers.map((p) => (
+        <PerformerCard
+          key={p.id}
+          containerWidth={width}
+          performer={p}
+          selecting={selectedIds.size > 0}
+          selected={selectedIds.has(p.id)}
+          onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
+            onSelectChange(p.id, selected, shiftKey)
+          }
+          extraCriteria={extraCriteria}
+        />
+      ))}
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -1,5 +1,5 @@
 import cloneDeep from "lodash-es/cloneDeep";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
@@ -19,12 +19,12 @@ import { DisplayMode } from "src/models/list-filter/types";
 import { PerformerTagger } from "../Tagger/performers/PerformerTagger";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
-import { IPerformerCardExtraCriteria, PerformerCard } from "./PerformerCard";
+import { IPerformerCardExtraCriteria } from "./PerformerCard";
 import { PerformerListTable } from "./PerformerListTable";
 import { EditPerformersDialog } from "./EditPerformersDialog";
 import { cmToImperial, cmToInches, kgToLbs } from "src/utils/units";
 import TextUtils from "src/utils/text";
-import { useContainerDimensions } from "../Shared/GridCard";
+import { PerformerCardGrid } from "./PerformerCardGrid";
 
 const PerformerItemList = makeItemList({
   filterMode: GQL.FilterMode.Performers,
@@ -235,9 +235,6 @@ export const PerformerList: React.FC<IPerformerList> = ({
     setIsExportDialogOpen(true);
   }
 
-  const componentRef = useRef<HTMLDivElement>(null);
-  const { width } = useContainerDimensions(componentRef);
-
   function renderContent(
     result: GQL.FindPerformersQueryResult,
     filter: ListFilterModel,
@@ -267,21 +264,13 @@ export const PerformerList: React.FC<IPerformerList> = ({
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center" ref={componentRef}>
-            {result.data.findPerformers.performers.map((p) => (
-              <PerformerCard
-                key={p.id}
-                containerWidth={width}
-                performer={p}
-                selecting={selectedIds.size > 0}
-                selected={selectedIds.has(p.id)}
-                onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
-                  onSelectChange(p.id, selected, shiftKey)
-                }
-                extraCriteria={extraCriteria}
-              />
-            ))}
-          </div>
+          <PerformerCardGrid
+            performers={result.data.findPerformers.performers}
+            zoomIndex={filter.zoomIndex}
+            selectedIds={selectedIds}
+            onSelectChange={onSelectChange}
+            extraCriteria={extraCriteria}
+          />
         );
       }
       if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -1,5 +1,5 @@
 import cloneDeep from "lodash-es/cloneDeep";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
@@ -24,6 +24,7 @@ import { PerformerListTable } from "./PerformerListTable";
 import { EditPerformersDialog } from "./EditPerformersDialog";
 import { cmToImperial, cmToInches, kgToLbs } from "src/utils/units";
 import TextUtils from "src/utils/text";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 const PerformerItemList = makeItemList({
   filterMode: GQL.FilterMode.Performers,
@@ -234,6 +235,9 @@ export const PerformerList: React.FC<IPerformerList> = ({
     setIsExportDialogOpen(true);
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderContent(
     result: GQL.FindPerformersQueryResult,
     filter: ListFilterModel,
@@ -263,10 +267,11 @@ export const PerformerList: React.FC<IPerformerList> = ({
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center">
+          <div className="row justify-content-center" ref={componentRef}>
             {result.data.findPerformers.performers.map((p) => (
               <PerformerCard
                 key={p.id}
+                containerWidth={width}
                 performer={p}
                 selecting={selectedIds.size > 0}
                 selected={selectedIds.has(p.id)}

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -76,11 +76,11 @@
   }
 
   &-image {
-    height: 30rem;
     min-width: 11.25rem;
     object-fit: cover;
     object-position: top;
     width: 100%;
+    aspect-ratio: 2/3;
   }
 
   .fi {

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -76,11 +76,11 @@
   }
 
   &-image {
+    aspect-ratio: 2/3;
     min-width: 11.25rem;
     object-fit: cover;
     object-position: top;
     width: 100%;
-    aspect-ratio: 2/3;
   }
 
   .fi {

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -45,6 +45,7 @@ import airplay from "@silvermine/videojs-airplay";
 // @ts-ignore
 import chromecast from "@silvermine/videojs-chromecast";
 import abLoopPlugin from "videojs-abloop";
+import ScreenUtils from "src/utils/screen";
 
 // register videojs plugins
 airplay(videojs);
@@ -284,7 +285,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     }
 
     const onResize = () => {
-      const show = window.innerHeight >= 450 && window.innerWidth >= 576;
+      const show = window.innerHeight >= 450 && !ScreenUtils.isMobile();
       setShowScrubber(show);
     };
     onResize();

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -32,6 +32,7 @@ import {
 import { objectPath, objectTitle } from "src/core/files";
 import { PreviewScrubber } from "./PreviewScrubber";
 import { PatchComponent } from "src/pluginApi";
+import ScreenUtils from "src/utils/screen";
 
 interface IScenePreviewProps {
   isPortrait: boolean;
@@ -497,7 +498,8 @@ export const SceneCard = PatchComponent(
       if (
         !props.containerWidth ||
         props.zoomIndex === undefined ||
-        !props.setPreviewHeight
+        !props.setPreviewHeight ||
+        ScreenUtils.isMobile()
       )
         return;
 
@@ -511,7 +513,7 @@ export const SceneCard = PatchComponent(
           maxCardWidth = 240;
           break;
         case 1:
-          maxCardWidth = 340;
+          maxCardWidth = 340; // this value is intentionally higher than 320
           break;
         case 2:
           maxCardWidth = 480;
@@ -523,7 +525,7 @@ export const SceneCard = PatchComponent(
       let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
       let imageHeight = (fittedCardWidth / 16) * 9;
       setCardWidth(fittedCardWidth);
-      props.setPreviewHeight(imageHeight);
+      // props.setPreviewHeight(imageHeight);
     }, [props, props.containerWidth, props.zoomIndex]);
 
     const cont = configuration?.interface.continuePlaylistDefault ?? false;

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -18,7 +18,7 @@ import TextUtils from "src/utils/text";
 import { SceneQueue } from "src/models/sceneQueue";
 import { ConfigurationContext } from "src/hooks/Config";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
-import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
+import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { FormattedNumber } from "react-intl";
 import {
@@ -512,7 +512,7 @@ export const SceneCard = PatchComponent(
           preferredCardWidth = 640;
       }
       let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-      let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
+      let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
       setCardWidth(fittedCardWidth);
     }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -506,26 +506,24 @@ export const SceneCard = PatchComponent(
       let containerPadding = 30;
       let containerWidth = props.containerWidth - containerPadding;
       let zoomValue = props.zoomIndex;
-      let maxCardWidth: number;
+      let preferredCardWidth: number;
       let paddingOffset = 10;
       switch (zoomValue) {
         case 0:
-          maxCardWidth = 240;
+          preferredCardWidth = 240;
           break;
         case 1:
-          maxCardWidth = 340; // this value is intentionally higher than 320
+          preferredCardWidth = 340; // this value is intentionally higher than 320
           break;
         case 2:
-          maxCardWidth = 480;
+          preferredCardWidth = 480;
           break;
         case 3:
-          maxCardWidth = 640;
+          preferredCardWidth = 640;
       }
-      let maxElementsOnRow = Math.ceil(containerWidth / maxCardWidth!);
+      let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
       let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
-      let imageHeight = (fittedCardWidth / 16) * 9;
       setCardWidth(fittedCardWidth);
-      // props.setPreviewHeight(imageHeight);
     }, [props, props.containerWidth, props.zoomIndex]);
 
     const cont = configuration?.interface.continuePlaylistDefault ?? false;

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -18,7 +18,7 @@ import TextUtils from "src/utils/text";
 import { SceneQueue } from "src/models/sceneQueue";
 import { ConfigurationContext } from "src/hooks/Config";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
-import { GridCard } from "../Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { FormattedNumber } from "react-intl";
 import {
@@ -495,11 +495,9 @@ export const SceneCard = PatchComponent(
       )
         return;
 
-      let containerPadding = 30;
       let containerWidth = props.containerWidth - containerPadding;
       let zoomValue = props.zoomIndex;
       let preferredCardWidth: number;
-      let paddingOffset = 10;
       switch (zoomValue) {
         case 0:
           preferredCardWidth = 240;
@@ -514,7 +512,7 @@ export const SceneCard = PatchComponent(
           preferredCardWidth = 640;
       }
       let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-      let fittedCardWidth = containerWidth / maxElementsOnRow - paddingOffset;
+      let fittedCardWidth = containerWidth / maxElementsOnRow - cardPadding;
       setCardWidth(fittedCardWidth);
     }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -18,7 +18,7 @@ import TextUtils from "src/utils/text";
 import { SceneQueue } from "src/models/sceneQueue";
 import { ConfigurationContext } from "src/hooks/Config";
 import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
-import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
+import { GridCard, calculateCardWidth } from "../Shared/GridCard";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { FormattedNumber } from "react-intl";
 import {
@@ -495,7 +495,6 @@ export const SceneCard = PatchComponent(
       )
         return;
 
-      let containerWidth = props.containerWidth - containerPadding;
       let zoomValue = props.zoomIndex;
       let preferredCardWidth: number;
       switch (zoomValue) {
@@ -511,8 +510,10 @@ export const SceneCard = PatchComponent(
         case 3:
           preferredCardWidth = 640;
       }
-      let maxElementsOnRow = Math.ceil(containerWidth / preferredCardWidth!);
-      let fittedCardWidth = containerWidth / maxElementsOnRow - cardMargin;
+      let fittedCardWidth = calculateCardWidth(
+        props.containerWidth,
+        preferredCardWidth!
+      );
       setCardWidth(fittedCardWidth);
     }, [props, props.containerWidth, props.zoomIndex]);
 

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -38,7 +38,6 @@ interface IScenePreviewProps {
   isPortrait: boolean;
   image?: string;
   video?: string;
-  height?: number;
   soundActive: boolean;
   vttPath?: string;
   onScrubberClick?: (timestamp: number) => void;
@@ -47,7 +46,6 @@ interface IScenePreviewProps {
 export const ScenePreview: React.FC<IScenePreviewProps> = ({
   image,
   video,
-  height,
   isPortrait,
   soundActive,
   vttPath,
@@ -74,10 +72,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
   }, [soundActive]);
 
   return (
-    <div
-      className={cx("scene-card-preview", { portrait: isPortrait })}
-      style={height ? { height: `${height}px` } : {}}
-    >
+    <div className={cx("scene-card-preview", { portrait: isPortrait })}>
       <img
         className="scene-card-preview-image"
         loading="lazy"
@@ -103,7 +98,6 @@ interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
   containerWidth?: number;
   previewHeight?: number;
-  setPreviewHeight?: React.Dispatch<React.SetStateAction<number | undefined>>;
   index?: number;
   queue?: SceneQueue;
   compact?: boolean;
@@ -452,7 +446,6 @@ const SceneCardImage = PatchComponent(
       <>
         <ScenePreview
           image={props.scene.paths.screenshot ?? undefined}
-          height={props.previewHeight}
           video={props.scene.paths.preview ?? undefined}
           isPortrait={isPortrait()}
           soundActive={configuration?.interface?.soundOnPreview ?? false}
@@ -498,7 +491,6 @@ export const SceneCard = PatchComponent(
       if (
         !props.containerWidth ||
         props.zoomIndex === undefined ||
-        !props.setPreviewHeight ||
         ScreenUtils.isMobile()
       )
         return;

--- a/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { SceneQueue } from "src/models/sceneQueue";
 import { SceneCard } from "./SceneCard";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 interface ISceneCardsGrid {
   scenes: GQL.SlimSceneDataFragment[];
@@ -18,11 +19,17 @@ export const SceneCardsGrid: React.FC<ISceneCardsGrid> = ({
   zoomIndex,
   onSelectChange,
 }) => {
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+  const [previewHeight, setPreviewHeight] = useState<number>();
   return (
-    <div className="row justify-content-center">
+    <div className="row justify-content-center" ref={componentRef}>
       {scenes.map((scene, index) => (
         <SceneCard
           key={scene.id}
+          containerWidth={width}
+          previewHeight={previewHeight}
+          setPreviewHeight={setPreviewHeight}
           scene={scene}
           queue={queue}
           index={index}

--- a/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { SceneQueue } from "src/models/sceneQueue";
 import { SceneCard } from "./SceneCard";

--- a/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCardsGrid.tsx
@@ -21,15 +21,12 @@ export const SceneCardsGrid: React.FC<ISceneCardsGrid> = ({
 }) => {
   const componentRef = useRef<HTMLDivElement>(null);
   const { width } = useContainerDimensions(componentRef);
-  const [previewHeight, setPreviewHeight] = useState<number>();
   return (
     <div className="row justify-content-center" ref={componentRef}>
       {scenes.map((scene, index) => (
         <SceneCard
           key={scene.id}
           containerWidth={width}
-          previewHeight={previewHeight}
-          setPreviewHeight={setPreviewHeight}
           scene={scene}
           queue={queue}
           index={index}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -168,6 +168,13 @@ textarea.scene-description {
   text-transform: uppercase;
 }
 
+.scene-card {
+
+  &-preview {
+    aspect-ratio: 16/9;
+  }
+}
+
 .scene-card,
 .gallery-card {
   a {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -169,7 +169,6 @@ textarea.scene-description {
 }
 
 .scene-card {
-
   &-preview {
     aspect-ratio: 16/9;
   }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -82,6 +82,10 @@ textarea.scene-description {
   }
 }
 
+.justify-content-center .studio-card .studio-card-image {
+  width: 100%;
+}
+
 .studio-card {
   padding: 0.5rem;
 
@@ -99,7 +103,7 @@ textarea.scene-description {
     max-height: 150px;
     object-fit: contain;
     vertical-align: middle;
-    width: 100%;
+    width: 320px;
 
     @media (max-width: 576px) {
       width: 100%;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -99,7 +99,7 @@ textarea.scene-description {
     max-height: 150px;
     object-fit: contain;
     vertical-align: middle;
-    width: 320px;
+    width: 100%;
 
     @media (max-width: 576px) {
       width: 100%;

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import cx from "classnames";
@@ -8,6 +8,7 @@ interface ICardProps {
   className?: string;
   linkClassName?: string;
   thumbnailSectionClassName?: string;
+  width?: number;
   url: string;
   pretitleIcon?: JSX.Element;
   title: JSX.Element | string;
@@ -22,6 +23,35 @@ interface ICardProps {
   duration?: number;
   interactiveHeatmap?: string;
 }
+
+export const useContainerDimensions = (
+  myRef: React.RefObject<HTMLDivElement>
+) => {
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const getDimensions = () => ({
+      width: myRef.current!.offsetWidth,
+      height: myRef.current!.offsetHeight,
+    });
+
+    const handleResize = () => {
+      setDimensions(getDimensions());
+    };
+
+    if (myRef.current) {
+      setDimensions(getDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [myRef]);
+
+  return dimensions;
+};
 
 export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
   function handleImageClick(event: React.MouseEvent<HTMLElement, MouseEvent>) {
@@ -116,6 +146,7 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
       onDragStart={handleDrag}
       onDragOver={handleDragOver}
       draggable={props.onSelectedChanged && props.selecting}
+      style={props.width ? { width: `${props.width}px` } : {}}
     >
       {maybeRenderCheckbox()}
 

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -151,7 +151,7 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
       onDragOver={handleDragOver}
       draggable={props.onSelectedChanged && props.selecting}
       style={
-        props.width && !ScreenUtils.isMobile
+        props.width && !ScreenUtils.isMobile()
           ? { width: `${props.width}px` }
           : {}
       }

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -3,6 +3,7 @@ import { Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import cx from "classnames";
 import { TruncatedText } from "./TruncatedText";
+import ScreenUtils from "src/utils/screen";
 
 interface ICardProps {
   className?: string;
@@ -24,8 +25,8 @@ interface ICardProps {
   interactiveHeatmap?: string;
 }
 
-export const containerPadding = 30
-export const cardPadding = 10
+export const containerPadding = 30;
+export const cardPadding = 10;
 
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
@@ -149,7 +150,11 @@ export const GridCard: React.FC<ICardProps> = (props: ICardProps) => {
       onDragStart={handleDrag}
       onDragOver={handleDragOver}
       draggable={props.onSelectedChanged && props.selecting}
-      style={props.width ? { width: `${props.width}px` } : {}}
+      style={
+        props.width && !ScreenUtils.isMobile
+          ? { width: `${props.width}px` }
+          : {}
+      }
     >
       {maybeRenderCheckbox()}
 

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -27,12 +27,7 @@ interface ICardProps {
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
 ) => {
-  const overflow = window?.visualViewport?.height! < window.innerHeight;
-  const defaultWidth = overflow ? window.innerWidth - 15 : window.innerWidth;
-  const [dimensions, setDimensions] = useState({
-    width: defaultWidth,
-    height: 0,
-  });
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
     const getDimensions = () => ({

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -27,7 +27,8 @@ interface ICardProps {
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
 ) => {
-  const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: 0 });
+  // 15 pixel offset accounts for scrollbar
+  const [dimensions, setDimensions] = useState({ width: window.innerWidth-15, height: 0 });
 
   useEffect(() => {
     const getDimensions = () => ({

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -26,7 +26,7 @@ interface ICardProps {
 }
 
 export const containerPadding = 30;
-export const cardPadding = 10;
+export const cardMargin = 10;
 
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -25,8 +25,16 @@ interface ICardProps {
   interactiveHeatmap?: string;
 }
 
-export const containerPadding = 30;
-export const cardMargin = 10;
+export const calculateCardWidth = (
+  containerWidth: number,
+  preferredWidth: number
+) => {
+  const containerPadding = 30;
+  const cardMargin = 10;
+  let maxUsableWidth = containerWidth - containerPadding;
+  let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredWidth);
+  return maxUsableWidth / maxElementsOnRow - cardMargin;
+};
 
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -24,6 +24,9 @@ interface ICardProps {
   interactiveHeatmap?: string;
 }
 
+export const containerPadding = 30
+export const cardPadding = 10
+
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
 ) => {

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -27,7 +27,7 @@ interface ICardProps {
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
 ) => {
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: 0 });
 
   useEffect(() => {
     const getDimensions = () => ({

--- a/ui/v2.5/src/components/Shared/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard.tsx
@@ -27,8 +27,12 @@ interface ICardProps {
 export const useContainerDimensions = (
   myRef: React.RefObject<HTMLDivElement>
 ) => {
-  // 15 pixel offset accounts for scrollbar
-  const [dimensions, setDimensions] = useState({ width: window.innerWidth-15, height: 0 });
+  const overflow = window?.visualViewport?.height! < window.innerHeight;
+  const defaultWidth = overflow ? window.innerWidth - 15 : window.innerWidth;
+  const [dimensions, setDimensions] = useState({
+    width: defaultWidth,
+    height: 0,
+  });
 
   useEffect(() => {
     const getDimensions = () => ({

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
@@ -10,6 +10,7 @@ import { RatingBanner } from "../Shared/RatingBanner";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
+  containerWidth?: number;
   hideParent?: boolean;
   selecting?: boolean;
   selected?: boolean;
@@ -59,11 +60,27 @@ function maybeRenderChildren(studio: GQL.StudioDataFragment) {
 
 export const StudioCard: React.FC<IProps> = ({
   studio,
+  containerWidth,
   hideParent,
   selecting,
   selected,
   onSelectedChanged,
 }) => {
+  const [cardWidth, setCardWidth] = useState<number>();
+
+  useEffect(() => {
+    if (!containerWidth) return;
+
+    let containerPadding = 30;
+    let maxUsableWidth = containerWidth - containerPadding;
+    let maxCardWidth = 340;
+    let paddingOffset = 10;
+
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    setCardWidth(fittedCardWidth);
+  }, [containerWidth]);
+
   function maybeRenderScenesPopoverButton() {
     if (!studio.scene_count) return;
 
@@ -156,6 +173,7 @@ export const StudioCard: React.FC<IProps> = ({
     <GridCard
       className="studio-card"
       url={`/studios/${studio.id}`}
+      width={cardWidth}
       title={studio.name}
       linkClassName="studio-card-header"
       image={

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
-import { GridCard, cardPadding, containerPadding } from "src/components/Shared/GridCard";
+import {
+  GridCard,
+  cardPadding,
+  containerPadding,
+} from "src/components/Shared/GridCard";
 import { ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -74,10 +74,10 @@ export const StudioCard: React.FC<IProps> = ({
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
-    let maxCardWidth = 340;
+    let preferredCardWidth = 340;
     let paddingOffset = 10;
 
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
     let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
-import { GridCard } from "src/components/Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "src/components/Shared/GridCard";
 import { ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
@@ -72,13 +72,11 @@ export const StudioCard: React.FC<IProps> = ({
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
-    let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
     let preferredCardWidth = 340;
-    let paddingOffset = 10;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -2,11 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
-import {
-  GridCard,
-  cardMargin,
-  containerPadding,
-} from "src/components/Shared/GridCard";
+import { GridCard, calculateCardWidth } from "src/components/Shared/GridCard";
 import { ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
@@ -76,11 +72,11 @@ export const StudioCard: React.FC<IProps> = ({
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
-    let maxUsableWidth = containerWidth - containerPadding;
     let preferredCardWidth = 340;
-
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -4,7 +4,7 @@ import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import {
   GridCard,
-  cardPadding,
+  cardMargin,
   containerPadding,
 } from "src/components/Shared/GridCard";
 import { ButtonGroup } from "react-bootstrap";
@@ -80,7 +80,7 @@ export const StudioCard: React.FC<IProps> = ({
     let preferredCardWidth = 340;
 
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [containerWidth]);
 

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -7,6 +7,7 @@ import { ButtonGroup } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import { RatingBanner } from "../Shared/RatingBanner";
+import ScreenUtils from "src/utils/screen";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
@@ -69,7 +70,7 @@ export const StudioCard: React.FC<IProps> = ({
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!containerWidth) return;
+    if (!containerWidth || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Studios/StudioCardGrid.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCardGrid.tsx
@@ -1,0 +1,38 @@
+import React, { useRef } from "react";
+import * as GQL from "src/core/generated-graphql";
+import { useContainerDimensions } from "../Shared/GridCard";
+import { StudioCard } from "./StudioCard";
+
+interface IStudioCardGrid {
+  studios: GQL.StudioDataFragment[];
+  fromParent: boolean | undefined;
+  selectedIds: Set<string>;
+  onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+}
+
+export const StudioCardGrid: React.FC<IStudioCardGrid> = ({
+  studios,
+  fromParent,
+  selectedIds,
+  onSelectChange,
+}) => {
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+  return (
+    <div className="row justify-content-center" ref={componentRef}>
+      {studios.map((studio) => (
+        <StudioCard
+          key={studio.id}
+          containerWidth={width}
+          studio={studio}
+          hideParent={fromParent}
+          selecting={selectedIds.size > 0}
+          selected={selectedIds.has(studio.id)}
+          onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
+            onSelectChange(studio.id, selected, shiftKey)
+          }
+        />
+      ))}
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
 import { useHistory } from "react-router-dom";
@@ -18,9 +18,8 @@ import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
-import { StudioCard } from "./StudioCard";
 import { StudioTagger } from "../Tagger/studios/StudioTagger";
-import { useContainerDimensions } from "../Shared/GridCard";
+import { StudioCardGrid } from "./StudioCardGrid";
 
 const StudioItemList = makeItemList({
   filterMode: GQL.FilterMode.Studios,
@@ -109,9 +108,6 @@ export const StudioList: React.FC<IStudioList> = ({
     setIsExportDialogOpen(true);
   }
 
-  const componentRef = useRef<HTMLDivElement>(null);
-  const { width } = useContainerDimensions(componentRef);
-
   function renderContent(
     result: GQL.FindStudiosQueryResult,
     filter: ListFilterModel,
@@ -139,21 +135,12 @@ export const StudioList: React.FC<IStudioList> = ({
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center" ref={componentRef}>
-            {result.data.findStudios.studios.map((studio) => (
-              <StudioCard
-                key={studio.id}
-                containerWidth={width}
-                studio={studio}
-                hideParent={fromParent}
-                selecting={selectedIds.size > 0}
-                selected={selectedIds.has(studio.id)}
-                onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
-                  onSelectChange(studio.id, selected, shiftKey)
-                }
-              />
-            ))}
-          </div>
+          <StudioCardGrid
+            studios={result.data.findStudios.studios}
+            fromParent={fromParent}
+            selectedIds={selectedIds}
+            onSelectChange={onSelectChange}
+          />
         );
       }
       if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import cloneDeep from "lodash-es/cloneDeep";
 import { useHistory } from "react-router-dom";
@@ -20,6 +20,7 @@ import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
 import { StudioCard } from "./StudioCard";
 import { StudioTagger } from "../Tagger/studios/StudioTagger";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 const StudioItemList = makeItemList({
   filterMode: GQL.FilterMode.Studios,
@@ -108,6 +109,9 @@ export const StudioList: React.FC<IStudioList> = ({
     setIsExportDialogOpen(true);
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderContent(
     result: GQL.FindStudiosQueryResult,
     filter: ListFilterModel,
@@ -135,10 +139,11 @@ export const StudioList: React.FC<IStudioList> = ({
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row px-xl-5 justify-content-center">
+          <div className="row justify-content-center" ref={componentRef}>
             {result.data.findStudios.studios.map((studio) => (
               <StudioCard
                 key={studio.id}
+                containerWidth={width}
                 studio={studio}
                 hideParent={fromParent}
                 selecting={selectedIds.size > 0}

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -1,5 +1,5 @@
 import { ButtonGroup } from "react-bootstrap";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
@@ -10,6 +10,7 @@ import { PopoverCountButton } from "../Shared/PopoverCountButton";
 
 interface IProps {
   tag: GQL.TagDataFragment;
+  containerWidth?: number;
   zoomIndex: number;
   selecting?: boolean;
   selected?: boolean;
@@ -18,11 +19,40 @@ interface IProps {
 
 export const TagCard: React.FC<IProps> = ({
   tag,
+  containerWidth,
   zoomIndex,
   selecting,
   selected,
   onSelectedChanged,
 }) => {
+  const [cardWidth, setCardWidth] = useState<number>();
+
+  useEffect(() => {
+    if (!containerWidth || zoomIndex === undefined) return;
+
+    let containerPadding = 30;
+    let maxUsableWidth = containerWidth - containerPadding;
+    let zoomValue = zoomIndex;
+    let maxCardWidth: number;
+    let paddingOffset = 10;
+    switch (zoomValue) {
+      case 0:
+        maxCardWidth = 240;
+        break;
+      case 1:
+        maxCardWidth = 340;
+        break;
+      case 2:
+        maxCardWidth = 480;
+        break;
+      case 3:
+        maxCardWidth = 640;
+    }
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    setCardWidth(fittedCardWidth);
+  }, [containerWidth, zoomIndex]);
+
   function maybeRenderDescription() {
     if (tag.description) {
       return (
@@ -181,6 +211,7 @@ export const TagCard: React.FC<IProps> = ({
     <GridCard
       className={`tag-card zoom-${zoomIndex}`}
       url={`/tags/${tag.id}`}
+      width={cardWidth}
       title={tag.name ?? ""}
       linkClassName="tag-card-header"
       image={

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -29,7 +29,8 @@ export const TagCard: React.FC<IProps> = ({
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!containerWidth || zoomIndex === undefined || ScreenUtils.isMobile()) return;
+    if (!containerWidth || zoomIndex === undefined || ScreenUtils.isMobile())
+      return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -7,6 +7,7 @@ import { FormattedMessage } from "react-intl";
 import { TruncatedText } from "../Shared/TruncatedText";
 import { GridCard } from "../Shared/GridCard";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
+import ScreenUtils from "src/utils/screen";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -28,7 +29,7 @@ export const TagCard: React.FC<IProps> = ({
   const [cardWidth, setCardWidth] = useState<number>();
 
   useEffect(() => {
-    if (!containerWidth || zoomIndex === undefined) return;
+    if (!containerWidth || zoomIndex === undefined || ScreenUtils.isMobile()) return;
 
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -5,7 +5,7 @@ import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import { FormattedMessage } from "react-intl";
 import { TruncatedText } from "../Shared/TruncatedText";
-import { GridCard } from "../Shared/GridCard";
+import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import ScreenUtils from "src/utils/screen";
 
@@ -32,11 +32,9 @@ export const TagCard: React.FC<IProps> = ({
     if (!containerWidth || zoomIndex === undefined || ScreenUtils.isMobile())
       return;
 
-    let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
     let zoomValue = zoomIndex;
     let preferredCardWidth: number;
-    let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
         preferredCardWidth = 240;
@@ -51,7 +49,7 @@ export const TagCard: React.FC<IProps> = ({
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
     setCardWidth(fittedCardWidth);
   }, [containerWidth, zoomIndex]);
 

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -5,7 +5,7 @@ import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import { FormattedMessage } from "react-intl";
 import { TruncatedText } from "../Shared/TruncatedText";
-import { GridCard, cardPadding, containerPadding } from "../Shared/GridCard";
+import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import ScreenUtils from "src/utils/screen";
 
@@ -49,7 +49,7 @@ export const TagCard: React.FC<IProps> = ({
         preferredCardWidth = 640;
     }
     let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardPadding;
+    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
     setCardWidth(fittedCardWidth);
   }, [containerWidth, zoomIndex]);
 

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -34,22 +34,22 @@ export const TagCard: React.FC<IProps> = ({
     let containerPadding = 30;
     let maxUsableWidth = containerWidth - containerPadding;
     let zoomValue = zoomIndex;
-    let maxCardWidth: number;
+    let preferredCardWidth: number;
     let paddingOffset = 10;
     switch (zoomValue) {
       case 0:
-        maxCardWidth = 240;
+        preferredCardWidth = 240;
         break;
       case 1:
-        maxCardWidth = 340;
+        preferredCardWidth = 340;
         break;
       case 2:
-        maxCardWidth = 480;
+        preferredCardWidth = 480;
         break;
       case 3:
-        maxCardWidth = 640;
+        preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / maxCardWidth!);
+    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
     let fittedCardWidth = maxUsableWidth / maxElementsOnRow - paddingOffset;
     setCardWidth(fittedCardWidth);
   }, [containerWidth, zoomIndex]);

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -5,7 +5,7 @@ import * as GQL from "src/core/generated-graphql";
 import NavUtils from "src/utils/navigation";
 import { FormattedMessage } from "react-intl";
 import { TruncatedText } from "../Shared/TruncatedText";
-import { GridCard, cardMargin, containerPadding } from "../Shared/GridCard";
+import { GridCard, calculateCardWidth } from "../Shared/GridCard";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import ScreenUtils from "src/utils/screen";
 
@@ -32,7 +32,6 @@ export const TagCard: React.FC<IProps> = ({
     if (!containerWidth || zoomIndex === undefined || ScreenUtils.isMobile())
       return;
 
-    let maxUsableWidth = containerWidth - containerPadding;
     let zoomValue = zoomIndex;
     let preferredCardWidth: number;
     switch (zoomValue) {
@@ -48,8 +47,10 @@ export const TagCard: React.FC<IProps> = ({
       case 3:
         preferredCardWidth = 640;
     }
-    let maxElementsOnRow = Math.ceil(maxUsableWidth / preferredCardWidth!);
-    let fittedCardWidth = maxUsableWidth / maxElementsOnRow - cardMargin;
+    let fittedCardWidth = calculateCardWidth(
+      containerWidth,
+      preferredCardWidth!
+    );
     setCardWidth(fittedCardWidth);
   }, [containerWidth, zoomIndex]);
 

--- a/ui/v2.5/src/components/Tags/TagCardGrid.tsx
+++ b/ui/v2.5/src/components/Tags/TagCardGrid.tsx
@@ -1,0 +1,38 @@
+import React, { useRef } from "react";
+import * as GQL from "src/core/generated-graphql";
+import { useContainerDimensions } from "../Shared/GridCard";
+import { TagCard } from "./TagCard";
+
+interface ITagCardGrid {
+  tags: GQL.TagDataFragment[];
+  selectedIds: Set<string>;
+  zoomIndex: number;
+  onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+}
+
+export const TagCardGrid: React.FC<ITagCardGrid> = ({
+  tags,
+  selectedIds,
+  zoomIndex,
+  onSelectChange,
+}) => {
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+  return (
+    <div className="row justify-content-center" ref={componentRef}>
+      {tags.map((tag) => (
+        <TagCard
+          key={tag.id}
+          containerWidth={width}
+          tag={tag}
+          zoomIndex={zoomIndex}
+          selecting={selectedIds.size > 0}
+          selected={selectedIds.has(tag.id)}
+          onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
+            onSelectChange(tag.id, selected, shiftKey)
+          }
+        />
+      ))}
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
@@ -24,11 +24,10 @@ import NavUtils from "src/utils/navigation";
 import { Icon } from "../Shared/Icon";
 import { ModalComponent } from "../Shared/Modal";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
-import { TagCard } from "./TagCard";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { tagRelationHook } from "../../core/tags";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import { useContainerDimensions } from "../Shared/GridCard";
+import { TagCardGrid } from "./TagCardGrid";
 
 interface ITagList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -162,9 +161,6 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
     }
   }
 
-  const componentRef = useRef<HTMLDivElement>(null);
-  const { width } = useContainerDimensions(componentRef);
-
   function renderContent(
     result: GQL.FindTagsQueryResult,
     filter: ListFilterModel,
@@ -192,21 +188,12 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row justify-content-center" ref={componentRef}>
-            {result.data.findTags.tags.map((tag) => (
-              <TagCard
-                key={tag.id}
-                containerWidth={width}
-                tag={tag}
-                zoomIndex={filter.zoomIndex}
-                selecting={selectedIds.size > 0}
-                selected={selectedIds.has(tag.id)}
-                onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
-                  onSelectChange(tag.id, selected, shiftKey)
-                }
-              />
-            ))}
-          </div>
+          <TagCardGrid
+            tags={result.data.findTags.tags}
+            zoomIndex={filter.zoomIndex}
+            selectedIds={selectedIds}
+            onSelectChange={onSelectChange}
+          />
         );
       }
       if (filter.displayMode === DisplayMode.List) {

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
@@ -28,6 +28,7 @@ import { TagCard } from "./TagCard";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { tagRelationHook } from "../../core/tags";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { useContainerDimensions } from "../Shared/GridCard";
 
 interface ITagList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -161,6 +162,9 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
     }
   }
 
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { width } = useContainerDimensions(componentRef);
+
   function renderContent(
     result: GQL.FindTagsQueryResult,
     filter: ListFilterModel,
@@ -188,10 +192,11 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
 
       if (filter.displayMode === DisplayMode.Grid) {
         return (
-          <div className="row px-xl-5 justify-content-center">
+          <div className="row justify-content-center" ref={componentRef}>
             {result.data.findTags.tags.map((tag) => (
               <TagCard
                 key={tag.id}
+                containerWidth={width}
                 tag={tag}
                 zoomIndex={filter.zoomIndex}
                 selecting={selectedIds.size > 0}

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -478,14 +478,36 @@ textarea.text-input {
 }
 
 .zoom-0 {
-  width: 240px;
+  .card-popovers {
+    svg {
+      height: .75rem;
+    }
 
-  .scene-card-preview {
-    height: 135px;
+    .btn {
+      padding-bottom: 1.8px;
+      padding-top: 1.8px;
+    }
+
+    .fa-icon {
+      margin: 0 .46rem;
+    }
   }
 
-  .portrait {
-    height: 180px;
+  h5 {
+    font-size: .875rem;
+  }
+
+  .card-section{
+    padding: .33rem .66rem 0;
+  }
+
+  .scene-card__details, .gallery-card__details {
+    margin-bottom: .66rem;
+  }
+
+  .scene-card__description,
+  span {
+    font-size: .75rem;
   }
 
   .gallery-card-image,
@@ -496,14 +518,6 @@ textarea.text-input {
 
 .zoom-1 {
   width: 320px;
-
-  .scene-card-preview {
-    height: 180px;
-  }
-
-  .portrait {
-    height: 240px;
-  }
 
   .gallery-card-image,
   .tag-card-image {
@@ -516,14 +530,36 @@ textarea.text-input {
 }
 
 .zoom-2 {
-  width: 480px;
+  .card-popovers {
+    svg {
+      height: 1.35rem;
+    }
 
-  .scene-card-preview {
-    height: 270px;
+    .btn {
+      padding-bottom: 4.8px;
+      padding-top: 4.8px;
+    }
+
+    .fa-icon {
+      margin: 0 .64rem;
+    }
   }
 
-  .portrait {
-    height: 360px;
+  h5 {
+    font-size: 2rem;
+  }
+
+  .card-section{
+    padding: .6rem 1.6rem 0;
+  }
+
+  .scene-card__details, .gallery-card__details {
+    margin-bottom: 1.6rem;
+  }
+
+  .scene-card__description,
+  span {
+    font-size: 1.35rem;
   }
 
   .gallery-card-image,
@@ -537,14 +573,36 @@ textarea.text-input {
 }
 
 .zoom-3 {
-  width: 640px;
+  .card-popovers {
+    svg {
+      height: 1.8rem;
+    }
 
-  .scene-card-preview {
-    height: 360px;
+    .btn {
+      padding-bottom: 5.4px;
+      padding-top: 5.4px;
+    }
+
+    .fa-icon {
+      margin: 0 .72rem;
+    }
   }
 
-  .portrait {
-    height: 480px;
+  h5 {
+    font-size: 2.25rem;
+  }
+
+  .card-section{
+    padding: .9rem 1.8rem 0;
+  }
+
+  .scene-card__details, .gallery-card__details {
+    margin-bottom: 1.8rem;
+  }
+
+  .scene-card__description,
+  span {
+    font-size: 1.8rem;
   }
 
   .tag-card-image,

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -478,7 +478,6 @@ textarea.text-input {
 }
 
 .zoom-0 {
-
   .gallery-card-image,
   .tag-card-image {
     max-height: 180px;
@@ -499,7 +498,6 @@ textarea.text-input {
 }
 
 .zoom-2 {
-
   .gallery-card-image,
   .tag-card-image {
     max-height: 360px;
@@ -511,7 +509,6 @@ textarea.text-input {
 }
 
 .zoom-3 {
-
   .tag-card-image,
   .gallery-card-image {
     max-height: 480px;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -478,37 +478,6 @@ textarea.text-input {
 }
 
 .zoom-0 {
-  .card-popovers {
-    svg {
-      height: .75rem;
-    }
-
-    .btn {
-      padding-bottom: 1.8px;
-      padding-top: 1.8px;
-    }
-
-    .fa-icon {
-      margin: 0 .46rem;
-    }
-  }
-
-  h5 {
-    font-size: .875rem;
-  }
-
-  .card-section{
-    padding: .33rem .66rem 0;
-  }
-
-  .scene-card__details, .gallery-card__details {
-    margin-bottom: .66rem;
-  }
-
-  .scene-card__description,
-  span {
-    font-size: .75rem;
-  }
 
   .gallery-card-image,
   .tag-card-image {
@@ -530,37 +499,6 @@ textarea.text-input {
 }
 
 .zoom-2 {
-  .card-popovers {
-    svg {
-      height: 1.35rem;
-    }
-
-    .btn {
-      padding-bottom: 4.8px;
-      padding-top: 4.8px;
-    }
-
-    .fa-icon {
-      margin: 0 .64rem;
-    }
-  }
-
-  h5 {
-    font-size: 2rem;
-  }
-
-  .card-section{
-    padding: .6rem 1.6rem 0;
-  }
-
-  .scene-card__details, .gallery-card__details {
-    margin-bottom: 1.6rem;
-  }
-
-  .scene-card__description,
-  span {
-    font-size: 1.35rem;
-  }
 
   .gallery-card-image,
   .tag-card-image {
@@ -573,37 +511,6 @@ textarea.text-input {
 }
 
 .zoom-3 {
-  .card-popovers {
-    svg {
-      height: 1.8rem;
-    }
-
-    .btn {
-      padding-bottom: 5.4px;
-      padding-top: 5.4px;
-    }
-
-    .fa-icon {
-      margin: 0 .72rem;
-    }
-  }
-
-  h5 {
-    font-size: 2.25rem;
-  }
-
-  .card-section{
-    padding: .9rem 1.8rem 0;
-  }
-
-  .scene-card__details, .gallery-card__details {
-    margin-bottom: 1.8rem;
-  }
-
-  .scene-card__description,
-  span {
-    font-size: 1.8rem;
-  }
 
   .tag-card-image,
   .gallery-card-image {

--- a/ui/v2.5/src/utils/screen.ts
+++ b/ui/v2.5/src/utils/screen.ts
@@ -1,5 +1,5 @@
 const isMobile = () =>
-  window.matchMedia("only screen and (max-width: 767px)").matches;
+  window.matchMedia("only screen and (max-width: 576px)").matches;
 
 const ScreenUtils = {
   isMobile,


### PR DESCRIPTION
The pull request updates the cards to be a bit smarter about the sizing so they properly fit into the container they exist in instead of leaving a lot of empty space on the left and right of the containers.

Here is a video of the behavior before this pull request:
https://discordapp.com/channels/559159668438728723/644934273459290145/1200240011694575656

Here is a video of the behavior after this pull request
https://discordapp.com/channels/559159668438728723/644934273459290145/1200233045987446885

Note that this pull request includes the changes from https://github.com/stashapp/stash/pull/4486, so that pull request can be closed if this gets merged first.