### PR TITLE
Make pagination more compact

### DIFF
--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -13,6 +13,121 @@ import useFocus from "src/utils/focus";
 import { Icon } from "../Shared/Icon";
 import { faCheck, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
+const PageCount: React.FC<{
+  totalPages: number;
+  currentPage: number;
+  onChangePage: (page: number) => void;
+}> = ({ totalPages, currentPage, onChangePage }) => {
+  const intl = useIntl();
+
+  const currentPageCtrl = useRef(null);
+
+  const [pageInput, pageFocus] = useFocus();
+
+  const [showSelectPage, setShowSelectPage] = useState(false);
+
+  useEffect(() => {
+    if (showSelectPage) {
+      pageFocus();
+    }
+  }, [showSelectPage, pageFocus]);
+
+  const pageOptions = useMemo(() => {
+    const maxPagesToShow = 10;
+    const min = Math.max(1, currentPage - maxPagesToShow / 2);
+    const max = Math.min(min + maxPagesToShow, totalPages);
+    const pages = [];
+    for (let i = min; i <= max; i++) {
+      pages.push(i);
+    }
+    return pages;
+  }, [totalPages, currentPage]);
+
+  function onCustomChangePage() {
+    const newPage = Number.parseInt(pageInput.current?.value ?? "0");
+    if (newPage) {
+      onChangePage(newPage);
+    }
+    setShowSelectPage(false);
+  }
+
+  return (
+    <div className="page-count-container">
+      <ButtonGroup>
+        <Button
+          variant="secondary"
+          className="page-count"
+          ref={currentPageCtrl}
+          onClick={() => {
+            setShowSelectPage(true);
+            pageFocus();
+          }}
+        >
+          <FormattedMessage
+            id="pagination.current_total"
+            values={{
+              current: intl.formatNumber(currentPage),
+              total: intl.formatNumber(totalPages),
+            }}
+          />
+        </Button>
+        <Dropdown>
+          <Dropdown.Toggle variant="secondary" className="page-count-dropdown">
+            <Icon size="xs" icon={faChevronDown} />
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            {pageOptions.map((s) => (
+              <Dropdown.Item
+                key={s}
+                active={s === currentPage}
+                onClick={() => onChangePage(s)}
+              >
+                {s}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
+      </ButtonGroup>
+      <Overlay
+        target={currentPageCtrl.current}
+        show={showSelectPage}
+        placement="bottom"
+        rootClose
+        onHide={() => setShowSelectPage(false)}
+      >
+        <Popover id="select_page_popover">
+          <Form inline>
+            <InputGroup>
+              <Form.Control
+                type="number"
+                min={1}
+                max={totalPages}
+                className="text-input"
+                ref={pageInput}
+                defaultValue={currentPage}
+                onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Enter") {
+                    onCustomChangePage();
+                    e.preventDefault();
+                  }
+                }}
+                onFocus={(e: React.FocusEvent<HTMLInputElement>) =>
+                  e.target.select()
+                }
+              />
+              <InputGroup.Append>
+                <Button variant="primary" onClick={() => onCustomChangePage()}>
+                  <Icon icon={faCheck} />
+                </Button>
+              </InputGroup.Append>
+            </InputGroup>
+          </Form>
+        </Popover>
+      </Overlay>
+    </div>
+  );
+};
+
 interface IPaginationProps {
   itemsPerPage: number;
   currentPage: number;
@@ -36,40 +151,10 @@ export const Pagination: React.FC<IPaginationProps> = ({
 }) => {
   const intl = useIntl();
 
-  const currentPageCtrl = useRef(null);
-  const [pageInput, pageFocus] = useFocus();
-
-  const [showSelectPage, setShowSelectPage] = useState(false);
-
-  useEffect(() => {
-    if (showSelectPage) {
-      pageFocus();
-    }
-  }, [showSelectPage, pageFocus]);
-
   const totalPages = useMemo(
     () => Math.ceil(totalItems / itemsPerPage),
     [totalItems, itemsPerPage]
   );
-
-  const pageOptions = useMemo(() => {
-    const maxPagesToShow = 10;
-    const min = Math.max(1, currentPage - maxPagesToShow / 2);
-    const max = Math.min(min + maxPagesToShow, totalPages);
-    const pages = [];
-    for (let i = min; i <= max; i++) {
-      pages.push(i);
-    }
-    return pages;
-  }, [totalPages, currentPage]);
-
-  function onCustomChangePage() {
-    const newPage = Number.parseInt(pageInput.current?.value ?? "0");
-    if (newPage) {
-      onChangePage(newPage);
-    }
-    setShowSelectPage(false);
-  }
 
   if (totalPages <= 1) return <div />;
 
@@ -91,85 +176,13 @@ export const Pagination: React.FC<IPaginationProps> = ({
       >
         &lt;
       </Button>
-      <div>
-        <ButtonGroup>
-          <Button
-            variant="secondary"
-            className="page-count"
-            ref={currentPageCtrl}
-            onClick={() => {
-              setShowSelectPage(true);
-              pageFocus();
-            }}
-          >
-            <FormattedMessage
-              id="pagination.current_total"
-              values={{
-                current: intl.formatNumber(currentPage),
-                total: intl.formatNumber(totalPages),
-              }}
-            />
-          </Button>
-          <Dropdown>
-            <Dropdown.Toggle
-              variant="secondary"
-              className="page-count-dropdown"
-            >
-              <Icon size="xs" icon={faChevronDown} />
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              {pageOptions.map((s) => (
-                <Dropdown.Item
-                  key={s}
-                  active={s === currentPage}
-                  onClick={() => onChangePage(s)}
-                >
-                  {s}
-                </Dropdown.Item>
-              ))}
-            </Dropdown.Menu>
-          </Dropdown>
-        </ButtonGroup>
-        <Overlay
-          target={currentPageCtrl.current}
-          show={showSelectPage}
-          placement="bottom"
-          rootClose
-          onHide={() => setShowSelectPage(false)}
-        >
-          <Popover id="select_page_popover">
-            <Form inline>
-              <InputGroup>
-                <Form.Control
-                  type="number"
-                  min={1}
-                  max={totalPages}
-                  className="text-input"
-                  ref={pageInput}
-                  defaultValue={currentPage}
-                  onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                    if (e.key === "Enter") {
-                      onCustomChangePage();
-                      e.preventDefault();
-                    }
-                  }}
-                  onFocus={(e: React.FocusEvent<HTMLInputElement>) =>
-                    e.target.select()
-                  }
-                />
-                <InputGroup.Append>
-                  <Button
-                    variant="primary"
-                    onClick={() => onCustomChangePage()}
-                  >
-                    <Icon icon={faCheck} />
-                  </Button>
-                </InputGroup.Append>
-              </InputGroup>
-            </Form>
-          </Popover>
-        </Overlay>
-      </div>
+
+      <PageCount
+        totalPages={totalPages}
+        currentPage={currentPage}
+        onChangePage={onChangePage}
+      />
+
       <Button
         variant="secondary"
         disabled={currentPage === totalPages}

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -1,6 +1,17 @@
-import React from "react";
-import { Button, ButtonGroup } from "react-bootstrap";
-import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  Form,
+  InputGroup,
+  Overlay,
+  Popover,
+} from "react-bootstrap";
+import { FormattedMessage, useIntl } from "react-intl";
+import useFocus from "src/utils/focus";
+import { Icon } from "../Shared/Icon";
+import { faCheck, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
 interface IPaginationProps {
   itemsPerPage: number;
@@ -23,91 +34,157 @@ export const Pagination: React.FC<IPaginationProps> = ({
   totalItems,
   onChangePage,
 }) => {
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const intl = useIntl();
 
-  let startPage: number;
-  let endPage: number;
-  if (totalPages <= 10) {
-    // less than 10 total pages so show all
-    startPage = 1;
-    endPage = totalPages;
-  } else if (currentPage <= 6) {
-    startPage = 1;
-    endPage = 10;
-  } else if (currentPage + 4 >= totalPages) {
-    startPage = totalPages - 9;
-    endPage = totalPages;
-  } else {
-    startPage = currentPage - 5;
-    endPage = currentPage + 4;
-  }
+  const currentPageCtrl = useRef(null);
+  const [pageInput, pageFocus] = useFocus();
 
-  const pages = [...Array(endPage + 1 - startPage).keys()].map(
-    (i) => startPage + i
+  const [showSelectPage, setShowSelectPage] = useState(false);
+
+  useEffect(() => {
+    if (showSelectPage) {
+      pageFocus();
+    }
+  }, [showSelectPage, pageFocus]);
+
+  const totalPages = useMemo(
+    () => Math.ceil(totalItems / itemsPerPage),
+    [totalItems, itemsPerPage]
   );
 
-  const calculatePageClass = (buttonPage: number) => {
-    if (pages.length <= 4) return "";
+  const pageOptions = useMemo(() => {
+    const maxPagesToShow = 10;
+    const min = Math.max(1, currentPage - maxPagesToShow / 2);
+    const max = Math.min(min + maxPagesToShow, totalPages);
+    const pages = [];
+    for (let i = min; i <= max; i++) {
+      pages.push(i);
+    }
+    return pages;
+  }, [totalPages, currentPage]);
 
-    if (currentPage === 1 && buttonPage <= 4) return "";
-    const maxPage = pages[pages.length - 1];
-    if (currentPage === maxPage && buttonPage > maxPage - 3) return "";
-    if (Math.abs(buttonPage - currentPage) <= 1) return "";
-    return "d-none d-sm-block";
-  };
+  function onCustomChangePage() {
+    const newPage = Number.parseInt(pageInput.current?.value ?? "0");
+    if (newPage) {
+      onChangePage(newPage);
+    }
+    setShowSelectPage(false);
+  }
 
-  const pageButtons = pages.map((page: number) => (
-    <Button
-      variant="secondary"
-      className={calculatePageClass(page)}
-      key={page}
-      active={currentPage === page}
-      onClick={() => onChangePage(page)}
-    >
-      <FormattedNumber value={page} />
-    </Button>
-  ));
-
-  if (pages.length <= 1) return <div />;
+  if (totalPages <= 1) return <div />;
 
   return (
-    <ButtonGroup className="filter-container pagination">
+    <ButtonGroup className="pagination">
       <Button
         variant="secondary"
         disabled={currentPage === 1}
         onClick={() => onChangePage(1)}
+        title={intl.formatMessage({ id: "pagination.first" })}
       >
-        <span className="d-none d-sm-inline">
-          <FormattedMessage id="pagination.first" />
-        </span>
-        <span className="d-inline d-sm-none">&#x300a;</span>
+        <span>«</span>
       </Button>
       <Button
-        className="d-none d-sm-block"
         variant="secondary"
         disabled={currentPage === 1}
         onClick={() => onChangePage(currentPage - 1)}
+        title={intl.formatMessage({ id: "pagination.previous" })}
       >
-        <FormattedMessage id="pagination.previous" />
+        &lt;
       </Button>
-      {pageButtons}
+      <div>
+        <ButtonGroup>
+          <Button
+            variant="secondary"
+            className="page-count"
+            ref={currentPageCtrl}
+            onClick={() => {
+              setShowSelectPage(true);
+              pageFocus();
+            }}
+          >
+            <FormattedMessage
+              id="pagination.current_total"
+              values={{
+                current: intl.formatNumber(currentPage),
+                total: intl.formatNumber(totalPages),
+              }}
+            />
+          </Button>
+          <Dropdown>
+            <Dropdown.Toggle
+              variant="secondary"
+              className="page-count-dropdown"
+            >
+              <Icon size="xs" icon={faChevronDown} />
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              {pageOptions.map((s) => (
+                <Dropdown.Item
+                  key={s}
+                  active={s === currentPage}
+                  onClick={() => onChangePage(s)}
+                >
+                  {s}
+                </Dropdown.Item>
+              ))}
+            </Dropdown.Menu>
+          </Dropdown>
+        </ButtonGroup>
+        <Overlay
+          target={currentPageCtrl.current}
+          show={showSelectPage}
+          placement="bottom"
+          rootClose
+          onHide={() => setShowSelectPage(false)}
+        >
+          <Popover id="select_page_popover">
+            <Form inline>
+              <InputGroup>
+                <Form.Control
+                  type="number"
+                  min={1}
+                  max={totalPages}
+                  className="text-input"
+                  ref={pageInput}
+                  defaultValue={currentPage}
+                  onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                    if (e.key === "Enter") {
+                      onCustomChangePage();
+                      e.preventDefault();
+                    }
+                  }}
+                  onFocus={(e: React.FocusEvent<HTMLInputElement>) =>
+                    e.target.select()
+                  }
+                />
+                <InputGroup.Append>
+                  <Button
+                    variant="primary"
+                    onClick={() => onCustomChangePage()}
+                  >
+                    <Icon icon={faCheck} />
+                  </Button>
+                </InputGroup.Append>
+              </InputGroup>
+            </Form>
+          </Popover>
+        </Overlay>
+      </div>
       <Button
-        className="d-none d-sm-block"
         variant="secondary"
         disabled={currentPage === totalPages}
         onClick={() => onChangePage(currentPage + 1)}
+        title={intl.formatMessage({ id: "pagination.next" })}
       >
-        <FormattedMessage id="pagination.next" />
+        &gt;
       </Button>
       <Button
         variant="secondary"
         disabled={currentPage === totalPages}
         onClick={() => onChangePage(totalPages)}
+        title={intl.formatMessage({ id: "pagination.last" })}
       >
-        <span className="d-none d-sm-inline">
-          <FormattedMessage id="pagination.last" />
-        </span>
-        <span className="d-inline d-sm-none">&#x300b;</span>
+        <span>»</span>
       </Button>
     </ButtonGroup>
   );

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -7,12 +7,6 @@
     padding-right: 15px;
     transition: none;
 
-    &.page-count,
-    &.page-count-dropdown {
-      background-color: $card-bg;
-      border-color: $card-bg;
-    }
-
     &.page-count {
       padding-right: 5px;
     }
@@ -23,11 +17,16 @@
 
     &:first-child {
       border-left: none;
+      border-right: none;
     }
 
     &:last-child {
       border-right: none;
     }
+  }
+
+  .page-count-container .btn {
+    border-radius: 0;
   }
 }
 

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -7,6 +7,20 @@
     padding-right: 15px;
     transition: none;
 
+    &.page-count,
+    &.page-count-dropdown {
+      background-color: $card-bg;
+      border-color: $card-bg;
+    }
+
+    &.page-count {
+      padding-right: 5px;
+    }
+
+    &.page-count-dropdown {
+      padding-left: 5px;
+    }
+
     &:first-child {
       border-left: none;
     }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -713,7 +713,8 @@ div.dropdown-menu {
 }
 
 .filter-container,
-.operation-container {
+.operation-container,
+.pagination {
   align-items: center;
   display: flex;
   justify-content: center;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -1331,6 +1331,11 @@ $detailTabWidth: calc(100% / 3);
   border-top-right-radius: 0;
 }
 
+.btn-group > .dropdown:not(:first-child) > .btn {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
 dl.details-list {
   display: grid;
   grid-column-gap: 10px;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1160,6 +1160,7 @@
     "version": "Version"
   },
   "pagination": {
+    "current_total": "{current} of {total}",
     "first": "First",
     "last": "Last",
     "next": "Next",


### PR DESCRIPTION
Lifted from #4453. Makes the pagination control more compact while attempting to maintain its existing functionality.

Shows the current and total page count, with buttons to go to the next, previous, first and last pages.

![image](https://github.com/stashapp/stash/assets/53250216/66079233-f1a4-4c5f-9396-68614657fc05)

Includes a dropdown control to the right of the count number that gives a selection of pages around the current page:

![image](https://github.com/stashapp/stash/assets/53250216/6d834e3a-aa8c-42d9-8009-e2098d0239b5)

Clicking on the count values show a dialog to enter a page number:

![image](https://github.com/stashapp/stash/assets/53250216/a2ad0483-7183-4b25-bc9f-fe248a40992f)

(Note: the colour and border-radii of the page count control in the above two screenshots are outdated, and I didn't want to redo them)

For reference, this is the existing pagination control:

![image](https://github.com/stashapp/stash/assets/53250216/a18c14d0-f4cc-4fb0-be67-890fdcac8ae6)

and on mobile:

![image](https://github.com/stashapp/stash/assets/53250216/a20dc475-95a4-4447-9981-0651d2fd11b9)

To summarise the difference in functionality:
- adds the ability to enter a page via text input
- removes the ability to skip multiple pages in a single click - this now requires clicking the dropdown, then the desired page
- adds the ability to see the total number of pages

