### PR TITLE
Fix video files with identical phashes being merged during scan

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -1100,7 +1100,8 @@ func (s *scanJob) removeOutdatedFingerprints(existing models.File, fp models.Fin
 
 	// oshash has changed, MD5 is missing - remove MD5 from the existing fingerprints
 	logger.Infof("Removing outdated checksum from %s", existing.Base().Path)
-	existing.Base().Fingerprints.Remove(models.FingerprintTypeMD5)
+	b := existing.Base()
+	b.Fingerprints = b.Fingerprints.Remove(models.FingerprintTypeMD5)
 }
 
 // returns a file only if it was updated

--- a/pkg/models/fingerprint.go
+++ b/pkg/models/fingerprint.go
@@ -28,16 +28,17 @@ func (f *Fingerprint) Value() string {
 
 type Fingerprints []Fingerprint
 
-func (f *Fingerprints) Remove(type_ string) {
+func (f Fingerprints) Remove(type_ string) Fingerprints {
 	var ret Fingerprints
 
-	for _, ff := range *f {
+	for _, ff := range f {
 		if ff.Type != type_ {
 			ret = append(ret, ff)
 		}
 	}
 
-	*f = ret
+	return ret
+}
 }
 
 // Equals returns true if the contents of this slice are equal to those in the other slice.

--- a/pkg/models/fingerprint.go
+++ b/pkg/models/fingerprint.go
@@ -39,6 +39,20 @@ func (f Fingerprints) Remove(type_ string) Fingerprints {
 
 	return ret
 }
+
+func (f Fingerprints) Filter(types ...string) Fingerprints {
+	var ret Fingerprints
+
+	for _, ff := range f {
+		for _, t := range types {
+			if ff.Type == t {
+				ret = append(ret, ff)
+				break
+			}
+		}
+	}
+
+	return ret
 }
 
 // Equals returns true if the contents of this slice are equal to those in the other slice.

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -16,6 +16,10 @@ import (
 
 var (
 	ErrNotVideoFile = errors.New("not a video file")
+
+	// fingerprint types to match with
+	// only try to match by data fingerprints, _not_ perceptual fingerprints
+	matchableFingerprintTypes = []string{models.FingerprintTypeOshash, models.FingerprintTypeMD5}
 )
 
 type ScanCreatorUpdater interface {
@@ -87,7 +91,7 @@ func (h *ScanHandler) Handle(ctx context.Context, f models.File, oldFile models.
 
 	if len(existing) == 0 {
 		// try also to match file by fingerprints
-		existing, err = h.CreatorUpdater.FindByFingerprints(ctx, videoFile.Fingerprints)
+		existing, err = h.CreatorUpdater.FindByFingerprints(ctx, videoFile.Fingerprints.Filter(matchableFingerprintTypes...))
 		if err != nil {
 			return fmt.Errorf("finding existing scene by fingerprints: %w", err)
 		}


### PR DESCRIPTION
Fixes issue reported on Discord where if files are rescanned after the scenes are deleted, and the files have identical phashes, then the two files would be added to a single scene.