### PR TITLE
Database connection pool refactor

### DIFF
--- a/pkg/sqlite/anonymise.go
+++ b/pkg/sqlite/anonymise.go
@@ -28,7 +28,7 @@ type Anonymiser struct {
 }
 
 func NewAnonymiser(db *Database, outPath string) (*Anonymiser, error) {
-	if _, err := db.db.Exec(fmt.Sprintf(`VACUUM INTO "%s"`, outPath)); err != nil {
+	if _, err := db.writeDB.Exec(fmt.Sprintf(`VACUUM INTO "%s"`, outPath)); err != nil {
 		return nil, fmt.Errorf("vacuuming into %s: %w", outPath, err)
 	}
 
@@ -75,12 +75,12 @@ func (db *Anonymiser) Anonymise(ctx context.Context) error {
 }
 
 func (db *Anonymiser) truncateColumn(tableName string, column string) error {
-	_, err := db.db.Exec("UPDATE " + tableName + " SET " + column + " = NULL")
+	_, err := db.writeDB.Exec("UPDATE " + tableName + " SET " + column + " = NULL")
 	return err
 }
 
 func (db *Anonymiser) truncateTable(tableName string) error {
-	_, err := db.db.Exec("DELETE FROM " + tableName)
+	_, err := db.writeDB.Exec("DELETE FROM " + tableName)
 	return err
 }
 

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -29,6 +29,9 @@ const (
 	// Closes a connection after a period of inactivity, which saves on memory and
 	// causes the sqlite -wal and -shm files to be automatically deleted.
 	dbConnTimeout = 30 * time.Second
+
+	// environment variable to set the cache size
+	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
 var appSchemaVersion uint = 67
@@ -242,6 +245,12 @@ func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, erro
 		url += "&_txlock=immediate"
 	} else {
 		url += "&mode=ro"
+	}
+
+	// #5155 - set the cache size if the environment variable is set
+	// default is -2000 which is 2MB
+	if cacheSize := os.Getenv(cacheSizeEnv); cacheSize != "" {
+		url += "&_cache_size=" + cacheSize
 	}
 
 	conn, err := sqlx.Open(sqlite3Driver, url)

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -238,6 +238,12 @@ func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, erro
 		url += "&_fk=true"
 	}
 
+	if writable {
+		url += "&_txlock=immediate"
+	} else {
+		url += "&mode=ro"
+	}
+
 	conn, err := sqlx.Open(sqlite3Driver, url)
 	if err != nil {
 		return nil, fmt.Errorf("db.Open(): %w", err)

--- a/pkg/sqlite/migrate.go
+++ b/pkg/sqlite/migrate.go
@@ -171,18 +171,5 @@ func (db *Database) RunAllMigrations() error {
 		}
 	}
 
-	// re-initialise the database
-	const disableForeignKeys = false
-	db.db, err = db.open(disableForeignKeys)
-	if err != nil {
-		return fmt.Errorf("re-initializing the database: %w", err)
-	}
-
-	// optimize database after migration
-	err = db.Optimise(ctx)
-	if err != nil {
-		logger.Warnf("error while performing post-migration optimisation: %v", err)
-	}
-
 	return nil
 }

--- a/pkg/sqlite/migrate.go
+++ b/pkg/sqlite/migrate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	sqlite3mig "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/logger"
 )
 
@@ -15,8 +16,9 @@ func (db *Database) needsMigration() bool {
 }
 
 type Migrator struct {
-	db *Database
-	m  *migrate.Migrate
+	db   *Database
+	conn *sqlx.DB
+	m    *migrate.Migrate
 }
 
 func NewMigrator(db *Database) (*Migrator, error) {
@@ -24,7 +26,18 @@ func NewMigrator(db *Database) (*Migrator, error) {
 		db: db,
 	}
 
+	const disableForeignKeys = true
+	const writable = true
 	var err error
+	m.conn, err = m.db.open(disableForeignKeys, writable)
+	if err != nil {
+		return nil, err
+	}
+
+	m.conn.SetMaxOpenConns(maxReadConnections)
+	m.conn.SetMaxIdleConns(maxReadConnections)
+	m.conn.SetConnMaxIdleTime(dbConnTimeout)
+
 	m.m, err = m.getMigrate()
 	return m, err
 }
@@ -51,13 +64,7 @@ func (m *Migrator) getMigrate() (*migrate.Migrate, error) {
 		return nil, err
 	}
 
-	const disableForeignKeys = true
-	conn, err := m.db.open(disableForeignKeys)
-	if err != nil {
-		return nil, err
-	}
-
-	driver, err := sqlite3mig.WithInstance(conn.DB, &sqlite3mig.Config{})
+	driver, err := sqlite3mig.WithInstance(m.conn.DB, &sqlite3mig.Config{})
 	if err != nil {
 		return nil, err
 	}
@@ -110,14 +117,7 @@ func (m *Migrator) runCustomMigrations(ctx context.Context, fns []customMigratio
 }
 
 func (m *Migrator) runCustomMigration(ctx context.Context, fn customMigrationFunc) error {
-	const disableForeignKeys = false
-	d, err := m.db.open(disableForeignKeys)
-	if err != nil {
-		return err
-	}
-
-	defer d.Close()
-	if err := fn(ctx, d); err != nil {
+	if err := fn(ctx, m.conn); err != nil {
 		return err
 	}
 
@@ -136,14 +136,7 @@ func (db *Database) getDatabaseSchemaVersion() (uint, error) {
 }
 
 func (db *Database) ReInitialise() error {
-	const disableForeignKeys = false
-	var err error
-	db.db, err = db.open(disableForeignKeys)
-	if err != nil {
-		return fmt.Errorf("re-initializing the database: %w", err)
-	}
-
-	return nil
+	return db.initialise()
 }
 
 // RunAllMigrations runs all migrations to bring the database up to the current schema version

--- a/pkg/sqlite/migrations/45_postmigrate.go
+++ b/pkg/sqlite/migrations/45_postmigrate.go
@@ -247,7 +247,7 @@ func (m *schema45Migrator) insertImage(data []byte, id int, destTable string, de
 func (m *schema45Migrator) dropTable(ctx context.Context, table string) error {
 	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
 		logger.Debugf("Dropping %s", table)
-		_, err := m.db.Exec(fmt.Sprintf("DROP TABLE `%s`", table))
+		_, err := tx.Exec(fmt.Sprintf("DROP TABLE `%s`", table))
 		return err
 	}); err != nil {
 		return err

--- a/pkg/sqlite/migrations/48_premigrate.go
+++ b/pkg/sqlite/migrations/48_premigrate.go
@@ -52,7 +52,7 @@ func (m *schema48PreMigrator) validateScrapedItems(ctx context.Context) error {
 func (m *schema48PreMigrator) fixStudioNames(ctx context.Context) error {
 	// First remove NULL names
 	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
-		_, err := m.db.Exec("UPDATE studios SET name = 'NULL' WHERE name IS NULL")
+		_, err := tx.Exec("UPDATE studios SET name = 'NULL' WHERE name IS NULL")
 		return err
 	}); err != nil {
 		return err
@@ -64,7 +64,7 @@ func (m *schema48PreMigrator) fixStudioNames(ctx context.Context) error {
 
 	// collect names
 	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
-		rows, err := m.db.Query("SELECT id, name FROM studios ORDER BY name, id")
+		rows, err := tx.Query("SELECT id, name FROM studios ORDER BY name, id")
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func (m *schema48PreMigrator) fixStudioNames(ctx context.Context) error {
 
 					var count int
 
-					row := m.db.QueryRowx("SELECT COUNT(*) FROM studios WHERE name = ?", newName)
+					row := tx.QueryRowx("SELECT COUNT(*) FROM studios WHERE name = ?", newName)
 					err := row.Scan(&count)
 					if err != nil {
 						return err
@@ -131,7 +131,7 @@ func (m *schema48PreMigrator) fixStudioNames(ctx context.Context) error {
 				}
 
 				logger.Infof("Renaming duplicate studio id %d to %s", id, newName)
-				_, err := m.db.Exec("UPDATE studios SET name = ? WHERE id = ?", newName, id)
+				_, err := tx.Exec("UPDATE studios SET name = ? WHERE id = ?", newName, id)
 				if err != nil {
 					return err
 				}

--- a/pkg/sqlite/migrations/60_postmigrate.go
+++ b/pkg/sqlite/migrations/60_postmigrate.go
@@ -48,7 +48,7 @@ func (m *schema60Migrator) migrate(ctx context.Context) error {
 	if err := m.withTxn(ctx, func(tx *sqlx.Tx) error {
 		query := "SELECT id, mode, find_filter, object_filter, ui_options FROM `saved_filters` WHERE `name` = ''"
 
-		rows, err := m.db.Query(query)
+		rows, err := tx.Query(query)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (m *schema60Migrator) migrate(ctx context.Context) error {
 
 		// remove the default filters from the database
 		query = "DELETE FROM `saved_filters` WHERE `name` = ''"
-		if _, err := m.db.Exec(query); err != nil {
+		if _, err := tx.Exec(query); err != nil {
 			return fmt.Errorf("deleting default filters: %w", err)
 		}
 

--- a/pkg/sqlite/transaction.go
+++ b/pkg/sqlite/transaction.go
@@ -17,7 +17,7 @@ type key int
 const (
 	txnKey key = iota + 1
 	dbKey
-	exclusiveKey
+	writableKey
 )
 
 func (db *Database) WithDatabase(ctx context.Context) (context.Context, error) {
@@ -26,10 +26,10 @@ func (db *Database) WithDatabase(ctx context.Context) (context.Context, error) {
 		return ctx, nil
 	}
 
-	return context.WithValue(ctx, dbKey, db.db), nil
+	return context.WithValue(ctx, dbKey, db.readDB), nil
 }
 
-func (db *Database) Begin(ctx context.Context, exclusive bool) (context.Context, error) {
+func (db *Database) Begin(ctx context.Context, writable bool) (context.Context, error) {
 	if tx, _ := getTx(ctx); tx != nil {
 		// log the stack trace so we can see
 		logger.Error(string(debug.Stack()))
@@ -37,22 +37,17 @@ func (db *Database) Begin(ctx context.Context, exclusive bool) (context.Context,
 		return nil, fmt.Errorf("already in transaction")
 	}
 
-	if exclusive {
-		if err := db.lock(ctx); err != nil {
-			return nil, err
-		}
+	dbtx := db.readDB
+	if writable {
+		dbtx = db.writeDB
 	}
 
-	tx, err := db.db.BeginTxx(ctx, nil)
+	tx, err := dbtx.BeginTxx(ctx, nil)
 	if err != nil {
-		// begin failed, unlock
-		if exclusive {
-			db.unlock()
-		}
 		return nil, fmt.Errorf("beginning transaction: %w", err)
 	}
 
-	ctx = context.WithValue(ctx, exclusiveKey, exclusive)
+	ctx = context.WithValue(ctx, writableKey, writable)
 
 	return context.WithValue(ctx, txnKey, tx), nil
 }
@@ -88,9 +83,6 @@ func (db *Database) Rollback(ctx context.Context) error {
 }
 
 func (db *Database) txnComplete(ctx context.Context) {
-	if exclusive := ctx.Value(exclusiveKey).(bool); exclusive {
-		db.unlock()
-	}
 }
 
 func getTx(ctx context.Context) (*sqlx.Tx, error) {

--- a/pkg/txn/transaction.go
+++ b/pkg/txn/transaction.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Manager interface {
-	Begin(ctx context.Context, exclusive bool) (context.Context, error)
+	Begin(ctx context.Context, writable bool) (context.Context, error)
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
 
@@ -28,34 +28,30 @@ type MustFunc func(ctx context.Context)
 
 // WithTxn executes fn in a transaction. If fn returns an error then
 // the transaction is rolled back. Otherwise it is committed.
-// Transaction is exclusive. Only one thread may run a transaction
-// using this function at a time. This function will wait until the
-// lock is available before executing.
+// This function will call m.Begin with writable = true.
 // This function should be used for making changes to the database.
 func WithTxn(ctx context.Context, m Manager, fn TxnFunc) error {
 	const (
 		execComplete = true
-		exclusive    = true
+		writable     = true
 	)
-	return withTxn(ctx, m, fn, exclusive, execComplete)
+	return withTxn(ctx, m, fn, writable, execComplete)
 }
 
 // WithReadTxn executes fn in a transaction. If fn returns an error then
 // the transaction is rolled back. Otherwise it is committed.
-// Transaction is not exclusive and does not enforce read-only restrictions.
-// Multiple threads can run transactions using this function concurrently,
-// but concurrent writes may result in locked database error.
+// This function will call m.Begin with writable = false.
 func WithReadTxn(ctx context.Context, m Manager, fn TxnFunc) error {
 	const (
 		execComplete = true
-		exclusive    = false
+		writable     = false
 	)
-	return withTxn(ctx, m, fn, exclusive, execComplete)
+	return withTxn(ctx, m, fn, writable, execComplete)
 }
 
-func withTxn(ctx context.Context, m Manager, fn TxnFunc, exclusive bool, execCompleteOnLocked bool) error {
+func withTxn(ctx context.Context, m Manager, fn TxnFunc, writable bool, execCompleteOnLocked bool) error {
 	// post-hooks should be executed with the outside context
-	txnCtx, err := begin(ctx, m, exclusive)
+	txnCtx, err := begin(ctx, m, writable)
 	if err != nil {
 		return err
 	}
@@ -94,9 +90,9 @@ func withTxn(ctx context.Context, m Manager, fn TxnFunc, exclusive bool, execCom
 	return err
 }
 
-func begin(ctx context.Context, m Manager, exclusive bool) (context.Context, error) {
+func begin(ctx context.Context, m Manager, writable bool) (context.Context, error) {
 	var err error
-	ctx, err = m.Begin(ctx, exclusive)
+	ctx, err = m.Begin(ctx, writable)
 	if err != nil {
 		return nil, err
 	}

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -149,6 +149,12 @@ These options are typically not exposed in the UI and must be changed manually i
 | `no_proxy` | A list of domains for which the proxy must not be used. Default is all local LAN: localhost,127.0.0.1,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12 |
 | `sequential_scanning` | Modifies behaviour of the scanning functionality to generate support files (previews/sprites/phash) at the same time as fingerprinting/screenshotting. Useful when scanning cached remote files. |
 
+The following environment variables are also supported:
+
+| Environment variable | Remarks |
+|----------------------|---------|
+| `STASH_SQLITE_CACHE_SIZE` | Sets the SQLite cache size. See https://www.sqlite.org/pragma.html#pragma_cache_size. Default is `-2000` which is 2MB. |
+
 ### Custom served folders
 
 Custom served folders are served when the server handles a request with the `/custom` URL prefix. The following is an example configuration:


### PR DESCRIPTION
Based on this helpful article https://kerkour.com/sqlite-for-servers

Separates database connections into one writeable connection and many read connections. The read-only connections are enforced with `mode=ro` and writable connections use `_txlock=immediate` to use `BEGIN IMMEDIATE` for transactions.

Writable transactions no longer lock the database using a mutex, but use the single connection to limit concurrent transactions.

Also adds support for `STASH_SQLITE_CACHE_SIZE` environment variable. The default is `-2000` or 2MB, which is likely too small for typical use, and in future we should determine a more suitable default. 

Resolves #5252 (hopefully)
Resolves #5155