### PR TITLE
Tweak to allow for auto-convert of metric measurements into US (Imperial)

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -488,14 +488,6 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
               </option>
             ))}
           </SelectSetting>
-        )}
-        <BooleanSetting
-          id="auto_convert_metric_measurements"
-          headingID="config.ui.editing.auto_convert_metric_measurements.heading"
-          subHeadingID="config.ui.editing.auto_convert_metric_measurements.description"
-          checked={ui.autoConvertMetricMeasurements ?? undefined}
-          onChange={(v) => saveUI({ autoConvertMetricMeasurements: v })}
-        />        
       </SettingSection>
         <SettingSection headingID="config.ui.image_lightbox.heading">
           <NumberSetting
@@ -745,6 +737,13 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
               ))}
             </SelectSetting>
           )}
+          <BooleanSetting
+            id="auto_convert_metric_measurements"
+            headingID="config.ui.editing.auto_convert_metric_measurements.heading"
+            subHeadingID="config.ui.editing.auto_convert_metric_measurements.description"
+            checked={ui.autoConvertMetricMeasurements ?? undefined}
+            onChange={(v) => saveUI({ autoConvertMetricMeasurements: v })}
+          />        
         </SettingSection>
 
         <SettingSection headingID="config.ui.custom_css.heading">

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -730,6 +730,13 @@ export const SettingsInterfacePanel: React.FC = () => {
             ))}
           </SelectSetting>
         )}
+        <BooleanSetting
+          id="auto_convert_metric_measurements"
+          headingID="config.ui.editing.auto_convert_metric_measurements.heading"
+          subHeadingID="config.ui.editing.auto_convert_metric_measurements.description"
+          checked={ui.autoConvertMetricMeasurements ?? undefined}
+          onChange={(v) => saveUI({ autoConvertMetricMeasurements: v })}
+        />        
       </SettingSection>
 
       <SettingSection headingID="config.ui.custom_css.heading">

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -60,6 +60,8 @@ export interface IUIConfig {
   enableTagBackgroundImage?: boolean;
   // if true view expanded details compact
   compactExpandedDetails?: boolean;
+  // if true measurements > 50-45-50 will be converted into US (Imperial) values
+  autoConvertMetricMeasurements?: boolean;
   // if true show all content details by default
   showAllDetails?: boolean;
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -642,7 +642,11 @@
               "stars": "Stars"
             }
           }
-        }
+        },
+        "auto_convert_metric_measurements": {
+          "description": "When enabled, this option will auto-convert metric measurements into US (Inches) for values > 50-45-50 (In Performer Edit)",
+          "heading": "Auto Convert Metric Measurements"
+        }        
       },
       "funscript_offset": {
         "description": "Time offset in milliseconds for interactive scripts playback.",


### PR DESCRIPTION
Simple tweak to add a user-configurable option (Settings->Interface->Editing) to allow for auto conversion of metric measurements (Bust-Hips-Waist) into US (Imperial) values.  It will auto-convert any set of measurements that are greater than 50-45-50 in all three fields, otherwise it will not affect the entry.  It will also convert letter cup sizes into US equivalents (For example "F" becomes "DD" if it performs a conversion.
