### PR TITLE
Truncate scenes_o_dates and scenes_view_dates as part of anonymize

### DIFF
--- a/pkg/sqlite/anonymise.go
+++ b/pkg/sqlite/anonymise.go
@@ -47,6 +47,8 @@ func (db *Anonymiser) Anonymise(ctx context.Context) error {
 		return utils.Do([]func() error{
 			func() error { return db.deleteBlobs() },
 			func() error { return db.deleteStashIDs() },
+			func() error { return db.clearOHistory() },
+			func() error { return db.clearWatchHistory() },
 			func() error { return db.anonymiseFolders(ctx) },
 			func() error { return db.anonymiseFiles(ctx) },
 			func() error { return db.anonymiseFingerprints(ctx) },
@@ -98,6 +100,18 @@ func (db *Anonymiser) deleteStashIDs() error {
 		func() error { return db.truncateTable("scene_stash_ids") },
 		func() error { return db.truncateTable("studio_stash_ids") },
 		func() error { return db.truncateTable("performer_stash_ids") },
+	})
+}
+
+func (db *Anonymiser) clearOHistory() error {
+	return utils.Do([]func() error{
+		func() error { return db.truncateTable("scenes_o_dates") },
+	})
+}
+
+func (db *Anonymiser) clearWatchHistory() error {
+	return utils.Do([]func() error{
+		func() error { return db.truncateTable("scenes_view_dates") },
 	})
 }
 


### PR DESCRIPTION
Seems like this sensitive information is not currently being anonymized. From discord "probably an oversight when O history and watch history was introduced". 

Separately, this file uses strings for table names, but most are actually defined in constants elsewhere. Can raise a separate PR to convert them to the defined constants for the whole file. 