### PR TITLE
Prevent bitmap images from being scanned as image clips

### DIFF
--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -69,7 +69,7 @@ func (d *Decorator) Decorate(ctx context.Context, fs models.FS, f models.File) (
 
 	isClip := true
 	// This list is derived from ffmpegImageThumbnail in pkg/image/thumbnail. If one gets updated, the other should be as well
-	for _, item := range []string{"png", "mjpeg", "webp"} {
+	for _, item := range []string{"png", "mjpeg", "webp", "bmp"} {
 		if item == probe.VideoCodec {
 			isClip = false
 		}


### PR DESCRIPTION
Fixes #4583. Existing bmp files need to be cleaned from the database and then rescanned. The easiest way is to remove bmp from the image extensions and run the clean task.