### PR TITLE
Fix penis length being incorrectly truncated

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -110,7 +110,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     weight: yupInputNumber().positive().truncate().nullable().defined(),
     measurements: yup.string().ensure(),
     fake_tits: yup.string().ensure(),
-    penis_length: yupInputNumber().positive().truncate().nullable().defined(),
+    penis_length: yupInputNumber().positive().nullable().defined(),
     circumcised: yupInputEnum(GQL.CircumisedEnum).nullable().defined(),
     tattoos: yup.string().ensure(),
     piercings: yup.string().ensure(),


### PR DESCRIPTION
Fixes latent UI issue that was truncating the penis length attribute to an integer value.

Fixes #4629 