### PR TITLE
Fix reading task defaults

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -286,10 +286,6 @@ var (
 	defaultMenuItems         = []string{"scenes", "images", "movies", "markers", "galleries", "performers", "studios", "tags"}
 )
 
-var jsonUnmarshalConf = koanf.UnmarshalConf{
-	Tag: "json",
-}
-
 type MissingConfigError struct {
 	missingFields []string
 }
@@ -1452,7 +1448,8 @@ func (i *Config) GetDefaultIdentifySettings() *identify.Options {
 
 	if v.Exists(DefaultIdentifySettings) && v.Get(DefaultIdentifySettings) != nil {
 		var ret identify.Options
-		if err := v.UnmarshalWithConf(DefaultIdentifySettings, &ret, jsonUnmarshalConf); err != nil {
+
+		if err := v.Unmarshal(DefaultIdentifySettings, &ret); err != nil {
 			return nil
 		}
 		return &ret
@@ -1471,7 +1468,7 @@ func (i *Config) GetDefaultScanSettings() *ScanMetadataOptions {
 
 	if v.Exists(DefaultScanSettings) && v.Get(DefaultScanSettings) != nil {
 		var ret ScanMetadataOptions
-		if err := v.UnmarshalWithConf(DefaultScanSettings, &ret, jsonUnmarshalConf); err != nil {
+		if err := v.Unmarshal(DefaultScanSettings, &ret); err != nil {
 			return nil
 		}
 		return &ret


### PR DESCRIPTION
Fixes issue reported on Discord where the identify task options would be lost being saved.