### PR TITLE
Scene filters save json

### DIFF
--- a/graphql/documents/data/scene-slim.graphql
+++ b/graphql/documents/data/scene-slim.graphql
@@ -11,6 +11,7 @@ fragment SlimSceneData on Scene {
   organized
   interactive
   interactive_speed
+  filters
   resume_time
   play_duration
   play_count

--- a/graphql/documents/data/scene.graphql
+++ b/graphql/documents/data/scene.graphql
@@ -11,6 +11,7 @@ fragment SceneData on Scene {
   organized
   interactive
   interactive_speed
+  filters
   captions {
     language_code
     caption_type

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -57,6 +57,8 @@ type Scene {
   play_duration: Float
   "The number ot times a scene has been played"
   play_count: Int
+  "Scene filters JSON data"
+  filters: String
 
   files: [VideoFile!]!
   paths: ScenePathsType! # Resolver
@@ -96,7 +98,7 @@ input SceneCreateInput {
   "This should be a URL or a base64 encoded data URL"
   cover_image: String
   stash_ids: [StashIDInput!]
-
+  filters: String
   """
   The first id will be assigned as primary.
   Files will be reassigned from existing scenes if applicable.
@@ -127,6 +129,7 @@ input SceneUpdateInput {
   "This should be a URL or a base64 encoded data URL"
   cover_image: String
   stash_ids: [StashIDInput!]
+  filters: String
 
   "The time index a scene was left at"
   resume_time: Float

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -48,6 +48,7 @@ func (r *mutationResolver) SceneCreate(ctx context.Context, input models.SceneCr
 	newScene.Rating = input.Rating100
 	newScene.Organized = translator.bool(input.Organized)
 	newScene.StashIDs = models.NewRelatedStashIDs(input.StashIds)
+	newScene.Filters = translator.string(input.Filters)
 
 	newScene.Date, err = translator.datePtr(input.Date)
 	if err != nil {
@@ -174,6 +175,7 @@ func scenePartialFromInput(input models.SceneUpdateInput, translator changesetTr
 	updatedScene.PlayDuration = translator.optionalFloat64(input.PlayDuration, "play_duration")
 	updatedScene.Organized = translator.optionalBool(input.Organized, "organized")
 	updatedScene.StashIDs = translator.updateStashIDs(input.StashIds, "stash_ids")
+	updatedScene.Filters = translator.optionalString(input.Filters, "filters")
 
 	var err error
 

--- a/pkg/models/jsonschema/scene.go
+++ b/pkg/models/jsonschema/scene.go
@@ -67,6 +67,7 @@ type Scene struct {
 	PlayCount    int              `json:"play_count,omitempty"`
 	PlayDuration float64          `json:"play_duration,omitempty"`
 	StashIDs     []models.StashID `json:"stash_ids,omitempty"`
+	Filters      string           `json:"filters,omitempty"`
 }
 
 func (s Scene) Filename(id int, basename string, hash string) string {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -46,8 +46,7 @@ type Scene struct {
 	PerformerIDs RelatedIDs      `json:"performer_ids"`
 	Movies       RelatedMovies   `json:"movies"`
 	StashIDs     RelatedStashIDs `json:"stash_ids"`
-	Filters       string 		 `json:"filters"`
-
+	Filters      string          `json:"filters"`
 }
 
 func NewScene() Scene {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -46,6 +46,8 @@ type Scene struct {
 	PerformerIDs RelatedIDs      `json:"performer_ids"`
 	Movies       RelatedMovies   `json:"movies"`
 	StashIDs     RelatedStashIDs `json:"stash_ids"`
+	Filters       string 		 `json:"filters"`
+
 }
 
 func NewScene() Scene {
@@ -75,6 +77,7 @@ type ScenePartial struct {
 	PlayDuration OptionalFloat64
 	PlayCount    OptionalInt
 	LastPlayedAt OptionalTime
+	Filters      OptionalString
 
 	URLs          *UpdateStrings
 	GalleryIDs    *UpdateIDs

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -95,6 +95,9 @@ type SceneFilterType struct {
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at
 	UpdatedAt *TimestampCriterionInput `json:"updated_at"`
+	// Filter by scene filters
+	Filters   *StringCriterionInput `json:"filters"`
+
 }
 
 type SceneQueryOptions struct {
@@ -138,6 +141,7 @@ type SceneCreateInput struct {
 	// This should be a URL or a base64 encoded data URL
 	CoverImage *string   `json:"cover_image"`
 	StashIds   []StashID `json:"stash_ids"`
+	Filters    *string   `json:"filters"`
 	// The first id will be assigned as primary.
 	// Files will be reassigned from existing scenes if applicable.
 	// Files must not already be primary for another scene.
@@ -162,6 +166,7 @@ type SceneUpdateInput struct {
 	PerformerIds     []string          `json:"performer_ids"`
 	Movies           []SceneMovieInput `json:"movies"`
 	TagIds           []string          `json:"tag_ids"`
+	Filters          *string           `json:"filters"`
 	// This should be a URL or a base64 encoded data URL
 	CoverImage    *string   `json:"cover_image"`
 	StashIds      []StashID `json:"stash_ids"`

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -96,8 +96,7 @@ type SceneFilterType struct {
 	// Filter by updated at
 	UpdatedAt *TimestampCriterionInput `json:"updated_at"`
 	// Filter by scene filters
-	Filters   *StringCriterionInput `json:"filters"`
-
+	Filters *StringCriterionInput `json:"filters"`
 }
 
 type SceneQueryOptions struct {

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -33,7 +33,7 @@ const (
 	dbConnTimeout = 30
 )
 
-var appSchemaVersion uint = 54
+var appSchemaVersion uint = 55
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/55_scene_filters.up.sql
+++ b/pkg/sqlite/migrations/55_scene_filters.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scenes
+ADD COLUMN filters text;

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -89,6 +89,7 @@ type sceneRow struct {
 	ResumeTime   float64       `db:"resume_time"`
 	PlayDuration float64       `db:"play_duration"`
 	PlayCount    int           `db:"play_count"`
+	Filters      zero.String   `db:"filters"`
 
 	// not used in resolutions or updates
 	CoverBlob zero.String `db:"cover_blob"`
@@ -111,6 +112,7 @@ func (r *sceneRow) fromScene(o models.Scene) {
 	r.ResumeTime = o.ResumeTime
 	r.PlayDuration = o.PlayDuration
 	r.PlayCount = o.PlayCount
+	r.Filters = zero.StringFrom(o.Filters)
 }
 
 type sceneQueryRow struct {
@@ -146,6 +148,7 @@ func (r *sceneQueryRow) resolve() *models.Scene {
 		ResumeTime:   r.ResumeTime,
 		PlayDuration: r.PlayDuration,
 		PlayCount:    r.PlayCount,
+		Filters:      r.Filters.String,
 	}
 
 	if r.PrimaryFileFolderPath.Valid && r.PrimaryFileBasename.Valid {
@@ -175,6 +178,7 @@ func (r *sceneRowRecord) fromPartial(o models.ScenePartial) {
 	r.setFloat64("resume_time", o.ResumeTime)
 	r.setFloat64("play_duration", o.PlayDuration)
 	r.setInt("play_count", o.PlayCount)
+	r.setNullString("filters", o.Filters)
 }
 
 type SceneStore struct {
@@ -1012,6 +1016,7 @@ func (qb *SceneStore) makeFilter(ctx context.Context, sceneFilter *models.SceneF
 	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.ResumeTime, "scenes.resume_time", nil))
 	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.PlayDuration, "scenes.play_duration", nil))
 	query.handleCriterion(ctx, intCriterionHandler(sceneFilter.PlayCount, "scenes.play_count", nil))
+	query.handleCriterion(ctx, stringCriterionHandler(sceneFilter.Filters, "scenes.filters"))
 
 	query.handleCriterion(ctx, sceneTagsCriterionHandler(qb, sceneFilter.Tags))
 	query.handleCriterion(ctx, sceneTagCountCriterionHandler(qb, sceneFilter.TagCount))

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -41,6 +41,7 @@ import {
   faChevronLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import { lazyComponent } from "src/utils/lazyComponent";
+import { updateSceneFilters, updateSceneFiltersStyle } from "src/utils/sceneFilters";
 
 const SubmitStashBoxDraft = lazyComponent(
   () => import("src/components/Dialogs/SubmitDraft")
@@ -75,7 +76,9 @@ const SceneVideoFilterPanel = lazyComponent(
 import { objectPath, objectTitle } from "src/core/files";
 
 interface IProps {
-  scene: GQL.SceneDataFragment;
+  scene: GQL.SceneDataFragment & {
+    filters?: string | null | undefined;
+  };
   setTimestamp: (num: number) => void;
   queueScenes: QueuedScene[];
   onQueueNext: () => void;
@@ -157,6 +160,7 @@ const ScenePage: React.FC<IProps> = ({
     Mousetrap.bind("q", () => setActiveTabKey("scene-queue-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("scene-edit-panel"));
     Mousetrap.bind("k", () => setActiveTabKey("scene-markers-panel"));
+    Mousetrap.bind("t", () => setActiveTabKey("scene-filters-panel"));
     Mousetrap.bind("i", () => setActiveTabKey("scene-file-info-panel"));
     Mousetrap.bind("o", () => {
       onIncrementClick();
@@ -171,6 +175,7 @@ const ScenePage: React.FC<IProps> = ({
       Mousetrap.unbind("q");
       Mousetrap.unbind("e");
       Mousetrap.unbind("k");
+      Mousetrap.unbind("t");
       Mousetrap.unbind("i");
       Mousetrap.unbind("o");
       Mousetrap.unbind("p n");
@@ -474,7 +479,9 @@ const ScenePage: React.FC<IProps> = ({
           </Tab.Pane>
         )}
         <Tab.Pane eventKey="scene-video-filter-panel">
-          <SceneVideoFilterPanel scene={scene} />
+          <SceneVideoFilterPanel scene={scene} 
+            isVisible={activeTabKey === "scene-filters-panel"}
+          />
         </Tab.Pane>
         <Tab.Pane className="file-info-panel" eventKey="scene-file-info-panel">
           <SceneFileInfoPanel scene={scene} />

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -41,7 +41,6 @@ import {
   faChevronLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import { lazyComponent } from "src/utils/lazyComponent";
-import { updateSceneFilters, updateSceneFiltersStyle } from "src/utils/sceneFilters";
 
 const SubmitStashBoxDraft = lazyComponent(
   () => import("src/components/Dialogs/SubmitDraft")
@@ -160,7 +159,7 @@ const ScenePage: React.FC<IProps> = ({
     Mousetrap.bind("q", () => setActiveTabKey("scene-queue-panel"));
     Mousetrap.bind("e", () => setActiveTabKey("scene-edit-panel"));
     Mousetrap.bind("k", () => setActiveTabKey("scene-markers-panel"));
-    Mousetrap.bind("t", () => setActiveTabKey("scene-filters-panel"));
+    Mousetrap.bind("f", () => setActiveTabKey("scene-video-filter-panel"));
     Mousetrap.bind("i", () => setActiveTabKey("scene-file-info-panel"));
     Mousetrap.bind("o", () => {
       onIncrementClick();
@@ -175,7 +174,7 @@ const ScenePage: React.FC<IProps> = ({
       Mousetrap.unbind("q");
       Mousetrap.unbind("e");
       Mousetrap.unbind("k");
-      Mousetrap.unbind("t");
+      Mousetrap.unbind("f");
       Mousetrap.unbind("i");
       Mousetrap.unbind("o");
       Mousetrap.unbind("p n");
@@ -479,7 +478,8 @@ const ScenePage: React.FC<IProps> = ({
           </Tab.Pane>
         )}
         <Tab.Pane eventKey="scene-video-filter-panel">
-          <SceneVideoFilterPanel scene={scene} 
+          <SceneVideoFilterPanel
+            scene={scene}
             isVisible={activeTabKey === "scene-filters-panel"}
           />
         </Tab.Pane>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1390,7 +1390,9 @@
     "started_auto_tagging": "Started auto tagging",
     "started_generating": "Started generating",
     "started_importing": "Started importing",
-    "updated_entity": "Updated {entity}"
+    "updated_entity": "Updated {entity}",
+    "scene_video_filter_saved": "Scene filter saved",
+    "scene_video_filter_deleted": "Scene filter deleted"
   },
   "total": "Total",
   "true": "True",

--- a/ui/v2.5/src/utils/sceneFilters.ts
+++ b/ui/v2.5/src/utils/sceneFilters.ts
@@ -1,0 +1,331 @@
+import { VIDEO_PLAYER_ID } from "src/components/ScenePlayer/util";
+
+type SliderRange = {
+  min: number;
+  default: number;
+  max: number;
+  divider: number;
+};
+
+export const sliderRanges: { [key: string]: SliderRange } = {
+  contrastRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 1,
+  },
+  brightnessRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 1,
+  },
+  gammaRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 200,
+  },
+  saturateRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 1,
+  },
+  hueRotateRange: {
+    min: 0,
+    default: 0,
+    max: 360,
+    divider: 1,
+  },
+  warmthRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 200,
+  },
+  colourRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 1,
+  },
+  blurRange: {
+    min: 0,
+    default: 0,
+    max: 250,
+    divider: 10,
+  },
+  rotateRange: {
+    min: 0,
+    default: 2,
+    max: 4,
+    divider: 1 / 90,
+  },
+  scaleRange: {
+    min: 0,
+    default: 100,
+    max: 200,
+    divider: 1,
+  },
+  aspectRatioRange: {
+    min: 0,
+    default: 150,
+    max: 300,
+    divider: 100,
+  },
+};
+
+// eslint-disable-next-line
+function getVideoElement(playerVideoContainer: any) {
+  let videoElements = playerVideoContainer.getElementsByTagName("canvas");
+
+  if (videoElements.length == 0) {
+    videoElements = playerVideoContainer.getElementsByTagName("video");
+  }
+
+  if (videoElements.length > 0) {
+    return videoElements[0];
+  }
+}
+
+export function updateSceneFilters(
+  gammaValue: number,
+  redValue: number,
+  greenValue: number,
+  blueValue: number,
+  warmthValue: number
+): void {
+  const filterContainer = document.getElementById("video-filter-container");
+
+  if (filterContainer == null) {
+    return;
+  }
+
+  const svg1 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  const videoFilter = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "filter"
+  );
+  videoFilter.setAttribute("id", "videoFilter");
+
+  if (
+    warmthValue !== sliderRanges.warmthRange.default ||
+    redValue !== sliderRanges.colourRange.default ||
+    greenValue !== sliderRanges.colourRange.default ||
+    blueValue !== sliderRanges.colourRange.default
+  ) {
+    const feColorMatrix = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feColorMatrix"
+    );
+    feColorMatrix.setAttribute(
+      "values",
+      `${
+        1 +
+        (warmthValue - sliderRanges.warmthRange.default) /
+          sliderRanges.warmthRange.divider +
+        (redValue - sliderRanges.colourRange.default) /
+          sliderRanges.colourRange.divider
+      } 0 0 0 0   0 ${
+        1.0 +
+        (greenValue - sliderRanges.colourRange.default) /
+          sliderRanges.colourRange.divider
+      } 0 0 0   0 0 ${
+        1 -
+        (warmthValue - sliderRanges.warmthRange.default) /
+          sliderRanges.warmthRange.divider +
+        (blueValue - sliderRanges.colourRange.default) /
+          sliderRanges.colourRange.divider
+      } 0 0   0 0 0 1.0 0`
+    );
+    videoFilter.appendChild(feColorMatrix);
+  }
+
+  if (gammaValue !== sliderRanges.gammaRange.default) {
+    const feComponentTransfer = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feComponentTransfer"
+    );
+
+    const feFuncR = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feFuncR"
+    );
+    feFuncR.setAttribute("type", "gamma");
+    feFuncR.setAttribute("amplitude", "1.0");
+    feFuncR.setAttribute(
+      "exponent",
+      `${
+        1 +
+        (sliderRanges.gammaRange.default - gammaValue) /
+          sliderRanges.gammaRange.divider
+      }`
+    );
+    feFuncR.setAttribute("offset", "0.0");
+    feComponentTransfer.appendChild(feFuncR);
+
+    const feFuncG = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feFuncG"
+    );
+    feFuncG.setAttribute("type", "gamma");
+    feFuncG.setAttribute("amplitude", "1.0");
+    feFuncG.setAttribute(
+      "exponent",
+      `${
+        1 +
+        (sliderRanges.gammaRange.default - gammaValue) /
+          sliderRanges.gammaRange.divider
+      }`
+    );
+    feFuncG.setAttribute("offset", "0.0");
+    feComponentTransfer.appendChild(feFuncG);
+
+    const feFuncB = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feFuncB"
+    );
+    feFuncB.setAttribute("type", "gamma");
+    feFuncB.setAttribute("amplitude", "1.0");
+    feFuncB.setAttribute(
+      "exponent",
+      `${
+        1 +
+        (sliderRanges.gammaRange.default - gammaValue) /
+          sliderRanges.gammaRange.divider
+      }`
+    );
+    feFuncB.setAttribute("offset", "0.0");
+    feComponentTransfer.appendChild(feFuncB);
+
+    const feFuncA = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "feFuncA"
+    );
+    feFuncA.setAttribute("type", "gamma");
+    feFuncA.setAttribute("amplitude", "1.0");
+    feFuncA.setAttribute("exponent", "1.0");
+    feFuncA.setAttribute("offset", "0.0");
+    feComponentTransfer.appendChild(feFuncA);
+
+    videoFilter.appendChild(feComponentTransfer);
+  }
+
+  svg1.appendChild(videoFilter);
+
+  // Add or Replace existing svg
+  const filterContainerSvgs = filterContainer.getElementsByTagNameNS(
+    "http://www.w3.org/2000/svg",
+    "svg"
+  );
+  if (filterContainerSvgs.length === 0) {
+    // attach container to document
+    filterContainer.appendChild(svg1);
+  } else {
+    // assume only one svg... maybe issue
+    filterContainer.replaceChild(svg1, filterContainerSvgs[0]);
+  }
+}
+
+export function updateSceneFiltersStyle(
+  aspectRatioValue: number,
+  blurValue: number,
+  brightnessValue: number,
+  contrastValue: number,
+  gammaValue: number,
+  hueRotateValue: number,
+  redValue: number,
+  greenValue: number,
+  blueValue: number,
+  rotateValue: number,
+  saturateValue: number,
+  scaleValue: number,
+  warmthValue: number
+): void {
+  const playerVideoContainer = document.getElementById(VIDEO_PLAYER_ID)!;
+  if (!playerVideoContainer) {
+    return;
+  }
+
+  const playerVideoElement = getVideoElement(playerVideoContainer);
+  if (playerVideoElement != null) {
+    let styleString = "filter:";
+    let style = playerVideoElement.attributes.getNamedItem("style");
+
+    if (style == null) {
+      style = document.createAttribute("style");
+      playerVideoElement.attributes.setNamedItem(style);
+    }
+
+    if (
+      warmthValue !== sliderRanges.warmthRange.default ||
+      redValue !== sliderRanges.colourRange.default ||
+      greenValue !== sliderRanges.colourRange.default ||
+      blueValue !== sliderRanges.colourRange.default ||
+      gammaValue !== sliderRanges.gammaRange.default
+    ) {
+      styleString += " url(#videoFilter)";
+    }
+
+    if (contrastValue !== sliderRanges.contrastRange.default) {
+      styleString += ` contrast(${contrastValue}%)`;
+    }
+
+    if (brightnessValue !== sliderRanges.brightnessRange.default) {
+      styleString += ` brightness(${brightnessValue}%)`;
+    }
+
+    if (saturateValue !== sliderRanges.saturateRange.default) {
+      styleString += ` saturate(${saturateValue}%)`;
+    }
+
+    if (hueRotateValue !== sliderRanges.hueRotateRange.default) {
+      styleString += ` hue-rotate(${hueRotateValue}deg)`;
+    }
+
+    if (blurValue > sliderRanges.blurRange.default) {
+      styleString += ` blur(${blurValue / sliderRanges.blurRange.divider}px)`;
+    }
+
+    styleString += "; transform:";
+
+    if (rotateValue !== sliderRanges.rotateRange.default) {
+      styleString += ` rotate(${
+        (rotateValue - sliderRanges.rotateRange.default) /
+        sliderRanges.rotateRange.divider
+      }deg)`;
+    }
+
+    if (
+      scaleValue !== sliderRanges.scaleRange.default ||
+      aspectRatioValue !== sliderRanges.aspectRatioRange.default
+    ) {
+      let xScale = scaleValue / sliderRanges.scaleRange.divider / 100.0;
+      let yScale = scaleValue / sliderRanges.scaleRange.divider / 100.0;
+
+      if (aspectRatioValue > sliderRanges.aspectRatioRange.default) {
+        xScale *=
+          (sliderRanges.aspectRatioRange.divider +
+            aspectRatioValue -
+            sliderRanges.aspectRatioRange.default) /
+          sliderRanges.aspectRatioRange.divider;
+      } else if (aspectRatioValue < sliderRanges.aspectRatioRange.default) {
+        yScale *=
+          (sliderRanges.aspectRatioRange.divider +
+            sliderRanges.aspectRatioRange.default -
+            aspectRatioValue) /
+          sliderRanges.aspectRatioRange.divider;
+      }
+
+      styleString += ` scale(${xScale},${yScale})`;
+    }
+
+    if (playerVideoElement.tagName == "CANVAS") {
+      styleString += "; width: 100%; height: 100%; position: absolute; top:0";
+    }
+
+    style.value = `${styleString};`;
+  }
+}
+

--- a/ui/v2.5/src/utils/sceneFilters.ts
+++ b/ui/v2.5/src/utils/sceneFilters.ts
@@ -328,4 +328,3 @@ export function updateSceneFiltersStyle(
     style.value = `${styleString};`;
   }
 }
-


### PR DESCRIPTION
As discussed on Discord this PR adds the ability to save scene filters with a different method to this [PR: 4026](https://github.com/stashapp/stash/pull/4026)

Added a scene filters column to the scenes table. All scene filters are packaged up as a JSON object client side to be saved. And upon scene load, they are retrieved and the filters are applied to the scene on scene load, and appropriate form slider values are set on the scenes filter tab

The scene filter tab is now set with mousetrap hotkey "f"

Maybe one change is needed, I thought the top was the most appropriate place for the save and delete buttons as the bottom is already crowded with transform and reset buttons?

Hopefully this is coded better than the last attempt and more suited to the direction of Stash.


