### PR TITLE
Bulk edit tags

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -325,6 +325,7 @@ type Mutation {
   tagDestroy(input: TagDestroyInput!): Boolean!
   tagsDestroy(ids: [ID!]!): Boolean!
   tagsMerge(input: TagsMergeInput!): Tag
+  bulkTagUpdate(input: BulkTagUpdateInput!): [Tag!]
 
   """
   Moves the given files to the given destination. Returns true if successful.

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -60,3 +60,14 @@ input TagsMergeInput {
   source: [ID!]!
   destination: ID!
 }
+
+input BulkTagUpdateInput {
+  ids: [ID!]
+  description: String
+  aliases: BulkUpdateStrings
+  ignore_auto_tag: Boolean
+  favorite: Boolean
+
+  parent_ids: BulkUpdateIds
+  child_ids: BulkUpdateIds
+}

--- a/pkg/models/mocks/TagReaderWriter.go
+++ b/pkg/models/mocks/TagReaderWriter.go
@@ -450,6 +450,29 @@ func (_m *TagReaderWriter) GetAliases(ctx context.Context, relatedID int) ([]str
 	return r0, r1
 }
 
+// GetChildIDs provides a mock function with given fields: ctx, relatedID
+func (_m *TagReaderWriter) GetChildIDs(ctx context.Context, relatedID int) ([]int, error) {
+	ret := _m.Called(ctx, relatedID)
+
+	var r0 []int
+	if rf, ok := ret.Get(0).(func(context.Context, int) []int); ok {
+		r0 = rf(ctx, relatedID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, relatedID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetImage provides a mock function with given fields: ctx, tagID
 func (_m *TagReaderWriter) GetImage(ctx context.Context, tagID int) ([]byte, error) {
 	ret := _m.Called(ctx, tagID)
@@ -466,6 +489,29 @@ func (_m *TagReaderWriter) GetImage(ctx context.Context, tagID int) ([]byte, err
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
 		r1 = rf(ctx, tagID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetParentIDs provides a mock function with given fields: ctx, relatedID
+func (_m *TagReaderWriter) GetParentIDs(ctx context.Context, relatedID int) ([]int, error) {
+	ret := _m.Called(ctx, relatedID)
+
+	var r0 []int
+	if rf, ok := ret.Get(0).(func(context.Context, int) []int); ok {
+		r0 = rf(ctx, relatedID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, relatedID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"time"
 )
 
@@ -12,6 +13,10 @@ type Tag struct {
 	IgnoreAutoTag bool      `json:"ignore_auto_tag"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
+
+	Aliases   RelatedStrings `json:"aliases"`
+	ParentIDs RelatedIDs     `json:"parent_ids"`
+	ChildIDs  RelatedIDs     `json:"tag_ids"`
 }
 
 func NewTag() Tag {
@@ -22,6 +27,24 @@ func NewTag() Tag {
 	}
 }
 
+func (s *Tag) LoadAliases(ctx context.Context, l AliasLoader) error {
+	return s.Aliases.load(func() ([]string, error) {
+		return l.GetAliases(ctx, s.ID)
+	})
+}
+
+func (s *Tag) LoadParentIDs(ctx context.Context, l TagRelationLoader) error {
+	return s.ParentIDs.load(func() ([]int, error) {
+		return l.GetParentIDs(ctx, s.ID)
+	})
+}
+
+func (s *Tag) LoadChildIDs(ctx context.Context, l TagRelationLoader) error {
+	return s.ChildIDs.load(func() ([]int, error) {
+		return l.GetChildIDs(ctx, s.ID)
+	})
+}
+
 type TagPartial struct {
 	Name          OptionalString
 	Description   OptionalString
@@ -29,6 +52,10 @@ type TagPartial struct {
 	IgnoreAutoTag OptionalBool
 	CreatedAt     OptionalTime
 	UpdatedAt     OptionalTime
+
+	Aliases   *UpdateStrings
+	ParentIDs *UpdateIDs
+	ChildIDs  *UpdateIDs
 }
 
 func NewTagPartial() TagPartial {

--- a/pkg/models/relationships.go
+++ b/pkg/models/relationships.go
@@ -24,6 +24,11 @@ type TagIDLoader interface {
 	GetTagIDs(ctx context.Context, relatedID int) ([]int, error)
 }
 
+type TagRelationLoader interface {
+	GetParentIDs(ctx context.Context, relatedID int) ([]int, error)
+	GetChildIDs(ctx context.Context, relatedID int) ([]int, error)
+}
+
 type FileIDLoader interface {
 	GetManyFileIDs(ctx context.Context, ids []int) ([][]FileID, error)
 }

--- a/pkg/models/repository_tag.go
+++ b/pkg/models/repository_tag.go
@@ -84,6 +84,7 @@ type TagReader interface {
 	TagCounter
 
 	AliasLoader
+	TagRelationLoader
 
 	All(ctx context.Context) ([]*Tag, error)
 	GetImage(ctx context.Context, tagID int) ([]byte, error)

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -36,6 +36,9 @@ var (
 	studiosStashIDsJoinTable = goqu.T("studio_stash_ids")
 
 	moviesURLsJoinTable = goqu.T(movieURLsTable)
+
+	tagsAliasesJoinTable  = goqu.T(tagAliasesTable)
+	tagRelationsJoinTable = goqu.T(tagRelationsTable)
 )
 
 var (
@@ -294,6 +297,24 @@ var (
 		table:    goqu.T(tagTable),
 		idColumn: goqu.T(tagTable).Col(idColumn),
 	}
+
+	tagsAliasesTableMgr = &stringTable{
+		table: table{
+			table:    tagsAliasesJoinTable,
+			idColumn: tagsAliasesJoinTable.Col(tagIDColumn),
+		},
+		stringColumn: tagsAliasesJoinTable.Col(tagAliasColumn),
+	}
+
+	tagsParentTagsTableMgr = &joinTable{
+		table: table{
+			table:    tagRelationsJoinTable,
+			idColumn: tagRelationsJoinTable.Col(tagChildIDColumn),
+		},
+		fkColumn: tagRelationsJoinTable.Col(tagParentIDColumn),
+	}
+
+	tagsChildTagsTableMgr = *tagsParentTagsTableMgr.invert()
 )
 
 var (

--- a/pkg/tag/update.go
+++ b/pkg/tag/update.go
@@ -33,6 +33,10 @@ type InvalidTagHierarchyError struct {
 }
 
 func (e *InvalidTagHierarchyError) Error() string {
+	if e.ApplyingTag == "" {
+		return fmt.Sprintf("cannot apply tag \"%s\" as a %s of tag as it is already %s", e.InvalidTag, e.Direction, e.CurrentRelation)
+	}
+
 	return fmt.Sprintf("cannot apply tag \"%s\" as a %s of \"%s\" as it is already %s (%s)", e.InvalidTag, e.Direction, e.ApplyingTag, e.CurrentRelation, e.TagPath)
 }
 
@@ -80,16 +84,83 @@ func EnsureAliasesUnique(ctx context.Context, id int, aliases []string, qb model
 type RelationshipFinder interface {
 	FindAllAncestors(ctx context.Context, tagID int, excludeIDs []int) ([]*models.TagPath, error)
 	FindAllDescendants(ctx context.Context, tagID int, excludeIDs []int) ([]*models.TagPath, error)
-	FindByChildTagID(ctx context.Context, childID int) ([]*models.Tag, error)
-	FindByParentTagID(ctx context.Context, parentID int) ([]*models.Tag, error)
+	models.TagRelationLoader
 }
 
-func ValidateHierarchy(ctx context.Context, tag *models.Tag, parentIDs, childIDs []int, qb RelationshipFinder) error {
-	id := tag.ID
+func ValidateHierarchyNew(ctx context.Context, parentIDs, childIDs []int, qb RelationshipFinder) error {
 	allAncestors := make(map[int]*models.TagPath)
 	allDescendants := make(map[int]*models.TagPath)
 
-	parentsAncestors, err := qb.FindAllAncestors(ctx, id, nil)
+	for _, parentID := range parentIDs {
+		parentsAncestors, err := qb.FindAllAncestors(ctx, parentID, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, ancestorTag := range parentsAncestors {
+			allAncestors[ancestorTag.ID] = ancestorTag
+		}
+	}
+
+	for _, childID := range childIDs {
+		childsDescendants, err := qb.FindAllDescendants(ctx, childID, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, descendentTag := range childsDescendants {
+			allDescendants[descendentTag.ID] = descendentTag
+		}
+	}
+
+	// Validate that the tag is not a parent of any of its ancestors
+	validateParent := func(testID int) error {
+		if parentTag, exists := allDescendants[testID]; exists {
+			return &InvalidTagHierarchyError{
+				Direction:       "parent",
+				CurrentRelation: "a descendant",
+				InvalidTag:      parentTag.Name,
+				TagPath:         parentTag.Path,
+			}
+		}
+
+		return nil
+	}
+
+	// Validate that the tag is not a child of any of its ancestors
+	validateChild := func(testID int) error {
+		if childTag, exists := allAncestors[testID]; exists {
+			return &InvalidTagHierarchyError{
+				Direction:       "child",
+				CurrentRelation: "an ancestor",
+				InvalidTag:      childTag.Name,
+				TagPath:         childTag.Path,
+			}
+		}
+
+		return nil
+	}
+
+	for _, parentID := range parentIDs {
+		if err := validateParent(parentID); err != nil {
+			return err
+		}
+	}
+
+	for _, childID := range childIDs {
+		if err := validateChild(childID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ValidateHierarchyExisting(ctx context.Context, tag *models.Tag, parentIDs, childIDs []int, qb RelationshipFinder) error {
+	allAncestors := make(map[int]*models.TagPath)
+	allDescendants := make(map[int]*models.TagPath)
+
+	parentsAncestors, err := qb.FindAllAncestors(ctx, tag.ID, nil)
 	if err != nil {
 		return err
 	}
@@ -98,7 +169,7 @@ func ValidateHierarchy(ctx context.Context, tag *models.Tag, parentIDs, childIDs
 		allAncestors[ancestorTag.ID] = ancestorTag
 	}
 
-	childsDescendants, err := qb.FindAllDescendants(ctx, id, nil)
+	childsDescendants, err := qb.FindAllDescendants(ctx, tag.ID, nil)
 	if err != nil {
 		return err
 	}
@@ -135,28 +206,6 @@ func ValidateHierarchy(ctx context.Context, tag *models.Tag, parentIDs, childIDs
 		return nil
 	}
 
-	if parentIDs == nil {
-		parentTags, err := qb.FindByChildTagID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		for _, parentTag := range parentTags {
-			parentIDs = append(parentIDs, parentTag.ID)
-		}
-	}
-
-	if childIDs == nil {
-		childTags, err := qb.FindByParentTagID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		for _, childTag := range childTags {
-			childIDs = append(childIDs, childTag.ID)
-		}
-	}
-
 	for _, parentID := range parentIDs {
 		if err := validateParent(parentID); err != nil {
 			return err
@@ -176,38 +225,38 @@ func MergeHierarchy(ctx context.Context, destination int, sources []int, qb Rela
 	var mergedParents, mergedChildren []int
 	allIds := append([]int{destination}, sources...)
 
-	addTo := func(mergedItems []int, tags []*models.Tag) []int {
+	addTo := func(mergedItems []int, tagIDs []int) []int {
 	Tags:
-		for _, tag := range tags {
+		for _, tagID := range tagIDs {
 			// Ignore tags which are already set
 			for _, existingItem := range mergedItems {
-				if tag.ID == existingItem {
+				if tagID == existingItem {
 					continue Tags
 				}
 			}
 
 			// Ignore tags which are being merged, as these are rolled up anyway (if A is merged into B any direct link between them can be ignored)
 			for _, id := range allIds {
-				if tag.ID == id {
+				if tagID == id {
 					continue Tags
 				}
 			}
 
-			mergedItems = append(mergedItems, tag.ID)
+			mergedItems = append(mergedItems, tagID)
 		}
 
 		return mergedItems
 	}
 
 	for _, id := range allIds {
-		parents, err := qb.FindByChildTagID(ctx, id)
+		parents, err := qb.GetParentIDs(ctx, id)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		mergedParents = addTo(mergedParents, parents)
 
-		children, err := qb.FindByParentTagID(ctx, id)
+		children, err := qb.GetChildIDs(ctx, id)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/tag/update_test.go
+++ b/pkg/tag/update_test.go
@@ -218,6 +218,14 @@ func TestEnsureHierarchy(t *testing.T) {
 	}
 }
 
+func idsFromSlice(tags []*models.Tag) []int {
+	ids := make([]int, len(tags))
+	for i, tag := range tags {
+		ids[i] = tag.ID
+	}
+	return ids
+}
+
 func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase, queryParents, queryChildren bool) {
 	db := mocks.NewDatabase()
 
@@ -246,12 +254,12 @@ func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase, queryParents,
 
 	if queryParents {
 		parentIDs = nil
-		db.Tag.On("FindByChildTagID", testCtx, tc.id).Return(tc.parents, nil).Once()
+		db.Tag.On("GetChildIDs", testCtx, tc.id).Return(idsFromSlice(tc.parents), nil).Once()
 	}
 
 	if queryChildren {
 		childIDs = nil
-		db.Tag.On("FindByParentTagID", testCtx, tc.id).Return(tc.children, nil).Once()
+		db.Tag.On("GetParentIDs", testCtx, tc.id).Return(idsFromSlice(tc.children), nil).Once()
 	}
 
 	db.Tag.On("FindAllAncestors", testCtx, mock.AnythingOfType("int"), []int(nil)).Return(func(ctx context.Context, tagID int, excludeIDs []int) []*models.TagPath {

--- a/pkg/tag/update_test.go
+++ b/pkg/tag/update_test.go
@@ -211,22 +211,11 @@ var testUniqueHierarchyCases = []testUniqueHierarchyCase{
 
 func TestEnsureHierarchy(t *testing.T) {
 	for _, tc := range testUniqueHierarchyCases {
-		testEnsureHierarchy(t, tc, false, false)
-		testEnsureHierarchy(t, tc, true, false)
-		testEnsureHierarchy(t, tc, false, true)
-		testEnsureHierarchy(t, tc, true, true)
+		testEnsureHierarchy(t, tc)
 	}
 }
 
-func idsFromSlice(tags []*models.Tag) []int {
-	ids := make([]int, len(tags))
-	for i, tag := range tags {
-		ids[i] = tag.ID
-	}
-	return ids
-}
-
-func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase, queryParents, queryChildren bool) {
+func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase) {
 	db := mocks.NewDatabase()
 
 	var parentIDs, childIDs []int
@@ -252,16 +241,6 @@ func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase, queryParents,
 		}
 	}
 
-	if queryParents {
-		parentIDs = nil
-		db.Tag.On("GetChildIDs", testCtx, tc.id).Return(idsFromSlice(tc.parents), nil).Once()
-	}
-
-	if queryChildren {
-		childIDs = nil
-		db.Tag.On("GetParentIDs", testCtx, tc.id).Return(idsFromSlice(tc.children), nil).Once()
-	}
-
 	db.Tag.On("FindAllAncestors", testCtx, mock.AnythingOfType("int"), []int(nil)).Return(func(ctx context.Context, tagID int, excludeIDs []int) []*models.TagPath {
 		return tc.onFindAllAncestors
 	}, func(ctx context.Context, tagID int, excludeIDs []int) error {
@@ -280,7 +259,7 @@ func testEnsureHierarchy(t *testing.T, tc testUniqueHierarchyCase, queryParents,
 		return fmt.Errorf("undefined descendants for: %d", tagID)
 	}).Maybe()
 
-	res := ValidateHierarchy(testCtx, testUniqueHierarchyTags[tc.id], parentIDs, childIDs, db.Tag)
+	res := ValidateHierarchyExisting(testCtx, testUniqueHierarchyTags[tc.id], parentIDs, childIDs, db.Tag)
 
 	assert := assert.New(t)
 

--- a/pkg/tag/validate.go
+++ b/pkg/tag/validate.go
@@ -1,0 +1,102 @@
+package tag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+var (
+	ErrNameMissing = errors.New("tag name must not be blank")
+)
+
+type NotFoundError struct {
+	id int
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("tag with id %d not found", e.id)
+}
+
+func ValidateCreate(ctx context.Context, tag models.Tag, qb models.TagReader) error {
+	if tag.Name == "" {
+		return ErrNameMissing
+	}
+
+	if err := EnsureTagNameUnique(ctx, 0, tag.Name, qb); err != nil {
+		return err
+	}
+
+	if tag.Aliases.Loaded() {
+		if err := EnsureAliasesUnique(ctx, tag.ID, tag.Aliases.List(), qb); err != nil {
+			return err
+		}
+	}
+
+	if len(tag.ParentIDs.List()) > 0 || len(tag.ChildIDs.List()) > 0 {
+		if err := ValidateHierarchyNew(ctx, tag.ParentIDs.List(), tag.ChildIDs.List(), qb); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ValidateUpdate(ctx context.Context, id int, partial models.TagPartial, qb models.TagReader) error {
+	existing, err := qb.Find(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if existing == nil {
+		return &NotFoundError{id}
+	}
+
+	if partial.Name.Set {
+		if partial.Name.Value == "" {
+			return ErrNameMissing
+		}
+
+		if err := EnsureTagNameUnique(ctx, id, partial.Name.Value, qb); err != nil {
+			return err
+		}
+	}
+
+	if partial.Aliases != nil {
+		if err := existing.LoadAliases(ctx, qb); err != nil {
+			return err
+		}
+
+		if err := EnsureAliasesUnique(ctx, id, partial.Aliases.Apply(existing.Aliases.List()), qb); err != nil {
+			return err
+		}
+	}
+
+	if partial.ParentIDs != nil || partial.ChildIDs != nil {
+		if err := existing.LoadParentIDs(ctx, qb); err != nil {
+			return err
+		}
+
+		if err := existing.LoadChildIDs(ctx, qb); err != nil {
+			return err
+		}
+
+		parentIDs := partial.ParentIDs
+		if parentIDs == nil {
+			parentIDs = &models.UpdateIDs{IDs: existing.ParentIDs.List(), Mode: models.RelationshipUpdateModeSet}
+		}
+
+		childIDs := partial.ChildIDs
+		if childIDs == nil {
+			childIDs = &models.UpdateIDs{IDs: existing.ChildIDs.List(), Mode: models.RelationshipUpdateModeSet}
+		}
+
+		if err := ValidateHierarchyExisting(ctx, existing, parentIDs.Apply(existing.ParentIDs.List()), childIDs.Apply(existing.ChildIDs.List()), qb); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/ui/v2.5/graphql/mutations/tag.graphql
+++ b/ui/v2.5/graphql/mutations/tag.graphql
@@ -18,6 +18,12 @@ mutation TagUpdate($input: TagUpdateInput!) {
   }
 }
 
+mutation BulkTagUpdate($input: BulkTagUpdateInput!) {
+  bulkTagUpdate(input: $input) {
+    ...TagData
+  }
+}
+
 mutation TagsMerge($source: [ID!]!, $destination: ID!) {
   tagsMerge(input: { source: $source, destination: $destination }) {
     ...TagData

--- a/ui/v2.5/src/components/Tags/EditTagsDialog.tsx
+++ b/ui/v2.5/src/components/Tags/EditTagsDialog.tsx
@@ -1,0 +1,237 @@
+import React, { useEffect, useState } from "react";
+import { Form } from "react-bootstrap";
+import { FormattedMessage, useIntl } from "react-intl";
+import { useBulkTagUpdate } from "src/core/StashService";
+import * as GQL from "src/core/generated-graphql";
+import { ModalComponent } from "../Shared/Modal";
+import { useToast } from "src/hooks/Toast";
+import { MultiSet } from "../Shared/MultiSet";
+import {
+  getAggregateState,
+  getAggregateStateObject,
+} from "src/utils/bulkUpdate";
+import { IndeterminateCheckbox } from "../Shared/IndeterminateCheckbox";
+import { BulkUpdateTextInput } from "../Shared/BulkUpdateTextInput";
+import { faPencilAlt } from "@fortawesome/free-solid-svg-icons";
+
+function Tags(props: {
+  isUpdating: boolean;
+  controlId: string;
+  messageId: string;
+  existingTagIds: string[] | undefined;
+  tagIDs: GQL.BulkUpdateIds;
+  setTagIDs: (value: React.SetStateAction<GQL.BulkUpdateIds>) => void;
+}) {
+  const {
+    isUpdating,
+    controlId,
+    messageId,
+    existingTagIds,
+    tagIDs,
+    setTagIDs,
+  } = props;
+
+  return (
+    <Form.Group controlId={controlId}>
+      <Form.Label>
+        <FormattedMessage id={messageId} />
+      </Form.Label>
+      <MultiSet
+        type="tags"
+        disabled={isUpdating}
+        onUpdate={(itemIDs) =>
+          setTagIDs((existing) => ({ ...existing, ids: itemIDs }))
+        }
+        onSetMode={(newMode) =>
+          setTagIDs((existing) => ({ ...existing, mode: newMode }))
+        }
+        existingIds={existingTagIds ?? []}
+        ids={tagIDs.ids ?? []}
+        mode={tagIDs.mode}
+      />
+    </Form.Group>
+  );
+}
+
+interface IListOperationProps {
+  selected: GQL.TagDataFragment[];
+  onClose: (applied: boolean) => void;
+}
+
+const tagFields = ["favorite", "description", "ignore_auto_tag"];
+
+export const EditTagsDialog: React.FC<IListOperationProps> = (
+  props: IListOperationProps
+) => {
+  const intl = useIntl();
+  const Toast = useToast();
+
+  const [parentTagIDs, setParentTagIDs_] = useState<GQL.BulkUpdateIds>({
+    mode: GQL.BulkUpdateIdMode.Add,
+  });
+
+  function setParentTagIDs(value: React.SetStateAction<GQL.BulkUpdateIds>) {
+    console.log(value);
+    setParentTagIDs_(value);
+  }
+
+  const [existingParentTagIds, setExistingParentTagIds] = useState<string[]>();
+
+  const [childTagIDs, setChildTagIDs] = useState<GQL.BulkUpdateIds>({
+    mode: GQL.BulkUpdateIdMode.Add,
+  });
+  const [existingChildTagIds, setExistingChildTagIds] = useState<string[]>();
+
+  const [updateInput, setUpdateInput] = useState<GQL.BulkTagUpdateInput>({});
+
+  const [updateTags] = useBulkTagUpdate(getTagInput());
+
+  // Network state
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  function setUpdateField(input: Partial<GQL.BulkTagUpdateInput>) {
+    setUpdateInput({ ...updateInput, ...input });
+  }
+
+  function getTagInput(): GQL.BulkTagUpdateInput {
+    const tagInput: GQL.BulkTagUpdateInput = {
+      ids: props.selected.map((tag) => {
+        return tag.id;
+      }),
+      ...updateInput,
+      parent_ids: parentTagIDs,
+      child_ids: childTagIDs,
+    };
+
+    return tagInput;
+  }
+
+  async function onSave() {
+    setIsUpdating(true);
+    try {
+      await updateTags();
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.updated_entity" },
+          {
+            entity: intl.formatMessage({ id: "tags" }).toLocaleLowerCase(),
+          }
+        )
+      );
+      props.onClose(true);
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsUpdating(false);
+  }
+
+  useEffect(() => {
+    const updateState: GQL.BulkTagUpdateInput = {};
+
+    const state = props.selected;
+    let updateParentTagIds: string[] = [];
+    let updateChildTagIds: string[] = [];
+    let first = true;
+
+    state.forEach((tag: GQL.TagDataFragment) => {
+      getAggregateStateObject(updateState, tag, tagFields, first);
+
+      const thisParents = (tag.parents ?? []).map((t) => t.id).sort();
+      updateParentTagIds =
+        getAggregateState(updateParentTagIds, thisParents, first) ?? [];
+
+      const thisChildren = (tag.children ?? []).map((t) => t.id).sort();
+      updateChildTagIds =
+        getAggregateState(updateChildTagIds, thisChildren, first) ?? [];
+
+      first = false;
+    });
+
+    setExistingParentTagIds(updateParentTagIds);
+    setExistingChildTagIds(updateChildTagIds);
+    setUpdateInput(updateState);
+  }, [props.selected]);
+
+  function renderTextField(
+    name: string,
+    value: string | undefined | null,
+    setter: (newValue: string | undefined) => void
+  ) {
+    return (
+      <Form.Group controlId={name}>
+        <Form.Label>
+          <FormattedMessage id={name} />
+        </Form.Label>
+        <BulkUpdateTextInput
+          value={value === null ? "" : value ?? undefined}
+          valueChanged={(newValue) => setter(newValue)}
+          unsetDisabled={props.selected.length < 2}
+        />
+      </Form.Group>
+    );
+  }
+
+  return (
+    <ModalComponent
+      dialogClassName="edit-tags-dialog"
+      show
+      icon={faPencilAlt}
+      header={intl.formatMessage(
+        { id: "actions.edit_entity" },
+        { entityType: intl.formatMessage({ id: "tags" }) }
+      )}
+      accept={{
+        onClick: onSave,
+        text: intl.formatMessage({ id: "actions.apply" }),
+      }}
+      cancel={{
+        onClick: () => props.onClose(false),
+        text: intl.formatMessage({ id: "actions.cancel" }),
+        variant: "secondary",
+      }}
+      isRunning={isUpdating}
+    >
+      <Form>
+        <Form.Group controlId="favorite">
+          <IndeterminateCheckbox
+            setChecked={(checked) => setUpdateField({ favorite: checked })}
+            checked={updateInput.favorite ?? undefined}
+            label={intl.formatMessage({ id: "favourite" })}
+          />
+        </Form.Group>
+
+        {renderTextField("description", updateInput.description, (v) =>
+          setUpdateField({ description: v })
+        )}
+
+        <Tags
+          isUpdating={isUpdating}
+          controlId="parent-tags"
+          messageId="parent_tags"
+          existingTagIds={existingParentTagIds}
+          tagIDs={parentTagIDs}
+          setTagIDs={setParentTagIDs}
+        />
+
+        <Tags
+          isUpdating={isUpdating}
+          controlId="sub-tags"
+          messageId="sub_tags"
+          existingTagIds={existingChildTagIds}
+          tagIDs={childTagIDs}
+          setTagIDs={setChildTagIDs}
+        />
+
+        <Form.Group controlId="ignore-auto-tags">
+          <IndeterminateCheckbox
+            label={intl.formatMessage({ id: "ignore_auto_tag" })}
+            setChecked={(checked) =>
+              setUpdateField({ ignore_auto_tag: checked })
+            }
+            checked={updateInput.ignore_auto_tag ?? undefined}
+          />
+        </Form.Group>
+      </Form>
+    </ModalComponent>
+  );
+};

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -28,6 +28,7 @@ import { ExportDialog } from "../Shared/ExportDialog";
 import { tagRelationHook } from "../../core/tags";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { TagCardGrid } from "./TagCardGrid";
+import { EditTagsDialog } from "./EditTagsDialog";
 
 interface ITagList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -325,6 +326,13 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
     );
   }
 
+  function renderEditDialog(
+    selectedTags: GQL.TagDataFragment[],
+    onClose: (confirmed: boolean) => void
+  ) {
+    return <EditTagsDialog selected={selectedTags} onClose={onClose} />;
+  }
+
   function renderDeleteDialog(
     selectedTags: GQL.TagDataFragment[],
     onClose: (confirmed: boolean) => void
@@ -361,6 +369,7 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
       addKeybinds={addKeybinds}
       renderContent={renderContent}
       renderDeleteDialog={renderDeleteDialog}
+      renderEditDialog={renderEditDialog}
     />
   );
 };

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -1873,6 +1873,17 @@ export const useTagUpdate = () =>
     },
   });
 
+export const useBulkTagUpdate = (input: GQL.BulkTagUpdateInput) =>
+  GQL.useBulkTagUpdateMutation({
+    variables: { input },
+    update(cache, result) {
+      if (!result.data?.bulkTagUpdate) return;
+
+      evictTypeFields(cache, tagMutationImpactedTypeFields);
+      evictQueries(cache, tagMutationImpactedQueries);
+    },
+  });
+
 export const useTagDestroy = (input: GQL.TagDestroyInput) =>
   GQL.useTagDestroyMutation({
     variables: input,


### PR DESCRIPTION
Refactors the tag types to use relationship fields like the other models. 

Adds bulk edit tags dialog:

![image](https://github.com/stashapp/stash/assets/53250216/8cc5b303-9e58-401b-ae66-07a602e6e3e9)

Resolves #1836 