### PR TITLE
Use the rescan option when rescanning files from menu

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -124,6 +124,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
 
     await mutateMetadataScan({
       paths: [path],
+      rescan: true,
     });
 
     Toast.success(

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -80,6 +80,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
 
     await mutateMetadataScan({
       paths: [objectPath(image)],
+      rescan: true,
     });
 
     Toast.success(

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -297,6 +297,7 @@ const ScenePage: React.FC<IProps> = ({
   async function onRescan() {
     await mutateMetadataScan({
       paths: [objectPath(scene)],
+      rescan: true,
     });
 
     Toast.success(


### PR DESCRIPTION
This means that files will be rescanned regardless of whether the file has changed when clicking on the `Rescan` menu item on the details pages.