### PR TITLE
Show upgradable packages only when checking for updates

### DIFF
--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -9,6 +9,7 @@ import {
   mutateUninstallPluginPackages,
   mutateUpdatePluginPackages,
   pluginMutationImpactedQueries,
+  isLoading,
 } from "src/core/StashService";
 import { useMonitorJob } from "src/utils/job";
 import {
@@ -25,8 +26,10 @@ export const InstalledPluginPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
-  const { data, previousData, refetch, loading, error } =
+  const { data, previousData, refetch, networkStatus, error } =
     useInstalledPluginPackages(loadUpgrades);
+
+  const loading = isLoading(networkStatus);
 
   async function onUpdatePackages(packages: GQL.PackageSpecInput[]) {
     const r = await mutateUpdatePluginPackages(packages);

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -9,6 +9,7 @@ import {
   mutateUninstallScraperPackages,
   mutateInstallScraperPackages,
   scraperMutationImpactedQueries,
+  isLoading,
 } from "src/core/StashService";
 import { useMonitorJob } from "src/utils/job";
 import {
@@ -25,8 +26,10 @@ export const InstalledScraperPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
-  const { data, previousData, refetch, loading, error } =
+  const { data, previousData, refetch, networkStatus, error } =
     useInstalledScraperPackages(loadUpgrades);
+
+  const loading = isLoading(networkStatus);
 
   async function onUpdatePackages(packages: GQL.PackageSpecInput[]) {
     const r = await mutateUpdateScraperPackages(packages);

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2,6 +2,7 @@ import {
   ApolloCache,
   DocumentNode,
   FetchResult,
+  NetworkStatus,
   useQuery,
 } from "@apollo/client";
 import { Modifiers } from "@apollo/client/cache";
@@ -91,6 +92,16 @@ function deleteObject(
     data: { [keyName]: null },
   });
   cache.evict({ id: cache.identify(obj) });
+}
+
+export function isLoading(networkStatus: NetworkStatus) {
+  // useQuery hook loading field only returns true when initially loading the query
+  // and not during subsequent fetches
+  return (
+    networkStatus === NetworkStatus.loading ||
+    networkStatus === NetworkStatus.fetchMore ||
+    networkStatus === NetworkStatus.refetch
+  );
 }
 
 /// Object queries

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1095,6 +1095,7 @@
     "latest_version": "Latest Version",
     "no_packages": "No packages found",
     "no_sources": "No sources configured",
+    "no_upgradable": "No upgradable packages found",
     "package": "Package",
     "required_by": "Required by {packages}",
     "selected_only": "Selected only",


### PR DESCRIPTION
Show upgradable packages only when clicking the `Check for updates` button. A new `Show all` button will be shown after clicking this button to show all packages. Upgradable packages will be sorted to the top in this view. In order to only see upgradable packages again, the `Check for updates` button will need to be clicked again.

![image](https://github.com/stashapp/stash/assets/53250216/7e4f595e-78b1-4762-acb6-2ea02c9088bb)

Also fixed the buttons not being disabled while refetching packages.

Resolves #4410 