### PR TITLE
Scene player fixes and improvements

### DIFF
--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -1,6 +1,7 @@
 package ffmpeg
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -230,7 +231,10 @@ func (sm *StreamManager) ServeTranscode(w http.ResponseWriter, r *http.Request, 
 	handler, err := sm.getTranscodeStream(lockCtx, options)
 
 	if err != nil {
-		logger.Errorf("[transcode] error transcoding video file: %v", err)
+		// don't log context canceled errors
+		if !errors.Is(err, context.Canceled) {
+			logger.Errorf("[transcode] error transcoding video file: %v", err)
+		}
 		w.WriteHeader(http.StatusBadRequest)
 		if _, err := w.Write([]byte(err.Error())); err != nil {
 			logger.Warnf("[transcode] error writing response: %v", err)

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -451,6 +451,14 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     if (!player) return;
 
     function canplay(this: VideoJsPlayer) {
+      // if we're seeking before starting, don't set the initial timestamp, and start playing
+      // when starting from the beginning, there is a small delay before the event
+      // is triggered, so we can't just check if the time is 0
+      if (this.currentTime() >= 0.1) {
+        this.play();
+        return;
+      }
+
       if (initialTimestamp.current !== -1) {
         this.currentTime(initialTimestamp.current);
         initialTimestamp.current = -1;

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -451,17 +451,25 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     if (!player) return;
 
     function canplay(this: VideoJsPlayer) {
-      // if we're seeking before starting, don't set the initial timestamp, and start playing
+      // if we're seeking before starting, don't set the initial timestamp
       // when starting from the beginning, there is a small delay before the event
       // is triggered, so we can't just check if the time is 0
       if (this.currentTime() >= 0.1) {
-        this.play();
         return;
       }
 
       if (initialTimestamp.current !== -1) {
         this.currentTime(initialTimestamp.current);
         initialTimestamp.current = -1;
+      }
+    }
+
+    function timeupdate(this: VideoJsPlayer) {
+      // fired when seeking
+      // check if we haven't started playing yet
+      // if so, start playing
+      if (!started.current) {
+        this.play();
       }
     }
 
@@ -485,12 +493,14 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     player.on("playing", playing);
     player.on("loadstart", loadstart);
     player.on("fullscreenchange", fullscreenchange);
+    player.on("timeupdate", timeupdate);
 
     return () => {
       player.off("canplay", canplay);
       player.off("playing", playing);
       player.off("loadstart", loadstart);
       player.off("fullscreenchange", fullscreenchange);
+      player.off("timeupdate", timeupdate);
     };
   }, [getPlayer]);
 

--- a/ui/v2.5/src/components/ScenePlayer/live.ts
+++ b/ui/v2.5/src/components/ScenePlayer/live.ts
@@ -156,7 +156,7 @@ function offsetMiddleware(player: VideoJsPlayer) {
       tech.setPlaybackRate(playbackRate);
       tech.one("canplay", () => {
         player.poster(poster);
-        if (seeking === 1) {
+        if (seeking === 1 || tech.scrubbing()) {
           tech.pause();
         }
         seeking = 0;

--- a/ui/v2.5/src/components/ScenePlayer/live.ts
+++ b/ui/v2.5/src/components/ScenePlayer/live.ts
@@ -1,3 +1,4 @@
+import { debounce } from "lodash-es";
 import videojs, { VideoJsPlayer } from "video.js";
 
 export interface ISource extends videojs.Tech.SourceObject {
@@ -9,6 +10,9 @@ interface ICue extends TextTrackCue {
   _startTime?: number;
   _endTime?: number;
 }
+
+// delay before loading new source after setting currentTime
+const loadDelay = 200;
 
 function offsetMiddleware(player: VideoJsPlayer) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- allow access to private tech methods
@@ -49,6 +53,34 @@ function offsetMiddleware(player: VideoJsPlayer) {
       }
     }
   }
+
+  const loadSource = debounce(
+    (seconds: number) => {
+      const srcUrl = new URL(source.src);
+      srcUrl.searchParams.set("start", seconds.toString());
+      source.src = srcUrl.toString();
+
+      const poster = player.poster();
+      const playbackRate = tech.playbackRate();
+      seeking = tech.paused() ? 1 : 2;
+      player.poster("");
+      tech.setSource(source);
+      tech.setPlaybackRate(playbackRate);
+      tech.one("canplay", () => {
+        player.poster(poster);
+        if (seeking === 1 || tech.scrubbing()) {
+          tech.pause();
+        }
+        seeking = 0;
+      });
+      tech.trigger("timeupdate");
+      tech.trigger("pause");
+      tech.trigger("seeking");
+      tech.play();
+    },
+    loadDelay,
+    { leading: true }
+  );
 
   return {
     setTech(newTech: videojs.Tech) {
@@ -144,27 +176,7 @@ function offsetMiddleware(player: VideoJsPlayer) {
 
       updateOffsetStart(seconds);
 
-      const srcUrl = new URL(source.src);
-      srcUrl.searchParams.set("start", seconds.toString());
-      source.src = srcUrl.toString();
-
-      const poster = player.poster();
-      const playbackRate = tech.playbackRate();
-      seeking = tech.paused() ? 1 : 2;
-      player.poster("");
-      tech.setSource(source);
-      tech.setPlaybackRate(playbackRate);
-      tech.one("canplay", () => {
-        player.poster(poster);
-        if (seeking === 1 || tech.scrubbing()) {
-          tech.pause();
-        }
-        seeking = 0;
-      });
-      tech.trigger("timeupdate");
-      tech.trigger("pause");
-      tech.trigger("seeking");
-      tech.play();
+      loadSource(seconds);
 
       return 0;
     },


### PR DESCRIPTION
Various scene player fixes and improvements:
- suppress logging of context cancelled errors during live transcode
- if scrubbing (ie mouse button is down while dragging the scrubber), then don't play the video. Makes this behaviour consistent with direct streaming
- debounce the source loading code during live transcoding. This means that fewer ffmpeg processes should be spawned while dragging across the scrubber
- video will now play from the position clicked on the scrubber instead of from the start/resume time when clicking the scrubber before the video is started