### PR TITLE
Convert json numbers to numbers in JSON inputs

### DIFF
--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// JSONNumberToNumber converts a JSON number to either a float64 or int64.
+func JSONNumberToNumber(n json.Number) interface{} {
+	if strings.Contains(string(n), ".") {
+		f, _ := n.Float64()
+		return f
+	}
+	ret, _ := n.Int64()
+	return ret
+}

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"strings"
 )
 
@@ -78,4 +79,20 @@ func MergeMaps(dest map[string]interface{}, src map[string]interface{}) {
 
 		dest[k] = v
 	}
+}
+
+// ConvertMapJSONNumbers converts all JSON numbers in a map to either float64 or int64.
+func ConvertMapJSONNumbers(m map[string]interface{}) (ret map[string]interface{}) {
+	ret = make(map[string]interface{})
+	for k, v := range m {
+		if n, ok := v.(json.Number); ok {
+			ret[k] = JSONNumberToNumber(n)
+		} else if mm, ok := v.(map[string]interface{}); ok {
+			ret[k] = ConvertMapJSONNumbers(mm)
+		} else {
+			ret[k] = v
+		}
+	}
+
+	return ret
 }

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNestedMapGet(t *testing.T) {
@@ -276,6 +279,58 @@ func TestMergeMaps(t *testing.T) {
 			if !reflect.DeepEqual(tt.dest, tt.result) {
 				t.Errorf("NestedMap.Set() got = %v, want %v", tt.dest, tt.result)
 			}
+		})
+	}
+}
+
+func TestConvertMapJSONNumbers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "Convert JSON numbers to numbers",
+			input: map[string]interface{}{
+				"int":    json.Number("12"),
+				"float":  json.Number("12.34"),
+				"string": "foo",
+			},
+			expected: map[string]interface{}{
+				"int":    int64(12),
+				"float":  12.34,
+				"string": "foo",
+			},
+		},
+		{
+			name: "Convert JSON numbers to numbers in nested maps",
+			input: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"int":           json.Number("56"),
+					"float":         json.Number("56.78"),
+					"nested-string": "bar",
+				},
+				"int":    json.Number("12"),
+				"float":  json.Number("12.34"),
+				"string": "foo",
+			},
+			expected: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"int":           int64(56),
+					"float":         56.78,
+					"nested-string": "bar",
+				},
+				"int":    int64(12),
+				"float":  12.34,
+				"string": "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertMapJSONNumbers(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Numeric values when provided to the server via the graphql interface, end up encoded `json.Number` if they do not have a specific schema type - for example, when passed in via a generic map. This means that the UI and plugin settings would save numeric values as strings. This caused an issue with the Image Wall margins, since it expected a numeric value and not a string value. This could also cause additional intended consequences.

This change converts `json.Number` values in map values to the correct `int64` or `float64` values.

Fixes #5483. Note that this will require re-saving the image margin value to fix the issue.