### PR TITLE
Add additional fields and restyle Movie select and Gallery select

### DIFF
--- a/pkg/sqlite/movies.go
+++ b/pkg/sqlite/movies.go
@@ -358,7 +358,7 @@ func (qb *MovieStore) makeQuery(ctx context.Context, movieFilter *models.MovieFi
 	distinctIDs(&query, movieTable)
 
 	if q := findFilter.Q; q != nil && *q != "" {
-		searchColumns := []string{"movies.name"}
+		searchColumns := []string{"movies.name", "movies.aliases"}
 		query.parseQueryString(searchColumns, *q)
 	}
 

--- a/ui/v2.5/graphql/data/gallery.graphql
+++ b/ui/v2.5/graphql/data/gallery.graphql
@@ -42,6 +42,16 @@ fragment GalleryData on Gallery {
 fragment SelectGalleryData on Gallery {
   id
   title
+  date
+  code
+  studio {
+    name
+  }
+  cover {
+    paths {
+      thumbnail
+    }
+  }
   files {
     path
   }

--- a/ui/v2.5/graphql/data/movie-slim.graphql
+++ b/ui/v2.5/graphql/data/movie-slim.graphql
@@ -8,5 +8,10 @@ fragment SlimMovieData on Movie {
 fragment SelectMovieData on Movie {
   id
   name
+  aliases
+  date
+  studio {
+    name
+  }
   front_image_path
 }

--- a/ui/v2.5/src/components/Galleries/GallerySelect.tsx
+++ b/ui/v2.5/src/components/Galleries/GallerySelect.tsx
@@ -33,10 +33,13 @@ import {
   CriterionValue,
 } from "src/models/list-filter/criteria/criterion";
 import { PathCriterion } from "src/models/list-filter/criteria/path";
+import { TruncatedText } from "../Shared/TruncatedText";
 
-export type Gallery = Pick<GQL.Gallery, "id" | "title"> & {
+export type Gallery = Pick<GQL.Gallery, "id" | "title" | "date" | "code"> & {
+  studio?: Pick<GQL.Studio, "name"> | null;
   files: Pick<GQL.GalleryFile, "path">[];
   folder?: Pick<GQL.Folder, "path"> | null;
+  cover?: Pick<GQL.Image, "paths"> | null;
 };
 type Option = SelectOption<Gallery>;
 
@@ -111,10 +114,41 @@ const _GallerySelect: React.FC<
     thisOptionProps = {
       ...optionProps,
       children: (
-        <span>
-          <span>{title}</span>
+        <span className="gallery-select-option">
+          <span className="gallery-select-row">
+            {object.cover?.paths?.thumbnail && (
+              <img
+                className="gallery-select-image"
+                src={object.cover.paths.thumbnail}
+                loading="lazy"
+              />
+            )}
+
+            <span className="gallery-select-details">
+              <TruncatedText
+                className="gallery-select-title"
+                text={title}
+                lineCount={1}
+              />
+
+              {object.studio?.name && (
+                <span className="gallery-select-studio">
+                  {object.studio?.name}
+                </span>
+              )}
+
+              {object.date && (
+                <span className="gallery-select-date">{object.date}</span>
+              )}
+
+              {object.code && (
+                <span className="gallery-select-code">{object.code}</span>
+              )}
+            </span>
+          </span>
+
           {matchedPath && (
-            <span className="gallery-select-alias">{` (${matchedPath})`}</span>
+            <span className="gallery-select-alias">{`(${matchedPath})`}</span>
           )}
         </span>
       ),

--- a/ui/v2.5/src/components/Galleries/styles.scss
+++ b/ui/v2.5/src/components/Galleries/styles.scss
@@ -349,8 +349,51 @@ $galleryTabWidth: 450px;
   padding-right: 2px;
 }
 
-.gallery-select-alias {
-  font-size: 0.8rem;
-  font-weight: bold;
-  white-space: pre;
+.gallery-select-option {
+  .gallery-select-row {
+    align-items: center;
+    display: flex;
+    width: 100%;
+
+    .gallery-select-image {
+      background-color: $body-bg;
+      margin-right: 0.4em;
+      max-height: 50px;
+      max-width: 89px;
+      object-fit: contain;
+      object-position: center;
+    }
+
+    .gallery-select-details {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      max-height: 4.1rem;
+      overflow: hidden;
+
+      .gallery-select-title {
+        flex-shrink: 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+
+      .gallery-select-date,
+      .gallery-select-studio,
+      .gallery-select-code {
+        color: $text-muted;
+        flex-shrink: 0;
+        font-size: 0.9rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+
+  .gallery-select-alias {
+    font-size: 0.8rem;
+    font-weight: bold;
+    width: 100%;
+    word-break: break-all;
+  }
 }

--- a/ui/v2.5/src/components/Movies/styles.scss
+++ b/ui/v2.5/src/components/Movies/styles.scss
@@ -78,8 +78,7 @@
       }
 
       .movie-select-date,
-      .movie-select-studio,
-      .movie-select-director {
+      .movie-select-studio {
         color: $text-muted;
         flex-shrink: 0;
         font-size: 0.9rem;

--- a/ui/v2.5/src/components/Movies/styles.scss
+++ b/ui/v2.5/src/components/Movies/styles.scss
@@ -43,3 +43,50 @@
 #movie-page .rating-number .text-input {
   width: auto;
 }
+
+.movie-select-option {
+  .movie-select-row {
+    align-items: center;
+    display: flex;
+    width: 100%;
+
+    .movie-select-image {
+      background-color: $body-bg;
+      margin-right: 0.4em;
+      max-height: 50px;
+      max-width: 89px;
+      object-fit: contain;
+      object-position: center;
+    }
+
+    .movie-select-details {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      max-height: 4.1rem;
+      overflow: hidden;
+
+      .movie-select-title {
+        flex-shrink: 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+
+        .movie-select-alias {
+          font-size: 0.8rem;
+          font-weight: bold;
+        }
+      }
+
+      .movie-select-date,
+      .movie-select-studio,
+      .movie-select-director {
+        color: $text-muted;
+        flex-shrink: 0;
+        font-size: 0.9rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+}

--- a/ui/v2.5/src/components/Scenes/SceneSelect.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneSelect.tsx
@@ -36,9 +36,7 @@ import { TruncatedText } from "../Shared/TruncatedText";
 
 export type Scene = Pick<GQL.Scene, "id" | "title" | "date" | "code"> & {
   studio?: Pick<GQL.Studio, "name"> | null;
-} & {
   files?: Pick<GQL.VideoFile, "path">[];
-} & {
   paths?: Pick<GQL.ScenePathsType, "screenshot">;
 };
 

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -215,7 +215,7 @@ export const ScrapedMoviesRow: React.FC<
     const value = resultValue ?? [];
 
     const selectValue = value.map((p) => {
-      const aliases: string[] = [];
+      const aliases: string = "";
       return {
         id: p.stored_id ?? "",
         name: p.name ?? "",


### PR DESCRIPTION
Updates the Movie and Gallery selects in line with the Scene select (#4832), closes #4790.

The Gallery select now has thumbnail, title, studio, date and code included.

The Movie select includes the front cover, title, studio and release date. The Movie aliases field is now queryable and alias matches are shown in the select.

![mov](https://github.com/stashapp/stash/assets/128322708/0ddbc037-77ef-4fea-998d-a5c4b1b4a093)
