### PR TITLE
Fix broken link in development documentation.

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 * [Go](https://golang.org/dl/)
 * [GolangCI](https://golangci-lint.run/) - A meta-linter which runs several linters in parallel
-  * To install, follow the [local installation instructions](https://golangci-lint.run/usage/install/#local-installation)
+  * To install, follow the [local installation instructions](https://golangci-lint.run/welcome/install/#local-installation)
 * [Yarn](https://yarnpkg.com/en/docs/install) - Yarn package manager
 
 ## Environment


### PR DESCRIPTION
The existing link 404s.

First commit, so please let me know if I've missed a step necessary to contribute!