### PR TITLE
Zoom slider to performer page

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerCard.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCard.tsx
@@ -37,6 +37,7 @@ interface IPerformerCardProps {
   containerWidth?: number;
   ageFromDate?: string;
   selecting?: boolean;
+  zoomIndex?: number;
   selected?: boolean;
   onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
   extraCriteria?: IPerformerCardExtraCriteria;
@@ -48,6 +49,7 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   ageFromDate,
   selecting,
   selected,
+  zoomIndex,
   onSelectedChanged,
   extraCriteria,
 }) => {
@@ -74,13 +76,24 @@ export const PerformerCard: React.FC<IPerformerCardProps> = ({
   useEffect(() => {
     if (!containerWidth || ScreenUtils.isMobile()) return;
 
-    let preferredCardWidth = 300;
-    let fittedCardWidth = calculateCardWidth(
-      containerWidth,
-      preferredCardWidth!
-    );
+    let preferredCardWidth: number;
+    switch (zoomIndex) {
+      case 0:
+        preferredCardWidth = 240;
+        break;
+      case 1:
+        preferredCardWidth = 340;
+        break;
+      case 2:
+        preferredCardWidth = 480;
+        break;
+      case 3:
+        preferredCardWidth = 640;
+    }
+
+    let fittedCardWidth = calculateCardWidth(containerWidth, preferredCardWidth);
     setCardWidth(fittedCardWidth);
-  }, [containerWidth]);
+  }, [containerWidth, zoomIndex]);
 
   function onToggleFavorite(v: boolean) {
     if (performer.id) {

--- a/ui/v2.5/src/components/Performers/PerformerCardGrid.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerCardGrid.tsx
@@ -14,6 +14,7 @@ interface IPerformerCardGrid {
 export const PerformerCardGrid: React.FC<IPerformerCardGrid> = ({
   performers,
   selectedIds,
+  zoomIndex,
   onSelectChange,
   extraCriteria,
 }) => {
@@ -25,6 +26,7 @@ export const PerformerCardGrid: React.FC<IPerformerCardGrid> = ({
           key={p.id}
           containerWidth={width}
           performer={p}
+          zoomIndex={zoomIndex}
           selecting={selectedIds.size > 0}
           selected={selectedIds.has(p.id)}
           onSelectedChanged={(selected: boolean, shiftKey: boolean) =>

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -329,6 +329,7 @@ export const PerformerList: React.FC<IPerformerList> = ({
       selectable
     >
       <ItemList
+        zoomable
         view={view}
         otherOperations={otherOperations}
         addKeybinds={addKeybinds}


### PR DESCRIPTION
Adding in a zoom slider to performers page. Let me know if this is up to snuff and I can look into adding it to  galleries, groups and markers

Relates to this one but won't close due to it also containing request for galleries, groups and markers.

https://github.com/stashapp/stash/issues/2201

For the non-devs: This will add the exact same functionality from the zoom slider on the scenes page just now it works with performers as well :) 