### PR TITLE
Support patching select sorting function

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -27,7 +27,7 @@ import {
 import { useCompare } from "src/hooks/state";
 import { Link } from "react-router-dom";
 import { sortByRelevance } from "src/utils/query";
-import { PatchComponent } from "src/patch";
+import { PatchComponent, PatchFunction } from "src/patch";
 
 export type SelectObject = {
   id: string;
@@ -40,6 +40,27 @@ export type Performer = Pick<
   "id" | "name" | "alias_list" | "disambiguation" | "image_path"
 >;
 type Option = SelectOption<Performer>;
+
+type FindPerformersResult = Awaited<
+  ReturnType<typeof queryFindPerformersForSelect>
+>["data"]["findPerformers"]["performers"];
+
+function sortPerformersByRelevance(
+  input: string,
+  performers: FindPerformersResult
+) {
+  return sortByRelevance(
+    input,
+    performers,
+    (p) => p.name,
+    (p) => p.alias_list
+  );
+}
+
+const performerSelectSort = PatchFunction(
+  "PerformerSelect.sort",
+  sortPerformersByRelevance
+);
 
 const _PerformerSelect: React.FC<
   IFilterProps & IFilterValueProps<Performer>
@@ -61,11 +82,9 @@ const _PerformerSelect: React.FC<
     filter.sortBy = "name";
     filter.sortDirection = GQL.SortDirectionEnum.Asc;
     const query = await queryFindPerformersForSelect(filter);
-    return sortByRelevance(
+    return performerSelectSort(
       input,
-      query.data.findPerformers.performers,
-      (p) => p.name,
-      (p) => p.alias_list
+      query.data.findPerformers.performers.slice()
     ).map((performer) => ({
       value: performer.id,
       object: performer,

--- a/ui/v2.5/src/components/Scenes/SceneSelect.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneSelect.tsx
@@ -27,7 +27,7 @@ import { useCompare } from "src/hooks/state";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
 import { objectTitle } from "src/core/files";
-import { PatchComponent } from "src/patch";
+import { PatchComponent, PatchFunction } from "src/patch";
 import {
   Criterion,
   CriterionValue,
@@ -47,6 +47,21 @@ type ExtraSceneProps = {
   excludeIds?: string[];
   extraCriteria?: Array<Criterion<CriterionValue>>;
 };
+
+type FindScenesResult = Awaited<
+  ReturnType<typeof queryFindScenesForSelect>
+>["data"]["findScenes"]["scenes"];
+
+function sortScenesByRelevance(input: string, scenes: FindScenesResult) {
+  return sortByRelevance(input, scenes, objectTitle, (s) => {
+    return s.files.map((f) => f.path);
+  });
+}
+
+const sceneSelectSort = PatchFunction(
+  "SceneSelect.sort",
+  sortScenesByRelevance
+);
 
 const _SceneSelect: React.FC<
   IFilterProps & IFilterValueProps<Scene> & ExtraSceneProps
@@ -77,9 +92,7 @@ const _SceneSelect: React.FC<
       return !exclude.includes(scene.id.toString());
     });
 
-    return sortByRelevance(input, ret, objectTitle, (s) => {
-      return s.files.map((f) => f.path);
-    }).map((scene) => ({
+    return sceneSelectSort(input, ret).map((scene) => ({
       value: scene.id,
       object: scene,
     }));

--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -137,7 +137,39 @@ Registers an after function. An after function is called after the render functi
 
 Returns `void`.
 
-#### `PluginApi.Event`
+#### Patchable components and functions
+
+- `CountrySelect`
+- `DateInput`
+- `FolderSelect`
+- `GalleryIDSelect`
+- `GallerySelect`
+- `GallerySelect.sort`
+- `Icon`
+- `MovieIDSelect`
+- `MovieSelect`
+- `MovieSelect.sort`
+- `PerformerIDSelect`
+- `PerformerSelect`
+- `PerformerSelect.sort`
+- `PluginRoutes`
+- `SceneCard`
+- `SceneCard.Details`
+- `SceneCard.Image`
+- `SceneCard.Overlays`
+- `SceneCard.Popovers`
+- `SceneIDSelect`
+- `SceneSelect`
+- `SceneSelect.sort`
+- `Setting`
+- `StudioIDSelect`
+- `StudioSelect`
+- `StudioSelect.sort`
+- `TagIDSelect`
+- `TagSelect`
+- `TagSelect.sort`
+
+### `PluginApi.Event`
 
 Allows plugins to listen for Stash's events.
 

--- a/ui/v2.5/src/patch.tsx
+++ b/ui/v2.5/src/patch.tsx
@@ -37,7 +37,10 @@ export function after(component: string, fn: Function) {
   afterFns[component].push(fn);
 }
 
-export function RegisterComponent(component: string, fn: Function) {
+export function RegisterComponent<T extends Function>(
+  component: string,
+  fn: T
+) {
   // register with the plugin api
   if (components[component]) {
     throw new Error("Component " + component + " has already been registered");
@@ -49,7 +52,7 @@ export function RegisterComponent(component: string, fn: Function) {
 }
 
 // patches a function to implement the before/instead/after functionality
-export function PatchFunction(name: string, fn: Function) {
+export function PatchFunction<T extends Function>(name: string, fn: T) {
   return new Proxy(fn, {
     apply(target, ctx, args) {
       let result;


### PR DESCRIPTION
Adds support for patching the select component sorting method:
- `GallerySelect.sort`
- `MovieSelect.sort`
- `PerformerSelect.sort`
- `SceneSelect.sort`
- `StudioSelect.sort`
- `TagSelect.sort`

I made a proof of concept plugin that changes the sorting methods to use the legacy sorting (by name). The code for it is below:

```
const PluginApi = window.PluginApi;

function noopSort(input, o) {
    return o;
}

PluginApi.patch.instead('TagSelect.sort', noopSort);
PluginApi.patch.instead('PerformerSelect.sort', noopSort);
PluginApi.patch.instead('MovieSelect.sort', noopSort);
PluginApi.patch.instead('GallerySelect.sort', noopSort);
PluginApi.patch.instead('StudioSelect.sort', noopSort);
PluginApi.patch.instead('SceneSelect.sort', noopSort);
```

And the yml file:
```
name: Select sort alphabetically
description: Overrides the default select sorting behavior to sort alphabetically
url: https://github.com/stashapp/CommunityScripts
version: 0.1
ui:
  javascript:
  - selectSort.js
 ```