### PR TITLE
Include director field when adding movies from the scene scrape dialog

### DIFF
--- a/ui/v2.5/src/core/movies.ts
+++ b/ui/v2.5/src/core/movies.ts
@@ -10,6 +10,7 @@ export const scrapedMovieToCreateInput = (toCreate: GQL.ScrapedMovie) => {
     back_image: toCreate.back_image,
     synopsis: toCreate.synopsis,
     date: toCreate.date,
+    director: toCreate.director,
     // #788 - convert duration and rating to the correct type
     duration: TextUtils.timestampToSeconds(toCreate.duration),
     studio_id: toCreate.studio?.stored_id,


### PR DESCRIPTION
This field was accidentally ignored even if the scraper returns it: see the [XConfessions](https://github.com/stashapp/CommunityScrapers/blob/master/scrapers/XConfessions.yml) scraper for an example