### PR TITLE
QOL Move Reload Scrapers to Top

### DIFF
--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -54,6 +54,15 @@ export const ScraperMenu: React.FC<{
       <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
       <Dropdown.Menu>
+        <Dropdown.Item onClick={() => onReloadScrapers()}>
+          <span className="fa-icon">
+            <Icon icon={faSyncAlt} />
+          </span>
+          <span>
+            <FormattedMessage id="actions.reload_scrapers" />
+          </span>
+        </Dropdown.Item>
+
         {(stashBoxes?.length ?? 0) + scrapers.length > minFilteredScrapers && (
           <ClearableInput
             placeholder={`${intl.formatMessage({ id: "filter" })}...`}
@@ -61,6 +70,7 @@ export const ScraperMenu: React.FC<{
             setValue={setFilter}
           />
         )}
+
         {filteredStashboxes.map((s, index) => (
           <Dropdown.Item
             key={s.endpoint}
@@ -86,14 +96,6 @@ export const ScraperMenu: React.FC<{
             {s.name}
           </Dropdown.Item>
         ))}
-        <Dropdown.Item onClick={() => onReloadScrapers()}>
-          <span className="fa-icon">
-            <Icon icon={faSyncAlt} />
-          </span>
-          <span>
-            <FormattedMessage id="actions.reload_scrapers" />
-          </span>
-        </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>
   );


### PR DESCRIPTION
QOL change to move the "Refresh Scrapers" button within the "Scrape with..." dropdown to the top.

Very small change, just moved the code up to generate that button first. Unable to test with more scrapers in dev environment but logic seems good.

Closes https://github.com/stashapp/stash/issues/2164