### PR TITLE
Fix auto tag from object not honouring the ignore autotag flag

### DIFF
--- a/internal/manager/task_autotag.go
+++ b/internal/manager/task_autotag.go
@@ -162,6 +162,11 @@ func (j *autoTagJob) autoTagPerformers(ctx context.Context, progress *job.Progre
 					return fmt.Errorf("performer with id %s not found", performerId)
 				}
 
+				if performer.IgnoreAutoTag {
+					logger.Infof("Skipping performer %s because auto-tag is disabled", performer.Name)
+					return nil
+				}
+
 				if err := performer.LoadAliases(ctx, r.Performer); err != nil {
 					return fmt.Errorf("loading aliases for performer %d: %w", performer.ID, err)
 				}
@@ -251,6 +256,11 @@ func (j *autoTagJob) autoTagStudios(ctx context.Context, progress *job.Progress,
 
 				if studio == nil {
 					return fmt.Errorf("studio with id %s not found", studioId)
+				}
+
+				if studio.IgnoreAutoTag {
+					logger.Infof("Skipping studio %s because auto-tag is disabled", studio.Name)
+					return nil
 				}
 
 				studios = append(studios, studio)
@@ -343,6 +353,11 @@ func (j *autoTagJob) autoTagTags(ctx context.Context, progress *job.Progress, pa
 
 				if tag == nil {
 					return fmt.Errorf("tag with id %s not found", tagId)
+				}
+
+				if tag.IgnoreAutoTag {
+					logger.Infof("Skipping tag %s because auto-tag is disabled", tag.Name)
+					return nil
 				}
 
 				tags = append(tags, tag)

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -380,6 +380,7 @@ const PerformerPage: React.FC<IProps> = ({ performer, tabKey }) => {
               onToggleEdit={() => toggleEditing()}
               onDelete={onDelete}
               onAutoTag={onAutoTag}
+              autoTagDisabled={performer.ignore_auto_tag}
               isNew={false}
               isEditing={false}
               onSave={() => {}}

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -13,6 +13,7 @@ interface IProps {
   saveDisabled?: boolean;
   onDelete: () => void;
   onAutoTag?: () => void;
+  autoTagDisabled?: boolean;
   onImageChange: (event: React.FormEvent<HTMLInputElement>) => void;
   onBackImageChange?: (event: React.FormEvent<HTMLInputElement>) => void;
   onImageChangeURL?: (url: string) => void;
@@ -94,6 +95,7 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
         <div>
           <Button
             variant="secondary"
+            disabled={props.autoTagDisabled}
             onClick={() => {
               if (props.onAutoTag) {
                 props.onAutoTag();

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -502,6 +502,7 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
           onImageChange={() => {}}
           onClearImage={() => {}}
           onAutoTag={onAutoTag}
+          autoTagDisabled={studio.ignore_auto_tag}
           onDelete={onDelete}
         />
       );

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -374,6 +374,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
           onImageChange={() => {}}
           onClearImage={() => {}}
           onAutoTag={onAutoTag}
+          autoTagDisabled={tag.ignore_auto_tag}
           onDelete={onDelete}
           classNames="mb-2"
           customButtons={renderMergeButton()}


### PR DESCRIPTION
Fixes issue reported in Discord where you could click the Auto Tag button on a Performer/Tag/Studio page where the Ignore Auto Tag flag was enabled and the auto tag operation would proceed. Backend now ignores and logs cases where a specific id was provided and has Ignore Auto Tag enabled. Also disabled the Auto Tag button on pages where the flag is enabled.