### PR TITLE
Fix view history imported from o-history json

### DIFF
--- a/pkg/scene/import.go
+++ b/pkg/scene/import.go
@@ -150,7 +150,7 @@ func (i *Importer) populateViewHistory() {
 }
 
 func (i *Importer) populateOHistory() {
-	i.viewHistory = getHistory(
+	i.oHistory = getHistory(
 		i.Input.OHistory,
 		i.Input.OCounter,
 		i.Input.CreatedAt, // no last o count date


### PR DESCRIPTION
Fixes issue reported on Discord where importing scene data from json incorrectly filled the view history from the o-history field.