### PR TITLE
Fix url not updated for default tab on Performer/Studio/Tag pages

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -48,7 +48,7 @@ import { ExternalLink } from "src/components/Shared/ExternalLink";
 
 interface IProps {
   performer: GQL.PerformerDataFragment;
-  tabKey: TabKey;
+  tabKey?: TabKey;
 }
 
 interface IPerformerParams {
@@ -65,8 +65,6 @@ const validTabs = [
   "appearswith",
 ] as const;
 type TabKey = (typeof validTabs)[number];
-
-const defaultTab: TabKey = "default";
 
 function isTabKey(tab: string): tab is TabKey {
   return validTabs.includes(tab as TabKey);
@@ -135,8 +133,7 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
 
   const setTabKey = useCallback(
     (newTabKey: string | null) => {
-      if (!newTabKey || newTabKey === defaultTab)
-        newTabKey = populatedDefaultTab;
+      if (!newTabKey) newTabKey = populatedDefaultTab;
       if (newTabKey === tabKey) return;
 
       if (isTabKey(newTabKey)) {
@@ -147,7 +144,7 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
   );
 
   useEffect(() => {
-    if (tabKey === defaultTab) {
+    if (!tabKey) {
       setTabKey(populatedDefaultTab);
     }
   }, [setTabKey, populatedDefaultTab, tabKey]);
@@ -625,11 +622,7 @@ const PerformerLoader: React.FC<RouteComponentProps<IPerformerParams>> = ({
   if (!data?.findPerformer)
     return <ErrorMessage error={`No performer found with id ${id}.`} />;
 
-  if (!tab) {
-    return <PerformerPage performer={data.findPerformer} tabKey={defaultTab} />;
-  }
-
-  if (!isTabKey(tab)) {
+  if (tab && !isTabKey(tab)) {
     return (
       <Redirect
         to={{
@@ -640,7 +633,12 @@ const PerformerLoader: React.FC<RouteComponentProps<IPerformerParams>> = ({
     );
   }
 
-  return <PerformerPage performer={data.findPerformer} tabKey={tab} />;
+  return (
+    <PerformerPage
+      performer={data.findPerformer}
+      tabKey={tab as TabKey | undefined}
+    />
+  );
 };
 
 export default PerformerLoader;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Tabs, Tab, Col, Row } from "react-bootstrap";
 import { useIntl } from "react-intl";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
@@ -133,20 +133,24 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
     return ret;
   }, [performer]);
 
-  if (tabKey === defaultTab) {
-    tabKey = populatedDefaultTab;
-  }
+  const setTabKey = useCallback(
+    (newTabKey: string | null) => {
+      if (!newTabKey || newTabKey === defaultTab)
+        newTabKey = populatedDefaultTab;
+      if (newTabKey === tabKey) return;
 
-  function setTabKey(newTabKey: string | null) {
-    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
-    if (newTabKey === tabKey) return;
+      if (isTabKey(newTabKey)) {
+        history.replace(`/performers/${performer.id}/${newTabKey}`);
+      }
+    },
+    [populatedDefaultTab, tabKey, history, performer.id]
+  );
 
-    if (newTabKey === populatedDefaultTab) {
-      history.replace(`/performers/${performer.id}`);
-    } else if (isTabKey(newTabKey)) {
-      history.replace(`/performers/${performer.id}/${newTabKey}`);
+  useEffect(() => {
+    if (tabKey === defaultTab) {
+      setTabKey(populatedDefaultTab);
     }
-  }
+  }, [setTabKey, populatedDefaultTab, tabKey]);
 
   async function onAutoTag() {
     try {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -48,7 +48,7 @@ import { ExternalLink } from "src/components/Shared/ExternalLink";
 
 interface IProps {
   studio: GQL.StudioDataFragment;
-  tabKey: TabKey;
+  tabKey?: TabKey;
 }
 
 interface IStudioParams {
@@ -140,8 +140,7 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
 
   const setTabKey = useCallback(
     (newTabKey: string | null) => {
-      if (!newTabKey || newTabKey === defaultTab)
-        newTabKey = populatedDefaultTab;
+      if (!newTabKey) newTabKey = populatedDefaultTab;
       if (newTabKey === tabKey) return;
 
       if (isTabKey(newTabKey)) {
@@ -578,11 +577,7 @@ const StudioLoader: React.FC<RouteComponentProps<IStudioParams>> = ({
   if (!data?.findStudio)
     return <ErrorMessage error={`No studio found with id ${id}.`} />;
 
-  if (!tab) {
-    return <StudioPage studio={data.findStudio} tabKey={defaultTab} />;
-  }
-
-  if (!isTabKey(tab)) {
+  if (tab && !isTabKey(tab)) {
     return (
       <Redirect
         to={{
@@ -593,7 +588,9 @@ const StudioLoader: React.FC<RouteComponentProps<IStudioParams>> = ({
     );
   }
 
-  return <StudioPage studio={data.findStudio} tabKey={tab} />;
+  return (
+    <StudioPage studio={data.findStudio} tabKey={tab as TabKey | undefined} />
+  );
 };
 
 export default StudioLoader;

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -1,5 +1,5 @@
 import { Button, Tabs, Tab } from "react-bootstrap";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -138,9 +138,24 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
     studio,
   ]);
 
-  if (tabKey === defaultTab) {
-    tabKey = populatedDefaultTab;
-  }
+  const setTabKey = useCallback(
+    (newTabKey: string | null) => {
+      if (!newTabKey || newTabKey === defaultTab)
+        newTabKey = populatedDefaultTab;
+      if (newTabKey === tabKey) return;
+
+      if (isTabKey(newTabKey)) {
+        history.replace(`/studios/${studio.id}/${newTabKey}`);
+      }
+    },
+    [populatedDefaultTab, tabKey, history, studio.id]
+  );
+
+  useEffect(() => {
+    if (tabKey === defaultTab) {
+      setTabKey(populatedDefaultTab);
+    }
+  }, [setTabKey, populatedDefaultTab, tabKey]);
 
   // set up hotkeys
   useEffect(() => {
@@ -267,17 +282,6 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
       return (
         <DetailImage className="logo" alt={studio.name} src={studioImage} />
       );
-    }
-  }
-
-  function setTabKey(newTabKey: string | null) {
-    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
-    if (newTabKey === tabKey) return;
-
-    if (newTabKey === populatedDefaultTab) {
-      history.replace(`/studios/${studio.id}`);
-    } else if (isTabKey(newTabKey)) {
-      history.replace(`/studios/${studio.id}/${newTabKey}`);
     }
   }
 

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -43,7 +43,7 @@ import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 interface IProps {
   tag: GQL.TagDataFragment;
-  tabKey: TabKey;
+  tabKey?: TabKey;
 }
 
 interface ITagParams {
@@ -60,8 +60,6 @@ const validTabs = [
   "performers",
 ] as const;
 type TabKey = (typeof validTabs)[number];
-
-const defaultTab: TabKey = "default";
 
 function isTabKey(tab: string): tab is TabKey {
   return validTabs.includes(tab as TabKey);
@@ -126,8 +124,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
 
   const setTabKey = useCallback(
     (newTabKey: string | null) => {
-      if (!newTabKey || newTabKey === defaultTab)
-        newTabKey = populatedDefaultTab;
+      if (!newTabKey) newTabKey = populatedDefaultTab;
       if (newTabKey === tabKey) return;
 
       if (isTabKey(newTabKey)) {
@@ -138,7 +135,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
   );
 
   useEffect(() => {
-    if (tabKey === defaultTab) {
+    if (!tabKey) {
       setTabKey(populatedDefaultTab);
     }
   }, [setTabKey, populatedDefaultTab, tabKey]);
@@ -568,11 +565,7 @@ const TagLoader: React.FC<RouteComponentProps<ITagParams>> = ({
   if (!data?.findTag)
     return <ErrorMessage error={`No tag found with id ${id}.`} />;
 
-  if (!tab) {
-    return <TagPage tag={data.findTag} tabKey={defaultTab} />;
-  }
-
-  if (!isTabKey(tab)) {
+  if (tab && !isTabKey(tab)) {
     return (
       <Redirect
         to={{
@@ -583,7 +576,7 @@ const TagLoader: React.FC<RouteComponentProps<ITagParams>> = ({
     );
   }
 
-  return <TagPage tag={data.findTag} tabKey={tab} />;
+  return <TagPage tag={data.findTag} tabKey={tab as TabKey | undefined} />;
 };
 
 export default TagLoader;

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -1,5 +1,5 @@
 import { Tabs, Tab, Dropdown, Button } from "react-bootstrap";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -124,20 +124,24 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
     return ret;
   }, [sceneCount, imageCount, galleryCount, sceneMarkerCount, performerCount]);
 
-  if (tabKey === defaultTab) {
-    tabKey = populatedDefaultTab;
-  }
+  const setTabKey = useCallback(
+    (newTabKey: string | null) => {
+      if (!newTabKey || newTabKey === defaultTab)
+        newTabKey = populatedDefaultTab;
+      if (newTabKey === tabKey) return;
 
-  function setTabKey(newTabKey: string | null) {
-    if (!newTabKey || newTabKey === defaultTab) newTabKey = populatedDefaultTab;
-    if (newTabKey === tabKey) return;
+      if (isTabKey(newTabKey)) {
+        history.replace(`/tags/${tag.id}/${newTabKey}`);
+      }
+    },
+    [populatedDefaultTab, tabKey, history, tag.id]
+  );
 
-    if (newTabKey === populatedDefaultTab) {
-      history.replace(`/tags/${tag.id}`);
-    } else if (isTabKey(newTabKey)) {
-      history.replace(`/tags/${tag.id}/${newTabKey}`);
+  useEffect(() => {
+    if (tabKey === defaultTab) {
+      setTabKey(populatedDefaultTab);
     }
-  }
+  }, [setTabKey, populatedDefaultTab, tabKey]);
 
   // set up hotkeys
   useEffect(() => {


### PR DESCRIPTION
I think it should be expected that the URL show the full URL on Performer/Studio/Tag (`/performers/x/scenes` vs `/performers/x` displaying the default scenes tab). I think also that some plugins are listening for URL changes, and the existing behaviour doesn't indicate the current view correctly for them.

Fixes #4209 