### PR TITLE
Enforce whitelist for sort values (CVE-2024-32231)

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -8,6 +8,7 @@ input FindFilterType {
   page: Int
   "use per_page = -1 to indicate all results. Defaults to 25."
   per_page: Int
+  # TODO - this should be refactored to not use a string
   sort: String
   direction: SortDirectionEnum
 }

--- a/pkg/sqlite/sql.go
+++ b/pkg/sqlite/sql.go
@@ -42,6 +42,30 @@ func getPaginationSQL(page int, perPage int) string {
 	return " LIMIT " + strconv.Itoa(perPage) + " OFFSET " + strconv.Itoa(page) + " "
 }
 
+const randomSeedPrefix = "random_" // prefix for random sort
+
+type sortOptions []string
+
+func (o sortOptions) validateSort(sort string) error {
+	if strings.HasPrefix(sort, randomSeedPrefix) {
+		// seed as a parameter from the UI
+		seedStr := sort[len(randomSeedPrefix):]
+		_, err := strconv.ParseUint(seedStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid random seed: %s", seedStr)
+		}
+		return nil
+	}
+
+	for _, v := range o {
+		if v == sort {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid sort: %s", sort)
+}
+
 func getSortDirection(direction string) string {
 	if direction != "ASC" && direction != "DESC" {
 		return "ASC"
@@ -51,8 +75,6 @@ func getSortDirection(direction string) string {
 }
 func getSort(sort string, direction string, tableName string) string {
 	direction = getSortDirection(direction)
-
-	const randomSeedPrefix = "random_"
 
 	switch {
 	case strings.HasSuffix(sort, "_count"):


### PR DESCRIPTION
Fixes vulnerability to SQL injection when entering specific values into the `sort` URL parameter. Changes the behaviour so that sort strings are validated against a white list of values and returns an error if it is not a valid value.

Fixes CVE-2024-32231