### PR TITLE
Fix Handy script not playing after revisiting scene

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -549,7 +549,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
 
     // always stop the interactive client on initialisation
     interactiveClient.pause();
-    interactiveReady.current = false;
 
     const isSafari = UAParser().browser.name?.includes("Safari");
     const isLandscape = file.height && file.width && file.width > file.height;


### PR DESCRIPTION
Resolves #5577

The problem seems to be that the hook for player initialization is executed after the hook for script uploading. `interactiveReady` is first set to true by the script uploading hook (correct), but then gets reset to false by the player initialization hook (incorrect).

I think it's safe to delete the line I deleted since it should get set to false by the script uploading hook anyway, but I'm rather new to React, so please correct me if I'm wrong. There might even be a better way of solving this, like somehow ensuring the script uploading hook gets executed *after* the player initialization hook.

I tested the change locally. It fixed the problem and everything else seemed fine.