### PR TITLE
Allow detection for n-prefixed ffmpeg version string

### DIFF
--- a/pkg/ffmpeg/ffmpeg.go
+++ b/pkg/ffmpeg/ffmpeg.go
@@ -158,7 +158,7 @@ func (f *FFMpeg) getVersion() error {
 		return err
 	}
 
-	version_re := regexp.MustCompile(`ffmpeg version ((\d+)\.(\d+)(?:\.(\d+))?)`)
+	version_re := regexp.MustCompile(`ffmpeg version n?((\d+)\.(\d+)(?:\.(\d+))?)`)
 	stdoutStr := stdout.String()
 	match := version_re.FindStringSubmatchIndex(stdoutStr)
 	if match == nil {


### PR DESCRIPTION
Some builds of FFmpeg (e.g. Arch's) have a version string that is prefixed with n (`n7.0.1` instead of `7.0.1`), which aligns with the tag name in the official FFmpeg repo. Previously, it will give a warning "FFMpeg version not detected version string malformed". This PR allows the version number of these builds to be detected correctly.