### PR TITLE
Update SceneDuplicateChecker table to show audio codec and file modification time.

### DIFF
--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -908,8 +908,8 @@ export const SceneDuplicateChecker: React.FC = () => {
                             {scene.title
                               ? scene.title
                               : TextUtils.fileNameFromPath(
-                                  file?.path ?? ""
-                                )}{" "}
+                                file?.path ?? ""
+                              )}{" "}
                           </Link>
                         </p>
                         <p className="scene-path">{file?.path ?? ""}</p>

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -908,8 +908,8 @@ export const SceneDuplicateChecker: React.FC = () => {
                             {scene.title
                               ? scene.title
                               : TextUtils.fileNameFromPath(
-                                file?.path ?? ""
-                              )}{" "}
+                                  file?.path ?? ""
+                                )}{" "}
                           </Link>
                         </p>
                         <p className="scene-path">{file?.path ?? ""}</p>
@@ -932,7 +932,9 @@ export const SceneDuplicateChecker: React.FC = () => {
                       </td>
                       <td>{file?.video_codec ?? ""}</td>
                       <td>{file?.audio_codec ?? ""}</td>
-                      <td>{file ? new Date(file.mod_time).toDateString() : ""}</td>
+                      <td>
+                        {file ? new Date(file.mod_time).toDateString() : ""}
+                      </td>
                       <td>
                         <Button
                           className="edit-button"

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -821,9 +821,9 @@ export const SceneDuplicateChecker: React.FC = () => {
             <col className={`${CLASSNAME}-filesize`} />
             <col className={`${CLASSNAME}-resolution`} />
             <col className={`${CLASSNAME}-bitrate`} />
-            <col className={`${CLASSNAME}-codec`} />
-            <col className={`${CLASSNAME}-codec`} />
-            <col className={`${CLASSNAME}-modified_time`} />
+            <col className={`${CLASSNAME}-video-codec`} />
+            <col className={`${CLASSNAME}-audio-codec`} />
+            <col className={`${CLASSNAME}-modified-time`} />
             <col className={`${CLASSNAME}-operations`} />
           </colgroup>
           <thead>
@@ -838,7 +838,7 @@ export const SceneDuplicateChecker: React.FC = () => {
               <th>{intl.formatMessage({ id: "bitrate" })}</th>
               <th>{intl.formatMessage({ id: "media_info.video_codec" })}</th>
               <th>{intl.formatMessage({ id: "media_info.audio_codec" })}</th>
-              <th>{intl.formatMessage({ id: "modified_time" })}</th>
+              <th>{intl.formatMessage({ id: "file_mod_time" })}</th>
               <th>{intl.formatMessage({ id: "actions.delete" })}</th>
             </tr>
           </thead>
@@ -932,7 +932,7 @@ export const SceneDuplicateChecker: React.FC = () => {
                       </td>
                       <td>{file?.video_codec ?? ""}</td>
                       <td>{file?.audio_codec ?? ""}</td>
-                      <td>{new Date(file?.mod_time).toDateString()}</td>
+                      <td>{file ? new Date(file.mod_time).toDateString() : ""}</td>
                       <td>
                         <Button
                           className="edit-button"

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -822,6 +822,8 @@ export const SceneDuplicateChecker: React.FC = () => {
             <col className={`${CLASSNAME}-resolution`} />
             <col className={`${CLASSNAME}-bitrate`} />
             <col className={`${CLASSNAME}-codec`} />
+            <col className={`${CLASSNAME}-codec`} />
+            <col className={`${CLASSNAME}-modified_time`} />
             <col className={`${CLASSNAME}-operations`} />
           </colgroup>
           <thead>
@@ -835,6 +837,8 @@ export const SceneDuplicateChecker: React.FC = () => {
               <th>{intl.formatMessage({ id: "resolution" })}</th>
               <th>{intl.formatMessage({ id: "bitrate" })}</th>
               <th>{intl.formatMessage({ id: "media_info.video_codec" })}</th>
+              <th>{intl.formatMessage({ id: "media_info.audio_codec" })}</th>
+              <th>{intl.formatMessage({ id: "modified_time" })}</th>
               <th>{intl.formatMessage({ id: "actions.delete" })}</th>
             </tr>
           </thead>
@@ -927,6 +931,8 @@ export const SceneDuplicateChecker: React.FC = () => {
                         &nbsp;mbps
                       </td>
                       <td>{file?.video_codec ?? ""}</td>
+                      <td>{file?.audio_codec ?? ""}</td>
+                      <td>{new Date(file?.mod_time).toDateString()}</td>
                       <td>
                         <Button
                           className="edit-button"


### PR DESCRIPTION
This should make identifying different versions of scenes easier without having to click through to the full scene page. The reason I want this is sometimes I have a copy of a scene that's somehow missing audio and while it flags as an exact duplicate, I'd like to keep the one with the audio intact.