### PR TITLE
Refactor ItemList code and re-enable viewing sub-tag/studio content

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -4,7 +4,7 @@ import cloneDeep from "lodash-es/cloneDeep";
 import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { queryFindGalleries, useFindGalleries } from "src/core/StashService";
@@ -16,16 +16,13 @@ import { GalleryListTable } from "./GalleryListTable";
 import { GalleryCardGrid } from "./GalleryGridCard";
 import { View } from "../List/views";
 
-const GalleryItemList = makeItemList({
-  filterMode: GQL.FilterMode.Galleries,
-  useResult: useFindGalleries,
-  getItems(result: GQL.FindGalleriesQueryResult) {
-    return result?.data?.findGalleries?.galleries ?? [];
-  },
-  getCount(result: GQL.FindGalleriesQueryResult) {
-    return result?.data?.findGalleries?.count ?? 0;
-  },
-});
+function getItems(result: GQL.FindGalleriesQueryResult) {
+  return result?.data?.findGalleries?.galleries ?? [];
+}
+
+function getCount(result: GQL.FindGalleriesQueryResult) {
+  return result?.data?.findGalleries?.count ?? 0;
+}
 
 interface IGalleryList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -42,6 +39,8 @@ export const GalleryList: React.FC<IGalleryList> = ({
   const history = useHistory();
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
+
+  const filterMode = GQL.FilterMode.Galleries;
 
   const otherOperations = [
     {
@@ -185,17 +184,25 @@ export const GalleryList: React.FC<IGalleryList> = ({
   }
 
   return (
-    <GalleryItemList
-      zoomable
-      selectable
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindGalleries}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderEditDialog={renderEditDialog}
-      renderDeleteDialog={renderDeleteDialog}
-    />
+      selectable
+    >
+      <ItemList
+        zoomable
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderEditDialog={renderEditDialog}
+        renderDeleteDialog={renderDeleteDialog}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -28,14 +28,12 @@ interface IGalleryList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
-  showEffectiveFilter?: boolean;
 }
 
 export const GalleryList: React.FC<IGalleryList> = ({
   filterHook,
   view,
   alterQuery,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -204,7 +202,6 @@ export const GalleryList: React.FC<IGalleryList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -28,12 +28,14 @@ interface IGalleryList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
+  showEffectiveFilter?: boolean;
 }
 
 export const GalleryList: React.FC<IGalleryList> = ({
   filterHook,
   view,
   alterQuery,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -202,6 +204,7 @@ export const GalleryList: React.FC<IGalleryList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -11,23 +11,20 @@ import {
   useFindGroups,
   useGroupsDestroy,
 } from "src/core/StashService";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { DeleteEntityDialog } from "../Shared/DeleteEntityDialog";
 import { GroupCardGrid } from "./GroupCardGrid";
 import { EditGroupsDialog } from "./EditGroupsDialog";
 import { View } from "../List/views";
 
-const GroupItemList = makeItemList({
-  filterMode: GQL.FilterMode.Groups,
-  useResult: useFindGroups,
-  getItems(result: GQL.FindGroupsQueryResult) {
-    return result?.data?.findGroups?.groups ?? [];
-  },
-  getCount(result: GQL.FindGroupsQueryResult) {
-    return result?.data?.findGroups?.count ?? 0;
-  },
-});
+function getItems(result: GQL.FindGroupsQueryResult) {
+  return result?.data?.findGroups?.groups ?? [];
+}
+
+function getCount(result: GQL.FindGroupsQueryResult) {
+  return result?.data?.findGroups?.count ?? 0;
+}
 
 interface IGroupList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -44,6 +41,8 @@ export const GroupList: React.FC<IGroupList> = ({
   const history = useHistory();
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
+
+  const filterMode = GQL.FilterMode.Groups;
 
   const otherOperations = [
     {
@@ -174,16 +173,24 @@ export const GroupList: React.FC<IGroupList> = ({
   }
 
   return (
-    <GroupItemList
-      selectable
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindGroups}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderEditDialog={renderEditDialog}
-      renderDeleteDialog={renderDeleteDialog}
-    />
+      selectable
+    >
+      <ItemList
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderEditDialog={renderEditDialog}
+        renderDeleteDialog={renderDeleteDialog}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -30,14 +30,12 @@ interface IGroupList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
-  showEffectiveFilter?: boolean;
 }
 
 export const GroupList: React.FC<IGroupList> = ({
   filterHook,
   alterQuery,
   view,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -192,7 +190,6 @@ export const GroupList: React.FC<IGroupList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -30,12 +30,14 @@ interface IGroupList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
+  showEffectiveFilter?: boolean;
 }
 
 export const GroupList: React.FC<IGroupList> = ({
   filterHook,
   alterQuery,
   view,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -190,6 +192,7 @@ export const GroupList: React.FC<IGroupList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -11,11 +11,7 @@ import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import { queryFindImages, useFindImages } from "src/core/StashService";
-import {
-  makeItemList,
-  IItemListOperation,
-  showWhenSelected,
-} from "../List/ItemList";
+import { makeItemList, showWhenSelected } from "../List/ItemList";
 import { useLightbox } from "src/hooks/Lightbox/hooks";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
@@ -31,6 +27,7 @@ import TextUtils from "src/utils/text";
 import { ConfigurationContext } from "src/hooks/Config";
 import { ImageGridCard } from "./ImageGridCard";
 import { View } from "../List/views";
+import { IItemListOperation } from "../List/FilteredListToolbar";
 
 interface IImageWallProps {
   images: GQL.SlimImageDataFragment[];

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -269,7 +269,6 @@ interface IImageList {
   alterQuery?: boolean;
   extraOperations?: IItemListOperation<GQL.FindImagesQueryResult>[];
   chapters?: GQL.GalleryChapterDataFragment[];
-  showEffectiveFilter?: boolean;
 }
 
 export const ImageList: React.FC<IImageList> = ({
@@ -278,7 +277,6 @@ export const ImageList: React.FC<IImageList> = ({
   alterQuery,
   extraOperations,
   chapters = [],
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -433,7 +431,6 @@ export const ImageList: React.FC<IImageList> = ({
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
         renderMetadataByline={renderMetadataByline}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -269,6 +269,7 @@ interface IImageList {
   alterQuery?: boolean;
   extraOperations?: IItemListOperation<GQL.FindImagesQueryResult>[];
   chapters?: GQL.GalleryChapterDataFragment[];
+  showEffectiveFilter?: boolean;
 }
 
 export const ImageList: React.FC<IImageList> = ({
@@ -277,6 +278,7 @@ export const ImageList: React.FC<IImageList> = ({
   alterQuery,
   extraOperations,
   chapters = [],
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -431,6 +433,7 @@ export const ImageList: React.FC<IImageList> = ({
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
         renderMetadataByline={renderMetadataByline}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -11,7 +11,7 @@ import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import { queryFindImages, useFindImages } from "src/core/StashService";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { useLightbox } from "src/hooks/Lightbox/hooks";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
@@ -219,51 +219,49 @@ const ImageListImages: React.FC<IImageListImages> = ({
   return <></>;
 };
 
-const ImageItemList = makeItemList({
-  filterMode: GQL.FilterMode.Images,
-  useResult: useFindImages,
-  getItems(result: GQL.FindImagesQueryResult) {
-    return result?.data?.findImages?.images ?? [];
-  },
-  getCount(result: GQL.FindImagesQueryResult) {
-    return result?.data?.findImages?.count ?? 0;
-  },
-  renderMetadataByline(result: GQL.FindImagesQueryResult) {
-    const megapixels = result?.data?.findImages?.megapixels;
-    const size = result?.data?.findImages?.filesize;
-    const filesize = size ? TextUtils.fileSize(size) : undefined;
+function getItems(result: GQL.FindImagesQueryResult) {
+  return result?.data?.findImages?.images ?? [];
+}
 
-    if (!megapixels && !size) {
-      return;
-    }
+function getCount(result: GQL.FindImagesQueryResult) {
+  return result?.data?.findImages?.count ?? 0;
+}
 
-    const separator = megapixels && size ? " - " : "";
+function renderMetadataByline(result: GQL.FindImagesQueryResult) {
+  const megapixels = result?.data?.findImages?.megapixels;
+  const size = result?.data?.findImages?.filesize;
+  const filesize = size ? TextUtils.fileSize(size) : undefined;
 
-    return (
-      <span className="images-stats">
-        &nbsp;(
-        {megapixels ? (
-          <span className="images-megapixels">
-            <FormattedNumber value={megapixels} /> Megapixels
-          </span>
-        ) : undefined}
-        {separator}
-        {size && filesize ? (
-          <span className="images-size">
-            <FormattedNumber
-              value={filesize.size}
-              maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
-                filesize.unit
-              )}
-            />
-            {` ${TextUtils.formatFileSizeUnit(filesize.unit)}`}
-          </span>
-        ) : undefined}
-        )
-      </span>
-    );
-  },
-});
+  if (!megapixels && !size) {
+    return;
+  }
+
+  const separator = megapixels && size ? " - " : "";
+
+  return (
+    <span className="images-stats">
+      &nbsp;(
+      {megapixels ? (
+        <span className="images-megapixels">
+          <FormattedNumber value={megapixels} /> Megapixels
+        </span>
+      ) : undefined}
+      {separator}
+      {size && filesize ? (
+        <span className="images-size">
+          <FormattedNumber
+            value={filesize.size}
+            maximumFractionDigits={TextUtils.fileSizeFractionalDigits(
+              filesize.unit
+            )}
+          />
+          {` ${TextUtils.formatFileSizeUnit(filesize.unit)}`}
+        </span>
+      ) : undefined}
+      )
+    </span>
+  );
+}
 
 interface IImageList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -285,6 +283,8 @@ export const ImageList: React.FC<IImageList> = ({
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
   const [slideshowRunning, setSlideshowRunning] = useState<boolean>(false);
+
+  const filterMode = GQL.FilterMode.Images;
 
   const otherOperations = [
     ...(extraOperations ?? []),
@@ -412,17 +412,26 @@ export const ImageList: React.FC<IImageList> = ({
   }
 
   return (
-    <ImageItemList
-      zoomable
-      selectable
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindImages}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderEditDialog={renderEditDialog}
-      renderDeleteDialog={renderDeleteDialog}
-    />
+      selectable
+    >
+      <ItemList
+        zoomable
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderEditDialog={renderEditDialog}
+        renderDeleteDialog={renderDeleteDialog}
+        renderMetadataByline={renderMetadataByline}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/components/List/FilterProvider.tsx
+++ b/ui/v2.5/src/components/List/FilterProvider.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { isFunction } from "lodash-es";
+import { useFilterURL } from "./util";
+
+interface IFilterContextOptions {
+  filter: ListFilterModel;
+  setFilter: React.Dispatch<React.SetStateAction<ListFilterModel>>;
+}
+
+export interface IFilterContextState {
+  filter: ListFilterModel;
+  setFilter: React.Dispatch<React.SetStateAction<ListFilterModel>>;
+}
+
+export const FilterStateContext =
+  React.createContext<IFilterContextState | null>(null);
+
+export const FilterContext = (
+  props: IFilterContextOptions & {
+    children?:
+      | ((props: IFilterContextState) => React.ReactNode)
+      | React.ReactNode;
+  }
+) => {
+  const { filter, setFilter, children } = props;
+
+  const state = {
+    filter,
+    setFilter,
+  };
+
+  return (
+    <FilterStateContext.Provider value={state}>
+      {isFunction(children)
+        ? (children as (props: IFilterContextState) => React.ReactNode)(state)
+        : children}
+    </FilterStateContext.Provider>
+  );
+};
+
+export function useFilter() {
+  const context = React.useContext(FilterStateContext);
+
+  if (context === null) {
+    throw new Error("useFilter must be used within a FilterStateContext");
+  }
+
+  return context;
+}
+
+// This component is used to set the filter from the URL.
+// It replaces the setFilter function to set the URL instead.
+// It also loads the default filter if the URL is empty.
+export const SetFilterURL = (props: {
+  defaultFilter?: ListFilterModel;
+  setURL?: boolean;
+  children?:
+    | ((props: IFilterContextState) => React.ReactNode)
+    | React.ReactNode;
+}) => {
+  const { defaultFilter, setURL = true, children } = props;
+
+  const { filter, setFilter: setFilterOrig } = useFilter();
+
+  const { setFilter } = useFilterURL(filter, setFilterOrig, {
+    defaultFilter,
+    setURL,
+  });
+
+  return (
+    <FilterContext filter={filter} setFilter={setFilter}>
+      {children}
+    </FilterContext>
+  );
+};

--- a/ui/v2.5/src/components/List/FilteredListToolbar.tsx
+++ b/ui/v2.5/src/components/List/FilteredListToolbar.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { QueryResult } from "@apollo/client";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { ListFilter } from "./ListFilter";
+import { ListViewOptions } from "./ListViewOptions";
+import {
+  IListFilterOperation,
+  ListOperationButtons,
+} from "./ListOperationButtons";
+import { DisplayMode } from "src/models/list-filter/types";
+import { ButtonToolbar } from "react-bootstrap";
+import { View } from "./views";
+import { useListContext } from "./ListProvider";
+import { useFilter } from "./FilterProvider";
+
+export interface IItemListOperation<T extends QueryResult> {
+  text: string;
+  onClick: (
+    result: T,
+    filter: ListFilterModel,
+    selectedIds: Set<string>
+  ) => Promise<void>;
+  isDisplayed?: (
+    result: T,
+    filter: ListFilterModel,
+    selectedIds: Set<string>
+  ) => boolean;
+  postRefetch?: boolean;
+  icon?: IconDefinition;
+  buttonVariant?: string;
+}
+
+export const FilteredListToolbar: React.FC<{
+  showEditFilter: (editingCriterion?: string) => void;
+  view?: View;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  operations?: IListFilterOperation[];
+  zoomable?: boolean;
+}> = ({
+  showEditFilter,
+  view,
+  onEdit,
+  onDelete,
+  operations,
+  zoomable = false,
+}) => {
+  const { getSelected, onSelectAll, onSelectNone } = useListContext();
+  const { filter, setFilter } = useFilter();
+
+  const filterOptions = filter.options;
+
+  function onChangeDisplayMode(displayMode: DisplayMode) {
+    setFilter(filter.setDisplayMode(displayMode));
+  }
+
+  function onChangeZoom(newZoomIndex: number) {
+    setFilter(filter.setZoom(newZoomIndex));
+  }
+
+  return (
+    <ButtonToolbar className="justify-content-center">
+      <ListFilter
+        onFilterUpdate={setFilter}
+        filter={filter}
+        openFilterDialog={() => showEditFilter()}
+        view={view}
+      />
+      <ListOperationButtons
+        onSelectAll={onSelectAll}
+        onSelectNone={onSelectNone}
+        otherOperations={operations}
+        itemsSelected={getSelected().length > 0}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+      <ListViewOptions
+        displayMode={filter.displayMode}
+        displayModeOptions={filterOptions.displayModeOptions}
+        onSetDisplayMode={onChangeDisplayMode}
+        zoomIndex={zoomable ? filter.zoomIndex : undefined}
+        onSetZoom={zoomable ? onChangeZoom : undefined}
+      />
+    </ButtonToolbar>
+  );
+};

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -104,36 +104,37 @@ interface IItemListProps<T extends QueryResult, E extends IHasID> {
 }
 
 const FilteredListToolbar: React.FC<{
-  filter: ListFilterModel;
-  updateFilter: (filter: ListFilterModel) => void;
   showEditFilter: (editingCriterion?: string) => void;
   view?: View;
   onEdit?: () => void;
   onDelete?: () => void;
   operations?: IListFilterOperation[];
-  onChangeZoom?: (zoomIndex: number) => void;
+  zoomable?: boolean;
 }> = ({
-  filter,
-  updateFilter,
   showEditFilter,
   view,
   onEdit,
   onDelete,
   operations,
-  onChangeZoom,
+  zoomable = false,
 }) => {
   const { getSelected, onSelectAll, onSelectNone } = useListContext();
+  const { filter, setFilter } = useFilter();
 
   const filterOptions = filter.options;
 
   function onChangeDisplayMode(displayMode: DisplayMode) {
-    updateFilter(filter.setDisplayMode(displayMode));
+    setFilter(filter.setDisplayMode(displayMode));
+  }
+
+  function onChangeZoom(newZoomIndex: number) {
+    setFilter(filter.setZoom(newZoomIndex));
   }
 
   return (
     <ButtonToolbar className="justify-content-center">
       <ListFilter
-        onFilterUpdate={updateFilter}
+        onFilterUpdate={setFilter}
         filter={filter}
         openFilterDialog={() => showEditFilter()}
         view={view}
@@ -150,8 +151,8 @@ const FilteredListToolbar: React.FC<{
         displayMode={filter.displayMode}
         displayModeOptions={filterOptions.displayModeOptions}
         onSetDisplayMode={onChangeDisplayMode}
-        zoomIndex={onChangeZoom ? filter.zoomIndex : undefined}
-        onSetZoom={onChangeZoom}
+        zoomIndex={zoomable ? filter.zoomIndex : undefined}
+        onSetZoom={zoomable ? onChangeZoom : undefined}
       />
     </ButtonToolbar>
   );
@@ -342,10 +343,6 @@ export function makeItemList<T extends QueryResult, E extends IHasID>({
       }
     }, [addKeybinds, result, effectiveFilter, selectedIds]);
 
-    function onChangeZoom(newZoomIndex: number) {
-      updateFilter(filter.setZoom(newZoomIndex));
-    }
-
     async function onOperationClicked(o: IItemListOperation<T>) {
       await o.onClick(result, effectiveFilter, selectedIds);
       if (o.postRefetch) {
@@ -426,12 +423,10 @@ export function makeItemList<T extends QueryResult, E extends IHasID>({
     return (
       <div className="item-list-container">
         <FilteredListToolbar
-          filter={filter}
-          updateFilter={updateFilter}
           showEditFilter={showEditFilter}
           view={view}
           operations={operations}
-          onChangeZoom={zoomable ? onChangeZoom : undefined}
+          zoomable={zoomable}
           onEdit={renderEditDialog ? onEdit : undefined}
           onDelete={renderDeleteDialog ? onDelete : undefined}
         />

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -37,6 +37,7 @@ interface IItemListProps<T extends QueryResult, E extends IHasID> {
   view?: View;
   zoomable?: boolean;
   otherOperations?: IItemListOperation<T>[];
+  showEffectiveFilter?: boolean;
   renderContent: (
     result: T,
     filter: ListFilterModel,
@@ -68,6 +69,7 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
     view,
     zoomable,
     otherOperations,
+    showEffectiveFilter = false,
     renderContent,
     renderEditDialog,
     renderDeleteDialog,
@@ -114,14 +116,21 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
 
       showModal(
         <EditFilterDialog
-          filter={filter}
+          filter={!showEffectiveFilter ? filter : effectiveFilter}
           onApply={onApplyEditFilter}
           onCancel={() => closeModal()}
           editingCriterion={editingCriterion}
         />
       );
     },
-    [filter, updateFilter, showModal, closeModal]
+    [
+      filter,
+      showEffectiveFilter,
+      effectiveFilter,
+      updateFilter,
+      showModal,
+      closeModal,
+    ]
   );
 
   useListKeyboardShortcuts({
@@ -226,7 +235,9 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
         onDelete={renderDeleteDialog ? onDelete : undefined}
       />
       <FilterTags
-        criteria={filter.criteria}
+        criteria={
+          !showEffectiveFilter ? filter.criteria : effectiveFilter.criteria
+        }
         onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
         onRemoveCriterion={onRemoveCriterion}
         onRemoveAll={() => onClearAllCriteria()}

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -37,7 +37,6 @@ interface IItemListProps<T extends QueryResult, E extends IHasID> {
   view?: View;
   zoomable?: boolean;
   otherOperations?: IItemListOperation<T>[];
-  showEffectiveFilter?: boolean;
   renderContent: (
     result: T,
     filter: ListFilterModel,
@@ -69,7 +68,6 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
     view,
     zoomable,
     otherOperations,
-    showEffectiveFilter = false,
     renderContent,
     renderEditDialog,
     renderDeleteDialog,
@@ -116,21 +114,14 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
 
       showModal(
         <EditFilterDialog
-          filter={!showEffectiveFilter ? filter : effectiveFilter}
+          filter={filter}
           onApply={onApplyEditFilter}
           onCancel={() => closeModal()}
           editingCriterion={editingCriterion}
         />
       );
     },
-    [
-      filter,
-      showEffectiveFilter,
-      effectiveFilter,
-      updateFilter,
-      showModal,
-      closeModal,
-    ]
+    [filter, updateFilter, showModal, closeModal]
   );
 
   useListKeyboardShortcuts({
@@ -235,9 +226,7 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
         onDelete={renderDeleteDialog ? onDelete : undefined}
       />
       <FilterTags
-        criteria={
-          !showEffectiveFilter ? filter.criteria : effectiveFilter.criteria
-        }
+        criteria={filter.criteria}
         onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
         onRemoveCriterion={onRemoveCriterion}
         onRemoveAll={() => onClearAllCriteria()}

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -19,7 +19,6 @@ import {
 import { Icon } from "../Shared/Icon";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import useFocus from "src/utils/focus";
-import { ListFilterOptions } from "src/models/list-filter/filter-options";
 import { FormattedMessage, useIntl } from "react-intl";
 import { SavedFilterDropdown } from "./SavedFilterList";
 import {
@@ -36,7 +35,6 @@ import { View } from "./views";
 interface IListFilterProps {
   onFilterUpdate: (newFilter: ListFilterModel) => void;
   filter: ListFilterModel;
-  filterOptions: ListFilterOptions;
   view?: View;
   openFilterDialog: () => void;
 }
@@ -46,7 +44,6 @@ const PAGE_SIZE_OPTIONS = ["20", "40", "60", "120", "250", "500", "1000"];
 export const ListFilter: React.FC<IListFilterProps> = ({
   onFilterUpdate,
   filter,
-  filterOptions,
   openFilterDialog,
   view,
 }) => {
@@ -57,6 +54,8 @@ export const ListFilter: React.FC<IListFilterProps> = ({
   );
   const perPageSelect = useRef(null);
   const [perPageInput, perPageFocus] = useFocus();
+
+  const filterOptions = filter.options;
 
   const searchQueryUpdated = useCallback(
     (value: string) => {

--- a/ui/v2.5/src/components/List/ListOperationButtons.tsx
+++ b/ui/v2.5/src/components/List/ListOperationButtons.tsx
@@ -16,7 +16,7 @@ import {
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 
-interface IListFilterOperation {
+export interface IListFilterOperation {
   text: string;
   onClick: () => void;
   isDisplayed?: () => boolean;

--- a/ui/v2.5/src/components/List/ListProvider.tsx
+++ b/ui/v2.5/src/components/List/ListProvider.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from "react";
+import { IListSelect, useCachedQueryResult, useListSelect } from "./util";
+import { isFunction } from "lodash-es";
+import { IHasID } from "src/utils/data";
+import { useFilter } from "./FilterProvider";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { QueryResult } from "@apollo/client";
+
+interface IListContextOptions<T extends IHasID> {
+  selectable?: boolean;
+  items: T[];
+}
+
+export type IListContextState<T extends IHasID = IHasID> = IListSelect<T> & {
+  selectable: boolean;
+  items: T[];
+};
+
+export const ListStateContext = React.createContext<IListContextState | null>(
+  null
+);
+
+export const ListContext = <T extends IHasID = IHasID>(
+  props: IListContextOptions<T> & {
+    children?:
+      | ((props: IListContextState) => React.ReactNode)
+      | React.ReactNode;
+  }
+) => {
+  const { selectable = false, items, children } = props;
+
+  const {
+    selectedIds,
+    getSelected,
+    onSelectChange,
+    onSelectAll,
+    onSelectNone,
+  } = useListSelect(items);
+
+  const state: IListContextState<T> = {
+    selectable,
+    selectedIds,
+    getSelected,
+    onSelectChange,
+    onSelectAll,
+    onSelectNone,
+    items,
+  };
+
+  return (
+    <ListStateContext.Provider value={state}>
+      {isFunction(children)
+        ? (children as (props: IListContextState) => React.ReactNode)(state)
+        : children}
+    </ListStateContext.Provider>
+  );
+};
+
+export function useListContext<T extends IHasID = IHasID>() {
+  const context = React.useContext(ListStateContext);
+
+  if (context === null) {
+    throw new Error("useListContext must be used within a ListStateContext");
+  }
+
+  return context as IListContextState<T>;
+}
+
+interface IQueryResultContextOptions<
+  T extends QueryResult,
+  E extends IHasID = IHasID
+> {
+  filterHook?: (filter: ListFilterModel) => ListFilterModel;
+  useResult: (filter: ListFilterModel) => T;
+  getCount: (data: T) => number;
+  getItems: (data: T) => E[];
+}
+
+export interface IQueryResultContextState<
+  T extends QueryResult = QueryResult,
+  E extends IHasID = IHasID
+> {
+  effectiveFilter: ListFilterModel;
+  result: T;
+  cachedResult: T;
+  items: E[];
+}
+
+export const QueryResultStateContext =
+  React.createContext<IQueryResultContextState | null>(null);
+
+export const QueryResultContext = <
+  T extends QueryResult,
+  E extends IHasID = IHasID
+>(
+  props: IQueryResultContextOptions<T, E> & {
+    children?:
+      | ((props: IListContextState) => React.ReactNode)
+      | React.ReactNode;
+  }
+) => {
+  const { filterHook, useResult, getItems, children } = props;
+
+  const { filter } = useFilter();
+  const effectiveFilter = useMemo(() => {
+    if (filterHook) {
+      return filterHook(filter.clone());
+    }
+    return filter;
+  }, [filter, filterHook]);
+
+  const result = useResult(effectiveFilter);
+
+  // use cached query result for pagination and metadata rendering
+  const cachedResult = useCachedQueryResult(effectiveFilter, result);
+
+  const items = useMemo(() => getItems(result), [getItems, result]);
+
+  const state: IQueryResultContextState<T, E> = {
+    effectiveFilter,
+    result,
+    cachedResult,
+    items,
+  };
+
+  return (
+    <QueryResultStateContext.Provider value={state}>
+      {isFunction(children)
+        ? (children as (props: IQueryResultContextState) => React.ReactNode)(
+            state
+          )
+        : children}
+    </QueryResultStateContext.Provider>
+  );
+};
+
+export function useQueryResultContext<
+  T extends QueryResult,
+  E extends IHasID = IHasID
+>() {
+  const context = React.useContext(QueryResultStateContext);
+
+  if (context === null) {
+    throw new Error(
+      "useQueryResultContext must be used within a ListStateContext"
+    );
+  }
+
+  return context as IQueryResultContextState<T, E>;
+}

--- a/ui/v2.5/src/components/List/ListProvider.tsx
+++ b/ui/v2.5/src/components/List/ListProvider.tsx
@@ -84,6 +84,7 @@ export interface IQueryResultContextState<
   result: T;
   cachedResult: T;
   items: E[];
+  totalCount: number;
 }
 
 export const QueryResultStateContext =
@@ -95,11 +96,11 @@ export const QueryResultContext = <
 >(
   props: IQueryResultContextOptions<T, E> & {
     children?:
-      | ((props: IListContextState) => React.ReactNode)
+      | ((props: IQueryResultContextState<T, E>) => React.ReactNode)
       | React.ReactNode;
   }
 ) => {
-  const { filterHook, useResult, getItems, children } = props;
+  const { filterHook, useResult, getItems, getCount, children } = props;
 
   const { filter } = useFilter();
   const effectiveFilter = useMemo(() => {
@@ -115,12 +116,17 @@ export const QueryResultContext = <
   const cachedResult = useCachedQueryResult(effectiveFilter, result);
 
   const items = useMemo(() => getItems(result), [getItems, result]);
+  const totalCount = useMemo(
+    () => getCount(cachedResult),
+    [getCount, cachedResult]
+  );
 
   const state: IQueryResultContextState<T, E> = {
     effectiveFilter,
     result,
     cachedResult,
     items,
+    totalCount,
   };
 
   return (

--- a/ui/v2.5/src/components/List/PagedList.tsx
+++ b/ui/v2.5/src/components/List/PagedList.tsx
@@ -1,0 +1,98 @@
+import React, { PropsWithChildren, useMemo } from "react";
+import { QueryResult } from "@apollo/client";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { Pagination, PaginationIndex } from "./Pagination";
+import { LoadingIndicator } from "../Shared/LoadingIndicator";
+
+export const PagedList: React.FC<
+  PropsWithChildren<{
+    result: QueryResult;
+    cachedResult: QueryResult;
+    filter: ListFilterModel;
+    totalCount: number;
+    onChangePage: (page: number) => void;
+    metadataByline?: React.ReactNode;
+  }>
+> = ({
+  result,
+  cachedResult,
+  filter,
+  totalCount,
+  onChangePage,
+  metadataByline,
+  children,
+}) => {
+  const pages = Math.ceil(totalCount / filter.itemsPerPage);
+
+  const pagination = useMemo(() => {
+    return (
+      <Pagination
+        itemsPerPage={filter.itemsPerPage}
+        currentPage={filter.currentPage}
+        totalItems={totalCount}
+        metadataByline={metadataByline}
+        onChangePage={onChangePage}
+      />
+    );
+  }, [
+    filter.itemsPerPage,
+    filter.currentPage,
+    totalCount,
+    metadataByline,
+    onChangePage,
+  ]);
+
+  const paginationIndex = useMemo(() => {
+    if (cachedResult.loading) return;
+    return (
+      <PaginationIndex
+        itemsPerPage={filter.itemsPerPage}
+        currentPage={filter.currentPage}
+        totalItems={totalCount}
+        metadataByline={metadataByline}
+      />
+    );
+  }, [
+    cachedResult.loading,
+    filter.itemsPerPage,
+    filter.currentPage,
+    totalCount,
+    metadataByline,
+  ]);
+
+  const content = useMemo(() => {
+    if (result.loading) {
+      return <LoadingIndicator />;
+    }
+    if (result.error) {
+      return <h1>{result.error.message}</h1>;
+    }
+
+    return (
+      <>
+        {children}
+        {!!pages && (
+          <>
+            {paginationIndex}
+            {pagination}
+          </>
+        )}
+      </>
+    );
+  }, [
+    result.loading,
+    result.error,
+    pages,
+    children,
+    pagination,
+    paginationIndex,
+  ]);
+
+  return (
+    <>
+      {pagination}
+      {paginationIndex}
+      {content}
+    </>
+  );
+};

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -1,8 +1,68 @@
-import { useContext, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
+import { useHistory, useLocation } from "react-router-dom";
+import { isEqual, isFunction } from "lodash-es";
 import * as GQL from "src/core/generated-graphql";
+import { QueryResult } from "@apollo/client";
+import { IHasID } from "src/utils/data";
 import { ConfigurationContext } from "src/hooks/Config";
 import { View } from "./views";
+
+export function useFilterURL(
+  filter: ListFilterModel,
+  setFilter: React.Dispatch<React.SetStateAction<ListFilterModel>>,
+  options?: {
+    defaultFilter?: ListFilterModel;
+    setURL?: boolean;
+  }
+) {
+  const { defaultFilter, setURL = true } = options ?? {};
+
+  const history = useHistory();
+  const location = useLocation();
+
+  // when the filter changes, update the URL
+  const updateFilter = useCallback(
+    (
+      value: ListFilterModel | ((prevState: ListFilterModel) => ListFilterModel)
+    ) => {
+      const newFilter = isFunction(value) ? value(filter) : value;
+
+      if (setURL) {
+        const newParams = newFilter.makeQueryParameters();
+        history.replace({ ...history.location, search: newParams });
+      } else {
+        // set the filter without updating the URL
+        setFilter(newFilter);
+      }
+    },
+    [history, setURL, setFilter, filter]
+  );
+
+  // This hook runs on every page location change (ie navigation),
+  // and updates the filter accordingly.
+  useEffect(() => {
+    // re-init to load default filter on empty new query params
+    if (!location.search) {
+      if (defaultFilter) updateFilter(defaultFilter.clone());
+      return;
+    }
+
+    // the query has changed, update filter if necessary
+    setFilter((prevFilter) => {
+      let newFilter = prevFilter.empty();
+      newFilter.configureFromQueryString(location.search);
+      if (!isEqual(newFilter, prevFilter)) {
+        return newFilter;
+      } else {
+        return prevFilter;
+      }
+    });
+  }, [location.search, defaultFilter, setFilter, updateFilter]);
+
+  return { setFilter: updateFilter };
+}
 
 export function useDefaultFilter(mode: GQL.FilterMode, view?: View) {
   const emptyFilter = useMemo(() => new ListFilterModel(mode), [mode]);
@@ -29,4 +89,259 @@ export function useDefaultFilter(mode: GQL.FilterMode, view?: View) {
   const retFilter = loading ? undefined : defaultFilter ?? emptyFilter;
 
   return { defaultFilter: retFilter, loading };
+}
+
+export function useListKeyboardShortcuts(props: {
+  currentPage?: number;
+  onChangePage?: (page: number) => void;
+  showEditFilter?: () => void;
+  pages?: number;
+  onSelectAll?: () => void;
+  onSelectNone?: () => void;
+}) {
+  const {
+    currentPage,
+    onChangePage,
+    showEditFilter,
+    pages = 0,
+    onSelectAll,
+    onSelectNone,
+  } = props;
+
+  // set up hotkeys
+  useEffect(() => {
+    if (showEditFilter) {
+      Mousetrap.bind("f", (e) => {
+        showEditFilter();
+        // prevent default behavior of typing f in a text field
+        // otherwise the filter dialog closes, the query field is focused and
+        // f is typed.
+        e.preventDefault();
+      });
+
+      return () => {
+        Mousetrap.unbind("f");
+      };
+    }
+  }, [showEditFilter]);
+
+  useEffect(() => {
+    if (!currentPage || !changePage || !pages) return;
+
+    function changePage(page: number) {
+      if (!currentPage || !onChangePage || !pages) return;
+      if (page >= 1 && page <= pages) {
+        onChangePage(page);
+      }
+    }
+
+    Mousetrap.bind("right", () => {
+      changePage(currentPage + 1);
+    });
+    Mousetrap.bind("left", () => {
+      changePage(currentPage - 1);
+    });
+    Mousetrap.bind("shift+right", () => {
+      changePage(Math.min(pages, currentPage + 10));
+    });
+    Mousetrap.bind("shift+left", () => {
+      changePage(Math.max(1, currentPage - 10));
+    });
+    Mousetrap.bind("ctrl+end", () => {
+      changePage(pages);
+    });
+    Mousetrap.bind("ctrl+home", () => {
+      changePage(1);
+    });
+
+    return () => {
+      Mousetrap.unbind("right");
+      Mousetrap.unbind("left");
+      Mousetrap.unbind("shift+right");
+      Mousetrap.unbind("shift+left");
+      Mousetrap.unbind("ctrl+end");
+      Mousetrap.unbind("ctrl+home");
+    };
+  }, [currentPage, onChangePage, pages]);
+
+  useEffect(() => {
+    Mousetrap.bind("s a", () => onSelectAll?.());
+    Mousetrap.bind("s n", () => onSelectNone?.());
+
+    return () => {
+      Mousetrap.unbind("s a");
+      Mousetrap.unbind("s n");
+    };
+  }, [onSelectAll, onSelectNone]);
+}
+
+export function useListSelect<T extends { id: string }>(items: T[]) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [lastClickedId, setLastClickedId] = useState<string>();
+
+  function singleSelect(id: string, selected: boolean) {
+    setLastClickedId(id);
+
+    const newSelectedIds = new Set(selectedIds);
+    if (selected) {
+      newSelectedIds.add(id);
+    } else {
+      newSelectedIds.delete(id);
+    }
+
+    setSelectedIds(newSelectedIds);
+  }
+
+  function selectRange(startIndex: number, endIndex: number) {
+    let start = startIndex;
+    let end = endIndex;
+    if (start > end) {
+      const tmp = start;
+      start = end;
+      end = tmp;
+    }
+
+    const subset = items.slice(start, end + 1);
+    const newSelectedIds = new Set<string>();
+
+    subset.forEach((item) => {
+      newSelectedIds.add(item.id);
+    });
+
+    setSelectedIds(newSelectedIds);
+  }
+
+  function multiSelect(id: string) {
+    let startIndex = 0;
+    let thisIndex = -1;
+
+    if (lastClickedId) {
+      startIndex = items.findIndex((item) => {
+        return item.id === lastClickedId;
+      });
+    }
+
+    thisIndex = items.findIndex((item) => {
+      return item.id === id;
+    });
+
+    selectRange(startIndex, thisIndex);
+  }
+
+  function onSelectChange(id: string, selected: boolean, shiftKey: boolean) {
+    if (shiftKey) {
+      multiSelect(id);
+    } else {
+      singleSelect(id, selected);
+    }
+  }
+
+  function onSelectAll() {
+    const newSelectedIds = new Set<string>();
+    items.forEach((item) => {
+      newSelectedIds.add(item.id);
+    });
+
+    setSelectedIds(newSelectedIds);
+    setLastClickedId(undefined);
+  }
+
+  function onSelectNone() {
+    const newSelectedIds = new Set<string>();
+    setSelectedIds(newSelectedIds);
+    setLastClickedId(undefined);
+  }
+
+  const getSelected = useMemo(() => {
+    let cached: T[] | undefined;
+    return () => {
+      if (cached) {
+        return cached;
+      }
+
+      cached = items.filter((value) => selectedIds.has(value.id));
+      return cached;
+    };
+  }, [items, selectedIds]);
+
+  return {
+    selectedIds,
+    getSelected,
+    onSelectChange,
+    onSelectAll,
+    onSelectNone,
+  };
+}
+
+export type IListSelect<T extends IHasID> = ReturnType<typeof useListSelect<T>>;
+
+// returns true if the filter has changed in a way that impacts the total count
+function totalCountImpacted(
+  oldFilter: ListFilterModel,
+  newFilter: ListFilterModel
+) {
+  return (
+    oldFilter.criteria.length !== newFilter.criteria.length ||
+    oldFilter.criteria.some((c) => {
+      const newCriterion = newFilter.criteria.find(
+        (nc) => nc.getId() === c.getId()
+      );
+      return !newCriterion || !isEqual(c, newCriterion);
+    })
+  );
+}
+
+// this hook caches a query result and count, and only updates it when the filter changes
+// in a way that would impact the result count
+// it is used to prevent the result count/pagination from flickering when changing pages or sorting
+export function useCachedQueryResult<T extends QueryResult>(
+  filter: ListFilterModel,
+  result: T
+) {
+  const [cachedResult, setCachedResult] = useState(result);
+  const [lastFilter, setLastFilter] = useState(filter);
+
+  // if we are only changing the page or sort, don't update the result count
+  useEffect(() => {
+    if (!result.loading) {
+      setCachedResult(result);
+    } else {
+      if (totalCountImpacted(lastFilter, filter)) {
+        setCachedResult(result);
+      }
+    }
+
+    setLastFilter(filter);
+  }, [filter, result, lastFilter]);
+
+  return cachedResult;
+}
+
+export function useScrollToTopOnPageChange(currentPage: number) {
+  // scroll to the top of the page when the page changes
+  useEffect(() => {
+    // if the current page has a detail-header, then
+    // scroll up relative to that rather than 0, 0
+    const detailHeader = document.querySelector(".detail-header");
+    if (detailHeader) {
+      window.scrollTo(0, detailHeader.scrollHeight - 50);
+    } else {
+      window.scrollTo(0, 0);
+    }
+  }, [currentPage]);
+}
+
+// handle case where page is more than there are pages
+export function useEnsureValidPage(
+  filter: ListFilterModel,
+  totalCount: number,
+  setFilter: React.Dispatch<React.SetStateAction<ListFilterModel>>
+) {
+  useEffect(() => {
+    const totalPages = Math.ceil(totalCount / filter.itemsPerPage);
+
+    if (totalPages > 0 && filter.currentPage > totalPages) {
+      setFilter((prevFilter) => prevFilter.changePage(1));
+    }
+  }, [filter, totalCount, setFilter]);
 }

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -3,7 +3,6 @@ import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { useHistory, useLocation } from "react-router-dom";
 import { isEqual, isFunction } from "lodash-es";
-import * as GQL from "src/core/generated-graphql";
 import { QueryResult } from "@apollo/client";
 import { IHasID } from "src/utils/data";
 import { ConfigurationContext } from "src/hooks/Config";
@@ -64,8 +63,7 @@ export function useFilterURL(
   return { setFilter: updateFilter };
 }
 
-export function useDefaultFilter(mode: GQL.FilterMode, view?: View) {
-  const emptyFilter = useMemo(() => new ListFilterModel(mode), [mode]);
+export function useDefaultFilter(emptyFilter: ListFilterModel, view?: View) {
   const { configuration: config, loading } = useContext(ConfigurationContext);
 
   const defaultFilter = useMemo(() => {

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -9,7 +9,7 @@ import {
   useFindPerformers,
   usePerformersDestroy,
 } from "src/core/StashService";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { PerformerTagger } from "../Tagger/performers/PerformerTagger";
@@ -23,16 +23,13 @@ import TextUtils from "src/utils/text";
 import { PerformerCardGrid } from "./PerformerCardGrid";
 import { View } from "../List/views";
 
-const PerformerItemList = makeItemList({
-  filterMode: GQL.FilterMode.Performers,
-  useResult: useFindPerformers,
-  getItems(result: GQL.FindPerformersQueryResult) {
-    return result?.data?.findPerformers?.performers ?? [];
-  },
-  getCount(result: GQL.FindPerformersQueryResult) {
-    return result?.data?.findPerformers?.count ?? 0;
-  },
-});
+function getItems(result: GQL.FindPerformersQueryResult) {
+  return result?.data?.findPerformers?.performers ?? [];
+}
+
+function getCount(result: GQL.FindPerformersQueryResult) {
+  return result?.data?.findPerformers?.count ?? 0;
+}
 
 export const FormatHeight = (height?: number | null) => {
   const intl = useIntl();
@@ -174,6 +171,8 @@ export const PerformerList: React.FC<IPerformerList> = ({
   const history = useHistory();
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
+
+  const filterMode = GQL.FilterMode.Performers;
 
   const otherOperations = [
     {
@@ -319,16 +318,24 @@ export const PerformerList: React.FC<IPerformerList> = ({
   }
 
   return (
-    <PerformerItemList
-      selectable
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindPerformers}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderEditDialog={renderEditDialog}
-      renderDeleteDialog={renderDeleteDialog}
-    />
+      selectable
+    >
+      <ItemList
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderEditDialog={renderEditDialog}
+        renderDeleteDialog={renderDeleteDialog}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -159,7 +159,6 @@ interface IPerformerList {
   view?: View;
   alterQuery?: boolean;
   extraCriteria?: IPerformerCardExtraCriteria;
-  showEffectiveFilter?: boolean;
 }
 
 export const PerformerList: React.FC<IPerformerList> = ({
@@ -167,7 +166,6 @@ export const PerformerList: React.FC<IPerformerList> = ({
   view,
   alterQuery,
   extraCriteria,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -337,7 +335,6 @@ export const PerformerList: React.FC<IPerformerList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -159,6 +159,7 @@ interface IPerformerList {
   view?: View;
   alterQuery?: boolean;
   extraCriteria?: IPerformerCardExtraCriteria;
+  showEffectiveFilter?: boolean;
 }
 
 export const PerformerList: React.FC<IPerformerList> = ({
@@ -166,6 +167,7 @@ export const PerformerList: React.FC<IPerformerList> = ({
   view,
   alterQuery,
   extraCriteria,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -335,6 +337,7 @@ export const PerformerList: React.FC<IPerformerList> = ({
         renderContent={renderContent}
         renderEditDialog={renderEditDialog}
         renderDeleteDialog={renderDeleteDialog}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -75,7 +75,6 @@ interface ISceneList {
   defaultSort?: string;
   view?: View;
   alterQuery?: boolean;
-  showEffectiveFilter?: boolean;
 }
 
 export const SceneList: React.FC<ISceneList> = ({
@@ -83,7 +82,6 @@ export const SceneList: React.FC<ISceneList> = ({
   defaultSort,
   view,
   alterQuery,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -372,7 +370,6 @@ export const SceneList: React.FC<ISceneList> = ({
           renderEditDialog={renderEditDialog}
           renderDeleteDialog={renderDeleteDialog}
           renderMetadataByline={renderMetadataByline}
-          showEffectiveFilter={showEffectiveFilter}
         />
       </ItemListContext>
     </TaggerContext>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -75,6 +75,7 @@ interface ISceneList {
   defaultSort?: string;
   view?: View;
   alterQuery?: boolean;
+  showEffectiveFilter?: boolean;
 }
 
 export const SceneList: React.FC<ISceneList> = ({
@@ -82,6 +83,7 @@ export const SceneList: React.FC<ISceneList> = ({
   defaultSort,
   view,
   alterQuery,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -370,6 +372,7 @@ export const SceneList: React.FC<ISceneList> = ({
           renderEditDialog={renderEditDialog}
           renderDeleteDialog={renderDeleteDialog}
           renderMetadataByline={renderMetadataByline}
+          showEffectiveFilter={showEffectiveFilter}
         />
       </ItemListContext>
     </TaggerContext>

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -9,22 +9,19 @@ import {
   useFindSceneMarkers,
 } from "src/core/StashService";
 import NavUtils from "src/utils/navigation";
-import { makeItemList } from "../List/ItemList";
+import { ItemList, ItemListContext } from "../List/ItemList";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { MarkerWallPanel } from "../Wall/WallPanel";
 import { View } from "../List/views";
 
-const SceneMarkerItemList = makeItemList({
-  filterMode: GQL.FilterMode.SceneMarkers,
-  useResult: useFindSceneMarkers,
-  getItems(result: GQL.FindSceneMarkersQueryResult) {
-    return result?.data?.findSceneMarkers?.scene_markers ?? [];
-  },
-  getCount(result: GQL.FindSceneMarkersQueryResult) {
-    return result?.data?.findSceneMarkers?.count ?? 0;
-  },
-});
+function getItems(result: GQL.FindSceneMarkersQueryResult) {
+  return result?.data?.findSceneMarkers?.scene_markers ?? [];
+}
+
+function getCount(result: GQL.FindSceneMarkersQueryResult) {
+  return result?.data?.findSceneMarkers?.count ?? 0;
+}
 
 interface ISceneMarkerList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
@@ -39,6 +36,8 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
 }) => {
   const intl = useIntl();
   const history = useHistory();
+
+  const filterMode = GQL.FilterMode.SceneMarkers;
 
   const otherOperations = [
     {
@@ -97,14 +96,22 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
   }
 
   return (
-    <SceneMarkerItemList
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindSceneMarkers}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-    />
+    >
+      <ItemList
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+      />
+    </ItemListContext>
   );
 };
 

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -27,14 +27,12 @@ interface ISceneMarkerList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
-  showEffectiveFilter?: boolean;
 }
 
 export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
   filterHook,
   view,
   alterQuery,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -112,7 +110,6 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
         otherOperations={otherOperations}
         addKeybinds={addKeybinds}
         renderContent={renderContent}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -27,12 +27,14 @@ interface ISceneMarkerList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
+  showEffectiveFilter?: boolean;
 }
 
 export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
   filterHook,
   view,
   alterQuery,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -110,6 +112,7 @@ export const SceneMarkerList: React.FC<ISceneMarkerList> = ({
         otherOperations={otherOperations}
         addKeybinds={addKeybinds}
         renderContent={renderContent}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -14,10 +14,7 @@ import cx from "classnames";
 
 import { useToast } from "src/hooks/Toast";
 import { useDebounce } from "src/hooks/debounce";
-
-interface IHasID {
-  id: string;
-}
+import { IHasID } from "src/utils/data";
 
 export type Option<T> = { value: string; object: T };
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -1,4 +1,24 @@
 .LoadingIndicator {
+  // fade in animation - delay showing
+  animation: fadeInAnimation ease 200ms;
+  animation-delay: 200ms;
+  animation-fill-mode: forwards;
+  animation-iteration-count: 1;
+
+  opacity: 0;
+}
+
+@keyframes fadeInAnimation {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.LoadingIndicator {
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -6,7 +26,7 @@
   width: 100%;
 
   &:not(.card-based) {
-    height: 70vh;
+    padding-top: 2rem;
   }
 
   &-message {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Tab } from "react-bootstrap";
+import { Tabs, Tab, Form } from "react-bootstrap";
 import React, { useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -79,16 +79,18 @@ const StudioTabs: React.FC<{
   abbreviateCounter: boolean;
   showAllCounts?: boolean;
 }> = ({ tabKey, studio, abbreviateCounter, showAllCounts = false }) => {
+  const [showAllDetails, setShowAllDetails] = useState<boolean>(showAllCounts);
+
   const sceneCount =
-    (showAllCounts ? studio.scene_count_all : studio.scene_count) ?? 0;
+    (showAllDetails ? studio.scene_count_all : studio.scene_count) ?? 0;
   const galleryCount =
-    (showAllCounts ? studio.gallery_count_all : studio.gallery_count) ?? 0;
+    (showAllDetails ? studio.gallery_count_all : studio.gallery_count) ?? 0;
   const imageCount =
-    (showAllCounts ? studio.image_count_all : studio.image_count) ?? 0;
+    (showAllDetails ? studio.image_count_all : studio.image_count) ?? 0;
   const performerCount =
-    (showAllCounts ? studio.performer_count_all : studio.performer_count) ?? 0;
+    (showAllDetails ? studio.performer_count_all : studio.performer_count) ?? 0;
   const groupCount =
-    (showAllCounts ? studio.group_count_all : studio.group_count) ?? 0;
+    (showAllDetails ? studio.group_count_all : studio.group_count) ?? 0;
 
   const populatedDefaultTab = useMemo(() => {
     let ret: TabKey = "scenes";
@@ -123,6 +125,21 @@ const StudioTabs: React.FC<{
     baseURL: `/studios/${studio.id}`,
   });
 
+  const contentSwitch = useMemo(
+    () => (
+      <div className="item-list-header">
+        <Form.Check
+          id="showSubContent"
+          checked={showAllDetails}
+          onChange={() => setShowAllDetails(!showAllDetails)}
+          type="switch"
+          label={<FormattedMessage id="include_sub_studio_content" />}
+        />
+      </div>
+    ),
+    [showAllDetails]
+  );
+
   return (
     <Tabs
       id="studio-tabs"
@@ -141,7 +158,12 @@ const StudioTabs: React.FC<{
           />
         }
       >
-        <StudioScenesPanel active={tabKey === "scenes"} studio={studio} />
+        {contentSwitch}
+        <StudioScenesPanel
+          active={tabKey === "scenes"}
+          studio={studio}
+          showChildStudioContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="galleries"
@@ -153,7 +175,12 @@ const StudioTabs: React.FC<{
           />
         }
       >
-        <StudioGalleriesPanel active={tabKey === "galleries"} studio={studio} />
+        {contentSwitch}
+        <StudioGalleriesPanel
+          active={tabKey === "galleries"}
+          studio={studio}
+          showChildStudioContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="images"
@@ -165,7 +192,12 @@ const StudioTabs: React.FC<{
           />
         }
       >
-        <StudioImagesPanel active={tabKey === "images"} studio={studio} />
+        {contentSwitch}
+        <StudioImagesPanel
+          active={tabKey === "images"}
+          studio={studio}
+          showChildStudioContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="performers"
@@ -177,9 +209,11 @@ const StudioTabs: React.FC<{
           />
         }
       >
+        {contentSwitch}
         <StudioPerformersPanel
           active={tabKey === "performers"}
           studio={studio}
+          showChildStudioContent={showAllDetails}
         />
       </Tab>
       <Tab
@@ -192,7 +226,12 @@ const StudioTabs: React.FC<{
           />
         }
       >
-        <StudioGroupsPanel active={tabKey === "groups"} studio={studio} />
+        {contentSwitch}
+        <StudioGroupsPanel
+          active={tabKey === "groups"}
+          studio={studio}
+          showChildStudioContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="childstudios"

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioChildrenPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioChildrenPanel.tsx
@@ -5,16 +5,8 @@ import { ListFilterModel } from "src/models/list-filter/filter";
 import { StudioList } from "../StudioList";
 import { View } from "src/components/List/views";
 
-interface IStudioChildrenPanel {
-  active: boolean;
-  studio: GQL.StudioDataFragment;
-}
-
-export const StudioChildrenPanel: React.FC<IStudioChildrenPanel> = ({
-  active,
-  studio,
-}) => {
-  function filterHook(filter: ListFilterModel) {
+function useFilterHook(studio: GQL.StudioDataFragment) {
+  return (filter: ListFilterModel) => {
     const studioValue = { id: studio.id!, label: studio.name! };
     // if studio is already present, then we modify it, otherwise add
     let parentStudioCriterion = filter.criteria.find((c) => {
@@ -44,7 +36,19 @@ export const StudioChildrenPanel: React.FC<IStudioChildrenPanel> = ({
     }
 
     return filter;
-  }
+  };
+}
+
+interface IStudioChildrenPanel {
+  active: boolean;
+  studio: GQL.StudioDataFragment;
+}
+
+export const StudioChildrenPanel: React.FC<IStudioChildrenPanel> = ({
+  active,
+  studio,
+}) => {
+  const filterHook = useFilterHook(studio);
 
   return (
     <StudioList

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface IStudioGalleriesPanel {
   active: boolean;
   studio: GQL.StudioDataFragment;
+  showChildStudioContent?: boolean;
 }
 
 export const StudioGalleriesPanel: React.FC<IStudioGalleriesPanel> = ({
   active,
   studio,
+  showChildStudioContent,
 }) => {
-  const filterHook = useStudioFilterHook(studio);
+  const filterHook = useStudioFilterHook(studio, showChildStudioContent);
   return (
     <GalleryList
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioGalleries}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioGalleriesPanel.tsx
@@ -19,6 +19,8 @@ export const StudioGalleriesPanel: React.FC<IStudioGalleriesPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioGalleries}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioGroupsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioGroupsPanel.tsx
@@ -19,6 +19,8 @@ export const StudioGroupsPanel: React.FC<IStudioGroupsPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioGroups}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioGroupsPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioGroupsPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface IStudioGroupsPanel {
   active: boolean;
   studio: GQL.StudioDataFragment;
+  showChildStudioContent?: boolean;
 }
 
 export const StudioGroupsPanel: React.FC<IStudioGroupsPanel> = ({
   active,
   studio,
+  showChildStudioContent,
 }) => {
-  const filterHook = useStudioFilterHook(studio);
+  const filterHook = useStudioFilterHook(studio, showChildStudioContent);
   return (
     <GroupList
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioGroups}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface IStudioImagesPanel {
   active: boolean;
   studio: GQL.StudioDataFragment;
+  showChildStudioContent?: boolean;
 }
 
 export const StudioImagesPanel: React.FC<IStudioImagesPanel> = ({
   active,
   studio,
+  showChildStudioContent,
 }) => {
-  const filterHook = useStudioFilterHook(studio);
+  const filterHook = useStudioFilterHook(studio, showChildStudioContent);
   return (
     <ImageList
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioImages}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioImagesPanel.tsx
@@ -19,6 +19,8 @@ export const StudioImagesPanel: React.FC<IStudioImagesPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioImages}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
@@ -8,11 +8,13 @@ import { View } from "src/components/List/views";
 interface IStudioPerformersPanel {
   active: boolean;
   studio: GQL.StudioDataFragment;
+  showChildStudioContent?: boolean;
 }
 
 export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
   active,
   studio,
+  showChildStudioContent,
 }) => {
   const studioCriterion = new StudiosCriterion();
   studioCriterion.value = {
@@ -28,7 +30,7 @@ export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
     groups: [studioCriterion],
   };
 
-  const filterHook = useStudioFilterHook(studio);
+  const filterHook = useStudioFilterHook(studio, showChildStudioContent);
 
   return (
     <PerformerList
@@ -36,8 +38,6 @@ export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
       extraCriteria={extraCriteria}
       alterQuery={active}
       view={View.StudioPerformers}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioPerformersPanel.tsx
@@ -36,6 +36,8 @@ export const StudioPerformersPanel: React.FC<IStudioPerformersPanel> = ({
       extraCriteria={extraCriteria}
       alterQuery={active}
       view={View.StudioPerformers}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
@@ -19,6 +19,8 @@ export const StudioScenesPanel: React.FC<IStudioScenesPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioScenes}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface IStudioScenesPanel {
   active: boolean;
   studio: GQL.StudioDataFragment;
+  showChildStudioContent?: boolean;
 }
 
 export const StudioScenesPanel: React.FC<IStudioScenesPanel> = ({
   active,
   studio,
+  showChildStudioContent,
 }) => {
-  const filterHook = useStudioFilterHook(studio);
+  const filterHook = useStudioFilterHook(studio, showChildStudioContent);
   return (
     <SceneList
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioScenes}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -9,7 +9,7 @@ import {
   useFindStudios,
   useStudiosDestroy,
 } from "src/core/StashService";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { ExportDialog } from "../Shared/ExportDialog";
@@ -18,16 +18,13 @@ import { StudioTagger } from "../Tagger/studios/StudioTagger";
 import { StudioCardGrid } from "./StudioCardGrid";
 import { View } from "../List/views";
 
-const StudioItemList = makeItemList({
-  filterMode: GQL.FilterMode.Studios,
-  useResult: useFindStudios,
-  getItems(result: GQL.FindStudiosQueryResult) {
-    return result?.data?.findStudios?.studios ?? [];
-  },
-  getCount(result: GQL.FindStudiosQueryResult) {
-    return result?.data?.findStudios?.count ?? 0;
-  },
-});
+function getItems(result: GQL.FindStudiosQueryResult) {
+  return result?.data?.findStudios?.studios ?? [];
+}
+
+function getCount(result: GQL.FindStudiosQueryResult) {
+  return result?.data?.findStudios?.count ?? 0;
+}
 
 interface IStudioList {
   fromParent?: boolean;
@@ -46,6 +43,8 @@ export const StudioList: React.FC<IStudioList> = ({
   const history = useHistory();
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isExportAll, setIsExportAll] = useState(false);
+
+  const filterMode = GQL.FilterMode.Studios;
 
   const otherOperations = [
     {
@@ -177,15 +176,23 @@ export const StudioList: React.FC<IStudioList> = ({
   }
 
   return (
-    <StudioItemList
-      selectable
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindStudios}
+      getItems={getItems}
+      getCount={getCount}
+      alterQuery={alterQuery}
       filterHook={filterHook}
       view={view}
-      alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderDeleteDialog={renderDeleteDialog}
-    />
+      selectable
+    >
+      <ItemList
+        view={view}
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderDeleteDialog={renderDeleteDialog}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -31,6 +31,7 @@ interface IStudioList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
+  showEffectiveFilter?: boolean;
 }
 
 export const StudioList: React.FC<IStudioList> = ({
@@ -38,6 +39,7 @@ export const StudioList: React.FC<IStudioList> = ({
   filterHook,
   view,
   alterQuery,
+  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -192,6 +194,7 @@ export const StudioList: React.FC<IStudioList> = ({
         addKeybinds={addKeybinds}
         renderContent={renderContent}
         renderDeleteDialog={renderDeleteDialog}
+        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -31,7 +31,6 @@ interface IStudioList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   view?: View;
   alterQuery?: boolean;
-  showEffectiveFilter?: boolean;
 }
 
 export const StudioList: React.FC<IStudioList> = ({
@@ -39,7 +38,6 @@ export const StudioList: React.FC<IStudioList> = ({
   filterHook,
   view,
   alterQuery,
-  showEffectiveFilter,
 }) => {
   const intl = useIntl();
   const history = useHistory();
@@ -194,7 +192,6 @@ export const StudioList: React.FC<IStudioList> = ({
         addKeybinds={addKeybinds}
         renderContent={renderContent}
         renderDeleteDialog={renderDeleteDialog}
-        showEffectiveFilter={showEffectiveFilter}
       />
     </ItemListContext>
   );

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Tab, Dropdown } from "react-bootstrap";
+import { Tabs, Tab, Dropdown, Form } from "react-bootstrap";
 import React, { useEffect, useMemo, useState } from "react";
 import { useHistory, Redirect, RouteComponentProps } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -82,20 +82,22 @@ const TagTabs: React.FC<{
   abbreviateCounter: boolean;
   showAllCounts?: boolean;
 }> = ({ tabKey, tag, abbreviateCounter, showAllCounts = false }) => {
+  const [showAllDetails, setShowAllDetails] = useState<boolean>(showAllCounts);
+
   const sceneCount =
-    (showAllCounts ? tag.scene_count_all : tag.scene_count) ?? 0;
+    (showAllDetails ? tag.scene_count_all : tag.scene_count) ?? 0;
   const imageCount =
-    (showAllCounts ? tag.image_count_all : tag.image_count) ?? 0;
+    (showAllDetails ? tag.image_count_all : tag.image_count) ?? 0;
   const galleryCount =
-    (showAllCounts ? tag.gallery_count_all : tag.gallery_count) ?? 0;
+    (showAllDetails ? tag.gallery_count_all : tag.gallery_count) ?? 0;
   const groupCount =
-    (showAllCounts ? tag.group_count_all : tag.group_count) ?? 0;
+    (showAllDetails ? tag.group_count_all : tag.group_count) ?? 0;
   const sceneMarkerCount =
-    (showAllCounts ? tag.scene_marker_count_all : tag.scene_marker_count) ?? 0;
+    (showAllDetails ? tag.scene_marker_count_all : tag.scene_marker_count) ?? 0;
   const performerCount =
-    (showAllCounts ? tag.performer_count_all : tag.performer_count) ?? 0;
+    (showAllDetails ? tag.performer_count_all : tag.performer_count) ?? 0;
   const studioCount =
-    (showAllCounts ? tag.studio_count_all : tag.studio_count) ?? 0;
+    (showAllDetails ? tag.studio_count_all : tag.studio_count) ?? 0;
 
   const populatedDefaultTab = useMemo(() => {
     let ret: TabKey = "scenes";
@@ -133,6 +135,21 @@ const TagTabs: React.FC<{
     baseURL: `/tags/${tag.id}`,
   });
 
+  const contentSwitch = useMemo(
+    () => (
+      <div className="item-list-header">
+        <Form.Check
+          id="showSubContent"
+          checked={showAllDetails}
+          onChange={() => setShowAllDetails(!showAllDetails)}
+          type="switch"
+          label={<FormattedMessage id="include_sub_tag_content" />}
+        />
+      </div>
+    ),
+    [showAllDetails]
+  );
+
   return (
     <Tabs
       id="tag-tabs"
@@ -151,7 +168,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagScenesPanel active={tabKey === "scenes"} tag={tag} />
+        {contentSwitch}
+        <TagScenesPanel
+          active={tabKey === "scenes"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="images"
@@ -163,7 +185,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagImagesPanel active={tabKey === "images"} tag={tag} />
+        {contentSwitch}
+        <TagImagesPanel
+          active={tabKey === "images"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="galleries"
@@ -175,7 +202,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagGalleriesPanel active={tabKey === "galleries"} tag={tag} />
+        {contentSwitch}
+        <TagGalleriesPanel
+          active={tabKey === "galleries"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="groups"
@@ -187,7 +219,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagGroupsPanel active={tabKey === "groups"} tag={tag} />
+        {contentSwitch}
+        <TagGroupsPanel
+          active={tabKey === "groups"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="markers"
@@ -199,7 +236,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagMarkersPanel active={tabKey === "markers"} tag={tag} />
+        {contentSwitch}
+        <TagMarkersPanel
+          active={tabKey === "markers"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="performers"
@@ -211,7 +253,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagPerformersPanel active={tabKey === "performers"} tag={tag} />
+        {contentSwitch}
+        <TagPerformersPanel
+          active={tabKey === "performers"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
       <Tab
         eventKey="studios"
@@ -223,7 +270,12 @@ const TagTabs: React.FC<{
           />
         }
       >
-        <TagStudiosPanel active={tabKey === "studios"} tag={tag} />
+        {contentSwitch}
+        <TagStudiosPanel
+          active={tabKey === "studios"}
+          tag={tag}
+          showSubTagContent={showAllDetails}
+        />
       </Tab>
     </Tabs>
   );

--- a/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface ITagGalleriesPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
 }
 
 export const TagGalleriesPanel: React.FC<ITagGalleriesPanel> = ({
   active,
   tag,
+  showSubTagContent,
 }) => {
-  const filterHook = useTagFilterHook(tag);
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
   return (
     <GalleryList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagGalleries}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagGalleriesPanel.tsx
@@ -19,6 +19,8 @@ export const TagGalleriesPanel: React.FC<ITagGalleriesPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagGalleries}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagGroupsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagGroupsPanel.tsx
@@ -6,14 +6,8 @@ import { GroupList } from "src/components/Groups/GroupList";
 export const TagGroupsPanel: React.FC<{
   active: boolean;
   tag: GQL.TagDataFragment;
-}> = ({ active, tag }) => {
-  const filterHook = useTagFilterHook(tag);
-  return (
-    <GroupList
-      filterHook={filterHook}
-      alterQuery={active}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
-    />
-  );
+  showSubTagContent?: boolean;
+}> = ({ active, tag, showSubTagContent }) => {
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
+  return <GroupList filterHook={filterHook} alterQuery={active} />;
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagGroupsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagGroupsPanel.tsx
@@ -8,5 +8,12 @@ export const TagGroupsPanel: React.FC<{
   tag: GQL.TagDataFragment;
 }> = ({ active, tag }) => {
   const filterHook = useTagFilterHook(tag);
-  return <GroupList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <GroupList
+      filterHook={filterHook}
+      alterQuery={active}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
@@ -7,17 +7,20 @@ import { View } from "src/components/List/views";
 interface ITagImagesPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
 }
 
-export const TagImagesPanel: React.FC<ITagImagesPanel> = ({ active, tag }) => {
-  const filterHook = useTagFilterHook(tag);
+export const TagImagesPanel: React.FC<ITagImagesPanel> = ({
+  active,
+  tag,
+  showSubTagContent,
+}) => {
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
   return (
     <ImageList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagImages}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagImagesPanel.tsx
@@ -16,6 +16,8 @@ export const TagImagesPanel: React.FC<ITagImagesPanel> = ({ active, tag }) => {
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagImages}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
@@ -58,6 +58,8 @@ export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagMarkers}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMarkersPanel.tsx
@@ -8,16 +8,8 @@ import {
 import { SceneMarkerList } from "src/components/Scenes/SceneMarkerList";
 import { View } from "src/components/List/views";
 
-interface ITagMarkersPanel {
-  active: boolean;
-  tag: GQL.TagDataFragment;
-}
-
-export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({
-  active,
-  tag,
-}) => {
-  function filterHook(filter: ListFilterModel) {
+function useFilterHook(tag: GQL.TagDataFragment, showSubTagContent?: boolean) {
+  return (filter: ListFilterModel) => {
     const tagValue = { id: tag.id, label: tag.name };
     // if tag is already present, then we modify it, otherwise add
     let tagCriterion = filter.criteria.find((c) => {
@@ -45,21 +37,33 @@ export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({
       tagCriterion.value = {
         items: [tagValue],
         excluded: [],
-        depth: 0,
+        depth: showSubTagContent ? -1 : 0,
       };
       filter.criteria.push(tagCriterion);
     }
 
     return filter;
-  }
+  };
+}
+
+interface ITagMarkersPanel {
+  active: boolean;
+  tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
+}
+
+export const TagMarkersPanel: React.FC<ITagMarkersPanel> = ({
+  active,
+  tag,
+  showSubTagContent,
+}) => {
+  const filterHook = useFilterHook(tag, showSubTagContent);
 
   return (
     <SceneMarkerList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagMarkers}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
@@ -19,6 +19,8 @@ export const TagPerformersPanel: React.FC<ITagPerformersPanel> = ({
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagPerformers}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
@@ -7,20 +7,20 @@ import { View } from "src/components/List/views";
 interface ITagPerformersPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
 }
 
 export const TagPerformersPanel: React.FC<ITagPerformersPanel> = ({
   active,
   tag,
+  showSubTagContent,
 }) => {
-  const filterHook = useTagFilterHook(tag);
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
   return (
     <PerformerList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagPerformers}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
@@ -16,6 +16,8 @@ export const TagScenesPanel: React.FC<ITagScenesPanel> = ({ active, tag }) => {
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagScenes}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
@@ -7,17 +7,20 @@ import { View } from "src/components/List/views";
 interface ITagScenesPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
 }
 
-export const TagScenesPanel: React.FC<ITagScenesPanel> = ({ active, tag }) => {
-  const filterHook = useTagFilterHook(tag);
+export const TagScenesPanel: React.FC<ITagScenesPanel> = ({
+  active,
+  tag,
+  showSubTagContent,
+}) => {
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
   return (
     <SceneList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagScenes}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
     />
   );
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagStudiosPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagStudiosPanel.tsx
@@ -6,19 +6,14 @@ import { StudioList } from "src/components/Studios/StudioList";
 interface ITagStudiosPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
+  showSubTagContent?: boolean;
 }
 
 export const TagStudiosPanel: React.FC<ITagStudiosPanel> = ({
   active,
   tag,
+  showSubTagContent,
 }) => {
-  const filterHook = useTagFilterHook(tag);
-  return (
-    <StudioList
-      filterHook={filterHook}
-      alterQuery={active}
-      // show the effective filter to allow changing the depth
-      showEffectiveFilter
-    />
-  );
+  const filterHook = useTagFilterHook(tag, showSubTagContent);
+  return <StudioList filterHook={filterHook} alterQuery={active} />;
 };

--- a/ui/v2.5/src/components/Tags/TagDetails/TagStudiosPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagStudiosPanel.tsx
@@ -13,5 +13,12 @@ export const TagStudiosPanel: React.FC<ITagStudiosPanel> = ({
   tag,
 }) => {
   const filterHook = useTagFilterHook(tag);
-  return <StudioList filterHook={filterHook} alterQuery={active} />;
+  return (
+    <StudioList
+      filterHook={filterHook}
+      alterQuery={active}
+      // show the effective filter to allow changing the depth
+      showEffectiveFilter
+    />
+  );
 };

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -3,7 +3,7 @@ import cloneDeep from "lodash-es/cloneDeep";
 import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
-import { makeItemList, showWhenSelected } from "../List/ItemList";
+import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { Button } from "react-bootstrap";
 import { Link, useHistory } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
@@ -27,26 +27,26 @@ import { TagCardGrid } from "./TagCardGrid";
 import { EditTagsDialog } from "./EditTagsDialog";
 import { View } from "../List/views";
 
+function getItems(result: GQL.FindTagsQueryResult) {
+  return result?.data?.findTags?.tags ?? [];
+}
+
+function getCount(result: GQL.FindTagsQueryResult) {
+  return result?.data?.findTags?.count ?? 0;
+}
+
 interface ITagList {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   alterQuery?: boolean;
 }
 
-const TagItemList = makeItemList({
-  filterMode: GQL.FilterMode.Tags,
-  useResult: useFindTags,
-  getItems(result: GQL.FindTagsQueryResult) {
-    return result?.data?.findTags?.tags ?? [];
-  },
-  getCount(result: GQL.FindTagsQueryResult) {
-    return result?.data?.findTags?.count ?? 0;
-  },
-});
-
 export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
   const Toast = useToast();
   const [deletingTag, setDeletingTag] =
     useState<Partial<GQL.TagDataFragment> | null>(null);
+
+  const filterMode = GQL.FilterMode.Tags;
+  const view = View.Tags;
 
   function getDeleteTagInput() {
     const tagInput: Partial<GQL.TagDestroyInput> = {};
@@ -355,18 +355,25 @@ export const TagList: React.FC<ITagList> = ({ filterHook, alterQuery }) => {
   }
 
   return (
-    <TagItemList
-      selectable
-      zoomable
-      defaultZoomIndex={0}
-      filterHook={filterHook}
-      view={View.Tags}
+    <ItemListContext
+      filterMode={filterMode}
+      useResult={useFindTags}
+      getItems={getItems}
+      getCount={getCount}
       alterQuery={alterQuery}
-      otherOperations={otherOperations}
-      addKeybinds={addKeybinds}
-      renderContent={renderContent}
-      renderDeleteDialog={renderDeleteDialog}
-      renderEditDialog={renderEditDialog}
-    />
+      filterHook={filterHook}
+      view={view}
+      selectable
+    >
+      <ItemList
+        view={view}
+        zoomable
+        otherOperations={otherOperations}
+        addKeybinds={addKeybinds}
+        renderContent={renderContent}
+        renderEditDialog={renderEditDialog}
+        renderDeleteDialog={renderDeleteDialog}
+      />
+    </ItemListContext>
   );
 };

--- a/ui/v2.5/src/core/studios.ts
+++ b/ui/v2.5/src/core/studios.ts
@@ -1,11 +1,11 @@
 import * as GQL from "src/core/generated-graphql";
 import { StudiosCriterion } from "src/models/list-filter/criteria/studios";
 import { ListFilterModel } from "src/models/list-filter/filter";
-import React from "react";
-import { ConfigurationContext } from "src/hooks/Config";
 
-export const useStudioFilterHook = (studio: GQL.StudioDataFragment) => {
-  const { configuration } = React.useContext(ConfigurationContext);
+export const useStudioFilterHook = (
+  studio: GQL.StudioDataFragment,
+  showChildStudioContent?: boolean
+) => {
   return (filter: ListFilterModel) => {
     const studioValue = { id: studio.id, label: studio.name };
     // if studio is already present, then we modify it, otherwise add
@@ -22,7 +22,7 @@ export const useStudioFilterHook = (studio: GQL.StudioDataFragment) => {
       studioCriterion.value = {
         items: [studioValue],
         excluded: [],
-        depth: configuration?.ui.showChildStudioContent ? -1 : 0,
+        depth: showChildStudioContent ? -1 : 0,
       };
       studioCriterion.modifier = GQL.CriterionModifier.Includes;
       filter.criteria.push(studioCriterion);

--- a/ui/v2.5/src/core/tags.ts
+++ b/ui/v2.5/src/core/tags.ts
@@ -6,11 +6,11 @@ import {
   TagsCriterionOption,
 } from "src/models/list-filter/criteria/tags";
 import { ListFilterModel } from "src/models/list-filter/filter";
-import React from "react";
-import { ConfigurationContext } from "src/hooks/Config";
 
-export const useTagFilterHook = (tag: GQL.TagDataFragment) => {
-  const { configuration } = React.useContext(ConfigurationContext);
+export const useTagFilterHook = (
+  tag: GQL.TagDataFragment,
+  showSubTagContent?: boolean
+) => {
   return (filter: ListFilterModel) => {
     const tagValue = { id: tag.id, label: tag.name };
     // if tag is already present, then we modify it, otherwise add
@@ -42,7 +42,7 @@ export const useTagFilterHook = (tag: GQL.TagDataFragment) => {
       tagCriterion.value = {
         items: [tagValue],
         excluded: [],
-        depth: configuration?.ui.showChildTagContent ? -1 : 0,
+        depth: showSubTagContent ? -1 : 0,
       };
       tagCriterion.modifier = GQL.CriterionModifier.IncludesAll;
       filter.criteria.push(tagCriterion);

--- a/ui/v2.5/src/hooks/modal.ts
+++ b/ui/v2.5/src/hooks/modal.ts
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function useModal() {
+  const [modal, setModal] = React.useState<React.ReactNode>();
+
+  const closeModal = () => setModal(undefined);
+  const showModal = (m: React.ReactNode) => setModal(m);
+
+  return { modal, closeModal, showModal };
+}

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -258,6 +258,15 @@ dd {
     padding: 5px 0;
   }
 
+  .item-list-header {
+    align-content: center;
+    // border-bottom: solid 2px #192127;
+    display: flex;
+    justify-content: center;
+    margin: 0;
+    padding: 5px 0 0 0;
+  }
+
   .item-list-container {
     padding-top: 15px;
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1086,6 +1086,7 @@
   "image_index": "Image #",
   "images": "Images",
   "include_parent_tags": "Include parent tags",
+  "include_sub_studio_content": "Include sub-studio content",
   "include_sub_studios": "Include subsidiary studios",
   "include_sub_tags": "Include sub-tags",
   "index_of_total": "{index} of {total}",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1088,6 +1088,7 @@
   "include_parent_tags": "Include parent tags",
   "include_sub_studio_content": "Include sub-studio content",
   "include_sub_studios": "Include subsidiary studios",
+  "include_sub_tag_content": "Include sub-tag content",
   "include_sub_tags": "Include sub-tags",
   "index_of_total": "{index} of {total}",
   "instagram": "Instagram",

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -89,6 +89,15 @@ export abstract class Criterion<V extends CriterionValue> {
     this.value = value;
   }
 
+  public clone(): Criterion<V> {
+    const newCriterion = new (this.constructor as new (
+      type: CriterionOption,
+      value: V
+    ) => Criterion<V>)(this.criterionOption, this.value);
+    newCriterion.modifier = this.modifier;
+    return newCriterion;
+  }
+
   public static getModifierLabel(intl: IntlShape, modifier: CriterionModifier) {
     const modifierMessageID = modifierMessageIDs[modifier];
 
@@ -251,6 +260,18 @@ export class ILabeledIdCriterionOption extends CriterionOption {
 }
 
 export class ILabeledIdCriterion extends Criterion<ILabeledId[]> {
+  public clone(): Criterion<ILabeledId[]> {
+    const newCriterion = new (this.constructor as new (
+      type: CriterionOption,
+      value: ILabeledId[]
+    ) => Criterion<ILabeledId[]>)(
+      this.criterionOption,
+      this.value.map((v) => ({ ...v }))
+    );
+    newCriterion.modifier = this.modifier;
+    return newCriterion;
+  }
+
   protected getLabelValue(_intl: IntlShape): string {
     return this.value.map((v) => v.label).join(", ");
   }
@@ -287,6 +308,19 @@ export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabe
     };
 
     super(type, value);
+  }
+
+  public clone(): Criterion<IHierarchicalLabelValue> {
+    const newCriterion = new (this.constructor as new (
+      type: CriterionOption,
+      value: IHierarchicalLabelValue
+    ) => Criterion<IHierarchicalLabelValue>)(this.criterionOption, {
+      ...this.value,
+      items: this.value.items.map((v) => ({ ...v })),
+      excluded: this.value.excluded.map((v) => ({ ...v })),
+    });
+    newCriterion.modifier = this.modifier;
+    return newCriterion;
   }
 
   override get modifier(): CriterionModifier {
@@ -503,6 +537,15 @@ export class StringCriterion extends Criterion<string> {
 export class MultiStringCriterion extends Criterion<string[]> {
   constructor(type: CriterionOption) {
     super(type, []);
+  }
+
+  public clone(): Criterion<string[]> {
+    const newCriterion = new (this.constructor as new (
+      type: CriterionOption,
+      value: string[]
+    ) => Criterion<string[]>)(this.criterionOption, this.value.slice());
+    newCriterion.modifier = this.modifier;
+    return newCriterion;
   }
 
   protected getLabelValue(_intl: IntlShape) {

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -260,11 +260,12 @@ export class ILabeledIdCriterionOption extends CriterionOption {
 }
 
 export class ILabeledIdCriterion extends Criterion<ILabeledId[]> {
+  constructor(type: CriterionOption, value: ILabeledId[] = []) {
+    super(type, value);
+  }
+
   public clone(): Criterion<ILabeledId[]> {
-    const newCriterion = new (this.constructor as new (
-      type: CriterionOption,
-      value: ILabeledId[]
-    ) => Criterion<ILabeledId[]>)(
+    const newCriterion = new ILabeledIdCriterion(
       this.criterionOption,
       this.value.map((v) => ({ ...v }))
     );
@@ -293,32 +294,29 @@ export class ILabeledIdCriterion extends Criterion<ILabeledId[]> {
 
     return this.value.length > 0;
   }
-
-  constructor(type: CriterionOption) {
-    super(type, []);
-  }
 }
 
 export class IHierarchicalLabeledIdCriterion extends Criterion<IHierarchicalLabelValue> {
-  constructor(type: CriterionOption) {
-    const value: IHierarchicalLabelValue = {
+  constructor(
+    type: CriterionOption,
+    value: IHierarchicalLabelValue = {
       items: [],
       excluded: [],
       depth: 0,
-    };
-
+    }
+  ) {
     super(type, value);
   }
 
   public clone(): Criterion<IHierarchicalLabelValue> {
-    const newCriterion = new (this.constructor as new (
-      type: CriterionOption,
-      value: IHierarchicalLabelValue
-    ) => Criterion<IHierarchicalLabelValue>)(this.criterionOption, {
-      ...this.value,
-      items: this.value.items.map((v) => ({ ...v })),
-      excluded: this.value.excluded.map((v) => ({ ...v })),
-    });
+    const newCriterion = new IHierarchicalLabeledIdCriterion(
+      this.criterionOption,
+      {
+        ...this.value,
+        items: this.value.items.map((v) => ({ ...v })),
+        excluded: this.value.excluded.map((v) => ({ ...v })),
+      }
+    );
     newCriterion.modifier = this.modifier;
     return newCriterion;
   }
@@ -535,15 +533,15 @@ export class StringCriterion extends Criterion<string> {
 }
 
 export class MultiStringCriterion extends Criterion<string[]> {
-  constructor(type: CriterionOption) {
-    super(type, []);
+  constructor(type: CriterionOption, value: string[] = []) {
+    super(type, value);
   }
 
   public clone(): Criterion<string[]> {
-    const newCriterion = new (this.constructor as new (
-      type: CriterionOption,
-      value: string[]
-    ) => Criterion<string[]>)(this.criterionOption, this.value.slice());
+    const newCriterion = new MultiStringCriterion(
+      this.criterionOption,
+      this.value.slice()
+    );
     newCriterion.modifier = this.modifier;
     return newCriterion;
   }

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -89,6 +89,10 @@ export class ListFilterModel {
     return Object.assign(new ListFilterModel(this.mode, this.config), this);
   }
 
+  public empty() {
+    return new ListFilterModel(this.mode, this.config, this.defaultZoomIndex);
+  }
+
   // returns the number of filters applied
   public count() {
     // don't include search term
@@ -442,5 +446,45 @@ export class ListFilterModel {
       display_mode: this.displayMode,
       zoom_index: this.zoomIndex,
     };
+  }
+
+  public clearCriteria() {
+    const ret = this.clone();
+    ret.criteria = [];
+    ret.currentPage = 1;
+    return ret;
+  }
+
+  public removeCriterion(type: CriterionType) {
+    const ret = this.clone();
+    const c = ret.criteria.find((cc) => cc.criterionOption.type === type);
+
+    if (!c) return ret;
+
+    const newCriteria = ret.criteria.filter((cc) => {
+      return cc.getId() !== c.getId();
+    });
+
+    ret.criteria = newCriteria;
+    ret.currentPage = 1;
+    return ret;
+  }
+
+  public changePage(page: number) {
+    const ret = this.clone();
+    ret.currentPage = page;
+    return ret;
+  }
+
+  public setZoom(zoomIndex: number) {
+    const ret = this.clone();
+    ret.zoomIndex = zoomIndex;
+    return ret;
+  }
+
+  public setDisplayMode(displayMode: DisplayMode) {
+    const ret = this.clone();
+    ret.displayMode = displayMode;
+    return ret;
   }
 }

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -67,21 +67,32 @@ export class ListFilterModel {
   public constructor(
     mode: FilterMode,
     config?: ConfigDataFragment,
-    defaultZoomIndex?: number
+    options?: {
+      defaultZoomIndex?: number;
+      defaultSortBy?: string;
+      defaultSortDir?: SortDirectionEnum;
+    }
   ) {
     this.mode = mode;
     this.config = config;
     this.options = getFilterOptions(mode);
     const { defaultSortBy, displayModeOptions } = this.options;
 
-    this.sortBy = defaultSortBy;
-    if (this.sortBy === "date") {
-      this.sortDirection = SortDirectionEnum.Desc;
+    if (options?.defaultSortBy) {
+      this.sortBy = options.defaultSortBy;
+      if (options.defaultSortDir) {
+        this.sortDirection = options.defaultSortDir;
+      }
+    } else {
+      this.sortBy = defaultSortBy;
+      if (this.sortBy === "date") {
+        this.sortDirection = SortDirectionEnum.Desc;
+      }
     }
     this.displayMode = displayModeOptions[0];
-    if (defaultZoomIndex !== undefined) {
-      this.defaultZoomIndex = defaultZoomIndex;
-      this.zoomIndex = defaultZoomIndex;
+    if (options?.defaultZoomIndex !== undefined) {
+      this.defaultZoomIndex = options.defaultZoomIndex;
+      this.zoomIndex = options.defaultZoomIndex;
     }
   }
 
@@ -95,7 +106,9 @@ export class ListFilterModel {
   }
 
   public empty() {
-    return new ListFilterModel(this.mode, this.config, this.defaultZoomIndex);
+    return new ListFilterModel(this.mode, this.config, {
+      defaultZoomIndex: this.defaultZoomIndex,
+    });
   }
 
   // returns the number of filters applied

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -86,7 +86,12 @@ export class ListFilterModel {
   }
 
   public clone() {
-    return Object.assign(new ListFilterModel(this.mode, this.config), this);
+    const ret = Object.assign(
+      new ListFilterModel(this.mode, this.config),
+      this
+    );
+    ret.criteria = this.criteria.map((c) => c.clone());
+    return ret;
   }
 
   public empty() {

--- a/ui/v2.5/src/utils/bulkUpdate.ts
+++ b/ui/v2.5/src/utils/bulkUpdate.ts
@@ -1,5 +1,6 @@
 import * as GQL from "src/core/generated-graphql";
 import isEqual from "lodash-es/isEqual";
+import { IHasID } from "./data";
 
 interface IHasRating {
   rating100?: GQL.Maybe<number> | undefined;
@@ -19,10 +20,6 @@ export function getAggregateRating(state: IHasRating[]) {
   });
 
   return ret;
-}
-
-interface IHasID {
-  id: string;
 }
 
 interface IHasStudio {

--- a/ui/v2.5/src/utils/data.ts
+++ b/ui/v2.5/src/utils/data.ts
@@ -1,6 +1,10 @@
 export const filterData = <T>(data?: (T | null | undefined)[] | null) =>
   data ? (data.filter((item) => item) as T[]) : [];
 
+export interface IHasID {
+  id: string;
+}
+
 export interface ITypename {
   __typename?: string;
 }


### PR DESCRIPTION
This PR provides a much-needed refactor to the ItemList code. This changes the `makeItemList` hook to be two separate components: `ItemListContext` and `ItemList`. This simplifies the item list code significantly, with URL filter setting moved into a hook, and filter and result states moved into contexts that can be accessed from anywhere in the child component tree.

While working in this area, I also changed the tag and studio views to show the filter tags so that users can change the sub-tag/studio visibility per previous behaviour. I think in future this should be changed to be a checkbox or something, but this will do for now.

Resolves #4938 