### PR TITLE
Fix link menu issues

### DIFF
--- a/ui/v2.5/src/components/Shared/ExternalLinksButton.tsx
+++ b/ui/v2.5/src/components/Shared/ExternalLinksButton.tsx
@@ -5,6 +5,7 @@ import { Icon } from "./Icon";
 import { IconDefinition, faLink } from "@fortawesome/free-solid-svg-icons";
 import { useMemo } from "react";
 import { faInstagram, faTwitter } from "@fortawesome/free-brands-svg-icons";
+import ReactDOM from "react-dom";
 
 export const ExternalLinksButton: React.FC<{
   icon?: IconDefinition;
@@ -15,25 +16,8 @@ export const ExternalLinksButton: React.FC<{
     return null;
   }
 
-  if (urls.length === 1) {
-    return (
-      <Button
-        as={ExternalLink}
-        href={TextUtils.sanitiseURL(urls[0])}
-        className={`minimal link external-links-button ${className}`}
-        title={urls[0]}
-      >
-        <Icon icon={icon} />
-      </Button>
-    );
-  }
-
-  return (
-    <Dropdown className="external-links-button">
-      <Dropdown.Toggle as={Button} className={`minimal link ${className}`}>
-        <Icon icon={icon} />
-      </Dropdown.Toggle>
-
+  const Menu = () =>
+    ReactDOM.createPortal(
       <Dropdown.Menu>
         {urls.map((url) => (
           <Dropdown.Item
@@ -45,7 +29,16 @@ export const ExternalLinksButton: React.FC<{
             {url}
           </Dropdown.Item>
         ))}
-      </Dropdown.Menu>
+      </Dropdown.Menu>,
+      document.body
+    );
+
+  return (
+    <Dropdown className="external-links-button">
+      <Dropdown.Toggle as={Button} className={`minimal link ${className}`}>
+        <Icon icon={icon} />
+      </Dropdown.Toggle>
+      <Menu />
     </Dropdown>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/stashapp/stash/issues/5292 via the following suggestion:

- make the 🔗 icon behave the same way regardless of the number of URLs - show the menu even with one link.

This PR also addresses an issue that results in the link menu clipping when the header height is less than the height of the menu containing the links. See https://discordapp.com/channels/559159668438728723/644934273459290145/1289087147697111082