### PR TITLE
Set UpdatedAt on SceneMarkers after generation tasks & include it in URLs

### DIFF
--- a/internal/api/urlbuilders/scene_markers.go
+++ b/internal/api/urlbuilders/scene_markers.go
@@ -7,16 +7,18 @@ import (
 )
 
 type SceneMarkerURLBuilder struct {
-	BaseURL  string
-	SceneID  string
-	MarkerID string
+	BaseURL   string
+	SceneID   string
+	MarkerID  string
+	UpdatedAt string
 }
 
 func NewSceneMarkerURLBuilder(baseURL string, sceneMarker *models.SceneMarker) SceneMarkerURLBuilder {
 	return SceneMarkerURLBuilder{
-		BaseURL:  baseURL,
-		SceneID:  strconv.Itoa(sceneMarker.SceneID),
-		MarkerID: strconv.Itoa(sceneMarker.ID),
+		BaseURL:   baseURL,
+		SceneID:   strconv.Itoa(sceneMarker.SceneID),
+		MarkerID:  strconv.Itoa(sceneMarker.ID),
+		UpdatedAt: strconv.FormatInt(sceneMarker.UpdatedAt.Unix(), 10),
 	}
 }
 
@@ -25,9 +27,9 @@ func (b SceneMarkerURLBuilder) GetStreamURL() string {
 }
 
 func (b SceneMarkerURLBuilder) GetPreviewURL() string {
-	return b.BaseURL + "/scene/" + b.SceneID + "/scene_marker/" + b.MarkerID + "/preview"
+	return b.BaseURL + "/scene/" + b.SceneID + "/scene_marker/" + b.MarkerID + "/preview?t=" + b.UpdatedAt
 }
 
 func (b SceneMarkerURLBuilder) GetScreenshotURL() string {
-	return b.BaseURL + "/scene/" + b.SceneID + "/scene_marker/" + b.MarkerID + "/screenshot"
+	return b.BaseURL + "/scene/" + b.SceneID + "/scene_marker/" + b.MarkerID + "/screenshot?t=" + b.UpdatedAt
 }


### PR DESCRIPTION
If any of the SceneMarker related generator tasks create something, update the UpdatedAt timestamp for that SceneMarker.

Additionally, include the UpdatedAt timestamp in the preview & screenshot URLs for the SceneMarker.

I modeled this change after how Scene screenshot generation works and how that URL includes the timestamp.

I didn't see an issue about this, but I'm happy to open one if that's the protocol.