### PR TITLE
Bitrate filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -214,6 +214,8 @@ input SceneFilterType {
   resolution: ResolutionCriterionInput
   "Filter by frame rate"
   framerate: IntCriterionInput
+  "Filter by bit rate"
+  bitrate: IntCriterionInput
   "Filter by video codec"
   video_codec: StringCriterionInput
   "Filter by audio codec"

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -41,6 +41,8 @@ type SceneFilterType struct {
 	Resolution *ResolutionCriterionInput `json:"resolution"`
 	// Filter by framerate
 	Framerate *IntCriterionInput `json:"framerate"`
+	// Filter by bitrate
+	Bitrate *IntCriterionInput `json:"bitrate"`
 	// Filter by video codec
 	VideoCodec *StringCriterionInput `json:"video_codec"`
 	// Filter by audio codec

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -983,6 +983,7 @@ func (qb *SceneStore) makeFilter(ctx context.Context, sceneFilter *models.SceneF
 	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.Duration, "video_files.duration", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, resolutionCriterionHandler(sceneFilter.Resolution, "video_files.height", "video_files.width", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, floatIntCriterionHandler(sceneFilter.Framerate, "ROUND(video_files.frame_rate)", qb.addVideoFilesTable))
+	query.handleCriterion(ctx, intCriterionHandler(sceneFilter.Bitrate, "video_files.bit_rate", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, codecCriterionHandler(sceneFilter.VideoCodec, "video_files.video_codec", qb.addVideoFilesTable))
 	query.handleCriterion(ctx, codecCriterionHandler(sceneFilter.AudioCodec, "video_files.audio_codec", qb.addVideoFilesTable))
 

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -73,6 +73,7 @@ const criterionOptions = [
   createMandatoryNumberCriterionOption("o_counter"),
   ResolutionCriterionOption,
   createMandatoryNumberCriterionOption("framerate"),
+  createMandatoryNumberCriterionOption("bitrate"),
   createStringCriterionOption("video_codec"),
   createStringCriterionOption("audio_codec"),
   createDurationCriterionOption("duration"),

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -121,6 +121,7 @@ export type CriterionType =
   | "resolution"
   | "average_resolution"
   | "framerate"
+  | "bitrate"
   | "video_codec"
   | "audio_codec"
   | "duration"


### PR DESCRIPTION
Adds a bitrate filter.
Fixes: https://github.com/stashapp/stash/issues/4661

The only oddity is that you might need absurdly huge numbers like:
10000000 (which is 10M)

But this is a NumberFilter (Formatter) issue.