### PR TITLE
Add polyfill for EventTarget constructor

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -36,6 +36,7 @@
     "base64-blob": "^1.4.1",
     "bootstrap": "^4.6.2",
     "classnames": "^2.3.2",
+    "event-target-polyfill": "^0.0.4",
     "flag-icons": "^6.6.6",
     "flexbin": "^0.2.0",
     "formik": "^2.4.5",

--- a/ui/v2.5/src/polyfills.ts
+++ b/ui/v2.5/src/polyfills.ts
@@ -5,6 +5,9 @@ import { shouldPolyfill as shouldPolyfillNumberformat } from "@formatjs/intl-num
 import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/should-polyfill";
 import "intersection-observer";
 
+// needed for older safari versions
+import "event-target-polyfill";
+
 // Required for browsers older than August 2020ish. Can be removed at some point.
 replaceAll.shim();
 

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -4108,6 +4108,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-polyfill@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz#060ee66e85aaedc76b6fa66079782dcc11cba496"
+  integrity sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==
+
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"


### PR DESCRIPTION
#4492 introduced the use of the `EventTarget` constructor, which is not supported by Safari browsers earlier than 14. This PR adds a polyfill for it.

Fixes #4712