### PR TITLE
Add `include_sub_groups` message ID

### DIFF
--- a/ui/v2.5/src/components/List/Filters/HierarchicalLabelValueFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/HierarchicalLabelValueFilter.tsx
@@ -70,7 +70,7 @@ export const HierarchicalLabelValueFilter: React.FC<
     if (inputType === "studios") {
       id = "include_sub_studios";
     } else if (inputType === "groups") {
-      id = "include-sub-groups";
+      id = "include_sub_groups";
     } else if (type === "children") {
       id = "include_parent_tags";
     } else {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1098,6 +1098,7 @@
   "images": "Images",
   "include_parent_tags": "Include parent tags",
   "include_sub_group_content": "Include sub-group content",
+  "include_sub_groups": "Include sub-groups",
   "include_sub_studio_content": "Include sub-studio content",
   "include_sub_studios": "Include subsidiary studios",
   "include_sub_tag_content": "Include sub-tag content",


### PR DESCRIPTION
Adds an entry for "Include sub-groups" text and updates `HierarchicalLabelValueFilter` to use it.