### PR TITLE
Fix hwCanFullHWTranscode not detecting no filter errors

### DIFF
--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -82,7 +82,11 @@ func (f *FFMpeg) InitHWSupport(ctx context.Context) {
 	f.hwCodecSupport = hwCodecSupport
 }
 
-func (f *FFMpeg) hwCanFullHWTranscode(ctx context.Context, vf *models.VideoFile, codec VideoCodec) bool {
+func (f *FFMpeg) hwCanFullHWTranscode(ctx context.Context, codec VideoCodec, vf *models.VideoFile, reqHeight int) bool {
+	if codec == VideoCodecCopy {
+		return false
+	}
+
 	var args Args
 	args = append(args, "-hide_banner")
 	args = args.LogLevel(LogLevelWarning)
@@ -91,7 +95,7 @@ func (f *FFMpeg) hwCanFullHWTranscode(ctx context.Context, vf *models.VideoFile,
 	args = args.Input(vf.Path)
 	args = args.Duration(0.1)
 
-	videoFilter := f.hwMaxResFilter(codec, vf.Width, vf.Height, minHeight, true)
+	videoFilter := f.hwMaxResFilter(codec, vf.Width, vf.Height, reqHeight, true)
 	args = append(args, CodecInit(codec)...)
 	args = args.VideoFilter(videoFilter)
 

--- a/pkg/ffmpeg/stream_segmented.go
+++ b/pkg/ffmpeg/stream_segmented.go
@@ -330,7 +330,7 @@ func (s *runningStream) makeStreamArgs(sm *StreamManager, segment int) Args {
 
 	codec := HLSGetCodec(sm, s.streamType.Name)
 
-	fullhw := sm.config.GetTranscodeHardwareAcceleration() && sm.encoder.hwCanFullHWTranscode(sm.context, s.vf, codec)
+	fullhw := sm.config.GetTranscodeHardwareAcceleration() && sm.encoder.hwCanFullHWTranscode(sm.context, codec, s.vf, s.maxTranscodeSize)
 	args = sm.encoder.hwDeviceInit(args, codec, fullhw)
 	args = append(args, extraInputArgs...)
 

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -186,7 +186,7 @@ func (o TranscodeOptions) makeStreamArgs(sm *StreamManager) Args {
 
 	codec := o.FileGetCodec(sm, maxTranscodeSize)
 
-	fullhw := sm.config.GetTranscodeHardwareAcceleration() && sm.encoder.hwCanFullHWTranscode(sm.context, o.VideoFile, codec)
+	fullhw := sm.config.GetTranscodeHardwareAcceleration() && sm.encoder.hwCanFullHWTranscode(sm.context, codec, o.VideoFile, maxTranscodeSize)
 	args = sm.encoder.hwDeviceInit(args, codec, fullhw)
 	args = append(args, extraInputArgs...)
 


### PR DESCRIPTION
A discord user experienced an error where full hardware transcoding didnt work without a filter (which wasn't tested, we always used a scale filter before).
This patch passes the requested resolution from the current transcode down to the tester, such that we test it with a filter if it needs one, or without a filter if it doesnt.

Note that the specific issue was:
```
ffmpeg error when running command <E:\stash\stash windows\ffmpeg.exe -hide_banner -v error -hwaccel_device 0 -hwaccel cuda -hwaccel_output_format cuda -extra_hw_frames 5 -i \path to movies\movies.mkv -c:v h264_nvenc -rc vbr -cq 15 -movflags frag_keyframe+empty_moov -ac 2 -f mp4 pipe:>: [h264_nvenc @ 0000022c1947be40] Provided device doesn't support required NVENC features

[vost#0:0/h264_nvenc @ 0000022c1947bb80] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.

Error while filtering: Function not implemented

[out#0/mp4 @ 0000022c19479580] Nothing was written into output file, because at least one of its streams received no packets.

```
Which usually indicates a driver/ffmpeg incompatibility, but nevertheless we shouldn't error out because of it.
It could also indicate 10 bit input file-hell, which is a rabbit hole of its own (which we could handle with scale_cuda=format=nv12 on some versions of ffmpeg, or simply fall back on no accelerated decode)