### PR TITLE
Change umask when creating config file to exclude user write (CVE-2024-32233)

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -453,7 +453,7 @@ func (i *Config) Write() error {
 		return err
 	}
 
-	return os.WriteFile(i.filePath, data, 0644)
+	return os.WriteFile(i.filePath, data, 0640)
 }
 
 func (i *Config) Marshal() ([]byte, error) {


### PR DESCRIPTION
Changes `config.yml` permissions to be user and group writable only when creating the file.

Fixes CVE-2024-32233