### PR TITLE
Fix scraped tags issues

### DIFF
--- a/ui/v2.5/src/hooks/tagsEdit.tsx
+++ b/ui/v2.5/src/hooks/tagsEdit.tsx
@@ -44,10 +44,15 @@ export function useTagsEdit(
       }
 
       // add the new tag to the new tags value
-      const newTagIds = tags
-        .map((t) => t.id)
-        .concat([result.data.tagCreate.id]);
-      setFieldValue(newTagIds);
+      onSetTags(
+        tags.concat([
+          {
+            id: result.data.tagCreate.id,
+            name: toCreate.name ?? "",
+            aliases: [],
+          },
+        ])
+      );
 
       // remove the tag from the list
       const newTagsClone = newTags!.concat();
@@ -77,20 +82,20 @@ export function useTagsEdit(
       return;
     }
 
-      // map tags to their ids and filter out those not found
+    // map tags to their ids and filter out those not found
     const idTags = scrapedTags.filter(
       (t) => t.stored_id !== undefined && t.stored_id !== null
     );
     const newNewTags = scrapedTags.filter((t) => !t.stored_id);
-      onSetTags(
+    onSetTags(
       idTags.map((p) => {
-          return {
-            id: p.stored_id!,
-            name: p.name ?? "",
-            aliases: [],
-          };
-        })
-      );
+        return {
+          id: p.stored_id!,
+          name: p.name ?? "",
+          aliases: [],
+        };
+      })
+    );
 
     setNewTags(newNewTags);
   }

--- a/ui/v2.5/src/hooks/tagsEdit.tsx
+++ b/ui/v2.5/src/hooks/tagsEdit.tsx
@@ -73,10 +73,17 @@ export function useTagsEdit(
   function updateTagsStateFromScraper(
     scrapedTags?: Pick<GQL.ScrapedTag, "name" | "stored_id">[]
   ) {
-    if (scrapedTags) {
+    if (!scrapedTags) {
+      return;
+    }
+
       // map tags to their ids and filter out those not found
+    const idTags = scrapedTags.filter(
+      (t) => t.stored_id !== undefined && t.stored_id !== null
+    );
+    const newNewTags = scrapedTags.filter((t) => !t.stored_id);
       onSetTags(
-        scrapedTags.map((p) => {
+      idTags.map((p) => {
           return {
             id: p.stored_id!,
             name: p.name ?? "",
@@ -85,8 +92,7 @@ export function useTagsEdit(
         })
       );
 
-      setNewTags(scrapedTags.filter((t) => !t.stored_id));
-    }
+    setNewTags(newNewTags);
   }
 
   function renderNewTags() {


### PR DESCRIPTION
Fixes #5516 

Fixes issue where unmatched scraped tags would be populated in the tags field when scraping groups (and likely other types).
Fixes issue where creating a new scraped tag would not update the tags field.