### PR TITLE
[RFC/WIP] Details operation toolbar

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useLayoutEffect,
 } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
 import { Link, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import * as GQL from "src/core/generated-graphql";
@@ -74,6 +74,8 @@ const SceneVideoFilterPanel = lazyComponent(
   () => import("./SceneVideoFilterPanel")
 );
 import { objectPath, objectTitle } from "src/core/files";
+import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
+import TextUtils from "src/utils/text";
 
 interface IProps {
   scene: GQL.SceneDataFragment;
@@ -420,27 +422,6 @@ const ScenePage: React.FC<IProps> = ({
               <FormattedMessage id="actions.edit" />
             </Nav.Link>
           </Nav.Item>
-          <ButtonGroup className="ml-auto">
-            <Nav.Item className="ml-auto">
-              <ExternalPlayerButton scene={scene} />
-            </Nav.Item>
-            <Nav.Item className="ml-auto">
-              <OCounterButton
-                value={scene.o_counter || 0}
-                onIncrement={onIncrementClick}
-                onDecrement={onDecrementClick}
-                onReset={onResetClick}
-              />
-            </Nav.Item>
-            <Nav.Item>
-              <OrganizedButton
-                loading={organizedLoading}
-                organized={scene.organized}
-                onClick={onOrganizedClick}
-              />
-            </Nav.Item>
-            <Nav.Item>{renderOperations()}</Nav.Item>
-          </ButtonGroup>
         </Nav>
       </div>
 
@@ -509,6 +490,11 @@ const ScenePage: React.FC<IProps> = ({
 
   const title = objectTitle(scene);
 
+  const file = useMemo(
+    () => (scene.files.length > 0 ? scene.files[0] : undefined),
+    [scene]
+  );
+
   return (
     <>
       <Helmet>
@@ -534,6 +520,50 @@ const ScenePage: React.FC<IProps> = ({
             </h1>
           )}
           <h3 className="scene-header">{title}</h3>
+
+          <div className="scene-subheader">
+            <span className="date">
+              {!!scene.date && (
+                <FormattedDate
+                  value={scene.date}
+                  format="long"
+                  timeZone="utc"
+                />
+              )}
+            </span>
+            {file?.width && file.height ? (
+              <span className="resolution">
+                {TextUtils.resolution(file.width, file.height)}
+              </span>
+            ) : undefined}
+          </div>
+
+          <div className="scene-toolbar">
+            <span>
+              <RatingSystem value={scene.rating100} disabled />
+            </span>
+            <ButtonGroup>
+              <span>
+                <ExternalPlayerButton scene={scene} />
+              </span>
+              <span>
+                <OCounterButton
+                  value={scene.o_counter || 0}
+                  onIncrement={onIncrementClick}
+                  onDecrement={onDecrementClick}
+                  onReset={onResetClick}
+                />
+              </span>
+              <span>
+                <OrganizedButton
+                  loading={organizedLoading}
+                  organized={scene.organized}
+                  onClick={onOrganizedClick}
+                />
+              </span>
+              <span>{renderOperations()}</span>
+            </ButtonGroup>
+          </div>
         </div>
         {renderTabs()}
       </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -46,6 +46,7 @@ import {
   OCounterButton,
   ViewCountButton,
 } from "src/components/Shared/CountButton";
+import { useRatingKeybinds } from "src/hooks/keybinds";
 import { lazyComponent } from "src/utils/lazyComponent";
 
 const SubmitStashBoxDraft = lazyComponent(
@@ -155,6 +156,23 @@ const ScenePage: React.FC<IProps> = ({
       Toast.error(e);
     }
   };
+
+  function setRating(v: number | null) {
+    updateScene({
+      variables: {
+        input: {
+          id: scene.id,
+          rating100: v,
+        },
+      },
+    });
+  }
+
+  useRatingKeybinds(
+    true,
+    configuration?.ui.ratingSystemOptions?.type,
+    setRating
+  );
 
   // set up hotkeys
   useEffect(() => {
@@ -534,7 +552,7 @@ const ScenePage: React.FC<IProps> = ({
 
           <div className="scene-toolbar">
             <span className="scene-toolbar-group">
-              <RatingSystem value={scene.rating100} disabled />
+              <RatingSystem value={scene.rating100} onSetRating={setRating} />
             </span>
             <span className="scene-toolbar-group">
               <span>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -48,6 +48,7 @@ import {
 } from "src/components/Shared/CountButton";
 import { useRatingKeybinds } from "src/hooks/keybinds";
 import { lazyComponent } from "src/utils/lazyComponent";
+import cx from "classnames";
 
 const SubmitStashBoxDraft = lazyComponent(
   () => import("src/components/Dialogs/SubmitDraft")
@@ -519,19 +520,23 @@ const ScenePage: React.FC<IProps> = ({
           collapsed ? "collapsed" : ""
         }`}
       >
-        <div className="d-none d-xl-block">
-          {scene.studio && (
-            <h1 className="mt-3 text-center">
-              <Link to={`/studios/${scene.studio.id}`}>
-                <img
-                  src={scene.studio.image_path ?? ""}
-                  alt={`${scene.studio.name} logo`}
-                  className="studio-logo"
-                />
-              </Link>
-            </h1>
-          )}
-          <h3 className="scene-header">{title}</h3>
+        <div>
+          <div className="scene-header-container">
+            {scene.studio && (
+              <h1 className="mt-3 text-center scene-studio-image">
+                <Link to={`/studios/${scene.studio.id}`}>
+                  <img
+                    src={scene.studio.image_path ?? ""}
+                    alt={`${scene.studio.name} logo`}
+                    className="studio-logo"
+                  />
+                </Link>
+              </h1>
+            )}
+            <h3 className={cx("scene-header", { "no-studio": !scene.studio })}>
+              {title}
+            </h3>
+          </div>
 
           <div className="scene-subheader">
             <span className="date">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -604,7 +604,11 @@ const ScenePage: React.FC<IProps> = ({
 
           <div className="scene-toolbar">
             <span className="scene-toolbar-group">
-              <RatingSystem value={scene.rating100} onSetRating={setRating} />
+              <RatingSystem
+                value={scene.rating100}
+                onSetRating={setRating}
+                clickToRate
+              />
             </span>
             <span className="scene-toolbar-group">
               <span>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -81,6 +81,53 @@ const SceneVideoFilterPanel = lazyComponent(
   () => import("./SceneVideoFilterPanel")
 );
 
+const VideoFrameRateResolution: React.FC<{
+  width?: number;
+  height?: number;
+  frameRate?: number;
+}> = ({ width, height, frameRate }) => {
+  const intl = useIntl();
+
+  const resolution = useMemo(() => {
+    if (width && height) {
+      return (
+        <span className="resolution">
+          {TextUtils.resolution(width, height)}
+        </span>
+      );
+    }
+    return undefined;
+  }, [width, height]);
+
+  const frameRateDisplay = useMemo(() => {
+    if (frameRate) {
+      return (
+        <span className="frame-rate">
+          <FormattedMessage
+            id="frames_per_second"
+            values={{ value: intl.formatNumber(frameRate ?? 0) }}
+          />
+        </span>
+      );
+    }
+    return undefined;
+  }, [intl, frameRate]);
+
+  const divider = useMemo(() => {
+    return resolution && frameRateDisplay ? (
+      <span className="divider"> | </span>
+    ) : undefined;
+  }, [resolution, frameRateDisplay]);
+
+  return (
+    <span>
+      {frameRateDisplay}
+      {divider}
+      {resolution}
+    </span>
+  );
+};
+
 interface IProps {
   scene: GQL.SceneDataFragment;
   setTimestamp: (num: number) => void;
@@ -548,11 +595,11 @@ const ScenePage: React.FC<IProps> = ({
                 />
               )}
             </span>
-            {file?.width && file.height ? (
-              <span className="resolution">
-                {TextUtils.resolution(file.width, file.height)}
-              </span>
-            ) : undefined}
+            <VideoFrameRateResolution
+              width={file?.width}
+              height={file?.height}
+              frameRate={file?.frame_rate}
+            />
           </div>
 
           <div className="scene-toolbar">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -7,8 +7,8 @@ import { TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
-import { objectTitle } from "src/core/files";
 import { DirectorLink } from "src/components/Shared/Link";
+import { objectTitle } from "src/core/files";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -7,7 +7,6 @@ import { TagLink } from "src/components/Shared/TagLink";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
-import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { objectTitle } from "src/core/files";
 import { DirectorLink } from "src/components/Shared/Link";
 
@@ -17,11 +16,6 @@ interface ISceneDetailProps {
 
 export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
   const intl = useIntl();
-
-  const file = useMemo(
-    () => (props.scene.files.length > 0 ? props.scene.files[0] : undefined),
-    [props.scene]
-  );
 
   function renderDetails() {
     if (!props.scene.details || props.scene.details === "") return;
@@ -91,29 +85,6 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
               <TruncatedText text={objectTitle(props.scene)} />
             </h3>
           </div>
-          {props.scene.date ? (
-            <h5>
-              <FormattedDate
-                value={props.scene.date}
-                format="long"
-                timeZone="utc"
-              />
-            </h5>
-          ) : undefined}
-          {props.scene.rating100 ? (
-            <h6>
-              <FormattedMessage id="rating" />:{" "}
-              <RatingSystem value={props.scene.rating100} disabled />
-            </h6>
-          ) : (
-            ""
-          )}
-          {file?.width && file?.height && (
-            <h6>
-              <FormattedMessage id="resolution" />:{" "}
-              {TextUtils.resolution(file.width, file.height)}
-            </h6>
-          )}
           <h6>
             <FormattedMessage id="created_at" />:{" "}
             {TextUtils.formatDateTime(intl, props.scene.created_at)}{" "}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneDetailPanel.tsx
@@ -1,14 +1,11 @@
-import React, { useMemo } from "react";
-import { Link } from "react-router-dom";
-import { FormattedDate, FormattedMessage, useIntl } from "react-intl";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
 import { TagLink } from "src/components/Shared/TagLink";
-import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { PerformerCard } from "src/components/Performers/PerformerCard";
 import { sortPerformers } from "src/core/performers";
 import { DirectorLink } from "src/components/Shared/Link";
-import { objectTitle } from "src/core/files";
 
 interface ISceneDetailProps {
   scene: GQL.SceneDataFragment;
@@ -79,12 +76,7 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
   return (
     <>
       <div className="row">
-        <div className={`${sceneDetailsWidth} col-xl-12 scene-details`}>
-          <div className="scene-header d-xl-none">
-            <h3>
-              <TruncatedText text={objectTitle(props.scene)} />
-            </h3>
-          </div>
+        <div className={`${sceneDetailsWidth} col-12 scene-details`}>
           <h6>
             <FormattedMessage id="created_at" />:{" "}
             {TextUtils.formatDateTime(intl, props.scene.created_at)}{" "}
@@ -105,17 +97,6 @@ export const SceneDetailPanel: React.FC<ISceneDetailProps> = (props) => {
             </h6>
           )}
         </div>
-        {props.scene.studio && (
-          <div className="col-3 d-xl-none">
-            <Link to={`/studios/${props.scene.studio.id}`}>
-              <img
-                src={props.scene.studio.image_path ?? ""}
-                alt={`${props.scene.studio.name} logo`}
-                className="studio-logo float-right"
-              />
-            </Link>
-          </div>
-        )}
       </div>
       <div className="row">
         <div className="col-12">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -33,7 +33,6 @@ import { IMovieEntry, SceneMovieTable } from "./SceneMovieTable";
 import { faSearch, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
-import { useRatingKeybinds } from "src/hooks/keybinds";
 import { lazyComponent } from "src/utils/lazyComponent";
 import isEqual from "lodash-es/isEqual";
 import {
@@ -128,7 +127,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     urls: yupUniqueStringList(intl),
     date: yupDateString(intl),
     director: yup.string().ensure(),
-    rating100: yup.number().integer().nullable().defined(),
     gallery_ids: yup.array(yup.string().required()).defined(),
     studio_id: yup.string().required().nullable(),
     performer_ids: yup.array(yup.string().required()).defined(),
@@ -153,7 +151,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
       urls: scene.urls ?? [],
       date: scene.date ?? "",
       director: scene.director ?? "",
-      rating100: scene.rating100 ?? null,
       gallery_ids: (scene.galleries ?? []).map((g) => g.id),
       studio_id: scene.studio?.id ?? null,
       performer_ids: (scene.performers ?? []).map((p) => p.id),
@@ -201,10 +198,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
       .filter((m) => m.movie !== undefined) as IMovieEntry[];
   }, [formik.values.movies, movies]);
 
-  function setRating(v: number) {
-    formik.setFieldValue("rating100", v);
-  }
-
   function onSetGalleries(items: Gallery[]) {
     setGalleries(items);
     formik.setFieldValue(
@@ -233,12 +226,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     setStudio(item);
     formik.setFieldValue("studio_id", item ? item.id : null);
   }
-
-  useRatingKeybinds(
-    isVisible,
-    stashConfig?.ui.ratingSystemOptions?.type,
-    setRating
-  );
 
   useEffect(() => {
     if (isVisible) {
@@ -726,7 +713,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     renderField,
     renderInputField,
     renderDateField,
-    renderRatingField,
     renderURLListField,
     renderStashIDsField,
   } = formikUtils(intl, formik, splitProps);
@@ -865,7 +851,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
             {renderDateField("date")}
             {renderInputField("director")}
-            {renderRatingField("rating100", "rating")}
 
             {renderGalleriesField()}
             {renderStudioField()}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -65,14 +65,17 @@
 
 @include media-breakpoint-only(lg) {
   .scene-header-container {
+    align-items: center;
     display: flex;
     justify-content: space-between;
 
     .scene-header {
+      flex: 0 0 75%;
       order: 1;
     }
 
     .scene-studio-image {
+      flex: 0 0 25%;
       order: 2;
     }
   }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -65,7 +65,30 @@
 
 .scene-header {
   flex-basis: auto;
+  font-size: 1.5rem;
   margin-top: 30px;
+}
+
+.scene-subheader {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+
+  .date {
+    color: $text-muted;
+  }
+
+  .resolution {
+    font-weight: bold;
+  }
+}
+
+.scene-toolbar {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+  margin-top: 0.5rem;
+  width: 100%;
 }
 
 #scene-details-container {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -111,6 +111,7 @@
   justify-content: space-between;
   margin-bottom: 0.25rem;
   margin-top: 0.5rem;
+  padding-bottom: 0.25rem;
   width: 100%;
 
   .scene-toolbar-group {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -84,11 +84,23 @@
 }
 
 .scene-toolbar {
+  align-items: center;
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.25rem;
   margin-top: 0.5rem;
   width: 100%;
+
+  .scene-toolbar-group {
+    align-items: center;
+    column-gap: 0.25rem;
+    display: flex;
+    width: 100%;
+
+    &:last-child {
+      justify-content: flex-end;
+    }
+  }
 }
 
 #scene-details-container {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -63,10 +63,29 @@
   max-width: 100%;
 }
 
+@include media-breakpoint-only(lg) {
+  .scene-header-container {
+    display: flex;
+    justify-content: space-between;
+
+    .scene-header {
+      order: 1;
+    }
+
+    .scene-studio-image {
+      order: 2;
+    }
+  }
+}
+
 .scene-header {
   flex-basis: auto;
   font-size: 1.5rem;
   margin-top: 30px;
+
+  @include media-breakpoint-down(xl) {
+    font-size: 1.75rem;
+  }
 }
 
 .scene-subheader {

--- a/ui/v2.5/src/components/Shared/CountButton.tsx
+++ b/ui/v2.5/src/components/Shared/CountButton.tsx
@@ -1,0 +1,54 @@
+import { faEye } from "@fortawesome/free-solid-svg-icons";
+import React from "react";
+import { Button, ButtonGroup } from "react-bootstrap";
+import { Icon } from "src/components/Shared/Icon";
+import { SweatDrops } from "./SweatDrops";
+import cx from "classnames";
+
+interface ICountButtonProps {
+  value: number;
+  icon: React.ReactNode;
+  onIncrement?: () => void;
+  onValueClicked?: () => void;
+  title?: string;
+}
+
+export const CountButton: React.FC<ICountButtonProps> = ({
+  value,
+  icon,
+  onIncrement,
+  onValueClicked,
+  title,
+}) => {
+  return (
+    <ButtonGroup
+      className={cx("count-button", { "increment-only": !onValueClicked })}
+    >
+      <Button
+        className="minimal count-icon"
+        variant="secondary"
+        onClick={() => onIncrement?.()}
+        title={title}
+      >
+        {icon}
+      </Button>
+      <Button
+        className="minimal count-value"
+        variant="secondary"
+        onClick={() => (onValueClicked ?? onIncrement)?.()}
+      >
+        <span>{value}</span>
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+type CountButtonPropsNoIcon = Omit<ICountButtonProps, "icon">;
+
+export const ViewCountButton: React.FC<CountButtonPropsNoIcon> = (props) => (
+  <CountButton {...props} icon={<Icon icon={faEye} />} />
+);
+
+export const OCounterButton: React.FC<CountButtonPropsNoIcon> = (props) => (
+  <CountButton {...props} icon={<SweatDrops />} />
+);

--- a/ui/v2.5/src/components/Shared/CountButton.tsx
+++ b/ui/v2.5/src/components/Shared/CountButton.tsx
@@ -4,6 +4,7 @@ import { Button, ButtonGroup } from "react-bootstrap";
 import { Icon } from "src/components/Shared/Icon";
 import { SweatDrops } from "./SweatDrops";
 import cx from "classnames";
+import { useIntl } from "react-intl";
 
 interface ICountButtonProps {
   value: number;
@@ -11,6 +12,7 @@ interface ICountButtonProps {
   onIncrement?: () => void;
   onValueClicked?: () => void;
   title?: string;
+  countTitle?: string;
 }
 
 export const CountButton: React.FC<ICountButtonProps> = ({
@@ -19,6 +21,7 @@ export const CountButton: React.FC<ICountButtonProps> = ({
   onIncrement,
   onValueClicked,
   title,
+  countTitle,
 }) => {
   return (
     <ButtonGroup
@@ -36,6 +39,7 @@ export const CountButton: React.FC<ICountButtonProps> = ({
         className="minimal count-value"
         variant="secondary"
         onClick={() => (onValueClicked ?? onIncrement)?.()}
+        title={!!onValueClicked ? countTitle : undefined}
       >
         <span>{value}</span>
       </Button>
@@ -45,10 +49,26 @@ export const CountButton: React.FC<ICountButtonProps> = ({
 
 type CountButtonPropsNoIcon = Omit<ICountButtonProps, "icon">;
 
-export const ViewCountButton: React.FC<CountButtonPropsNoIcon> = (props) => (
-  <CountButton {...props} icon={<Icon icon={faEye} />} />
-);
+export const ViewCountButton: React.FC<CountButtonPropsNoIcon> = (props) => {
+  const intl = useIntl();
+  return (
+    <CountButton
+      {...props}
+      icon={<Icon icon={faEye} />}
+      title={intl.formatMessage({ id: "media_info.play_count" })}
+      countTitle={intl.formatMessage({ id: "actions.view_history" })}
+    />
+  );
+};
 
-export const OCounterButton: React.FC<CountButtonPropsNoIcon> = (props) => (
-  <CountButton {...props} icon={<SweatDrops />} />
-);
+export const OCounterButton: React.FC<CountButtonPropsNoIcon> = (props) => {
+  const intl = useIntl();
+  return (
+    <CountButton
+      {...props}
+      icon={<SweatDrops />}
+      title={intl.formatMessage({ id: "o_count" })}
+      countTitle={intl.formatMessage({ id: "actions.view_history" })}
+    />
+  );
+};

--- a/ui/v2.5/src/components/Shared/Rating/RatingNumber.tsx
+++ b/ui/v2.5/src/components/Shared/Rating/RatingNumber.tsx
@@ -1,14 +1,25 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
+import { Button } from "react-bootstrap";
+import { Icon } from "../Icon";
+import { faPencil } from "@fortawesome/free-solid-svg-icons";
+import { useFocusOnce } from "src/utils/focus";
 
 export interface IRatingNumberProps {
   value: number | null;
   onSetRating?: (value: number | null) => void;
   disabled?: boolean;
+  clickToRate?: boolean;
 }
 
 export const RatingNumber: React.FC<IRatingNumberProps> = (
   props: IRatingNumberProps
 ) => {
+  const [editing, setEditing] = useState(false);
+
+  const showTextField = !props.disabled && (editing || !props.clickToRate);
+
+  const [ratingRef] = useFocusOnce(editing, true);
+
   const text = ((props.value ?? 0) / 10).toFixed(1);
   const useValidation = useRef(true);
 
@@ -90,22 +101,38 @@ export const RatingNumber: React.FC<IRatingNumberProps> = (
     }
   }
 
-  if (props.disabled) {
+  function onBlur() {
+    setEditing(false);
+  }
+
+  if (!showTextField) {
     return (
       <div className="rating-number disabled">
         <span>{Number((props.value ?? 0) / 10).toFixed(1)}</span>
+        {!props.disabled && props.clickToRate && (
+          <Button
+            variant="minimal"
+            size="sm"
+            className="edit-rating-button"
+            onClick={() => setEditing(true)}
+          >
+            <Icon className="text-primary" icon={faPencil} />
+          </Button>
+        )}
       </div>
     );
   } else {
     return (
       <div className="rating-number">
         <input
+          ref={ratingRef}
           className="text-input form-control"
           name="ratingnumber"
           type="number"
           onMouseDown={stepChange}
           onKeyDown={nonStepChange}
           onChange={handleChange}
+          onBlur={onBlur}
           value={text}
           min="0.0"
           step="0.1"

--- a/ui/v2.5/src/components/Shared/Rating/RatingSystem.tsx
+++ b/ui/v2.5/src/components/Shared/Rating/RatingSystem.tsx
@@ -13,6 +13,8 @@ export interface IRatingSystemProps {
   onSetRating?: (value: number | null) => void;
   disabled?: boolean;
   valueRequired?: boolean;
+  // if true, requires a click first to edit the rating
+  clickToRate?: boolean;
 }
 
 export const RatingSystem: React.FC<IRatingSystemProps> = (
@@ -40,6 +42,7 @@ export const RatingSystem: React.FC<IRatingSystemProps> = (
         value={props.value ?? null}
         onSetRating={props.onSetRating}
         disabled={props.disabled}
+        clickToRate={props.clickToRate}
       />
     );
   }

--- a/ui/v2.5/src/components/Shared/Rating/styles.scss
+++ b/ui/v2.5/src/components/Shared/Rating/styles.scss
@@ -93,7 +93,13 @@
   margin: auto 0.5rem;
 }
 
-.rating-number.disabled {
-  align-items: center;
-  display: inline-flex;
+.rating-number {
+  .edit-rating-button {
+    font-size: 0.75rem;
+  }
+
+  &.disabled {
+    align-items: center;
+    display: inline-flex;
+  }
 }

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -552,3 +552,43 @@ button.btn.favorite-button {
     box-shadow: none;
   }
 }
+
+.count-button {
+  border-radius: 5px;
+
+  &:hover {
+    background: rgba(138, 155, 168, 0.15);
+    color: #f5f8fa;
+  }
+
+  .count-icon {
+    padding-left: 0.5rem;
+    padding-right: 0.25rem;
+  }
+
+  .count-value {
+    padding-left: 0.25rem;
+    padding-right: 0.5rem;
+  }
+
+  button.count-icon,
+  &.increment-only button.count-value {
+    &:hover {
+      background: none;
+      color: #f5f8fa;
+    }
+  }
+
+  button.btn-secondary.count-icon,
+  button.btn-secondary.count-value {
+    &:focus {
+      border: none;
+      box-shadow: none;
+      color: #f5f8fa;
+
+      &:not(:hover) {
+        background: none;
+      }
+    }
+  }
+}

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -402,12 +402,14 @@ li.active .optional-field.excluded .scene-link {
 //   margin-left: 1rem;
 // }
 
-.scene-details,
-.original-scene-details {
-  margin-top: 0.5rem;
+.tagger-container {
+  .scene-details,
+  .original-scene-details {
+    margin-top: 0.5rem;
 
-  > .row {
-    width: 100%;
+    > .row {
+      width: 100%;
+    }
   }
 }
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -134,6 +134,7 @@
     "temp_enable": "Enable temporarily…",
     "unset": "Unset",
     "use_default": "Use default",
+    "view_history": "View history",
     "view_random": "View Random"
   },
   "actions_name": "Actions",

--- a/ui/v2.5/src/utils/focus.ts
+++ b/ui/v2.5/src/utils/focus.ts
@@ -14,16 +14,16 @@ const useFocus = () => {
 };
 
 // focuses on the element only once on mount
-export const useFocusOnce = (active?: boolean) => {
+export const useFocusOnce = (active?: boolean, override?: boolean) => {
   const [htmlElRef, setFocus] = useFocus();
   const focused = useRef(false);
 
   useEffect(() => {
-    if (!focused.current && active) {
+    if ((!focused.current || override) && active) {
       setFocus();
       focused.current = true;
     }
-  }, [setFocus, active]);
+  }, [setFocus, active, override]);
 
   return [htmlElRef, setFocus] as const;
 };


### PR DESCRIPTION
This is an offshoot of #4699. I'm taking my own advice and reducing the scope of changes so that more focused feedback can be provided and get this implemented sooner.

The summary of changes is as follows:
* date, frame rate and resolution are moved to a sub-header under the main title
* a toolbar has been added between the date/resolution sub-header and the tabs. This toolbar includes the rating, a new play count button, the o-count button, organised button and the overflow menu.
* rating has been removed from the edit panel. Rating can be set in any panel now. Keybinds have been shifted across as well
* o-count button has been restyled. The dropdown menu is removed - the other functions can be accessed in the history tab. The play count works the same way. 
* the numeric rating control is displayed as a read-only field by default, the editable text field is accessed by clicking the accompanying pencil button, which shows and focuses on the field. Clicking away from the field restores the read-only field.

![image](https://github.com/stashapp/stash/assets/53250216/739b1b22-60c6-44d2-966a-7a0d3f5adc2a)
![image](https://github.com/stashapp/stash/assets/53250216/25ff793e-d6f9-4c7e-b6ed-0f4fee37028c)
![image](https://github.com/stashapp/stash/assets/53250216/62c4a63d-402f-45f2-bde1-40f3e962f285)

I plan to add to this PR to roll this out to the image and gallery detail pages, once I've gotten some feedback.

Image will have the date and resolution in the sub-header, and all but the view count button in the toolbar. Gallery will have the date and potentially image count in the sub-header, and the same toolbar buttons as image.