### PR TITLE
Set max-height for all modals

### DIFF
--- a/ui/v2.5/src/components/Help/styles.scss
+++ b/ui/v2.5/src/components/Help/styles.scss
@@ -21,6 +21,11 @@
     padding-left: 2rem;
   }
 
+  .modal-body {
+    // reset max-height so that we don't end up with two scroll bars
+    max-height: initial;
+  }
+
   .manual-content,
   .manual-toc {
     max-height: calc(100vh - 10rem);

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -154,6 +154,7 @@ input[type="range"].zoom-slider {
   }
 
   .modal-body {
+    max-height: min(550px, calc(100vh - 12rem));
     padding-left: 0;
     padding-right: 0;
   }
@@ -166,8 +167,6 @@ input[type="range"].zoom-slider {
   .criterion-list {
     flex-direction: column;
     flex-wrap: nowrap;
-    max-height: 550px;
-    overflow-y: auto;
 
     .pinned-criterion-divider {
       padding-bottom: 2.5rem;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -1385,3 +1385,9 @@ select {
 .table-list .rating-number {
   width: 6rem;
 }
+
+.modal-body {
+  max-height: calc(100vh - 12rem);
+  overflow-y: auto;
+  padding-right: 1.5rem;
+}


### PR DESCRIPTION
Fixes #5232 

Sets the `max-height` on all modal windows, and adjusted other styles accordingly. The modal window should no longer flow past the bottom of the screen.