### PR TITLE
Show option for sub-content only if there are child objects

### DIFF
--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -79,7 +79,9 @@ const StudioTabs: React.FC<{
   abbreviateCounter: boolean;
   showAllCounts?: boolean;
 }> = ({ tabKey, studio, abbreviateCounter, showAllCounts = false }) => {
-  const [showAllDetails, setShowAllDetails] = useState<boolean>(showAllCounts);
+  const [showAllDetails, setShowAllDetails] = useState<boolean>(
+    showAllCounts && studio.child_studios.length > 0
+  );
 
   const sceneCount =
     (showAllDetails ? studio.scene_count_all : studio.scene_count) ?? 0;
@@ -125,8 +127,12 @@ const StudioTabs: React.FC<{
     baseURL: `/studios/${studio.id}`,
   });
 
-  const contentSwitch = useMemo(
-    () => (
+  const contentSwitch = useMemo(() => {
+    if (!studio.child_studios.length) {
+      return null;
+    }
+
+    return (
       <div className="item-list-header">
         <Form.Check
           id="showSubContent"
@@ -136,9 +142,8 @@ const StudioTabs: React.FC<{
           label={<FormattedMessage id="include_sub_studio_content" />}
         />
       </div>
-    ),
-    [showAllDetails]
-  );
+    );
+  }, [showAllDetails, studio.child_studios.length]);
 
   return (
     <Tabs

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -82,7 +82,9 @@ const TagTabs: React.FC<{
   abbreviateCounter: boolean;
   showAllCounts?: boolean;
 }> = ({ tabKey, tag, abbreviateCounter, showAllCounts = false }) => {
-  const [showAllDetails, setShowAllDetails] = useState<boolean>(showAllCounts);
+  const [showAllDetails, setShowAllDetails] = useState<boolean>(
+    showAllCounts && tag.children.length > 0
+  );
 
   const sceneCount =
     (showAllDetails ? tag.scene_count_all : tag.scene_count) ?? 0;
@@ -135,8 +137,12 @@ const TagTabs: React.FC<{
     baseURL: `/tags/${tag.id}`,
   });
 
-  const contentSwitch = useMemo(
-    () => (
+  const contentSwitch = useMemo(() => {
+    if (tag.children.length === 0) {
+      return null;
+    }
+
+    return (
       <div className="item-list-header">
         <Form.Check
           id="showSubContent"
@@ -146,9 +152,8 @@ const TagTabs: React.FC<{
           label={<FormattedMessage id="include_sub_tag_content" />}
         />
       </div>
-    ),
-    [showAllDetails]
-  );
+    );
+  }, [showAllDetails, tag.children.length]);
 
   return (
     <Tabs


### PR DESCRIPTION
Hides the `Include sub-studio/tag content` buttons when the Studio/Tag has no sub-studio/tag.