### PR TITLE
Default SetCoverImage to true in identify

### DIFF
--- a/internal/identify/identify.go
+++ b/internal/identify/identify.go
@@ -252,7 +252,8 @@ func (t *SceneIdentifier) getSceneUpdater(ctx context.Context, s *models.Scene, 
 		}
 	}
 
-	if utils.IsTrue(options.SetCoverImage) {
+	// SetCoverImage defaults to true if unset
+	if options.SetCoverImage == nil || *options.SetCoverImage {
 		ret.CoverImage, err = rel.cover(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes issue where `setCoverImage` option in `metadataIdentify` would default to false if not provided. The documentation and intention is that the cover image is set by default. This issue only occurs if `setCoverImage` is not set, so this should not impact identify calls made from the UI, since it provides this option.