### PR TITLE
[WIP] Adding In Tagger Buttons

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -185,6 +185,69 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
     }
   }
 
+  function maybeRenderSearchAllButton() {
+    const searchButtons = document.querySelectorAll('.input-group-append .btn.btn-primary');
+  
+    if (searchButtons.length > 0) {
+      return (
+        <Button onClick={handleSearchAllClick}>
+          <FormattedMessage id="component_tagger.verb_search_all" />
+        </Button>
+      );
+    }
+    return null;
+  }
+
+  function handleSearchAllClick() {
+    const searchButtons = document.querySelectorAll('.input-group-append .btn.btn-primary');
+  
+    searchButtons.forEach((button, index) => {
+      setTimeout(() => {
+        console.log(`Clicking button ${index + 1}:`, button);
+        
+        if (button instanceof HTMLElement) {
+          button.click();
+        }
+      }, index * 700); // 700ms delay between clicks... its a lot but if it goes too quick then the UI breaks and skips scenes.
+    });
+  }
+
+  function maybeRenderCreateAllButton() {
+    const CreateButtons = document.querySelectorAll('.row.no-gutters.align-items-center.mt-2 .btn-group .btn.btn-secondary');
+  
+    if (CreateButtons.length > 0) {
+      return (
+        <Button onClick={handleCreateAllClick}>
+          <FormattedMessage id="component_tagger.verb_create_all" />
+        </Button>
+      );
+    }
+    return null;
+  }
+
+  function handleCreateAllClick() {
+    const createButtons = document.querySelectorAll('.row.no-gutters.align-items-center.mt-2 .btn-group .btn.btn-secondary');
+  
+    createButtons.forEach((button, index) => {
+      setTimeout(() => {
+        console.log(`Clicking create button ${index + 1}:`, button);
+        
+        if (button instanceof HTMLElement) {
+          button.click();
+
+          setTimeout(() => {
+            const saveButton = document.querySelector('.ModalFooter.modal-footer .ml-2.btn.btn-primary');
+            if (saveButton instanceof HTMLElement) {
+              saveButton.click();
+            } else {
+              console.warn(`Save button not found for create button ${index + 1}`);
+            }
+          }, 500); 
+        }
+      }, index * 800);
+    });
+  }
+
   function maybeRenderSubmitFingerprintsButton() {
     if (pendingFingerprints.length) {
       return (
@@ -253,6 +316,8 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
           <div className="d-flex justify-content-between align-items-center flex-wrap">
             <div className="w-auto">{renderSourceSelector()}</div>
             <div className="d-flex">
+              {maybeRenderCreateAllButton()}
+              {maybeRenderSearchAllButton()}
               {maybeRenderShowHideUnmatchedButton()}
               {maybeRenderSubmitFingerprintsButton()}
               {renderFragmentScrapeButton()}

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  .d-flex .btn.btn-primary{
+    margin-right: 3px;
+  }
+
   .sprite-button {
     bottom: 5px;
     filter: drop-shadow(1px 1px 1px #222);

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -205,6 +205,8 @@
     "verb_match_fp": "Match Fingerprints",
     "verb_matched": "Matched",
     "verb_scrape_all": "Scrape All",
+    "verb_search_all": "Search All",
+    "verb_create_all": "Create All",
     "verb_submit_fp": "Submit {fpCount, plural, one{# Fingerprint} other{# Fingerprints}}",
     "verb_toggle_config": "{toggle} {configuration}",
     "verb_toggle_unmatched": "{toggle} unmatched scenes"


### PR DESCRIPTION
Adding in Search all and Create all buttons to tagger view.

So far this will add a Search All button, and then if any scenes have been found, generate a create all button. Once you are comfortable that all scenes are matched correctly you can click "create all" and it will create all performers and studios for you.

This is currently a WIP, the core functionality is there, but the CSS is a smidge wonky. I will also be adding in a "Save ID" button which will click the save StashID button so that any performers and scenes can get an associated StashID. This takes some very well used userscripts and plugins to the core app.

closes https://github.com/stashapp/stash/issues/3122