### PR TITLE
Extend orientation / rotation support for files on load

### DIFF
--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -249,7 +249,6 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 
 		// define "rotate" to true when either the video stream tag or the side data has a rotation
 		rotate := false
-		fmt.Print("videoStream.Tags.Rotate: ", videoStream.Tags.Rotate, " videoStream.Frames: ", probeJSON.PacketsAndFrames)
 		if rotationFromTag, err := strconv.ParseInt(videoStream.Tags.Rotate, 10, 64); err == nil && rotationFromTag != 180 {
 			rotate = true
 		}

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -147,7 +147,7 @@ func (f *FFProbe) Path() string {
 
 // NewVideoFile runs ffprobe on the given path and returns a VideoFile.
 func (f *FFProbe) NewVideoFile(videoPath string) (*VideoFile, error) {
-	args := []string{"-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", "-show_error", videoPath}
+	args := []string{"-v", "quiet", "-print_format", "json", "-count_frames", "-show_format", "-show_streams", "-show_entries", "side_data=rotation", "-show_error", videoPath}
 	cmd := stashExec.Command(string(*f), args...)
 	out, err := cmd.Output()
 
@@ -166,7 +166,7 @@ func (f *FFProbe) NewVideoFile(videoPath string) (*VideoFile, error) {
 // GetReadFrameCount counts the actual frames of the video file.
 // Used when the frame count is missing or incorrect.
 func (f *FFProbe) GetReadFrameCount(path string) (int64, error) {
-	args := []string{"-v", "quiet", "-print_format", "json", "-count_frames", "-show_format", "-show_streams", "-show_error", path}
+	args := []string{"-v", "quiet", "-print_format", "json", "-count_frames", "-show_format", "-show_streams", "-show_entries", "side_data=rotation", "-show_error", path}
 	out, err := stashExec.Command(string(*f), args...).Output()
 
 	if err != nil {

--- a/pkg/ffmpeg/types.go
+++ b/pkg/ffmpeg/types.go
@@ -27,8 +27,14 @@ type FFProbeJSON struct {
 			Comment          string        `json:"comment"`
 		} `json:"tags"`
 	} `json:"format"`
-	Streams []FFProbeStream `json:"streams"`
-	Error   struct {
+	Streams          []FFProbeStream `json:"streams"`
+	PacketsAndFrames []struct {
+		Type         string `json:"type"`
+		SideDataList []struct {
+			Rotation int `json:"rotation"`
+		} `json:"side_data_list"`
+	} `json:"packets_and_frames"`
+	Error struct {
 		Code   int    `json:"code"`
 		String string `json:"string"`
 	} `json:"error"`


### PR DESCRIPTION
Potentially fixes #4555, #4738, #3479 by adding support to parse out `rotation` frame side_data from FFMPEG / ffprobe

I manually tested this with a small set of reproducing JPEG images, but have not yet had the chance to try out other image types.

Thanks to @onlyhooops for their repro images, and to @zhyu for calling out the ffprobe tooling.