### PR TITLE
Update PerformerModal.tsx to fix aliases exclusions

### DIFF
--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -283,8 +283,8 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
         performerData[k] = undefined;
       }
       // #5565 - special case aliases as the names differ
-      if (k == "alias_list" && excluded["aliases"]) {
-        performerData["alias_list"] = undefined;
+      if (k == "alias_list" && excluded.aliases) {
+        performerData.alias_list = undefined;
       }
     });
 

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -282,6 +282,10 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
       if (excluded[k] || !performerData[k]) {
         performerData[k] = undefined;
       }
+      // #5565 - special case aliases as the names differ
+      if (k == "alias_list" && excluded["aliases"]) {
+        performerData["alias_list"] = undefined;
+      }
     });
 
     onSave(performerData);


### PR DESCRIPTION
Resolves #5565

The exclude function doesn't work for aliases when tagging performers. I think this is since the GQL field and the performer data names differ, so alias_list is always sent even when aliases is in the exclude array. I'm a complete novice so am sure there's a better way to resolve but this works when testing.