### PR TITLE
Exclude null values from image studio id index

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 67
+var appSchemaVersion uint = 68
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/68_image_studio_index.up.sql
+++ b/pkg/sqlite/migrations/68_image_studio_index.up.sql
@@ -1,0 +1,7 @@
+-- with the existing index, if no images have a studio id, then the index is 
+-- not used when filtering by studio id. The assumption with this change is that
+-- most images don't have a studio id, so filtering by non-null studio id should
+-- be faster with this index. This is a tradeoff, as filtering by null studio id
+-- will be slower.
+DROP INDEX index_images_on_studio_id;
+CREATE INDEX `index_images_on_studio_id` on `images` (`studio_id`) WHERE `studio_id` IS NOT NULL;


### PR DESCRIPTION
With the existing index, if no images have a studio id, then the index is not used when filtering by studio id. The assumption with this change is that most images don't have a studio id, so filtering by non-null studio id should be faster with this index. This is a tradeoff, as filtering by null studio id will be slower.

Fixes issue where studio performer counts were very slow when the database had a large number of images with no studios.