### PR TITLE
fix image card width on front page

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -308,7 +308,8 @@
 @media (max-width: 576px) {
   .slick-list .scene-card.card,
   .slick-list .studio-card.card,
-  .slick-list .gallery-card.card {
+  .slick-list .gallery-card.card,
+  .slick-list .image-card.card {
     width: 20rem;
   }
 


### PR DESCRIPTION
Fixes #4664. The original CSS for the front page never really considered images resulting in the issue mentioned in #4664.