### PR TITLE
Scene Marker duration filter and sort

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -193,6 +193,8 @@ input SceneMarkerFilterType {
   performers: MultiCriterionInput
   "Filter to only include scene markers from these scenes"
   scenes: MultiCriterionInput
+  "Filter by duration (in seconds)"
+  duration: IntCriterionInput
   "Filter by creation time"
   created_at: TimestampCriterionInput
   "Filter by last update time"

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -194,7 +194,7 @@ input SceneMarkerFilterType {
   "Filter to only include scene markers from these scenes"
   scenes: MultiCriterionInput
   "Filter by duration (in seconds)"
-  duration: IntCriterionInput
+  duration: FloatCriterionInput
   "Filter by creation time"
   created_at: TimestampCriterionInput
   "Filter by last update time"

--- a/pkg/models/scene_marker.go
+++ b/pkg/models/scene_marker.go
@@ -11,6 +11,8 @@ type SceneMarkerFilterType struct {
 	Performers *MultiCriterionInput `json:"performers"`
 	// Filter to only include scene markers from these scenes
 	Scenes *MultiCriterionInput `json:"scenes"`
+	// Filter by duration (in seconds)
+	Duration *IntCriterionInput `json:"duration"`
 	// Filter by created at
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at

--- a/pkg/models/scene_marker.go
+++ b/pkg/models/scene_marker.go
@@ -12,7 +12,7 @@ type SceneMarkerFilterType struct {
 	// Filter to only include scene markers from these scenes
 	Scenes *MultiCriterionInput `json:"scenes"`
 	// Filter by duration (in seconds)
-	Duration *IntCriterionInput `json:"duration"`
+	Duration *FloatCriterionInput `json:"duration"`
 	// Filter by created at
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -389,7 +389,7 @@ func (qb *SceneMarkerStore) setSceneMarkerSort(query *queryBuilder, findFilter *
 		query.sortAndPagination += " ORDER BY COALESCE(NULLIF(scene_markers.title,''), tags.name) COLLATE NATURAL_CI " + direction
 	case "duration":
 		sort = "(scene_markers.end_seconds - scene_markers.seconds)"
-		query.sortAndPagination += getSort(sort, direction, sceneTable)
+		query.sortAndPagination += getSort(sort, direction, sceneMarkerTable)
 	default:
 		query.sortAndPagination += getSort(sort, direction, sceneMarkerTable)
 	}

--- a/pkg/sqlite/scene_marker.go
+++ b/pkg/sqlite/scene_marker.go
@@ -367,6 +367,7 @@ var sceneMarkerSortOptions = sortOptions{
 	"scenes_updated_at",
 	"seconds",
 	"updated_at",
+	"duration",
 }
 
 func (qb *SceneMarkerStore) setSceneMarkerSort(query *queryBuilder, findFilter *models.FindFilterType) error {
@@ -386,6 +387,9 @@ func (qb *SceneMarkerStore) setSceneMarkerSort(query *queryBuilder, findFilter *
 	case "title":
 		query.join(tagTable, "", "scene_markers.primary_tag_id = tags.id")
 		query.sortAndPagination += " ORDER BY COALESCE(NULLIF(scene_markers.title,''), tags.name) COLLATE NATURAL_CI " + direction
+	case "duration":
+		sort = "(scene_markers.end_seconds - scene_markers.seconds)"
+		query.sortAndPagination += getSort(sort, direction, sceneTable)
 	default:
 		query.sortAndPagination += getSort(sort, direction, sceneMarkerTable)
 	}

--- a/pkg/sqlite/scene_marker_filter.go
+++ b/pkg/sqlite/scene_marker_filter.go
@@ -41,7 +41,7 @@ func (qb *sceneMarkerFilterHandler) criterionHandler() criterionHandler {
 		qb.sceneTagsCriterionHandler(sceneMarkerFilter.SceneTags),
 		qb.performersCriterionHandler(sceneMarkerFilter.Performers),
 		qb.scenesCriterionHandler(sceneMarkerFilter.Scenes),
-		floatIntCriterionHandler(sceneMarkerFilter.Duration, "COALESCE(scene_markers.end_seconds - scene_markers.seconds, 0)", nil),
+		floatCriterionHandler(sceneMarkerFilter.Duration, "COALESCE(scene_markers.end_seconds - scene_markers.seconds, NULL)", nil),
 		&timestampCriterionHandler{sceneMarkerFilter.CreatedAt, "scene_markers.created_at", nil},
 		&timestampCriterionHandler{sceneMarkerFilter.UpdatedAt, "scene_markers.updated_at", nil},
 		&dateCriterionHandler{sceneMarkerFilter.SceneDate, "scenes.date", qb.joinScenes},

--- a/pkg/sqlite/scene_marker_filter.go
+++ b/pkg/sqlite/scene_marker_filter.go
@@ -41,6 +41,7 @@ func (qb *sceneMarkerFilterHandler) criterionHandler() criterionHandler {
 		qb.sceneTagsCriterionHandler(sceneMarkerFilter.SceneTags),
 		qb.performersCriterionHandler(sceneMarkerFilter.Performers),
 		qb.scenesCriterionHandler(sceneMarkerFilter.Scenes),
+		floatIntCriterionHandler(sceneMarkerFilter.Duration, "COALESCE(scene_markers.end_seconds - scene_markers.seconds, 0)", nil),
 		&timestampCriterionHandler{sceneMarkerFilter.CreatedAt, "scene_markers.created_at", nil},
 		&timestampCriterionHandler{sceneMarkerFilter.UpdatedAt, "scene_markers.updated_at", nil},
 		&dateCriterionHandler{sceneMarkerFilter.SceneDate, "scenes.date", qb.joinScenes},

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -427,7 +427,6 @@ var (
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers, tagIdx2WithMarkers}},
 		{sceneIdxWithMarkerAndTag, tagIdxWithPrimaryMarkers, nil},
 		{sceneIdxWithMarkerTwoTags, tagIdxWithPrimaryMarkers, nil},
-		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, nil},
 	}
 )
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -276,6 +276,8 @@ const (
 	markerIdxWithScene = iota
 	markerIdxWithTag
 	markerIdxWithSceneTag
+	markerIdxWithDuration
+	markerIdx2WithDuration
 	totalMarkers
 )
 
@@ -425,6 +427,7 @@ var (
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers, tagIdx2WithMarkers}},
 		{sceneIdxWithMarkerAndTag, tagIdxWithPrimaryMarkers, nil},
 		{sceneIdxWithMarkerTwoTags, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, nil},
 	}
 )
 
@@ -1754,10 +1757,20 @@ func createStudios(ctx context.Context, n int, o int) error {
 	return nil
 }
 
+func getMarkerEndSeconds(index int) *float64 {
+	if index != markerIdxWithDuration && index != markerIdx2WithDuration {
+		return nil
+	}
+	ret := float64(index)
+	return &ret
+}
+
 func createMarker(ctx context.Context, mqb models.SceneMarkerReaderWriter, markerSpec markerSpec) error {
+	markerIdx := len(markerIDs)
 	marker := models.SceneMarker{
 		SceneID:      sceneIDs[markerSpec.sceneIdx],
 		PrimaryTagID: tagIDs[markerSpec.primaryTagIdx],
+		EndSeconds:   getMarkerEndSeconds(markerIdx),
 	}
 
 	err := mqb.Create(ctx, &marker)

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -637,7 +637,11 @@ export function createNumberCriterionOption(
 }
 
 export class NullNumberCriterionOption extends CriterionOption {
-  constructor(messageID: string, value: CriterionType) {
+  constructor(
+    messageID: string,
+    value: CriterionType,
+    makeCriterion?: () => Criterion<CriterionValue>
+  ) {
     super({
       messageID,
       type: value,
@@ -653,7 +657,9 @@ export class NullNumberCriterionOption extends CriterionOption {
       ],
       defaultModifier: CriterionModifier.Equals,
       inputType: "number",
-      makeCriterion: () => new NumberCriterion(this),
+      makeCriterion: makeCriterion
+        ? makeCriterion
+        : () => new NumberCriterion(this),
     });
   }
 }
@@ -778,6 +784,19 @@ export function createDurationCriterionOption(
   messageID?: string
 ) {
   return new DurationCriterionOption(messageID ?? value, value);
+}
+
+export class NullDurationCriterionOption extends NullNumberCriterionOption {
+  constructor(messageID: string, value: CriterionType) {
+    super(messageID, value, () => new DurationCriterion(this));
+  }
+}
+
+export function createNullDurationCriterionOption(
+  value: CriterionType,
+  messageID?: string
+) {
+  return new NullDurationCriterionOption(messageID ?? value, value);
 }
 
 export class DurationCriterion extends Criterion<INumberValue> {

--- a/ui/v2.5/src/models/list-filter/scene-markers.ts
+++ b/ui/v2.5/src/models/list-filter/scene-markers.ts
@@ -6,10 +6,12 @@ import { DisplayMode } from "./types";
 import {
   createDateCriterionOption,
   createMandatoryTimestampCriterionOption,
+  createDurationCriterionOption,
 } from "./criteria/criterion";
 
 const defaultSortBy = "title";
 const sortByOptions = [
+  "duration",
   "title",
   "seconds",
   "scene_id",
@@ -22,6 +24,7 @@ const criterionOptions = [
   MarkersScenesCriterionOption,
   SceneTagsCriterionOption,
   PerformersCriterionOption,
+  createDurationCriterionOption("duration"),
   createMandatoryTimestampCriterionOption("created_at"),
   createMandatoryTimestampCriterionOption("updated_at"),
   createDateCriterionOption("scene_date"),

--- a/ui/v2.5/src/models/list-filter/scene-markers.ts
+++ b/ui/v2.5/src/models/list-filter/scene-markers.ts
@@ -6,7 +6,7 @@ import { DisplayMode } from "./types";
 import {
   createDateCriterionOption,
   createMandatoryTimestampCriterionOption,
-  createDurationCriterionOption,
+  createNullDurationCriterionOption,
 } from "./criteria/criterion";
 
 const defaultSortBy = "title";
@@ -24,7 +24,7 @@ const criterionOptions = [
   MarkersScenesCriterionOption,
   SceneTagsCriterionOption,
   PerformersCriterionOption,
-  createDurationCriterionOption("duration"),
+  createNullDurationCriterionOption("duration"),
   createMandatoryTimestampCriterionOption("created_at"),
   createMandatoryTimestampCriterionOption("updated_at"),
   createDateCriterionOption("scene_date"),


### PR DESCRIPTION
Adds the ability to sort and filter Markers by their duration (the difference between `seconds` and `end_seconds`). Markers without an end point have zero duration so a 0:00 duration filter can be used to filter for them.