### PR TITLE
Setting marker end time with clock button uses full precision

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkerForm.tsx
@@ -232,10 +232,7 @@ export const SceneMarkerForm: React.FC<ISceneMarkerForm> = ({
           value={formik.values.end_seconds}
           setValue={(v) => formik.setFieldValue("end_seconds", v ?? null)}
           onReset={() =>
-            formik.setFieldValue(
-              "end_seconds",
-              Math.round(getPlayerPosition() ?? 0)
-            )
+            formik.setFieldValue("end_seconds", getPlayerPosition() ?? 0)
           }
           error={error}
         />


### PR DESCRIPTION
This is similar to how start time setting already worked.