### PR TITLE
fix missing transgender SVG color

### DIFF
--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -150,6 +150,7 @@
   color: #f38cac;
 }
 
+.fa-transgender,
 .fa-transgender-alt {
   color: #c8a2c8;
 }


### PR DESCRIPTION
The transgender SVG has been lacking cover for over a year now. At some point the library providing the SVG must have stopped using the `fa-transgender-alt` class for the SVG.