### PR TITLE
Fix typo in in-app manual 

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -99,15 +99,15 @@ ui:
     connect-src:
       - http://alloweddomain.com
 
-  # map of setting names to be displayed in the plugins page in the UI
-  settings:
-    # internal name
-    foo:
-      # name to display in the UI
-      displayName: Foo
-      # type of the attribute to show in the UI
-      # can be BOOLEAN, NUMBER, or STRING
-      type: BOOLEAN
+# map of setting names to be displayed in the plugins page in the UI
+settings:
+  # internal name
+  foo:
+  # name to display in the UI
+  displayName: Foo
+  # type of the attribute to show in the UI
+  # can be BOOLEAN, NUMBER, or STRING
+  type: BOOLEAN
 
 # the following are used for plugin tasks only
 exec:


### PR DESCRIPTION
Correct syntax in plugin configuration file format