### PR TITLE
Add linkTypes to performer popover

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -142,7 +142,12 @@ export const GalleryCard: React.FC<IProps> = (props) => {
   function maybeRenderPerformerPopoverButton() {
     if (props.gallery.performers.length <= 0) return;
 
-    return <PerformerPopoverButton performers={props.gallery.performers} />;
+    return (
+      <PerformerPopoverButton
+        performers={props.gallery.performers}
+        linkType="gallery"
+      />
+    );
   }
 
   function maybeRenderImagesPopoverButton() {

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -100,7 +100,12 @@ export const ImageCard: React.FC<IImageCardProps> = (
   function maybeRenderPerformerPopoverButton() {
     if (props.image.performers.length <= 0) return;
 
-    return <PerformerPopoverButton performers={props.image.performers} />;
+    return (
+      <PerformerPopoverButton
+        performers={props.image.performers}
+        linkType="image"
+      />
+    );
   }
 
   function maybeRenderOCounter() {

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -165,7 +165,12 @@ const SceneCardPopovers = PatchComponent(
     function maybeRenderPerformerPopoverButton() {
       if (props.scene.performers.length <= 0) return;
 
-      return <PerformerPopoverButton performers={props.scene.performers} />;
+      return (
+        <PerformerPopoverButton
+          performers={props.scene.performers}
+          linkType="scene"
+        />
+      );
     }
 
     function maybeRenderGroupPopoverButton() {

--- a/ui/v2.5/src/components/Shared/PerformerPopoverButton.tsx
+++ b/ui/v2.5/src/components/Shared/PerformerPopoverButton.tsx
@@ -6,16 +6,20 @@ import * as GQL from "src/core/generated-graphql";
 import { sortPerformers } from "src/core/performers";
 import { HoverPopover } from "./HoverPopover";
 import { Icon } from "./Icon";
-import { PerformerLink } from "./TagLink";
+import { PerformerLink, PerformerLinkType } from "./TagLink";
 
 interface IProps {
   performers: Pick<
     GQL.Performer,
     "id" | "name" | "image_path" | "disambiguation" | "gender"
   >[];
+  linkType?: PerformerLinkType;
 }
 
-export const PerformerPopoverButton: React.FC<IProps> = ({ performers }) => {
+export const PerformerPopoverButton: React.FC<IProps> = ({
+  performers,
+  linkType,
+}) => {
   const sorted = sortPerformers(performers);
   const popoverContent = sorted.map((performer) => (
     <div className="performer-tag-container row" key={performer.id}>
@@ -33,6 +37,7 @@ export const PerformerPopoverButton: React.FC<IProps> = ({ performers }) => {
         key={performer.id}
         performer={performer}
         className="d-block"
+        linkType={linkType}
       />
     </div>
   ));

--- a/ui/v2.5/src/components/Shared/TagLink.tsx
+++ b/ui/v2.5/src/components/Shared/TagLink.tsx
@@ -42,6 +42,8 @@ interface IPerformerLinkProps {
   className?: string;
 }
 
+export type PerformerLinkType = IPerformerLinkProps["linkType"];
+
 export const PerformerLink: React.FC<IPerformerLinkProps> = ({
   performer,
   linkType = "scene",


### PR DESCRIPTION
Adds linkTypes to the performer popover so the links in gallery and image cards link to their respective filters and not to scenes, as it is currently. This is how the tag popovers function and it appears this was intended for performer popovers but never implemented.

(This is incredibly pedantic; I might be the only user who has even noticed, let alone cares!)