### PR TITLE
Fix text color of medium fingerprint matches

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -39,7 +39,7 @@ const getDurationIcon = (matchPercentage: number) => {
   if (matchPercentage > 35)
     return (
       <Icon
-        className="SceneTaggerIcon text-warn"
+        className="SceneTaggerIcon text-warning"
         icon={faTriangleExclamation}
       />
     );


### PR DESCRIPTION
Text is supposed to be orange, but I forgot to test it I guess.

![image](https://github.com/stashapp/stash/assets/117855276/f500bce1-5010-45f8-9983-0f33e4da6011)
