### PR TITLE
Allow SSL cert paths to be specified in config

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -232,6 +232,9 @@ const (
 	SecurityTripwireAccessedFromPublicInternet        = "security_tripwire_accessed_from_public_internet"
 	securityTripwireAccessedFromPublicInternetDefault = ""
 
+	sslCertPath = "ssl_cert_path"
+	sslKeyPath  = "ssl_key_path"
+
 	// DLNA options
 	DLNAServerName         = "dlna.server_name"
 	DLNADefaultEnabled     = "dlna.default_enabled"
@@ -360,8 +363,17 @@ func (i *Config) InitTLS() {
 		paths.GetStashHomeDirectory(),
 	}
 
-	i.certFile = fsutil.FindInPaths(tlsPaths, "stash.crt")
-	i.keyFile = fsutil.FindInPaths(tlsPaths, "stash.key")
+	i.certFile = i.getString(sslCertPath)
+	if i.certFile == "" {
+		// Look for default file
+		i.certFile = fsutil.FindInPaths(tlsPaths, "stash.crt")
+	}
+
+	i.keyFile = i.getString(sslKeyPath)
+	if i.keyFile == "" {
+		// Look for default file
+		i.keyFile = fsutil.FindInPaths(tlsPaths, "stash.key")
+	}
 }
 
 func (i *Config) GetTLSFiles() (certFile, keyFile string) {


### PR DESCRIPTION
Being able to specify the location of the certificate files makes it easier than having an extra step outside of Stash to make them conform to the hardcoded locations/filenames.

Documentation update https://github.com/stashapp/Stash-Docs/pull/78