### PR TITLE
Movie scene sorting

### DIFF
--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1549,8 +1549,13 @@ func (qb *SceneStore) setSceneSort(query *queryBuilder, findFilter *models.FindF
 	direction := findFilter.GetDirection()
 	switch sort {
 	case "movie_scene_number":
-		query.join(moviesScenesTable, "movies_join", "scenes.id = movies_join.scene_id")
-		query.sortAndPagination += fmt.Sprintf(" ORDER BY movies_join.scene_index %s", getSortDirection(direction))
+		if strings.Contains(strings.Join(query.whereClauses, ""), moviesScenesTable) {
+			// query already has movies_scenes table from filter
+			query.sortAndPagination += getSort("scene_index", direction, moviesScenesTable)
+		} else {
+			query.join(moviesScenesTable, "movies_join", "scenes.id = movies_join.scene_id")
+			query.sortAndPagination += fmt.Sprintf(" ORDER BY movies_join.scene_index %s", getSortDirection(direction))
+		}
 	case "tag_count":
 		query.sortAndPagination += getCountSort(sceneTable, scenesTagsTable, sceneIDColumn, direction)
 	case "performer_count":

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1549,13 +1549,8 @@ func (qb *SceneStore) setSceneSort(query *queryBuilder, findFilter *models.FindF
 	direction := findFilter.GetDirection()
 	switch sort {
 	case "movie_scene_number":
-		if strings.Contains(strings.Join(query.whereClauses, ""), moviesScenesTable) {
-			// query already has movies_scenes table from filter
-			query.sortAndPagination += getSort("scene_index", direction, moviesScenesTable)
-		} else {
-			query.join(moviesScenesTable, "movies_join", "scenes.id = movies_join.scene_id")
-			query.sortAndPagination += fmt.Sprintf(" ORDER BY movies_join.scene_index %s", getSortDirection(direction))
-		}
+		query.join(moviesScenesTable, "", "scenes.id = movies_scenes.scene_id")
+		query.sortAndPagination += getSort("scene_index", direction, moviesScenesTable)
 	case "tag_count":
 		query.sortAndPagination += getCountSort(sceneTable, scenesTagsTable, sceneIDColumn, direction)
 	case "performer_count":


### PR DESCRIPTION
Taking a stab to fix #2798. Makes the sort use the `movies_scenes` table joined by the filter, when it exists. When there is only one movie in the filter, like on a movie page, the scenes will sort according to that movie's sort order.