### PR TITLE
Add apple encoder and fix extra_hw_frames bug

### DIFF
--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -204,26 +204,19 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 	return videoFilter
 }
 
-var scaler_re = regexp.MustCompile(`scale=(?P<value>[-\d]+:[-\d]+)`)
+var scaler_re = regexp.MustCompile(`scale=(?P<value>([-\d]+):([-\d]+))`)
 
 func templateReplaceScale(input string, template string, match []int, vf *models.VideoFile, minusonehack bool) string {
 	result := []byte{}
 
 	if minusonehack {
-		matches := scaler_re.FindStringSubmatch(input)
-		split := strings.Split(matches[1], ":")
-		if len(split) != 2 {
-			logger.Error("split not found")
-			return input
-		}
-
 		// Parse width and height
-		w, err := strconv.Atoi(split[0])
+		w, err := strconv.Atoi(input[match[4]:match[5]])
 		if err != nil {
 			logger.Error("failed to parse width")
 			return input
 		}
-		h, err := strconv.Atoi(split[1])
+		h, err := strconv.Atoi(input[match[6]:match[7]])
 		if err != nil {
 			logger.Error("failed to parse height")
 			return input

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -97,7 +97,7 @@ func (f *FFMpeg) hwCanFullHWTranscode(ctx context.Context, codec VideoCodec, vf 
 	args = args.XError()
 	args = f.hwDeviceInit(args, codec, true)
 	args = args.Input(vf.Path)
-	args = args.Duration(0.1)
+	args = args.Duration(1)
 
 	videoFilter := f.hwMaxResFilter(codec, vf, reqHeight, true)
 	args = append(args, CodecInit(codec)...)

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -197,7 +197,7 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 		VideoCodecIVP9:
 		if !fullhw {
 			videoFilter = videoFilter.Append("hwupload=extra_hw_frames=64")
-			videoFilter = videoFilter.Append("format=yuv420p")
+			videoFilter = videoFilter.Append("format=qsv")
 		}
 	}
 
@@ -274,7 +274,7 @@ func (f *FFMpeg) hwApplyFullHWFilter(args VideoFilter, codec VideoCodec, fullhw 
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			args = args.Append("scale_qsv=format=yuv420p")
+			args = args.Append("scale_qsv=format=qsv")
 		}
 	}
 
@@ -299,7 +299,7 @@ func (f *FFMpeg) hwApplyScaleTemplate(sargs string, codec VideoCodec, match []in
 	case VideoCodecI264, VideoCodecIVP9:
 		template = "scale_qsv=$value"
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			template += ":format=yuv420p"
+			template += ":format=qsv"
 		}
 	case VideoCodecM264:
 		template = "scale_vt=$value"

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -182,10 +182,9 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 	var videoFilter VideoFilter
 	switch toCodec {
 	case VideoCodecV264,
-		VideoCodecVVP9,
-		VideoCodecM264:
+		VideoCodecVVP9:
 		if !fullhw {
-			videoFilter = videoFilter.Append("format=yuv420p")
+			videoFilter = videoFilter.Append("format=vaapi_vld")
 			videoFilter = videoFilter.Append("hwupload")
 		}
 	case VideoCodecN264:
@@ -198,6 +197,11 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 		if !fullhw {
 			videoFilter = videoFilter.Append("hwupload=extra_hw_frames=64")
 			videoFilter = videoFilter.Append("format=qsv")
+		}
+	case VideoCodecM264:
+		if !fullhw {
+			videoFilter = videoFilter.Append("format=nv12")
+			videoFilter = videoFilter.Append("hwupload")
 		}
 	}
 
@@ -270,7 +274,7 @@ func (f *FFMpeg) hwApplyFullHWFilter(args VideoFilter, codec VideoCodec, fullhw 
 		}
 	case VideoCodecV264, VideoCodecVVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
-			args = args.Append("scale_vaapi=format=yuv420p")
+			args = args.Append("scale_vaapi=format=vaapi_vld")
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -27,7 +27,7 @@ var (
 	VideoCodecVVPX VideoCodec = "vp8_vaapi"
 )
 
-const minHeight int = 256
+const minHeight int = 480
 
 // Tests all (given) hardware codec's
 func (f *FFMpeg) InitHWSupport(ctx context.Context) {

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -128,12 +128,12 @@ func (f *FFMpeg) hwDeviceInit(args Args, toCodec VideoCodec, fullhw bool) Args {
 		args = append(args, "-hwaccel_device")
 		args = append(args, "0")
 		if fullhw {
+			args = append(args, "-threads")
+			args = append(args, "1")
 			args = append(args, "-hwaccel")
 			args = append(args, "cuda")
 			args = append(args, "-hwaccel_output_format")
 			args = append(args, "cuda")
-			args = append(args, "-extra_hw_frames")
-			args = append(args, "5")
 		}
 	case VideoCodecV264,
 		VideoCodecVVP9:
@@ -170,19 +170,19 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 	case VideoCodecV264,
 		VideoCodecVVP9:
 		if !fullhw {
-			videoFilter = videoFilter.Append("format=nv12")
+			videoFilter = videoFilter.Append("format=yuv420p")
 			videoFilter = videoFilter.Append("hwupload")
 		}
 	case VideoCodecN264:
 		if !fullhw {
-			videoFilter = videoFilter.Append("format=nv12")
+			videoFilter = videoFilter.Append("format=yuv420p")
 			videoFilter = videoFilter.Append("hwupload_cuda")
 		}
 	case VideoCodecI264,
 		VideoCodecIVP9:
 		if !fullhw {
 			videoFilter = videoFilter.Append("hwupload=extra_hw_frames=64")
-			videoFilter = videoFilter.Append("format=qsv")
+			videoFilter = videoFilter.Append("format=yuv420p")
 		}
 	}
 
@@ -225,15 +225,15 @@ func (f *FFMpeg) hwApplyFullHWFilter(args VideoFilter, codec VideoCodec, fullhw 
 	switch codec {
 	case VideoCodecN264:
 		if fullhw && f.version.major >= 5 { // Added in FFMpeg 5
-			args = args.Append("scale_cuda=format=nv12")
+			args = args.Append("scale_cuda=format=yuv420p")
 		}
 	case VideoCodecV264, VideoCodecVVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
-			args = args.Append("scale_vaapi=format=nv12")
+			args = args.Append("scale_vaapi=format=yuv420p")
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			args = args.Append("scale_qsv=format=nv12")
+			args = args.Append("scale_qsv=format=yuv420p")
 		}
 	}
 
@@ -248,17 +248,17 @@ func (f *FFMpeg) hwApplyScaleTemplate(sargs string, codec VideoCodec, match []in
 	case VideoCodecN264:
 		template = "scale_cuda=$value"
 		if fullhw && f.version.major >= 5 { // Added in FFMpeg 5
-			template += ":format=nv12"
+			template += ":format=yuv420p"
 		}
 	case VideoCodecV264, VideoCodecVVP9:
 		template = "scale_vaapi=$value"
 		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
-			template += ":format=nv12"
+			template += ":format=yuv420p"
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		template = "scale_qsv=$value"
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			template += ":format=nv12"
+			template += ":format=yuv420p"
 		}
 	default:
 		return VideoFilter(sargs)

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -323,8 +323,7 @@ func (f *FFMpeg) hwApplyScaleTemplate(sargs string, codec VideoCodec, match []in
 	isIntel := codec == VideoCodecI264 || codec == VideoCodecIVP9
 	// BUG: scale_vt doesn't call ff_scale_adjust_dimensions, thus cant accept negative size values
 	isApple := codec == VideoCodecM264
-	isDebug := true
-	return VideoFilter(templateReplaceScale(sargs, template, match, vf, isIntel || isApple || isDebug))
+	return VideoFilter(templateReplaceScale(sargs, template, match, vf, isIntel || isApple))
 }
 
 // Returns the max resolution for a given codec, or a default

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -269,15 +269,15 @@ func (f *FFMpeg) hwCodecFilter(args VideoFilter, codec VideoCodec, vf *models.Vi
 func (f *FFMpeg) hwApplyFullHWFilter(args VideoFilter, codec VideoCodec, fullhw bool) VideoFilter {
 	switch codec {
 	case VideoCodecN264:
-		if fullhw && f.version.major >= 5 { // Added in FFMpeg 5
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 5}) { // Added in FFMpeg 5
 			args = args.Append("scale_cuda=format=yuv420p")
 		}
 	case VideoCodecV264, VideoCodecVVP9:
-		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 3, minor: 1}) { // Added in FFMpeg 3.1
 			args = args.Append("scale_vaapi=format=nv12")
 		}
 	case VideoCodecI264, VideoCodecIVP9:
-		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 3, minor: 3}) { // Added in FFMpeg 3.3
 			args = args.Append("scale_qsv=format=nv12")
 		}
 	}
@@ -292,17 +292,17 @@ func (f *FFMpeg) hwApplyScaleTemplate(sargs string, codec VideoCodec, match []in
 	switch codec {
 	case VideoCodecN264:
 		template = "scale_cuda=$value"
-		if fullhw && f.version.major >= 5 { // Added in FFMpeg 5
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 5}) { // Added in FFMpeg 5
 			template += ":format=yuv420p"
 		}
 	case VideoCodecV264, VideoCodecVVP9:
 		template = "scale_vaapi=$value"
-		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 3, minor: 1}) { // Added in FFMpeg 3.1
 			template += ":format=nv12"
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		template = "scale_qsv=$value"
-		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
+		if fullhw && f.version.Gteq(FFMpegVersion{major: 3, minor: 3}) { // Added in FFMpeg 3.3
 			template += ":format=nv12"
 		}
 	case VideoCodecM264:

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -199,11 +199,6 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 			videoFilter = videoFilter.Append("hwupload=extra_hw_frames=64")
 			videoFilter = videoFilter.Append("format=yuv420p")
 		}
-	case VideoCodecM264:
-		if !fullhw {
-			videoFilter = videoFilter.Append("format=yuv420p")
-			videoFilter = videoFilter.Append("hwupload")
-		}
 	}
 
 	return videoFilter
@@ -244,10 +239,10 @@ func templateReplaceScale(input string, template string, match []int, vf *models
 
 		// Fix not divisible by 2 errors
 		if w%2 != 0 {
-			w += 1
+			w++
 		}
 		if h%2 != 0 {
-			h += 1
+			h++
 		}
 
 		template = strings.ReplaceAll(template, "$value", fmt.Sprintf("%d:%d", w, h))

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -355,7 +355,8 @@ func (f *FFMpeg) hwCodecHLSCompatible() *VideoCodec {
 		case VideoCodecN264,
 			VideoCodecI264,
 			VideoCodecV264,
-			VideoCodecR264:
+			VideoCodecR264,
+			VideoCodecM264:
 			return &element
 		}
 	}
@@ -367,7 +368,8 @@ func (f *FFMpeg) hwCodecMP4Compatible() *VideoCodec {
 	for _, element := range f.hwCodecSupport {
 		switch element {
 		case VideoCodecN264,
-			VideoCodecI264:
+			VideoCodecI264,
+			VideoCodecM264:
 			return &element
 		}
 	}

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -356,7 +356,7 @@ func (f *FFMpeg) hwCodecHLSCompatible() *VideoCodec {
 			VideoCodecI264,
 			VideoCodecV264,
 			VideoCodecR264,
-			VideoCodecM264:
+			VideoCodecM264: // Note that the Apple encoder sucks at startup, thus HLS quality is crap
 			return &element
 		}
 	}

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -184,7 +184,7 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 	case VideoCodecV264,
 		VideoCodecVVP9:
 		if !fullhw {
-			videoFilter = videoFilter.Append("format=vaapi_vld")
+			videoFilter = videoFilter.Append("format=nv12")
 			videoFilter = videoFilter.Append("hwupload")
 		}
 	case VideoCodecN264:
@@ -274,11 +274,11 @@ func (f *FFMpeg) hwApplyFullHWFilter(args VideoFilter, codec VideoCodec, fullhw 
 		}
 	case VideoCodecV264, VideoCodecVVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
-			args = args.Append("scale_vaapi=format=vaapi_vld")
+			args = args.Append("scale_vaapi=format=nv12")
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			args = args.Append("scale_qsv=format=qsv")
+			args = args.Append("scale_qsv=format=nv12")
 		}
 	}
 
@@ -298,12 +298,12 @@ func (f *FFMpeg) hwApplyScaleTemplate(sargs string, codec VideoCodec, match []in
 	case VideoCodecV264, VideoCodecVVP9:
 		template = "scale_vaapi=$value"
 		if fullhw && f.version.major >= 3 && f.version.minor >= 1 { // Added in FFMpeg 3.1
-			template += ":format=yuv420p"
+			template += ":format=nv12"
 		}
 	case VideoCodecI264, VideoCodecIVP9:
 		template = "scale_qsv=$value"
 		if fullhw && f.version.major >= 3 && f.version.minor >= 3 { // Added in FFMpeg 3.3
-			template += ":format=qsv"
+			template += ":format=nv12"
 		}
 	case VideoCodecM264:
 		template = "scale_vt=$value"

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -179,7 +179,8 @@ func (f *FFMpeg) hwFilterInit(toCodec VideoCodec, fullhw bool) VideoFilter {
 	var videoFilter VideoFilter
 	switch toCodec {
 	case VideoCodecV264,
-		VideoCodecVVP9:
+		VideoCodecVVP9,
+		VideoCodecM264:
 		if !fullhw {
 			videoFilter = videoFilter.Append("format=yuv420p")
 			videoFilter = videoFilter.Append("hwupload")

--- a/pkg/ffmpeg/ffmpeg.go
+++ b/pkg/ffmpeg/ffmpeg.go
@@ -195,6 +195,20 @@ type FFMpegVersion struct {
 	patch int
 }
 
+// Gteq returns true if the version is greater than or equal to the other version.
+func (v FFMpegVersion) Gteq(other FFMpegVersion) bool {
+	if v.major > other.major {
+		return true
+	}
+	if v.major == other.major && v.minor > other.minor {
+		return true
+	}
+	if v.major == other.major && v.minor == other.minor && v.patch >= other.patch {
+		return true
+	}
+	return false
+}
+
 // FFMpeg provides an interface to ffmpeg.
 type FFMpeg struct {
 	ffmpeg         string

--- a/pkg/ffmpeg/ffmpeg_test.go
+++ b/pkg/ffmpeg/ffmpeg_test.go
@@ -1,0 +1,75 @@
+// Package ffmpeg provides a wrapper around the ffmpeg and ffprobe executables.
+package ffmpeg
+
+import "testing"
+
+func TestFFMpegVersion_GreaterThan(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  FFMpegVersion
+		other FFMpegVersion
+		want  bool
+	}{
+		{
+			"major greater, minor equal, patch equal",
+			FFMpegVersion{2, 0, 0},
+			FFMpegVersion{1, 0, 0},
+			true,
+		},
+		{
+			"major greater, minor less, patch less",
+			FFMpegVersion{2, 1, 1},
+			FFMpegVersion{1, 0, 0},
+			true,
+		},
+		{
+			"major equal, minor greater, patch equal",
+			FFMpegVersion{1, 1, 0},
+			FFMpegVersion{1, 0, 0},
+			true,
+		},
+		{
+			"major equal, minor equal, patch greater",
+			FFMpegVersion{1, 0, 1},
+			FFMpegVersion{1, 0, 0},
+			true,
+		},
+		{
+			"major equal, minor equal, patch equal",
+			FFMpegVersion{1, 0, 0},
+			FFMpegVersion{1, 0, 0},
+			true,
+		},
+		{
+			"major less, minor equal, patch equal",
+			FFMpegVersion{1, 0, 0},
+			FFMpegVersion{2, 0, 0},
+			false,
+		},
+		{
+			"major equal, minor less, patch equal",
+			FFMpegVersion{1, 0, 0},
+			FFMpegVersion{1, 1, 0},
+			false,
+		},
+		{
+			"major equal, minor equal, patch less",
+			FFMpegVersion{1, 0, 0},
+			FFMpegVersion{1, 0, 1},
+			false,
+		},
+		{
+			"major less, minor less, patch less",
+			FFMpegVersion{1, 0, 0},
+			FFMpegVersion{2, 1, 1},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.this.Gteq(tt.other); got != tt.want {
+				t.Errorf("FFMpegVersion.GreaterThan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ffmpeg/filter.go
+++ b/pkg/ffmpeg/filter.go
@@ -59,35 +59,28 @@ func (f VideoFilter) ScaleMax(inputWidth, inputHeight, maxSize int) VideoFilter 
 	return f.ScaleDimensions(maxSize, -2)
 }
 
-// ScaleMaxLM returns a VideoFilter scaling to maxSize with respect to a max size.
+// ScaleMaxLM scales an image to fit within specified maximum dimensions while maintaining its aspect ratio.
 func (f VideoFilter) ScaleMaxLM(width int, height int, reqHeight int, maxWidth int, maxHeight int) VideoFilter {
-	if maxWidth != 0 && maxHeight != 0 {
-		// calculate the aspect ratio of the current resolution
-		aspectRatio := width / height
-
-		// find the max height
-		desiredHeight := reqHeight
-		if desiredHeight == 0 {
-			desiredHeight = height
-		}
-
-		// calculate the desired width based on the desired height and the aspect ratio
-		desiredWidth := int(desiredHeight * aspectRatio)
-
-		// check which dimension to scale based on the maximum resolution
-		if desiredHeight > maxHeight || desiredWidth > maxWidth {
-			if desiredHeight-maxHeight > desiredWidth-maxWidth {
-				// scale the height down to the maximum height
-				return f.ScaleDimensions(-2, maxHeight)
-			} else {
-				// scale the width down to the maximum width
-				return f.ScaleDimensions(maxWidth, -2)
-			}
-		}
+	if maxWidth == 0 || maxHeight == 0 {
+		return f.ScaleMax(width, height, reqHeight)
 	}
 
-	// the current resolution can be scaled to the desired height without exceeding the maximum resolution
-	return f.ScaleMax(width, height, reqHeight)
+	aspectRatio := float64(width) / float64(height)
+	desiredHeight := reqHeight
+	if desiredHeight == 0 {
+		desiredHeight = height
+	}
+	desiredWidth := int(float64(desiredHeight) * aspectRatio)
+
+	if desiredHeight <= maxHeight && desiredWidth <= maxWidth {
+		return f.ScaleMax(width, height, reqHeight)
+	}
+
+	if float64(desiredHeight-maxHeight) > float64(desiredWidth-maxWidth) {
+		return f.ScaleDimensions(-2, maxHeight)
+	} else {
+		return f.ScaleDimensions(maxWidth, -2)
+	}
 }
 
 // Fps returns a VideoFilter setting the frames per second.

--- a/pkg/ffmpeg/filter.go
+++ b/pkg/ffmpeg/filter.go
@@ -61,26 +61,28 @@ func (f VideoFilter) ScaleMax(inputWidth, inputHeight, maxSize int) VideoFilter 
 
 // ScaleMaxLM returns a VideoFilter scaling to maxSize with respect to a max size.
 func (f VideoFilter) ScaleMaxLM(width int, height int, reqHeight int, maxWidth int, maxHeight int) VideoFilter {
-	// calculate the aspect ratio of the current resolution
-	aspectRatio := width / height
+	if maxWidth != 0 && maxHeight != 0 {
+		// calculate the aspect ratio of the current resolution
+		aspectRatio := width / height
 
-	// find the max height
-	desiredHeight := reqHeight
-	if desiredHeight == 0 {
-		desiredHeight = height
-	}
+		// find the max height
+		desiredHeight := reqHeight
+		if desiredHeight == 0 {
+			desiredHeight = height
+		}
 
-	// calculate the desired width based on the desired height and the aspect ratio
-	desiredWidth := int(desiredHeight * aspectRatio)
+		// calculate the desired width based on the desired height and the aspect ratio
+		desiredWidth := int(desiredHeight * aspectRatio)
 
-	// check which dimension to scale based on the maximum resolution
-	if desiredHeight > maxHeight || desiredWidth > maxWidth {
-		if desiredHeight-maxHeight > desiredWidth-maxWidth {
-			// scale the height down to the maximum height
-			return f.ScaleDimensions(-2, maxHeight)
-		} else {
-			// scale the width down to the maximum width
-			return f.ScaleDimensions(maxWidth, -2)
+		// check which dimension to scale based on the maximum resolution
+		if desiredHeight > maxHeight || desiredWidth > maxWidth {
+			if desiredHeight-maxHeight > desiredWidth-maxWidth {
+				// scale the height down to the maximum height
+				return f.ScaleDimensions(-2, maxHeight)
+			} else {
+				// scale the width down to the maximum width
+				return f.ScaleDimensions(maxWidth, -2)
+			}
 		}
 	}
 

--- a/pkg/ffmpeg/stream_segmented.go
+++ b/pkg/ffmpeg/stream_segmented.go
@@ -342,7 +342,7 @@ func (s *runningStream) makeStreamArgs(sm *StreamManager, segment int) Args {
 
 	videoOnly := ProbeAudioCodec(s.vf.AudioCodec) == MissingUnsupported
 
-	videoFilter := sm.encoder.hwMaxResFilter(codec, s.vf.Width, s.vf.Height, s.maxTranscodeSize, fullhw)
+	videoFilter := sm.encoder.hwMaxResFilter(codec, s.vf, s.maxTranscodeSize, fullhw)
 
 	args = append(args, s.streamType.Args(codec, segment, videoFilter, videoOnly, s.outputDir)...)
 

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -60,7 +60,6 @@ func CodecInit(codec VideoCodec) (args Args) {
 		)
 	case VideoCodecM264:
 		args = append(args,
-			"-prio_speed", "1",
 			"-realtime", "1",
 		)
 	case VideoCodecO264:

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -61,6 +61,7 @@ func CodecInit(codec VideoCodec) (args Args) {
 	case VideoCodecM264:
 		args = append(args,
 			"-prio_speed", "1",
+			"-realtime", "1",
 		)
 	case VideoCodecO264:
 		args = append(args,

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -199,7 +199,7 @@ func (o TranscodeOptions) makeStreamArgs(sm *StreamManager) Args {
 
 	videoOnly := ProbeAudioCodec(o.VideoFile.AudioCodec) == MissingUnsupported
 
-	videoFilter := sm.encoder.hwMaxResFilter(codec, o.VideoFile.Width, o.VideoFile.Height, maxTranscodeSize, fullhw)
+	videoFilter := sm.encoder.hwMaxResFilter(codec, o.VideoFile, maxTranscodeSize, fullhw)
 
 	args = append(args, o.StreamType.Args(codec, videoFilter, videoOnly)...)
 


### PR DESCRIPTION
A discord user complained that the decoder was bugging out, i suspected this was due to extra_hw_frames, jellyfin fixed this by switching from nv12 to yuv420p which disables passthrough.
Jellyfin also adds -threads 1 to cuda to save vram.

Additionally adds the apple encoder for hardware acceleration and brings the requisite fixes.
Like scale_vt lacking dimension adjustments, so we retrofitted the intel hack to calculate the dimensions and used it for apple too.
It also lacks a format switcher, so no 10bit fixes for it.
It also has a higher min resolution than anything we've seen yet, so upped the test resolution.

The only note is that given the apple encoders nature, it really sucks at startup, and given HLS's current tendency to start and stop, it makes the video look like crap.
It technically works, but i dont know that we should keep it.

Last time i fixed a bug that caused using no filter to error out because of the pixel format, so now we can add a format switcher if available.

Closes https://github.com/stashapp/stash/issues/4945