### PR TITLE
feat: Add ETA for tasks

### DIFF
--- a/ui/v2.5/graphql/subscriptions.graphql
+++ b/ui/v2.5/graphql/subscriptions.graphql
@@ -8,6 +8,7 @@ subscription JobsSubscribe {
       description
       progress
       error
+      startTime
     }
   }
 }

--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -50,6 +50,7 @@
     "intersection-observer": "^0.12.2",
     "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
+    "moment": "^2.30.1",
     "mousetrap": "^1.6.5",
     "mousetrap-pause": "^1.0.0",
     "normalize-url": "^4.5.1",

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -48,6 +48,8 @@ import "./pluginApi";
 import { ConnectionMonitor } from "./ConnectionMonitor";
 import { PatchFunction } from "./patch";
 
+import moment from "moment/min/moment-with-locales";
+
 const Performers = lazyComponent(
   () => import("./components/Performers/Performers")
 );
@@ -158,6 +160,7 @@ export const App: React.FC = () => {
       });
 
       setMessages(newMessages);
+      moment.locale([language, defaultLocale]);
     };
 
     setLocale();

--- a/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/JobTable.tsx
@@ -7,10 +7,10 @@ import {
   faHourglassStart,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 import React, { useEffect, useState } from "react";
 import { Button, Card, ProgressBar } from "react-bootstrap";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "src/components/Shared/Icon";
 import {
   mutateStopJob,
@@ -142,11 +142,15 @@ const Task: React.FC<IJob> = ({ job }) => {
     ) {
       const now = new Date();
       const start = new Date(job.startTime);
-      const now_ms = now.valueOf();
-      const start_ms = start.valueOf();
-      const estimated_length = (now_ms - start_ms) / job.progress;
-      const est_len_str = moment.duration(estimated_length).humanize();
-      return <span>ETA: {est_len_str}</span>;
+      const nowMS = now.valueOf();
+      const startMS = start.valueOf();
+      const estimatedLength = (nowMS - startMS) / job.progress;
+      const estLenStr = moment.duration(estimatedLength).humanize();
+      return (
+        <span className="job-eta">
+          <FormattedMessage id="eta" />: {estLenStr}
+        </span>
+      );
     }
   }
 
@@ -185,12 +189,7 @@ const Task: React.FC<IJob> = ({ job }) => {
           <Icon icon={faTimes} />
         </Button>
         <div className={`job-status ${getStatusClass()}`}>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-            }}
-          >
+          <div className="job-description">
             <div>
               {getStatusIcon()}
               <span>{job.description}</span>

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -293,6 +293,11 @@
     width: 100%;
   }
 
+  .job-description {
+    display: flex;
+    justify-content: space-between;
+  }
+
   .stop:not(:disabled),
   .stopping .fa-icon,
   .cancelled .fa-icon {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1054,6 +1054,7 @@
     "loading_type": "Error loading {type}",
     "something_went_wrong": "Something went wrong."
   },
+  "eta": "ETA",
   "ethnicity": "Ethnicity",
   "existing_value": "existing value",
   "eye_color": "Eye Colour",

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -5818,6 +5818,11 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 moment@~2.29.1:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"


### PR DESCRIPTION
This adds an ETA for tasks when possible. This is estimated at best effort using a simple linear estimation.

### Preview
![Screenshot 2024-12-06 at 13-09-51 Settings Stash](https://github.com/user-attachments/assets/85e08414-569f-423c-a4c5-3cff04f03139)

### Note: 
This adds the `moment` package to display a clean duration, as the current `intl` implementation is not able to produce good enough duration formatting imo.