### PR TITLE
Find scene markers by ID

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -44,7 +44,7 @@ type Query {
   "A function which queries SceneMarker objects"
   findSceneMarkers(
     scene_marker_filter: SceneMarkerFilterType
-    filter: FindFilterType,
+    filter: FindFilterType
     ids: [ID!]
   ): FindSceneMarkersResultType!
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -44,7 +44,8 @@ type Query {
   "A function which queries SceneMarker objects"
   findSceneMarkers(
     scene_marker_filter: SceneMarkerFilterType
-    filter: FindFilterType
+    filter: FindFilterType,
+    ids: [ID!]
   ): FindSceneMarkersResultType!
 
   findImage(id: ID, checksum: String): Image


### PR DESCRIPTION
Adds `ids` lookup to the `findSceneMarkers` graphql query.

This probably isn't very useful for the current web UI, but can be for other clients.