### PR TITLE
Serve original filename with image

### DIFF
--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -199,6 +199,12 @@ func (f *BaseFile) Serve(fs FS, w http.ResponseWriter, r *http.Request) error {
 	} else {
 		w.Header().Set("Cache-Control", "no-cache")
 	}
+
+	// Set filename if not previously set
+	if w.Header().Get("Content-Disposition") == "" {
+		w.Header().Set("Content-Disposition", fmt.Sprintf("filename=%s", f.Basename))
+	}
+
 	http.ServeContent(w, r, f.Basename, f.ModTime, content)
 
 	return nil


### PR DESCRIPTION
This commit addresses https://github.com/stashapp/stash/issues/4605
It simply sets the "Content-Disposition" header which tells the client what the filename is.
Tested in: Firefox, Chrome and Safari

The only real question is "Do we want this?"