### PR TITLE
Filter scenes & images by filename/basename

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -230,6 +230,8 @@ input SceneFilterType {
   phash_distance: PhashDistanceCriterionInput
   "Filter by path"
   path: StringCriterionInput
+  "Filter by filename/basename"
+  filename: StringCriterionInput
   "Filter by file count"
   file_count: IntCriterionInput
   # rating expressed as 1-100
@@ -613,6 +615,8 @@ input ImageFilterType {
   checksum: StringCriterionInput
   "Filter by path"
   path: StringCriterionInput
+  "Filter by filename/basename"
+  filename: StringCriterionInput
   "Filter by file count"
   file_count: IntCriterionInput
   # rating expressed as 1-100

--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -13,6 +13,8 @@ type ImageFilterType struct {
 	Checksum *StringCriterionInput `json:"checksum"`
 	// Filter by path
 	Path *StringCriterionInput `json:"path"`
+	// Filter by filename/basename
+	Filename *StringCriterionInput `json:"filename"`
 	// Filter by file count
 	FileCount *IntCriterionInput `json:"file_count"`
 	// Filter by rating expressed as 1-100

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -25,6 +25,8 @@ type SceneFilterType struct {
 	PhashDistance *PhashDistanceCriterionInput `json:"phash_distance"`
 	// Filter by path
 	Path *StringCriterionInput `json:"path"`
+	// Filter by filename/basename
+	Filename *StringCriterionInput `json:"filename"`
 	// Filter by file count
 	FileCount *IntCriterionInput `json:"file_count"`
 	// Filter by rating expressed as 1-100

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -93,6 +93,17 @@ func enumCriterionHandler(modifier models.CriterionModifier, values []string, co
 	}
 }
 
+func filenameCriterionHandler(c *models.StringCriterionInput, basenameColumn string, addJoinFn func(f *filterBuilder)) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if c != nil {
+			if addJoinFn != nil {
+				addJoinFn(f)
+			}
+			stringCriterionHandler(c, basenameColumn)(ctx, f)
+		}
+	}
+}
+
 func pathCriterionHandler(c *models.StringCriterionInput, pathColumn string, basenameColumn string, addJoinFn func(f *filterBuilder)) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if c != nil {

--- a/pkg/sqlite/image_filter.go
+++ b/pkg/sqlite/image_filter.go
@@ -68,6 +68,7 @@ func (qb *imageFilterHandler) criterionHandler() criterionHandler {
 		stringCriterionHandler(imageFilter.Photographer, "images.photographer"),
 
 		pathCriterionHandler(imageFilter.Path, "folders.path", "files.basename", imageRepository.addFoldersTable),
+		filenameCriterionHandler(imageFilter.Filename, "files.basename", imageRepository.addImagesFilesTable),
 		qb.fileCountCriterionHandler(imageFilter.FileCount),
 		intCriterionHandler(imageFilter.Rating100, "images.rating", nil),
 		intCriterionHandler(imageFilter.OCounter, "images.o_counter", nil),

--- a/pkg/sqlite/scene_filter.go
+++ b/pkg/sqlite/scene_filter.go
@@ -57,6 +57,7 @@ func (qb *sceneFilterHandler) criterionHandler() criterionHandler {
 	return compoundHandler{
 		intCriterionHandler(sceneFilter.ID, "scenes.id", nil),
 		pathCriterionHandler(sceneFilter.Path, "folders.path", "files.basename", qb.addFoldersTable),
+		filenameCriterionHandler(sceneFilter.Filename, "files.basename", qb.addFilesTable),
 		qb.fileCountCriterionHandler(sceneFilter.FileCount),
 		stringCriterionHandler(sceneFilter.Title, "scenes.title"),
 		stringCriterionHandler(sceneFilter.Code, "scenes.code"),
@@ -383,8 +384,8 @@ func (qb *sceneFilterHandler) captionCriterionHandler(captions *models.StringCri
 		},
 		excludeHandler: func(f *filterBuilder, criterion *models.StringCriterionInput) {
 			excludeClause := `scenes.id NOT IN (
-				SELECT scenes_files.scene_id from scenes_files 
-				INNER JOIN video_captions on video_captions.file_id = scenes_files.file_id 
+				SELECT scenes_files.scene_id from scenes_files
+				INNER JOIN video_captions on video_captions.file_id = scenes_files.file_id
 				WHERE video_captions.language_code LIKE ?
 			)`
 			f.addWhere(excludeClause, criterion.Value)

--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -41,7 +41,10 @@ const criterionOptions = [
   createStringCriterionOption("photographer"),
   createMandatoryStringCriterionOption("checksum", "media_info.checksum"),
   PathCriterionOption,
-  createStringCriterionOption("filename", "component_tagger.config.query_mode_filename"),
+  createStringCriterionOption(
+    "filename",
+    "component_tagger.config.query_mode_filename"
+  ),
   GalleriesCriterionOption,
   OrganizedCriterionOption,
   createMandatoryNumberCriterionOption("o_counter", "o_count"),

--- a/ui/v2.5/src/models/list-filter/images.ts
+++ b/ui/v2.5/src/models/list-filter/images.ts
@@ -41,6 +41,7 @@ const criterionOptions = [
   createStringCriterionOption("photographer"),
   createMandatoryStringCriterionOption("checksum", "media_info.checksum"),
   PathCriterionOption,
+  createStringCriterionOption("filename", "component_tagger.config.query_mode_filename"),
   GalleriesCriterionOption,
   OrganizedCriterionOption,
   createMandatoryNumberCriterionOption("o_counter", "o_count"),

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -77,7 +77,10 @@ const criterionOptions = [
   createStringCriterionOption("title"),
   createStringCriterionOption("code", "scene_code"),
   PathCriterionOption,
-  createStringCriterionOption("filename", "component_tagger.config.query_mode_filename"),
+  createStringCriterionOption(
+    "filename",
+    "component_tagger.config.query_mode_filename"
+  ),
   createStringCriterionOption("details"),
   createStringCriterionOption("director"),
   createMandatoryStringCriterionOption("oshash", "media_info.hash"),

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -77,6 +77,7 @@ const criterionOptions = [
   createStringCriterionOption("title"),
   createStringCriterionOption("code", "scene_code"),
   PathCriterionOption,
+  createStringCriterionOption("filename", "component_tagger.config.query_mode_filename"),
   createStringCriterionOption("details"),
   createStringCriterionOption("director"),
   createMandatoryStringCriterionOption("oshash", "media_info.hash"),

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -125,6 +125,7 @@ export interface IOptionType {
 
 export type CriterionType =
   | "path"
+  | "filename"
   | "rating100"
   | "organized"
   | "o_counter"


### PR DESCRIPTION
Adds a new `filename` filter to images and scenes which filters using the basename of the file's path.

I'm unsure of two things though:
1. Is `filename` descriptive enough?
2. Is using `component_tagger.config.query_mode_filename` for the message ID okay for this?