### PR TITLE
Create missing items by default in Identify

### DIFF
--- a/internal/identify/options.go
+++ b/internal/identify/options.go
@@ -26,7 +26,7 @@ type Options struct {
 }
 
 type MetadataOptions struct {
-	// any fields missing from here are defaulted to MERGE and createMissing false
+	// any fields missing from here are defaulted to MERGE and createMissing true
 	FieldOptions []*FieldOptions `json:"fieldOptions"`
 	// defaults to true if not provided
 	SetCoverImage *bool `json:"setCoverImage"`

--- a/internal/identify/scene.go
+++ b/internal/identify/scene.go
@@ -41,7 +41,10 @@ type sceneRelationships struct {
 func (g sceneRelationships) studio(ctx context.Context) (*int, error) {
 	existingID := g.scene.StudioID
 	fieldStrategy := g.fieldOptions["studio"]
-	createMissing := fieldStrategy != nil && utils.IsTrue(fieldStrategy.CreateMissing)
+	createMissing := true
+	if fieldStrategy != nil {
+		createMissing = utils.IsTrue(fieldStrategy.CreateMissing)
+	}
 
 	scraped := g.result.result.Studio
 	endpoint := g.result.source.RemoteSite
@@ -77,10 +80,11 @@ func (g sceneRelationships) performers(ctx context.Context, ignoreMale bool) ([]
 		return nil, nil
 	}
 
-	createMissing := fieldStrategy != nil && utils.IsTrue(fieldStrategy.CreateMissing)
+	createMissing := true
 	strategy := FieldStrategyMerge
 	if fieldStrategy != nil {
 		strategy = fieldStrategy.Strategy
+		createMissing = utils.IsTrue(fieldStrategy.CreateMissing)
 	}
 
 	endpoint := g.result.source.RemoteSite
@@ -138,10 +142,11 @@ func (g sceneRelationships) tags(ctx context.Context) ([]int, error) {
 		return nil, nil
 	}
 
-	createMissing := fieldStrategy != nil && utils.IsTrue(fieldStrategy.CreateMissing)
+	createMissing := true
 	strategy := FieldStrategyMerge
 	if fieldStrategy != nil {
 		strategy = fieldStrategy.Strategy
+		createMissing = utils.IsTrue(fieldStrategy.CreateMissing)
 	}
 
 	var tagIDs []int

--- a/pkg/scraper/stashbox/graphql/generated_models.go
+++ b/pkg/scraper/stashbox/graphql/generated_models.go
@@ -1034,7 +1034,7 @@ type TagQueryInput struct {
 	// Filter to search name - assumes like query unless quoted
 	Name *string `json:"name,omitempty"`
 	// Filter to category ID
-	IsFavorite *bool `json:"is_favorite,omitempty"`
+	IsFavorite *bool             `json:"is_favorite,omitempty"`
 	CategoryID *string           `json:"category_id,omitempty"`
 	Page       int               `json:"page"`
 	PerPage    int               `json:"per_page"`

--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/FieldOptions.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/FieldOptions.tsx
@@ -52,7 +52,7 @@ const FieldOptionsEditor: React.FC<IFieldOptionsEditor> = ({
       toSet = {
         field,
         strategy: undefined,
-        createMissing: undefined,
+        createMissing: true,
       };
     } else {
       toSet = {


### PR DESCRIPTION
Changes the default behavior so that studios/performers/tags that are missing are created when using Identify.