### PR TITLE
Better support for Samsung SmartTV for built-in DLNA server

### DIFF
--- a/internal/dlna/cds.go
+++ b/internal/dlna/cds.go
@@ -85,7 +85,6 @@ func sceneToContainer(scene *models.Scene, parent string, host string) interface
 		Path:   iconPath,
 		RawQuery: url.Values{
 			"scene": {strconv.Itoa(scene.ID)},
-			"c":     {"jpeg"},
 		}.Encode(),
 	}).String()
 

--- a/internal/dlna/dms.go
+++ b/internal/dlna/dms.go
@@ -595,6 +595,8 @@ func (me *Server) initMux(mux *http.ServeMux) {
 			return
 		}
 
+		w.Header().Set("transferMode.dlna.org", "Streaming")
+		w.Header().Set("contentFeatures.dlna.org", "DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01500000000000000000000000000000")
 		me.sceneServer.StreamSceneDirect(scene, w, r)
 	})
 	mux.HandleFunc(rootDescPath, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes #1768
Seems DLNA implementation in Tizen OS Samsung SmartTV requires several headers in order not to try load media files as a whole, but preform file rendering as a stream.
Also c=jpeg parameter within scene icon URL gets decoded by Samsung as ```/icon?scene=XYZ&amp;c=jpeg```. As far as this parameter is not used anywhere within DLNA implementation in StashApp, I've decided to drop it.