### PR TITLE
Restore group synopsis in collapsed view

### DIFF
--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupDetailsPanel.tsx
@@ -60,11 +60,6 @@ export const GroupDetailsPanel: React.FC<IGroupDetailsPanel> = ({
       return (
         <>
           <DetailItem
-            id="synopsis"
-            value={group.synopsis}
-            fullWidth={fullWidth}
-          />
-          <DetailItem
             id="tags"
             value={renderTagsField()}
             fullWidth={fullWidth}
@@ -120,6 +115,7 @@ export const GroupDetailsPanel: React.FC<IGroupDetailsPanel> = ({
         }
         fullWidth={fullWidth}
       />
+      <DetailItem id="synopsis" value={group.synopsis} fullWidth={fullWidth} />
       {maybeRenderExtraDetails()}
     </div>
   );


### PR DESCRIPTION
This PR restores the group synopsis in the collapsed view. Portions of the synopsis, which could fit within 3 lines, were included in the original details page redesign work. The same is the case for studios and tags since these items generally have little in terms of details, leaving plenty of unused space that could be used to provide additional details rather than requiring users to expand details to view something their window may have had space for in the collapsed view. I believe the synopsis is also core information for a movie/group. We show the info on the small cards. It seems odd to hide the info in a space with more real estate.