### PR TITLE
Validate custom locale and javascript strings

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -135,6 +135,22 @@ export const SettingsInterfacePanel: React.FC = () => {
     });
   }
 
+  function validateLocaleString(v: string) {
+    if (!v) return;
+    try {
+      JSON.parse(v);
+    } catch (e) {
+      throw new Error(
+        intl.formatMessage(
+          { id: "errors.invalid_json_string" },
+          {
+            error: (e as SyntaxError).message,
+          }
+        )
+      );
+    }
+  }
+
   if (error) return <h1>{error.message}</h1>;
   if (loading) return <LoadingIndicator />;
 
@@ -754,16 +770,23 @@ export const SettingsInterfacePanel: React.FC = () => {
           subHeadingID="config.ui.custom_locales.description"
           value={iface.customLocales ?? undefined}
           onChange={(v) => saveInterface({ customLocales: v })}
-          renderField={(value, setValue) => (
-            <Form.Control
-              as="textarea"
-              value={value}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setValue(e.currentTarget.value)
-              }
-              rows={16}
-              className="text-input code"
-            />
+          validateChange={validateLocaleString}
+          renderField={(value, setValue, err) => (
+            <>
+              <Form.Control
+                as="textarea"
+                value={value}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setValue(e.currentTarget.value)
+                }
+                rows={16}
+                className="text-input code"
+                isInvalid={!!err}
+              />
+              <Form.Control.Feedback type="invalid">
+                {err}
+              </Form.Control.Feedback>
+            </>
           )}
           renderValue={() => {
             return <></>;

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -151,6 +151,24 @@ export const SettingsInterfacePanel: React.FC = () => {
     }
   }
 
+  function validateJavascriptString(v: string) {
+    if (!v) return;
+    try {
+      // creates a function from the string to validate it but does not execute it
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      new Function(v);
+    } catch (e) {
+      throw new Error(
+        intl.formatMessage(
+          { id: "errors.invalid_javascript_string" },
+          {
+            error: (e as SyntaxError).message,
+          }
+        )
+      );
+    }
+  }
+
   if (error) return <h1>{error.message}</h1>;
   if (loading) return <LoadingIndicator />;
 
@@ -740,16 +758,23 @@ export const SettingsInterfacePanel: React.FC = () => {
           subHeadingID="config.ui.custom_javascript.description"
           value={iface.javascript ?? undefined}
           onChange={(v) => saveInterface({ javascript: v })}
-          renderField={(value, setValue) => (
-            <Form.Control
-              as="textarea"
-              value={value}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setValue(e.currentTarget.value)
-              }
-              rows={16}
-              className="text-input code"
-            />
+          validateChange={validateJavascriptString}
+          renderField={(value, setValue, err) => (
+            <>
+              <Form.Control
+                as="textarea"
+                value={value}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setValue(e.currentTarget.value)
+                }
+                rows={16}
+                className="text-input code"
+                isInvalid={!!err}
+              />
+              <Form.Control.Feedback type="invalid">
+                {err}
+              </Form.Control.Feedback>
+            </>
           )}
           renderValue={() => {
             return <></>;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1017,7 +1017,8 @@
   "errors": {
     "header": "Error",
     "image_index_greater_than_zero": "Image index must be greater than 0",
-    "invalid_json_string": "invalid JSON string: {error}",
+    "invalid_javascript_string": "Invalid javascript code: {error}",
+    "invalid_json_string": "Invalid JSON string: {error}",
     "lazy_component_error_help": "If you recently upgraded Stash, please reload the page or clear your browser cache.",
     "loading_type": "Error loading {type}",
     "something_went_wrong": "Something went wrong."

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1017,6 +1017,7 @@
   "errors": {
     "header": "Error",
     "image_index_greater_than_zero": "Image index must be greater than 0",
+    "invalid_json_string": "invalid JSON string: {error}",
     "lazy_component_error_help": "If you recently upgraded Stash, please reload the page or clear your browser cache.",
     "loading_type": "Error loading {type}",
     "something_went_wrong": "Something went wrong."


### PR DESCRIPTION
Resolves #4841 (in terms of improving UX when invalid code is input)

Validates the custom localisation string and displays an error if it is invalid:
![image](https://github.com/stashapp/stash/assets/53250216/f9ae6bc4-6fcf-4738-81ca-a955d7c56997)

It will not be possible to save the string if it has errors.

Validates the custom javascript string for syntax errors, and displays an error if it is invalid:
![image](https://github.com/stashapp/stash/assets/53250216/d0a24be0-0857-48ba-8583-bc2d116be0a4)

No validation is performed for custom css as I could find no simple way to do it.