### PR TITLE
Persist tagger settings and change defaults

### DIFF
--- a/ui/v2.5/src/components/Tagger/config.ts
+++ b/ui/v2.5/src/components/Tagger/config.ts
@@ -1,0 +1,20 @@
+import { useCallback, useContext } from "react";
+import { ConfigurationContext } from "src/hooks/Config";
+import { initialConfig, ITaggerConfig } from "./constants";
+import { useConfigureUISetting } from "src/core/StashService";
+
+export function useTaggerConfig() {
+  const { configuration: stashConfig } = useContext(ConfigurationContext);
+  const [saveUISetting] = useConfigureUISetting();
+
+  const config = stashConfig?.ui.taggerConfig ?? initialConfig;
+
+  const setConfig = useCallback(
+    (c: ITaggerConfig) => {
+      saveUISetting({ variables: { key: "taggerConfig", value: c } });
+    },
+    [saveUISetting]
+  );
+
+  return { config, setConfig };
+}

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -11,7 +11,6 @@ export interface ITaggerSource {
   supportSceneFragment?: boolean;
 }
 
-export const LOCAL_FORAGE_KEY = "tagger";
 export const DEFAULT_BLACKLIST = [
   "\\sXXX\\s",
   "1080p",

--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -27,10 +27,10 @@ export const DEFAULT_EXCLUDED_STUDIO_FIELDS = ["name"];
 
 export const initialConfig: ITaggerConfig = {
   blacklist: DEFAULT_BLACKLIST,
-  showMales: false,
+  showMales: true,
   mode: "auto",
   setCoverImage: true,
-  setTags: false,
+  setTags: true,
   tagOperation: "merge",
   fingerprintQueue: {},
   excludedPerformerFields: DEFAULT_EXCLUDED_PERFORMER_FIELDS,

--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import {
-  initialConfig,
-  ITaggerConfig,
-  LOCAL_FORAGE_KEY,
-} from "src/components/Tagger/constants";
+import { initialConfig, ITaggerConfig } from "src/components/Tagger/constants";
 import * as GQL from "src/core/generated-graphql";
 import {
   queryFindPerformer,
@@ -20,12 +16,12 @@ import {
   useStudioUpdate,
   useTagCreate,
 } from "src/core/StashService";
-import { useLocalForage } from "src/hooks/LocalForage";
 import { useToast } from "src/hooks/Toast";
 import { ConfigurationContext } from "src/hooks/Config";
 import { ITaggerSource, SCRAPER_PREFIX, STASH_BOX_PREFIX } from "./constants";
 import { errorToString } from "src/utils";
 import { mergeStudioStashIDs } from "./utils";
+import { useTaggerConfig } from "./config";
 
 export interface ITaggerContextState {
   config: ITaggerConfig;
@@ -110,11 +106,6 @@ export interface ISceneQueryResult {
 }
 
 export const TaggerContext: React.FC = ({ children }) => {
-  const [{ data: config }, setConfig] = useLocalForage<ITaggerConfig>(
-    LOCAL_FORAGE_KEY,
-    initialConfig
-  );
-
   const [loading, setLoading] = useState(false);
   const [loadingMulti, setLoadingMulti] = useState(false);
   const [sources, setSources] = useState<ITaggerSource[]>([]);
@@ -127,6 +118,8 @@ export const TaggerContext: React.FC = ({ children }) => {
   const stopping = useRef(false);
 
   const { configuration: stashConfig } = React.useContext(ConfigurationContext);
+  const { config, setConfig } = useTaggerConfig();
+
   const Scrapers = useListSceneScrapers();
 
   const Toast = useToast();

--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -3,7 +3,6 @@ import { Button, Card, Form, InputGroup, ProgressBar } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 import { HashLink } from "react-router-hash-link";
-import { useLocalForage } from "src/hooks/LocalForage";
 
 import * as GQL from "src/core/generated-graphql";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
@@ -21,12 +20,13 @@ import { ConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
 import PerformerConfig from "./Config";
-import { LOCAL_FORAGE_KEY, ITaggerConfig, initialConfig } from "../constants";
+import { ITaggerConfig } from "../constants";
 import PerformerModal from "../PerformerModal";
 import { useUpdatePerformer } from "../queries";
 import { faStar, faTags } from "@fortawesome/free-solid-svg-icons";
 import { mergeStashIDs } from "src/utils/stashbox";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
+import { useTaggerConfig } from "../config";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -621,10 +621,7 @@ export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
   const jobsSubscribe = useJobsSubscribe();
   const intl = useIntl();
   const { configuration: stashConfig } = React.useContext(ConfigurationContext);
-  const [{ data: config }, setConfig] = useLocalForage<ITaggerConfig>(
-    LOCAL_FORAGE_KEY,
-    initialConfig
-  );
+  const { config, setConfig } = useTaggerConfig();
   const [showConfig, setShowConfig] = useState(false);
   const [showManual, setShowManual] = useState(false);
 

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -3,7 +3,6 @@ import { Button, Card, Form, InputGroup, ProgressBar } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 import { HashLink } from "react-router-hash-link";
-import { useLocalForage } from "src/hooks/LocalForage";
 
 import * as GQL from "src/core/generated-graphql";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
@@ -22,13 +21,14 @@ import { ConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
 import StudioConfig from "./Config";
-import { LOCAL_FORAGE_KEY, ITaggerConfig, initialConfig } from "../constants";
+import { ITaggerConfig } from "../constants";
 import StudioModal from "../scenes/StudioModal";
 import { useUpdateStudio } from "../queries";
 import { apolloError } from "src/utils";
 import { faStar, faTags } from "@fortawesome/free-solid-svg-icons";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
 import { mergeStudioStashIDs } from "../utils";
+import { useTaggerConfig } from "../config";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -670,10 +670,7 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
   const jobsSubscribe = useJobsSubscribe();
   const intl = useIntl();
   const { configuration: stashConfig } = React.useContext(ConfigurationContext);
-  const [{ data: config }, setConfig] = useLocalForage<ITaggerConfig>(
-    LOCAL_FORAGE_KEY,
-    initialConfig
-  );
+  const { config, setConfig } = useTaggerConfig();
   const [showConfig, setShowConfig] = useState(false);
   const [showManual, setShowManual] = useState(false);
 

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -8,6 +8,7 @@ import {
   SortDirectionEnum,
 } from "./generated-graphql";
 import { View } from "src/components/List/views";
+import { ITaggerConfig } from "src/components/Tagger/constants";
 
 // NOTE: double capitals aren't converted correctly in the backend
 
@@ -97,6 +98,8 @@ export interface IUIConfig {
   taskDefaults?: Record<string, {}>;
 
   defaultFilters?: DefaultFilters;
+
+  taggerConfig?: ITaggerConfig;
 }
 
 export function getFrontPageContent(

--- a/ui/v2.5/src/docs/en/ReleaseNotes/index.ts
+++ b/ui/v2.5/src/docs/en/ReleaseNotes/index.ts
@@ -3,6 +3,7 @@ import v0200 from "./v0200.md";
 import v0240 from "./v0240.md";
 import v0250 from "./v0250.md";
 import v0260 from "./v0260.md";
+import v0270 from "./v0270.md";
 
 export interface IReleaseNotes {
   // handle should be in the form of YYYYMMDD
@@ -12,6 +13,11 @@ export interface IReleaseNotes {
 }
 
 export const releaseNotes: IReleaseNotes[] = [
+  {
+    date: 20240826,
+    version: "v0.27.0",
+    content: v0270,
+  },
   {
     date: 20240510,
     version: "v0.26.0",

--- a/ui/v2.5/src/docs/en/ReleaseNotes/v0270.md
+++ b/ui/v2.5/src/docs/en/ReleaseNotes/v0270.md
@@ -1,0 +1,1 @@
+Tagger settings have been reset, but are now persisted between browser sessions. `Show male performers` and `Set Tags` are now defaulted to true. Please verify your settings before using the Tagger.


### PR DESCRIPTION
Resolves #3210 
Resolves #4982 
Resolves #5065 

Moves the tagger settings from the local forage into the UI config. This makes the settings and fingerprint queue persistent between browsers and browser sessions. Existing local forage settings are _not_ moved.

Accordingly, `Show male performers` and `Set Tags` now default to true. 

A release note is included to indicate that settings have been reset and the new defaults.