### PR TITLE
More scene player bug fixes

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -457,11 +457,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       if (this.currentTime() >= 0.1) {
         return;
       }
-
-      if (initialTimestamp.current !== -1) {
-        this.currentTime(initialTimestamp.current);
-        initialTimestamp.current = -1;
-      }
     }
 
     function playing(this: VideoJsPlayer) {
@@ -672,6 +667,10 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
 
     player.ready(() => {
       player.vttThumbnails().src(scene.paths.vtt ?? null);
+
+      if (startPosition) {
+        player.currentTime(startPosition);
+      }
     });
 
     started.current = false;

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -243,7 +243,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
   const [fullscreen, setFullscreen] = useState(false);
   const [showScrubber, setShowScrubber] = useState(false);
 
-  const initialTimestamp = useRef(-1);
   const started = useRef(false);
   const auto = useRef(false);
   const interactiveReady = useRef(false);
@@ -659,7 +658,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       startPosition = resumeTime;
     }
 
-    initialTimestamp.current = startPosition;
     setTime(startPosition);
 
     player.load();
@@ -799,7 +797,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     if (started.current) {
       getPlayer()?.currentTime(seconds);
     } else {
-      initialTimestamp.current = seconds;
       setTime(seconds);
     }
   }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -464,15 +464,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
       }
     }
 
-    function timeupdate(this: VideoJsPlayer) {
-      // fired when seeking
-      // check if we haven't started playing yet
-      // if so, start playing
-      if (!started.current) {
-        this.play();
-      }
-    }
-
     function playing(this: VideoJsPlayer) {
       // This still runs even if autoplay failed on Safari,
       // only set flag if actually playing
@@ -493,14 +484,12 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     player.on("playing", playing);
     player.on("loadstart", loadstart);
     player.on("fullscreenchange", fullscreenchange);
-    player.on("timeupdate", timeupdate);
 
     return () => {
       player.off("canplay", canplay);
       player.off("playing", playing);
       player.off("loadstart", loadstart);
       player.off("fullscreenchange", fullscreenchange);
-      player.off("timeupdate", timeupdate);
     };
   }, [getPlayer]);
 

--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -196,8 +196,12 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
         console.log(`Trying next source in playlist: '${newSource.label}'`);
         this.menu.setSelectedSource(newSource);
 
+        const currentTime = player.currentTime();
         player.src(newSource);
         player.load();
+        player.one("canplay", () => {
+          player.currentTime(currentTime);
+        });
         player.play();
       } else {
         console.log("No more sources in playlist");


### PR DESCRIPTION
- clicking on the video timeline when video is not started will no longer start the video
- start position is now set on initialisation rather than starting the video
- video player will now maintain position when switching to another source due to player error