### PR TITLE
Fix Tag and Alias odd spacing

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -140,7 +140,9 @@ const _PerformerSelect: React.FC<
                   <span>
                     {name}
                     {alias && (
-                      <span className="performer-select-alias">{` (${alias})`}</span>
+                      <span className="performer-select-alias">
+                        &nbsp;({alias})
+                      </span>
                     )}
                   </span>
                 }

--- a/ui/v2.5/src/components/Studios/StudioSelect.tsx
+++ b/ui/v2.5/src/components/Studios/StudioSelect.tsx
@@ -117,7 +117,7 @@ const _StudioSelect: React.FC<
       children: (
         <span className="react-select-image-option">
           <span>{name}</span>
-          {alias && <span className="alias">{` (${alias})`}</span>}
+          {alias && <span className="alias">&nbsp;({alias})</span>}
         </span>
       ),
     };

--- a/ui/v2.5/src/components/Tags/TagSelect.tsx
+++ b/ui/v2.5/src/components/Tags/TagSelect.tsx
@@ -133,7 +133,7 @@ const _TagSelect: React.FC<
               </a>
             </TagPopover> */}
             <span>{name}</span>
-            {alias && <span className="alias">{` (${alias})`}</span>}
+            {alias && <span className="alias">&nbsp;({alias})</span>}
           </span>
         </TagPopover>
       ),


### PR DESCRIPTION
As Echo6ix brough up the HTML engine doesn't generate whitespace at the beginning of a string. Modifying it to use `&nbsp;` so that the spacing will be correct.

fixes https://github.com/stashapp/stash/issues/4997