### PR TITLE
Add option to generate image thumbnails during generate

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -12,6 +12,7 @@ input GenerateMetadataInput {
   forceTranscodes: Boolean
   phashes: Boolean
   interactiveHeatmapsSpeeds: Boolean
+  imageThumbnails: Boolean
   clipPreviews: Boolean
 
   "scene ids to generate for"
@@ -48,6 +49,7 @@ type GenerateMetadataOptions {
   transcodes: Boolean
   phashes: Boolean
   interactiveHeatmapsSpeeds: Boolean
+  imageThumbnails: Boolean
   clipPreviews: Boolean
 }
 

--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/remeh/sizedwaitgroup"
 	"github.com/stashapp/stash/internal/desktop"
 	"github.com/stashapp/stash/internal/dlna"
 	"github.com/stashapp/stash/internal/log"
@@ -79,6 +80,8 @@ func Initialize(cfg *config.Config, l *log.Logger) (*Manager, error) {
 		Logger: l,
 
 		Paths: mgrPaths,
+
+		ImageThumbnailGenerateWaitGroup: sizedwaitgroup.New(1),
 
 		JobManager:      initJobManager(cfg),
 		ReadLockManager: fsutil.NewReadLockManager(),

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/remeh/sizedwaitgroup"
 	"github.com/stashapp/stash/internal/dlna"
 	"github.com/stashapp/stash/internal/log"
 	"github.com/stashapp/stash/internal/manager/config"
@@ -32,6 +33,10 @@ import (
 type Manager struct {
 	Config *config.Config
 	Logger *log.Logger
+
+	// ImageThumbnailGenerateWaitGroup is the global wait group image thumbnail generation
+	// It uses the parallel tasks setting from the configuration.
+	ImageThumbnailGenerateWaitGroup sizedwaitgroup.SizedWaitGroup
 
 	Paths *paths.Paths
 
@@ -107,6 +112,8 @@ func (s *Manager) RefreshConfig() {
 		if err := fsutil.EnsureDir(s.Paths.Generated.InteractiveHeatmap); err != nil {
 			logger.Warnf("could not create interactive heatmaps directory: %v", err)
 		}
+
+		s.ImageThumbnailGenerateWaitGroup.Size = cfg.GetParallelTasksWithAutoDetection()
 	}
 }
 

--- a/internal/manager/task_generate_image_thumbnail.go
+++ b/internal/manager/task_generate_image_thumbnail.go
@@ -1,0 +1,79 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stashapp/stash/pkg/fsutil"
+	"github.com/stashapp/stash/pkg/image"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type GenerateImageThumbnailTask struct {
+	Image     models.Image
+	Overwrite bool
+}
+
+func (t *GenerateImageThumbnailTask) GetDescription() string {
+	return fmt.Sprintf("Generating Thumbnail for image %s", t.Image.Path)
+}
+
+func (t *GenerateImageThumbnailTask) Start(ctx context.Context) {
+	if !t.required() {
+		return
+	}
+
+	thumbPath := GetInstance().Paths.Generated.GetThumbnailPath(t.Image.Checksum, models.DefaultGthumbWidth)
+	f := t.Image.Files.Primary()
+	path := f.Base().Path
+
+	logger.Debugf("Generating thumbnail for %s", path)
+
+	mgr := GetInstance()
+	c := mgr.Config
+
+	clipPreviewOptions := image.ClipPreviewOptions{
+		InputArgs:  c.GetTranscodeInputArgs(),
+		OutputArgs: c.GetTranscodeOutputArgs(),
+		Preset:     c.GetPreviewPreset().String(),
+	}
+
+	encoder := image.NewThumbnailEncoder(mgr.FFMpeg, mgr.FFProbe, clipPreviewOptions)
+	data, err := encoder.GetThumbnail(f, models.DefaultGthumbWidth)
+
+	if err != nil {
+		// don't log for animated images
+		if !errors.Is(err, image.ErrNotSupportedForThumbnail) {
+			logger.Errorf("[generator] getting thumbnail for image %s: %w", path, err)
+		}
+		return
+	}
+
+	err = fsutil.WriteFile(thumbPath, data)
+	if err != nil {
+		logger.Errorf("[generator] writing thumbnail for image %s: %w", path, err)
+		return
+	}
+}
+
+func (t *GenerateImageThumbnailTask) required() bool {
+	vf, ok := t.Image.Files.Primary().(models.VisualFile)
+	if !ok {
+		return false
+	}
+
+	if vf.GetHeight() <= models.DefaultGthumbWidth && vf.GetWidth() <= models.DefaultGthumbWidth {
+		return false
+	}
+
+	if t.Overwrite {
+		return true
+	}
+
+	thumbPath := GetInstance().Paths.Generated.GetThumbnailPath(t.Image.Checksum, models.DefaultGthumbWidth)
+	exists, _ := fsutil.FileExists(thumbPath)
+
+	return !exists
+}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -412,9 +411,12 @@ func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f model
 
 	if t.ScanGenerateThumbnails {
 		// this should be quick, so always generate sequentially
-		if err := g.generateThumbnail(ctx, i, f); err != nil {
-			logger.Errorf("Error generating thumbnail for %s: %v", path, err)
+		taskThumbnail := GenerateImageThumbnailTask{
+			Image:     *i,
+			Overwrite: overwrite,
 		}
+
+		taskThumbnail.Start(ctx)
 	}
 
 	// avoid adding a task if the file isn't a video file
@@ -441,54 +443,6 @@ func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f model
 		} else {
 			g.taskQueue.Add(fmt.Sprintf("Generating preview for %s", path), previewsFn)
 		}
-	}
-
-	return nil
-}
-
-func (g *imageGenerators) generateThumbnail(ctx context.Context, i *models.Image, f models.File) error {
-	thumbPath := g.paths.Generated.GetThumbnailPath(i.Checksum, models.DefaultGthumbWidth)
-	exists, _ := fsutil.FileExists(thumbPath)
-	if exists {
-		return nil
-	}
-
-	path := f.Base().Path
-
-	vf, ok := f.(models.VisualFile)
-	if !ok {
-		return fmt.Errorf("file %s is not a visual file", path)
-	}
-
-	if vf.GetHeight() <= models.DefaultGthumbWidth && vf.GetWidth() <= models.DefaultGthumbWidth {
-		return nil
-	}
-
-	logger.Debugf("Generating thumbnail for %s", path)
-
-	mgr := GetInstance()
-	c := mgr.Config
-
-	clipPreviewOptions := image.ClipPreviewOptions{
-		InputArgs:  c.GetTranscodeInputArgs(),
-		OutputArgs: c.GetTranscodeOutputArgs(),
-		Preset:     c.GetPreviewPreset().String(),
-	}
-
-	encoder := image.NewThumbnailEncoder(mgr.FFMpeg, mgr.FFProbe, clipPreviewOptions)
-	data, err := encoder.GetThumbnail(f, models.DefaultGthumbWidth)
-
-	if err != nil {
-		// don't log for animated images
-		if !errors.Is(err, image.ErrNotSupportedForThumbnail) {
-			return fmt.Errorf("getting thumbnail for image %s: %w", path, err)
-		}
-		return nil
-	}
-
-	err = fsutil.WriteFile(thumbPath, data)
-	if err != nil {
-		return fmt.Errorf("writing thumbnail for image %s: %w", path, err)
 	}
 
 	return nil

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -18,6 +18,7 @@ type GenerateMetadataOptions struct {
 	Transcodes                bool                    `json:"transcodes"`
 	Phashes                   bool                    `json:"phashes"`
 	InteractiveHeatmapsSpeeds bool                    `json:"interactiveHeatmapsSpeeds"`
+	ImageThumbnails           bool                    `json:"imageThumbnails"`
 	ClipPreviews              bool                    `json:"clipPreviews"`
 }
 

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -196,6 +196,7 @@ fragment ConfigDefaultSettingsData on ConfigDefaultSettingsResult {
     phashes
     interactiveHeatmapsSpeeds
     clipPreviews
+    imageThumbnails
   }
 
   deleteFile

--- a/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
@@ -17,11 +17,13 @@ import { SettingsContext } from "../Settings/context";
 interface ISceneGenerateDialog {
   selectedIds?: string[];
   onClose: () => void;
+  type: "scene"; // TODO - add image generate
 }
 
 export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
   selectedIds,
   onClose,
+  type,
 }) => {
   const { configuration } = React.useContext(ConfigurationContext);
 
@@ -200,6 +202,7 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
         <SettingsContext>
           <SettingSection>
             <GenerateOptions
+              type={type}
               options={options}
               setOptions={setOptions}
               selection

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -278,6 +278,7 @@ const ScenePage: React.FC<IProps> = ({
           onClose={() => {
             setIsGenerateDialogOpen(false);
           }}
+          type="scene"
         />
       );
     }

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -235,6 +235,7 @@ export const SceneList: React.FC<ISceneList> = ({
       if (isGenerateDialogOpen) {
         return (
           <GenerateDialog
+            type="scene"
             selectedIds={Array.from(selectedIds.values())}
             onClose={() => setIsGenerateDialogOpen(false)}
           />

--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -7,12 +7,14 @@ import {
 } from "../GeneratePreviewOptions";
 
 interface IGenerateOptions {
+  type?: "scene" | "image";
   selection?: boolean;
   options: GQL.GenerateMetadataInput;
   setOptions: (s: GQL.GenerateMetadataInput) => void;
 }
 
 export const GenerateOptions: React.FC<IGenerateOptions> = ({
+  type,
   selection,
   options,
   setOptions: setOptionsState,
@@ -24,136 +26,153 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
     setOptionsState({ ...options, ...input });
   }
 
+  const showSceneOptions = !type || type === "scene";
+  const showImageOptions = !type || type === "image";
+
   return (
     <>
-      <BooleanSetting
-        id="covers-task"
-        headingID="dialogs.scene_gen.covers"
-        checked={options.covers ?? false}
-        onChange={(v) => setOptions({ covers: v })}
-      />
-      <BooleanSetting
-        id="preview-task"
-        checked={options.previews ?? false}
-        headingID="dialogs.scene_gen.video_previews"
-        tooltipID="dialogs.scene_gen.video_previews_tooltip"
-        onChange={(v) => setOptions({ previews: v })}
-      />
-      <BooleanSetting
-        advanced
-        className="sub-setting"
-        id="image-preview-task"
-        checked={options.imagePreviews ?? false}
-        disabled={!options.previews}
-        headingID="dialogs.scene_gen.image_previews"
-        tooltipID="dialogs.scene_gen.image_previews_tooltip"
-        onChange={(v) => setOptions({ imagePreviews: v })}
-      />
+      {showSceneOptions && (
+        <>
+          <BooleanSetting
+            id="covers-task"
+            headingID="dialogs.scene_gen.covers"
+            checked={options.covers ?? false}
+            onChange={(v) => setOptions({ covers: v })}
+          />
+          <BooleanSetting
+            id="preview-task"
+            checked={options.previews ?? false}
+            headingID="dialogs.scene_gen.video_previews"
+            tooltipID="dialogs.scene_gen.video_previews_tooltip"
+            onChange={(v) => setOptions({ previews: v })}
+          />
+          <BooleanSetting
+            advanced
+            className="sub-setting"
+            id="image-preview-task"
+            checked={options.imagePreviews ?? false}
+            disabled={!options.previews}
+            headingID="dialogs.scene_gen.image_previews"
+            tooltipID="dialogs.scene_gen.image_previews_tooltip"
+            onChange={(v) => setOptions({ imagePreviews: v })}
+          />
 
-      {/* #2251 - only allow preview generation options to be overridden when generating from a selection */}
-      {selection ? (
-        <ModalSetting<VideoPreviewSettingsInput>
-          id="video-preview-settings"
-          className="sub-setting"
-          disabled={!options.previews}
-          headingID="dialogs.scene_gen.override_preview_generation_options"
-          tooltipID="dialogs.scene_gen.override_preview_generation_options_desc"
-          value={{
-            previewExcludeEnd: previewOptions.previewExcludeEnd,
-            previewExcludeStart: previewOptions.previewExcludeStart,
-            previewSegmentDuration: previewOptions.previewSegmentDuration,
-            previewSegments: previewOptions.previewSegments,
-          }}
-          onChange={(v) => setOptions({ previewOptions: v })}
-          renderField={(value, setValue) => (
-            <VideoPreviewInput value={value ?? {}} setValue={setValue} />
-          )}
-          renderValue={() => {
-            return <></>;
-          }}
-        />
-      ) : undefined}
+          {/* #2251 - only allow preview generation options to be overridden when generating from a selection */}
+          {selection ? (
+            <ModalSetting<VideoPreviewSettingsInput>
+              id="video-preview-settings"
+              className="sub-setting"
+              disabled={!options.previews}
+              headingID="dialogs.scene_gen.override_preview_generation_options"
+              tooltipID="dialogs.scene_gen.override_preview_generation_options_desc"
+              value={{
+                previewExcludeEnd: previewOptions.previewExcludeEnd,
+                previewExcludeStart: previewOptions.previewExcludeStart,
+                previewSegmentDuration: previewOptions.previewSegmentDuration,
+                previewSegments: previewOptions.previewSegments,
+              }}
+              onChange={(v) => setOptions({ previewOptions: v })}
+              renderField={(value, setValue) => (
+                <VideoPreviewInput value={value ?? {}} setValue={setValue} />
+              )}
+              renderValue={() => {
+                return <></>;
+              }}
+            />
+          ) : undefined}
 
-      <BooleanSetting
-        id="sprite-task"
-        checked={options.sprites ?? false}
-        headingID="dialogs.scene_gen.sprites"
-        tooltipID="dialogs.scene_gen.sprites_tooltip"
-        onChange={(v) => setOptions({ sprites: v })}
-      />
-      <BooleanSetting
-        id="marker-task"
-        checked={options.markers ?? false}
-        headingID="dialogs.scene_gen.markers"
-        tooltipID="dialogs.scene_gen.markers_tooltip"
-        onChange={(v) => setOptions({ markers: v })}
-      />
-      <BooleanSetting
-        advanced
-        id="marker-image-preview-task"
-        className="sub-setting"
-        checked={options.markerImagePreviews ?? false}
-        disabled={!options.markers}
-        headingID="dialogs.scene_gen.marker_image_previews"
-        tooltipID="dialogs.scene_gen.marker_image_previews_tooltip"
-        onChange={(v) =>
-          setOptions({
-            markerImagePreviews: v,
-          })
-        }
-      />
-      <BooleanSetting
-        advanced
-        id="marker-screenshot-task"
-        className="sub-setting"
-        checked={options.markerScreenshots ?? false}
-        disabled={!options.markers}
-        headingID="dialogs.scene_gen.marker_screenshots"
-        tooltipID="dialogs.scene_gen.marker_screenshots_tooltip"
-        onChange={(v) => setOptions({ markerScreenshots: v })}
-      />
+          <BooleanSetting
+            id="sprite-task"
+            checked={options.sprites ?? false}
+            headingID="dialogs.scene_gen.sprites"
+            tooltipID="dialogs.scene_gen.sprites_tooltip"
+            onChange={(v) => setOptions({ sprites: v })}
+          />
+          <BooleanSetting
+            id="marker-task"
+            checked={options.markers ?? false}
+            headingID="dialogs.scene_gen.markers"
+            tooltipID="dialogs.scene_gen.markers_tooltip"
+            onChange={(v) => setOptions({ markers: v })}
+          />
+          <BooleanSetting
+            advanced
+            id="marker-image-preview-task"
+            className="sub-setting"
+            checked={options.markerImagePreviews ?? false}
+            disabled={!options.markers}
+            headingID="dialogs.scene_gen.marker_image_previews"
+            tooltipID="dialogs.scene_gen.marker_image_previews_tooltip"
+            onChange={(v) =>
+              setOptions({
+                markerImagePreviews: v,
+              })
+            }
+          />
+          <BooleanSetting
+            advanced
+            id="marker-screenshot-task"
+            className="sub-setting"
+            checked={options.markerScreenshots ?? false}
+            disabled={!options.markers}
+            headingID="dialogs.scene_gen.marker_screenshots"
+            tooltipID="dialogs.scene_gen.marker_screenshots_tooltip"
+            onChange={(v) => setOptions({ markerScreenshots: v })}
+          />
 
-      <BooleanSetting
-        advanced
-        id="transcode-task"
-        checked={options.transcodes ?? false}
-        headingID="dialogs.scene_gen.transcodes"
-        tooltipID="dialogs.scene_gen.transcodes_tooltip"
-        onChange={(v) => setOptions({ transcodes: v })}
-      />
-      {selection ? (
+          <BooleanSetting
+            advanced
+            id="transcode-task"
+            checked={options.transcodes ?? false}
+            headingID="dialogs.scene_gen.transcodes"
+            tooltipID="dialogs.scene_gen.transcodes_tooltip"
+            onChange={(v) => setOptions({ transcodes: v })}
+          />
+          {selection ? (
+            <BooleanSetting
+              advanced
+              id="force-transcode"
+              className="sub-setting"
+              checked={options.forceTranscodes ?? false}
+              disabled={!options.transcodes}
+              headingID="dialogs.scene_gen.force_transcodes"
+              tooltipID="dialogs.scene_gen.force_transcodes_tooltip"
+              onChange={(v) => setOptions({ forceTranscodes: v })}
+            />
+          ) : undefined}
+
+          <BooleanSetting
+            id="phash-task"
+            checked={options.phashes ?? false}
+            headingID="dialogs.scene_gen.phash"
+            tooltipID="dialogs.scene_gen.phash_tooltip"
+            onChange={(v) => setOptions({ phashes: v })}
+          />
+
+          <BooleanSetting
+            id="interactive-heatmap-speed-task"
+            checked={options.interactiveHeatmapsSpeeds ?? false}
+            headingID="dialogs.scene_gen.interactive_heatmap_speed"
+            onChange={(v) => setOptions({ interactiveHeatmapsSpeeds: v })}
+          />
+        </>
+      )}
+      {showImageOptions && (
+        <>
         <BooleanSetting
-          advanced
-          id="force-transcode"
-          className="sub-setting"
-          checked={options.forceTranscodes ?? false}
-          disabled={!options.transcodes}
-          headingID="dialogs.scene_gen.force_transcodes"
-          tooltipID="dialogs.scene_gen.force_transcodes_tooltip"
-          onChange={(v) => setOptions({ forceTranscodes: v })}
+          id="clip-previews"
+          checked={options.clipPreviews ?? false}
+          headingID="dialogs.scene_gen.clip_previews"
+          onChange={(v) => setOptions({ clipPreviews: v })}
         />
-      ) : undefined}
-
-      <BooleanSetting
-        id="phash-task"
-        checked={options.phashes ?? false}
-        headingID="dialogs.scene_gen.phash"
-        tooltipID="dialogs.scene_gen.phash_tooltip"
-        onChange={(v) => setOptions({ phashes: v })}
-      />
-
-      <BooleanSetting
-        id="interactive-heatmap-speed-task"
-        checked={options.interactiveHeatmapsSpeeds ?? false}
-        headingID="dialogs.scene_gen.interactive_heatmap_speed"
-        onChange={(v) => setOptions({ interactiveHeatmapsSpeeds: v })}
-      />
-      <BooleanSetting
-        id="clip-previews"
-        checked={options.clipPreviews ?? false}
-        headingID="dialogs.scene_gen.clip_previews"
-        onChange={(v) => setOptions({ clipPreviews: v })}
-      />
+        <BooleanSetting
+          id="image-thumbnails"
+          checked={options.imageThumbnails ?? false}
+          headingID="dialogs.scene_gen.image_thumbnails"
+          onChange={(v) => setOptions({ imageThumbnails: v })}
+        />
+        </>
+      )}
       <BooleanSetting
         id="overwrite"
         checked={options.overwrite ?? false}

--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -159,18 +159,18 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
       )}
       {showImageOptions && (
         <>
-        <BooleanSetting
-          id="clip-previews"
-          checked={options.clipPreviews ?? false}
-          headingID="dialogs.scene_gen.clip_previews"
-          onChange={(v) => setOptions({ clipPreviews: v })}
-        />
-        <BooleanSetting
-          id="image-thumbnails"
-          checked={options.imageThumbnails ?? false}
-          headingID="dialogs.scene_gen.image_thumbnails"
-          onChange={(v) => setOptions({ imageThumbnails: v })}
-        />
+          <BooleanSetting
+            id="clip-previews"
+            checked={options.clipPreviews ?? false}
+            headingID="dialogs.scene_gen.clip_previews"
+            onChange={(v) => setOptions({ clipPreviews: v })}
+          />
+          <BooleanSetting
+            id="image-thumbnails"
+            checked={options.imageThumbnails ?? false}
+            headingID="dialogs.scene_gen.image_thumbnails"
+            onChange={(v) => setOptions({ imageThumbnails: v })}
+          />
         </>
       )}
       <BooleanSetting

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -875,6 +875,7 @@
       "force_transcodes_tooltip": "By default, transcodes are only generated when the video file is not supported in the browser. When enabled, transcodes will be generated even when the video file appears to be supported in the browser.",
       "image_previews": "Animated Image Previews",
       "image_previews_tooltip": "Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files.",
+      "image_thumbnails": "Image Thumbnails",
       "interactive_heatmap_speed": "Generate heatmaps and speeds for interactive scenes",
       "marker_image_previews": "Marker Animated Image Previews",
       "marker_image_previews_tooltip": "Also generate animated (webp) previews, only required when Scene/Marker Wall Preview Type is set to Animated Image. When browsing they use less CPU than the video previews, but are generated in addition to them and are larger files.",


### PR DESCRIPTION
Resolves #4189 

Adds option to generate image thumbnails during the generate task.

![image](https://github.com/stashapp/stash/assets/53250216/45886846-4398-48dd-9b3e-ba55cdd52933)

Changes the on-the-fly image thumbnail generation to use the number of parallel tasks as a maximum number of concurrent generation threads.

Also changes the scene generate dialog to only show relevant scene options.