### PR TITLE
Fix URL prefix re-inserted when redirecting settings page

### DIFF
--- a/ui/v2.5/src/components/Settings/Settings.tsx
+++ b/ui/v2.5/src/components/Settings/Settings.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tab, Nav, Row, Col, Form } from "react-bootstrap";
-import { Redirect } from "react-router-dom";
+import { Redirect, useLocation } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { Helmet } from "react-helmet";
@@ -41,23 +41,10 @@ function isTabKey(tab: string | null): tab is TabKey {
   return validTabs.includes(tab as TabKey);
 }
 
-const SettingTabs: React.FC = () => {
-  const tab = new URLSearchParams(location.search).get("tab");
-
+const SettingTabs: React.FC<{ tab: TabKey }> = ({ tab }) => {
   const { advancedMode, setAdvancedMode } = useSettings();
 
   const titleProps = useTitleProps({ id: "settings" });
-
-  if (!isTabKey(tab)) {
-    return (
-      <Redirect
-        to={{
-          ...location,
-          search: `tab=${defaultTab}`,
-        }}
-      />
-    );
-  }
 
   return (
     <Tab.Container activeKey={tab} id="configuration-tabs">
@@ -215,9 +202,23 @@ const SettingTabs: React.FC = () => {
 };
 
 export const Settings: React.FC = () => {
+  const location = useLocation();
+  const tab = new URLSearchParams(location.search).get("tab");
+
+  if (!isTabKey(tab)) {
+    return (
+      <Redirect
+        to={{
+          ...location,
+          search: `tab=${defaultTab}`,
+        }}
+      />
+    );
+  }
+
   return (
     <SettingsContext>
-      <SettingTabs />
+      <SettingTabs tab={tab} />
     </SettingsContext>
   );
 };


### PR DESCRIPTION
Fixes issue reported on Discord where, when using a reverse proxy with a site prefix, that prefix would be re-inserted when redirecting from `/settings` to the default tab.

This appears to have been introduced in #4378 where the `Settings` component was separated into `SettingTabs` and `Settings`. Using the global `location` variable within a component that isn't a page route appears to have broken the URL resolution in the `Redirect` component. Using `useLocation` instead appears to fix the issue. I moved the redirect logic into `Settings` as well, since it seemed a more appropriate place for it.