### PR TITLE
Update KeyboardShortcuts.md

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -62,6 +62,12 @@
 | `,` | Hide/Show sidebar |
 | `.` | Hide/Show scene scrubber |
 | `o` | Increment O-Counter |
+| Ratings ||
+| `r {1-5}` | Set rating (stars) |
+| `r 0` | Unset rating (stars) |
+| `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
+| ``r ` `` | Unset rating (decimal) |
+| Playback ||
 | `p n` | Play next scene in queue |
 | `p p` | Play previous scene in queue |
 | `p r` | Play random scene in queue |
@@ -88,14 +94,10 @@
 |-------------------|--------|
 | `n` | Display Create Markers dialog |
 
-### Edit Scene tab shortcuts
+### Scene Edit tab shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|
-| `r {1-5}` | Set rating (stars) |
-| `r 0` | Unset rating (stars) |
-| `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
-| ``r ` `` | Unset rating (decimal) |
 | `s s` | Save Scene |
 | `d d` | Delete Scene |
 | `Ctrl + v` | Paste Scene cover |
@@ -106,6 +108,25 @@
 [//]: # "(| `p` | Focus Performers selector |)"
 [//]: # "(| `v` | Focus Groups selector |)"
 [//]: # "(| `t` | Focus Tags selector |)"
+
+## Image Page shortcuts
+
+| Keyboard sequence | Action |
+|-------------------|--------|
+| `e` | Edit tab |
+| `o` | Increment O-Counter |
+| Ratings ||
+| `r {1-5}` | Set rating (stars) |
+| `r 0` | Unset rating (stars) |
+| `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
+| ``r ` `` | Unset rating (decimal) |
+
+### Image Edit tab shortcuts
+
+| Keyboard sequence | Action |
+|-------------------|--------|
+| `s s` | Save Scene |
+| `d d` | Delete Scene |
 
 ## Groups Page shortcuts
 
@@ -120,12 +141,13 @@
 | `e` | Edit Group |
 | `s s` | Save Group |
 | `d d` | Delete Group |
-| `r {1-5}` | [Edit mode] Set rating (stars) |
-| `r 0` | [Edit mode] Unset rating (stars) |
-| `r {0-9} {0-9}` | [Edit mode] Set rating (decimal - `r 0 0` for `10.0`) |
 | ``r ` `` | [Edit mode] Unset rating (decimal) |
 | `,` | Expand/Collapse Details |
 | `Ctrl + v` | Paste Group image |
+| Ratings ||
+| `r {1-5}` | [Edit mode] Set rating (stars) |
+| `r 0` | [Edit mode] Unset rating (stars) |
+| `r {0-9} {0-9}` | [Edit mode] Set rating (decimal - `r 0 0` for `10.0`) |
 
 [//]: # "Commented until implementation is dealt with"
 [//]: # "(| `u` | Focus Studio selector (in edit mode) |)"

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -175,7 +175,7 @@
 | `f` | Toggle favourite |
 | `,` | Expand/Collapse Details |
 
-### Edit Performer tab shortcuts
+### Performer Edit tab shortcuts
 
 | Keyboard sequence | Action |
 |-------------------|--------|


### PR DESCRIPTION
- Added table of shortcuts for Image page
- Reorganized a few tables to include sub-headings
- Renamed `Edit Scene tab [...]` heading to `Scene Edit tab [...]` for logical consistency with other headings
- Moved Scene page rating shortcuts from vestigial location in *Edit Scene* section to global Scene page section