### PR TITLE
[Bug Fix] Fix Studio Pluralization

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -51,8 +51,6 @@ function maybeRenderParent(
 
 function maybeRenderChildren(studio: GQL.StudioDataFragment) {
   if (studio.child_studios.length > 0) {
-    const studioLabel =
-      studio.child_studios.length === 1 ? "studio" : "studios";
     return (
       <div className="studio-child-studios">
         <FormattedMessage
@@ -60,7 +58,11 @@ function maybeRenderChildren(studio: GQL.StudioDataFragment) {
           values={{
             children: (
               <Link to={NavUtils.makeChildStudiosUrl(studio)}>
-                {studio.child_studios.length} {studioLabel}
+                {studio.child_studios.length}&nbsp;
+                <FormattedMessage
+                  id="countables.studios"
+                  values={{ count: studio.child_studios.length }}
+                />
               </Link>
             ),
           }}

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -51,6 +51,8 @@ function maybeRenderParent(
 
 function maybeRenderChildren(studio: GQL.StudioDataFragment) {
   if (studio.child_studios.length > 0) {
+    const studioLabel =
+      studio.child_studios.length === 1 ? "studio" : "studios";
     return (
       <div className="studio-child-studios">
         <FormattedMessage
@@ -58,7 +60,7 @@ function maybeRenderChildren(studio: GQL.StudioDataFragment) {
           values={{
             children: (
               <Link to={NavUtils.makeChildStudiosUrl(studio)}>
-                {studio.child_studios.length} studios
+                {studio.child_studios.length} {studioLabel}
               </Link>
             ),
           }}


### PR DESCRIPTION
Small bug fix so that if a studio only has 1 child studio then the correct pluralization is used.

[Before](https://gyazo.com/ec063fb3c3301e77a2bdd61027db8b79) vs [after](https://gyazo.com/ecd8034358835d8281a6ebd6d2830ce1)

closes https://github.com/stashapp/stash/issues/4609