### PR TITLE
Updating Reload Scrapers formatting

### DIFF
--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Dropdown, Button } from "react-bootstrap";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "./Icon";
 import { stashboxDisplayName } from "src/utils/stashbox";
 import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
@@ -26,6 +26,8 @@ export const ScraperMenu: React.FC<{
 }) => {
   const intl = useIntl();
   const [filter, setFilter] = useState("");
+  const listOverflowable =
+    (stashBoxes?.length ?? 0) + scrapers.length > minFilteredScrapers;
 
   const filteredStashboxes = useMemo(() => {
     if (!stashBoxes) return [];
@@ -46,80 +48,76 @@ export const ScraperMenu: React.FC<{
     );
   }, [scrapers, filter]);
 
+  function maybeRenderScraperFilterInput() {
+    if (!listOverflowable) return;
+
+    return (
+      <ClearableInput
+        placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+        value={filter}
+        setValue={setFilter}
+      />
+    );
+  }
+
+  function maybeRenderReloadLabel() {
+    if (listOverflowable) return;
+
+    return (
+      <span>
+        <FormattedMessage id="actions.reload_scrapers" />
+      </span>
+    );
+  }
+
   return (
-    <div className="scraper-menu">
-      <Dropdown
-        className="d-inline"
-        title={intl.formatMessage({ id: "actions.reload_scrapers" })}
-      >
-        <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
+    <Dropdown
+      className="scraper-menu"
+      title={intl.formatMessage({ id: "actions.scrape_query" })}
+    >
+      <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
-        <Dropdown.Menu>
-          <div className="filter-container d-flex align-items-center px-2">
-            <div className="input-button-wrapper d-flex w-100">
-              {(stashBoxes?.length ?? 0) + scrapers.length >
-              minFilteredScrapers ? (
-                <>
-                  {/* Filter box is visible: render input + normal button */}
-                  <ClearableInput
-                    className="filter-input"
-                    placeholder={`${intl.formatMessage({ id: "filter" })}...`}
-                    value={filter}
-                    setValue={setFilter}
-                  />
-                  <Button
-                    variant="outline-primary"
-                    onClick={onReloadScrapers}
-                    className="refresh-button"
-                  >
-                    <Icon icon={faSyncAlt} />
-                  </Button>
-                </>
-              ) : (
-                <>
-                  {/* No filter: Stretch button to full width */}
-                  <Button
-                    variant="outline-primary"
-                    onClick={onReloadScrapers}
-                    className="refresh-button full-width-button"
-                  >
-                    <Icon icon={faSyncAlt} />
-                    <span className="ml-2">
-                      {intl.formatMessage({ id: "actions.reload_scrapers" })}
-                    </span>
-                  </Button>
-                </>
-              )}
-            </div>
+      <Dropdown.Menu>
+        <div className="filter-container">
+          <div className="btn-group">
+            {maybeRenderScraperFilterInput()}
+            <Button
+              onClick={onReloadScrapers}
+              className="reload-button"
+              title={intl.formatMessage({ id: "actions.reload_scrapers" })}
+            >
+              <Icon icon={faSyncAlt} />
+              {maybeRenderReloadLabel()}
+            </Button>
           </div>
+        </div>
 
-          {filteredStashboxes.map((s, index) => (
-            <Dropdown.Item
-              key={s.endpoint}
-              onClick={() =>
-                onScraperClicked({
-                  stash_box_endpoint: s.endpoint,
-                })
-              }
-            >
-              {stashboxDisplayName(s.name, index)}
-            </Dropdown.Item>
-          ))}
+        {filteredStashboxes.map((s, index) => (
+          <Dropdown.Item
+            key={s.endpoint}
+            onClick={() =>
+              onScraperClicked({
+                stash_box_endpoint: s.endpoint,
+              })
+            }
+          >
+            {stashboxDisplayName(s.name, index)}
+          </Dropdown.Item>
+        ))}
 
-          {filteredStashboxes.length > 0 && filteredScrapers.length > 0 && (
-            <Dropdown.Divider />
-          )}
+        {filteredStashboxes.length > 0 && filteredScrapers.length > 0 && (
+          <Dropdown.Divider />
+        )}
 
-          {filteredScrapers.map((s) => (
-            <Dropdown.Item
-              key={s.name}
-              onClick={() => onScraperClicked({ scraper_id: s.id })}
-            >
-              {s.name}
-            </Dropdown.Item>
-          ))}
-        </Dropdown.Menu>
-      </Dropdown>
-    </div>
+        {filteredScrapers.map((s) => (
+          <Dropdown.Item
+            key={s.name}
+            onClick={() => onScraperClicked({ scraper_id: s.id })}
+          >
+            {s.name}
+          </Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
-import { Dropdown } from "react-bootstrap";
-import { FormattedMessage, useIntl } from "react-intl";
+import { Dropdown, Button } from "react-bootstrap";
+import { useIntl } from "react-intl";
 import { Icon } from "./Icon";
 import { stashboxDisplayName } from "src/utils/stashbox";
 import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
@@ -47,56 +47,79 @@ export const ScraperMenu: React.FC<{
   }, [scrapers, filter]);
 
   return (
-    <Dropdown
-      className="scraper-menu"
-      title={intl.formatMessage({ id: "actions.scrape_query" })}
-    >
-      <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
+    <div className="scraper-menu">
+      <Dropdown
+        className="d-inline"
+        title={intl.formatMessage({ id: "actions.reload_scrapers" })}
+      >
+        <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
-      <Dropdown.Menu>
-        <Dropdown.Item onClick={() => onReloadScrapers()}>
-          <span className="fa-icon">
-            <Icon icon={faSyncAlt} />
-          </span>
-          <span>
-            <FormattedMessage id="actions.reload_scrapers" />
-          </span>
-        </Dropdown.Item>
+        <Dropdown.Menu>
+          <div className="filter-container d-flex align-items-center px-2">
+            <div className="input-button-wrapper d-flex w-100">
+              {(stashBoxes?.length ?? 0) + scrapers.length >
+              minFilteredScrapers ? (
+                <>
+                  {/* Filter box is visible: render input + normal button */}
+                  <ClearableInput
+                    className="filter-input"
+                    placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+                    value={filter}
+                    setValue={setFilter}
+                  />
+                  <Button
+                    variant="outline-primary"
+                    onClick={onReloadScrapers}
+                    className="refresh-button"
+                  >
+                    <Icon icon={faSyncAlt} />
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {/* No filter: Stretch button to full width */}
+                  <Button
+                    variant="outline-primary"
+                    onClick={onReloadScrapers}
+                    className="refresh-button full-width-button"
+                  >
+                    <Icon icon={faSyncAlt} />
+                    <span className="ml-2">
+                      {intl.formatMessage({ id: "actions.reload_scrapers" })}
+                    </span>
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
 
-        {(stashBoxes?.length ?? 0) + scrapers.length > minFilteredScrapers && (
-          <ClearableInput
-            placeholder={`${intl.formatMessage({ id: "filter" })}...`}
-            value={filter}
-            setValue={setFilter}
-          />
-        )}
+          {filteredStashboxes.map((s, index) => (
+            <Dropdown.Item
+              key={s.endpoint}
+              onClick={() =>
+                onScraperClicked({
+                  stash_box_endpoint: s.endpoint,
+                })
+              }
+            >
+              {stashboxDisplayName(s.name, index)}
+            </Dropdown.Item>
+          ))}
 
-        {filteredStashboxes.map((s, index) => (
-          <Dropdown.Item
-            key={s.endpoint}
-            onClick={() =>
-              onScraperClicked({
-                stash_box_endpoint: s.endpoint,
-              })
-            }
-          >
-            {stashboxDisplayName(s.name, index)}
-          </Dropdown.Item>
-        ))}
+          {filteredStashboxes.length > 0 && filteredScrapers.length > 0 && (
+            <Dropdown.Divider />
+          )}
 
-        {filteredStashboxes.length > 0 && filteredScrapers.length > 0 && (
-          <Dropdown.Divider />
-        )}
-
-        {filteredScrapers.map((s) => (
-          <Dropdown.Item
-            key={s.name}
-            onClick={() => onScraperClicked({ scraper_id: s.id })}
-          >
-            {s.name}
-          </Dropdown.Item>
-        ))}
-      </Dropdown.Menu>
-    </Dropdown>
+          {filteredScrapers.map((s) => (
+            <Dropdown.Item
+              key={s.name}
+              onClick={() => onScraperClicked({ scraper_id: s.id })}
+            >
+              {s.name}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
   );
 };

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -1,13 +1,11 @@
 import React, { useMemo, useState } from "react";
 import { Dropdown, Button } from "react-bootstrap";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 import { Icon } from "./Icon";
 import { stashboxDisplayName } from "src/utils/stashbox";
 import { ScraperSourceInput, StashBox } from "src/core/generated-graphql";
 import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import { ClearableInput } from "./ClearableInput";
-
-const minFilteredScrapers = 5;
 
 export const ScraperMenu: React.FC<{
   toggle: React.ReactNode;
@@ -26,8 +24,6 @@ export const ScraperMenu: React.FC<{
 }) => {
   const intl = useIntl();
   const [filter, setFilter] = useState("");
-  const listOverflowable =
-    (stashBoxes?.length ?? 0) + scrapers.length > minFilteredScrapers;
 
   const filteredStashboxes = useMemo(() => {
     if (!stashBoxes) return [];
@@ -48,28 +44,6 @@ export const ScraperMenu: React.FC<{
     );
   }, [scrapers, filter]);
 
-  function maybeRenderScraperFilterInput() {
-    if (!listOverflowable) return;
-
-    return (
-      <ClearableInput
-        placeholder={`${intl.formatMessage({ id: "filter" })}...`}
-        value={filter}
-        setValue={setFilter}
-      />
-    );
-  }
-
-  function maybeRenderReloadLabel() {
-    if (listOverflowable) return;
-
-    return (
-      <span>
-        <FormattedMessage id="actions.reload_scrapers" />
-      </span>
-    );
-  }
-
   return (
     <Dropdown
       className="scraper-menu"
@@ -80,14 +54,17 @@ export const ScraperMenu: React.FC<{
       <Dropdown.Menu>
         <div className="scraper-filter-container">
           <div className="btn-group">
-            {maybeRenderScraperFilterInput()}
+            <ClearableInput
+              placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+              value={filter}
+              setValue={setFilter}
+            />
             <Button
               onClick={onReloadScrapers}
               className="reload-button"
               title={intl.formatMessage({ id: "actions.reload_scrapers" })}
             >
               <Icon icon={faSyncAlt} />
-              {maybeRenderReloadLabel()}
             </Button>
           </div>
         </div>

--- a/ui/v2.5/src/components/Shared/ScraperMenu.tsx
+++ b/ui/v2.5/src/components/Shared/ScraperMenu.tsx
@@ -78,7 +78,7 @@ export const ScraperMenu: React.FC<{
       <Dropdown.Toggle variant={variant}>{toggle}</Dropdown.Toggle>
 
       <Dropdown.Menu>
-        <div className="filter-container">
+        <div className="scraper-filter-container">
           <div className="btn-group">
             {maybeRenderScraperFilterInput()}
             <Button

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -640,12 +640,9 @@ button.btn.favorite-button {
   display: inline-block;
 }
 
-.dropdown-menu:has(.scraper-filter-container) {
-  padding-top: 0;
-}
-
 .scraper-menu .dropdown-menu {
   min-width: 250px;
+  padding-top: 0;
 
   .dropdown-divider {
     border-top-color: $textfield-bg;
@@ -653,21 +650,21 @@ button.btn.favorite-button {
   }
 
   .scraper-filter-container {
-    background-color: $dark-gray5;
-    border-bottom: solid 1px rgba(16, 22, 26, 0.3);
+    background-color: $secondary;
+    border-bottom: solid 1px $textfield-bg;
     padding: 5px;
     position: sticky;
     top: 0;
     z-index: 1;
 
     .btn-group {
-      border: solid 1px rgba(16, 22, 26, 0.3);
+      border: solid 1px $textfield-bg;
       border-radius: 5px;
       width: 100%;
     }
 
     .clearable-text-field {
-      background-color: #26333d;
+      background-color: $textfield-bg;
     }
 
     .clearable-text-field-clear {

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -154,6 +154,38 @@
   }
 }
 
+.filter-input {
+  border: 1px solid #ffffff20;
+  border-radius: 0.25rem;
+  color: #ffffff30;
+  max-width: 125px;
+}
+
+.refresh-button {
+  align-items: center;
+  background-color: #137cbd;
+  border-radius: 0.25rem;
+  color: #fff;
+  display: flex;
+  height: 37px;
+  justify-content: center;
+  min-width: 37px;
+  padding: 6px;
+}
+
+.dropdown-menu.show > .filter-container {
+  justify-content: center;
+  margin-left: 1px;
+  width: 180px;
+}
+
+.full-width-button {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
 .scrape-dialog {
   .modal-content .dialog-container {
     max-height: calc(100vh - 14rem);

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -675,18 +675,9 @@ button.btn.favorite-button {
       border: unset;
     }
 
-    .reload-button.btn:first-child {
-      border-bottom-left-radius: 0.25rem;
-      border-top-left-radius: 0.25rem;
-    }
-
     .reload-button.btn {
       border-bottom-right-radius: 0.25rem;
       border-top-right-radius: 0.25rem;
-    }
-
-    .reload-button.btn svg {
-      margin-left: 0;
     }
   }
 }

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -640,7 +640,7 @@ button.btn.favorite-button {
   display: inline-block;
 }
 
-.dropdown-menu:has(.filter-container) {
+.dropdown-menu:has(.scraper-filter-container) {
   padding-top: 0;
 }
 
@@ -652,7 +652,7 @@ button.btn.favorite-button {
     margin: 0;
   }
 
-  .filter-container {
+  .scraper-filter-container {
     background-color: $dark-gray5;
     border-bottom: solid 1px rgba(16, 22, 26, 0.3);
     padding: 5px;

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -154,38 +154,6 @@
   }
 }
 
-.filter-input {
-  border: 1px solid #ffffff20;
-  border-radius: 0.25rem;
-  color: #ffffff30;
-  max-width: 125px;
-}
-
-.refresh-button {
-  align-items: center;
-  background-color: #137cbd;
-  border-radius: 0.25rem;
-  color: #fff;
-  display: flex;
-  height: 37px;
-  justify-content: center;
-  min-width: 37px;
-  padding: 6px;
-}
-
-.dropdown-menu.show > .filter-container {
-  justify-content: center;
-  margin-left: 1px;
-  width: 180px;
-}
-
-.full-width-button {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  width: 100%;
-}
-
 .scrape-dialog {
   .modal-content .dialog-container {
     max-height: calc(100vh - 14rem);
@@ -672,11 +640,53 @@ button.btn.favorite-button {
   display: inline-block;
 }
 
+.dropdown-menu:has(.filter-container) {
+  padding-top: 0;
+}
+
 .scraper-menu .dropdown-menu {
   min-width: 250px;
 
   .dropdown-divider {
     border-top-color: $textfield-bg;
     margin: 0;
+  }
+
+  .filter-container {
+    background-color: $dark-gray5;
+    border-bottom: solid 1px rgba(16, 22, 26, 0.3);
+    padding: 5px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
+    .btn-group {
+      border: solid 1px rgba(16, 22, 26, 0.3);
+      border-radius: 5px;
+      width: 100%;
+    }
+
+    .clearable-text-field {
+      background-color: #26333d;
+    }
+
+    .clearable-text-field-clear {
+      background-color: unset;
+      border: unset;
+    }
+
+    .reload-button.btn:first-child {
+      border-bottom-left-radius: 0.25rem;
+      border-top-left-radius: 0.25rem;
+    }
+
+    .reload-button.btn {
+      border-bottom-right-radius: 0.25rem;
+      border-top-right-radius: 0.25rem;
+    }
+
+    .reload-button.btn svg {
+      margin-left: 0;
+    }
   }
 }


### PR DESCRIPTION
Per convo with people on Discord. I have updated the Reload Scrapers UI. It now adds a button if the filter box appears and then the button extends and takes up the whole space if the filter box does not exist. Added in different `<div>`s as well so that it was easier to target for theming/plugins

The CSS is... janky at best. Not too great with it so opinions and potential fixes would be greatly appreciated. I figured using the default colors was best practice and people can theme them to be whatever they want.

With filter: 
![filter](https://github.com/user-attachments/assets/d491c94e-5257-4cc5-b885-7b53fb82acdf)

Without filter
![no filter](https://github.com/user-attachments/assets/2385f81e-0e33-4129-954d-3da808f53a20)

closes https://github.com/stashapp/stash/issues/5233
