### PR TITLE
Remove unnecessary scroll to top on mount for top level query pages

### DIFF
--- a/ui/v2.5/src/components/Galleries/Galleries.tsx
+++ b/ui/v2.5/src/components/Galleries/Galleries.tsx
@@ -5,7 +5,6 @@ import { useTitleProps } from "src/hooks/title";
 import Gallery from "./GalleryDetails/Gallery";
 import GalleryCreate from "./GalleryDetails/GalleryCreate";
 import { GalleryList } from "./GalleryList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 import { LoadingIndicator } from "../Shared/LoadingIndicator";
 import { ErrorMessage } from "../Shared/ErrorMessage";
@@ -41,8 +40,6 @@ const GalleryImage: React.FC<RouteComponentProps<IGalleryImageParams>> = ({
 };
 
 const Galleries: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <GalleryList view={View.Galleries} />;
 };
 

--- a/ui/v2.5/src/components/Groups/Groups.tsx
+++ b/ui/v2.5/src/components/Groups/Groups.tsx
@@ -5,12 +5,9 @@ import { useTitleProps } from "src/hooks/title";
 import Group from "./GroupDetails/Group";
 import GroupCreate from "./GroupDetails/GroupCreate";
 import { GroupList } from "./GroupList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 
 const Groups: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <GroupList view={View.Groups} />;
 };
 

--- a/ui/v2.5/src/components/Images/Images.tsx
+++ b/ui/v2.5/src/components/Images/Images.tsx
@@ -4,12 +4,9 @@ import { Helmet } from "react-helmet";
 import { useTitleProps } from "src/hooks/title";
 import Image from "./ImageDetails/Image";
 import { ImageList } from "./ImageList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 
 const Images: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <ImageList view={View.Images} />;
 };
 

--- a/ui/v2.5/src/components/Performers/Performers.tsx
+++ b/ui/v2.5/src/components/Performers/Performers.tsx
@@ -5,12 +5,9 @@ import { useTitleProps } from "src/hooks/title";
 import Performer from "./PerformerDetails/Performer";
 import PerformerCreate from "./PerformerDetails/PerformerCreate";
 import { PerformerList } from "./PerformerList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 
 const Performers: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <PerformerList view={View.Performers} />;
 };
 

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -3,7 +3,6 @@ import { Route, Switch } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import { useTitleProps } from "src/hooks/title";
 import { lazyComponent } from "src/utils/lazyComponent";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 
 const SceneList = lazyComponent(() => import("./SceneList"));
@@ -12,14 +11,10 @@ const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
 const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));
 
 const Scenes: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <SceneList view={View.Scenes} />;
 };
 
 const SceneMarkers: React.FC = () => {
-  useScrollToTopOnMount();
-
   const titleProps = useTitleProps({ id: "markers" });
   return (
     <>

--- a/ui/v2.5/src/components/Studios/Studios.tsx
+++ b/ui/v2.5/src/components/Studios/Studios.tsx
@@ -5,12 +5,9 @@ import { useTitleProps } from "src/hooks/title";
 import Studio from "./StudioDetails/Studio";
 import StudioCreate from "./StudioDetails/StudioCreate";
 import { StudioList } from "./StudioList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { View } from "../List/views";
 
 const Studios: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <StudioList view={View.Studios} />;
 };
 

--- a/ui/v2.5/src/components/Tags/Tags.tsx
+++ b/ui/v2.5/src/components/Tags/Tags.tsx
@@ -5,11 +5,8 @@ import { useTitleProps } from "src/hooks/title";
 import Tag from "./TagDetails/Tag";
 import TagCreate from "./TagDetails/TagCreate";
 import { TagList } from "./TagList";
-import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 
 const Tags: React.FC = () => {
-  useScrollToTopOnMount();
-
   return <TagList />;
 };
 


### PR DESCRIPTION
Related to #1647 

The presence of `useScrollToTopOnMount` on all of the top-level pages meant that the page would scroll to the top when navigating back to these pages. I'm not sure what the purpose of the original inclusion was.