### PR TITLE
Fix scene filter panel colour slider range

### DIFF
--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -341,6 +341,10 @@ input[type="range"].filter-slider {
   padding-right: 0;
 }
 
+.filter-slider-value {
+  cursor: pointer;
+}
+
 @mixin contrast-slider() {
   background: rgb(255, 255, 255);
   background: linear-gradient(


### PR DESCRIPTION
Changes the behaviour of the red/green/blue filter sliders in the scene filter panel so that they range between 0-200%. Includes some refactoring and adds a pointer cursor to the slider values to hint at the click to reset behaviour.

Fixes #5215