### PR TITLE
Validate tagger blacklist entries

### DIFF
--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -83,6 +83,17 @@ export function prepareQueryString(
   mode: ParseMode,
   blacklist: string[]
 ) {
+  const regexs = blacklist
+    .map((b) => {
+      try {
+        return new RegExp(b, "gi");
+      } catch {
+        // ignore
+        return null;
+      }
+    })
+    .filter((r) => r !== null) as RegExp[];
+
   if ((mode === "auto" && scene.date && scene.studio) || mode === "metadata") {
     let str = [
       scene.date,
@@ -92,8 +103,8 @@ export function prepareQueryString(
     ]
       .filter((s) => s !== "")
       .join(" ");
-    blacklist.forEach((b) => {
-      str = str.replace(new RegExp(b, "gi"), " ");
+    regexs.forEach((re) => {
+      str = str.replace(re, " ");
     });
     return str;
   }
@@ -106,8 +117,9 @@ export function prepareQueryString(
   } else if (mode === "dir" && paths.length) {
     s = paths[paths.length - 1];
   }
-  blacklist.forEach((b) => {
-    s = s.replace(new RegExp(b, "gi"), " ");
+
+  regexs.forEach((re) => {
+    s = s.replace(re, " ");
   });
   s = parseDate(s);
   return s.replace(/\./g, " ").replace(/ +/g, " ");

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -173,6 +173,9 @@
       "active_instance": "Active stash-box instance:",
       "blacklist_desc": "Blacklist items are excluded from queries. Note that they are regular expressions and also case-insensitive. Certain characters must be escaped with a backslash: {chars_require_escape}",
       "blacklist_label": "Blacklist",
+      "errors": {
+        "blacklist_duplicate": "Duplicate blacklist item"
+      },
       "mark_organized_desc": "Immediately mark the scene as Organized after the Save button is clicked.",
       "mark_organized_label": "Mark as Organized on save",
       "query_mode_auto": "Auto",


### PR DESCRIPTION
- Fixes UI crash if there are invalid regex strings in the tagger blacklist
- Shows an error when trying to add an invalid regex to the blacklist, or when trying to add a duplicate regex string

![image](https://github.com/user-attachments/assets/d68f31c0-50cb-4338-ae42-408d353a5b2e)
![image](https://github.com/user-attachments/assets/795b2e2c-bbf5-450c-8887-9f13b2661785)


Fixes #5481 