### PR TITLE
Show page numbers on low page count

### DIFF
--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -8,7 +8,7 @@ import {
   Overlay,
   Popover,
 } from "react-bootstrap";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, FormattedNumber, useIntl } from "react-intl";
 import useFocus from "src/utils/focus";
 import { Icon } from "../Shared/Icon";
 import { faCheck, faChevronDown } from "@fortawesome/free-solid-svg-icons";
@@ -143,6 +143,8 @@ interface IPaginationIndexProps {
   metadataByline?: React.ReactNode;
 }
 
+const minPagesForCompact = 4;
+
 export const Pagination: React.FC<IPaginationProps> = ({
   itemsPerPage,
   currentPage,
@@ -155,6 +157,30 @@ export const Pagination: React.FC<IPaginationProps> = ({
     () => Math.ceil(totalItems / itemsPerPage),
     [totalItems, itemsPerPage]
   );
+
+  const pageButtons = useMemo(() => {
+    if (totalPages >= minPagesForCompact)
+      return (
+        <PageCount
+          totalPages={totalPages}
+          currentPage={currentPage}
+          onChangePage={onChangePage}
+        />
+      );
+
+    const pages = [...Array(totalPages).keys()].map((i) => i + 1);
+
+    return pages.map((page: number) => (
+      <Button
+        variant="secondary"
+        key={page}
+        active={currentPage === page}
+        onClick={() => onChangePage(page)}
+      >
+        <FormattedNumber value={page} />
+      </Button>
+    ));
+  }, [totalPages, currentPage, onChangePage]);
 
   if (totalPages <= 1) return <div />;
 
@@ -176,13 +202,7 @@ export const Pagination: React.FC<IPaginationProps> = ({
       >
         &lt;
       </Button>
-
-      <PageCount
-        totalPages={totalPages}
-        currentPage={currentPage}
-        onChangePage={onChangePage}
-      />
-
+      {pageButtons}
       <Button
         variant="secondary"
         disabled={currentPage === totalPages}


### PR DESCRIPTION
Shows individual page numbers (per the previous pagination behaviour) instead of the page count selector when pages < 4. Just a convenience improvement. Usability-wise it could have a little more page buttons before it gets overwealming, but up to three pages plus the first/last/next/previous buttons is as much as would fit on the smallest viewports. 

![image](https://github.com/user-attachments/assets/e8e1ff86-997b-47bd-9190-e750009828c9)
![image](https://github.com/user-attachments/assets/7bbff16b-07ae-4028-b0c1-a7ba72ea5119)
