### PR TITLE
Add birthdate to performer select and restyle

### DIFF
--- a/ui/v2.5/graphql/data/performer-slim.graphql
+++ b/ui/v2.5/graphql/data/performer-slim.graphql
@@ -39,4 +39,6 @@ fragment SelectPerformerData on Performer {
   disambiguation
   alias_list
   image_path
+  birthdate
+  death_date
 }

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -28,6 +28,8 @@ import { useCompare } from "src/hooks/state";
 import { Link } from "react-router-dom";
 import { sortByRelevance } from "src/utils/query";
 import { PatchComponent, PatchFunction } from "src/patch";
+import { TruncatedText } from "../Shared/TruncatedText";
+import TextUtils from "src/utils/text";
 
 export type SelectObject = {
   id: string;
@@ -37,7 +39,13 @@ export type SelectObject = {
 
 export type Performer = Pick<
   GQL.Performer,
-  "id" | "name" | "alias_list" | "disambiguation" | "image_path"
+  | "id"
+  | "name"
+  | "alias_list"
+  | "disambiguation"
+  | "image_path"
+  | "birthdate"
+  | "death_date"
 >;
 type Option = SelectOption<Performer>;
 
@@ -112,23 +120,49 @@ const _PerformerSelect: React.FC<
     thisOptionProps = {
       ...optionProps,
       children: (
-        <span className="react-select-image-option performer-select-option">
-          <Link
-            to={`/performers/${object.id}`}
-            target="_blank"
-            className="performer-select-image-link"
-          >
-            <img
-              className="performer-select-image"
-              src={object.image_path ?? ""}
-              loading="lazy"
-            />
-          </Link>
-          <span>{name}</span>
-          {object.disambiguation && (
-            <span className="performer-disambiguation">{` (${object.disambiguation})`}</span>
-          )}
-          {alias && <span className="alias">{` (${alias})`}</span>}
+        <span className="performer-select-option">
+          <span className="performer-select-row">
+            <Link
+              to={`/performers/${object.id}`}
+              target="_blank"
+              className="performer-select-image-link"
+            >
+              <img
+                className="performer-select-image"
+                src={object.image_path ?? ""}
+                loading="lazy"
+              />
+            </Link>
+            <span className="performer-select-details">
+              <TruncatedText
+                className="performer-select-name"
+                text={
+                  <span>
+                    {name}
+                    {alias && (
+                      <span className="performer-select-alias">{` (${alias})`}</span>
+                    )}
+                  </span>
+                }
+                lineCount={1}
+              />
+
+              {object.disambiguation && (
+                <span className="performer-select-disambiguation">
+                  {object.disambiguation}
+                </span>
+              )}
+
+              {object.birthdate && (
+                <span className="performer-select-birthdate">{`${
+                  object.birthdate
+                } (${TextUtils.age(
+                  object.birthdate,
+                  object.death_date
+                )})`}</span>
+              )}
+            </span>
+          </span>
         </span>
       ),
     };

--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -198,24 +198,46 @@
   }
 }
 
-.performer-select {
-  .performer-disambiguation {
-    white-space: pre;
-  }
+.performer-select-option {
+  .performer-select-row {
+    align-items: center;
+    display: flex;
+    width: 100%;
 
-  .performer-select-value .performer-disambiguation {
-    color: initial;
-  }
+    .performer-select-image {
+      margin-right: 0.4em;
+      max-height: 50px;
+      max-width: 50px;
+    }
 
-  .alias {
-    font-weight: bold;
-    white-space: pre;
-  }
+    .performer-select-details {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      max-height: 4.1rem;
+      overflow: hidden;
 
-  .performer-select-image {
-    margin-right: 0.5em;
-    max-height: 50px;
-    max-width: 50px;
+      .performer-select-name {
+        flex-shrink: 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+
+        .performer-select-alias {
+          font-size: 0.8rem;
+          font-weight: bold;
+        }
+      }
+
+      .performer-select-disambiguation,
+      .performer-select-birthdate {
+        color: $text-muted;
+        flex-shrink: 0;
+        font-size: 0.9rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Restyles the Performer select in a similar pattern to the Scene, Gallery and  Movie/Group selects.

As suggested in #5062, moves the disambiguation to a new line and adds the birthdate and calculated age to a third line.

Example in the scene editor:
![after1](https://github.com/user-attachments/assets/b53d5c7f-2869-4052-90a6-65fee16f1788)

Example In the tagger interface:
![after2](https://github.com/user-attachments/assets/9cc0c25e-9268-4b49-8601-36e78d24c56c)

Resolves #5062 