### PR TITLE
remove bencoder.pyx, update vips

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -15,12 +15,10 @@ COPY --from=binary /stash /usr/bin/
 # vips version 8.15.0-r0 breaks thumbnail generation on arm32v6
 # need to use 8.14.3-r0 from alpine 3.18 instead
 
-RUN apk add --no-cache --virtual .build-deps gcc python3-dev musl-dev \
-    && apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg ruby tzdata \
+RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg ruby tzdata \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.18/community vips=8.14.3-r0 vips-tools=8.14.3-r0 \
-    && pip install --user --break-system-packages mechanicalsoup cloudscraper bencoder.pyx stashapp-tools \
-    && gem install faraday \
-    && apk del .build-deps
+    && pip install --user --break-system-packages mechanicalsoup cloudscraper stashapp-tools \
+    && gem install faraday
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 # Basic build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -12,11 +12,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-linux-arm32v6; \
 FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 
-# vips version 8.15.0-r0 breaks thumbnail generation on arm32v6
-# need to use 8.14.3-r0 from alpine 3.18 instead
-
-RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg ruby tzdata \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.18/community vips=8.14.3-r0 vips-tools=8.14.3-r0 \
+RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg ruby tzdata vips vips-tools \
     && pip install --user --break-system-packages mechanicalsoup cloudscraper stashapp-tools \
     && gem install faraday
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml


### PR DESCRIPTION
# bencoder
bencoder.pyx can be replaced by drop-in fastbencode https://github.com/stashapp/CommunityScrapers/pull/2077

Originally added in https://github.com/stashapp/stash/pull/3273

This removes the need for build dependencies and should cut down on build time https://github.com/stashapp/stash/pull/3278 as musl wheels are pre-distributed. Since the build dependencies don't make it into the final image, there is no benefit in keeping them.

# vips
reverts https://github.com/stashapp/stash/pull/4402, originally from [discord](https://discord.com/channels/559159668438728723/559159910550732809/1189511610893602856)

alpine:latest (currently 3.20) is on [8.15.2-r1](https://pkgs.alpinelinux.org/package/v3.20/community/x86_64/vips) which had a relevant bug [fixed in 8.15.1](https://www.github.com/libvips/libvips/pull/3763) Testing on `linux/arm/v6` produces proper thumbnails, MCVE [attached](https://github.com/user-attachments/files/17499136/arm-vips.zip)