### PR TITLE
Metadata Providers -> Scraper list improvements

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -25,20 +25,35 @@ import {
 } from "./ScraperPackageManager";
 import { ExternalLink } from "../Shared/ExternalLink";
 import { ClearableInput } from "../Shared/ClearableInput";
+import { Counter } from "../Shared/Counter";
 
 const ScraperTable: React.FC<
   PropsWithChildren<{
     entityType: string;
+    count?: number;
   }>
-> = ({ entityType, children }) => {
+> = ({ entityType, count, children }) => {
   const intl = useIntl();
-  const title = intl.formatMessage(
-    { id: "config.scraping.entity_scrapers" },
-    { entityType: intl.formatMessage({ id: entityType }) }
-  );
+
+  const titleEl = useMemo(() => {
+    const title = intl.formatMessage(
+      { id: "config.scraping.entity_scrapers" },
+      { entityType: intl.formatMessage({ id: entityType }) }
+    );
+
+    if (count) {
+      return (
+        <span>
+          {title} <Counter count={count} />
+        </span>
+      );
+    }
+
+    return title;
+  }, [count, entityType, intl]);
 
   return (
-    <CollapseButton text={title}>
+    <CollapseButton text={titleEl}>
       <table className="scraper-table">
         <thead>
           <tr>
@@ -239,53 +254,73 @@ const ScrapersSection: React.FC = () => {
       </div>
 
       <div className="content">
-        <ScraperTable entityType="scene">
-          {filteredScrapers.scenes?.map((scraper) => (
-            <ScraperTableRow
-              key={scraper.id}
-              name={scraper.name}
-              entityType="scene"
-              supportedScrapes={scraper.scene?.supported_scrapes ?? []}
-              urls={scraper.scene?.urls ?? []}
-            />
-          ))}
-        </ScraperTable>
+        {!!filteredScrapers.scenes?.length && (
+          <ScraperTable
+            entityType="scene"
+            count={filteredScrapers.scenes?.length}
+          >
+            {filteredScrapers.scenes?.map((scraper) => (
+              <ScraperTableRow
+                key={scraper.id}
+                name={scraper.name}
+                entityType="scene"
+                supportedScrapes={scraper.scene?.supported_scrapes ?? []}
+                urls={scraper.scene?.urls ?? []}
+              />
+            ))}
+          </ScraperTable>
+        )}
 
-        <ScraperTable entityType="gallery">
-          {filteredScrapers.galleries?.map((scraper) => (
-            <ScraperTableRow
-              key={scraper.id}
-              name={scraper.name}
-              entityType="gallery"
-              supportedScrapes={scraper.gallery?.supported_scrapes ?? []}
-              urls={scraper.gallery?.urls ?? []}
-            />
-          ))}
-        </ScraperTable>
+        {!!filteredScrapers.galleries?.length && (
+          <ScraperTable
+            entityType="gallery"
+            count={filteredScrapers.galleries?.length}
+          >
+            {filteredScrapers.galleries?.map((scraper) => (
+              <ScraperTableRow
+                key={scraper.id}
+                name={scraper.name}
+                entityType="gallery"
+                supportedScrapes={scraper.gallery?.supported_scrapes ?? []}
+                urls={scraper.gallery?.urls ?? []}
+              />
+            ))}
+          </ScraperTable>
+        )}
 
-        <ScraperTable entityType="performer">
-          {filteredScrapers.performers?.map((scraper) => (
-            <ScraperTableRow
-              key={scraper.id}
-              name={scraper.name}
-              entityType="performer"
-              supportedScrapes={scraper.performer?.supported_scrapes ?? []}
-              urls={scraper.performer?.urls ?? []}
-            />
-          ))}
-        </ScraperTable>
+        {!!filteredScrapers.performers?.length && (
+          <ScraperTable
+            entityType="performer"
+            count={filteredScrapers.performers?.length}
+          >
+            {filteredScrapers.performers?.map((scraper) => (
+              <ScraperTableRow
+                key={scraper.id}
+                name={scraper.name}
+                entityType="performer"
+                supportedScrapes={scraper.performer?.supported_scrapes ?? []}
+                urls={scraper.performer?.urls ?? []}
+              />
+            ))}
+          </ScraperTable>
+        )}
 
-        <ScraperTable entityType="group">
-          {filteredScrapers.groups?.map((scraper) => (
-            <ScraperTableRow
-              key={scraper.id}
-              name={scraper.name}
-              entityType="group"
-              supportedScrapes={scraper.group?.supported_scrapes ?? []}
-              urls={scraper.group?.urls ?? []}
-            />
-          ))}
-        </ScraperTable>
+        {!!filteredScrapers.groups?.length && (
+          <ScraperTable
+            entityType="group"
+            count={filteredScrapers.groups?.length}
+          >
+            {filteredScrapers.groups?.map((scraper) => (
+              <ScraperTableRow
+                key={scraper.id}
+                name={scraper.name}
+                entityType="group"
+                supportedScrapes={scraper.group?.supported_scrapes ?? []}
+                urls={scraper.group?.urls ?? []}
+              />
+            ))}
+          </ScraperTable>
+        )}
       </div>
     </SettingSection>
   );

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -110,9 +110,6 @@ interface IURLList {
 }
 
 const URLList: React.FC<IURLList> = ({ urls }) => {
-  const maxCollapsedItems = 5;
-  const [expanded, setExpanded] = useState<boolean>(false);
-
   const items = useMemo(() => {
     function linkSite(url: string) {
       const u = new URL(url);
@@ -130,22 +127,8 @@ const URLList: React.FC<IURLList> = ({ urls }) => {
       );
     });
 
-    if (ret.length > maxCollapsedItems) {
-      if (!expanded) {
-        ret.length = maxCollapsedItems;
-      }
-
-      ret.push(
-        <li>
-          <Button onClick={() => setExpanded(!expanded)} variant="link">
-            {expanded ? "less" : "more"}
-          </Button>
-        </li>
-      );
-    }
-
     return ret;
-  }, [urls, expanded]);
+  }, [urls]);
 
   return <ul>{items}</ul>;
 };

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -116,16 +116,19 @@ const URLList: React.FC<IURLList> = ({ urls }) => {
       return `${u.protocol}//${u.host}`;
     }
 
-    const ret = urls.map((u) => {
-      const sanitised = TextUtils.sanitiseURL(u);
-      const siteURL = linkSite(sanitised!);
+    const ret = urls
+      .slice()
+      .sort()
+      .map((u) => {
+        const sanitised = TextUtils.sanitiseURL(u);
+        const siteURL = linkSite(sanitised!);
 
-      return (
-        <li key={u}>
-          <ExternalLink href={siteURL}>{sanitised}</ExternalLink>
-        </li>
-      );
-    });
+        return (
+          <li key={u}>
+            <ExternalLink href={siteURL}>{sanitised}</ExternalLink>
+          </li>
+        );
+      });
 
     return ret;
   }, [urls]);

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -153,8 +153,9 @@ const ScraperTableRow: React.FC<{
   );
 };
 
-export const SettingsScrapingPanel: React.FC = () => {
+const ScrapersSection: React.FC = () => {
   const Toast = useToast();
+
   const { data: performerScrapers, loading: loadingPerformers } =
     useListPerformerScrapers();
   const { data: sceneScrapers, loading: loadingScenes } =
@@ -164,9 +165,6 @@ export const SettingsScrapingPanel: React.FC = () => {
   const { data: groupScrapers, loading: loadingGroups } =
     useListGroupScrapers();
 
-  const { general, scraping, loading, error, saveGeneral, saveScraping } =
-    useSettings();
-
   async function onReloadScrapers() {
     try {
       await mutateReloadScrapers();
@@ -175,15 +173,85 @@ export const SettingsScrapingPanel: React.FC = () => {
     }
   }
 
+  if (loadingScenes || loadingGalleries || loadingPerformers || loadingGroups)
+    return (
+      <SettingSection headingID="config.scraping.scrapers">
+        <LoadingIndicator />
+      </SettingSection>
+    );
+
+  return (
+    <SettingSection headingID="config.scraping.scrapers">
+      <div className="content">
+        <Button onClick={() => onReloadScrapers()}>
+          <span className="fa-icon">
+            <Icon icon={faSyncAlt} />
+          </span>
+          <span>
+            <FormattedMessage id="actions.reload_scrapers" />
+          </span>
+        </Button>
+      </div>
+
+      <div className="content">
+        <ScraperTable entityType="scene">
+          {sceneScrapers?.listScrapers.map((scraper) => (
+            <ScraperTableRow
+              key={scraper.id}
+              name={scraper.name}
+              entityType="scene"
+              supportedScrapes={scraper.scene?.supported_scrapes ?? []}
+              urls={scraper.scene?.urls ?? []}
+            />
+          ))}
+        </ScraperTable>
+
+        <ScraperTable entityType="gallery">
+          {galleryScrapers?.listScrapers.map((scraper) => (
+            <ScraperTableRow
+              key={scraper.id}
+              name={scraper.name}
+              entityType="gallery"
+              supportedScrapes={scraper.gallery?.supported_scrapes ?? []}
+              urls={scraper.gallery?.urls ?? []}
+            />
+          ))}
+        </ScraperTable>
+
+        <ScraperTable entityType="performer">
+          {performerScrapers?.listScrapers.map((scraper) => (
+            <ScraperTableRow
+              key={scraper.id}
+              name={scraper.name}
+              entityType="performer"
+              supportedScrapes={scraper.performer?.supported_scrapes ?? []}
+              urls={scraper.performer?.urls ?? []}
+            />
+          ))}
+        </ScraperTable>
+
+        <ScraperTable entityType="group">
+          {groupScrapers?.listScrapers.map((scraper) => (
+            <ScraperTableRow
+              key={scraper.id}
+              name={scraper.name}
+              entityType="group"
+              supportedScrapes={scraper.group?.supported_scrapes ?? []}
+              urls={scraper.group?.urls ?? []}
+            />
+          ))}
+        </ScraperTable>
+      </div>
+    </SettingSection>
+  );
+};
+
+export const SettingsScrapingPanel: React.FC = () => {
+  const { general, scraping, loading, error, saveGeneral, saveScraping } =
+    useSettings();
+
   if (error) return <h1>{error.message}</h1>;
-  if (
-    loading ||
-    loadingScenes ||
-    loadingGalleries ||
-    loadingPerformers ||
-    loadingGroups
-  )
-    return <LoadingIndicator />;
+  if (loading) return <LoadingIndicator />;
 
   return (
     <>
@@ -229,68 +297,7 @@ export const SettingsScrapingPanel: React.FC = () => {
       <InstalledScraperPackages />
       <AvailableScraperPackages />
 
-      <SettingSection headingID="config.scraping.scrapers">
-        <div className="content">
-          <Button onClick={() => onReloadScrapers()}>
-            <span className="fa-icon">
-              <Icon icon={faSyncAlt} />
-            </span>
-            <span>
-              <FormattedMessage id="actions.reload_scrapers" />
-            </span>
-          </Button>
-        </div>
-
-        <div className="content">
-          <ScraperTable entityType="scene">
-            {sceneScrapers?.listScrapers.map((scraper) => (
-              <ScraperTableRow
-                key={scraper.id}
-                name={scraper.name}
-                entityType="scene"
-                supportedScrapes={scraper.scene?.supported_scrapes ?? []}
-                urls={scraper.scene?.urls ?? []}
-              />
-            ))}
-          </ScraperTable>
-
-          <ScraperTable entityType="gallery">
-            {galleryScrapers?.listScrapers.map((scraper) => (
-              <ScraperTableRow
-                key={scraper.id}
-                name={scraper.name}
-                entityType="gallery"
-                supportedScrapes={scraper.gallery?.supported_scrapes ?? []}
-                urls={scraper.gallery?.urls ?? []}
-              />
-            ))}
-          </ScraperTable>
-
-          <ScraperTable entityType="performer">
-            {performerScrapers?.listScrapers.map((scraper) => (
-              <ScraperTableRow
-                key={scraper.id}
-                name={scraper.name}
-                entityType="performer"
-                supportedScrapes={scraper.performer?.supported_scrapes ?? []}
-                urls={scraper.performer?.urls ?? []}
-              />
-            ))}
-          </ScraperTable>
-
-          <ScraperTable entityType="group">
-            {groupScrapers?.listScrapers.map((scraper) => (
-              <ScraperTableRow
-                key={scraper.id}
-                name={scraper.name}
-                entityType="group"
-                supportedScrapes={scraper.group?.supported_scrapes ?? []}
-                urls={scraper.group?.urls ?? []}
-              />
-            ))}
-          </ScraperTable>
-        </div>
-      </SettingSection>
+      <ScrapersSection />
     </>
   );
 };

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -256,6 +256,11 @@
   }
 }
 
+.scraper-toolbar {
+  display: flex;
+  justify-content: space-between;
+}
+
 .job-table.card {
   background-color: $card-bg;
   height: 10em;

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -228,6 +228,7 @@
 .scraper-table {
   display: block;
   margin-bottom: 16px;
+  max-height: 300px;
   overflow: auto;
   width: 100%;
 

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -248,6 +248,8 @@
 
   ul {
     margin-bottom: 0;
+    max-height: 100px;
+    overflow: auto;
     padding-left: 0;
   }
 

--- a/ui/v2.5/src/components/Shared/CollapseButton.tsx
+++ b/ui/v2.5/src/components/Shared/CollapseButton.tsx
@@ -7,7 +7,7 @@ import { Button, Collapse } from "react-bootstrap";
 import { Icon } from "./Icon";
 
 interface IProps {
-  text: string;
+  text: React.ReactNode;
 }
 
 export const CollapseButton: React.FC<React.PropsWithChildren<IProps>> = (


### PR DESCRIPTION
Refactors the scraper list in the Metadata Providers setting page and adds the following improvements:
- adds a filter text box which will filter the scrapers by name and URL
- shows a counter for each scraper type
- sets a maximum height for each table with a scrollbar
- replaces the URLs "more/less" link by showing all URLs, adding a maximum height and scrollbar

![image](https://github.com/stashapp/stash/assets/53250216/9e74b906-1a2c-43e1-8971-e85100164908)
