### PR TITLE
Fix UI config mutation not working

### DIFF
--- a/ui/v2.5/graphql/client-schema.graphql
+++ b/ui/v2.5/graphql/client-schema.graphql
@@ -22,5 +22,5 @@ extend input SetDefaultFilterInput {
 }
 
 extend type Mutation {
-  configureUI(input: UIConfig!): UIConfig!
+  configureUI(input: Map!): UIConfig!
 }

--- a/ui/v2.5/graphql/mutations/config.graphql
+++ b/ui/v2.5/graphql/mutations/config.graphql
@@ -36,7 +36,7 @@ mutation ConfigureDefaults($input: ConfigDefaultSettingsInput!) {
   }
 }
 
-mutation ConfigureUI($input: UIConfig!) {
+mutation ConfigureUI($input: Map!) {
   configureUI(input: $input)
 }
 

--- a/ui/v2.5/src/components/Settings/context.tsx
+++ b/ui/v2.5/src/components/Settings/context.tsx
@@ -423,13 +423,15 @@ export const SettingsContext: React.FC = ({ children }) => {
     });
   }
 
+  type UIConfigInput = GQL.Scalars["Map"]["input"];
+
   // saves the configuration if no further changes are made after a half second
   const saveUIConfig = useDebounce(async (input: IUIConfig) => {
     try {
       setUpdateSuccess(undefined);
       await updateUIConfig({
         variables: {
-          input,
+          input: input as UIConfigInput,
         },
       });
 


### PR DESCRIPTION
Fixes issue presumably introduced by #4511 where the `ConfigureUI` mutation errored out due to the server not knowing what `UIConfig` is. @DingDongSoLong4 you may have a cleaner fix for this, but this appears to fix the issue for the moment.