### PR TITLE
Only use details background image when provided

### DIFF
--- a/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/Movie.tsx
@@ -362,18 +362,22 @@ const MoviePage: React.FC<IProps> = ({ movie }) => {
   function maybeRenderHeaderBackgroundImage() {
     let image = movie.front_image_path;
     if (enableBackgroundImage && !isEditing && image) {
-      return (
-        <div className="background-image-container">
-          <picture>
-            <source src={image} />
-            <img
-              className="background-image"
-              src={image}
-              alt={`${movie.name} background`}
-            />
-          </picture>
-        </div>
-      );
+      const imageURL = new URL(image);
+      let isDefaultImage = imageURL.searchParams.get("default");
+      if (!isDefaultImage) {
+        return (
+          <div className="background-image-container">
+            <picture>
+              <source src={image} />
+              <img
+                className="background-image"
+                src={image}
+                alt={`${movie.name} background`}
+              />
+            </picture>
+          </div>
+        );
+      }
     }
   }
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -336,18 +336,22 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
 
   function maybeRenderHeaderBackgroundImage() {
     if (enableBackgroundImage && !isEditing && activeImage) {
-      return (
-        <div className="background-image-container">
-          <picture>
-            <source src={activeImage} />
-            <img
-              className="background-image"
-              src={activeImage}
-              alt={`${performer.name} background`}
-            />
-          </picture>
-        </div>
-      );
+      const activeImageURL = new URL(activeImage);
+      let isDefaultImage = activeImageURL.searchParams.get("default");
+      if (!isDefaultImage) {
+        return (
+          <div className="background-image-container">
+            <picture>
+              <source src={activeImage} />
+              <img
+                className="background-image"
+                src={activeImage}
+                alt={`${performer.name} background`}
+              />
+            </picture>
+          </div>
+        );
+      }
     }
   }
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -455,18 +455,22 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
   function maybeRenderHeaderBackgroundImage() {
     let studioImage = studio.image_path;
     if (enableBackgroundImage && !isEditing && studioImage) {
-      return (
-        <div className="background-image-container">
-          <picture>
-            <source src={studioImage} />
-            <img
-              className="background-image"
-              src={studioImage}
-              alt={`${studio.name} background`}
-            />
-          </picture>
-        </div>
-      );
+      const studioImageURL = new URL(studioImage);
+      let isDefaultImage = studioImageURL.searchParams.get("default");
+      if (!isDefaultImage) {
+        return (
+          <div className="background-image-container">
+            <picture>
+              <source src={studioImage} />
+              <img
+                className="background-image"
+                src={studioImage}
+                alt={`${studio.name} background`}
+              />
+            </picture>
+          </div>
+        );
+      }
     }
   }
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -471,18 +471,22 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
   function maybeRenderHeaderBackgroundImage() {
     let tagImage = tag.image_path;
     if (enableBackgroundImage && !isEditing && tagImage) {
-      return (
-        <div className="background-image-container">
-          <picture>
-            <source src={tagImage} />
-            <img
-              className="background-image"
-              src={tagImage}
-              alt={`${tag.name} background`}
-            />
-          </picture>
-        </div>
-      );
+      const tagImageURL = new URL(tagImage);
+      let isDefaultImage = tagImageURL.searchParams.get("default");
+      if (!isDefaultImage) {
+        return (
+          <div className="background-image-container">
+            <picture>
+              <source src={tagImage} />
+              <img
+                className="background-image"
+                src={tagImage}
+                alt={`${tag.name} background`}
+              />
+            </picture>
+          </div>
+        );
+      }
     }
   }
 


### PR DESCRIPTION
This pull request updates the details page so that it only uses a background image when an image is provided.