### PR TITLE
Fix variables for help links in Stash Setup Wizard

### DIFF
--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -790,7 +790,7 @@ const ErrorStep: React.FC<{ error: string; goBack: () => void }> = ({
         <p>
           <FormattedMessage
             id="setup.errors.something_went_wrong_description"
-            values={{ GithubLink, DiscordLink }}
+            values={{ githubLink: GithubLink, discordLink: DiscordLink }}
           />
         </p>
       </section>
@@ -881,7 +881,7 @@ const SuccessStep: React.FC<{}> = () => {
         <p>
           <FormattedMessage
             id="setup.success.help_links"
-            values={{ DiscordLink, GithubLink }}
+            values={{ discordLink: DiscordLink, githubLink: GithubLink }}
           />
         </p>
       </section>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1363,7 +1363,7 @@
     "success": {
       "download_ffmpeg": "Download ffmpeg",
       "getting_help": "Getting help",
-      "help_links": "If you run into issues or have any questions or suggestions, feel free to open an issue in the {githubLink}, or ask the community in the {discordLink}.",
+      "help_links": "If you run into issues or have any questions or suggestions, feel free to open an issue in the {GithubLink}, or ask the community in the {DiscordLink}.",
       "in_app_manual_explained": "You are encouraged to check out the in-app manual which can be accessed from the icon in the top-right corner of the screen that looks like this: {icon}",
       "missing_ffmpeg": "You are missing the required <code>ffmpeg</code> binary. You can automatically download it into your configuration directory by checking the box below. Alternatively, you can supply paths to the <code>ffmpeg</code> and <code>ffprobe</code> binaries in the System Settings. These binaries must be present for Stash to function.",
       "next_config_step_one": "You will be taken to the Configuration page next. This page will allow you to customize what files to include and exclude, set a username and password to protect your system, and a whole bunch of other options.",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1363,7 +1363,7 @@
     "success": {
       "download_ffmpeg": "Download ffmpeg",
       "getting_help": "Getting help",
-      "help_links": "If you run into issues or have any questions or suggestions, feel free to open an issue in the {GithubLink}, or ask the community in the {DiscordLink}.",
+      "help_links": "If you run into issues or have any questions or suggestions, feel free to open an issue in the {githubLink}, or ask the community in the {discordLink}.",
       "in_app_manual_explained": "You are encouraged to check out the in-app manual which can be accessed from the icon in the top-right corner of the screen that looks like this: {icon}",
       "missing_ffmpeg": "You are missing the required <code>ffmpeg</code> binary. You can automatically download it into your configuration directory by checking the box below. Alternatively, you can supply paths to the <code>ffmpeg</code> and <code>ffprobe</code> binaries in the System Settings. These binaries must be present for Stash to function.",
       "next_config_step_one": "You will be taken to the Configuration page next. This page will allow you to customize what files to include and exclude, set a username and password to protect your system, and a whole bunch of other options.",


### PR DESCRIPTION
https://github.com/stashapp/stash/pull/5459 changed the variable from `githubLink`, `discordLink` to `GithubLink`, `DiscordLink`.

Not sure if reverting the variable name is preferred instead. 