### PR TITLE
Correct Stash box endpoint inputs

### DIFF
--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -128,7 +128,7 @@ input ScraperSourceInput {
   stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
   "Stash-box endpoint"
   stash_box_endpoint: String
-  "Scraper ID to scrape with. Should be unset if stash_box_index is set"
+  "Scraper ID to scrape with. Should be unset if stash_box_endpoint/stash_box_index is set"
   scraper_id: ID
 }
 
@@ -137,7 +137,7 @@ type ScraperSource {
   stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
   "Stash-box endpoint"
   stash_box_endpoint: String
-  "Scraper ID to scrape with. Should be unset if stash_box_index is set"
+  "Scraper ID to scrape with. Should be unset if stash_box_endpoint/stash_box_index is set"
   scraper_id: ID
 }
 
@@ -196,7 +196,9 @@ input ScrapeSingleMovieInput {
 
 input StashBoxSceneQueryInput {
   "Index of the configured stash-box instance to use"
-  stash_box_index: Int!
+  stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
+  "Endpoint of the stash-box instance to use"
+  stash_box_endpoint: String
   "Instructs query by scene fingerprints"
   scene_ids: [ID!]
   "Query by query string"
@@ -205,7 +207,9 @@ input StashBoxSceneQueryInput {
 
 input StashBoxPerformerQueryInput {
   "Index of the configured stash-box instance to use"
-  stash_box_index: Int!
+  stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
+  "Endpoint of the stash-box instance to use"
+  stash_box_endpoint: String
   "Instructs query by scene fingerprints"
   performer_ids: [ID!]
   "Query by query string"
@@ -226,7 +230,9 @@ type StashBoxFingerprint {
 "If neither ids nor names are set, tag all items"
 input StashBoxBatchTagInput {
   "Stash endpoint to use for the tagging"
-  endpoint: Int!
+  endpoint: Int @deprecated(reason: "use stash_box_endpoint")
+  "Endpoint of the stash-box instance to use"
+  stash_box_endpoint: String
   "Fields to exclude when executing the tagging"
   exclude_fields: [String!]
   "Refresh items already tagged by StashBox if true. Only tag items with no StashBox tagging if false"

--- a/graphql/schema/types/stash-box.graphql
+++ b/graphql/schema/types/stash-box.graphql
@@ -22,10 +22,12 @@ input StashIDInput {
 
 input StashBoxFingerprintSubmissionInput {
   scene_ids: [String!]!
-  stash_box_index: Int!
+  stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
+  stash_box_endpoint: String
 }
 
 input StashBoxDraftSubmissionInput {
   id: String!
-  stash_box_index: Int!
+  stash_box_index: Int @deprecated(reason: "use stash_box_endpoint")
+  stash_box_endpoint: String
 }

--- a/internal/api/resolver_query_scraper.go
+++ b/internal/api/resolver_query_scraper.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/stashapp/stash/internal/manager"
-	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/scraper"
@@ -190,18 +189,6 @@ func (r *queryResolver) ScrapeMovieURL(ctx context.Context, url string) (*models
 	return marshalScrapedMovie(content)
 }
 
-func (r *queryResolver) getStashBoxClient(index int) (*stashbox.Client, error) {
-	boxes := config.GetInstance().GetStashBoxes()
-
-	if index < 0 || index >= len(boxes) {
-		return nil, fmt.Errorf("%w: invalid stash_box_index %d", ErrInput, index)
-	}
-
-	return stashbox.NewClient(*boxes[index], r.stashboxRepository()), nil
-}
-
-// FIXME - in the following resolvers, we're processing the deprecated field and not processing the new endpoint input
-
 func (r *queryResolver) ScrapeSingleScene(ctx context.Context, source scraper.Source, input ScrapeSingleSceneInput) ([]*scraper.ScrapedScene, error) {
 	var ret []*scraper.ScrapedScene
 
@@ -245,11 +232,13 @@ func (r *queryResolver) ScrapeSingleScene(ctx context.Context, source scraper.So
 		if err != nil {
 			return nil, err
 		}
-	case source.StashBoxIndex != nil:
-		client, err := r.getStashBoxClient(*source.StashBoxIndex)
+	case source.StashBoxIndex != nil || source.StashBoxEndpoint != nil:
+		b, err := resolveStashBox(source.StashBoxIndex, source.StashBoxEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
+		client := r.newStashBoxClient(*b)
 
 		switch {
 		case input.SceneID != nil:
@@ -275,11 +264,13 @@ func (r *queryResolver) ScrapeSingleScene(ctx context.Context, source scraper.So
 func (r *queryResolver) ScrapeMultiScenes(ctx context.Context, source scraper.Source, input ScrapeMultiScenesInput) ([][]*scraper.ScrapedScene, error) {
 	if source.ScraperID != nil {
 		return nil, ErrNotImplemented
-	} else if source.StashBoxIndex != nil {
-		client, err := r.getStashBoxClient(*source.StashBoxIndex)
+	} else if source.StashBoxIndex != nil || source.StashBoxEndpoint != nil {
+		b, err := resolveStashBox(source.StashBoxIndex, source.StashBoxEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
+		client := r.newStashBoxClient(*b)
 
 		sceneIDs, err := stringslice.StringSliceToIntSlice(input.SceneIds)
 		if err != nil {
@@ -293,11 +284,13 @@ func (r *queryResolver) ScrapeMultiScenes(ctx context.Context, source scraper.So
 }
 
 func (r *queryResolver) ScrapeSingleStudio(ctx context.Context, source scraper.Source, input ScrapeSingleStudioInput) ([]*models.ScrapedStudio, error) {
-	if source.StashBoxIndex != nil {
-		client, err := r.getStashBoxClient(*source.StashBoxIndex)
+	if source.StashBoxIndex != nil || source.StashBoxEndpoint != nil {
+		b, err := resolveStashBox(source.StashBoxIndex, source.StashBoxEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
+		client := r.newStashBoxClient(*b)
 
 		var ret []*models.ScrapedStudio
 		out, err := client.FindStashBoxStudio(ctx, *input.Query)
@@ -346,12 +339,13 @@ func (r *queryResolver) ScrapeSinglePerformer(ctx context.Context, source scrape
 		default:
 			return nil, ErrNotImplemented
 		}
-		// FIXME - we're relying on a deprecated field and not processing the endpoint input
-	case source.StashBoxIndex != nil:
-		client, err := r.getStashBoxClient(*source.StashBoxIndex)
+	case source.StashBoxIndex != nil || source.StashBoxEndpoint != nil:
+		b, err := resolveStashBox(source.StashBoxIndex, source.StashBoxEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
+		client := r.newStashBoxClient(*b)
 
 		var res []*stashbox.StashBoxPerformerQueryResult
 		switch {
@@ -382,11 +376,13 @@ func (r *queryResolver) ScrapeSinglePerformer(ctx context.Context, source scrape
 func (r *queryResolver) ScrapeMultiPerformers(ctx context.Context, source scraper.Source, input ScrapeMultiPerformersInput) ([][]*models.ScrapedPerformer, error) {
 	if source.ScraperID != nil {
 		return nil, ErrNotImplemented
-	} else if source.StashBoxIndex != nil {
-		client, err := r.getStashBoxClient(*source.StashBoxIndex)
+	} else if source.StashBoxIndex != nil || source.StashBoxEndpoint != nil {
+		b, err := resolveStashBox(source.StashBoxIndex, source.StashBoxEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
+		client := r.newStashBoxClient(*b)
 
 		return client.FindStashBoxPerformersByPerformerNames(ctx, input.PerformerIds)
 	}
@@ -397,7 +393,7 @@ func (r *queryResolver) ScrapeMultiPerformers(ctx context.Context, source scrape
 func (r *queryResolver) ScrapeSingleGallery(ctx context.Context, source scraper.Source, input ScrapeSingleGalleryInput) ([]*scraper.ScrapedGallery, error) {
 	var ret []*scraper.ScrapedGallery
 
-	if source.StashBoxIndex != nil {
+	if source.StashBoxIndex != nil || source.StashBoxEndpoint != nil {
 		return nil, ErrNotSupported
 	}
 

--- a/internal/api/stash_box.go
+++ b/internal/api/stash_box.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stashapp/stash/internal/manager/config"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/scraper/stashbox"
+)
+
+func (r *Resolver) newStashBoxClient(box models.StashBox) *stashbox.Client {
+	return stashbox.NewClient(box, r.stashboxRepository())
+}
+
+func resolveStashBoxFn(indexField, endpointField string) func(index *int, endpoint *string) (*models.StashBox, error) {
+	return func(index *int, endpoint *string) (*models.StashBox, error) {
+		boxes := config.GetInstance().GetStashBoxes()
+
+		// prefer endpoint over index
+		if endpoint != nil {
+			for _, box := range boxes {
+				if strings.EqualFold(*endpoint, box.Endpoint) {
+					return box, nil
+				}
+			}
+			return nil, fmt.Errorf("stash box not found")
+		}
+
+		if index != nil {
+			if *index < 0 || *index >= len(boxes) {
+				return nil, fmt.Errorf("invalid %s %d", indexField, index)
+			}
+
+			return boxes[*index], nil
+		}
+
+		return nil, fmt.Errorf("%s not provided", endpointField)
+	}
+}
+
+var (
+	resolveStashBox              = resolveStashBoxFn("stash_box_index", "stash_box_endpoint")
+	resolveStashBoxBatchTagInput = resolveStashBoxFn("endpoint", "stash_box_endpoint")
+)

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -366,8 +366,9 @@ func (s *Manager) MigrateHash(ctx context.Context) int {
 
 // If neither ids nor names are set, tag all items
 type StashBoxBatchTagInput struct {
-	// Stash endpoint to use for the tagging
-	Endpoint int `json:"endpoint"`
+	// Stash endpoint to use for the tagging - deprecated - use StashBoxEndpoint
+	Endpoint         *int    `json:"endpoint"`
+	StashBoxEndpoint *string `json:"stash_box_endpoint"`
 	// Fields to exclude when executing the tagging
 	ExcludeFields []string `json:"exclude_fields"`
 	// Refresh items already tagged by StashBox if true. Only tag items with no StashBox tagging if false
@@ -388,15 +389,9 @@ type StashBoxBatchTagInput struct {
 	PerformerNames []string `json:"performer_names"`
 }
 
-func (s *Manager) StashBoxBatchPerformerTag(ctx context.Context, input StashBoxBatchTagInput) int {
+func (s *Manager) StashBoxBatchPerformerTag(ctx context.Context, box *models.StashBox, input StashBoxBatchTagInput) int {
 	j := job.MakeJobExec(func(ctx context.Context, progress *job.Progress) error {
 		logger.Infof("Initiating stash-box batch performer tag")
-
-		boxes := config.GetInstance().GetStashBoxes()
-		if input.Endpoint < 0 || input.Endpoint >= len(boxes) {
-			return fmt.Errorf("invalid stash_box_index %d", input.Endpoint)
-		}
-		box := boxes[input.Endpoint]
 
 		var tasks []StashBoxBatchTagTask
 
@@ -526,15 +521,9 @@ func (s *Manager) StashBoxBatchPerformerTag(ctx context.Context, input StashBoxB
 	return s.JobManager.Add(ctx, "Batch stash-box performer tag...", j)
 }
 
-func (s *Manager) StashBoxBatchStudioTag(ctx context.Context, input StashBoxBatchTagInput) int {
+func (s *Manager) StashBoxBatchStudioTag(ctx context.Context, box *models.StashBox, input StashBoxBatchTagInput) int {
 	j := job.MakeJobExec(func(ctx context.Context, progress *job.Progress) error {
 		logger.Infof("Initiating stash-box batch studio tag")
-
-		boxes := config.GetInstance().GetStashBoxes()
-		if input.Endpoint < 0 || input.Endpoint >= len(boxes) {
-			return fmt.Errorf("invalid stash_box_index %d", input.Endpoint)
-		}
-		box := boxes[input.Endpoint]
 
 		var tasks []StashBoxBatchTagTask
 

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -251,11 +251,13 @@ func (c Client) findStashBoxScenesByFingerprints(ctx context.Context, scenes [][
 	return ret, nil
 }
 
-func (c Client) SubmitStashBoxFingerprints(ctx context.Context, sceneIDs []string, endpoint string) (bool, error) {
+func (c Client) SubmitStashBoxFingerprints(ctx context.Context, sceneIDs []string) (bool, error) {
 	ids, err := stringslice.StringSliceToIntSlice(sceneIDs)
 	if err != nil {
 		return false, err
 	}
+
+	endpoint := c.box.Endpoint
 
 	var fingerprints []graphql.FingerprintSubmission
 
@@ -945,12 +947,13 @@ func appendFingerprintUnique(v []*graphql.FingerprintInput, toAdd *graphql.Finge
 	return append(v, toAdd)
 }
 
-func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpoint string, cover []byte) (*string, error) {
+func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, cover []byte) (*string, error) {
 	draft := graphql.SceneDraftInput{}
 	var image io.Reader
 	r := c.repository
 	pqb := r.Performer
 	sqb := r.Studio
+	endpoint := c.box.Endpoint
 
 	if scene.Title != "" {
 		draft.Title = &scene.Title
@@ -1115,10 +1118,11 @@ func (c Client) SubmitSceneDraft(ctx context.Context, scene *models.Scene, endpo
 	// return id, nil
 }
 
-func (c Client) SubmitPerformerDraft(ctx context.Context, performer *models.Performer, endpoint string) (*string, error) {
+func (c Client) SubmitPerformerDraft(ctx context.Context, performer *models.Performer) (*string, error) {
 	draft := graphql.PerformerDraftInput{}
 	var image io.Reader
 	pqb := c.repository.Performer
+	endpoint := c.box.Endpoint
 
 	if err := performer.LoadAliases(ctx, pqb); err != nil {
 		return nil, err

--- a/ui/v2.5/src/components/Dialogs/SubmitDraft.tsx
+++ b/ui/v2.5/src/components/Dialogs/SubmitDraft.tsx
@@ -52,17 +52,18 @@ export const SubmitStashBoxDraft: React.FC<IProps> = ({
   }, [show, type, boxes, entity]);
 
   async function doSubmit() {
+    if (!selectedBox) return;
+
+    const input = {
+      id: entity.id,
+      stash_box_endpoint: selectedBox.endpoint,
+    };
+
     if (type === "scene") {
-      const r = await mutateSubmitStashBoxSceneDraft({
-        id: entity.id,
-        stash_box_index: selectedBoxIndex,
-      });
+      const r = await mutateSubmitStashBoxSceneDraft(input);
       return r.data?.submitStashBoxSceneDraft;
     } else if (type === "performer") {
-      const r = await mutateSubmitStashBoxPerformerDraft({
-        id: entity.id,
-        stash_box_index: selectedBoxIndex,
-      });
+      const r = await mutateSubmitStashBoxPerformerDraft(input);
       return r.data?.submitStashBoxPerformerDraft;
     }
   }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerStashBoxModal.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerStashBoxModal.tsx
@@ -160,7 +160,7 @@ const PerformerStashBoxModal: React.FC<IProps> = ({
   const { data, loading } = GQL.useScrapeSinglePerformerQuery({
     variables: {
       source: {
-        stash_box_index: instance.index,
+        stash_box_endpoint: instance.endpoint,
       },
       input: {
         query,

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -419,7 +419,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
               key={s.endpoint}
               onClick={() =>
                 onScrapeQueryClicked({
-                  stash_box_index: index,
                   stash_box_endpoint: s.endpoint,
                 })
               }
@@ -451,7 +450,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
   function onSceneSelected(s: GQL.ScrapedSceneDataFragment) {
     if (!scraper) return;
 
-    if (scraper?.stash_box_index !== undefined) {
+    if (scraper?.stash_box_endpoint !== undefined) {
       // must be stash-box - assume full scene
       setScrapedScene(s);
     } else {
@@ -491,7 +490,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
             key={s.endpoint}
             onClick={() =>
               onScrapeClicked({
-                stash_box_index: index,
                 stash_box_endpoint: s.endpoint,
               })
             }

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -5,7 +5,6 @@ export const SCRAPER_PREFIX = "scraper:";
 
 export interface ITaggerSource {
   id: string;
-  stashboxEndpoint?: string;
   sourceInput: ScraperSourceInput;
   displayName: string;
   supportSceneQuery?: boolean;

--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -238,7 +238,6 @@ interface IPerformerTaggerListProps {
   selectedEndpoint: { endpoint: string; index: number };
   isIdle: boolean;
   config: ITaggerConfig;
-  stashBoxes?: GQL.StashBox[];
   onBatchAdd: (performerInput: string) => void;
   onBatchUpdate: (ids: string[] | undefined, refresh: boolean) => void;
 }
@@ -248,7 +247,6 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
   selectedEndpoint,
   isIdle,
   config,
-  stashBoxes,
   onBatchAdd,
   onBatchUpdate,
 }) => {
@@ -277,7 +275,7 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
   >();
 
   const doBoxSearch = (performerID: string, searchVal: string) => {
-    stashBoxPerformerQuery(searchVal, selectedEndpoint.index)
+    stashBoxPerformerQuery(searchVal, selectedEndpoint.endpoint)
       .then((queryData) => {
         const s = queryData.data?.scrapeSinglePerformer ?? [];
         setSearchResults({
@@ -309,14 +307,14 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
   const doBoxUpdate = (
     performerID: string,
     stashID: string,
-    endpointIndex: number
+    endpoint: string
   ) => {
     setLoadingUpdate(stashID);
     setError({
       ...error,
       [performerID]: undefined,
     });
-    stashBoxPerformerQuery(stashID, endpointIndex)
+    stashBoxPerformerQuery(stashID, endpoint)
       .then((queryData) => {
         const data = queryData.data?.scrapeSinglePerformer ?? [];
         if (data.length > 0) {
@@ -477,29 +475,27 @@ const PerformerTaggerList: React.FC<IPerformerTaggerListProps> = ({
           <div className="small">{stashID.stash_id}</div>
         );
 
-        const endpointIndex =
-          stashBoxes?.findIndex((box) => box.endpoint === stashID.endpoint) ??
-          -1;
-
         subContent = (
           <div key={performer.id}>
             <InputGroup className="PerformerTagger-box-link">
               <InputGroup.Text>{link}</InputGroup.Text>
               <InputGroup.Append>
-                {endpointIndex !== -1 && (
-                  <Button
-                    onClick={() =>
-                      doBoxUpdate(performer.id, stashID.stash_id, endpointIndex)
-                    }
-                    disabled={!!loadingUpdate}
-                  >
-                    {loadingUpdate === stashID.stash_id ? (
-                      <LoadingIndicator inline small message="" />
-                    ) : (
-                      <FormattedMessage id="actions.refresh" />
-                    )}
-                  </Button>
-                )}
+                <Button
+                  onClick={() =>
+                    doBoxUpdate(
+                      performer.id,
+                      stashID.stash_id,
+                      stashID.endpoint
+                    )
+                  }
+                  disabled={!!loadingUpdate}
+                >
+                  {loadingUpdate === stashID.stash_id ? (
+                    <LoadingIndicator inline small message="" />
+                  ) : (
+                    <FormattedMessage id="actions.refresh" />
+                  )}
+                </Button>
               </InputGroup.Append>
             </InputGroup>
             {error[performer.id] && (
@@ -787,7 +783,6 @@ export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
               }}
               isIdle={batchJobID === undefined}
               config={config}
-              stashBoxes={stashConfig?.general.stashBoxes}
               onBatchAdd={batchAdd}
               onBatchUpdate={batchUpdate}
             />

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -327,8 +327,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     }
   }, [isActive, loading, stashScene, index, resolveScene, scene]);
 
-  const stashBoxBaseURL = currentSource?.stashboxEndpoint
-    ? getStashboxBase(currentSource.stashboxEndpoint)
+  const stashBoxBaseURL = currentSource?.sourceInput.stash_box_endpoint
+    ? getStashboxBase(currentSource.sourceInput.stash_box_endpoint)
     : undefined;
   const stashBoxURL = useMemo(() => {
     if (stashBoxBaseURL) {
@@ -404,7 +404,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     const includeStashID = !excludedFieldList.includes("stash_ids");
     if (
       includeStashID &&
-      currentSource?.stashboxEndpoint &&
+      currentSource?.sourceInput.stash_box_endpoint &&
       scene.remote_site_id
     ) {
       sceneCreateInput.stash_ids = [
@@ -415,9 +415,11 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
               stash_id: s.stash_id,
             };
           })
-          .filter((s) => s.endpoint !== currentSource.stashboxEndpoint) ?? []),
+          .filter(
+            (s) => s.endpoint !== currentSource.sourceInput.stash_box_endpoint
+          ) ?? []),
         {
-          endpoint: currentSource.stashboxEndpoint,
+          endpoint: currentSource.sourceInput.stash_box_endpoint,
           stash_id: scene.remote_site_id,
         },
       ];
@@ -662,7 +664,9 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             selectedID={studioID}
             setSelectedID={(id) => setStudioID(id)}
             onCreate={() => showStudioModal(scene.studio!)}
-            endpoint={currentSource?.stashboxEndpoint}
+            endpoint={
+              currentSource?.sourceInput.stash_box_endpoint ?? undefined
+            }
             onLink={async () => {
               await linkStudio(scene.studio!, studioID!);
             }}
@@ -691,7 +695,9 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
               onLink={async () => {
                 await linkPerformer(performer, performerIDs[performerIndex]!);
               }}
-              endpoint={currentSource?.stashboxEndpoint}
+              endpoint={
+                currentSource?.sourceInput.stash_box_endpoint ?? undefined
+              }
               key={`${performer.name ?? performer.remote_site_id ?? ""}`}
             />
           ))}

--- a/ui/v2.5/src/components/Tagger/scenes/sceneTaggerModals.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/sceneTaggerModals.tsx
@@ -106,7 +106,7 @@ export const SceneTaggerModals: React.FC = ({ children }) => {
     setStudioCallback(() => callback);
   }
 
-  const endpoint = currentSource?.stashboxEndpoint;
+  const endpoint = currentSource?.sourceInput.stash_box_endpoint ?? undefined;
 
   return (
     <SceneTaggerModalsState.Provider

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -268,7 +268,6 @@ interface IStudioTaggerListProps {
   selectedEndpoint: { endpoint: string; index: number };
   isIdle: boolean;
   config: ITaggerConfig;
-  stashBoxes?: GQL.StashBox[];
   onBatchAdd: (studioInput: string, createParent: boolean) => void;
   onBatchUpdate: (
     ids: string[] | undefined,
@@ -282,7 +281,6 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
   selectedEndpoint,
   isIdle,
   config,
-  stashBoxes,
   onBatchAdd,
   onBatchUpdate,
 }) => {
@@ -315,7 +313,7 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
   >();
 
   const doBoxSearch = (studioID: string, searchVal: string) => {
-    stashBoxStudioQuery(searchVal, selectedEndpoint.index)
+    stashBoxStudioQuery(searchVal, selectedEndpoint.endpoint)
       .then((queryData) => {
         const s = queryData.data?.scrapeSingleStudio ?? [];
         setSearchResults({
@@ -344,17 +342,13 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
     setLoading(true);
   };
 
-  const doBoxUpdate = (
-    studioID: string,
-    stashID: string,
-    endpointIndex: number
-  ) => {
+  const doBoxUpdate = (studioID: string, stashID: string, endpoint: string) => {
     setLoadingUpdate(stashID);
     setError({
       ...error,
       [studioID]: undefined,
     });
-    stashBoxStudioQuery(stashID, endpointIndex)
+    stashBoxStudioQuery(stashID, endpoint)
       .then((queryData) => {
         const data = queryData.data?.scrapeSingleStudio ?? [];
         if (data.length > 0) {
@@ -535,29 +529,23 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
           <div className="small">{stashID.stash_id}</div>
         );
 
-        const endpointIndex =
-          stashBoxes?.findIndex((box) => box.endpoint === stashID.endpoint) ??
-          -1;
-
         subContent = (
           <div key={studio.id}>
             <InputGroup className="StudioTagger-box-link">
               <InputGroup.Text>{link}</InputGroup.Text>
               <InputGroup.Append>
-                {endpointIndex !== -1 && (
-                  <Button
-                    onClick={() =>
-                      doBoxUpdate(studio.id, stashID.stash_id, endpointIndex)
-                    }
-                    disabled={!!loadingUpdate}
-                  >
-                    {loadingUpdate === stashID.stash_id ? (
-                      <LoadingIndicator inline small message="" />
-                    ) : (
-                      <FormattedMessage id="actions.refresh" />
-                    )}
-                  </Button>
-                )}
+                <Button
+                  onClick={() =>
+                    doBoxUpdate(studio.id, stashID.stash_id, stashID.endpoint)
+                  }
+                  disabled={!!loadingUpdate}
+                >
+                  {loadingUpdate === stashID.stash_id ? (
+                    <LoadingIndicator inline small message="" />
+                  ) : (
+                    <FormattedMessage id="actions.refresh" />
+                  )}
+                </Button>
               </InputGroup.Append>
             </InputGroup>
             {error[studio.id] && (
@@ -849,7 +837,6 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
               }}
               isIdle={batchJobID === undefined}
               config={config}
-              stashBoxes={stashConfig?.general.stashBoxes}
               onBatchAdd={batchAdd}
               onBatchUpdate={batchUpdate}
             />

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2054,19 +2054,21 @@ export const queryScrapeSceneQueryFragment = (
 
 export const stashBoxSceneBatchQuery = (
   sceneIds: string[],
-  stashBoxIndex: number
+  stashBoxEndpoint: string
 ) =>
-  client.query<GQL.ScrapeMultiScenesQuery>({
-    query: GQL.ScrapeMultiScenesDocument,
-    variables: {
-      source: {
-        stash_box_index: stashBoxIndex,
+  client.query<GQL.ScrapeMultiScenesQuery, GQL.ScrapeMultiScenesQueryVariables>(
+    {
+      query: GQL.ScrapeMultiScenesDocument,
+      variables: {
+        source: {
+          stash_box_endpoint: stashBoxEndpoint,
+        },
+        input: {
+          scene_ids: sceneIds,
+        },
       },
-      input: {
-        scene_ids: sceneIds,
-      },
-    },
-  });
+    }
+  );
 
 export const useListPerformerScrapers = () =>
   GQL.useListPerformerScrapersQuery();
@@ -2110,13 +2112,16 @@ export const queryScrapePerformerURL = (url: string) =>
 
 export const stashBoxPerformerQuery = (
   searchVal: string,
-  stashBoxIndex: number
+  stashBoxEndpoint: string
 ) =>
-  client.query<GQL.ScrapeSinglePerformerQuery>({
+  client.query<
+    GQL.ScrapeSinglePerformerQuery,
+    GQL.ScrapeSinglePerformerQueryVariables
+  >({
     query: GQL.ScrapeSinglePerformerDocument,
     variables: {
       source: {
-        stash_box_index: stashBoxIndex,
+        stash_box_endpoint: stashBoxEndpoint,
       },
       input: {
         query: searchVal,
@@ -2127,13 +2132,16 @@ export const stashBoxPerformerQuery = (
 
 export const stashBoxStudioQuery = (
   query: string | null,
-  stashBoxIndex: number
+  stashBoxEndpoint: string
 ) =>
-  client.query<GQL.ScrapeSingleStudioQuery>({
+  client.query<
+    GQL.ScrapeSingleStudioQuery,
+    GQL.ScrapeSingleStudioQueryVariables
+  >({
     query: GQL.ScrapeSingleStudioDocument,
     variables: {
       source: {
-        stash_box_index: stashBoxIndex,
+        stash_box_endpoint: stashBoxEndpoint,
       },
       input: {
         query: query,


### PR DESCRIPTION
Adds `stash_box_endpoint` to inputs where stash box index is used, and deprecates index fields.

Changed resolver code to correctly use (and prefer) `stash_box_endpoint`.

Changed UI code to remove usage of deprecated stash box index fields.

Resolves #2932 