### PR TITLE
Build UI artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,13 +92,16 @@ jobs:
         docker exec -t build /bin/bash -c "make build-cc-linux-arm32v6"
         docker exec -t build /bin/bash -c "make build-cc-freebsd"
 
+    - name: Zip UI
+      run: docker exec -t build /bin/bash -c "make zip-ui"
+
     - name: Cleanup build container
       run: docker rm -f -v build
 
     - name: Generate checksums
       run: |
         git describe --tags --exclude latest_develop | tee CHECKSUMS_SHA1
-        sha1sum dist/Stash.app.zip dist/stash-* | sed 's/dist\///g' | tee -a CHECKSUMS_SHA1
+        sha1sum dist/Stash.app.zip dist/stash-* dist/stash-ui.zip | sed 's/dist\///g' | tee -a CHECKSUMS_SHA1
         echo "STASH_VERSION=$(git describe --tags --exclude latest_develop)" >> $GITHUB_ENV
         echo "RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
 
@@ -126,6 +129,14 @@ jobs:
         name: stash-linux
         path: dist/stash-linux
 
+    - name: Upload UI
+      # only upload for pull requests
+      if: ${{ github.event_name == 'pull_request' && github.base_ref != 'refs/heads/develop' && github.base_ref != 'refs/heads/master'}}
+      uses: actions/upload-artifact@v2
+      with:
+        name: stash-ui.zip
+        path: dist/stash-ui.zip
+
     - name: Update latest_develop tag
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       run : git tag -f latest_develop; git push -f --tags
@@ -147,6 +158,7 @@ jobs:
           dist/stash-linux-arm32v7
           dist/stash-linux-arm32v6
           dist/stash-freebsd
+          dist/stash-ui.zip
           CHECKSUMS_SHA1
 
     - name: Master release
@@ -166,6 +178,7 @@ jobs:
           dist/stash-linux-arm32v7
           dist/stash-linux-arm32v6
           dist/stash-freebsd
+          dist/stash-ui.zip
           CHECKSUMS_SHA1
         gzip: false
 

--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,11 @@ endif
 ui: ui-env
 	cd ui/v2.5 && yarn build
 
+.PHONY: zip-ui
+zip-ui:
+	rm -f dist/stash-ui.zip
+	cd ui/v2.5/build && zip -r ../../../dist/stash-ui.zip .
+
 .PHONY: ui-start
 ui-start: ui-env
 	cd ui/v2.5 && yarn start --host

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -61,7 +61,8 @@ func (dir osFS) ReadDir(name string) ([]os.DirEntry, error) {
 	fullname := string(dir) + "/" + name
 	entries, err := os.ReadDir(fullname)
 	if err != nil {
-		if e, ok := err.(*os.PathError); ok {
+		var e *os.PathError
+		if errors.As(err, &e) {
 			// See comment in dirFS.Open.
 			e.Path = name
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,6 +53,27 @@ type Server struct {
 	manager *manager.Manager
 }
 
+// TODO - os.DirFS doesn't implement ReadDir, so re-implement it here
+// This can be removed when we upgrade go
+type osFS string
+
+func (dir osFS) ReadDir(name string) ([]os.DirEntry, error) {
+	fullname := string(dir) + "/" + name
+	entries, err := os.ReadDir(fullname)
+	if err != nil {
+		if e, ok := err.(*os.PathError); ok {
+			// See comment in dirFS.Open.
+			e.Path = name
+		}
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (dir osFS) Open(name string) (fs.File, error) {
+	return os.DirFS(string(dir)).Open(name)
+}
+
 // Called at startup
 func Initialize() (*Server, error) {
 	mgr := manager.GetInstance()
@@ -213,25 +234,31 @@ func Initialize() (*Server, error) {
 		r.Mount("/custom", getCustomRoutes(customServedFolders))
 	}
 
-	customUILocation := cfg.GetCustomUILocation()
-	staticUI := statigz.FileServer(ui.UIBox.(fs.ReadDirFS))
+	var uiFS fs.FS
+	var staticUI *statigz.Server
+	customUILocation := cfg.GetUILocation()
+	if customUILocation != "" {
+		logger.Debugf("Serving UI from %s", customUILocation)
+		uiFS = osFS(customUILocation)
+		staticUI = statigz.FileServer(uiFS.(fs.ReadDirFS))
+	} else {
+		logger.Debug("Serving embedded UI")
+		uiFS = ui.UIBox
+		staticUI = statigz.FileServer(ui.UIBox.(fs.ReadDirFS))
+	}
 
 	// Serve the web app
 	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
 		ext := path.Ext(r.URL.Path)
 
-		if customUILocation != "" {
-			if r.URL.Path == "index.html" || ext == "" {
-				r.URL.Path = "/"
-			}
-
-			http.FileServer(http.Dir(customUILocation)).ServeHTTP(w, r)
-			return
+		if ext == ".html" || ext == "" {
+			w.Header().Set("Content-Type", "text/html")
+			setPageSecurityHeaders(w, r, pluginCache.ListPlugins())
 		}
 
-		if ext == ".html" || ext == "" {
+		if ext == "" || r.URL.Path == "/" || r.URL.Path == "/index.html" {
 			themeColor := cfg.GetThemeColor()
-			data, err := fs.ReadFile(ui.UIBox, "index.html")
+			data, err := fs.ReadFile(uiFS, "index.html")
 			if err != nil {
 				panic(err)
 			}
@@ -240,9 +267,6 @@ func Initialize() (*Server, error) {
 			prefix := getProxyPrefix(r)
 			indexHtml = strings.ReplaceAll(indexHtml, "%COLOR%", themeColor)
 			indexHtml = strings.Replace(indexHtml, `<base href="/"`, fmt.Sprintf(`<base href="%s/"`, prefix), 1)
-
-			w.Header().Set("Content-Type", "text/html")
-			setPageSecurityHeaders(w, r, pluginCache.ListPlugins())
 
 			utils.ServeStaticContent(w, r, []byte(indexHtml))
 		} else {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -159,7 +159,10 @@ const (
 
 	// UI directory. Overrides to serve the UI from a specific location
 	// rather than use the embedded UI.
-	CustomUILocation = "custom_ui_location"
+	UILocation = "ui_location"
+
+	// backwards compatible name
+	LegacyCustomUILocation = "custom_ui_location"
 
 	// Gallery Cover Regex
 	GalleryCoverRegex        = "gallery_cover_regex"
@@ -1057,8 +1060,12 @@ func (i *Config) GetCustomServedFolders() utils.URLMap {
 	return i.getStringMapString(CustomServedFolders)
 }
 
-func (i *Config) GetCustomUILocation() string {
-	return i.getString(CustomUILocation)
+func (i *Config) GetUILocation() string {
+	if ret := i.getString(UILocation); ret != "" {
+		return ret
+	}
+
+	return i.getString(LegacyCustomUILocation)
 }
 
 // Interface options

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -72,7 +72,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.GetCredentials()
 				i.Set(MaxSessionAge, i.GetMaxSessionAge())
 				i.Set(CustomServedFolders, i.GetCustomServedFolders())
-				i.Set(CustomUILocation, i.GetCustomUILocation())
+				i.Set(LegacyCustomUILocation, i.GetUILocation())
 				i.Set(MenuItems, i.GetMenuItems())
 				i.Set(SoundOnPreview, i.GetSoundOnPreview())
 				i.Set(WallShowTitle, i.GetWallShowTitle())


### PR DESCRIPTION
- Makes the UI routing code consistent when using a custom UI location.
- Allows the UI location to be provided from the environment (`$STASH_UI`), or the command line (`--ui-location <path>` or `-u <path>`.
- Adds Makefile target `zip-ui` to zip the UI files into `dist/stash-ui.zip`
- Makes the github build action include `stash-ui.zip` in the release and build artifacts

The main purpose of this PR is to make it easier to run stash with a custom UI, and to make it easier for users to grab the UI files  from PRs and the development build.