### PR TITLE
Remove {entityType} from delete_entity

### DIFF
--- a/ui/v2.5/src/locales/af-ZA.json
+++ b/ui/v2.5/src/locales/af-ZA.json
@@ -19,7 +19,7 @@
         "create_entity": "Skep {entityType}",
         "create_parent_studio": "Skep ouerateljee",
         "delete": "Verwyder",
-        "delete_entity": "Verwyder {entityType}",
+        "delete_entity": "Verwyder",
         "delete_file_and_funscript": "Verwyder lêer (en funscript)",
         "delete_generated_supporting_files": "Verwyder gegenereerde ondersteunende lêers",
         "disable": "Deaktiveer",

--- a/ui/v2.5/src/locales/bn-BD.json
+++ b/ui/v2.5/src/locales/bn-BD.json
@@ -25,7 +25,7 @@
         "created_entity": "তৈরি হয়েছে {entity_type}: {entity_name}",
         "customise": "সাজাও",
         "delete": "মুছুন",
-        "delete_entity": "{entityType} মুছুন",
+        "delete_entity": "মুছুন",
         "delete_file": "ফাইল মুছুন",
         "delete_file_and_funscript": "ফাইল মুছুন (সাথে funscript ও)",
         "delete_generated_supporting_files": "জেনারেট হওয়া সমর্থিত ফাইলসমূহ মুছুন",

--- a/ui/v2.5/src/locales/ca-ES.json
+++ b/ui/v2.5/src/locales/ca-ES.json
@@ -25,7 +25,7 @@
         "create_parent_studio": "Crea un estudi pare",
         "created_entity": "Creat {entity_type}: {entity_name}",
         "customise": "Personalitza",
-        "delete_entity": "Suprimeix {entityType}",
+        "delete_entity": "Suprimeix",
         "delete_file": "Suprimeix el fitxer",
         "delete_file_and_funscript": "Suprimeix el fitxer (i funscript)",
         "delete_generated_supporting_files": "Suprimeix els fitxers de suport generats",

--- a/ui/v2.5/src/locales/cs-CZ.json
+++ b/ui/v2.5/src/locales/cs-CZ.json
@@ -25,7 +25,7 @@
         "created_entity": "Vytvořen {entity_type}: {entity_name}",
         "customise": "Customizovat",
         "delete": "Odstranit",
-        "delete_entity": "Odstranit {entityType}",
+        "delete_entity": "Odstranit",
         "delete_file": "Odstranit soubor",
         "delete_file_and_funscript": "Odstranit soubor (a funscript)",
         "delete_generated_supporting_files": "Odstranit generované podpůrné soubory",

--- a/ui/v2.5/src/locales/da-DK.json
+++ b/ui/v2.5/src/locales/da-DK.json
@@ -27,7 +27,7 @@
         "created_entity": "Lavet {entity_type}: {entity_name}",
         "customise": "Tilpas",
         "delete": "Slet",
-        "delete_entity": "Slet {entityType}",
+        "delete_entity": "Slet",
         "delete_file": "Slet fil",
         "delete_file_and_funscript": "Slet fil (og funscript)",
         "delete_generated_supporting_files": "Slet genereret filer",

--- a/ui/v2.5/src/locales/de-DE.json
+++ b/ui/v2.5/src/locales/de-DE.json
@@ -27,7 +27,7 @@
         "created_entity": "{entity_type} erstellt: {entity_name}",
         "customise": "Anpassen",
         "delete": "Löschen",
-        "delete_entity": "Lösche {entityType}",
+        "delete_entity": "Lösche",
         "delete_file": "Lösche Datei",
         "delete_file_and_funscript": "Datei löschen (inkl. funscript)",
         "delete_generated_supporting_files": "Lösche generierte Hilfsdaten",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -36,7 +36,7 @@
     "created_entity": "Created {entity_type}: {entity_name}",
     "customise": "Customise",
     "delete": "Delete",
-    "delete_entity": "Delete {entityType}",
+    "delete_entity": "Delete",
     "delete_file": "Delete file",
     "delete_file_and_funscript": "Delete file (and funscript)",
     "delete_generated_supporting_files": "Delete generated supporting files",

--- a/ui/v2.5/src/locales/es-ES.json
+++ b/ui/v2.5/src/locales/es-ES.json
@@ -27,7 +27,7 @@
         "created_entity": "{entity_type} creado: {entity_name}",
         "customise": "Personalizar",
         "delete": "Eliminar",
-        "delete_entity": "Eliminar {entityType}",
+        "delete_entity": "Eliminar",
         "delete_file": "Eliminar archivo",
         "delete_file_and_funscript": "Eliminar archivo (y funscript)",
         "delete_generated_supporting_files": "Eliminar ficheros de soporte generados",

--- a/ui/v2.5/src/locales/et-EE.json
+++ b/ui/v2.5/src/locales/et-EE.json
@@ -27,7 +27,7 @@
         "created_entity": "Loodud {entity_type}: {entity_name}",
         "customise": "Kohanda",
         "delete": "Kustuta",
-        "delete_entity": "Kustuta {entityType}",
+        "delete_entity": "Kustuta",
         "delete_file": "Kustuta fail",
         "delete_file_and_funscript": "Kustuta fail (ja funscript)",
         "delete_generated_supporting_files": "Kustuta genereeritud toetusfailid",

--- a/ui/v2.5/src/locales/fi-FI.json
+++ b/ui/v2.5/src/locales/fi-FI.json
@@ -27,7 +27,7 @@
         "created_entity": "Luotu: {entityType}: {entity_name}",
         "customise": "Kustomoi",
         "delete": "Poista",
-        "delete_entity": "Poista {entityType}",
+        "delete_entity": "Poista",
         "delete_file": "Poista tiedosto",
         "delete_file_and_funscript": "Poista tiedosto (ja funscript)",
         "delete_generated_supporting_files": "Poista generoidut lisätiedostot",

--- a/ui/v2.5/src/locales/fr-FR.json
+++ b/ui/v2.5/src/locales/fr-FR.json
@@ -29,7 +29,7 @@
         "created_entity": "Créé {entity_type} : {entity_name}",
         "customise": "Personnaliser",
         "delete": "Supprimer",
-        "delete_entity": "Supprimer {entityType}",
+        "delete_entity": "Supprimer",
         "delete_file": "Supprimer le fichier",
         "delete_file_and_funscript": "Supprimer le fichier (et script interactif)",
         "delete_generated_supporting_files": "Supprimer les fichiers générés associés",

--- a/ui/v2.5/src/locales/hi.json
+++ b/ui/v2.5/src/locales/hi.json
@@ -27,7 +27,7 @@
         "create_parent_studio": "पैरेंट स्टूडियो बनाएं",
         "created_entity": "बनाया गया {entity_type}: {entity_name}",
         "customise": "कस्टमाइज करें",
-        "delete_entity": "{entityType} मिटाएं",
+        "delete_entity": "मिटाएं",
         "disable": "अक्षम करें",
         "delete_generated_supporting_files": "उत्पन्न की गई सहायक फ़ाइलें मिटाएं",
         "download": "डाउनलोड करें",

--- a/ui/v2.5/src/locales/hr-HR.json
+++ b/ui/v2.5/src/locales/hr-HR.json
@@ -22,7 +22,7 @@
         "create_marker": "Napravi Marker",
         "created_entity": "Stvoren {entity_type}: {entity_name}",
         "delete": "Izbrisati",
-        "delete_entity": "Izbrišite {entityType}",
+        "delete_entity": "Izbrišite",
         "delete_file": "Izbrišite datoteku",
         "delete_generated_supporting_files": "Izbrišite generirane datoteke",
         "disallow": "Zabrani",

--- a/ui/v2.5/src/locales/hu-HU.json
+++ b/ui/v2.5/src/locales/hu-HU.json
@@ -23,7 +23,7 @@
         "create": "Létrehoz",
         "create_entity": "{entityType} Létrehozása",
         "delete": "Törlés",
-        "delete_entity": "{entityType} Törlése",
+        "delete_entity": "Törlése",
         "delete_file": "Fájl Törlése",
         "delete_generated_supporting_files": "Létrehozott kiegészítő fájlok törlése",
         "disallow": "Tiltás",

--- a/ui/v2.5/src/locales/id-ID.json
+++ b/ui/v2.5/src/locales/id-ID.json
@@ -36,7 +36,7 @@
         "created_entity": "Telah dibuat {entity_type}: {entity_name}",
         "customise": "Sesuaikan",
         "delete": "Hapus",
-        "delete_entity": "Hapus {entityType}",
+        "delete_entity": "Hapus",
         "delete_file": "Hapus berkas",
         "delete_file_and_funscript": "Hapus berkas (dan funscript)",
         "delete_generated_supporting_files": "Hapus file pendukung yang dihasilkan",

--- a/ui/v2.5/src/locales/it-IT.json
+++ b/ui/v2.5/src/locales/it-IT.json
@@ -27,7 +27,7 @@
         "created_entity": "Creata/o {entity_type}: {entity_name}",
         "customise": "Personalizza",
         "delete": "Cancella",
-        "delete_entity": "Cancella {entityType}",
+        "delete_entity": "Cancella",
         "delete_file": "Cancella file",
         "delete_file_and_funscript": "Cancella file (e funscript)",
         "delete_generated_supporting_files": "Cancella file di supporto creati",

--- a/ui/v2.5/src/locales/ja-JP.json
+++ b/ui/v2.5/src/locales/ja-JP.json
@@ -26,7 +26,7 @@
         "created_entity": "{entity_type}を作成しました: {entity_name}",
         "customise": "カスタマイズ",
         "delete": "削除",
-        "delete_entity": "{entityType}を削除",
+        "delete_entity": "を削除",
         "delete_file": "ファイルを削除",
         "delete_file_and_funscript": "ファイルを削除 (ファンスクリプトを含む)",
         "delete_generated_supporting_files": "生成済みのサポートファイルを削除",

--- a/ui/v2.5/src/locales/ko-KR.json
+++ b/ui/v2.5/src/locales/ko-KR.json
@@ -27,7 +27,7 @@
         "created_entity": "{entity_type}을 생성했습니다. ({entity_name})",
         "customise": "사용자 정의",
         "delete": "삭제",
-        "delete_entity": "{entityType} 삭제",
+        "delete_entity": "삭제",
         "delete_file": "파일 삭제",
         "delete_file_and_funscript": "파일 삭제 (funscript 포함)",
         "delete_generated_supporting_files": "생성된 컨텐츠 파일들까지 삭제",

--- a/ui/v2.5/src/locales/lv.json
+++ b/ui/v2.5/src/locales/lv.json
@@ -33,7 +33,7 @@
         "clear_image": "Notīrīt bildi",
         "create": "Izveidot",
         "assign_stashid_to_parent_studio": "Piešķirt pagaidu ID esošajai vecākstudijai un atjaunināt metadatus",
-        "delete_entity": "Dzēst {EntityType}",
+        "delete_entity": "Dzēst",
         "create_parent_studio": "Izveidot pamatstudiju",
         "clear_date_data": "Notīrīt visus datus",
         "add_manual_date": "Pievienot manuālo datumu",

--- a/ui/v2.5/src/locales/nl-NL.json
+++ b/ui/v2.5/src/locales/nl-NL.json
@@ -25,7 +25,7 @@
         "created_entity": "Aangemaakt {entity_type}: {entity_name}",
         "customise": "Aanpassen",
         "delete": "Verwijder",
-        "delete_entity": "Verwijder {entityType}",
+        "delete_entity": "Verwijder",
         "delete_file": "Verwijder bestand",
         "delete_file_and_funscript": "Verwijder bestand (en funscript)",
         "delete_generated_supporting_files": "Verwijder gegenereerde ondersteuningsbestanden",

--- a/ui/v2.5/src/locales/nn.json
+++ b/ui/v2.5/src/locales/nn.json
@@ -29,7 +29,7 @@
         "created_entity": "Oppretta {entity_type}: {entity_name}",
         "customise": "Tilpass",
         "delete": "Slett",
-        "delete_entity": "Slett {entityType}",
+        "delete_entity": "Slett",
         "delete_file": "Slett fil",
         "disable": "Slå av",
         "remove_date": "Fjern dato",

--- a/ui/v2.5/src/locales/pl-PL.json
+++ b/ui/v2.5/src/locales/pl-PL.json
@@ -27,7 +27,7 @@
         "created_entity": "Utworzono {entity_type}: {entity_name}",
         "customise": "Dostosuj",
         "delete": "Usuń",
-        "delete_entity": "Usuń {entityType}",
+        "delete_entity": "Usuń",
         "delete_file": "Usuń plik",
         "delete_file_and_funscript": "Usuń plik (i skrypt funscript)",
         "delete_generated_supporting_files": "Usuń wygenerowane pliki pomocnicze",

--- a/ui/v2.5/src/locales/pt-BR.json
+++ b/ui/v2.5/src/locales/pt-BR.json
@@ -29,7 +29,7 @@
         "created_entity": "Criar {entity_type}: {entity_name}",
         "customise": "Customizar",
         "delete": "Apagar",
-        "delete_entity": "Apagar {entityType}",
+        "delete_entity": "Apagar",
         "delete_file": "Apagar arquivo",
         "delete_file_and_funscript": "Deletar arquivo (e funscript)",
         "delete_generated_supporting_files": "Apagar arquivos gerados de suporte",

--- a/ui/v2.5/src/locales/ro-RO.json
+++ b/ui/v2.5/src/locales/ro-RO.json
@@ -23,7 +23,7 @@
         "created_entity": "S-a creat {entity_type}: {entity_name}",
         "customise": "Personalizați",
         "delete": "Șterge",
-        "delete_entity": "Șterge {entityType}",
+        "delete_entity": "Șterge",
         "delete_file": "Șterge fişier",
         "delete_file_and_funscript": "Șterge fişier (şi funscript)",
         "disallow": "Nu se permite",

--- a/ui/v2.5/src/locales/ru-RU.json
+++ b/ui/v2.5/src/locales/ru-RU.json
@@ -27,7 +27,7 @@
         "created_entity": "Создано {entity_type}: {entity_name}",
         "customise": "Настроить",
         "delete": "Удалить",
-        "delete_entity": "Удалить {entityType}",
+        "delete_entity": "Удалить",
         "delete_file": "Удалить файл",
         "delete_file_and_funscript": "Удалить файл (вместе с funscript)",
         "delete_generated_supporting_files": "Удалить сгенерированные вспомогательные файлы",

--- a/ui/v2.5/src/locales/sv-SE.json
+++ b/ui/v2.5/src/locales/sv-SE.json
@@ -29,7 +29,7 @@
         "created_entity": "Skapade {entity_type}: {entity_name}",
         "customise": "Ändra",
         "delete": "Radera",
-        "delete_entity": "Radera {entityType}",
+        "delete_entity": "Radera",
         "delete_file": "Radera fil",
         "delete_file_and_funscript": "Radera fil (och funskript)",
         "delete_generated_supporting_files": "Radera genererade filer",

--- a/ui/v2.5/src/locales/th-TH.json
+++ b/ui/v2.5/src/locales/th-TH.json
@@ -25,7 +25,7 @@
         "created_entity": "สร้าง{entity_type}: {entity_name}",
         "customise": "ปรับแต่ง",
         "delete": "ลบ",
-        "delete_entity": "ลบ{entityType}",
+        "delete_entity": "ลบ",
         "delete_file": "ลบไฟล์",
         "delete_file_and_funscript": "ลบไฟล์ (และ funscript)",
         "delete_generated_supporting_files": "ลบไฟล์ที่เกี่ยวข้อง",

--- a/ui/v2.5/src/locales/tr-TR.json
+++ b/ui/v2.5/src/locales/tr-TR.json
@@ -24,7 +24,7 @@
         "create_marker": "Yer İmi Oluştur",
         "created_entity": "{entity_type}: {entity_name} oluşturuldu",
         "delete": "Sil",
-        "delete_entity": "{entityType} Sil",
+        "delete_entity": "Sil",
         "delete_file": "Dosyayı sil",
         "delete_generated_supporting_files": "Oluşturulan ek dosyaları sil",
         "disallow": "İzin verme",

--- a/ui/v2.5/src/locales/uk-UA.json
+++ b/ui/v2.5/src/locales/uk-UA.json
@@ -25,7 +25,7 @@
         "created_entity": "Створений {entity_type}:{entity_name}",
         "customise": "Кастомізувати",
         "delete": "Видалити",
-        "delete_entity": "Видалити {entityType}",
+        "delete_entity": "Видалити",
         "delete_file": "Видалити Файл",
         "delete_file_and_funscript": "Видалити Файл (і фанскрипт)",
         "delete_generated_supporting_files": "Видалити згенеровані файли підтрикм",

--- a/ui/v2.5/src/locales/zh-CN.json
+++ b/ui/v2.5/src/locales/zh-CN.json
@@ -27,7 +27,7 @@
         "created_entity": "已创建{entity_type}: {entity_name}",
         "customise": "自定义",
         "delete": "删除",
-        "delete_entity": "删除{entityType}",
+        "delete_entity": "删除",
         "delete_file": "删除文件",
         "delete_file_and_funscript": "删除文件 (和 funscript)",
         "delete_generated_supporting_files": "删除已生成的附加文件",

--- a/ui/v2.5/src/locales/zh-TW.json
+++ b/ui/v2.5/src/locales/zh-TW.json
@@ -27,7 +27,7 @@
         "created_entity": "已建立{entity_type}：{entity_name}",
         "customise": "自訂",
         "delete": "刪除",
-        "delete_entity": "刪除{entityType}",
+        "delete_entity": "刪除",
         "delete_file": "刪除檔案",
         "delete_file_and_funscript": "刪除檔案 (及其 Funscript)",
         "delete_generated_supporting_files": "刪除已生成的資訊檔案",


### PR DESCRIPTION
Removed the Entity type from delete_entity. This was proven on scenes tab and galleries tab. I have no images to delete in Dev so can't test that.

[Before](https://gyazo.com/47f25feb7eab0cacc3a0eeca8248ef1d) and [after](https://gyazo.com/2633bb262a062a36022b419df61599e3)

closes https://github.com/stashapp/stash/issues/4600