### PR TITLE
Stash Docker Installer

### DIFF
--- a/docker/StashDockerInstaller/CreateContainer.cmd
+++ b/docker/StashDockerInstaller/CreateContainer.cmd
@@ -13,7 +13,7 @@
 :: Example skipping docker-compose:
 ::					CreateContainer.cmd ContainerName "stashapp/stash:v0.26.2" 9992 C:\Videos SKIP
 set NewContainerName=%1
-:: Example image arguments:stashapp/stash:latest, stashapp/stash:v0.27.2, stashapp/stash:v0.26.2
+:: Example image arguments:  stashapp/stash:latest, stashapp/stash:v0.27.2, stashapp/stash:v0.26.2
 set Image=%2
 :: Example Port Numbers: 9999, 9990, 9991, 9995, 9998
 set STASH_PORT=%3
@@ -101,7 +101,6 @@ if /I [%STASH_PORT%]==[DLNA] 	(set DLNAFunctionality=yes) & (set STASH_PORT=)
 if /I [%STASH_PORT%]==[SKIP] 	(set SkipDockerCompose=yes) & (set STASH_PORT=)
 if /I [%STASH_PORT%]==[IMAGE]	(set PullDockerStashImage=yes) & (set STASH_PORT=)
 if /I [%STASH_PORT%]==[PULL] 	(set PullDockerStashImage=yes) & (set STASH_PORT=)
-echo SkipDockerCompose = %SkipDockerCompose% ; DLNAFunctionality = %DLNAFunctionality%
 set DockerComposeFile="docker-compose.yml"
 
 if [%NewContainerName%]==[] goto :MissingArgumentNewContainerName
@@ -114,8 +113,9 @@ if [%NewContainerName%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
 if [%Image%]==[] goto :MissingArgumentImage
 goto :HaveVariableImage
 :MissingArgumentImage
-set /p Image="Enter the image name: "
-if [%Image%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
+SET "Image=stashapp/stash:latest"
+set /p Image="Enter image name (or press enter to use default <%Image%>): "
+echo Image name=%Image%
 :HaveVariableImage
 
 :CHECK_STASH_PORT
@@ -126,12 +126,15 @@ goto :HaveVariableSTASH_PORT
 echo Error ******************
 echo Argument #3 requires a numeric value for Stash-Port.  You entered "%STASH_PORT%" instead.  Please enter a numberic value for Stash Port.
 :MissingArgumentSTASH_PORT
-set STASH_PORT=
-set /p STASH_PORT="Enter the Stash port number: "
-if [%STASH_PORT%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
+set STASH_PORT=9999
+set /p STASH_PORT="Enter the Stash port number (or press enter to use default <%STASH_PORT%>): "
 goto :CHECK_STASH_PORT
 :HaveVariableSTASH_PORT
 
+if [%STASH_PORT%]==[9999] (set DLNAFunctionality=yes)
+
+
+echo STASH_PORT = %STASH_PORT%; SkipDockerCompose = %SkipDockerCompose%; DLNAFunctionality = %DLNAFunctionality%
 if exist %NewContainerName%\ (
   echo %NewContainerName% already exists. 
 ) else (

--- a/docker/StashDockerInstaller/CreateContainer.cmd
+++ b/docker/StashDockerInstaller/CreateContainer.cmd
@@ -1,0 +1,215 @@
+@ECHO OFF
+:: This file is to create Stash Docker containers, and should be copied and called from the following path:
+:: C:\Users\MyUserName\AppData\Local\Docker\wsl\CreateContainer.cmd
+:: Example usage: 
+::				CreateContainer.cmd MyContainerName "stashapp/stash:latest" 9998
+:: Example with shared mount paths: 
+::				CreateContainer.cmd ContainerName1 "stashapp/stash:latest" 9991 C:\MySharedMountPath C:\Another\Shared\Folder
+:: Example adding Stash IMAGE and container:
+::				CreateContainer.cmd NewContainer27.2 "stashapp/stash:v0.27.2" 9997 IMAGE
+::		Note: The image name (stashapp/stash:v0.27.2) must be an image name listed in following link: https://hub.docker.com/r/stashapp/stash/tags
+:: Example with DLNA:
+::				CreateContainer.cmd MyDLNA272 "stashapp/stash:v0.27.2" 9996 C:\downloads DLNA
+:: Example skipping docker-compose:
+::					CreateContainer.cmd ContainerName "stashapp/stash:v0.26.2" 9992 C:\Videos SKIP
+set NewContainerName=%1
+:: Example image arguments:stashapp/stash:latest, stashapp/stash:v0.27.2, stashapp/stash:v0.26.2
+set Image=%2
+:: Example Port Numbers: 9999, 9990, 9991, 9995, 9998
+set STASH_PORT=%3
+:: The SharedMountPath's variables are optional arguments, and can be empty.
+:: Use SharedMountPath's to specify shared paths that are mounted as READ-ONLY.
+:: Example SharedMountPath: C:\Videos, E:\MyMedia, Z:\MyVideoCollections, C:\Users\MyUserName\Videos, C:\Users\MyUserName\download
+set SharedMountPath=%4
+set SharedMountPath2=%5
+set SharedMountPath3=%6
+set SharedMountPath4=%7
+set SharedMountPath5=%8
+set SharedMountPath6=%9
+shift
+shift
+shift
+shift
+shift
+set SharedMountPath7=%5
+set SharedMountPath8=%6
+set SharedMountPath9=%7
+set SharedMountPath10=%8
+set SharedMountPath11=%9
+set SkipDockerCompose=
+set DLNAFunctionality="no"
+set PullDockerStashImage=
+set MountAccess=:ro
+if /I [%SharedMountPath%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath=)
+if /I [%SharedMountPath%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath=)
+if /I [%SharedMountPath%]==[IMAGE]	 (set PullDockerStashImage=yes) & (set SharedMountPath=)
+if /I [%SharedMountPath%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath=)
+if /I [%SharedMountPath2%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath2=)
+if /I [%SharedMountPath2%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath2=)
+if /I [%SharedMountPath2%]==[IMAGE]  (set PullDockerStashImage=yes) & (set SharedMountPath2=)
+if /I [%SharedMountPath2%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath2=)
+if /I [%SharedMountPath2%]==[WRITE]	 (set MountAccess=) & (set SharedMountPath2=)
+if /I [%SharedMountPath3%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath3=)
+if /I [%SharedMountPath3%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath3=)
+if /I [%SharedMountPath3%]==[IMAGE]  (set PullDockerStashImage=yes) & (set SharedMountPath3=)
+if /I [%SharedMountPath3%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath3=)
+if /I [%SharedMountPath3%]==[WRITE]	 (set MountAccess=) & (set SharedMountPath3=)
+if /I [%SharedMountPath4%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath4=)
+if /I [%SharedMountPath4%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath4=)
+if /I [%SharedMountPath4%]==[IMAGE]  (set PullDockerStashImage=yes) & (set SharedMountPath4=)
+if /I [%SharedMountPath4%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath4=)
+if /I [%SharedMountPath4%]==[WRITE]	 (set MountAccess=) & (set SharedMountPath4=)
+if /I [%SharedMountPath5%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath5=)
+if /I [%SharedMountPath5%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath5=)
+if /I [%SharedMountPath5%]==[IMAGE]  (set PullDockerStashImage=yes) & (set SharedMountPath5=)
+if /I [%SharedMountPath5%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath5=)
+if /I [%SharedMountPath5%]==[WRITE]	 (set MountAccess=) & (set SharedMountPath5=)
+if /I [%SharedMountPath6%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath6=)
+if /I [%SharedMountPath6%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath6=)
+if /I [%SharedMountPath6%]==[IMAGE]	 (set PullDockerStashImage=yes) & (set SharedMountPath6=)
+if /I [%SharedMountPath6%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath6=)
+if /I [%SharedMountPath6%]==[WRITE]  (set MountAccess=) & (set SharedMountPath6=)
+if /I [%SharedMountPath7%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath7=)
+if /I [%SharedMountPath7%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath7=)
+if /I [%SharedMountPath7%]==[IMAGE]	 (set PullDockerStashImage=yes) & (set SharedMountPath7=)
+if /I [%SharedMountPath7%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath7=)
+if /I [%SharedMountPath7%]==[WRITE]  (set MountAccess=) & (set SharedMountPath7=)
+if /I [%SharedMountPath8%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath8=)
+if /I [%SharedMountPath8%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath8=)
+if /I [%SharedMountPath8%]==[IMAGE]	 (set PullDockerStashImage=yes) & (set SharedMountPath8=)
+if /I [%SharedMountPath8%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath8=)
+if /I [%SharedMountPath8%]==[WRITE]  (set MountAccess=) & (set SharedMountPath8=)
+if /I [%SharedMountPath9%]==[DLNA] 	 (set DLNAFunctionality=yes) & (set SharedMountPath9=)
+if /I [%SharedMountPath9%]==[SKIP] 	 (set SkipDockerCompose=yes) & (set SharedMountPath9=)
+if /I [%SharedMountPath9%]==[IMAGE]	 (set PullDockerStashImage=yes) & (set SharedMountPath9=)
+if /I [%SharedMountPath9%]==[PULL] 	 (set PullDockerStashImage=yes) & (set SharedMountPath9=)
+if /I [%SharedMountPath9%]==[WRITE]  (set MountAccess=) & (set SharedMountPath9=)
+if /I [%SharedMountPath10%]==[DLNA]  (set DLNAFunctionality=yes) & (set SharedMountPath10=)
+if /I [%SharedMountPath10%]==[SKIP]  (set SkipDockerCompose=yes) & (set SharedMountPath10=)
+if /I [%SharedMountPath10%]==[IMAGE] (set PullDockerStashImage=yes) & (set SharedMountPath10=)
+if /I [%SharedMountPath10%]==[PULL]  (set PullDockerStashImage=yes) & (set SharedMountPath10=)
+if /I [%SharedMountPath10%]==[WRITE] (set MountAccess=) & (set SharedMountPath10=)
+if /I [%SharedMountPath11%]==[DLNA]  (set DLNAFunctionality=yes) & (set SharedMountPath11=)
+if /I [%SharedMountPath11%]==[SKIP]  (set SkipDockerCompose=yes) & (set SharedMountPath11=)
+if /I [%SharedMountPath11%]==[IMAGE] (set PullDockerStashImage=yes) & (set SharedMountPath11=)
+if /I [%SharedMountPath11%]==[PULL]  (set PullDockerStashImage=yes) & (set SharedMountPath11=)
+if /I [%SharedMountPath11%]==[WRITE] (set MountAccess=) & (set SharedMountPath11=)
+
+
+:: If user incorrectly enters below arguments instead of Stash-Port, fetch the values, and let CHECK_STASH_PORT get the required Stash-Port.
+if /I [%STASH_PORT%]==[DLNA] 	(set DLNAFunctionality=yes) & (set STASH_PORT=)
+if /I [%STASH_PORT%]==[SKIP] 	(set SkipDockerCompose=yes) & (set STASH_PORT=)
+if /I [%STASH_PORT%]==[IMAGE]	(set PullDockerStashImage=yes) & (set STASH_PORT=)
+if /I [%STASH_PORT%]==[PULL] 	(set PullDockerStashImage=yes) & (set STASH_PORT=)
+echo SkipDockerCompose = %SkipDockerCompose% ; DLNAFunctionality = %DLNAFunctionality%
+set DockerComposeFile="docker-compose.yml"
+
+if [%NewContainerName%]==[] goto :MissingArgumentNewContainerName
+goto :HaveVariableNewContainerName
+:MissingArgumentNewContainerName
+set /p NewContainerName="Enter the new container name: "
+if [%NewContainerName%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
+:HaveVariableNewContainerName
+
+if [%Image%]==[] goto :MissingArgumentImage
+goto :HaveVariableImage
+:MissingArgumentImage
+set /p Image="Enter the image name: "
+if [%Image%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
+:HaveVariableImage
+
+:CHECK_STASH_PORT
+if [%STASH_PORT%]==[] goto :MissingArgumentSTASH_PORT
+IF 1%STASH_PORT% NEQ +1%STASH_PORT% goto STASH_PORT_NOT_NUMERIC
+goto :HaveVariableSTASH_PORT
+:STASH_PORT_NOT_NUMERIC
+echo Error ******************
+echo Argument #3 requires a numeric value for Stash-Port.  You entered "%STASH_PORT%" instead.  Please enter a numberic value for Stash Port.
+:MissingArgumentSTASH_PORT
+set STASH_PORT=
+set /p STASH_PORT="Enter the Stash port number: "
+if [%STASH_PORT%]==[] call:ExitWithError 160 "ERROR_BAD_ARGUMENTS"
+goto :CHECK_STASH_PORT
+:HaveVariableSTASH_PORT
+
+if exist %NewContainerName%\ (
+  echo %NewContainerName% already exists. 
+) else (
+  echo creating folder %NewContainerName%
+  mkdir %NewContainerName%
+)
+cd %NewContainerName%
+echo DockerComposeFile=%DockerComposeFile%; NewContainerName=%NewContainerName%; Image=%Image%; STASH_PORT=%STASH_PORT%; DLNAFunctionality=%DLNAFunctionality%; SharedMountPath=%SharedMountPath%; SharedMountPath1=%SharedMountPath1%; SharedMountPath2=%SharedMountPath2%
+echo services:> %DockerComposeFile%
+echo   stash:>> %DockerComposeFile%
+echo     image: %Image%>> %DockerComposeFile%
+echo     container_name: %NewContainerName%>> %DockerComposeFile%
+echo     restart: unless-stopped>> %DockerComposeFile%
+if [%DLNAFunctionality%]==[yes] goto :DoDLNA_Functionality
+echo     ports:>> %DockerComposeFile%
+echo       - "%STASH_PORT%:9999">> %DockerComposeFile%
+goto :SkipDLNA_Functionality
+:DoDLNA_Functionality
+echo     network_mode: host>> %DockerComposeFile%
+:SkipDLNA_Functionality
+echo     logging:>> %DockerComposeFile%
+echo       driver: "json-file">> %DockerComposeFile%
+echo       options:>> %DockerComposeFile%
+echo         max-file: "10">> %DockerComposeFile%
+echo         max-size: "2m">> %DockerComposeFile%
+echo     environment:>> %DockerComposeFile%
+echo       - STASH_STASH=/data/>> %DockerComposeFile%
+echo       - STASH_GENERATED=/generated/>> %DockerComposeFile%
+echo       - STASH_METADATA=/metadata/>> %DockerComposeFile%
+echo       - STASH_CACHE=/cache/>> %DockerComposeFile%
+if [%DLNAFunctionality%]==[yes] goto :DoDLNA_Functionality_pt2
+echo       - STASH_PORT=9999>> %DockerComposeFile%
+goto :SkipDLNA_Functionality_pt2
+:DoDLNA_Functionality_pt2
+echo       - STASH_PORT=%STASH_PORT%>> %DockerComposeFile%
+:SkipDLNA_Functionality_pt2
+echo     volumes:>> %DockerComposeFile%
+echo       - /etc/localtime:/etc/localtime:ro>> %DockerComposeFile%
+echo       - ./config:/root/.stash>> %DockerComposeFile%
+echo       - ./data:/data>> %DockerComposeFile%
+echo       - ./metadata:/metadata>> %DockerComposeFile%
+echo       - ./cache:/cache>> %DockerComposeFile%
+echo       - ./blobs:/blobs>> %DockerComposeFile%
+echo       - ./generated:/generated>> %DockerComposeFile%
+if [%SharedMountPath%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath%:/external%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath2%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath2%:/external2%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath3%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath3%:/external3%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath4%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath4%:/external4%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath5%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath5%:/external5%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath6%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath6%:/external6%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath7%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath7%:/external7%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath8%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath8%:/external8%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath9%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath9%:/external9%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath10%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath10%:/external10%MountAccess%>> %DockerComposeFile%
+if [%SharedMountPath11%]==[] goto :SkipSharedMountPaths
+echo       - %SharedMountPath11%:/external11%MountAccess%>> %DockerComposeFile%
+:SkipSharedMountPaths
+
+if [%SkipDockerCompose%] NEQ [] goto :DoNot_DockerCompose
+if [%PullDockerStashImage%] NEQ [yes] goto :SkipPullDockerStashImage
+docker pull %Image%
+:SkipPullDockerStashImage
+docker-compose up -d
+:DoNot_DockerCompose
+cd ..
+Goto :eof
+
+:ExitWithError
+Echo Error: Exiting with error code %1 and error message %2
+Exit %~1
+Goto :eof

--- a/docker/StashDockerInstaller/README.md
+++ b/docker/StashDockerInstaller/README.md
@@ -40,6 +40,7 @@ If any of the above arguments are missing, the script will prompt user for each 
 ### DLNA Functionality
 - The script can create a Stash container with DLNA Functionality. To add DLNA Functionality, append **DLNA** to the command line.
   - Example:`CreateContainer.cmd v272 "stashapp/stash:v0.27.2" 9996 DLNA`
+- If the stash port is set to 9999, DLNA is automatically enabled.
 
 ### Skip docker-compose
 - By default, `docker-compose up -d` is called after the script creates the **docker-compose.yml** file. To skip this call, append SKIP to the command line.

--- a/docker/StashDockerInstaller/README.md
+++ b/docker/StashDockerInstaller/README.md
@@ -1,0 +1,57 @@
+# Create Docker Stash Container (By David Maisonave)
+
+CreateContainer.cmd is a Windows script that is used to create a Stash container on Docker.
+
+To use it, first copy the file to the following path:
+`C:\Users\MyUserName\AppData\Local\Docker\wsl\CreateContainer.cmd`
+
+Note: Replace **MyUserName** with the actual user name.
+
+Then use a DOS window to change to the **ws1** directory before calling the script.
+### The script requires at minumum 3 arguments.
+- New Container Name
+- Image Name
+- Stash Port Number
+
+If any of the above arguments are missing, the script will prompt user for each missing argument before proceeding.
+
+### Example Commands:
+- Example usage with minumum arguments:
+  - `CreateContainer.cmd MyContainerName "stashapp/stash:latest" 9998`
+- Example adding Stash **Image** and container:
+  - `CreateContainer.cmd MyStashContainer "stashapp/stash:latest" 9997 IMAGE`
+- Example with shared mount paths: 
+  - `CreateContainer.cmd NewContainer27.2 "stashapp/stash:v0.27.2" 9991 C:\MySharedMountPath C:\Another\Shared\Folder`
+  - The script supports up to 11 shared mount paths.
+    - `CreateContainer.cmd StashCnt "stashapp/stash:latest" 9991 C:\downloads C:\tmp\foo C:\img C:\share\vid E:\vids G:\vid2`
+- Example with shared mount paths with write access: 
+  - `CreateContainer.cmd ContainerName1 "stashapp/stash:latest" 9991 C:\MyShared  WRITE`
+- Example with DLNA:
+  - `CreateContainer.cmd MyDLNA272 "stashapp/stash:v0.27.2" 9996 C:\downloads DLNA`
+- Example skipping docker-compose:
+  - `CreateContainer.cmd ContainerName "stashapp/stash:v0.26.2" 9992 C:\Videos SKIP`
+
+### Shared Mount Paths
+- CreateContainer.cmd can create up to 11 shared mount paths on the container. A shared mount path is a HOST path that is mounted on the container, which allows the container to access the files on the host machine.
+  - The container gets the mount paths mounted to /external /external2 /external3 /external4 /external5 /external6, etc....
+- By default the shared mount is READ-ONLY, but by appending **WRITE** to the command line, the script will make all the shared mounts with read-write access.
+  - Example:  `CreateContainer.cmd ContainerName1 "stashapp/stash:latest" 9999 C:\MySharedMountPath WRITE`
+
+### DLNA Functionality
+- The script can create a Stash container with DLNA Functionality. To add DLNA Functionality, append **DLNA** to the command line.
+  - Example:`CreateContainer.cmd v272 "stashapp/stash:v0.27.2" 9996 DLNA`
+
+### Skip docker-compose
+- By default, `docker-compose up -d` is called after the script creates the **docker-compose.yml** file. To skip this call, append SKIP to the command line.
+  - Example:  `CreateContainer.cmd ContainerName "stashapp/stash:v0.26.2" 9992 SKIP`
+- When SKIP is used, the script only creates the container directory and creates the **docker-compose.yml** file in the newly created directory.
+- This option is mainly used for debugging purposes.
+
+### Downloads
+- Docker
+  - Use the following link to download Docker
+  - [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/)
+- Stash Image
+  - The CreateContainer.cmd script can download the Image before creating the container by adding **IMAGE** at the end of the command line.
+  - Example: `CreateContainer.cmd ver0272 "stashapp/stash:v0.27.2" 9999 IMAGE`
+  - To see what Stash images are available, see the following link: [https://hub.docker.com/r/stashapp/stash/tags](https://hub.docker.com/r/stashapp/stash/tags).


### PR DESCRIPTION
CreateContainer.cmd is a DOS script that is used to create a Stash container on Docker.
- Installs Stash container with following options:
  - Mount paths Read-Only
  - Mount paths read-write
  - Install both image and container
  - DLNA option
  - Stash port number option
 
See readme for more details. (https://github.com/David-Maisonave/Axter-Stash/tree/main/Docker)

This batch script is for Windows, but if there's interest, I'll add a Linux script as well.