### PR TITLE
Update tripwire link

### DIFF
--- a/internal/api/authentication.go
+++ b/internal/api/authentication.go
@@ -16,12 +16,12 @@ import (
 
 const (
 	tripwireActivatedErrMsg = "Stash is exposed to the public internet without authentication, and is not serving any more content to protect your privacy. " +
-		"More information and fixes are available at https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet"
+		"More information and fixes are available at https://docs.stashapp.cc/faq/setup/#protecting-against-accidental-exposure-to-the-internet"
 
 	externalAccessErrMsg = "You have attempted to access Stash over the internet, and authentication is not enabled. " +
 		"This is extremely dangerous! The whole world can see your your stash page and browse your files! " +
 		"Stash is not answering any other requests to protect your privacy. " +
-		"Please read the log entry or visit https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet"
+		"Please read the log entry or visit https://docs.stashapp.cc/faq/setup/#protecting-against-accidental-exposure-to-the-internet"
 )
 
 func allowUnauthenticated(r *http.Request) bool {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -1533,7 +1533,7 @@ func (i *Config) GetDefaultGenerateSettings() *models.GenerateMetadataOptions {
 }
 
 // GetDangerousAllowPublicWithoutAuth determines if the security feature is enabled.
-// See https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet
+// See https://docs.stashapp.cc/faq/setup/#protecting-against-accidental-exposure-to-the-internet
 func (i *Config) GetDangerousAllowPublicWithoutAuth() bool {
 	return i.getBool(dangerousAllowPublicWithoutAuth)
 }

--- a/pkg/session/authentication.go
+++ b/pkg/session/authentication.go
@@ -81,6 +81,6 @@ func LogExternalAccessError(err ExternalAccessError) {
 		"You probably forwarded a port from your router. At the very least, add a password to stash in the settings. \n"+
 		"Stash will not serve requests until you edit config.yml, remove the security_tripwire_accessed_from_public_internet key and restart stash. \n"+
 		"This behaviour can be overridden (but not recommended) by setting dangerous_allow_public_without_auth to true in config.yml. \n"+
-		"More information is available at https://docs.stashapp.cc/networking/authentication-required-when-accessing-stash-from-the-internet \n"+
+		"More information is available at https://docs.stashapp.cc/faq/setup/#protecting-against-accidental-exposure-to-the-internet \n"+
 		"Stash is not answering any other requests to protect your privacy.", net.IP(err).String())
 }


### PR DESCRIPTION
Recent documentation site update moved the link. Keeping legacy link active until the next release. 