### PR TITLE
lint: switch exportloopref to copyloopvar per warning message

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,11 +15,11 @@ linters:
     - unused
     # Linters added by the stash project.
     # - contextcheck
+    - copyloopvar
     - dogsled
     - errchkjson
     - errorlint
     # - exhaustive
-    - exportloopref
     - gocritic
     # - goerr113
     - gofmt


### PR DESCRIPTION
Running `make lint` produces a warning message as follows: 
```text
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```
This small one-line update makes that change. This new linter seems to be close enough to the old one such that there are no code changes required. 