### PR TITLE
Restore image performer age filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -500,6 +500,8 @@ input ImageFilterType {
   performer_count: IntCriterionInput
   "Filter images that have performers that have been favorited"
   performer_favorite: Boolean
+  "Filter images by performer age at time of image"
+  performer_age: IntCriterionInput
   "Filter to only include images with these galleries"
   galleries: MultiCriterionInput
   "Filter by creation time"

--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -47,6 +47,8 @@ type ImageFilterType struct {
 	PerformerCount *IntCriterionInput `json:"performer_count"`
 	// Filter images that have performers that have been favorited
 	PerformerFavorite *bool `json:"performer_favorite"`
+	// Filter images by performer age at time of image
+	PerformerAge *IntCriterionInput `json:"performer_age"`
 	// Filter to only include images with these galleries
 	Galleries *MultiCriterionInput `json:"galleries"`
 	// Filter by created at

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -720,6 +720,7 @@ func (qb *ImageStore) makeFilter(ctx context.Context, imageFilter *models.ImageF
 	query.handleCriterion(ctx, studioCriterionHandler(imageTable, imageFilter.Studios))
 	query.handleCriterion(ctx, imagePerformerTagsCriterionHandler(qb, imageFilter.PerformerTags))
 	query.handleCriterion(ctx, imagePerformerFavoriteCriterionHandler(imageFilter.PerformerFavorite))
+	query.handleCriterion(ctx, imagePerformerAgeCriterionHandler(imageFilter.PerformerAge))
 	query.handleCriterion(ctx, timestampCriterionHandler(imageFilter.CreatedAt, "images.created_at"))
 	query.handleCriterion(ctx, timestampCriterionHandler(imageFilter.UpdatedAt, "images.updated_at"))
 
@@ -1021,6 +1022,22 @@ JOIN performers ON performers.id = performers_images.performer_id
 GROUP BY performers_images.image_id HAVING SUM(performers.favorite) = 0)`, "nofaves", "images.id = nofaves.id")
 				f.addWhere("performers_images.image_id IS NULL OR nofaves.id IS NOT NULL")
 			}
+		}
+	}
+}
+
+func imagePerformerAgeCriterionHandler(performerAge *models.IntCriterionInput) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if performerAge != nil {
+			f.addInnerJoin("performers_images", "", "images.id = performers_images.image_id")
+			f.addInnerJoin("performers", "", "performers_images.performer_id = performers.id")
+
+			f.addWhere("images.date != '' AND performers.birthdate != ''")
+			f.addWhere("images.date IS NOT NULL AND performers.birthdate IS NOT NULL")
+
+			ageCalc := "cast(strftime('%Y.%m%d', images.date) - strftime('%Y.%m%d', performers.birthdate) as int)"
+			whereClause, args := getIntWhereClause(ageCalc, performerAge.Modifier, performerAge.Value, performerAge.Value2)
+			f.addWhere(whereClause, args...)
 		}
 	}
 }

--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -52,6 +52,7 @@ const criterionOptions = [
   PerformerTagsCriterionOption,
   PerformersCriterionOption,
   createMandatoryNumberCriterionOption("performer_count"),
+  createMandatoryNumberCriterionOption("performer_age"),
   PerformerFavoriteCriterionOption,
   StudiosCriterionOption,
   createStringCriterionOption("url"),


### PR DESCRIPTION
Looks like the performer age image filter was omitted because images didn't have dates. Now images _do_ have dates it can be restored. Brings images into parity with the other objects that have performers and dates (eg. galleries, scenes).

Closes #3941.