### PR TITLE
Add console javascript object for backwards compatibility

### DIFF
--- a/pkg/javascript/console.go
+++ b/pkg/javascript/console.go
@@ -1,0 +1,26 @@
+package javascript
+
+import "fmt"
+
+type console struct {
+	Log
+}
+
+func (c *console) AddToVM(globalName string, vm *VM) error {
+	console := vm.NewObject()
+	if err := SetAll(console,
+		ObjectValueDef{"log", c.logInfo},
+		ObjectValueDef{"error", c.logError},
+		ObjectValueDef{"warn", c.logWarn},
+		ObjectValueDef{"info", c.logInfo},
+		ObjectValueDef{"debug", c.logDebug},
+	); err != nil {
+		return err
+	}
+
+	if err := vm.Set(globalName, console); err != nil {
+		return fmt.Errorf("unable to set console: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/javascript/vm.go
+++ b/pkg/javascript/vm.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/dop251/goja"
+	"github.com/stashapp/stash/pkg/logger"
 )
 
 type VM struct {
@@ -36,6 +37,17 @@ func (tfm optionalFieldNameMapper) MethodName(t reflect.Type, m reflect.Method) 
 
 func NewVM() *VM {
 	r := goja.New()
+
+	// enable console for backwards compatibility
+	c := console{
+		Log{
+			Logger: logger.Logger,
+		},
+	}
+
+	// there should not be any reason for this to fail
+	_ = c.AddToVM("console", &VM{Runtime: r})
+
 	r.SetFieldNameMapper(optionalFieldNameMapper{goja.TagFieldNameMapper("json", true)})
 	return &VM{Runtime: r}
 }


### PR DESCRIPTION
Fixes issue identified in #4936. Adds `console` global object to the javascript vm to maintain backwards compatibility.

`console.log` and `console.info` log to `info` log level
`console.warn` logs to `warn`
`console.error` logs to `error`
`console.debug` logs to `debug`

