### PR TITLE
Plugin manager - don't error out if a single source url not fetched

### DIFF
--- a/pkg/pkg/manager.go
+++ b/pkg/pkg/manager.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path/filepath"
 
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 )
 
@@ -98,7 +99,8 @@ func (m *Manager) ListInstalledRemotes(ctx context.Context, installed LocalPacka
 	for _, remoteURL := range remoteURLs {
 		remoteList, err := m.ListRemote(ctx, remoteURL)
 		if err != nil {
-			return nil, err
+			logger.Warnf("error listing remote package %s: %v", remoteURL, err)
+			continue
 		}
 
 		allRemoteList.merge(remoteList)


### PR DESCRIPTION
Fixes #4504 