### PR TITLE
Fix python not being resolved correctly if not in path

### DIFF
--- a/pkg/python/exec.go
+++ b/pkg/python/exec.go
@@ -35,7 +35,7 @@ func Resolve(configuredPythonPath string) (*Python, error) {
 		case err == nil && !isFile:
 			logger.Warnf("configured python path is not a file: %s", configuredPythonPath)
 		case err != nil:
-			logger.Warnf("unable to use configured python path: %s", err)
+			logger.Warnf("unable to use configured python path: %v", err)
 		}
 	}
 
@@ -44,7 +44,7 @@ func Resolve(configuredPythonPath string) (*Python, error) {
 	if err != nil {
 		python, err := exec.LookPath("python")
 		if err != nil {
-			return nil, fmt.Errorf("python executable not in PATH: %s", err)
+			return nil, fmt.Errorf("python executable not in PATH: %w", err)
 		}
 		ret := Python(python)
 		return &ret, nil


### PR DESCRIPTION
Fixes issue where if the `Exec` command for a plugin config was not found on the path, then the `Exec` field would be mutated with the plugin path.

Fixes issue where plugin path would be inserted into python command strings if python was not found on the path, meaning that the python setting would not be honoured.

Fixes #4859