### PR TITLE
Toast improvements

### DIFF
--- a/ui/v2.5/src/components/Galleries/GallerySelect.tsx
+++ b/ui/v2.5/src/components/Galleries/GallerySelect.tsx
@@ -27,7 +27,7 @@ import { useCompare } from "src/hooks/state";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
 import { galleryTitle } from "src/core/galleries";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 export type Gallery = Pick<GQL.Gallery, "id" | "title"> & {
   files: Pick<GQL.GalleryFile, "path">[];

--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -33,7 +33,7 @@ import {
   faVideo,
 } from "@fortawesome/free-solid-svg-icons";
 import { baseURL } from "src/core/createClient";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 interface IMenuItem {
   name: string;

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -27,7 +27,7 @@ import {
 import { useCompare } from "src/hooks/state";
 import { Link } from "react-router-dom";
 import { sortByRelevance } from "src/utils/query";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 export type SelectObject = {
   id: string;

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -31,7 +31,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { objectPath, objectTitle } from "src/core/files";
 import { PreviewScrubber } from "./PreviewScrubber";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 import ScreenUtils from "src/utils/screen";
 import { StudioOverlay } from "../Shared/GridCard/StudioOverlay";
 

--- a/ui/v2.5/src/components/Settings/Inputs.tsx
+++ b/ui/v2.5/src/components/Settings/Inputs.tsx
@@ -4,7 +4,7 @@ import { Button, Collapse, Form, Modal, ModalProps } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "../Shared/Icon";
 import { StringListInput } from "../Shared/StringListInput";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 import { useSettings, useSettingsOptional } from "./context";
 
 interface ISetting {

--- a/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from "react-intl";
 import { Link } from "react-router-dom";
 import { Setting } from "./Inputs";
 import { SettingSection } from "./SettingSection";
-import { PatchContainerComponent } from "src/pluginApi";
+import { PatchContainerComponent } from "src/patch";
 
 const SettingsToolsSection = PatchContainerComponent("SettingsToolsSection");
 

--- a/ui/v2.5/src/components/Shared/CountrySelect.tsx
+++ b/ui/v2.5/src/components/Shared/CountrySelect.tsx
@@ -3,7 +3,7 @@ import Creatable from "react-select/creatable";
 import { useIntl } from "react-intl";
 import { getCountries } from "src/utils/country";
 import { CountryLabel } from "./CountryLabel";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 interface IProps {
   value?: string;

--- a/ui/v2.5/src/components/Shared/DateInput.tsx
+++ b/ui/v2.5/src/components/Shared/DateInput.tsx
@@ -7,7 +7,7 @@ import { Icon } from "./Icon";
 
 import "react-datepicker/dist/react-datepicker.css";
 import { useIntl } from "react-intl";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 interface IProps {
   disabled?: boolean;

--- a/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FolderSelect/FolderSelect.tsx
@@ -7,7 +7,7 @@ import { faEllipsis, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { useDebounce } from "src/hooks/debounce";
 import TextUtils from "src/utils/text";
 import { useDirectoryPaths } from "./useDirectoryPaths";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 interface IProps {
   currentDirectory: string;

--- a/ui/v2.5/src/components/Shared/Icon.tsx
+++ b/ui/v2.5/src/components/Shared/Icon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconDefinition, SizeProp } from "@fortawesome/fontawesome-svg-core";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 interface IIcon {
   icon: IconDefinition;

--- a/ui/v2.5/src/components/Studios/StudioSelect.tsx
+++ b/ui/v2.5/src/components/Studios/StudioSelect.tsx
@@ -27,7 +27,7 @@ import {
 import { useCompare } from "src/hooks/state";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 export type SelectObject = {
   id: string;

--- a/ui/v2.5/src/components/Tags/TagSelect.tsx
+++ b/ui/v2.5/src/components/Tags/TagSelect.tsx
@@ -28,7 +28,7 @@ import { useCompare } from "src/hooks/state";
 import { TagPopover } from "./TagPopover";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
-import { PatchComponent } from "src/pluginApi";
+import { PatchComponent } from "src/patch";
 
 export type SelectObject = {
   id: string;

--- a/ui/v2.5/src/hooks/Toast.tsx
+++ b/ui/v2.5/src/hooks/Toast.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage } from "react-intl";
 import { Icon } from "src/components/Shared/Icon";
 import { ModalComponent } from "src/components/Shared/Modal";
 import { errorToString } from "src/utils";
+import cx from "classnames";
 
 export interface IToast {
   content: JSX.Element | string;
@@ -31,6 +32,7 @@ const ToastContext = createContext<(item: IToast) => void>(() => {});
 
 export const ToastProvider: React.FC = ({ children }) => {
   const [toast, setToast] = useState<IActiveToast>();
+  const [hiding, setHiding] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
   function expand() {
@@ -44,7 +46,7 @@ export const ToastProvider: React.FC = ({ children }) => {
       <Toast
         autohide
         key={toast.id}
-        onClose={() => setToast(undefined)}
+        onClose={() => setHiding(true)}
         className={toast.variant ?? "success"}
         delay={toast.delay ?? 3000}
       >
@@ -67,7 +69,8 @@ export const ToastProvider: React.FC = ({ children }) => {
   }, [toast, expanded]);
 
   function addToast(item: IToast) {
-    if (!toast || (item.priority ?? 0) >= (toast.priority ?? 0)) {
+    if (hiding || !toast || (item.priority ?? 0) >= (toast.priority ?? 0)) {
+      setHiding(false);
       setToast({ ...item, id: toastID++ });
     }
   }
@@ -108,7 +111,9 @@ export const ToastProvider: React.FC = ({ children }) => {
           {toast?.content}
         </ModalComponent>
       )}
-      <div className="toast-container row">{toastItem}</div>
+      <div className={cx("toast-container row", { hidden: !toast || hiding })}>
+        {toastItem}
+      </div>
     </ToastContext.Provider>
   );
 };

--- a/ui/v2.5/src/hooks/Toast.tsx
+++ b/ui/v2.5/src/hooks/Toast.tsx
@@ -9,7 +9,6 @@ import { Toast } from "react-bootstrap";
 import { errorToString } from "src/utils";
 
 export interface IToast {
-  header?: string;
   content: React.ReactNode | string;
   delay?: number;
   variant?: "success" | "danger" | "warning";
@@ -38,9 +37,8 @@ export const ToastProvider: React.FC = ({ children }) => {
       delay={toast.delay ?? 3000}
     >
       <Toast.Header>
-        <span className="mr-auto">{toast.header}</span>
+        <span className="mr-auto">{toast.content}</span>
       </Toast.Header>
-      <Toast.Body>{toast.content}</Toast.Body>
     </Toast>
   ));
 
@@ -73,7 +71,6 @@ export const useToast = () => {
         console.error(error);
         addToast({
           variant: "danger",
-          header: "Error",
           content: message,
         });
       },

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -891,6 +891,16 @@ div.dropdown-menu {
   }
 }
 
+@include media-breakpoint-down(xs) {
+  .toast-container {
+    bottom: 4rem;
+    left: 50%;
+    margin-left: -175px;
+    right: unset;
+    top: unset;
+  }
+}
+
 .image-input {
   margin-bottom: 0;
   position: relative;
@@ -940,6 +950,7 @@ div.dropdown-menu {
 .top-nav {
   justify-content: start;
   padding: 0.25rem 1rem;
+  z-index: 1052;
 
   @include media-breakpoint-down(xs) {
     padding: 0.25rem 2rem;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -884,9 +884,36 @@ div.dropdown-menu {
     padding: 1rem;
     white-space: pre-wrap;
 
-    .close {
+    .close,
+    .expand-error-button {
       color: $text-color;
       text-shadow: none;
+    }
+
+    .expand-error-button {
+      opacity: 0.5;
+      padding-left: 0.25rem;
+      padding-right: 0.25rem;
+
+      &:hover {
+        opacity: 0.75;
+      }
+    }
+  }
+
+  .toast.danger .toast-header > span {
+    cursor: pointer;
+  }
+}
+
+.toast-expanded-dialog {
+  .modal-header {
+    align-items: center;
+    justify-content: start;
+
+    .fa-icon {
+      color: $danger;
+      margin-right: 0.5rem;
     }
   }
 }
@@ -950,7 +977,6 @@ div.dropdown-menu {
 .top-nav {
   justify-content: start;
   padding: 0.25rem 1rem;
-  z-index: 1052;
 
   @include media-breakpoint-down(xs) {
     padding: 0.25rem 2rem;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -859,7 +859,12 @@ div.dropdown-menu {
   position: fixed;
   right: 2rem;
   top: 4rem;
+  transition: right 0.5s;
   z-index: 1051;
+
+  &.hidden {
+    right: -350px;
+  }
 
   .success {
     background-color: $success;
@@ -925,6 +930,12 @@ div.dropdown-menu {
     margin-left: -175px;
     right: unset;
     top: unset;
+
+    transition: left 0.5s;
+
+    &.hidden {
+      left: -350px;
+    }
   }
 }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -854,10 +854,11 @@ div.dropdown-menu {
 }
 
 .toast-container {
-  left: 45%;
   max-width: 350px;
+  opacity: 0.9;
   position: fixed;
-  top: 2rem;
+  right: 2rem;
+  top: 4rem;
   z-index: 1051;
 
   .success {
@@ -880,15 +881,13 @@ div.dropdown-menu {
     background-color: transparent;
     border: none;
     color: $text-color;
+    padding: 1rem;
+    white-space: pre-wrap;
 
     .close {
       color: $text-color;
       text-shadow: none;
     }
-  }
-
-  .toast-body {
-    white-space: pre-wrap;
   }
 }
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -21,6 +21,7 @@
     "close": "Close",
     "confirm": "Confirm",
     "continue": "Continue",
+    "copy_to_clipboard": "Copy to clipboard",
     "create": "Create",
     "create_chapters": "Create Chapter",
     "create_entity": "Create {entityType}",
@@ -974,6 +975,7 @@
   },
   "empty_server": "Add some scenes to your server to view recommendations on this page.",
   "errors": {
+    "header": "Error",
     "image_index_greater_than_zero": "Image index must be greater than 0",
     "lazy_component_error_help": "If you recently upgraded Stash, please reload the page or clear your browser cache.",
     "loading_type": "Error loading {type}",

--- a/ui/v2.5/src/patch.tsx
+++ b/ui/v2.5/src/patch.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { HoverPopover } from "./components/Shared/HoverPopover";
+import { TagLink } from "./components/Shared/TagLink";
+import { LoadingIndicator } from "./components/Shared/LoadingIndicator";
+
+export const components: Record<string, Function> = {
+  HoverPopover,
+  TagLink,
+  LoadingIndicator,
+};
+
+const beforeFns: Record<string, Function[]> = {};
+const insteadFns: Record<string, Function> = {};
+const afterFns: Record<string, Function[]> = {};
+
+// patch functions
+// registers a patch to a function. Before functions are expected to return the
+// new arguments to be passed to the function.
+export function before(component: string, fn: Function) {
+  if (!beforeFns[component]) {
+    beforeFns[component] = [];
+  }
+  beforeFns[component].push(fn);
+}
+
+export function instead(component: string, fn: Function) {
+  if (insteadFns[component]) {
+    throw new Error("instead has already been called for " + component);
+  }
+  insteadFns[component] = fn;
+}
+
+export function after(component: string, fn: Function) {
+  if (!afterFns[component]) {
+    afterFns[component] = [];
+  }
+  afterFns[component].push(fn);
+}
+
+export function RegisterComponent(component: string, fn: Function) {
+  // register with the plugin api
+  if (components[component]) {
+    throw new Error("Component " + component + " has already been registered");
+  }
+
+  components[component] = fn;
+
+  return fn;
+}
+
+// patches a function to implement the before/instead/after functionality
+export function PatchFunction(name: string, fn: Function) {
+  return new Proxy(fn, {
+    apply(target, ctx, args) {
+      let result;
+
+      for (const beforeFn of beforeFns[name] || []) {
+        args = beforeFn.apply(ctx, args);
+      }
+      if (insteadFns[name]) {
+        result = insteadFns[name].apply(ctx, args.concat(target));
+      } else {
+        result = target.apply(ctx, args);
+      }
+      for (const afterFn of afterFns[name] || []) {
+        result = afterFn.apply(ctx, args.concat(result));
+      }
+      return result;
+    },
+  });
+}
+
+// patches a component and registers it in the pluginapi components object
+export function PatchComponent<T>(
+  component: string,
+  fn: React.FC<T>
+): React.FC<T> {
+  const ret = PatchFunction(component, fn);
+
+  // register with the plugin api
+  RegisterComponent(component, ret);
+  return ret as React.FC<T>;
+}
+
+// patches a component and registers it in the pluginapi components object
+export function PatchContainerComponent(
+  component: string
+): React.FC<React.PropsWithChildren<{}>> {
+  const fn = (props: React.PropsWithChildren<{}>) => {
+    return <>{props.children}</>;
+  };
+
+  return PatchComponent(component, fn);
+}

--- a/ui/v2.5/src/plugins.tsx
+++ b/ui/v2.5/src/plugins.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PatchFunction } from "./pluginApi";
+import { PatchFunction } from "./patch";
 
 export const PluginRoutes: React.FC<React.PropsWithChildren<{}>> =
   PatchFunction("PluginRoutes", (props: React.PropsWithChildren<{}>) => {


### PR DESCRIPTION
Resolves #1323 

Changes the toast placement from center top to top right:

![image](https://github.com/stashapp/stash/assets/53250216/e071d493-3b5d-496e-bc41-486dc3a6d7cb)

The toast container is now animated to slide in and out from the right edge of the window.

On mobile viewports the toast is placed center bottom, and slides in from the left:

![image](https://github.com/stashapp/stash/assets/53250216/c4455972-2203-4c91-b01d-3b8b58991484)

The error toast is changed to add a button and handle clicks to bring up a dialog. On https connections, the dialog gives the option to copy the error message to clipboard:

![image](https://github.com/stashapp/stash/assets/53250216/29e2294d-871a-478d-90c5-39dc593798eb)
![image](https://github.com/stashapp/stash/assets/53250216/42eb39b7-b74c-420f-9fe8-64a62d4da51a)
