### PR TITLE
Markers scene filter

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -191,6 +191,8 @@ input SceneMarkerFilterType {
   scene_tags: HierarchicalMultiCriterionInput
   "Filter to only include scene markers with these performers"
   performers: MultiCriterionInput
+  "Filter to only include scene markers from these scenes"
+  scenes: MultiCriterionInput
   "Filter by creation time"
   created_at: TimestampCriterionInput
   "Filter by last update time"

--- a/pkg/models/scene_marker.go
+++ b/pkg/models/scene_marker.go
@@ -9,6 +9,8 @@ type SceneMarkerFilterType struct {
 	SceneTags *HierarchicalMultiCriterionInput `json:"scene_tags"`
 	// Filter to only include scene markers with these performers
 	Performers *MultiCriterionInput `json:"performers"`
+	// Filter to only include scene markers from these scenes
+	Scenes *MultiCriterionInput `json:"scenes"`
 	// Filter by created at
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at

--- a/pkg/sqlite/scene_marker_filter.go
+++ b/pkg/sqlite/scene_marker_filter.go
@@ -40,6 +40,7 @@ func (qb *sceneMarkerFilterHandler) criterionHandler() criterionHandler {
 		qb.tagsCriterionHandler(sceneMarkerFilter.Tags),
 		qb.sceneTagsCriterionHandler(sceneMarkerFilter.SceneTags),
 		qb.performersCriterionHandler(sceneMarkerFilter.Performers),
+		qb.scenesCriterionHandler(sceneMarkerFilter.Scenes),
 		&timestampCriterionHandler{sceneMarkerFilter.CreatedAt, "scene_markers.created_at", nil},
 		&timestampCriterionHandler{sceneMarkerFilter.UpdatedAt, "scene_markers.updated_at", nil},
 		&dateCriterionHandler{sceneMarkerFilter.SceneDate, "scenes.date", qb.joinScenes},
@@ -186,4 +187,19 @@ func (qb *sceneMarkerFilterHandler) performersCriterionHandler(performers *model
 		qb.joinScenes(f)
 		handler(ctx, f)
 	}
+}
+
+func (qb *sceneMarkerFilterHandler) scenesCriterionHandler(scenes *models.MultiCriterionInput) criterionHandlerFunc {
+	addJoinsFunc := func(f *filterBuilder) {
+		f.addLeftJoin(sceneTable, "markers_scenes", "markers_scenes.id = scene_markers.scene_id")
+	}
+	h := multiCriterionHandlerBuilder{
+		primaryTable: sceneMarkerTable,
+		foreignTable: "markers_scenes",
+		joinTable:    "",
+		primaryFK:    sceneIDColumn,
+		foreignFK:    sceneIDColumn,
+		addJoinsFunc: addJoinsFunc,
+	}
+	return h.handler(scenes)
 }

--- a/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Form } from "react-bootstrap";
 import { FilterSelect, SelectObject } from "src/components/Shared/Select";
+import { objectTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
 import { ILabeledId } from "src/models/list-filter/types";
@@ -31,8 +32,11 @@ export const LabeledIdFilter: React.FC<ILabeledIdFilterProps> = ({
   }
 
   function getLabel(i: SelectObject) {
-    if (inputType === "galleries") {
-      return galleryTitle(i);
+    switch (inputType) {
+      case "galleries":
+        return galleryTitle(i);
+      case "scenes":
+        return objectTitle(i);
     }
 
     return i.name ?? i.title ?? "";

--- a/ui/v2.5/src/models/list-filter/criteria/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/scenes.ts
@@ -1,4 +1,9 @@
-import { ILabeledIdCriterion, ILabeledIdCriterionOption } from "./criterion";
+import {
+  CriterionOption,
+  ILabeledIdCriterion,
+  ILabeledIdCriterionOption,
+} from "./criterion";
+import { CriterionModifier } from "src/core/generated-graphql";
 
 const inputType = "scenes";
 
@@ -13,5 +18,27 @@ export const ScenesCriterionOption = new ILabeledIdCriterionOption(
 export class ScenesCriterion extends ILabeledIdCriterion {
   constructor() {
     super(ScenesCriterionOption);
+  }
+}
+
+const modifierOptions = [
+  CriterionModifier.Includes,
+  CriterionModifier.Excludes,
+];
+
+const defaultModifier = CriterionModifier.Includes;
+
+export const MarkersScenesCriterionOption = new CriterionOption({
+  messageID: "scenes",
+  type: "scenes",
+  modifierOptions,
+  defaultModifier,
+  inputType,
+  makeCriterion: () => new MarkersScenesCriterion(),
+});
+
+export class MarkersScenesCriterion extends ILabeledIdCriterion {
+  constructor() {
+    super(MarkersScenesCriterionOption);
   }
 }

--- a/ui/v2.5/src/models/list-filter/scene-markers.ts
+++ b/ui/v2.5/src/models/list-filter/scene-markers.ts
@@ -1,4 +1,5 @@
 import { PerformersCriterionOption } from "./criteria/performers";
+import { MarkersScenesCriterionOption } from "./criteria/scenes";
 import { SceneTagsCriterionOption, TagsCriterionOption } from "./criteria/tags";
 import { ListFilterOptions } from "./filter-options";
 import { DisplayMode } from "./types";
@@ -18,6 +19,7 @@ const sortByOptions = [
 const displayModeOptions = [DisplayMode.Wall];
 const criterionOptions = [
   TagsCriterionOption,
+  MarkersScenesCriterionOption,
   SceneTagsCriterionOption,
   PerformersCriterionOption,
   createMandatoryTimestampCriterionOption("created_at"),


### PR DESCRIPTION
Adds the ability to filter the Marker list by the Scene the Marker belongs to. `Includes` and `Excludes` only as it _should_ not be be possible to have an orphaned Marker where the Scene is `null`.