### PR TITLE
Fix studio selection in scraping dialogs

### DIFF
--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -54,7 +54,11 @@ export const ScrapedStudioRow: React.FC<IScrapedStudioRow> = ({
         isDisabled={!isNew}
         onSelect={(items) => {
           if (onChangeFn) {
-            onChangeFn(items[0]);
+            const { id, ...data } = items[0];
+            onChangeFn({
+              ...data,
+              stored_id: id
+            });
           }
         }}
         values={selectValue}

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -57,7 +57,7 @@ export const ScrapedStudioRow: React.FC<IScrapedStudioRow> = ({
             const { id, ...data } = items[0];
             onChangeFn({
               ...data,
-              stored_id: id
+              stored_id: id,
             });
           }
         }}


### PR DESCRIPTION
Manually selected studios in the scrape dialog don't get applied because they have `id` instead of `stored_id`.