### PR TITLE
Fix tag popper over card

### DIFF
--- a/ui/v2.5/src/components/Tags/styles.scss
+++ b/ui/v2.5/src/components/Tags/styles.scss
@@ -70,6 +70,7 @@
     box-shadow: none;
     max-width: calc(100vw - 2rem);
     padding: 0;
+    width: 240px;
   }
 }
 


### PR DESCRIPTION
The tag popper used to inherit the `width: 240px` property from the `.zoom-0` rule. The width property was removed from the `.zoom-0` rule in https://github.com/stashapp/stash/pull/4514. This pull request intends to restore that style to the tag popper cards.