### PR TITLE
Scene queue looping and scene looping

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -203,6 +203,7 @@ interface IScenePlayerProps {
   autoplay?: boolean;
   permitLoop?: boolean;
   initialTimestamp: number;
+  forceLoop?: boolean;
   sendSetTimestamp: (setTimestamp: (value: number) => void) => void;
   onComplete: () => void;
   onNext: () => void;
@@ -215,6 +216,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
   autoplay,
   permitLoop = true,
   initialTimestamp: _initialTimestamp,
+  forceLoop,
   sendSetTimestamp,
   onComplete,
   onNext,
@@ -264,11 +266,12 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
   const maxLoopDuration = interfaceConfig?.maximumLoopDuration ?? 0;
   const looping = useMemo(
     () =>
-      !!file?.duration &&
-      permitLoop &&
-      maxLoopDuration !== 0 &&
-      file.duration < maxLoopDuration,
-    [file, permitLoop, maxLoopDuration]
+      forceLoop ||
+      (!!file?.duration &&
+        permitLoop &&
+        maxLoopDuration !== 0 &&
+        file.duration < maxLoopDuration),
+    [file, permitLoop, maxLoopDuration, forceLoop]
   );
 
   const getPlayer = useCallback(() => {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/QueueViewer.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/QueueViewer.tsx
@@ -8,6 +8,7 @@ import {
   faChevronDown,
   faChevronUp,
   faRandom,
+  faRepeat,
   faStepBackward,
   faStepForward,
 } from "@fortawesome/free-solid-svg-icons";
@@ -20,6 +21,10 @@ export interface IPlaylistViewer {
   start?: number;
   continue?: boolean;
   hasMoreScenes: boolean;
+  loopQueue: boolean;
+  loopScene: boolean;
+  setLoopQueue: (v: boolean) => void;
+  setLoopScene: (v: boolean) => void;
   setContinue: (v: boolean) => void;
   onSceneClicked: (id: string) => void;
   onNext: () => void;
@@ -35,6 +40,10 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
   start = 0,
   continue: continuePlaylist = false,
   hasMoreScenes,
+  loopQueue,
+  loopScene,
+  setLoopQueue,
+  setLoopScene,
   setContinue,
   onNext,
   onPrevious,
@@ -46,8 +55,6 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
   const intl = useIntl();
   const [lessLoading, setLessLoading] = useState(false);
   const [moreLoading, setMoreLoading] = useState(false);
-
-  const currentIndex = scenes.findIndex((s) => s.id === currentID);
 
   useEffect(() => {
     setLessLoading(false);
@@ -74,6 +81,19 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
   function moreClicked() {
     setMoreLoading(true);
     onMoreScenes();
+  }
+
+  function handleLoopClick() {
+    if (loopQueue) {
+      setLoopQueue(false);
+      setLoopScene(true);
+    } else if (loopScene) {
+      setLoopQueue(false);
+      setLoopScene(false);
+    } else {
+      setLoopQueue(true);
+      setLoopScene(false);
+    }
   }
 
   function renderPlaylistEntry(scene: QueuedScene) {
@@ -111,7 +131,6 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
       </li>
     );
   }
-
   return (
     <div id="queue-viewer">
       <div className="queue-controls">
@@ -124,33 +143,39 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
               setContinue(!continuePlaylist);
             }}
           />
-        </div>
-        <div>
-          {currentIndex > 0 || start > 1 ? (
-            <Button
-              className="minimal"
-              variant="secondary"
-              onClick={() => onPrevious()}
-            >
-              <Icon icon={faStepBackward} />
-            </Button>
-          ) : (
-            ""
-          )}
-          {currentIndex < scenes.length - 1 || hasMoreScenes ? (
-            <Button
-              className="minimal"
-              variant="secondary"
-              onClick={() => onNext()}
-            >
-              <Icon icon={faStepForward} />
-            </Button>
-          ) : (
-            ""
-          )}
           <Button
             className="minimal"
             variant="secondary"
+            disabled={!continuePlaylist}
+            active={loopScene || loopQueue}
+            onClick={() => handleLoopClick()}
+          >
+            <Icon icon={faRepeat} />
+            {loopScene && 1}
+          </Button>
+        </div>
+        <div>
+          <Button
+            className="minimal"
+            variant="secondary"
+            disabled={scenes.length <= 1}
+            onClick={() => onPrevious()}
+          >
+            <Icon icon={faStepBackward} />
+          </Button>
+
+          <Button
+            className="minimal"
+            variant="secondary"
+            disabled={scenes.length <= 1}
+            onClick={() => onNext()}
+          >
+            <Icon icon={faStepForward} />
+          </Button>
+          <Button
+            className="minimal"
+            variant="secondary"
+            disabled={scenes.length <= 1}
             onClick={() => onRandom()}
           >
             <Icon icon={faRandom} />

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -628,6 +628,10 @@ input[type="range"].blue-slider {
     position: sticky;
     top: 0;
     z-index: 100;
+
+    .form-check {
+      display: inline-block;
+    }
   }
 
   .queue-scene-details {


### PR DESCRIPTION
I thought this might be useful for PMV enjoyers and anyone who makes use of playlists. 

Allows manual naviagtion of the scene queue from the first scene on the first page to the last scene on the last page and vice versa.

Adds a new button to the scene controls to control the autoplay behaviour. In the default state the queue behaves as it does now and stops at the end of the queue.
![1](https://github.com/stashapp/stash/assets/128322708/d5b7e316-055c-4b89-9c65-7a53514caf0d)

One click (`loop queue`) will allow the queue to loop automatically to the start when the last scene in the queue ends. Resolves #2913.
![2](https://github.com/stashapp/stash/assets/128322708/7ac62265-fa53-4025-97e2-0951e6744642)

Another click (`loop scene`) will force the current scene to loop repeatedly irrespective of the `Maximum loop duration` setting. Resolves #3302.
![3](https://github.com/stashapp/stash/assets/128322708/33e8bfc5-8ee9-4334-9b96-48865d48eea2)

Another final click returns to the default state.

When there is one scene in the queue the controls are now disabled instead of not rendered and both `loop scene` and `loop queue` settings will cause the scene to loop repeatedly. 
![4](https://github.com/stashapp/stash/assets/128322708/896486f6-2132-4cc2-ad08-9d3be1033938)


