### PR TITLE
Scraper menu filter

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -1,14 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import {
-  Button,
-  Dropdown,
-  DropdownButton,
-  Form,
-  Col,
-  Row,
-  ButtonGroup,
-} from "react-bootstrap";
+import { Button, Dropdown, Form, Col, Row, ButtonGroup } from "react-bootstrap";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
@@ -49,6 +41,7 @@ import { Studio, StudioSelect } from "src/components/Studios/StudioSelect";
 import { Gallery, GallerySelect } from "src/components/Galleries/GallerySelect";
 import { Group } from "src/components/Groups/GroupSelect";
 import { useTagsEdit } from "src/hooks/tagsEdit";
+import { ScraperMenu } from "src/components/Shared/ScraperMenu";
 
 const SceneScrapeDialog = lazyComponent(() => import("./SceneScrapeDialog"));
 const SceneQueryModal = lazyComponent(() => import("./SceneQueryModal"));
@@ -468,47 +461,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     );
   };
 
-  function renderScraperMenu() {
-    const stashBoxes = stashConfig?.general.stashBoxes ?? [];
-
-    return (
-      <DropdownButton
-        className="d-inline-block"
-        id="scene-scrape"
-        title={intl.formatMessage({ id: "actions.scrape_with" })}
-      >
-        {stashBoxes.map((s, index) => (
-          <Dropdown.Item
-            key={s.endpoint}
-            onClick={() =>
-              onScrapeClicked({
-                stash_box_endpoint: s.endpoint,
-              })
-            }
-          >
-            {stashboxDisplayName(s.name, index)}
-          </Dropdown.Item>
-        ))}
-        {fragmentScrapers.map((s) => (
-          <Dropdown.Item
-            key={s.name}
-            onClick={() => onScrapeClicked({ scraper_id: s.id })}
-          >
-            {s.name}
-          </Dropdown.Item>
-        ))}
-        <Dropdown.Item onClick={() => onReloadScrapers()}>
-          <span className="fa-icon">
-            <Icon icon={faSyncAlt} />
-          </span>
-          <span>
-            <FormattedMessage id="actions.reload_scrapers" />
-          </span>
-        </Dropdown.Item>
-      </DropdownButton>
-    );
-  }
-
   function urlScrapable(scrapedUrl: string): boolean {
     return (Scrapers?.data?.listScrapers ?? []).some((s) =>
       (s?.scene?.urls ?? []).some((u) => scrapedUrl.includes(u))
@@ -801,7 +753,12 @@ export const SceneEditPanel: React.FC<IProps> = ({
           {!isNew && (
             <div className="ml-auto text-right d-flex">
               <ButtonGroup className="scraper-group">
-                {renderScraperMenu()}
+                <ScraperMenu
+                  stashBoxes={stashConfig?.general.stashBoxes ?? []}
+                  fragmentScrapers={fragmentScrapers}
+                  onScrapeClicked={onScrapeClicked}
+                  onReloadScrapers={onReloadScrapers}
+                />
                 {renderScrapeQueryMenu()}
               </ButtonGroup>
             </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Button, Dropdown, Form, Col, Row, ButtonGroup } from "react-bootstrap";
+import { Button, Form, Col, Row, ButtonGroup } from "react-bootstrap";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
@@ -20,9 +20,8 @@ import { getStashIDs } from "src/utils/stashIds";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { ConfigurationContext } from "src/hooks/Config";
-import { stashboxDisplayName } from "src/utils/stashbox";
 import { IGroupEntry, SceneGroupTable } from "./SceneGroupTable";
-import { faSearch, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import { lazyComponent } from "src/utils/lazyComponent";
@@ -387,51 +386,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
     );
   }
 
-  function renderScrapeQueryMenu() {
-    const stashBoxes = stashConfig?.general.stashBoxes ?? [];
-
-    if (stashBoxes.length === 0 && queryableScrapers.length === 0) return;
-
-    return (
-      <Dropdown title={intl.formatMessage({ id: "actions.scrape_query" })}>
-        <Dropdown.Toggle variant="secondary">
-          <Icon icon={faSearch} />
-        </Dropdown.Toggle>
-
-        <Dropdown.Menu>
-          {stashBoxes.map((s, index) => (
-            <Dropdown.Item
-              key={s.endpoint}
-              onClick={() =>
-                onScrapeQueryClicked({
-                  stash_box_endpoint: s.endpoint,
-                })
-              }
-            >
-              {stashboxDisplayName(s.name, index)}
-            </Dropdown.Item>
-          ))}
-          {queryableScrapers.map((s) => (
-            <Dropdown.Item
-              key={s.name}
-              onClick={() => onScrapeQueryClicked({ scraper_id: s.id })}
-            >
-              {s.name}
-            </Dropdown.Item>
-          ))}
-          <Dropdown.Item onClick={() => onReloadScrapers()}>
-            <span className="fa-icon">
-              <Icon icon={faSyncAlt} />
-            </span>
-            <span>
-              <FormattedMessage id="actions.reload_scrapers" />
-            </span>
-          </Dropdown.Item>
-        </Dropdown.Menu>
-      </Dropdown>
-    );
-  }
-
   function onSceneSelected(s: GQL.ScrapedSceneDataFragment) {
     if (!scraper) return;
 
@@ -754,12 +708,20 @@ export const SceneEditPanel: React.FC<IProps> = ({
             <div className="ml-auto text-right d-flex">
               <ButtonGroup className="scraper-group">
                 <ScraperMenu
+                  toggle={intl.formatMessage({ id: "actions.scrape_with" })}
                   stashBoxes={stashConfig?.general.stashBoxes ?? []}
-                  fragmentScrapers={fragmentScrapers}
-                  onScrapeClicked={onScrapeClicked}
+                  scrapers={fragmentScrapers}
+                  onScraperClicked={onScrapeClicked}
                   onReloadScrapers={onReloadScrapers}
                 />
-                {renderScrapeQueryMenu()}
+                <ScraperMenu
+                  variant="secondary"
+                  toggle={<Icon icon={faSearch} />}
+                  stashBoxes={stashConfig?.general.stashBoxes ?? []}
+                  scrapers={queryableScrapers}
+                  onScraperClicked={onScrapeQueryClicked}
+                  onReloadScrapers={onReloadScrapers}
+                />
               </ButtonGroup>
             </div>
           )}

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -9,7 +9,7 @@ import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 export const ScraperMenu: React.FC<{
   toggle: React.ReactNode;
   variant?: string;
-  stashBoxes: StashBox[];
+  stashBoxes?: StashBox[];
   scrapers: { id: string; name: string }[];
   onScraperClicked: (s: ScraperSourceInput) => void;
   onReloadScrapers: () => void;
@@ -28,7 +28,7 @@ export const ScraperMenu: React.FC<{
       <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
       <Dropdown.Menu>
-        {stashBoxes.map((s, index) => (
+        {stashBoxes?.map((s, index) => (
           <Dropdown.Item
             key={s.endpoint}
             onClick={() =>

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dropdown, DropdownButton } from "react-bootstrap";
+import { Dropdown } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "./Icon";
 import { stashboxDisplayName } from "src/utils/stashbox";
@@ -7,46 +7,56 @@ import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
 import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 
 export const ScraperMenu: React.FC<{
+  toggle: React.ReactNode;
+  variant?: string;
   stashBoxes: StashBox[];
-  fragmentScrapers: { id: string; name: string }[];
-  onScrapeClicked: (s: ScraperSourceInput) => void;
+  scrapers: { id: string; name: string }[];
+  onScraperClicked: (s: ScraperSourceInput) => void;
   onReloadScrapers: () => void;
-}> = ({ stashBoxes, fragmentScrapers, onScrapeClicked, onReloadScrapers }) => {
+}> = ({
+  toggle,
+  variant,
+  stashBoxes,
+  scrapers,
+  onScraperClicked,
+  onReloadScrapers,
+}) => {
   const intl = useIntl();
 
   return (
-    <DropdownButton
-      className="scraper-menu"
-      title={intl.formatMessage({ id: "actions.scrape_with" })}
-    >
-      {stashBoxes.map((s, index) => (
-        <Dropdown.Item
-          key={s.endpoint}
-          onClick={() =>
-            onScrapeClicked({
-              stash_box_endpoint: s.endpoint,
-            })
-          }
-        >
-          {stashboxDisplayName(s.name, index)}
+    <Dropdown title={intl.formatMessage({ id: "actions.scrape_query" })}>
+      <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        {stashBoxes.map((s, index) => (
+          <Dropdown.Item
+            key={s.endpoint}
+            onClick={() =>
+              onScraperClicked({
+                stash_box_endpoint: s.endpoint,
+              })
+            }
+          >
+            {stashboxDisplayName(s.name, index)}
+          </Dropdown.Item>
+        ))}
+        {scrapers.map((s) => (
+          <Dropdown.Item
+            key={s.name}
+            onClick={() => onScraperClicked({ scraper_id: s.id })}
+          >
+            {s.name}
+          </Dropdown.Item>
+        ))}
+        <Dropdown.Item onClick={() => onReloadScrapers()}>
+          <span className="fa-icon">
+            <Icon icon={faSyncAlt} />
+          </span>
+          <span>
+            <FormattedMessage id="actions.reload_scrapers" />
+          </span>
         </Dropdown.Item>
-      ))}
-      {fragmentScrapers.map((s) => (
-        <Dropdown.Item
-          key={s.name}
-          onClick={() => onScrapeClicked({ scraper_id: s.id })}
-        >
-          {s.name}
-        </Dropdown.Item>
-      ))}
-      <Dropdown.Item onClick={() => onReloadScrapers()}>
-        <span className="fa-icon">
-          <Icon icon={faSyncAlt} />
-        </span>
-        <span>
-          <FormattedMessage id="actions.reload_scrapers" />
-        </span>
-      </Dropdown.Item>
-    </DropdownButton>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -73,6 +73,11 @@ export const ScraperMenu: React.FC<{
             {stashboxDisplayName(s.name, index)}
           </Dropdown.Item>
         ))}
+
+        {filteredStashboxes.length > 0 && filteredScrapers.length > 0 && (
+          <Dropdown.Divider />
+        )}
+
         {filteredScrapers.map((s) => (
           <Dropdown.Item
             key={s.name}

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,10 +1,13 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { Dropdown } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "./Icon";
 import { stashboxDisplayName } from "src/utils/stashbox";
 import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
 import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+import { ClearableInput } from "./ClearableInput";
+
+const minFilteredScrapers = 5;
 
 export const ScraperMenu: React.FC<{
   toggle: React.ReactNode;
@@ -22,13 +25,43 @@ export const ScraperMenu: React.FC<{
   onReloadScrapers,
 }) => {
   const intl = useIntl();
+  const [filter, setFilter] = useState("");
+
+  const filteredStashboxes = useMemo(() => {
+    if (!stashBoxes) return [];
+    if (!filter) return stashBoxes;
+
+    return stashBoxes.filter((s) =>
+      s.name.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [stashBoxes, filter]);
+
+  const filteredScrapers = useMemo(() => {
+    if (!filter) return scrapers;
+
+    return scrapers.filter(
+      (s) =>
+        s.name.toLowerCase().includes(filter.toLowerCase()) ||
+        s.id.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [scrapers, filter]);
 
   return (
-    <Dropdown title={intl.formatMessage({ id: "actions.scrape_query" })}>
+    <Dropdown
+      className="scraper-menu"
+      title={intl.formatMessage({ id: "actions.scrape_query" })}
+    >
       <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
       <Dropdown.Menu>
-        {stashBoxes?.map((s, index) => (
+        {(stashBoxes?.length ?? 0) + scrapers.length > minFilteredScrapers && (
+          <ClearableInput
+            placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+            value={filter}
+            setValue={setFilter}
+          />
+        )}
+        {filteredStashboxes.map((s, index) => (
           <Dropdown.Item
             key={s.endpoint}
             onClick={() =>
@@ -40,7 +73,7 @@ export const ScraperMenu: React.FC<{
             {stashboxDisplayName(s.name, index)}
           </Dropdown.Item>
         ))}
-        {scrapers.map((s) => (
+        {filteredScrapers.map((s) => (
           <Dropdown.Item
             key={s.name}
             onClick={() => onScraperClicked({ scraper_id: s.id })}

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Dropdown, DropdownButton } from "react-bootstrap";
+import { FormattedMessage, useIntl } from "react-intl";
+import { Icon } from "./Icon";
+import { stashboxDisplayName } from "src/utils/stashbox";
+import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
+import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+
+export const ScraperMenu: React.FC<{
+  stashBoxes: StashBox[];
+  fragmentScrapers: { id: string; name: string }[];
+  onScrapeClicked: (s: ScraperSourceInput) => void;
+  onReloadScrapers: () => void;
+}> = ({ stashBoxes, fragmentScrapers, onScrapeClicked, onReloadScrapers }) => {
+  const intl = useIntl();
+
+  return (
+    <DropdownButton
+      className="scraper-menu"
+      title={intl.formatMessage({ id: "actions.scrape_with" })}
+    >
+      {stashBoxes.map((s, index) => (
+        <Dropdown.Item
+          key={s.endpoint}
+          onClick={() =>
+            onScrapeClicked({
+              stash_box_endpoint: s.endpoint,
+            })
+          }
+        >
+          {stashboxDisplayName(s.name, index)}
+        </Dropdown.Item>
+      ))}
+      {fragmentScrapers.map((s) => (
+        <Dropdown.Item
+          key={s.name}
+          onClick={() => onScrapeClicked({ scraper_id: s.id })}
+        >
+          {s.name}
+        </Dropdown.Item>
+      ))}
+      <Dropdown.Item onClick={() => onReloadScrapers()}>
+        <span className="fa-icon">
+          <Icon icon={faSyncAlt} />
+        </span>
+        <span>
+          <FormattedMessage id="actions.reload_scrapers" />
+        </span>
+      </Dropdown.Item>
+    </DropdownButton>
+  );
+};

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -596,3 +596,7 @@ button.btn.favorite-button {
 .external-links-button {
   display: inline-block;
 }
+
+.scraper-menu .dropdown-menu {
+  min-width: 250px;
+}

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -599,4 +599,9 @@ button.btn.favorite-button {
 
 .scraper-menu .dropdown-menu {
   min-width: 250px;
+
+  .dropdown-divider {
+    border-top-color: $textfield-bg;
+    margin: 0;
+  }
 }


### PR DESCRIPTION
Refactors scraper menu into a reusable component. Adds a filter text field to the scraper menu when there are more than 5 menu items. Also adds a subtle divider between stash box items and scrapers.

![image](https://github.com/stashapp/stash/assets/53250216/7fdd1ab7-cd12-4193-aa74-c58847389c64)
