### PR TITLE
Group details: Flippable images in expanded view.

### DIFF
--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -21,7 +21,7 @@ import {
   GroupDetailsPanel,
 } from "./GroupDetailsPanel";
 import { GroupEditPanel } from "./GroupEditPanel";
-import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { faRefresh, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { ConfigurationContext } from "src/hooks/Config";
 import { DetailImage } from "src/components/Shared/DetailImage";
@@ -39,8 +39,9 @@ import {
   TabTitleCounter,
   useTabKey,
 } from "src/components/Shared/DetailsPage/Tabs";
-import { Tab, Tabs } from "react-bootstrap";
+import { Button, Tab, Tabs } from "react-bootstrap";
 import { GroupSubGroupsPanel } from "./GroupSubGroupsPanel";
+import { Icon } from "src/components/Shared/Icon";
 
 const validTabs = ["default", "scenes", "subgroups"] as const;
 type TabKey = (typeof validTabs)[number];
@@ -129,6 +130,8 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
   const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
   const showAllDetails = uiConfig?.showAllDetails ?? true;
   const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+
+  const [focusedOnFront, setFocusedOnFront] = useState<boolean>(true);
 
   const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
   const loadStickyHeader = useLoadStickyHeader();
@@ -328,7 +331,13 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
             <div className="group-images">
               {!!activeFrontImage && (
                 <LightboxLink images={lightboxImages}>
-                  <DetailImage alt="Front Cover" src={activeFrontImage} />
+                  <DetailImage
+                    className={`front-cover ${
+                      focusedOnFront ? "active" : "inactive"
+                    }`}
+                    alt="Front Cover"
+                    src={activeFrontImage}
+                  />
                 </LightboxLink>
               )}
               {!!activeBackImage && (
@@ -336,8 +345,22 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
                   images={lightboxImages}
                   index={lightboxImages.length - 1}
                 >
-                  <DetailImage alt="Back Cover" src={activeBackImage} />
+                  <DetailImage
+                    className={`back-cover ${
+                      !focusedOnFront ? "active" : "inactive"
+                    }`}
+                    alt="Back Cover"
+                    src={activeBackImage}
+                  />
                 </LightboxLink>
+              )}
+              {!!(activeFrontImage && activeBackImage) && (
+                <Button
+                  className="flip"
+                  onClick={() => setFocusedOnFront(!focusedOnFront)}
+                >
+                  <Icon icon={faRefresh} />
+                </Button>
               )}
             </div>
           </HeaderImage>

--- a/ui/v2.5/src/components/Groups/styles.scss
+++ b/ui/v2.5/src/components/Groups/styles.scss
@@ -97,10 +97,12 @@ button.flip {
 
 #group-page .full-width {
   .group-images {
+    padding: .375rem .75rem;
     position: relative;
     z-index: 1;
 
     button.btn-link {
+      padding: 0;
       position: relative;
       transition: all 0.3s;
       z-index: 1;
@@ -117,11 +119,17 @@ button.flip {
     }
 
     button.flip {
+      align-items: center;
       border-radius: 50%;
-      bottom: 0;
-      display: block;
+      bottom: -5px;
+      display: flex;
+      font-size: 20px;
+      height: 40px;
+      justify-content: center;
+      padding: 0;
       position: absolute;
-      right: 0;
+      right: -5px;
+      width: 40px;
       z-index: 2;
     }
 

--- a/ui/v2.5/src/components/Groups/styles.scss
+++ b/ui/v2.5/src/components/Groups/styles.scss
@@ -91,6 +91,55 @@
   }
 }
 
+button.flip {
+  display: none;
+}
+
+#group-page .full-width {
+  .group-images {
+    height: auto;
+    margin: 0 auto 0;
+    max-width: 500px;
+    position: relative;
+    z-index: 1;
+
+    button.btn-link {
+      line-height: 0;
+      position: relative;
+      transition: all 0.3s;
+      z-index: 1;
+    }
+
+    button:has(.active) {
+      z-index: 2;
+    }
+
+    button:has(.inactive) {
+      cursor: default;
+      opacity: 0.5;
+      padding: 0;
+      transform: rotateY(180deg);
+    }
+
+    button.flip {
+      border-radius: 50%;
+      bottom: 0;
+      display: block;
+      position: absolute;
+      right: 0;
+      z-index: 2;
+    }
+
+    img.active {
+      max-width: 22rem;
+    }
+
+    img.inactive {
+      display: none;
+    }
+  }
+}
+
 .groups-list {
   list-style-type: none;
   padding-inline-start: 0;

--- a/ui/v2.5/src/components/Groups/styles.scss
+++ b/ui/v2.5/src/components/Groups/styles.scss
@@ -138,6 +138,10 @@ button.flip {
       display: none;
     }
   }
+
+  .detail-item .detail-item-title {
+    width: 150px;
+  }
 }
 
 .groups-list {

--- a/ui/v2.5/src/components/Groups/styles.scss
+++ b/ui/v2.5/src/components/Groups/styles.scss
@@ -95,9 +95,9 @@ button.flip {
   display: none;
 }
 
-#group-page .full-width {
+#group-page .detail-header:not(.collapsed) {
   .group-images {
-    padding: .375rem .75rem;
+    padding: 0.375rem 0.75rem;
     position: relative;
     z-index: 1;
 

--- a/ui/v2.5/src/components/Groups/styles.scss
+++ b/ui/v2.5/src/components/Groups/styles.scss
@@ -97,14 +97,10 @@ button.flip {
 
 #group-page .full-width {
   .group-images {
-    height: auto;
-    margin: 0 auto 0;
-    max-width: 500px;
     position: relative;
     z-index: 1;
 
     button.btn-link {
-      line-height: 0;
       position: relative;
       transition: all 0.3s;
       z-index: 1;
@@ -115,7 +111,6 @@ button.flip {
     }
 
     button:has(.inactive) {
-      cursor: default;
       opacity: 0.5;
       padding: 0;
       transform: rotateY(180deg);

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -299,7 +299,7 @@ dd {
 
     .detail-item-title {
       display: table-cell;
-      width: 130px;
+      width: 150px;
     }
 
     .detail-item-value.age {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -299,7 +299,7 @@ dd {
 
     .detail-item-title {
       display: table-cell;
-      width: 150px;
+      width: 130px;
     }
 
     .detail-item-value.age {


### PR DESCRIPTION
It's been on my mind to revisit the movie/group image section of the details page since I completed this work a while back. At the time I recall a user had suggested a solution to toggle between the front and back covers rather than displaying both. I've implemented such a solution here when the details are expanded. In this view, we would ideally want to enlarge the images; the main issue was that doing so would take up too much horizontal space since two images were present. That is no longer the case with this solution. Given the amount of free real estate in the compact view, I still see the value in showing both images.

The video demo can be viewed here: https://discordapp.com/channels/559159668438728723/644934273459290145/1294513740279971862