### PR TITLE
Fix scene marker query

### DIFF
--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -301,6 +301,7 @@ func (qb *SceneMarkerStore) makeQuery(ctx context.Context, sceneMarkerFilter *mo
 	distinctIDs(&query, sceneMarkerTable)
 
 	if q := findFilter.Q; q != nil && *q != "" {
+		query.join(sceneTable, "", "scenes.id = scene_markers.scene_id")
 		query.join(tagTable, "", "scene_markers.primary_tag_id = tags.id")
 		searchColumns := []string{"scene_markers.title", "scenes.title", "tags.name"}
 		query.parseQueryString(searchColumns, *q)

--- a/pkg/sqlite/scene_marker_test.go
+++ b/pkg/sqlite/scene_marker_test.go
@@ -74,6 +74,27 @@ func TestMarkerCountByTagID(t *testing.T) {
 	})
 }
 
+func TestMarkerQueryQ(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		q := getSceneTitle(sceneIdxWithMarkers)
+		m, _, err := db.SceneMarker.Query(ctx, nil, &models.FindFilterType{
+			Q: &q,
+		})
+
+		if err != nil {
+			t.Errorf("Error querying scene markers: %s", err.Error())
+		}
+
+		if !assert.Greater(t, len(m), 0) {
+			return nil
+		}
+
+		assert.Equal(t, sceneIDs[sceneIdxWithMarkers], m[0].SceneID)
+
+		return nil
+	})
+}
+
 func TestMarkerQuerySortBySceneUpdated(t *testing.T) {
 	withTxn(func(ctx context.Context) error {
 		sort := "scenes_updated_at"


### PR DESCRIPTION
Fixed bug introduced by #4861 that caused an SQL error when querying scene markers with the `q` query string populated. Restores the missing `scenes` join.

Fixes #5013