### PR TITLE
docs: Add note about lack of SOCKS5 support

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -145,7 +145,7 @@ These options are typically not exposed in the UI and must be changed manually i
 | `max_upload_size` | Maximum file upload size for import files. Defaults to 1GB. |
 | `theme_color` | Sets the `theme-color` property in the UI. |
 | `gallery_cover_regex` | The regex responsible for selecting images as gallery covers |
-| `proxy` | The url of a HTTP(S) proxy to be used when stash makes calls to online services Example: https://user:password@my.proxy:8080 |
+| `proxy` | The url of a HTTP(S) proxy to be used when stash makes calls to online services. Example: https://user:password@my.proxy:8080. Note: SOCKS5 proxies are unsupported. |
 | `no_proxy` | A list of domains for which the proxy must not be used. Default is all local LAN: localhost,127.0.0.1,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12 |
 | `sequential_scanning` | Modifies behaviour of the scanning functionality to generate support files (previews/sprites/phash) at the same time as fingerprinting/screenshotting. Useful when scanning cached remote files. |
 


### PR DESCRIPTION
Per https://github.com/stashapp/stash/pull/3284

> SOCKS5 proxies are officially unsupported 😊 In practice they work, but crash python & CDP scrapers