### PR TITLE
Make directors and photographers clickable in detail view

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
@@ -3,12 +3,13 @@ import { Link } from "react-router-dom";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { DirectorLink, TagLink } from "src/components/Shared/TagLink";
+import { TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { sortPerformers } from "src/core/performers";
 import { galleryTitle } from "src/core/galleries";
+import { PhotographerLink } from "src/components/Shared/Link";
 
 interface IGalleryDetailProps {
   gallery: GQL.GalleryDataFragment;
@@ -117,9 +118,12 @@ export const GalleryDetailPanel: React.FC<IGalleryDetailProps> = ({
             </h6>
           )}
           {gallery.photographer && (
-            
             <h6>
-              <FormattedMessage id="photographer" />: <DirectorLink director={gallery.photographer} linkType="gallery"></DirectorLink>
+              <FormattedMessage id="photographer" />:{" "}
+              <PhotographerLink
+                photographer={gallery.photographer}
+                linkType="gallery"
+              />
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryDetailPanel.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { TagLink } from "src/components/Shared/TagLink";
+import { DirectorLink, TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
@@ -117,8 +117,9 @@ export const GalleryDetailPanel: React.FC<IGalleryDetailProps> = ({
             </h6>
           )}
           {gallery.photographer && (
+            
             <h6>
-              <FormattedMessage id="photographer" />: {gallery.photographer}{" "}
+              <FormattedMessage id="photographer" />: <DirectorLink director={gallery.photographer} linkType="gallery"></DirectorLink>
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
@@ -2,13 +2,14 @@ import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { DirectorLink, GalleryLink, TagLink } from "src/components/Shared/TagLink";
+import { GalleryLink, TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { sortPerformers } from "src/core/performers";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import { objectTitle } from "src/core/files";
+import { PhotographerLink } from "src/components/Shared/Link";
 interface IImageDetailProps {
   image: GQL.ImageDataFragment;
 }
@@ -154,7 +155,11 @@ export const ImageDetailPanel: React.FC<IImageDetailProps> = (props) => {
           )}
           {props.image.photographer && (
             <h6>
-              <FormattedMessage id="photographer" />: <DirectorLink director={props.image.photographer} linkType="image"></DirectorLink>
+              <FormattedMessage id="photographer" />:{" "}
+              <PhotographerLink
+                photographer={props.image.photographer}
+                linkType="image"
+              />
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageDetailPanel.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { GalleryLink, TagLink } from "src/components/Shared/TagLink";
+import { DirectorLink, GalleryLink, TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
@@ -154,7 +154,7 @@ export const ImageDetailPanel: React.FC<IImageDetailProps> = (props) => {
           )}
           {props.image.photographer && (
             <h6>
-              <FormattedMessage id="photographer" />: {props.image.photographer}{" "}
+              <FormattedMessage id="photographer" />: <DirectorLink director={props.image.photographer} linkType="image"></DirectorLink>
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -4,7 +4,6 @@ import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
 import { DetailItem } from "src/components/Shared/DetailItem";
 import { Link } from "react-router-dom";
-import { DirectorLink } from "src/components/Shared/TagLink";
 import NavUtils from "src/utils/navigation";
 
 interface IMovieDetailsPanel {

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -4,7 +4,7 @@ import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
 import { DetailItem } from "src/components/Shared/DetailItem";
 import { Link } from "react-router-dom";
-import NavUtils from "src/utils/navigation";
+import { DirectorLink } from "src/components/Shared/Link";
 
 interface IMovieDetailsPanel {
   movie: GQL.MovieDataFragment;
@@ -46,12 +46,11 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({
         fullWidth={fullWidth}
       />
 
-      <DetailItem id="director"
+      <DetailItem
+        id="director"
         value={
           movie.director ? (
-            <Link to={NavUtils.makeDirectorMoviesUrl(movie.director)}>
-              {movie.director}
-            </Link> 
+            <DirectorLink director={movie.director} linkType="movie" />
           ) : (
             ""
           )

--- a/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Movies/MovieDetails/MovieDetailsPanel.tsx
@@ -4,6 +4,8 @@ import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
 import { DetailItem } from "src/components/Shared/DetailItem";
 import { Link } from "react-router-dom";
+import { DirectorLink } from "src/components/Shared/TagLink";
+import NavUtils from "src/utils/navigation";
 
 interface IMovieDetailsPanel {
   movie: GQL.MovieDataFragment;
@@ -45,7 +47,18 @@ export const MovieDetailsPanel: React.FC<IMovieDetailsPanel> = ({
         fullWidth={fullWidth}
       />
 
-      <DetailItem id="director" value={movie.director} fullWidth={fullWidth} />
+      <DetailItem id="director"
+        value={
+          movie.director ? (
+            <Link to={NavUtils.makeDirectorMoviesUrl(movie.director)}>
+              {movie.director}
+            </Link> 
+          ) : (
+            ""
+          )
+        }
+        fullWidth={fullWidth}
+      />
       <DetailItem id="synopsis" value={movie.synopsis} fullWidth={fullWidth} />
     </div>
   );

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -3,12 +3,13 @@ import { Link } from "react-router-dom";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { DirectorLink, TagLink } from "src/components/Shared/TagLink";
+import { TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { objectTitle } from "src/core/files";
+import { DirectorLink } from "src/components/Shared/Link";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;
@@ -128,7 +129,8 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
           )}
           {props.scene.director && (
             <h6>
-              <FormattedMessage id="director" />: <DirectorLink director={props.scene.director} linkType="scene"></DirectorLink>
+              <FormattedMessage id="director" />:{" "}
+              <DirectorLink director={props.scene.director} linkType="scene" />
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
-import { TagLink } from "src/components/Shared/TagLink";
+import { DirectorLink, TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
@@ -128,7 +128,7 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
           )}
           {props.scene.director && (
             <h6>
-              <FormattedMessage id="director" />: {props.scene.director}{" "}
+              <FormattedMessage id="director" />: <DirectorLink director={props.scene.director} linkType="scene"></DirectorLink>
             </h6>
           )}
         </div>

--- a/ui/v2.5/src/components/Shared/Link.tsx
+++ b/ui/v2.5/src/components/Shared/Link.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import NavUtils from "src/utils/navigation";
+
+// common link components
+
+export const DirectorLink: React.FC<{
+  director: string;
+  linkType: "scene" | "movie";
+}> = ({ director: director, linkType = "scene" }) => {
+  const link = useMemo(() => {
+    switch (linkType) {
+      case "scene":
+        return NavUtils.makeDirectorScenesUrl(director);
+      case "movie":
+        return NavUtils.makeDirectorMoviesUrl(director);
+    }
+  }, [director, linkType]);
+
+  return <Link to={link}>{director}</Link>;
+};
+
+export const PhotographerLink: React.FC<{
+  photographer: string;
+  linkType: "gallery" | "image";
+}> = ({ photographer, linkType = "image" }) => {
+  const link = useMemo(() => {
+    switch (linkType) {
+      case "gallery":
+        return NavUtils.makePhotographerGalleriesUrl(photographer);
+      case "image":
+        return NavUtils.makePhotographerImagesUrl(photographer);
+    }
+  }, [photographer, linkType]);
+
+  return <Link to={link}>{photographer}</Link>;
+};

--- a/ui/v2.5/src/components/Shared/TagLink.tsx
+++ b/ui/v2.5/src/components/Shared/TagLink.tsx
@@ -251,3 +251,32 @@ export const TagLink: React.FC<ITagLinkProps> = ({
     </CommonLinkComponent>
   );
 };
+
+interface IDirectorLinkProps {
+  director: string;
+  linkType?: "scene" | "gallery" | "image";
+  className?: string;
+}
+
+export const DirectorLink: React.FC<IDirectorLinkProps> = ({
+  director: director,
+  linkType = "scene",
+}) => {
+  const link = useMemo(() => {
+    switch (linkType) {
+      case "scene":
+        return NavUtils.makeDirectorScenesUrl(director);
+      case "gallery":
+        return NavUtils.makeDirectorGalleriesUrl(director);
+      case "image":
+        return NavUtils.makeDirectorImagesUrl(director);
+    }
+  }, [director, linkType]);
+
+
+  return (
+    <CommonLinkComponent link={link}>
+      {director}
+    </CommonLinkComponent>
+  );
+};

--- a/ui/v2.5/src/components/Shared/TagLink.tsx
+++ b/ui/v2.5/src/components/Shared/TagLink.tsx
@@ -254,7 +254,7 @@ export const TagLink: React.FC<ITagLinkProps> = ({
 
 interface IDirectorLinkProps {
   director: string;
-  linkType?: "scene" | "gallery" | "image";
+  linkType?: "scene" | "gallery" | "image" | "movie";
   className?: string;
 }
 
@@ -270,6 +270,8 @@ export const DirectorLink: React.FC<IDirectorLinkProps> = ({
         return NavUtils.makeDirectorGalleriesUrl(director);
       case "image":
         return NavUtils.makeDirectorImagesUrl(director);
+      case "movie":
+        return NavUtils.makeDirectorMoviesUrl(director);
     }
   }, [director, linkType]);
 

--- a/ui/v2.5/src/components/Shared/TagLink.tsx
+++ b/ui/v2.5/src/components/Shared/TagLink.tsx
@@ -251,34 +251,3 @@ export const TagLink: React.FC<ITagLinkProps> = ({
     </CommonLinkComponent>
   );
 };
-
-interface IDirectorLinkProps {
-  director: string;
-  linkType?: "scene" | "gallery" | "image" | "movie";
-  className?: string;
-}
-
-export const DirectorLink: React.FC<IDirectorLinkProps> = ({
-  director: director,
-  linkType = "scene",
-}) => {
-  const link = useMemo(() => {
-    switch (linkType) {
-      case "scene":
-        return NavUtils.makeDirectorScenesUrl(director);
-      case "gallery":
-        return NavUtils.makeDirectorGalleriesUrl(director);
-      case "image":
-        return NavUtils.makeDirectorImagesUrl(director);
-      case "movie":
-        return NavUtils.makeDirectorMoviesUrl(director);
-    }
-  }, [director, linkType]);
-
-
-  return (
-    <CommonLinkComponent link={link}>
-      {director}
-    </CommonLinkComponent>
-  );
-};

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -15,6 +15,7 @@ import { ListFilterModel } from "src/models/list-filter/filter";
 import { MoviesCriterion } from "src/models/list-filter/criteria/movies";
 import {
   Criterion,
+  CriterionOption,
   CriterionValue,
   StringCriterion,
   createStringCriterionOption,
@@ -357,47 +358,54 @@ const makeGalleryImagesUrl = (
   return `/images?${filter.makeQueryParameters()}`;
 };
 
+function stringEqualsCriterion(option: CriterionOption, value: string) {
+  const criterion = new StringCriterion(option);
+  criterion.modifier = GQL.CriterionModifier.Equals;
+  criterion.value = value;
+  return criterion;
+}
+
 const makeDirectorScenesUrl = (director: string) => {
   if (director.length == 0) return "#";
   const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
-  const criterion = new StringCriterion(createStringCriterionOption("director"));
-  criterion.modifier = GQL.CriterionModifier.Equals;
-  criterion.value = director;
-  filter.criteria.push(criterion);
+  filter.criteria.push(
+    stringEqualsCriterion(createStringCriterionOption("director"), director)
+  );
   return `/scenes?${filter.makeQueryParameters()}`;
-};
-
-const makeDirectorGalleriesUrl = (director: string) => {
-  if (director.length == 0) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
-  const criterion = new StringCriterion(createStringCriterionOption("photographer"));
-  criterion.modifier = GQL.CriterionModifier.Equals;
-  criterion.value = director;
-  filter.criteria.push(criterion);
-  return `/galleries?${filter.makeQueryParameters()}`;
-};
-
-const makeDirectorImagesUrl = (director: string) => {
-  if (director.length == 0) return "#";
-  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
-  const criterion = new StringCriterion(createStringCriterionOption("photographer"));
-  criterion.modifier = GQL.CriterionModifier.Equals;
-  criterion.value = director;
-  filter.criteria.push(criterion);
-  return `/images?${filter.makeQueryParameters()}`;
 };
 
 const makeDirectorMoviesUrl = (director: string) => {
   if (director.length == 0) return "#";
   const filter = new ListFilterModel(GQL.FilterMode.Movies, undefined);
-  const criterion = new StringCriterion(createStringCriterionOption("director"));
-  criterion.modifier = GQL.CriterionModifier.Equals;
-  criterion.value = director;
-  filter.criteria.push(criterion);
+  filter.criteria.push(
+    stringEqualsCriterion(createStringCriterionOption("director"), director)
+  );
   return `/movies?${filter.makeQueryParameters()}`;
 };
 
+const makePhotographerGalleriesUrl = (photographer: string) => {
+  if (photographer.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  filter.criteria.push(
+    stringEqualsCriterion(
+      createStringCriterionOption("photographer"),
+      photographer
+    )
+  );
+  return `/galleries?${filter.makeQueryParameters()}`;
+};
 
+const makePhotographerImagesUrl = (photographer: string) => {
+  if (photographer.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
+  filter.criteria.push(
+    stringEqualsCriterion(
+      createStringCriterionOption("photographer"),
+      photographer
+    )
+  );
+  return `/images?${filter.makeQueryParameters()}`;
+};
 
 export function handleUnsavedChanges(
   intl: IntlShape,
@@ -439,8 +447,8 @@ const NavUtils = {
   makeChildStudiosUrl,
   makeGalleryImagesUrl,
   makeDirectorScenesUrl,
-  makeDirectorGalleriesUrl,
-  makeDirectorImagesUrl,
+  makePhotographerGalleriesUrl,
+  makePhotographerImagesUrl,
   makeDirectorMoviesUrl,
 };
 

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -389,6 +389,16 @@ const makeDirectorImagesUrl = (director: string) => {
   return `/images?${filter.makeQueryParameters()}`;
 };
 
+const makeDirectorMoviesUrl = (director: string) => {
+  if (director.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Movies, undefined);
+  const criterion = new StringCriterion(createStringCriterionOption("director"));
+  criterion.modifier = GQL.CriterionModifier.Equals;
+  criterion.value = director;
+  filter.criteria.push(criterion);
+  return `/movies?${filter.makeQueryParameters()}`;
+};
+
 
 
 export function handleUnsavedChanges(
@@ -433,6 +443,7 @@ const NavUtils = {
   makeDirectorScenesUrl,
   makeDirectorGalleriesUrl,
   makeDirectorImagesUrl,
+  makeDirectorMoviesUrl,
 };
 
 export default NavUtils;

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -15,10 +15,8 @@ import { ListFilterModel } from "src/models/list-filter/filter";
 import { MoviesCriterion } from "src/models/list-filter/criteria/movies";
 import {
   Criterion,
-  CriterionOption,
   CriterionValue,
   StringCriterion,
-  StringCriterionOption,
   createStringCriterionOption,
 } from "src/models/list-filter/criteria/criterion";
 import { GalleriesCriterion } from "src/models/list-filter/criteria/galleries";

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -15,7 +15,11 @@ import { ListFilterModel } from "src/models/list-filter/filter";
 import { MoviesCriterion } from "src/models/list-filter/criteria/movies";
 import {
   Criterion,
+  CriterionOption,
   CriterionValue,
+  StringCriterion,
+  StringCriterionOption,
+  createStringCriterionOption,
 } from "src/models/list-filter/criteria/criterion";
 import { GalleriesCriterion } from "src/models/list-filter/criteria/galleries";
 import { PhashCriterion } from "src/models/list-filter/criteria/phash";
@@ -355,6 +359,38 @@ const makeGalleryImagesUrl = (
   return `/images?${filter.makeQueryParameters()}`;
 };
 
+const makeDirectorScenesUrl = (director: string) => {
+  if (director.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Scenes, undefined);
+  const criterion = new StringCriterion(createStringCriterionOption("director"));
+  criterion.modifier = GQL.CriterionModifier.Equals;
+  criterion.value = director;
+  filter.criteria.push(criterion);
+  return `/scenes?${filter.makeQueryParameters()}`;
+};
+
+const makeDirectorGalleriesUrl = (director: string) => {
+  if (director.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Galleries, undefined);
+  const criterion = new StringCriterion(createStringCriterionOption("photographer"));
+  criterion.modifier = GQL.CriterionModifier.Equals;
+  criterion.value = director;
+  filter.criteria.push(criterion);
+  return `/galleries?${filter.makeQueryParameters()}`;
+};
+
+const makeDirectorImagesUrl = (director: string) => {
+  if (director.length == 0) return "#";
+  const filter = new ListFilterModel(GQL.FilterMode.Images, undefined);
+  const criterion = new StringCriterion(createStringCriterionOption("photographer"));
+  criterion.modifier = GQL.CriterionModifier.Equals;
+  criterion.value = director;
+  filter.criteria.push(criterion);
+  return `/images?${filter.makeQueryParameters()}`;
+};
+
+
+
 export function handleUnsavedChanges(
   intl: IntlShape,
   basepath: string,
@@ -394,6 +430,9 @@ const NavUtils = {
   makeMovieScenesUrl,
   makeChildStudiosUrl,
   makeGalleryImagesUrl,
+  makeDirectorScenesUrl,
+  makeDirectorGalleriesUrl,
+  makeDirectorImagesUrl,
 };
 
 export default NavUtils;


### PR DESCRIPTION
This PR is meant to address #4568 by making director/photographer names clickable in scene, movie, gallery, and image detail views. A new component type `DirectorLink` is added based on `TagLink` which links to the scenes, galleries, or images page as applicable with a filter applied for items where the director/photographer `EQUALS` the name that was clicked.

The movie details page does not use this new component, in favour of a standard `Link` to better match the other detail items visually.

Close https://github.com/stashapp/stash/issues/4568