### PR TITLE
Bottom Page-Count button causes scenes page to reset to top

### DIFF
--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -25,7 +25,7 @@ const PageCount: React.FC<{
 
   useEffect(() => {
     if (showSelectPage) {
-      // delaying the focus to stop layout shifts which is what I think was causing the page to shift.
+      // delaying the focus to the next execution loop so that rendering takes place first and stops the page from resetting.
       setTimeout(() => {
         pageFocus();
       }, 0);

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -19,16 +19,16 @@ const PageCount: React.FC<{
   onChangePage: (page: number) => void;
 }> = ({ totalPages, currentPage, onChangePage }) => {
   const intl = useIntl();
-
   const currentPageCtrl = useRef(null);
-
   const [pageInput, pageFocus] = useFocus();
-
   const [showSelectPage, setShowSelectPage] = useState(false);
 
   useEffect(() => {
     if (showSelectPage) {
-      pageFocus();
+      // delaying the focus to stop layout shifts which is what I think was causing the page to shift.
+      setTimeout(() => {
+        pageFocus();
+      }, 0);
     }
   }, [showSelectPage, pageFocus]);
 
@@ -105,7 +105,8 @@ const PageCount: React.FC<{
                 className="text-input"
                 ref={pageInput}
                 defaultValue={currentPage}
-                onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                // onKeyPress is depreciated now so changing to onKeyDown.
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === "Enter") {
                     onCustomChangePage();
                     e.preventDefault();
@@ -152,7 +153,6 @@ export const Pagination: React.FC<IPaginationProps> = ({
   onChangePage,
 }) => {
   const intl = useIntl();
-
   const totalPages = useMemo(
     () => Math.ceil(totalItems / itemsPerPage),
     [totalItems, itemsPerPage]

--- a/ui/v2.5/src/components/List/Pagination.tsx
+++ b/ui/v2.5/src/components/List/Pagination.tsx
@@ -105,7 +105,6 @@ const PageCount: React.FC<{
                 className="text-input"
                 ref={pageInput}
                 defaultValue={currentPage}
-                // onKeyPress is depreciated now so changing to onKeyDown.
                 onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === "Enter") {
                     onCustomChangePage();


### PR DESCRIPTION
I think what was happening is the browser was trying to do too much at once (Rendering the popup and focusing the input simultaneously). I believe it was triggering a reflow and setting the site back to default aka: back to the top.

I set the timeout to 0 which moves the execution of the "second" event to the next loop. It gives the browser time to do one and then the other, not both at the same time.

I added some comments to what I did as well (Trying to get better at that).

I moved `onKeyPress` to `onKeyDown` due to the former being depreciated. Can also move this to another PR if requested so it's doesn't get lost in the sauce.

As always, let me know if there is a better/less dumb way to implement this.

fixes https://github.com/stashapp/stash/issues/5239