### PR TITLE
Don't focus query field on select

### DIFF
--- a/ui/v2.5/src/components/List/Filters/SelectableFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/SelectableFilter.tsx
@@ -24,6 +24,7 @@ import { CriterionModifier } from "src/core/generated-graphql";
 import { keyboardClickHandler } from "src/utils/keyboard";
 import { useDebounce } from "src/hooks/debounce";
 import useFocus from "src/utils/focus";
+import ScreenUtils from "src/utils/screen";
 
 interface ISelectedItem {
   item: ILabeledId;
@@ -235,7 +236,10 @@ export const ObjectsFilter = <
     setDisplayQuery("");
 
     // focus the input box
-    setInputFocus();
+    // don't do this on touch devices, as it's annoying
+    if (!ScreenUtils.isTouch()) {
+      setInputFocus();
+    }
   }
 
   const onUnselect = useCallback(


### PR DESCRIPTION
Fixes irritating behaviour on mobile where selecting an item in selectable filters (tags, performers, studios), the query field would be focused, bringing up the on-screen keyboard. Changed to disable this behaviour on touch devices.