### PR TITLE
In performer scrapers, forward non-http single performer images

### DIFF
--- a/pkg/models/model_scraped_item.go
+++ b/pkg/models/model_scraped_item.go
@@ -125,7 +125,7 @@ type ScrapedPerformer struct {
 	Aliases        *string       `json:"aliases"`
 	Tags           []*ScrapedTag `json:"tags"`
 	// This should be a base64 encoded data URL
-	Image        *string  `json:"image"`
+	Image        *string  `json:"image"` // deprecated: use Images
 	Images       []string `json:"images"`
 	Details      *string  `json:"details"`
 	DeathDate    *string  `json:"death_date"`

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -12,11 +12,14 @@ import (
 )
 
 func setPerformerImage(ctx context.Context, client *http.Client, p *models.ScrapedPerformer, globalConfig GlobalConfig) error {
-	if p.Image == nil {
+	// backwards compatibility: we fetch the image if it's a URL and set it to the first image
+	// Image is deprecated, so only do this if Images is unset
+	if p.Image == nil || len(p.Images) > 0 {
 		// nothing to do
 		return nil
 	}
 
+	// don't try to get the image if it doesn't appear to be a URL
 	if !strings.HasPrefix(*p.Image, "http") {
 		p.Images = []string{*p.Image}
 		return nil

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -12,8 +12,13 @@ import (
 )
 
 func setPerformerImage(ctx context.Context, client *http.Client, p *models.ScrapedPerformer, globalConfig GlobalConfig) error {
-	if p.Image == nil || !strings.HasPrefix(*p.Image, "http") {
+	if p.Image == nil {
 		// nothing to do
+		return nil
+	}
+
+	if !strings.HasPrefix(*p.Image, "http") {
+		p.Images = []string{*p.Image}
 		return nil
 	}
 


### PR DESCRIPTION
I noticed Stash behaves differently when performer scrapers return Image and Images:
 - for the Images array, if any of the strings begins with "http", then it's fetched and used instead. Otherwise, it's used as is, without changes.
 - for the single Image, if the string begins with "http", then it's fetched and used instead. Otherwise, it's ignored and not used at all.

Basically, in the Images array you can e.g. pass an image as base64-encoded data. It's not possible in the Image field.

Perhaps it was intended (to force scrapers to migrate to the Images array?). Anyway, I believe it's better to have both behave the same, thus this PR.