### PR TITLE
Fix hwaccel for AMD APUs #4701

### DIFF
--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -46,7 +46,7 @@ func (f *FFMpeg) InitHWSupport(ctx context.Context) {
 
 		videoFilter := f.hwFilterInit(codec)
 		// Test scaling
-		videoFilter = videoFilter.ScaleDimensions(-2, 160)
+		videoFilter = videoFilter.ScaleDimensions(256, 160)
 		videoFilter = f.hwCodecFilter(videoFilter, codec)
 		args = append(args, CodecInit(codec)...)
 		args = args.VideoFilter(videoFilter)


### PR DESCRIPTION
This fixes ffmpeg hardware acceleration for AMD APUs #4701 