### PR TITLE
Tagger preview scrubber and thumbnail

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -69,6 +69,8 @@ const Scene: React.FC<{
           : undefined
       }
       showLightboxImage={showLightboxImage}
+      queue={queue}
+      index={index}
     >
       {searchResult && searchResult.results?.length ? (
         <SceneSearchResults scenes={searchResult.results} target={scene} />

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -12,22 +12,19 @@
 
   .scene-card-preview {
     border-radius: 3px;
+    color: $text-color;
+    height: 100px;
     margin-bottom: 0;
-    max-height: 100px;
     overflow: hidden;
-    width: 150px;
-
-    &-video {
-      background-color: #495b68;
-    }
+    width: auto;
   }
 
   .sprite-button {
-    bottom: 5px;
     filter: drop-shadow(1px 1px 1px #222);
     padding: 0;
     position: absolute;
     right: 5px;
+    top: 5px;
   }
 
   .sub-content {


### PR DESCRIPTION
Enables the scene scrubber in previews in Tagger view and prevents the thumbnail being hidden on mouseover when there is no preview generated.

This also moves the sprite button from the bottom-right to the top-right to prevent it from being obscured by the scrubber (I think the scrubber makes the sprite button redundant and could be removed at some point).

![Screenshot (89)](https://github.com/user-attachments/assets/609d1c41-c9ce-49b2-8706-300fbb589206)

Fixes #5488.