### PR TITLE
Fix `source-selector` being blocked on mobile

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -360,6 +360,10 @@ $sceneTabWidth: 450px;
         height: 1.4em;
         width: 1.4em;
       }
+
+      .vjs-source-selector .vjs-menu {
+        z-index: 9999;
+      }
     }
 
     .vjs-menu-button-popup .vjs-menu {


### PR DESCRIPTION
Small CSS change to allow the `source-selector` to be brought to the front of the controls to allow people to select which source they would like. Added it into the section for mobile changes ( < 576px) as it's not really needed on anything bigger but can move it if told otherwise

At first, I was going more complex. I created functions that would disable the `big-buttons` if a menu was open and I got it mostly working but I felt like it was overkill when we can modify like 3-4 lines of CSS and get the same result.

fixes https://github.com/stashapp/stash/issues/4066