### PR TITLE
Address resize loop

### DIFF
--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -44,7 +44,7 @@ interface IDimension {
 
 export const useContainerDimensions = <
   T extends HTMLElement = HTMLDivElement
->(): [MutableRefObject<T | null>, IDimension] => {
+>(reduceSensitivity=true): [MutableRefObject<T | null>, IDimension] => {
   const target = useRef<T | null>(null);
   const [dimension, setDimension] = useState<IDimension>({
     width: 0,
@@ -58,7 +58,7 @@ export const useContainerDimensions = <
     // the dimensions toggle back and forward when the window is adjusted perfectly such that overflow
     // is trigger then immediable disabled because of a resize event then continues this loop endlessly.
     // 15 pixels is the amount of space the scrollbar takes up by default
-    if (difference > 15) {
+    if (!reduceSensitivity || difference > 15) {
       setDimension({ width, height });
     }
   });

--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -1,10 +1,11 @@
-import React, { MutableRefObject, useRef, useState } from "react";
+import React, { MutableRefObject, useEffect, useRef, useState } from "react";
 import { Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import cx from "classnames";
 import { TruncatedText } from "../TruncatedText";
 import ScreenUtils from "src/utils/screen";
 import useResizeObserver from "@react-hook/resize-observer";
+import { CooldownTimer } from "../CooldownTimer";
 
 interface ICardProps {
   className?: string;
@@ -53,7 +54,14 @@ export const useContainerDimensions = <
 
   useResizeObserver(target, (entry) => {
     const { inlineSize: width, blockSize: height } = entry.contentBoxSize[0];
-    setDimension({ width, height });
+    let difference = Math.abs(dimension.width - width);
+    // Only adjust when width changed by a significant margin. This addresses the cornercase that sees
+    // the dimensions toggle back and forward when the window is adjusted perfectly such that overflow
+    // is trigger then immediable disabled because of a resize event then continues this loop endlessly.
+    // 15 pixels is the amount of space the scrollbar takes up by default
+    if (difference > 15) {
+      setDimension({ width, height });
+    }
   });
 
   return [target, dimension];

--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -43,7 +43,7 @@ interface IDimension {
 }
 
 export const useContainerDimensions = <T extends HTMLElement = HTMLDivElement>(
-  sensitivityThreshold = 15
+  sensitivityThreshold = 20
 ): [MutableRefObject<T | null>, IDimension] => {
   const target = useRef<T | null>(null);
   const [dimension, setDimension] = useState<IDimension>({
@@ -57,7 +57,7 @@ export const useContainerDimensions = <T extends HTMLElement = HTMLDivElement>(
     // Only adjust when width changed by a significant margin. This addresses the cornercase that sees
     // the dimensions toggle back and forward when the window is adjusted perfectly such that overflow
     // is trigger then immediable disabled because of a resize event then continues this loop endlessly.
-    // 15 pixels is the amount of space the scrollbar takes up by default
+    // the scrollbar size varies between platforms. Windows is apparently around 17 pixels.
     if (difference > sensitivityThreshold) {
       setDimension({ width, height });
     }

--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -42,9 +42,9 @@ interface IDimension {
   height: number;
 }
 
-export const useContainerDimensions = <
-  T extends HTMLElement = HTMLDivElement
->(reduceSensitivity=true): [MutableRefObject<T | null>, IDimension] => {
+export const useContainerDimensions = <T extends HTMLElement = HTMLDivElement>(
+  reduceSensitivity = true
+): [MutableRefObject<T | null>, IDimension] => {
   const target = useRef<T | null>(null);
   const [dimension, setDimension] = useState<IDimension>({
     width: 0,

--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -1,11 +1,10 @@
-import React, { MutableRefObject, useEffect, useRef, useState } from "react";
+import React, { MutableRefObject, useRef, useState } from "react";
 import { Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import cx from "classnames";
 import { TruncatedText } from "../TruncatedText";
 import ScreenUtils from "src/utils/screen";
 import useResizeObserver from "@react-hook/resize-observer";
-import { CooldownTimer } from "../CooldownTimer";
 
 interface ICardProps {
   className?: string;

--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -43,7 +43,7 @@ interface IDimension {
 }
 
 export const useContainerDimensions = <T extends HTMLElement = HTMLDivElement>(
-  reduceSensitivity = true
+  sensitivityThreshold = 15
 ): [MutableRefObject<T | null>, IDimension] => {
   const target = useRef<T | null>(null);
   const [dimension, setDimension] = useState<IDimension>({
@@ -58,7 +58,7 @@ export const useContainerDimensions = <T extends HTMLElement = HTMLDivElement>(
     // the dimensions toggle back and forward when the window is adjusted perfectly such that overflow
     // is trigger then immediable disabled because of a resize event then continues this loop endlessly.
     // 15 pixels is the amount of space the scrollbar takes up by default
-    if (!reduceSensitivity || difference > 15) {
+    if (difference > sensitivityThreshold) {
       setDimension({ width, height });
     }
   });


### PR DESCRIPTION
This pull request updates the card resize code to only adjust the size when the container width changes by a significant enough margin. In this case, that margin is 15 pixels, which is the amount of horizontal space I see that the default scrollbar occupies. This value can increased if necessary.