### PR TITLE
Warn if ffmpeg lacks codecs

### DIFF
--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -269,9 +269,14 @@ func (s *Manager) RefreshFFMpeg(ctx context.Context) {
 
 	// ensure the paths are valid
 	if ffmpegPath != "" {
+		// path was set explicitly
 		if err := ffmpeg.ValidateFFMpeg(ffmpegPath); err != nil {
 			logger.Errorf("invalid ffmpeg path: %v", err)
 			return
+		}
+
+		if err := ffmpeg.ValidateFFMpegCodecSupport(ffmpegPath); err != nil {
+			logger.Warn(err)
 		}
 	} else {
 		ffmpegPath = ffmpeg.ResolveFFMpeg(configDirectory, stashHomeDir)


### PR DESCRIPTION
Fixes regression introduced in #4688 where it was no longer possible to use an ffmpeg binary if it didn't have support for certain codecs.

New behaviour is:
- if ffmpeg path is specified, use that always and log if it is missing codec support
- if ffmpeg is not specified, try to resolve it from config directory, `$PATH` and `$HOME/.stash`. It will use the first one it finds that has all of the codec support, falling back to the first one if none of them have support.

Fixes #4814
