### PR TITLE
Make migration an asynchronous task

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -226,7 +226,9 @@ type Query {
 
 type Mutation {
   setup(input: SetupInput!): Boolean!
-  migrate(input: MigrateInput!): Boolean!
+
+  "Migrates the schema to the required version. Returns the job ID"
+  migrate(input: MigrateInput!): ID!
 
   sceneCreate(input: SceneCreateInput!): Scene
   sceneUpdate(input: SceneUpdateInput!): Scene

--- a/graphql/schema/types/job.graphql
+++ b/graphql/schema/types/job.graphql
@@ -4,6 +4,7 @@ enum JobStatus {
   FINISHED
   STOPPING
   CANCELLED
+  FAILED
 }
 
 type Job {
@@ -15,6 +16,7 @@ type Job {
   startTime: Time
   endTime: Time
   addTime: Time!
+  error: String
 }
 
 input FindJobInput {

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -21,11 +21,6 @@ func (r *mutationResolver) Setup(ctx context.Context, input manager.SetupInput) 
 	return err == nil, err
 }
 
-func (r *mutationResolver) Migrate(ctx context.Context, input manager.MigrateInput) (bool, error) {
-	err := manager.GetInstance().Migrate(ctx, input)
-	return err == nil, err
-}
-
 func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGeneralInput) (*ConfigGeneralResult, error) {
 	c := config.GetInstance()
 

--- a/internal/api/resolver_mutation_migrate.go
+++ b/internal/api/resolver_mutation_migrate.go
@@ -38,3 +38,16 @@ func (r *mutationResolver) MigrateBlobs(ctx context.Context, input MigrateBlobsI
 
 	return strconv.Itoa(jobID), nil
 }
+
+func (r *mutationResolver) Migrate(ctx context.Context, input manager.MigrateInput) (string, error) {
+	mgr := manager.GetInstance()
+	t := &task.MigrateJob{
+		BackupPath: input.BackupPath,
+		Config:     mgr.Config,
+		Database:   mgr.Database,
+	}
+
+	jobID := mgr.JobManager.Add(ctx, "Migrating database...", t)
+
+	return strconv.Itoa(jobID), nil
+}

--- a/internal/api/resolver_query_job.go
+++ b/internal/api/resolver_query_job.go
@@ -41,6 +41,7 @@ func jobToJobModel(j job.Job) *Job {
 		StartTime:   j.StartTime,
 		EndTime:     j.EndTime,
 		AddTime:     j.AddTime,
+		Error:       j.Error,
 	}
 
 	if j.Progress != -1 {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -325,7 +325,7 @@ func (s *Manager) Migrate(ctx context.Context, input MigrateInput) error {
 		return fmt.Errorf("error backing up database: %s", err)
 	}
 
-	if err := database.RunMigrations(); err != nil {
+	if err := database.RunAllMigrations(); err != nil {
 		errStr := fmt.Sprintf("error performing migration: %s", err)
 
 		// roll back to the backed up version

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -303,52 +303,6 @@ func (s *Manager) validateFFmpeg() error {
 	return nil
 }
 
-func (s *Manager) Migrate(ctx context.Context, input MigrateInput) error {
-	database := s.Database
-
-	// always backup so that we can roll back to the previous version if
-	// migration fails
-	backupPath := input.BackupPath
-	if backupPath == "" {
-		backupPath = database.DatabaseBackupPath(s.Config.GetBackupDirectoryPath())
-	} else {
-		// check if backup path is a filename or path
-		// filename goes into backup directory, path is kept as is
-		filename := filepath.Base(backupPath)
-		if backupPath == filename {
-			backupPath = filepath.Join(s.Config.GetBackupDirectoryPathOrDefault(), filename)
-		}
-	}
-
-	// perform database backup
-	if err := database.Backup(backupPath); err != nil {
-		return fmt.Errorf("error backing up database: %s", err)
-	}
-
-	if err := database.RunAllMigrations(); err != nil {
-		errStr := fmt.Sprintf("error performing migration: %s", err)
-
-		// roll back to the backed up version
-		restoreErr := database.RestoreFromBackup(backupPath)
-		if restoreErr != nil {
-			errStr = fmt.Sprintf("ERROR: unable to restore database from backup after migration failure: %s\n%s", restoreErr.Error(), errStr)
-		} else {
-			errStr = "An error occurred migrating the database to the latest schema version. The backup database file was automatically renamed to restore the database.\n" + errStr
-		}
-
-		return errors.New(errStr)
-	}
-
-	// if no backup path was provided, then delete the created backup
-	if input.BackupPath == "" {
-		if err := os.Remove(backupPath); err != nil {
-			logger.Warnf("error removing unwanted database backup (%s): %s", backupPath, err.Error())
-		}
-	}
-
-	return nil
-}
-
 func (s *Manager) BackupDatabase(download bool) (string, string, error) {
 	var backupPath string
 	var backupName string

--- a/internal/manager/task/clean_generated.go
+++ b/internal/manager/task/clean_generated.go
@@ -106,17 +106,15 @@ func (j *CleanGeneratedJob) logError(err error) {
 	}
 }
 
-func (j *CleanGeneratedJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *CleanGeneratedJob) Execute(ctx context.Context, progress *job.Progress) error {
 	j.tasksComplete = 0
 
 	if !j.BlobsStorageType.IsValid() {
-		logger.Errorf("invalid blobs storage type: %s", j.BlobsStorageType)
-		return
+		return fmt.Errorf("invalid blobs storage type: %s", j.BlobsStorageType)
 	}
 
 	if !j.VideoFileNamingAlgorithm.IsValid() {
-		logger.Errorf("invalid video file naming algorithm: %s", j.VideoFileNamingAlgorithm)
-		return
+		return fmt.Errorf("invalid video file naming algorithm: %s", j.VideoFileNamingAlgorithm)
 	}
 
 	if j.Options.DryRun {
@@ -183,10 +181,11 @@ func (j *CleanGeneratedJob) Execute(ctx context.Context, progress *job.Progress)
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 
 	logger.Infof("Finished cleaning generated files")
+	return nil
 }
 
 func (j *CleanGeneratedJob) setTaskProgress(taskProgress float64, progress *job.Progress) {

--- a/internal/manager/task/migrate.go
+++ b/internal/manager/task/migrate.go
@@ -1,0 +1,153 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/stashapp/stash/pkg/job"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/sqlite"
+)
+
+type migrateJobConfig interface {
+	GetBackupDirectoryPath() string
+	GetBackupDirectoryPathOrDefault() string
+}
+
+type MigrateJob struct {
+	BackupPath string
+	Config     migrateJobConfig
+	Database   *sqlite.Database
+}
+
+func (s *MigrateJob) Execute(ctx context.Context, progress *job.Progress) error {
+	required, err := s.required()
+	if err != nil {
+		return err
+	}
+
+	if required == 0 {
+		logger.Infof("database is already at the latest schema version")
+		return nil
+	}
+
+	// set the number of tasks = required steps + optimise
+	progress.SetTotal(int(required + 1))
+
+	database := s.Database
+
+	// always backup so that we can roll back to the previous version if
+	// migration fails
+	backupPath := s.BackupPath
+	if backupPath == "" {
+		backupPath = database.DatabaseBackupPath(s.Config.GetBackupDirectoryPath())
+	} else {
+		// check if backup path is a filename or path
+		// filename goes into backup directory, path is kept as is
+		filename := filepath.Base(backupPath)
+		if backupPath == filename {
+			backupPath = filepath.Join(s.Config.GetBackupDirectoryPathOrDefault(), filename)
+		}
+	}
+
+	// perform database backup
+	if err := database.Backup(backupPath); err != nil {
+		return fmt.Errorf("error backing up database: %s", err)
+	}
+
+	if err := s.runMigrations(ctx, progress); err != nil {
+		errStr := fmt.Sprintf("error performing migration: %s", err)
+
+		// roll back to the backed up version
+		restoreErr := database.RestoreFromBackup(backupPath)
+		if restoreErr != nil {
+			errStr = fmt.Sprintf("ERROR: unable to restore database from backup after migration failure: %s\n%s", restoreErr.Error(), errStr)
+		} else {
+			errStr = "An error occurred migrating the database to the latest schema version. The backup database file was automatically renamed to restore the database.\n" + errStr
+		}
+
+		return errors.New(errStr)
+	}
+
+	// if no backup path was provided, then delete the created backup
+	if s.BackupPath == "" {
+		if err := os.Remove(backupPath); err != nil {
+			logger.Warnf("error removing unwanted database backup (%s): %s", backupPath, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (s *MigrateJob) required() (uint, error) {
+	database := s.Database
+
+	m, err := sqlite.NewMigrator(database)
+	if err != nil {
+		return 0, err
+	}
+
+	defer m.Close()
+
+	currentSchemaVersion := m.CurrentSchemaVersion()
+	targetSchemaVersion := m.RequiredSchemaVersion()
+
+	if targetSchemaVersion < currentSchemaVersion {
+		// shouldn't happen
+		return 0, nil
+	}
+
+	return targetSchemaVersion - currentSchemaVersion, nil
+}
+
+func (s *MigrateJob) runMigrations(ctx context.Context, progress *job.Progress) error {
+	database := s.Database
+
+	m, err := sqlite.NewMigrator(database)
+	if err != nil {
+		return err
+	}
+
+	defer m.Close()
+
+	for {
+		currentSchemaVersion := m.CurrentSchemaVersion()
+		targetSchemaVersion := m.RequiredSchemaVersion()
+
+		if currentSchemaVersion >= targetSchemaVersion {
+			break
+		}
+
+		var err error
+		progress.ExecuteTask(fmt.Sprintf("Migrating database to schema version %d", currentSchemaVersion+1), func() {
+			err = m.RunMigration(ctx, currentSchemaVersion+1)
+		})
+
+		if err != nil {
+			return fmt.Errorf("error running migration for schema %d: %s", currentSchemaVersion+1, err)
+		}
+
+		progress.Increment()
+	}
+
+	// reinitialise the database
+	if err := database.ReInitialise(); err != nil {
+		return fmt.Errorf("error reinitialising database: %s", err)
+	}
+
+	// optimise the database
+	progress.ExecuteTask("Optimising database", func() {
+		err = database.Optimise(ctx)
+	})
+
+	if err != nil {
+		return fmt.Errorf("error optimising database: %s", err)
+	}
+
+	progress.Increment()
+
+	return nil
+}

--- a/internal/manager/task/migrate_blobs.go
+++ b/internal/manager/task/migrate_blobs.go
@@ -26,7 +26,7 @@ type MigrateBlobsJob struct {
 	DeleteOld  bool
 }
 
-func (j *MigrateBlobsJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *MigrateBlobsJob) Execute(ctx context.Context, progress *job.Progress) error {
 	var (
 		count int
 		err   error
@@ -37,13 +37,12 @@ func (j *MigrateBlobsJob) Execute(ctx context.Context, progress *job.Progress) {
 	})
 
 	if err != nil {
-		logger.Errorf("Error counting blobs: %s", err.Error())
-		return
+		return fmt.Errorf("error counting blobs: %w", err)
 	}
 
 	if count == 0 {
 		logger.Infof("No blobs to migrate")
-		return
+		return nil
 	}
 
 	logger.Infof("Migrating %d blobs", count)
@@ -54,12 +53,11 @@ func (j *MigrateBlobsJob) Execute(ctx context.Context, progress *job.Progress) {
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Cancelled migrating blobs")
-		return
+		return nil
 	}
 
 	if err != nil {
-		logger.Errorf("Error migrating blobs: %v", err)
-		return
+		return fmt.Errorf("error migrating blobs: %w", err)
 	}
 
 	// run a vacuum to reclaim space
@@ -71,6 +69,7 @@ func (j *MigrateBlobsJob) Execute(ctx context.Context, progress *job.Progress) {
 	})
 
 	logger.Infof("Finished migrating blobs")
+	return nil
 }
 
 func (j *MigrateBlobsJob) countBlobs(ctx context.Context) (int, error) {

--- a/internal/manager/task/migrate_scene_screenshots.go
+++ b/internal/manager/task/migrate_scene_screenshots.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ type MigrateSceneScreenshotsJob struct {
 	TxnManager      txn.Manager
 }
 
-func (j *MigrateSceneScreenshotsJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *MigrateSceneScreenshotsJob) Execute(ctx context.Context, progress *job.Progress) error {
 	var err error
 	progress.ExecuteTask("Counting files", func() {
 		var count int
@@ -30,8 +31,7 @@ func (j *MigrateSceneScreenshotsJob) Execute(ctx context.Context, progress *job.
 	})
 
 	if err != nil {
-		logger.Errorf("Error counting files: %s", err.Error())
-		return
+		return fmt.Errorf("error counting files: %w", err)
 	}
 
 	progress.ExecuteTask("Migrating files", func() {
@@ -40,15 +40,15 @@ func (j *MigrateSceneScreenshotsJob) Execute(ctx context.Context, progress *job.
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Cancelled migrating scene screenshots")
-		return
+		return nil
 	}
 
 	if err != nil {
-		logger.Errorf("Error migrating scene screenshots: %v", err)
-		return
+		return fmt.Errorf("error migrating scene screenshots: %w", err)
 	}
 
 	logger.Infof("Finished migrating scene screenshots")
+	return nil
 }
 
 func (j *MigrateSceneScreenshotsJob) countFiles(ctx context.Context) (int, error) {

--- a/internal/manager/task/packages.go
+++ b/internal/manager/task/packages.go
@@ -30,13 +30,13 @@ type InstallPackagesJob struct {
 	Packages []*models.PackageSpecInput
 }
 
-func (j *InstallPackagesJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *InstallPackagesJob) Execute(ctx context.Context, progress *job.Progress) error {
 	progress.SetTotal(len(j.Packages))
 
 	for _, p := range j.Packages {
 		if job.IsCancelled(ctx) {
 			logger.Info("Cancelled installing packages")
-			return
+			return nil
 		}
 
 		logger.Infof("Installing package %s", p.ID)
@@ -53,6 +53,7 @@ func (j *InstallPackagesJob) Execute(ctx context.Context, progress *job.Progress
 	}
 
 	logger.Infof("Finished installing packages")
+	return nil
 }
 
 type UpdatePackagesJob struct {
@@ -60,13 +61,12 @@ type UpdatePackagesJob struct {
 	Packages []*models.PackageSpecInput
 }
 
-func (j *UpdatePackagesJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *UpdatePackagesJob) Execute(ctx context.Context, progress *job.Progress) error {
 	// if no packages are specified, update all
 	if len(j.Packages) == 0 {
 		installed, err := j.PackageManager.InstalledStatus(ctx)
 		if err != nil {
-			logger.Errorf("Error getting installed packages: %v", err)
-			return
+			return fmt.Errorf("error getting installed packages: %w", err)
 		}
 
 		for _, p := range installed {
@@ -84,7 +84,7 @@ func (j *UpdatePackagesJob) Execute(ctx context.Context, progress *job.Progress)
 	for _, p := range j.Packages {
 		if job.IsCancelled(ctx) {
 			logger.Info("Cancelled updating packages")
-			return
+			return nil
 		}
 
 		logger.Infof("Updating package %s", p.ID)
@@ -101,6 +101,7 @@ func (j *UpdatePackagesJob) Execute(ctx context.Context, progress *job.Progress)
 	}
 
 	logger.Infof("Finished updating packages")
+	return nil
 }
 
 type UninstallPackagesJob struct {
@@ -108,13 +109,13 @@ type UninstallPackagesJob struct {
 	Packages []*models.PackageSpecInput
 }
 
-func (j *UninstallPackagesJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *UninstallPackagesJob) Execute(ctx context.Context, progress *job.Progress) error {
 	progress.SetTotal(len(j.Packages))
 
 	for _, p := range j.Packages {
 		if job.IsCancelled(ctx) {
 			logger.Info("Cancelled installing packages")
-			return
+			return nil
 		}
 
 		logger.Infof("Uninstalling package %s", p.ID)
@@ -131,4 +132,5 @@ func (j *UninstallPackagesJob) Execute(ctx context.Context, progress *job.Progre
 	}
 
 	logger.Infof("Finished uninstalling packages")
+	return nil
 }

--- a/internal/manager/task_autotag.go
+++ b/internal/manager/task_autotag.go
@@ -25,7 +25,7 @@ type autoTagJob struct {
 	cache match.Cache
 }
 
-func (j *autoTagJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *autoTagJob) Execute(ctx context.Context, progress *job.Progress) error {
 	begin := time.Now()
 
 	input := j.input
@@ -38,6 +38,7 @@ func (j *autoTagJob) Execute(ctx context.Context, progress *job.Progress) {
 	}
 
 	logger.Infof("Finished auto-tag after %s", time.Since(begin).String())
+	return nil
 }
 
 func (j *autoTagJob) isFileBasedAutoTag(input AutoTagMetadataInput) bool {

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -32,7 +32,7 @@ type cleanJob struct {
 	scanSubs     *subscriptionManager
 }
 
-func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	logger.Infof("Starting cleaning of tracked files")
 	start := time.Now()
 	if j.input.DryRun {
@@ -47,7 +47,7 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) {
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 
 	j.cleanEmptyGalleries(ctx)
@@ -55,6 +55,7 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) {
 	j.scanSubs.notify()
 	elapsed := time.Since(start)
 	logger.Info(fmt.Sprintf("Finished Cleaning (%s)", elapsed))
+	return nil
 }
 
 func (j *cleanJob) cleanEmptyGalleries(ctx context.Context) {

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -80,7 +80,7 @@ type totalsGenerate struct {
 	tasks int
 }
 
-func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error {
 	var scenes []*models.Scene
 	var err error
 	var markers []*models.SceneMarker
@@ -223,11 +223,12 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) {
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 
 	elapsed := time.Since(start)
 	logger.Info(fmt.Sprintf("Generate finished (%s)", elapsed))
+	return nil
 }
 
 func (j *GenerateJob) queueTasks(ctx context.Context, g *generate.Generator, queue chan<- Task) {

--- a/internal/manager/task_identify.go
+++ b/internal/manager/task_identify.go
@@ -34,18 +34,17 @@ func CreateIdentifyJob(input identify.Options) *IdentifyJob {
 	}
 }
 
-func (j *IdentifyJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *IdentifyJob) Execute(ctx context.Context, progress *job.Progress) error {
 	j.progress = progress
 
 	// if no sources provided - just return
 	if len(j.input.Sources) == 0 {
-		return
+		return nil
 	}
 
 	sources, err := j.getSources()
 	if err != nil {
-		logger.Error(err)
-		return
+		return err
 	}
 
 	// if scene ids provided, use those
@@ -84,8 +83,10 @@ func (j *IdentifyJob) Execute(ctx context.Context, progress *job.Progress) {
 
 		return nil
 	}); err != nil {
-		logger.Errorf("Error encountered while identifying scenes: %v", err)
+		return fmt.Errorf("error encountered while identifying scenes: %w", err)
 	}
+
+	return nil
 }
 
 func (j *IdentifyJob) identifyAllScenes(ctx context.Context, sources []identify.ScraperSource) error {

--- a/internal/manager/task_optimise.go
+++ b/internal/manager/task_optimise.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/stashapp/stash/pkg/job"
@@ -17,7 +18,7 @@ type OptimiseDatabaseJob struct {
 	Optimiser Optimiser
 }
 
-func (j *OptimiseDatabaseJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *OptimiseDatabaseJob) Execute(ctx context.Context, progress *job.Progress) error {
 	logger.Info("Optimising database")
 	progress.SetTotal(2)
 
@@ -31,11 +32,10 @@ func (j *OptimiseDatabaseJob) Execute(ctx context.Context, progress *job.Progres
 	})
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 	if err != nil {
-		logger.Errorf("Error analyzing database: %v", err)
-		return
+		return fmt.Errorf("Error analyzing database: %w", err)
 	}
 
 	progress.ExecuteTask("Vacuuming database", func() {
@@ -44,13 +44,13 @@ func (j *OptimiseDatabaseJob) Execute(ctx context.Context, progress *job.Progres
 	})
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 	if err != nil {
-		logger.Errorf("Error vacuuming database: %v", err)
-		return
+		return fmt.Errorf("error vacuuming database: %w", err)
 	}
 
 	elapsed := time.Since(start)
 	logger.Infof("Finished optimising database after %s", elapsed)
+	return nil
 }

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -34,12 +34,12 @@ type ScanJob struct {
 	subscriptions *subscriptionManager
 }
 
-func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
+func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	input := j.input
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 
 	sp := getScanPaths(input.Paths)
@@ -74,13 +74,14 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) {
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
-		return
+		return nil
 	}
 
 	elapsed := time.Since(start)
 	logger.Info(fmt.Sprintf("Scan finished (%s)", elapsed))
 
 	j.subscriptions.notify()
+	return nil
 }
 
 type extensionConfig struct {

--- a/pkg/job/manager.go
+++ b/pkg/job/manager.go
@@ -206,7 +206,10 @@ func (m *Manager) executeJob(ctx context.Context, j *Job, done chan struct{}) {
 	}()
 
 	progress := m.newProgress(j)
-	j.exec.Execute(ctx, progress)
+	if err := j.exec.Execute(ctx, progress); err != nil {
+		logger.Errorf("task failed due to error: %v", err)
+		j.error(err)
+	}
 }
 
 func (m *Manager) onJobFinish(job *Job) {

--- a/pkg/job/manager_test.go
+++ b/pkg/job/manager_test.go
@@ -24,7 +24,7 @@ func newTestExec(finish chan struct{}) *testExec {
 	}
 }
 
-func (e *testExec) Execute(ctx context.Context, p *Progress) {
+func (e *testExec) Execute(ctx context.Context, p *Progress) error {
 	e.progress = p
 	close(e.started)
 
@@ -38,6 +38,8 @@ func (e *testExec) Execute(ctx context.Context, p *Progress) {
 			// fall through
 		}
 	}
+
+	return nil
 }
 
 func TestAdd(t *testing.T) {

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -10,9 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/golang-migrate/migrate/v4"
-	sqlite3mig "github.com/golang-migrate/migrate/v4/database/sqlite3"
-	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/stashapp/stash/pkg/fsutil"
@@ -144,7 +141,7 @@ func (db *Database) Open(dbPath string) error {
 
 	if databaseSchemaVersion == 0 {
 		// new database, just run the migrations
-		if err := db.RunMigrations(); err != nil {
+		if err := db.RunAllMigrations(); err != nil {
 			return fmt.Errorf("error running initial schema migrations: %w", err)
 		}
 	} else {
@@ -312,11 +309,6 @@ func (db *Database) RestoreFromBackup(backupPath string) error {
 	return os.Rename(backupPath, db.dbPath)
 }
 
-// Migrate the database
-func (db *Database) needsMigration() bool {
-	return db.schemaVersion != appSchemaVersion
-}
-
 func (db *Database) AppSchemaVersion() uint {
 	return appSchemaVersion
 }
@@ -347,100 +339,6 @@ func (db *Database) AnonymousDatabasePath(backupDirectoryPath string) string {
 
 func (db *Database) Version() uint {
 	return db.schemaVersion
-}
-
-func (db *Database) getMigrate() (*migrate.Migrate, error) {
-	migrations, err := iofs.New(migrationsBox, "migrations")
-	if err != nil {
-		return nil, err
-	}
-
-	const disableForeignKeys = true
-	conn, err := db.open(disableForeignKeys)
-	if err != nil {
-		return nil, err
-	}
-
-	driver, err := sqlite3mig.WithInstance(conn.DB, &sqlite3mig.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	// use sqlite3Driver so that migration has access to durationToTinyInt
-	return migrate.NewWithInstance(
-		"iofs",
-		migrations,
-		db.dbPath,
-		driver,
-	)
-}
-
-func (db *Database) getDatabaseSchemaVersion() (uint, error) {
-	m, err := db.getMigrate()
-	if err != nil {
-		return 0, err
-	}
-	defer m.Close()
-
-	ret, _, _ := m.Version()
-	return ret, nil
-}
-
-// Migrate the database
-func (db *Database) RunMigrations() error {
-	ctx := context.Background()
-
-	m, err := db.getMigrate()
-	if err != nil {
-		return err
-	}
-	defer m.Close()
-
-	databaseSchemaVersion, _, _ := m.Version()
-	stepNumber := appSchemaVersion - databaseSchemaVersion
-	if stepNumber != 0 {
-		logger.Infof("Migrating database from version %d to %d", databaseSchemaVersion, appSchemaVersion)
-
-		// run each migration individually, and run custom migrations as needed
-		var i uint = 1
-		for ; i <= stepNumber; i++ {
-			newVersion := databaseSchemaVersion + i
-
-			// run pre migrations as needed
-			if err := db.runCustomMigrations(ctx, preMigrations[newVersion]); err != nil {
-				return fmt.Errorf("running pre migrations for schema version %d: %w", newVersion, err)
-			}
-
-			err = m.Steps(1)
-			if err != nil {
-				// migration failed
-				return err
-			}
-
-			// run post migrations as needed
-			if err := db.runCustomMigrations(ctx, postMigrations[newVersion]); err != nil {
-				return fmt.Errorf("running post migrations for schema version %d: %w", newVersion, err)
-			}
-		}
-	}
-
-	// update the schema version
-	db.schemaVersion, _, _ = m.Version()
-
-	// re-initialise the database
-	const disableForeignKeys = false
-	db.db, err = db.open(disableForeignKeys)
-	if err != nil {
-		return fmt.Errorf("re-initializing the database: %w", err)
-	}
-
-	// optimize database after migration
-	err = db.Optimise(ctx)
-	if err != nil {
-		logger.Warnf("error while performing post-migration optimisation: %v", err)
-	}
-
-	return nil
 }
 
 func (db *Database) Optimise(ctx context.Context) error {
@@ -523,29 +421,4 @@ func (db *Database) QuerySQL(ctx context.Context, query string, args []interface
 	}
 
 	return cols, ret, nil
-}
-
-func (db *Database) runCustomMigrations(ctx context.Context, fns []customMigrationFunc) error {
-	for _, fn := range fns {
-		if err := db.runCustomMigration(ctx, fn); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (db *Database) runCustomMigration(ctx context.Context, fn customMigrationFunc) error {
-	const disableForeignKeys = false
-	d, err := db.open(disableForeignKeys)
-	if err != nil {
-		return err
-	}
-
-	defer d.Close()
-	if err := fn(ctx, d); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/sqlite/migrate.go
+++ b/pkg/sqlite/migrate.go
@@ -36,6 +36,15 @@ func (m *Migrator) Close() {
 	}
 }
 
+func (m *Migrator) CurrentSchemaVersion() uint {
+	databaseSchemaVersion, _, _ := m.m.Version()
+	return databaseSchemaVersion
+}
+
+func (m *Migrator) RequiredSchemaVersion() uint {
+	return appSchemaVersion
+}
+
 func (m *Migrator) getMigrate() (*migrate.Migrate, error) {
 	migrations, err := iofs.New(migrationsBox, "migrations")
 	if err != nil {

--- a/pkg/sqlite/migrate.go
+++ b/pkg/sqlite/migrate.go
@@ -1,0 +1,179 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang-migrate/migrate/v4"
+	sqlite3mig "github.com/golang-migrate/migrate/v4/database/sqlite3"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/stashapp/stash/pkg/logger"
+)
+
+func (db *Database) needsMigration() bool {
+	return db.schemaVersion != appSchemaVersion
+}
+
+type Migrator struct {
+	db *Database
+	m  *migrate.Migrate
+}
+
+func NewMigrator(db *Database) (*Migrator, error) {
+	m := &Migrator{
+		db: db,
+	}
+
+	var err error
+	m.m, err = m.getMigrate()
+	return m, err
+}
+
+func (m *Migrator) Close() {
+	if m.m != nil {
+		m.m.Close()
+		m.m = nil
+	}
+}
+
+func (m *Migrator) getMigrate() (*migrate.Migrate, error) {
+	migrations, err := iofs.New(migrationsBox, "migrations")
+	if err != nil {
+		return nil, err
+	}
+
+	const disableForeignKeys = true
+	conn, err := m.db.open(disableForeignKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	driver, err := sqlite3mig.WithInstance(conn.DB, &sqlite3mig.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	// use sqlite3Driver so that migration has access to durationToTinyInt
+	return migrate.NewWithInstance(
+		"iofs",
+		migrations,
+		m.db.dbPath,
+		driver,
+	)
+}
+
+func (m *Migrator) RunMigration(ctx context.Context, newVersion uint) error {
+	databaseSchemaVersion, _, _ := m.m.Version()
+
+	if newVersion != databaseSchemaVersion+1 {
+		return fmt.Errorf("invalid migration version %d, expected %d", newVersion, databaseSchemaVersion+1)
+	}
+
+	// run pre migrations as needed
+	if err := m.runCustomMigrations(ctx, preMigrations[newVersion]); err != nil {
+		return fmt.Errorf("running pre migrations for schema version %d: %w", newVersion, err)
+	}
+
+	if err := m.m.Steps(1); err != nil {
+		// migration failed
+		return err
+	}
+
+	// run post migrations as needed
+	if err := m.runCustomMigrations(ctx, postMigrations[newVersion]); err != nil {
+		return fmt.Errorf("running post migrations for schema version %d: %w", newVersion, err)
+	}
+
+	// update the schema version
+	m.db.schemaVersion, _, _ = m.m.Version()
+
+	return nil
+}
+
+func (m *Migrator) runCustomMigrations(ctx context.Context, fns []customMigrationFunc) error {
+	for _, fn := range fns {
+		if err := m.runCustomMigration(ctx, fn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Migrator) runCustomMigration(ctx context.Context, fn customMigrationFunc) error {
+	const disableForeignKeys = false
+	d, err := m.db.open(disableForeignKeys)
+	if err != nil {
+		return err
+	}
+
+	defer d.Close()
+	if err := fn(ctx, d); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (db *Database) getDatabaseSchemaVersion() (uint, error) {
+	m, err := NewMigrator(db)
+	if err != nil {
+		return 0, err
+	}
+	defer m.Close()
+
+	ret, _, _ := m.m.Version()
+	return ret, nil
+}
+
+func (db *Database) ReInitialise() error {
+	const disableForeignKeys = false
+	var err error
+	db.db, err = db.open(disableForeignKeys)
+	if err != nil {
+		return fmt.Errorf("re-initializing the database: %w", err)
+	}
+
+	return nil
+}
+
+// RunAllMigrations runs all migrations to bring the database up to the current schema version
+func (db *Database) RunAllMigrations() error {
+	ctx := context.Background()
+
+	m, err := NewMigrator(db)
+	if err != nil {
+		return err
+	}
+	defer m.Close()
+
+	databaseSchemaVersion, _, _ := m.m.Version()
+	stepNumber := appSchemaVersion - databaseSchemaVersion
+	if stepNumber != 0 {
+		logger.Infof("Migrating database from version %d to %d", databaseSchemaVersion, appSchemaVersion)
+
+		// run each migration individually, and run custom migrations as needed
+		var i uint = 1
+		for ; i <= stepNumber; i++ {
+			newVersion := databaseSchemaVersion + i
+			if err := m.RunMigration(ctx, newVersion); err != nil {
+				return err
+			}
+		}
+	}
+
+	// re-initialise the database
+	const disableForeignKeys = false
+	db.db, err = db.open(disableForeignKeys)
+	if err != nil {
+		return fmt.Errorf("re-initializing the database: %w", err)
+	}
+
+	// optimize database after migration
+	err = db.Optimise(ctx)
+	if err != nil {
+		logger.Warnf("error while performing post-migration optimisation: %v", err)
+	}
+
+	return nil
+}

--- a/ui/v2.5/graphql/data/job.graphql
+++ b/ui/v2.5/graphql/data/job.graphql
@@ -7,4 +7,5 @@ fragment JobData on Job {
   startTime
   endTime
   addTime
+  error
 }

--- a/ui/v2.5/graphql/subscriptions.graphql
+++ b/ui/v2.5/graphql/subscriptions.graphql
@@ -7,6 +7,7 @@ subscription JobsSubscribe {
       subTasks
       description
       progress
+      error
     }
   }
 }

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -49,6 +49,7 @@ import { PluginRoutes } from "./plugins";
 
 // import plugin_api to run code
 import "./pluginApi";
+import { ConnectionMonitor } from "./ConnectionMonitor";
 
 const Performers = lazyComponent(
   () => import("./components/Performers/Performers")
@@ -369,6 +370,7 @@ export const App: React.FC = () => {
           >
             {maybeRenderReleaseNotes()}
             <ToastProvider>
+              <ConnectionMonitor />
               <Suspense fallback={<LoadingIndicator />}>
                 <LightboxProvider>
                   <ManualProvider>

--- a/ui/v2.5/src/ConnectionMonitor.tsx
+++ b/ui/v2.5/src/ConnectionMonitor.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { getWSClient, useWSState } from "./core/StashService";
+import { useToast } from "./hooks/Toast";
+import { useIntl } from "react-intl";
+
+export const ConnectionMonitor: React.FC = () => {
+  const Toast = useToast();
+  const intl = useIntl();
+
+  const { state } = useWSState(getWSClient());
+  const [cachedState, setCacheState] = useState<typeof state>(state);
+
+  useEffect(() => {
+    if (cachedState === "connecting" && state === "error") {
+      Toast.error(
+        intl.formatMessage({
+          id: "connection_monitor.websocket_connection_failed",
+        })
+      );
+    }
+
+    if (state === "connected" && cachedState === "error") {
+      Toast.success(
+        intl.formatMessage({
+          id: "connection_monitor.websocket_connection_reestablished",
+        })
+      );
+    }
+
+    setCacheState(state);
+  }, [state, cachedState, Toast, intl]);
+
+  return null;
+};

--- a/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
@@ -96,12 +96,12 @@ const Task: React.FC<IJob> = ({ job }) => {
       case GQL.JobStatus.Finished:
         icon = faCheck;
         break;
-        case GQL.JobStatus.Cancelled:
-          icon = faBan;
-          break;
-        case GQL.JobStatus.Failed:
-          icon = faCircleExclamation;
-          break;
+      case GQL.JobStatus.Cancelled:
+        icon = faBan;
+        break;
+      case GQL.JobStatus.Failed:
+        icon = faCircleExclamation;
+        break;
     }
 
     return <Icon icon={icon} className={`fa-fw ${iconClass}`} />;
@@ -143,11 +143,7 @@ const Task: React.FC<IJob> = ({ job }) => {
     }
 
     if (job.status === GQL.JobStatus.Failed && job.error) {
-      return (
-        <div className="job-error">
-          {job.error}
-        </div>
-      )
+      return <div className="job-error">{job.error}</div>;
     }
   }
 

--- a/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
@@ -12,6 +12,7 @@ import {
   faBan,
   faCheck,
   faCircle,
+  faCircleExclamation,
   faCog,
   faHourglassStart,
   faTimes,
@@ -19,7 +20,7 @@ import {
 
 type JobFragment = Pick<
   GQL.Job,
-  "id" | "status" | "subTasks" | "description" | "progress"
+  "id" | "status" | "subTasks" | "description" | "progress" | "error"
 >;
 
 interface IJob {
@@ -37,6 +38,7 @@ const Task: React.FC<IJob> = ({ job }) => {
   useEffect(() => {
     if (
       job.status === GQL.JobStatus.Cancelled ||
+      job.status === GQL.JobStatus.Failed ||
       job.status === GQL.JobStatus.Finished
     ) {
       // fade out around 10 seconds
@@ -71,6 +73,8 @@ const Task: React.FC<IJob> = ({ job }) => {
         return "finished";
       case GQL.JobStatus.Cancelled:
         return "cancelled";
+      case GQL.JobStatus.Failed:
+        return "failed";
     }
   }
 
@@ -92,9 +96,12 @@ const Task: React.FC<IJob> = ({ job }) => {
       case GQL.JobStatus.Finished:
         icon = faCheck;
         break;
-      case GQL.JobStatus.Cancelled:
-        icon = faBan;
-        break;
+        case GQL.JobStatus.Cancelled:
+          icon = faBan;
+          break;
+        case GQL.JobStatus.Failed:
+          icon = faCircleExclamation;
+          break;
     }
 
     return <Icon icon={icon} className={`fa-fw ${iconClass}`} />;
@@ -133,6 +140,14 @@ const Task: React.FC<IJob> = ({ job }) => {
           {/* eslint-enable react/no-array-index-key */}
         </div>
       );
+    }
+
+    if (job.status === GQL.JobStatus.Failed && job.error) {
+      return (
+        <div className="job-error">
+          {job.error}
+        </div>
+      )
     }
   }
 

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -296,6 +296,10 @@
     color: $success;
   }
 
+  .failed .fa-icon {
+    color: $danger;
+  }
+
   .ready .fa-icon {
     color: $warning;
   }
@@ -303,6 +307,10 @@
   .cancelled,
   .finished {
     color: $text-muted;
+  }
+
+  .job-error {
+    color: $danger;
   }
 }
 

--- a/ui/v2.5/src/components/Setup/styles.scss
+++ b/ui/v2.5/src/components/Setup/styles.scss
@@ -7,3 +7,20 @@
     padding: 16px;
   }
 }
+
+.migrate-loading-status {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 70vh;
+  justify-content: center;
+  width: 100%;
+
+  .progress {
+    width: 60%;
+  }
+
+  h4 span {
+    margin-left: 0.5rem;
+  }
+}

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -18,7 +18,7 @@ import { createClient } from "./createClient";
 import { Client } from "graphql-ws";
 import { useEffect, useState } from "react";
 
-const { client, wsClient } = createClient();
+const { client, wsClient, cache: clientCache } = createClient();
 
 export const getClient = () => client;
 export const getWSClient = () => wsClient;
@@ -2381,12 +2381,13 @@ export const mutateMigrate = (input: GQL.MigrateInput) =>
   client.mutate<GQL.MigrateMutation>({
     mutation: GQL.MigrateDocument,
     variables: { input },
-    update(cache, result) {
-      if (!result.data?.migrate) return;
-
-      evictQueries(cache, setupMutationImpactedQueries);
-    },
   });
+
+// migrate now runs asynchronously, so we need to evict queries
+// once it successfully completes
+export function postMigrate() {
+  evictQueries(clientCache, setupMutationImpactedQueries);
+}
 
 /// Packages
 

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -15,10 +15,36 @@ import { ListFilterModel } from "../models/list-filter/filter";
 import * as GQL from "./generated-graphql";
 
 import { createClient } from "./createClient";
+import { Client } from "graphql-ws";
+import { useEffect, useState } from "react";
 
-const { client } = createClient();
+const { client, wsClient } = createClient();
 
 export const getClient = () => client;
+export const getWSClient = () => wsClient;
+
+export function useWSState(ws: Client) {
+  const [state, setState] = useState<"connecting" | "connected" | "error">(
+    "connecting"
+  );
+
+  useEffect(() => {
+    const disposeConnected = ws.on("connected", () => {
+      setState("connected");
+    });
+
+    const disposeError = ws.on("error", () => {
+      setState("error");
+    });
+
+    return () => {
+      disposeConnected();
+      disposeError();
+    };
+  }, [ws]);
+
+  return { state };
+}
 
 // Evicts cached results for the given queries.
 // Will also call a cache GC afterwards.

--- a/ui/v2.5/src/core/createClient.ts
+++ b/ui/v2.5/src/core/createClient.ts
@@ -144,15 +144,15 @@ export const createClient = () => {
 
   const httpLink = createUploadLink({ uri: url.toString() });
 
-  const wsLink = new GraphQLWsLink(
-    createWSClient({
-      url: wsUrl.toString(),
-      retryAttempts: Infinity,
-      shouldRetry() {
-        return true;
-      },
-    })
-  );
+  const wsClient = createWSClient({
+    url: wsUrl.toString(),
+    retryAttempts: Infinity,
+    shouldRetry() {
+      return true;
+    },
+  });
+
+  const wsLink = new GraphQLWsLink(wsClient);
 
   const errorLink = onError(({ networkError }) => {
     // handle graphql unauthorized error
@@ -211,5 +211,6 @@ Please disable it on the server and refresh the page.`);
   return {
     cache,
     client,
+    wsClient,
   };
 };

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -776,6 +776,10 @@
     }
   },
   "configuration": "Configuration",
+  "connection_monitor": {
+    "websocket_connection_failed": "Unable to make websocket connection: see browser console for details",
+    "websocket_connection_reestablished": "Websocket connection re-established"
+  },
   "countables": {
     "files": "{count, plural, one {File} other {Files}}",
     "galleries": "{count, plural, one {Gallery} other {Galleries}}",


### PR DESCRIPTION
This addresses a long standing issue where running a schema migration that takes a long time can time out the connection if running through a reverse proxy.

This changes the migration operation to be a job-based task rather than synchronous operation. This is a breaking change to the `migrate` mutation - it now returns a job ID immediately. It is left to the client to monitor the status of the migration job.

The UI is changed to monitor the job, and display a progress bar with the current migration task being performed.

![image](https://github.com/stashapp/stash/assets/53250216/fb9b294d-b48e-4066-9149-0137482609c0)

Job monitoring nominally uses the websocket connection, and it's possible that this connection is not present. The lack of a websocket connection would prevent job monitoring, so if the websocket connection isn't available, then it falls back to polling every second. 

To receive errors when the migration task fails, the `Job` type has been expanded to include an `error` field, and a new status `FAILED` is available.

This PR also includes a connection monitor component which detects if the websocket connection fails to establish and displays a toast error. If the websocket connection is later re-established, then a toast message is shown.

![image](https://github.com/stashapp/stash/assets/53250216/56253093-6696-4f70-9dac-9e28a3510bd9)
![image](https://github.com/stashapp/stash/assets/53250216/531fe02e-1bfa-4212-99e1-5fd228a6974e)

