### PR TITLE
Return 401 code for `ErrUnauthorized` errors

### DIFF
--- a/internal/api/authentication.go
+++ b/internal/api/authentication.go
@@ -42,7 +42,7 @@ func authenticateHandler() func(http.Handler) http.Handler {
 
 			userID, err := manager.GetInstance().SessionStore.Authenticate(w, r)
 			if err != nil {
-				if errors.Is(err, session.ErrUnauthorized) {
+				if !errors.Is(err, session.ErrUnauthorized) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}


### PR DESCRIPTION
A very tiny PR so that an `401 Unauthorized` is returned when the request is unauthorized instead of a `500 Internal Server Error`.

This was the behavior before an [error lint PR reversed the if condition](https://github.com/stashapp/stash/pull/1796/files#diff-2591b9ac79fca516f3e900bddd650c09d147dba12bac4c002d6eec976216621aR43) probably accidentally.