### PR TITLE
Improve handling of moved and added video files

### DIFF
--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -19,14 +19,17 @@ import (
 )
 
 func useAsVideo(pathname string) bool {
-	if instance.Config.IsCreateImageClipsFromVideos() && config.StashConfigs.GetStashFromDirPath(instance.Config.GetStashPaths(), pathname).ExcludeVideo {
+	stash := config.StashConfigs.GetStashFromDirPath(instance.Config.GetStashPaths(), pathname)
+
+	if instance.Config.IsCreateImageClipsFromVideos() && stash != nil && stash.ExcludeVideo {
 		return false
 	}
 	return isVideo(pathname)
 }
 
 func useAsImage(pathname string) bool {
-	if instance.Config.IsCreateImageClipsFromVideos() && config.StashConfigs.GetStashFromDirPath(instance.Config.GetStashPaths(), pathname).ExcludeVideo {
+	stash := config.StashConfigs.GetStashFromDirPath(instance.Config.GetStashPaths(), pathname)
+	if instance.Config.IsCreateImageClipsFromVideos() && stash != nil && stash.ExcludeVideo {
 		return isImage(pathname) || isVideo(pathname)
 	}
 	return isImage(pathname)

--- a/internal/manager/task_generate_phash.go
+++ b/internal/manager/task_generate_phash.go
@@ -25,25 +25,74 @@ func (t *GeneratePhashTask) Start(ctx context.Context) {
 		return
 	}
 
-	hash, err := videophash.Generate(instance.FFMpeg, t.File)
-	if err != nil {
-		logger.Errorf("error generating phash: %s", err.Error())
-		logErrorOutput(err)
-		return
+	var hash int64
+	set := false
+
+	// #4393 - if there is a file with the same oshash, we can use the same phash
+	// only use this if we're not overwriting
+	if !t.Overwrite {
+		existing, err := t.findExistingPhash(ctx)
+		if err != nil {
+			logger.Warnf("Error finding existing phash: %v", err)
+		} else if existing != nil {
+			logger.Infof("Using existing phash for %s", t.File.Path)
+			hash = existing.(int64)
+			set = true
+		}
+	}
+
+	if !set {
+		generated, err := videophash.Generate(instance.FFMpeg, t.File)
+		if err != nil {
+			logger.Errorf("Error generating phash: %v", err)
+			logErrorOutput(err)
+			return
+		}
+
+		hash = int64(*generated)
 	}
 
 	r := t.repository
 	if err := r.WithTxn(ctx, func(ctx context.Context) error {
-		hashValue := int64(*hash)
 		t.File.Fingerprints = t.File.Fingerprints.AppendUnique(models.Fingerprint{
 			Type:        models.FingerprintTypePhash,
-			Fingerprint: hashValue,
+			Fingerprint: hash,
 		})
 
 		return r.File.Update(ctx, t.File)
 	}); err != nil && ctx.Err() == nil {
 		logger.Errorf("Error setting phash: %v", err)
 	}
+}
+
+func (t *GeneratePhashTask) findExistingPhash(ctx context.Context) (interface{}, error) {
+	r := t.repository
+	var ret interface{}
+	if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
+		oshash := t.File.Fingerprints.Get(models.FingerprintTypeOshash)
+
+		// find other files with the same oshash
+		files, err := r.File.FindByFingerprint(ctx, models.Fingerprint{
+			Type:        models.FingerprintTypeOshash,
+			Fingerprint: oshash,
+		})
+		if err != nil {
+			return fmt.Errorf("finding files by oshash: %w", err)
+		}
+
+		// find the first file with a phash
+		for _, file := range files {
+			if phash := file.Base().Fingerprints.Get(models.FingerprintTypePhash); phash != nil {
+				ret = phash
+				return nil
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
 }
 
 func (t *GeneratePhashTask) required() bool {

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -264,6 +264,12 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 		return false
 	}
 
+	s := f.stashPaths.GetStashFromDirPath(path)
+	if s == nil {
+		logger.Debugf("Skipping %s as it is not in the stash library", path)
+		return false
+	}
+
 	isVideoFile := useAsVideo(path)
 	isImageFile := useAsImage(path)
 	isZipFile := fsutil.MatchExtension(path, f.zipExt)
@@ -285,13 +291,6 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	// #1756 - skip zero length files
 	if !info.IsDir() && info.Size() == 0 {
 		logger.Infof("Skipping zero-length file: %s", path)
-		return false
-	}
-
-	s := f.stashPaths.GetStashFromDirPath(path)
-
-	if s == nil {
-		logger.Debugf("Skipping %s as it is not in the stash library", path)
 		return false
 	}
 


### PR DESCRIPTION
- if a file was copied to a new directory and the old location is no longer in the library paths, then scan will now treat the file as being moved from the old location
- when generating phash for a video file, it will now check for existing video files with the same oshash and use any existing phash instead of re-generating the phash

Fixes #4393 