### PR TITLE
Standardizing the delete dropdown.

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -189,7 +189,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
             onClick={() => setIsDeleteAlertOpen(true)}
           >
             <FormattedMessage
-              id="actions.delete_entity"
+              id="actions.delete"
               values={{ entityType: intl.formatMessage({ id: "gallery" }) }}
             />
           </Dropdown.Item>

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -193,7 +193,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
             onClick={() => setIsDeleteAlertOpen(true)}
           >
             <FormattedMessage
-              id="actions.delete_entity"
+              id="actions.delete"
               values={{ entityType: intl.formatMessage({ id: "image" }) }}
             />
           </Dropdown.Item>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -408,7 +408,7 @@ const ScenePage: React.FC<IProps> = ({
           onClick={() => setIsDeleteAlertOpen(true)}
         >
           <FormattedMessage
-            id="actions.delete_entity"
+            id="actions.delete"
             values={{ entityType: intl.formatMessage({ id: "scene" }) }}
           />
         </Dropdown.Item>


### PR DESCRIPTION
As WP requested, changed this up to use "delete" rather than "delete_entity" key

Same as https://github.com/stashapp/stash/pull/5157

closes https://github.com/stashapp/stash/issues/4600