### PR TITLE
Fix SQL error when querying performers with missing aliases

### DIFF
--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -744,6 +744,7 @@ func (qb *PerformerStore) QueryCount(ctx context.Context, performerFilter *model
 	return query.executeCount(ctx)
 }
 
+// TODO - we need to provide a whitelist of possible values
 func performerIsMissingCriterionHandler(qb *PerformerStore, isMissing *string) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if isMissing != nil && *isMissing != "" {
@@ -756,6 +757,9 @@ func performerIsMissingCriterionHandler(qb *PerformerStore, isMissing *string) c
 			case "stash_id":
 				performersStashIDsTableMgr.join(f, "performer_stash_ids", "performers.id")
 				f.addWhere("performer_stash_ids.performer_id IS NULL")
+			case "aliases":
+				performersAliasesTableMgr.join(f, "", "performers.id")
+				f.addWhere("performer_aliases.alias IS NULL")
 			default:
 				f.addWhere("(performers." + *isMissing + " IS NULL OR TRIM(performers." + *isMissing + ") = '')")
 			}

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1420,6 +1420,14 @@ func performerStashID(i int) models.StashID {
 	}
 }
 
+func performerAliases(i int) []string {
+	if i%5 == 0 {
+		return []string{}
+	}
+
+	return []string{getPerformerStringValue(i, "alias")}
+}
+
 // createPerformers creates n performers with plain Name and o performers with camel cased NaMe included
 func createPerformers(ctx context.Context, n int, o int) error {
 	pqb := db.Performer
@@ -1443,7 +1451,7 @@ func createPerformers(ctx context.Context, n int, o int) error {
 		performer := models.Performer{
 			Name:           getPerformerStringValue(index, name),
 			Disambiguation: getPerformerStringValue(index, "disambiguation"),
-			Aliases:        models.NewRelatedStrings([]string{getPerformerStringValue(index, "alias")}),
+			Aliases:        models.NewRelatedStrings(performerAliases(index)),
 			URL:            getPerformerNullStringValue(i, urlField),
 			Favorite:       getPerformerBoolValue(i),
 			Birthdate:      getPerformerBirthdate(i),


### PR DESCRIPTION
Fixes issue reported on Discord where querying for performers with is missing set to aliases results in an sql error.