### PR TITLE
Default create missing to true in Identify

### DIFF
--- a/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/IdentifyDialog/IdentifyDialog.tsx
@@ -46,6 +46,21 @@ export const IdentifyDialog: React.FC<IIdentifyDialogProps> = ({
           field: "title",
           strategy: GQL.IdentifyFieldStrategy.Overwrite,
         },
+        {
+          field: "studio",
+          strategy: GQL.IdentifyFieldStrategy.Merge,
+          createMissing: true,
+        },
+        {
+          field: "performers",
+          strategy: GQL.IdentifyFieldStrategy.Merge,
+          createMissing: true,
+        },
+        {
+          field: "tags",
+          strategy: GQL.IdentifyFieldStrategy.Merge,
+          createMissing: true,
+        },
       ],
       includeMalePerformers: true,
       setCoverImage: true,

--- a/ui/v2.5/src/docs/en/Manual/Identify.md
+++ b/ui/v2.5/src/docs/en/Manual/Identify.md
@@ -28,7 +28,7 @@ Field specific options may be set as well. Each field may have a Strategy. The b
 | Overwrite | Overwrite existing value. |
 | Merge (*default*) | For multi-value fields, adds to existing values. For single-value fields, only sets if not already set. |
 
-For Studio, Performers and Tags, an option is also available to Create Missing objects. This is false by default. When true, if a Studio/Performer/Tag is included during the identification process and does not exist in the system, then it will be created.
+For Studio, Performers and Tags, an option is also available to Create Missing objects. This is enabled by default. When true, if a Studio/Performer/Tag is included during the identification process and does not exist in the system, then it will be created.
 
 Default Options are applied to all sources unless overridden in specific source options. 
 


### PR DESCRIPTION
Defaults create missing studios/performers/tags to true in the UI.

Supercedes #4857 