### PR TITLE
Fix performer disambiguation styling in select

### DIFF
--- a/ui/v2.5/src/components/Performers/styles.scss
+++ b/ui/v2.5/src/components/Performers/styles.scss
@@ -199,6 +199,10 @@
   }
 }
 
+.performer-select-value .performer-disambiguation {
+  color: initial;
+}
+
 .performer-select-option {
   .performer-select-row {
     align-items: center;


### PR DESCRIPTION
Fixes issue introduced in #5076 where the disambiguation of the performer would not be styled correctly in the value field.