### PR TITLE
Fix scraping stash-box performers with null birthdates

### DIFF
--- a/graphql/stash-box/query.graphql
+++ b/graphql/stash-box/query.graphql
@@ -30,11 +30,6 @@ fragment TagFragment on Tag {
   id
 }
 
-fragment FuzzyDateFragment on FuzzyDate {
-  date
-  accuracy
-}
-
 fragment MeasurementsFragment on Measurements {
   band_size
   cup_size
@@ -60,9 +55,7 @@ fragment PerformerFragment on Performer {
   images {
     ...ImageFragment
   }
-  birthdate {
-    ...FuzzyDateFragment
-  }
+  birth_date
   ethnicity
   country
   eye_color

--- a/pkg/scraper/stashbox/graphql/generated_client.go
+++ b/pkg/scraper/stashbox/graphql/generated_client.go
@@ -139,24 +139,6 @@ func (t *TagFragment) GetID() string {
 	return t.ID
 }
 
-type FuzzyDateFragment struct {
-	Date     string           "json:\"date\" graphql:\"date\""
-	Accuracy DateAccuracyEnum "json:\"accuracy\" graphql:\"accuracy\""
-}
-
-func (t *FuzzyDateFragment) GetDate() string {
-	if t == nil {
-		t = &FuzzyDateFragment{}
-	}
-	return t.Date
-}
-func (t *FuzzyDateFragment) GetAccuracy() *DateAccuracyEnum {
-	if t == nil {
-		t = &FuzzyDateFragment{}
-	}
-	return &t.Accuracy
-}
-
 type MeasurementsFragment struct {
 	BandSize *int    "json:\"band_size,omitempty\" graphql:\"band_size\""
 	CupSize  *string "json:\"cup_size,omitempty\" graphql:\"cup_size\""
@@ -216,7 +198,7 @@ type PerformerFragment struct {
 	MergedIds       []string                    "json:\"merged_ids\" graphql:\"merged_ids\""
 	Urls            []*URLFragment              "json:\"urls\" graphql:\"urls\""
 	Images          []*ImageFragment            "json:\"images\" graphql:\"images\""
-	Birthdate       *FuzzyDateFragment          "json:\"birthdate,omitempty\" graphql:\"birthdate\""
+	BirthDate       *string                     "json:\"birth_date,omitempty\" graphql:\"birth_date\""
 	Ethnicity       *EthnicityEnum              "json:\"ethnicity,omitempty\" graphql:\"ethnicity\""
 	Country         *string                     "json:\"country,omitempty\" graphql:\"country\""
 	EyeColor        *EyeColorEnum               "json:\"eye_color,omitempty\" graphql:\"eye_color\""
@@ -278,11 +260,11 @@ func (t *PerformerFragment) GetImages() []*ImageFragment {
 	}
 	return t.Images
 }
-func (t *PerformerFragment) GetBirthdate() *FuzzyDateFragment {
+func (t *PerformerFragment) GetBirthDate() *string {
 	if t == nil {
 		t = &PerformerFragment{}
 	}
-	return t.Birthdate
+	return t.BirthDate
 }
 func (t *PerformerFragment) GetEthnicity() *EthnicityEnum {
 	if t == nil {
@@ -877,9 +859,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -897,10 +877,6 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1015,9 +991,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1035,10 +1009,6 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1153,9 +1123,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1173,10 +1141,6 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1291,9 +1255,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1311,10 +1273,6 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1368,9 +1326,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1398,10 +1354,6 @@ fragment ImageFragment on Image {
 	url
 	width
 	height
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1450,9 +1402,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1480,10 +1430,6 @@ fragment ImageFragment on Image {
 	url
 	width
 	height
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size
@@ -1593,9 +1539,7 @@ fragment PerformerFragment on Performer {
 	images {
 		... ImageFragment
 	}
-	birthdate {
-		... FuzzyDateFragment
-	}
+	birth_date
 	ethnicity
 	country
 	eye_color
@@ -1613,10 +1557,6 @@ fragment PerformerFragment on Performer {
 	piercings {
 		... BodyModificationFragment
 	}
-}
-fragment FuzzyDateFragment on FuzzyDate {
-	date
-	accuracy
 }
 fragment MeasurementsFragment on Measurements {
 	band_size

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -1357,12 +1357,17 @@ func (c *Client) submitDraft(ctx context.Context, query string, input interface{
 }
 
 func padFuzzyDate(date *string) *string {
+	if date == nil {
+		return nil
+	}
+
 	var paddedDate string
-	if len(*date) == 10 {
-		return date
-	} else if len(*date) == 7 {
+	switch len(*date) {
+	case 10:
+		paddedDate = *date
+	case 7:
 		paddedDate = fmt.Sprintf("%s-01", *date)
-	} else if len(*date) == 4 {
+	case 4:
 		paddedDate = fmt.Sprintf("%s-01-01", *date)
 	}
 	return &paddedDate

--- a/pkg/scraper/stashbox/stash_box.go
+++ b/pkg/scraper/stashbox/stash_box.go
@@ -648,9 +648,8 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 		sp.Height = &hs
 	}
 
-	if p.Birthdate != nil {
-		b := p.Birthdate.Date
-		sp.Birthdate = &b
+	if p.BirthDate != nil {
+		sp.Birthdate = padFuzzyDate(p.BirthDate)
 	}
 
 	if p.Gender != nil {
@@ -1355,4 +1354,16 @@ func (c *Client) submitDraft(ctx context.Context, query string, input interface{
 	}
 
 	return err
+}
+
+func padFuzzyDate(date *string) *string {
+	var paddedDate string
+	if len(*date) == 10 {
+		return date
+	} else if len(*date) == 7 {
+		paddedDate = fmt.Sprintf("%s-01", *date)
+	} else if len(*date) == 4 {
+		paddedDate = fmt.Sprintf("%s-01-01", *date)
+	}
+	return &paddedDate
 }


### PR DESCRIPTION
I'm getting errors when fetching stash-box performers without a birthdate. The empty date should be omitted since it's presumably null, but it ends up populated with empty values which crashes. A change in gqlgenc I guess.

Anyway, that endpoint has been deprecated for years. I've switched the query to `birth_date` which just returns truncated date strings instead. With padding the result is the same. 