### PR TITLE
Don't set image.title to file basename in graphql

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -35,12 +35,6 @@ models:
     model: github.com/stashapp/stash/internal/api.BoolMap
   PluginConfigMap:
     model: github.com/stashapp/stash/internal/api.PluginConfigMap
-  # define to force resolvers
-  Image:
-    model: github.com/stashapp/stash/pkg/models.Image
-    fields:
-      title:
-        resolver: true
   VideoFile:
     fields:
       # override float fields - #1572

--- a/internal/api/resolver_model_image.go
+++ b/internal/api/resolver_model_image.go
@@ -18,11 +18,6 @@ func (r *imageResolver) getFiles(ctx context.Context, obj *models.Image) ([]mode
 	return files, firstError(errs)
 }
 
-func (r *imageResolver) Title(ctx context.Context, obj *models.Image) (*string, error) {
-	ret := obj.GetTitle()
-	return &ret, nil
-}
-
 func (r *imageResolver) VisualFiles(ctx context.Context, obj *models.Image) ([]VisualFile, error) {
 	files, err := r.getFiles(ctx, obj)
 	if err != nil {

--- a/ui/v2.5/graphql/data/image-slim.graphql
+++ b/ui/v2.5/graphql/data/image-slim.graphql
@@ -10,10 +10,6 @@ fragment SlimImageData on Image {
   organized
   o_counter
 
-  files {
-    ...ImageFileData
-  }
-
   paths {
     thumbnail
     preview

--- a/ui/v2.5/graphql/data/image.graphql
+++ b/ui/v2.5/graphql/data/image.graphql
@@ -12,10 +12,6 @@ fragment ImageData on Image {
   created_at
   updated_at
 
-  files {
-    ...ImageFileData
-  }
-
   paths {
     thumbnail
     preview

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -18,7 +18,7 @@ import {
   faSearch,
   faTag,
 } from "@fortawesome/free-solid-svg-icons";
-import { objectTitle } from "src/core/files";
+import { imageTitle } from "src/core/files";
 import { TruncatedText } from "../Shared/TruncatedText";
 import ScreenUtils from "src/utils/screen";
 import { StudioOverlay } from "../Shared/GridCard/StudioOverlay";
@@ -197,7 +197,7 @@ export const ImageCard: React.FC<IImageCardProps> = (
       className={`image-card zoom-${props.zoomIndex}`}
       url={`/images/${props.image.id}`}
       width={cardWidth}
-      title={objectTitle(props.image)}
+      title={imageTitle(props.image)}
       linkClassName="image-card-link"
       image={
         <>

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -25,7 +25,7 @@ import { ImageEditPanel } from "./ImageEditPanel";
 import { ImageDetailPanel } from "./ImageDetailPanel";
 import { DeleteImagesDialog } from "../DeleteImagesDialog";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
-import { objectPath, objectTitle } from "src/core/files";
+import { imagePath, imageTitle } from "src/core/files";
 import { isVideo } from "src/utils/visualFile";
 import { useScrollToTopOnMount } from "src/hooks/scrollToTop";
 import { useRatingKeybinds } from "src/hooks/keybinds";
@@ -79,7 +79,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
     }
 
     await mutateMetadataScan({
-      paths: [objectPath(image)],
+      paths: [imagePath(image)],
       rescan: true,
     });
 
@@ -274,11 +274,11 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
   });
 
   const file = useMemo(
-    () => (image.files.length > 0 ? image.files[0] : undefined),
+    () => (image.visual_files.length > 0 ? image.visual_files[0] : undefined),
     [image]
   );
 
-  const title = objectTitle(image);
+  const title = imageTitle(image);
   const ImageView =
     image.visual_files.length > 0 && isVideo(image.visual_files[0])
       ? "video"

--- a/ui/v2.5/src/core/files.ts
+++ b/ui/v2.5/src/core/files.ts
@@ -29,3 +29,28 @@ export function objectPath(s: IObjectWithFiles) {
   }
   return "";
 }
+
+interface IObjectWithVisualFiles {
+  visual_files?: IFile[];
+}
+
+export interface IObjectWithTitleVisualFiles extends IObjectWithVisualFiles {
+  title?: GQL.Maybe<string>;
+}
+
+export function imageTitle(s: Partial<IObjectWithTitleVisualFiles>) {
+  if (s.title) {
+    return s.title;
+  }
+  if (s.visual_files && s.visual_files.length > 0) {
+    return TextUtils.fileNameFromPath(s.visual_files[0].path);
+  }
+  return "";
+}
+
+export function imagePath(s: IObjectWithVisualFiles) {
+  if (s.visual_files && s.visual_files.length > 0) {
+    return s.visual_files[0].path;
+  }
+  return "";
+}


### PR DESCRIPTION
The `Image.title` graphql field was incorrectly set to the file basename if it did not have a title set. This is inconsistent with the other media object types.

This PR removes the resolver from the `title` field on `Image`. `title` will no longer be populated with the file basename. Also removed the deprecated `files` field from the `Image` data fragments in the UI, in favour of `visual_files`.

Resolves #5657 