### PR TITLE
Fix typos in docs (en)

### DIFF
--- a/ui/v2.5/src/docs/en/Changelog/v0200.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0200.md
@@ -47,7 +47,7 @@ Once migrated, these files can be deleted. The files can be optionally deleted d
 * Fixed `/stream` endpoint serving directory list. ([#3541](https://github.com/stashapp/stash/pull/3541))
 * Fixed error when querying with a large or unlimited page size. ([#3544](https://github.com/stashapp/stash/pull/3544))
 * Fixed sprites not being displayed for scenes with numeric-only hashes. ([#3513](https://github.com/stashapp/stash/pull/3513))
-* Fixed Save button being disabled when stting Tag image. ([#3509](https://github.com/stashapp/stash/pull/3509))
+* Fixed Save button being disabled when setting Tag image. ([#3509](https://github.com/stashapp/stash/pull/3509))
 * Fixed incorrect performer with identical name being matched when scraping from stash-box. ([#3488](https://github.com/stashapp/stash/pull/3488))
 * Fixed scene cover not being included when submitting file-less scenes to stash-box. ([#3465](https://github.com/stashapp/stash/pull/3465))
 * Fixed URL not being during stash-box scrape if the Studio URL is not set. ([#3439](https://github.com/stashapp/stash/pull/3439))

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -15,7 +15,7 @@ Regex patterns can be added in the config file or from the UI.
 If you add manually to the config file a restart is needed while from the UI you just need to click the Save button.  
 When added through the config file directly special care must be given to double escape the `\` character.
 
-There are 2 sperate exclusion settings. One is for videos, another is for images/galleries.
+There are 2 separate exclusion settings. One is for videos, another is for images/galleries.
 
 Some examples:
 
@@ -23,7 +23,7 @@ Some examples:
 - `"/\.[[:word:]]+/"` will exclude all hidden directories like `/.directoryname/`.
 - `"c:\\stash\\videos\\exclude"` will exclude specific Windows directory `c:\stash\videos\exclude`.
 - `"^/stash/videos/exclude/"` will exclude all directories that match `/stash/videos/exclude/` pattern.
-- `"\\\\stash\\network\\share\\excl\\"` will exlcude specific Windows network path `\\stash\network\share\excl\`.
+- `"\\\\stash\\network\\share\\excl\\"` will exclude specific Windows network path `\\stash\network\share\excl\`.
 
 > **Note:** If a directory is excluded for images and videos, then the directory will be excluded from scans completely.
 

--- a/ui/v2.5/src/docs/en/Manual/Introduction.md
+++ b/ui/v2.5/src/docs/en/Manual/Introduction.md
@@ -2,6 +2,6 @@
 
 Stash works by cataloging your media using the paths that you provide. Once you have [configured](/settings?tab=library) the locations where your media is stored, you can click the Scan button in [`Settings -> Tasks`](/settings?tab=tasks) and stash will begin scanning and importing your media into its library.
 
-For the best experience, it is recommmended that after a scan is finished, that video previews and sprites are generated. You can do this in [`Settings -> Tasks`](/settings?tab=tasks). Note that currently it is only possible to perform one task at a time and but there is a task queue, so the generate tasks should be performed after scan is complete.
+For the best experience, it is recommended that after a scan is finished, that video previews and sprites are generated. You can do this in [`Settings -> Tasks`](/settings?tab=tasks). Note that currently it is only possible to perform one task at a time and but there is a task queue, so the generate tasks should be performed after scan is complete.
 
 Once your media is imported, you are ready to begin creating Performers, Studios and Tags, and curating your content!

--- a/ui/v2.5/src/docs/en/ReleaseNotes/v0240.md
+++ b/ui/v2.5/src/docs/en/ReleaseNotes/v0240.md
@@ -1,5 +1,5 @@
 This release introduces scraper and plugin management interfaces. This allows installing, updating and removing scrapers and plugins from the WebUI. 
 
-Default package sources have been automatically configured to point at the _stable_ branches of the `CommunityScrapers` and `CommunityScripts` respositories. These branches will correspond to the current stable version of stash. 
+Default package sources have been automatically configured to point at the _stable_ branches of the `CommunityScrapers` and `CommunityScripts` repositories. These branches will correspond to the current stable version of stash. 
 
 **Note:** existing scrapers and plugins will _not_ be able to be managed using the management interface. It is recommended that any existing scrapers and plugins that are available from the community repositories are backed up and removed from the applicable `scrapers` or `plugins` directory, and reinstalled using the management UI.


### PR DESCRIPTION
Found some typos throughout the docs. Figured worth a PR.