### PR TITLE
Scene player presentation improvements

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -2,6 +2,7 @@ import videojs, { VideoJsPlayer } from "video.js";
 
 export interface ISource extends videojs.Tech.SourceObject {
   label?: string;
+  errored?: boolean;
 }
 
 class SourceMenuItem extends videojs.getComponent("MenuItem") {
@@ -90,6 +91,13 @@ class SourceMenuButton extends videojs.getComponent("MenuButton") {
       item.selected(item.source === this.selectedSource);
     }
   }
+
+  markSourceErrored(source: ISource) {
+    const item = this.items.find((i) => i.source.src === source.src);
+    if (item === undefined) return;
+
+    item.addClass("vjs-source-menu-item-error");
+  }
 }
 
 class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
@@ -167,6 +175,10 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
 
       const currentSource = player.currentSource() as ISource;
       console.log(`Source '${currentSource.label}' is unsupported`);
+
+      // mark current source as errored
+      currentSource.errored = true;
+      this.menu.markSourceErrored(currentSource);
 
       // don't auto play next source if user manually selected a source
       if (this.manuallySelected) {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -219,6 +219,14 @@ $sceneTabWidth: 450px;
       content: "\f110";
       font-family: VideoJS;
     }
+
+    .vjs-menu-item.vjs-source-menu-item-error:not(.vjs-selected) {
+      color: $text-muted;
+    }
+
+    .vjs-menu-item.vjs-source-menu-item-error {
+      font-style: italic;
+    }
   }
 
   .vjs-vr-selector {

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -43,6 +43,24 @@ $sceneTabWidth: 450px;
     display: flex;
   }
 
+  // show controls even when an error is displayed
+  /* stylelint-disable declaration-no-important */
+  &.vjs-error .vjs-control-bar {
+    display: flex !important;
+  }
+  /* stylelint-enable declaration-no-important */
+
+  // allow interaction with the controls when error is displayed
+  .vjs-error-display,
+  .vjs-error-display .vjs-modal-dialog-content {
+    position: static;
+  }
+
+  // hide spinner when error is displayed
+  &.vjs-error .vjs-loading-spinner {
+    display: none;
+  }
+
   .vjs-button {
     outline: none;
   }

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -39,6 +39,10 @@ $sceneTabWidth: 450px;
   position: absolute;
   width: 100%;
 
+  &:not(.vjs-has-started) .vjs-control-bar {
+    display: flex;
+  }
+
   .vjs-button {
     outline: none;
   }


### PR DESCRIPTION
Scene player controls are now shown before the video is loaded, so that the volume, sources etc can be interacted with without playing the video.

![image](https://github.com/user-attachments/assets/6313c44e-79cb-429d-bbdc-76bf4773bac8)

The error dialog now allows interacting with the controls.

![image](https://github.com/user-attachments/assets/c4972fe3-aa68-44fe-b1d3-61273bbd7e9a)

The source selector will no longer remove failed sources from the list. Sources that failed to load are now shown with a muted styling and italics.

![image](https://github.com/user-attachments/assets/96eb6c12-811e-4f3f-afd6-058a4c3a0375)

The source selector will no longer automatically play the next source due to a load failure if the source was manually selected by the user.