### PR TITLE
Marker tag filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -237,6 +237,10 @@ input SceneFilterType {
   duration: IntCriterionInput
   "Filter to only include scenes which have markers. `true` or `false`"
   has_markers: String
+  "Filter to only include scenes with markers having these tags"
+  marker_tags: HierarchicalMultiCriterionInput
+  "Filter to only include scenes with markers having these primary tags"
+  primary_marker_tags: HierarchicalMultiCriterionInput
   "Filter to only include scenes missing this property"
   is_missing: String
   "Filter to only include scenes with this studio"

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -51,6 +51,10 @@ type SceneFilterType struct {
 	Duration *IntCriterionInput `json:"duration"`
 	// Filter to only include scenes which have markers. `true` or `false`
 	HasMarkers *string `json:"has_markers"`
+	// Filter to only include scenes with markers having these tags
+	MarkerTags *HierarchicalMultiCriterionInput `json:"marker_tags"`
+	// Filter to only include scenes with markers having these primary tags
+	PrimaryMarkerTags *HierarchicalMultiCriterionInput `json:"primary_marker_tags"`
 	// Filter to only include scenes missing this property
 	IsMissing *string `json:"is_missing"`
 	// Filter to only include scenes with this studio

--- a/pkg/sqlite/scene_marker_test.go
+++ b/pkg/sqlite/scene_marker_test.go
@@ -52,7 +52,7 @@ func TestMarkerCountByTagID(t *testing.T) {
 			t.Errorf("error calling CountByTagID: %s", err.Error())
 		}
 
-		assert.Equal(t, 6, markerCount)
+		assert.Equal(t, 8, markerCount)
 
 		markerCount, err = mqb.CountByTagID(ctx, tagIDs[tagIdxWithMarkers])
 
@@ -60,7 +60,7 @@ func TestMarkerCountByTagID(t *testing.T) {
 			t.Errorf("error calling CountByTagID: %s", err.Error())
 		}
 
-		assert.Equal(t, 2, markerCount)
+		assert.Equal(t, 4, markerCount)
 
 		markerCount, err = mqb.CountByTagID(ctx, 0)
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -66,13 +66,10 @@ const (
 	sceneIdxWithThreeTags
 	sceneIdxWithTagAndMarker
 	sceneIdxWithTwoTagsAndMarker
-	sceneIdxWithMarkerParentTag
-	sceneIdxWithTwoMarkers
 	sceneIdxWithStudio
 	sceneIdx1WithStudio
 	sceneIdx2WithStudio
 	sceneIdxWithMarkers
-	sceneIdxWithoutMarkers
 	sceneIdxWithPerformerTag
 	sceneIdxWithTwoPerformerTag
 	sceneIdxWithPerformerTwoTags
@@ -81,6 +78,9 @@ const (
 	sceneIdxWithGrandChildStudio
 	sceneIdxMissingPhash
 	sceneIdxWithPerformerParentTag
+	sceneIdxWithMarkerParentTag
+	sceneIdxWithTwoMarkers
+	sceneIdxWithoutMarkers
 	// new indexes above
 	lastSceneIdx
 
@@ -197,10 +197,8 @@ const (
 	tagIdx1WithScene
 	tagIdx2WithScene
 	tagIdx3WithScene
-	tagIdxWithPrimaryMarkers  // tag is primary tag for multiple markers
-	tagIdx2WithPrimaryMarkers // tag is primary tag for multiple markers (alt)
-	tagIdxWithMarkers         // tag is secondary tag for multiple markers
-	tagIdx2WithMarkers        // tag is secondary tag for multiple markers (alt)
+	tagIdxWithPrimaryMarkers // tag is primary tag for multiple markers
+	tagIdxWithMarkers        // tag is secondary tag for multiple markers
 	tagIdxWithCoverImage
 	tagIdxWithImage
 	tagIdx1WithImage
@@ -218,6 +216,8 @@ const (
 	tagIdxWithGrandChild
 	tagIdxWithParentAndChild
 	tagIdxWithGrandParent
+	tagIdx2WithMarkers        // tag is secondary tag for multiple markers (alt)
+	tagIdx2WithPrimaryMarkers // tag is primary tag for multiple markers (alt)
 	// new indexes above
 	// tags with dup names start from the end
 	tagIdx1WithDupName
@@ -1559,7 +1559,7 @@ func createTags(ctx context.Context, tqb models.TagReaderWriter, n int, o int) e
 
 		tag := models.Tag{
 			Name:          getTagStringValue(index, name),
-			IgnoreAutoTag: getIgnoreAutoTag(i),
+			IgnoreAutoTag: getIgnoreAutoTag(index),
 		}
 
 		err := tqb.Create(ctx, &tag)

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -64,12 +64,15 @@ const (
 	sceneIdxWithTag
 	sceneIdxWithTwoTags
 	sceneIdxWithThreeTags
-	sceneIdxWithMarkerAndTag
-	sceneIdxWithMarkerTwoTags
+	sceneIdxWithTagAndMarker
+	sceneIdxWithTwoTagsAndMarker
+	sceneIdxWithMarkerParentTag
+	sceneIdxWithTwoMarkers
 	sceneIdxWithStudio
 	sceneIdx1WithStudio
 	sceneIdx2WithStudio
 	sceneIdxWithMarkers
+	sceneIdxWithoutMarkers
 	sceneIdxWithPerformerTag
 	sceneIdxWithTwoPerformerTag
 	sceneIdxWithPerformerTwoTags
@@ -194,8 +197,10 @@ const (
 	tagIdx1WithScene
 	tagIdx2WithScene
 	tagIdx3WithScene
-	tagIdxWithPrimaryMarkers
-	tagIdxWithMarkers
+	tagIdxWithPrimaryMarkers  // tag is primary tag for multiple markers
+	tagIdx2WithPrimaryMarkers // tag is primary tag for multiple markers (alt)
+	tagIdxWithMarkers         // tag is secondary tag for multiple markers
+	tagIdx2WithMarkers        // tag is secondary tag for multiple markers (alt)
 	tagIdxWithCoverImage
 	tagIdxWithImage
 	tagIdx1WithImage
@@ -213,7 +218,6 @@ const (
 	tagIdxWithGrandChild
 	tagIdxWithParentAndChild
 	tagIdxWithGrandParent
-	tagIdx2WithMarkers
 	// new indexes above
 	// tags with dup names start from the end
 	tagIdx1WithDupName
@@ -353,11 +357,11 @@ var (
 
 var (
 	sceneTags = linkMap{
-		sceneIdxWithTag:           {tagIdxWithScene},
-		sceneIdxWithTwoTags:       {tagIdx1WithScene, tagIdx2WithScene},
-		sceneIdxWithThreeTags:     {tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
-		sceneIdxWithMarkerAndTag:  {tagIdx3WithScene},
-		sceneIdxWithMarkerTwoTags: {tagIdx2WithScene, tagIdx3WithScene},
+		sceneIdxWithTag:              {tagIdxWithScene},
+		sceneIdxWithTwoTags:          {tagIdx1WithScene, tagIdx2WithScene},
+		sceneIdxWithThreeTags:        {tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+		sceneIdxWithTagAndMarker:     {tagIdx3WithScene},
+		sceneIdxWithTwoTagsAndMarker: {tagIdx2WithScene, tagIdx3WithScene},
 	}
 
 	scenePerformers = linkMap{
@@ -403,8 +407,12 @@ var (
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers}},
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdx2WithMarkers}},
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers, tagIdx2WithMarkers}},
-		{sceneIdxWithMarkerAndTag, tagIdxWithPrimaryMarkers, nil},
-		{sceneIdxWithMarkerTwoTags, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithMarkers, tagIdx2WithPrimaryMarkers, []int{tagIdxWithMarkers, tagIdx2WithMarkers}},
+		{sceneIdxWithTwoMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers}},
+		{sceneIdxWithTwoMarkers, tagIdxWithPrimaryMarkers, []int{tagIdx2WithMarkers}},
+		{sceneIdxWithTagAndMarker, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithTwoTagsAndMarker, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithMarkerParentTag, tagIdxWithParentAndChild, nil},
 	}
 )
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1075,6 +1075,8 @@
     "generic": "Loading…"
   },
   "marker_count": "Marker Count",
+  "primary_marker_tag": "Marker Primary Tag",
+  "marker_tags": "Marker Tags",
   "markers": "Markers",
   "measurements": "Measurements",
   "media_info": {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1075,7 +1075,7 @@
     "generic": "Loading…"
   },
   "marker_count": "Marker Count",
-  "primary_marker_tag": "Marker Primary Tag",
+  "primary_marker_tags": "Primary Marker Tag",
   "marker_tags": "Marker Tags",
   "markers": "Markers",
   "measurements": "Measurements",

--- a/ui/v2.5/src/models/list-filter/criteria/tags.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/tags.ts
@@ -65,7 +65,6 @@ export const PrimaryMarkerTagsCriterionOption = new BaseTagsCriterionOption(
   "primary_marker_tags",
   "primary_marker_tags",
   [
-    CriterionModifier.IncludesAll,
     CriterionModifier.Includes
   ]
 );

--- a/ui/v2.5/src/models/list-filter/criteria/tags.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/tags.ts
@@ -55,6 +55,21 @@ export const PerformerTagsCriterionOption = new BaseTagsCriterionOption(
   withoutEqualsModifierOptions
 );
 
+export const MarkerTagsCriterionOption = new BaseTagsCriterionOption(
+  "marker_tags",
+  "marker_tags",
+  withoutEqualsModifierOptions
+);
+
+export const PrimaryMarkerTagsCriterionOption = new BaseTagsCriterionOption(
+  "primary_marker_tags",
+  "primary_marker_tags",
+  [
+    CriterionModifier.IncludesAll,
+    CriterionModifier.Includes
+  ]
+);
+
 export const ParentTagsCriterionOption = new BaseTagsCriterionOption(
   "parent_tags",
   "parents",

--- a/ui/v2.5/src/models/list-filter/criteria/tags.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/tags.ts
@@ -64,9 +64,7 @@ export const MarkerTagsCriterionOption = new BaseTagsCriterionOption(
 export const PrimaryMarkerTagsCriterionOption = new BaseTagsCriterionOption(
   "primary_marker_tags",
   "primary_marker_tags",
-  [
-    CriterionModifier.Includes
-  ]
+  withoutEqualsModifierOptions
 );
 
 export const ParentTagsCriterionOption = new BaseTagsCriterionOption(

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -15,6 +15,8 @@ import { ResolutionCriterionOption } from "./criteria/resolution";
 import { StudiosCriterionOption } from "./criteria/studios";
 import { InteractiveCriterionOption } from "./criteria/interactive";
 import {
+  MarkerTagsCriterionOption,
+  PrimaryMarkerTagsCriterionOption,
   PerformerTagsCriterionOption,
   TagsCriterionOption,
 } from "./criteria/tags";
@@ -83,6 +85,8 @@ const criterionOptions = [
   createDurationCriterionOption("play_duration"),
   createMandatoryNumberCriterionOption("play_count"),
   HasMarkersCriterionOption,
+  MarkerTagsCriterionOption,
+  PrimaryMarkerTagsCriterionOption,
   SceneIsMissingCriterionOption,
   TagsCriterionOption,
   createMandatoryNumberCriterionOption("tag_count"),

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -136,6 +136,8 @@ export type CriterionType =
   | "duration"
   | "filter_favorites"
   | "has_markers"
+  | "primary_marker_tags"
+  | "marker_tags"
   | "is_missing"
   | "tags"
   | "scene_tags"


### PR DESCRIPTION
This adds scene filters to filter either by markers having a specific primary tag, or by markers having any tag (primary or secondary).

Fixes #4772
Fixes #4350
