### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/models/model_joins.go
+++ b/pkg/models/model_joins.go
@@ -33,7 +33,7 @@ func (u *UpdateGroupIDs) SceneMovieInputs() []SceneMovieInput {
 		return nil
 	}
 
-	ret := make([]SceneMovieInput, len(u.Groups))
+	ret := make([]SceneMovieInput, 0, len(u.Groups))
 	for _, id := range u.Groups {
 		ret = append(ret, id.SceneMovieInput())
 	}


### PR DESCRIPTION


The intention here should be to initialize a slice with a capacity of   len(u.Groups)  rather than initializing the length of this slice.

