### PR TITLE
Add Open Container Image annotations as labels to the Docker image

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -23,5 +23,13 @@ RUN apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev \
     && apk del .build-deps
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
+# Basic build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.title="Stash" \
+    org.opencontainers.image.description="An organizer for your porn, written in Go." \
+    org.opencontainers.image.url="https://stashapp.cc" \
+    org.opencontainers.image.documentation="https://docs.stashapp.cc" \
+    org.opencontainers.image.source="https://github.com/stashapp/stash" \
+    org.opencontainers.image.licenses="AGPL-3.0"
+
 EXPOSE 9999
 CMD ["stash"]


### PR DESCRIPTION
This PR introduces [Open Container Image (OCI)](https://opencontainers.org/) format [annotations](https://specs.opencontainers.org/image-spec/annotations/) as labels to the built Docker image.

By adding OCI-compliant annotations, we can embed information such as the source of the image, description, authorship, and versioning details directly within the image. This makes it easier to track the origin and intent of the image during distribution and use. Note that version has been omitted in this PR, since this information is not passed into the Dockerfile.

### Key Benefits

- **Enhanced Metadata**: The added labels include essential details like the image’s source repository, description, and version. This allows anyone inspecting the image to easily understand its purpose and origins.
- **Integration with Dependency Management Tools**: Tools like [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) and [Renovate](https://docs.renovatebot.com/) will be able to recognise these labels and use them when opening PRs for dependency updates. This allows these tools to display detailed information about changes, making it easier for developers to assess the impact of updates.
- **Standardization**: Following OCI standards ensures compatibility with a wide range of container registries and tools that expect this metadata, improving interoperability across different platforms.

By including this metadata directly within the Docker image, we are ensuring better visibility into its lifecycle, contributing to improved automation and monitoring in CI/CD pipelines and simplifying compliance with image management standards.
