### PR TITLE
Added Sort Performers by Last O At / Last Played At / Play Count and Added Filter Performers by Play Count. Changes to display O Count rather than O-Counter for better consistency. Grammar fixes for 'Interactive Speed' and 'pHash'.

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -143,6 +143,8 @@ input PerformerFilterType {
   image_count: IntCriterionInput
   "Filter by gallery count"
   gallery_count: IntCriterionInput
+  "Filter by play count"
+  play_count: IntCriterionInput
   "Filter by o count"
   o_counter: IntCriterionInput
   "Filter by StashID"

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -160,6 +160,8 @@ type PerformerFilterType struct {
 	ImageCount *IntCriterionInput `json:"image_count"`
 	// Filter by gallery count
 	GalleryCount *IntCriterionInput `json:"gallery_count"`
+	// Filter by play count
+	PlayCount *IntCriterionInput `json:"play_count"`
 	// Filter by O count
 	OCounter *IntCriterionInput `json:"o_counter"`
 	// Filter by StashID

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -874,6 +874,44 @@ var selectPerformerOCountSQL = utils.StrFormat(
 	},
 )
 
+// used for sorting on performer last o_date
+var selectPerformerLastOAtSQL = utils.StrFormat(
+	"SELECT MAX(o_date) FROM ("+
+		"SELECT {o_date} FROM {performers_scenes} s "+
+		"LEFT JOIN {scenes} ON {scenes}.id = s.{scene_id} "+
+		"LEFT JOIN {scenes_o_dates} ON {scenes_o_dates}.{scene_id} = {scenes}.id "+
+		"WHERE s.{performer_id} = {performers}.id"+
+		")",
+	map[string]interface{}{
+		"performer_id":      performerIDColumn,
+		"performers":        performerTable,
+		"performers_scenes": performersScenesTable,
+		"scenes":            sceneTable,
+		"scene_id":          sceneIDColumn,
+		"scenes_o_dates":    scenesODatesTable,
+		"o_date":            sceneODateColumn,
+	},
+)
+
+// used for sorting on performer last view_date
+var selectPerformerLastPlayedAtSQL = utils.StrFormat(
+	"SELECT MAX(view_date) FROM ("+
+		"SELECT {view_date} FROM {performers_scenes} s "+
+		"LEFT JOIN {scenes} ON {scenes}.id = s.{scene_id} "+
+		"LEFT JOIN {scenes_view_dates} ON {scenes_view_dates}.{scene_id} = {scenes}.id "+
+		"WHERE s.{performer_id} = {performers}.id"+
+		")",
+	map[string]interface{}{
+		"performer_id":      performerIDColumn,
+		"performers":        performerTable,
+		"performers_scenes": performersScenesTable,
+		"scenes":            sceneTable,
+		"scene_id":          sceneIDColumn,
+		"scenes_view_dates": scenesViewDatesTable,
+		"view_date":         sceneViewDateColumn,
+	},
+)
+
 func performerOCounterCriterionHandler(qb *PerformerStore, count *models.IntCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if count == nil {
@@ -1027,6 +1065,16 @@ func (qb *PerformerStore) sortByOCounter(direction string) string {
 	return " ORDER BY (" + selectPerformerOCountSQL + ") " + direction
 }
 
+func (qb *PerformerStore) sortByLastOAt(direction string) string {
+	// need to get the o_dates from scenes
+	return " ORDER BY (" + selectPerformerLastOAtSQL + ") " + direction
+}
+
+func (qb *PerformerStore) sortByLastPlayedAt(direction string) string {
+	// need to get the view_dates from scenes
+	return " ORDER BY (" + selectPerformerLastPlayedAtSQL + ") " + direction
+}
+
 func (qb *PerformerStore) getPerformerSort(findFilter *models.FindFilterType) string {
 	var sort string
 	var direction string
@@ -1050,6 +1098,10 @@ func (qb *PerformerStore) getPerformerSort(findFilter *models.FindFilterType) st
 		sortQuery += getCountSort(performerTable, performersGalleriesTable, performerIDColumn, direction)
 	case "o_counter":
 		sortQuery += qb.sortByOCounter(direction)
+	case "last_played_at":
+		sortQuery += qb.sortByLastPlayedAt(direction)
+	case "last_o_at":
+		sortQuery += qb.sortByLastOAt(direction)
 	default:
 		sortQuery += getSort(sort, direction, "performers")
 	}

--- a/ui/v2.5/src/components/Performers/PerformerListTable.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerListTable.tsx
@@ -350,7 +350,7 @@ export const PerformerListTable: React.FC<IPerformerListTableProps> = (
     },
     {
       value: "o_counter",
-      label: intl.formatMessage({ id: "o_counter" }),
+      label: intl.formatMessage({ id: "o_count" }),
       defaultShow: true,
       render: OCounterCell,
     },

--- a/ui/v2.5/src/components/Scenes/SceneListTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneListTable.tsx
@@ -334,7 +334,7 @@ export const SceneListTable: React.FC<ISceneListTableProps> = (
     },
     {
       value: "o_counter",
-      label: intl.formatMessage({ id: "o_counter" }),
+      label: intl.formatMessage({ id: "o_count" }),
       render: (s) => <>{s.o_counter}</>,
     },
     {

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -410,7 +410,7 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
           onChange={(value) => setRating(value)}
         />
         <ScrapeDialogRow
-          title={intl.formatMessage({ id: "o_counter" })}
+          title={intl.formatMessage({ id: "o_count" })}
           result={oCounter}
           renderOriginalField={() => (
             <FormControl

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -971,7 +971,7 @@
     "select_youngest": "Select the youngest file in the duplicate group",
     "title": "Duplicate Scenes"
   },
-  "duplicated_phash": "Duplicated (phash)",
+  "duplicated_phash": "Duplicated (pHash)",
   "duration": "Duration",
   "effect_filters": {
     "aspect": "Aspect",
@@ -1066,7 +1066,7 @@
   "index_of_total": "{index} of {total}",
   "instagram": "Instagram",
   "interactive": "Interactive",
-  "interactive_speed": "Interactive speed",
+  "interactive_speed": "Interactive Speed",
   "isMissing": "Is Missing",
   "last_o_at": "Last O At",
   "last_played_at": "Last Played At",
@@ -1082,7 +1082,7 @@
     "checksum": "Checksum",
     "downloaded_from": "Downloaded From",
     "hash": "Hash",
-    "interactive_speed": "Interactive speed",
+    "interactive_speed": "Interactive Speed",
     "o_count": "O Count",
     "performer_card": {
       "age": "{age} {years_old}",
@@ -1156,7 +1156,7 @@
   "penis": "Penis",
   "penis_length": "Penis Length",
   "penis_length_cm": "Penis Length (cm)",
-  "perceptual_similarity": "Perceptual Similarity (phash)",
+  "perceptual_similarity": "Perceptual Similarity (pHash)",
   "performer": "Performer",
   "performer_age": "Performer Age",
   "performer_count": "Performer Count",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1102,6 +1102,7 @@
   "name": "Name",
   "new": "New",
   "none": "None",
+  "o_count": "O Count",
   "o_counter": "O-Counter",
   "o_history": "O History",
   "odate_recorded_no": "No O Date Recorded",

--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -24,18 +24,14 @@ import { GalleriesCriterionOption } from "./criteria/galleries";
 
 const defaultSortBy = "path";
 
-const sortByOptions = [
-  "filesize",
-  "file_count",
-  "date",
-  ...MediaSortByOptions,
-].map(ListFilterOptions.createSortBy)
-.concat([
-  {
-    messageID: "o_count",
-    value: "o_counter",
-  },
-]);
+const sortByOptions = ["filesize", "file_count", "date", ...MediaSortByOptions]
+  .map(ListFilterOptions.createSortBy)
+  .concat([
+    {
+      messageID: "o_count",
+      value: "o_counter",
+    },
+  ]);
 const displayModeOptions = [DisplayMode.Grid, DisplayMode.Wall];
 const criterionOptions = [
   createStringCriterionOption("title"),

--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -25,13 +25,17 @@ import { GalleriesCriterionOption } from "./criteria/galleries";
 const defaultSortBy = "path";
 
 const sortByOptions = [
-  "o_counter",
   "filesize",
   "file_count",
   "date",
   ...MediaSortByOptions,
-].map(ListFilterOptions.createSortBy);
-
+].map(ListFilterOptions.createSortBy)
+.concat([
+  {
+    messageID: "o_count",
+    value: "o_counter",
+  },
+]);
 const displayModeOptions = [DisplayMode.Grid, DisplayMode.Wall];
 const criterionOptions = [
   createStringCriterionOption("title"),
@@ -42,7 +46,7 @@ const criterionOptions = [
   PathCriterionOption,
   GalleriesCriterionOption,
   OrganizedCriterionOption,
-  createMandatoryNumberCriterionOption("o_counter"),
+  createMandatoryNumberCriterionOption("o_counter", "o_count"),
   ResolutionCriterionOption,
   OrientationCriterionOption,
   ImageIsMissingCriterionOption,

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -45,6 +45,10 @@ const sortByOptions = [
       value: "galleries_count",
     },
     {
+      messageID: "play_count",
+      value: "play_count",
+    },
+    {
       messageID: "o_counter",
       value: "o_counter",
     },
@@ -93,6 +97,7 @@ const criterionOptions = [
   createMandatoryNumberCriterionOption("scene_count"),
   createMandatoryNumberCriterionOption("image_count"),
   createMandatoryNumberCriterionOption("gallery_count"),
+  createMandatoryNumberCriterionOption("play_count"),
   createMandatoryNumberCriterionOption("o_counter"),
   createBooleanCriterionOption("ignore_auto_tag"),
   CountryCriterionOption,

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -27,6 +27,7 @@ const sortByOptions = [
   "random",
   "rating",
   "penis_length",
+  "play_count",
   "last_played_at",
   "last_o_at",
 ]
@@ -43,10 +44,6 @@ const sortByOptions = [
     {
       messageID: "gallery_count",
       value: "galleries_count",
-    },
-    {
-      messageID: "play_count",
-      value: "play_count",
     },
     {
       messageID: "o_counter",

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -27,6 +27,8 @@ const sortByOptions = [
   "random",
   "rating",
   "penis_length",
+  "last_played_at",
+  "last_o_at",
 ]
   .map(ListFilterOptions.createSortBy)
   .concat([

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -46,7 +46,7 @@ const sortByOptions = [
       value: "galleries_count",
     },
     {
-      messageID: "o_counter",
+      messageID: "o_count",
       value: "o_counter",
     },
   ]);
@@ -95,7 +95,7 @@ const criterionOptions = [
   createMandatoryNumberCriterionOption("image_count"),
   createMandatoryNumberCriterionOption("gallery_count"),
   createMandatoryNumberCriterionOption("play_count"),
-  createMandatoryNumberCriterionOption("o_counter"),
+  createMandatoryNumberCriterionOption("o_counter", "o_count"),
   createBooleanCriterionOption("ignore_auto_tag"),
   CountryCriterionOption,
   createNumberCriterionOption("height_cm", "height"),

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -50,13 +50,14 @@ const sortByOptions = [
   "interactive_speed",
   "perceptual_similarity",
   ...MediaSortByOptions,
-].map(ListFilterOptions.createSortBy)
-.concat([
-  {
-    messageID: "o_count",
-    value: "o_counter",
-  },
-]);
+]
+  .map(ListFilterOptions.createSortBy)
+  .concat([
+    {
+      messageID: "o_count",
+      value: "o_counter",
+    },
+  ]);
 const displayModeOptions = [
   DisplayMode.Grid,
   DisplayMode.List,

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -34,7 +34,6 @@ import { OrientationCriterionOption } from "./criteria/orientation";
 const defaultSortBy = "date";
 const sortByOptions = [
   "organized",
-  "o_counter",
   "date",
   "file_count",
   "filesize",
@@ -51,8 +50,13 @@ const sortByOptions = [
   "interactive_speed",
   "perceptual_similarity",
   ...MediaSortByOptions,
-].map(ListFilterOptions.createSortBy);
-
+].map(ListFilterOptions.createSortBy)
+.concat([
+  {
+    messageID: "o_count",
+    value: "o_counter",
+  },
+]);
 const displayModeOptions = [
   DisplayMode.Grid,
   DisplayMode.List,
@@ -72,7 +76,7 @@ const criterionOptions = [
   DuplicatedCriterionOption,
   OrganizedCriterionOption,
   RatingCriterionOption,
-  createMandatoryNumberCriterionOption("o_counter"),
+  createMandatoryNumberCriterionOption("o_counter", "o_count"),
   ResolutionCriterionOption,
   OrientationCriterionOption,
   createMandatoryNumberCriterionOption("framerate"),


### PR DESCRIPTION
This pull request adds the option to sort (and filter) the performer page by recent activity, which can provide interesting and more dynamic arrangements compared to the static values such as height. I first added options to sort them by Last O At and Last Played At, to compliment the same set of options now available in scenes.
 
While I could filter the 'Last O At' performers with an 'O Count Greater than Zero' to better sort the results by ascending/descending, it was not possible to do the same with the 'Last Played At' performers, so I felt it necessary to include the option to filter performers by Play Count as well.

The only thing still missing from these additions, taking advantage of the full parity between the new Play/O date data, was the option to sort Performers by Play Count so I've added that as well. As users build up more of a long-term view/o-history the benefits of these additional sorts and filters should become clear.

The O-Counter text has been changed to 'O Count', as it makes for far more legibility and coherence if it matches the other sort and filter options it is placed alongside, like Gallery Count, Image Count, Play Count, Scene Count, Tag Count, File Count and Performer Count. I kept the O-Counter hover text for the literal O-Counter button but have changed it first in the sort/filter then where I could additionally find it, in two list tables and the merge scene dialogue.

Finally, I had to fix a couple of things that now looked out of place in the beautiful cleaner sort list - using Title Case capitalization for 'Interactive speed' to match the other sort/filter text and using the correct mid-word capitalization for pHash.