### PR TITLE
Add JS plugin name to the log line prefix

### DIFF
--- a/pkg/javascript/log.go
+++ b/pkg/javascript/log.go
@@ -10,10 +10,14 @@ import (
 	"github.com/stashapp/stash/pkg/logger"
 )
 
-const pluginPrefix = "[Plugin] "
-
+// Log provides log wrappers for usable from the JS VM.
 type Log struct {
-	Progress chan float64
+	// Logger is the LoggerImpl to forward log messages to.
+	Logger logger.LoggerImpl
+	// Prefix is the prefix to prepend to log messages.
+	Prefix string
+	// ProgressChan is a channel that receives float64s indicating the current progress of an operation.
+	ProgressChan chan float64
 }
 
 func (l *Log) argToString(call goja.FunctionCall) string {
@@ -33,27 +37,27 @@ func (l *Log) argToString(call goja.FunctionCall) string {
 }
 
 func (l *Log) logTrace(call goja.FunctionCall) goja.Value {
-	logger.Trace(pluginPrefix + l.argToString(call))
+	l.Logger.Trace(l.Prefix, l.argToString(call))
 	return nil
 }
 
 func (l *Log) logDebug(call goja.FunctionCall) goja.Value {
-	logger.Debug(pluginPrefix + l.argToString(call))
+	l.Logger.Debug(l.Prefix, l.argToString(call))
 	return nil
 }
 
 func (l *Log) logInfo(call goja.FunctionCall) goja.Value {
-	logger.Info(pluginPrefix + l.argToString(call))
+	l.Logger.Info(l.Prefix, l.argToString(call))
 	return nil
 }
 
 func (l *Log) logWarn(call goja.FunctionCall) goja.Value {
-	logger.Warn(pluginPrefix + l.argToString(call))
+	l.Logger.Warn(l.Prefix, l.argToString(call))
 	return nil
 }
 
 func (l *Log) logError(call goja.FunctionCall) goja.Value {
-	logger.Error(pluginPrefix + l.argToString(call))
+	l.Logger.Error(l.Prefix, l.argToString(call))
 	return nil
 }
 
@@ -62,7 +66,7 @@ func (l *Log) logError(call goja.FunctionCall) goja.Value {
 // complete. Values outside of this range will be clamp to be within it.
 func (l *Log) logProgress(value float64) {
 	value = math.Min(math.Max(0, value), 1)
-	l.Progress <- value
+	l.ProgressChan <- value
 }
 
 func (l *Log) AddToVM(globalName string, vm *VM) error {

--- a/pkg/plugin/js.go
+++ b/pkg/plugin/js.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/stashapp/stash/pkg/javascript"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/plugin/common"
 )
 
@@ -73,8 +74,12 @@ func (t *jsPluginTask) initVM() error {
 		return fmt.Errorf("error setting input: %w", err)
 	}
 
+	const pluginPrefix = "[Plugin / %s] "
+
 	log := &javascript.Log{
-		Progress: t.progress,
+		Logger:       logger.Logger,
+		Prefix:       fmt.Sprintf(pluginPrefix, t.plugin.Name),
+		ProgressChan: t.progress,
 	}
 
 	if err := log.AddToVM("log", t.vm); err != nil {


### PR DESCRIPTION
Plugins prepend the log message with '[Plugin / <plugin name>] ' for external type of plugins but only with '[Plugin] ' for JS plugins.

This change will make JS logging similar with how the other loggers work.