### PR TITLE
Add wrap on detail item values

### DIFF
--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -422,8 +422,8 @@ dd {
   align-items: center;
   display: flex;
   flex-direction: row;
-  white-space: pre-line;
   flex-wrap: wrap;
+  white-space: pre-line;
 
   .birthdate,
   .height-imperial,

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -423,6 +423,7 @@ dd {
   display: flex;
   flex-direction: row;
   white-space: pre-line;
+  flex-wrap: wrap;
 
   .birthdate,
   .height-imperial,


### PR DESCRIPTION
Add a `flex-wrap` to allow for proper wrapping in detail pages

Before:
![image](https://github.com/stashapp/stash/assets/22910497/e9ad5206-43f4-405e-8893-fa9f951af307)

After:
![image](https://github.com/stashapp/stash/assets/22910497/5b37508b-c403-4587-8e80-51cd5aad8a04)


Fixes #4559