### PR TITLE
Fix 404 not returning immediately in asset handler

### DIFF
--- a/internal/api/routes_plugin.go
+++ b/internal/api/routes_plugin.go
@@ -50,6 +50,7 @@ func (rs pluginRoutes) Assets(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path, dir = p.UI.Assets.GetFilesystemLocation(r.URL.Path)
 	if dir == "" {
 		http.NotFound(w, r)
+		return
 	}
 
 	dir = filepath.Join(pluginDir, filepath.FromSlash(dir))


### PR DESCRIPTION
Fixes issue where if `GetFilesystemLocation` returned an invalid directory, then the handler would give a not found error, then fall through to try to serve the requested file anyway.