### PR TITLE
feat: Make DLNA port configurable

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -469,6 +469,8 @@ input ConfigDLNAInput {
   serverName: String
   "True if DLNA service should be enabled by default"
   enabled: Boolean
+  "Defaults to 1338"
+  port: Int
   "List of IPs whitelisted for DLNA service"
   whitelistedIPs: [String!]
   "List of interfaces to run DLNA on. Empty for all"
@@ -481,6 +483,8 @@ type ConfigDLNAResult {
   serverName: String!
   "True if DLNA service should be enabled by default"
   enabled: Boolean!
+  "Defaults to 1338"
+  port: Int!
   "List of IPs whitelisted for DLNA service"
   whitelistedIPs: [String!]!
   "List of interfaces to run DLNA on. Empty for all"

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -576,6 +576,10 @@ func (r *mutationResolver) ConfigureDlna(ctx context.Context, input ConfigDLNAIn
 		c.Set(config.DLNAVideoSortOrder, input.VideoSortOrder)
 	}
 
+	if input.Port != nil {
+		c.Set(config.DLNAPort, *input.Port)
+	}
+
 	refresh := false
 	if input.Enabled != nil {
 		c.Set(config.DLNADefaultEnabled, *input.Enabled)

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -199,6 +199,7 @@ func makeConfigDLNAResult() *ConfigDLNAResult {
 	return &ConfigDLNAResult{
 		ServerName:     config.GetDLNAServerName(),
 		Enabled:        config.GetDLNADefaultEnabled(),
+		Port:           config.GetDLNAPort(),
 		WhitelistedIPs: config.GetDLNADefaultIPWhitelist(),
 		Interfaces:     config.GetDLNAInterfaces(),
 		VideoSortOrder: config.GetVideoSortOrder(),

--- a/internal/dlna/service.go
+++ b/internal/dlna/service.go
@@ -76,6 +76,7 @@ type Config interface {
 	GetDLNAServerName() string
 	GetDLNADefaultIPWhitelist() []string
 	GetVideoSortOrder() string
+	GetDLNAPortAsString() string
 }
 
 type Service struct {
@@ -138,7 +139,7 @@ func (s *Service) init() error {
 	var dmsConfig = &dmsConfig{
 		Path:           "",
 		IfNames:        s.config.GetDLNADefaultIPWhitelist(),
-		Http:           ":1338",
+		Http:           s.config.GetDLNAPortAsString(),
 		FriendlyName:   friendlyName,
 		LogHeaders:     false,
 		NotifyInterval: 30 * time.Second,
@@ -241,7 +242,7 @@ func (s *Service) Start(duration *time.Duration) error {
 		}
 
 		go func() {
-			logger.Info("Starting DLNA")
+			logger.Info("Starting DLNA " + s.server.HTTPConn.Addr().String())
 			if err := s.server.Serve(); err != nil {
 				logger.Error(err)
 			}

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"sync"
@@ -236,6 +237,9 @@ const (
 
 	DLNAVideoSortOrder        = "dlna.video_sort_order"
 	dlnaVideoSortOrderDefault = "title"
+
+	DLNAPort        = "dlna.port"
+	DLNAPortDefault = 1338
 
 	// Logging options
 	LogFile          = "logFile"
@@ -1475,6 +1479,21 @@ func (i *Config) GetDLNADefaultIPWhitelist() []string {
 // empty, runs on all interfaces.
 func (i *Config) GetDLNAInterfaces() []string {
 	return i.getStringSlice(DLNAInterfaces)
+}
+
+// GetDLNAPort returns the port to run the DLNA server on. If empty, 1338
+// will be used.
+func (i *Config) GetDLNAPort() int {
+	ret := i.getInt(DLNAPort)
+	if ret == 0 {
+		ret = DLNAPortDefault
+	}
+	return ret
+}
+
+// GetDLNAPortAsString returns the port to run the DLNA server on as a string.
+func (i *Config) GetDLNAPortAsString() string {
+	return ":" + strconv.Itoa(i.GetDLNAPort())
 }
 
 // GetVideoSortOrder returns the sort order to display videos. If

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -97,6 +97,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.Set(DLNADefaultEnabled, i.GetDLNADefaultEnabled())
 				i.Set(DLNADefaultIPWhitelist, i.GetDLNADefaultIPWhitelist())
 				i.Set(DLNAInterfaces, i.GetDLNAInterfaces())
+				i.Set(DLNAPort, i.GetDLNAPort())
 				i.Set(LogFile, i.GetLogFile())
 				i.Set(LogOut, i.GetLogOut())
 				i.Set(LogLevel, i.GetLogLevel())

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -111,6 +111,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
 fragment ConfigDLNAData on ConfigDLNAResult {
   serverName
   enabled
+  port
   whitelistedIPs
   interfaces
   videoSortOrder

--- a/ui/v2.5/src/components/Settings/SettingsServicesPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsServicesPanel.tsx
@@ -19,6 +19,7 @@ import {
   StringListSetting,
   StringSetting,
   SelectSetting,
+  NumberSetting,
 } from "./Inputs";
 import { useSettings } from "./context";
 import {
@@ -30,6 +31,8 @@ import {
   faTimes,
   faUserClock,
 } from "@fortawesome/free-solid-svg-icons";
+
+const defaultDLNAPort = 1338;
 
 export const SettingsServicesPanel: React.FC = () => {
   const intl = useIntl();
@@ -415,6 +418,15 @@ export const SettingsServicesPanel: React.FC = () => {
             )}
             value={dlna.serverName ?? undefined}
             onChange={(v) => saveDLNA({ serverName: v })}
+          />
+
+          <NumberSetting
+            headingID="config.dlna.server_port"
+            subHeading={intl.formatMessage({
+              id: "config.dlna.server_port_desc",
+            })}
+            value={dlna.port ?? undefined}
+            onChange={(v) => saveDLNA({ port: v ? v : defaultDLNAPort })}
           />
 
           <BooleanSetting

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -257,6 +257,8 @@
       "recent_ip_addresses": "Recent IP addresses",
       "server_display_name": "Server Display Name",
       "server_display_name_desc": "Display name for the DLNA server. Defaults to {server_name} if empty.",
+      "server_port": "Server Port",
+      "server_port_desc": "Port to run the DLNA server on. Requires DLNA restart after changing.",
       "successfully_cancelled_temporary_behaviour": "Successfully cancelled temporary behaviour",
       "until_restart": "until restart",
       "video_sort_order": "Default Video Sort Order",


### PR DESCRIPTION
Resolves #4760 

This PR makes the DLNA port configurable by specifying the port number in the `config.yml` file:

```
dlna:
    port: 7777
```

This PR does not enable the DLNA port configuration from the UI. I thought it would be better to create a separate PR to speed up review :)