### PR TITLE
Default database backup to same directory as database

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -702,7 +702,8 @@ func (i *Config) GetBackupDirectoryPath() string {
 func (i *Config) GetBackupDirectoryPathOrDefault() string {
 	ret := i.GetBackupDirectoryPath()
 	if ret == "" {
-		return i.GetConfigPath()
+		// #4915 - default to the same directory as the database
+		return filepath.Dir(i.GetDatabasePath())
 	}
 
 	return ret


### PR DESCRIPTION
Resolves #4915

Sets the default database backup directory to the same directory as the database if a specific backup directory is not set.