### PR TITLE
Removing White Space from InputFields.

### DIFF
--- a/ui/v2.5/src/utils/form.tsx
+++ b/ui/v2.5/src/utils/form.tsx
@@ -113,6 +113,12 @@ export function formikUtils<V extends FormikValues>(
       value = "";
     }
 
+    // trimming leading and trailing spaces from inputs
+    const handleBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
+      formik.setFieldValue(field, e.target.value.trim());
+      formik.handleBlur(e);
+    };
+
     let control: React.ReactNode;
     if (type === "checkbox") {
       control = (
@@ -141,6 +147,7 @@ export function formikUtils<V extends FormikValues>(
           className="text-input"
           placeholder={placeholder}
           {...formikProps}
+          onBlur={handleBlur}
           value={value}
           isInvalid={!!error}
         />


### PR DESCRIPTION
I only added it in to `<InputFIeld>` Reason being is, if I'm not mistaken, the other fields aren't really sortable anyway so it shouldn't affect sorting.

People should still be able to add following and trailing spaces in things like description, Piercings, Tattoos, etc. Personally I see no reason to remove that unless there is something I am missing.

fixes https://github.com/stashapp/stash/issues/789