### PR TITLE
Improve scene tagger prioritization

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -189,7 +189,10 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
       calculatePhashComparisonScore(stashScene, sceneB);
 
     // If only one scene has matching phash, prefer that scene
-    if (nbPhashMatchSceneA != nbPhashMatchSceneB && nbPhashMatchSceneA === 0 || nbPhashMatchSceneB === 0) {
+    if (
+      (nbPhashMatchSceneA != nbPhashMatchSceneB && nbPhashMatchSceneA === 0) ||
+      nbPhashMatchSceneB === 0
+    ) {
       return nbPhashMatchSceneB - nbPhashMatchSceneA;
     }
 

--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -188,11 +188,17 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
     const [nbPhashMatchSceneB, ratioPhashMatchSceneB] =
       calculatePhashComparisonScore(stashScene, sceneB);
 
-    if (nbPhashMatchSceneA != nbPhashMatchSceneB) {
+    // If only one scene has matching phash, prefer that scene
+    if (nbPhashMatchSceneA != nbPhashMatchSceneB && nbPhashMatchSceneA === 0 || nbPhashMatchSceneB === 0) {
       return nbPhashMatchSceneB - nbPhashMatchSceneA;
     }
 
-    // Same number of phash matches, check duration
+    // Prefer scene with highest ratio of phash matches
+    if (ratioPhashMatchSceneA !== ratioPhashMatchSceneB) {
+      return ratioPhashMatchSceneB - ratioPhashMatchSceneA;
+    }
+
+    // Same ratio of phash matches, check duration
     const [
       nbDurationMatchSceneA,
       ratioDurationMatchSceneA,
@@ -211,11 +217,6 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
     // Same number of phash & duration, check duration ratio
     if (ratioDurationMatchSceneA != ratioDurationMatchSceneB) {
       return ratioDurationMatchSceneB - ratioDurationMatchSceneA;
-    }
-
-    // Damn this is close... Check phash ratio
-    if (ratioPhashMatchSceneA !== ratioPhashMatchSceneB) {
-      return ratioPhashMatchSceneB - ratioPhashMatchSceneA;
     }
 
     // fall back to duration difference - less is better

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -5,12 +5,14 @@ import { FormattedMessage, useIntl } from "react-intl";
 import uniq from "lodash-es/uniq";
 import { blobToBase64 } from "base64-blob";
 import { distance } from "src/utils/hamming";
+import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
+import { faPlus, faTriangleExclamation, faXmark} from "@fortawesome/free-solid-svg-icons";
 
 import * as GQL from "src/core/generated-graphql";
 import { HoverPopover } from "src/components/Shared/HoverPopover";
 import { Icon } from "src/components/Shared/Icon";
-import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { SuccessIcon } from "src/components/Shared/SuccessIcon";
+import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { TagSelect } from "src/components/Shared/Select";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { OperationButton } from "src/components/Shared/OperationButton";
@@ -22,9 +24,17 @@ import { SceneTaggerModalsState } from "./sceneTaggerModals";
 import PerformerResult from "./PerformerResult";
 import StudioResult from "./StudioResult";
 import { useInitialState } from "src/hooks/state";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { getStashboxBase } from "src/utils/stashbox";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
+
+const getDurationIcon = (matchPercentage: number) => {
+  if (matchPercentage > 65)
+    return <Icon className="SceneTaggerIcon text-success" icon={faCheckCircle} />;
+  if (matchPercentage > 35)
+    return <Icon className="SceneTaggerIcon text-warn" icon={faTriangleExclamation} />;
+
+  return <Icon className="SceneTaggerIcon text-danger" icon={faXmark} />;
+}
 
 const getDurationStatus = (
   scene: IScrapedScene,
@@ -52,10 +62,12 @@ const getDurationStatus = (
   else if (scene.duration && Math.abs(scene.duration - stashDuration) < 5)
     match = <FormattedMessage id="component_tagger.results.fp_matches" />;
 
+  const matchPercentage = (matchCount / durations.length) * 100;
+
   if (match)
     return (
       <div className="font-weight-bold">
-        <SuccessIcon className="mr-2" />
+        { getDurationIcon(matchPercentage) }
         {match}
       </div>
     );
@@ -146,7 +158,7 @@ const getFingerprintStatus = (
       <div>
         {phashMatches.length > 0 && (
           <div className="font-weight-bold">
-            <SuccessIcon className="mr-2" />
+            <SuccessIcon className="SceneTaggerIcon" />
             <HoverPopover
               placement="bottom"
               content={phashList}

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -6,7 +6,11 @@ import uniq from "lodash-es/uniq";
 import { blobToBase64 } from "base64-blob";
 import { distance } from "src/utils/hamming";
 import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
-import { faPlus, faTriangleExclamation, faXmark} from "@fortawesome/free-solid-svg-icons";
+import {
+  faPlus,
+  faTriangleExclamation,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
 
 import * as GQL from "src/core/generated-graphql";
 import { HoverPopover } from "src/components/Shared/HoverPopover";
@@ -29,12 +33,19 @@ import { ExternalLink } from "src/components/Shared/ExternalLink";
 
 const getDurationIcon = (matchPercentage: number) => {
   if (matchPercentage > 65)
-    return <Icon className="SceneTaggerIcon text-success" icon={faCheckCircle} />;
+    return (
+      <Icon className="SceneTaggerIcon text-success" icon={faCheckCircle} />
+    );
   if (matchPercentage > 35)
-    return <Icon className="SceneTaggerIcon text-warn" icon={faTriangleExclamation} />;
+    return (
+      <Icon
+        className="SceneTaggerIcon text-warn"
+        icon={faTriangleExclamation}
+      />
+    );
 
   return <Icon className="SceneTaggerIcon text-danger" icon={faXmark} />;
-}
+};
 
 const getDurationStatus = (
   scene: IScrapedScene,
@@ -67,7 +78,7 @@ const getDurationStatus = (
   if (match)
     return (
       <div className="font-weight-bold">
-        { getDurationIcon(matchPercentage) }
+        {getDurationIcon(matchPercentage)}
         {match}
       </div>
     );

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -76,6 +76,12 @@
       background-color: #137cbd;
     }
   }
+
+  .SceneTaggerIcon {
+    margin-left: .25em;
+    margin-right: 10px;
+    width: var(--fa-fw-width, 1.25em);
+  }
 }
 
 .selected-result {

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -78,7 +78,7 @@
   }
 
   .SceneTaggerIcon {
-    margin-left: .25em;
+    margin-left: 0.25em;
     margin-right: 10px;
     width: var(--fa-fw-width, 1.25em);
   }


### PR DESCRIPTION
Changes the scene tagger sorting to use ratio of phash matches rather than the absolute count.

In the linked example the scene that gets prioritized has 100 matching phashes due to a short, generic video hitting a phash "pit" so to speak. However it only has about 50% match rate, so by using that instead we can deprioritize it.

https://discord.com/channels/559159668438728723/798641040029777980/1211226733978718259

Also tweaks the icons to warn when a scene has a poor phash match rate.