### PR TITLE
Adding Frame_rate to Scene Cards

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -347,9 +347,21 @@ const SceneCardImage = PatchComponent(
 
     function maybeRenderSceneSpecsOverlay() {
       let sizeObj = null;
+      let frameRate = "";
+
       if (file?.size) {
         sizeObj = TextUtils.fileSize(file.size);
       }
+
+      if (file?.frame_rate) {
+        frameRate = `${Math.round(file.frame_rate)}`;
+      }
+
+      const resolution =
+        file?.width && file?.height
+          ? TextUtils.resolution(file?.width, file?.height)
+          : "";
+
       return (
         <div className="scene-specs-overlay">
           {sizeObj != null ? (
@@ -365,10 +377,10 @@ const SceneCardImage = PatchComponent(
           ) : (
             ""
           )}
-          {file?.width && file?.height ? (
+          {resolution || frameRate ? (
             <span className="overlay-resolution">
-              {" "}
-              {TextUtils.resolution(file?.width, file?.height)}
+              {resolution}
+              {frameRate ? `${frameRate}` : ""}
             </span>
           ) : (
             ""

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -644,6 +644,13 @@ input[type="range"].blue-slider {
     }
   }
 
+  .overlay-resolution {
+    font-weight: 900;
+    margin-right: 0.3rem;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
   .queue-scene-studio {
     color: #d3d0d0;
     font-weight: 600;


### PR DESCRIPTION
Currently stash uses 1080P, note the capital P, I prefer 1080p but who cares about what I prefer. 

I kept the P capital, since that's the standard, and just tacked the frame_rate to the end.

[Before](https://gyazo.com/7616c90c460150fefd739382093f80a7) vs [after](https://gyazo.com/74f8da62ca7ba5ddaaa94fe9cd9a3b2e)

closes https://github.com/stashapp/stash/issues/3856