### PR TITLE
update popover delay

### DIFF
--- a/ui/v2.5/src/components/Shared/HoverPopover.tsx
+++ b/ui/v2.5/src/components/Shared/HoverPopover.tsx
@@ -14,7 +14,7 @@ interface IHoverPopover {
 
 export const HoverPopover: React.FC<IHoverPopover> = ({
   enterDelay = 200,
-  leaveDelay = 0,
+  leaveDelay = 200,
   content,
   children,
   className,

--- a/ui/v2.5/src/components/Shared/HoverPopover.tsx
+++ b/ui/v2.5/src/components/Shared/HoverPopover.tsx
@@ -13,8 +13,8 @@ interface IHoverPopover {
 }
 
 export const HoverPopover: React.FC<IHoverPopover> = ({
-  enterDelay = 0,
-  leaveDelay = 400,
+  enterDelay = 200,
+  leaveDelay = 0,
   content,
   children,
   className,


### PR DESCRIPTION
This pull request adjusts the card popover entry and exit delay. Previously, the popovers were set to delay exit by 400 milliseconds, making hovering over individual popovers feel clumsy as the delayed exit often gets in the way of attempting to hover over different popover items. Interestingly, when adjusting the values to remove the existing delay, I noticed the UI is more responsive with other transitions I have applied to the cards in my CSS.