### PR TITLE
Fix ffmpeg resolution when in current directory

### DIFF
--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) Setup(ctx context.Context, input manager.SetupInput) 
 
 func (r *mutationResolver) DownloadFFMpeg(ctx context.Context) (string, error) {
 	mgr := manager.GetInstance()
-	configDir := mgr.Config.GetConfigPath()
+	configDir := mgr.Config.GetConfigPathAbs()
 
 	// don't run if ffmpeg is already installed
 	ffmpegPath := ffmpeg.FindFFMpeg(configDir)

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -496,6 +496,20 @@ func (i *Config) GetConfigPath() string {
 	return filepath.Dir(i.GetConfigFile())
 }
 
+// GetConfigPathAbs returns the path of the directory containing the used
+// configuration file, resolved to an absolute path. Returns the return value
+// of GetConfigPath if the path cannot be made into an absolute path.
+func (i *Config) GetConfigPathAbs() string {
+	p := filepath.Dir(i.GetConfigFile())
+
+	ret, _ := filepath.Abs(p)
+	if ret == "" {
+		return p
+	}
+
+	return ret
+}
+
 // GetDefaultDatabaseFilePath returns the default database filename,
 // which is located in the same directory as the config file.
 func (i *Config) GetDefaultDatabaseFilePath() string {

--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -260,7 +260,9 @@ func (s *Manager) writeStashIcon() {
 
 func (s *Manager) RefreshFFMpeg(ctx context.Context) {
 	// use same directory as config path
-	configDirectory := s.Config.GetConfigPath()
+	// executing binaries requires directory to be included
+	// https://pkg.go.dev/os/exec#hdr-Executables_in_the_current_directory
+	configDirectory := s.Config.GetConfigPathAbs()
 	stashHomeDir := paths.GetStashHomeDirectory()
 
 	// prefer the configured paths

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -91,7 +91,7 @@ type PluginSetting struct {
 type ServerConfig interface {
 	GetHost() string
 	GetPort() int
-	GetConfigPath() string
+	GetConfigPathAbs() string
 	HasTLSConfig() bool
 	GetPluginsPath() string
 	GetDisabledPlugins() []string
@@ -249,7 +249,7 @@ func (c Cache) makeServerConnection(ctx context.Context) common.StashServerConne
 		Host:          c.config.GetHost(),
 		Port:          c.config.GetPort(),
 		SessionCookie: cookie,
-		Dir:           c.config.GetConfigPath(),
+		Dir:           c.config.GetConfigPathAbs(),
 	}
 
 	if c.config.HasTLSConfig() {


### PR DESCRIPTION
Added `config.GetConfigPathAbs` which returns the absolute path to the config file's directory, and use this to resolve ffmpeg. This fixes an issue where ffmpeg could not be run in the config directory because it's path was not included.

Also changes `server_connection.dir` sent to plugins to use the absolute path as well, since a relative path may not be useful to plugins.