### PR TITLE
Fix scraping multiple URLs 

### DIFF
--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -1148,7 +1148,7 @@ func (s mappedScraper) scrapeImage(ctx context.Context, q mappedQuery) (*Scraped
 	imageStudioMap := imageScraperConfig.Studio
 
 	logger.Debug(`Processing image:`)
-	results := imageMap.process(ctx, q, s.Common)
+	results := imageMap.process(ctx, q, s.Common, urlsIsMulti)
 
 	// now apply the performers and tags
 	if imagePerformersMap != nil {
@@ -1163,7 +1163,7 @@ func (s mappedScraper) scrapeImage(ctx context.Context, q mappedQuery) (*Scraped
 
 	if imageStudioMap != nil {
 		logger.Debug(`Processing image studio:`)
-		studioResults := imageStudioMap.process(ctx, q, s.Common)
+		studioResults := imageStudioMap.process(ctx, q, s.Common, nil)
 
 		if len(studioResults) > 0 {
 			studio := &models.ScrapedStudio{}

--- a/pkg/scraper/mapped.go
+++ b/pkg/scraper/mapped.go
@@ -43,7 +43,9 @@ func (s mappedConfig) applyCommon(c commonMappedConfig, src string) string {
 	return ret
 }
 
-func (s mappedConfig) process(ctx context.Context, q mappedQuery, common commonMappedConfig) mappedResults {
+type isMultiFunc func(key string) bool
+
+func (s mappedConfig) process(ctx context.Context, q mappedQuery, common commonMappedConfig, isMulti isMultiFunc) mappedResults {
 	var ret mappedResults
 
 	for k, attrConfig := range s {
@@ -51,7 +53,7 @@ func (s mappedConfig) process(ctx context.Context, q mappedQuery, common commonM
 		if attrConfig.Fixed != "" {
 			// TODO - not sure if this needs to set _all_ indexes for the key
 			const i = 0
-			ret = ret.setKey(i, k, attrConfig.Fixed)
+			ret = ret.setSingleValue(i, k, attrConfig.Fixed)
 		} else {
 			selector := attrConfig.Selector
 			selector = s.applyCommon(common, selector)
@@ -63,8 +65,15 @@ func (s mappedConfig) process(ctx context.Context, q mappedQuery, common commonM
 
 			if len(found) > 0 {
 				result := s.postProcess(ctx, q, attrConfig, found)
-				for i, text := range result {
-					ret = ret.setKey(i, k, text)
+
+				// HACK - if the key is URLs, then we need to set the value as a multi-value
+				isMulti := isMulti != nil && isMulti(k)
+				if isMulti {
+					ret = ret.setMultiValue(0, k, result)
+				} else {
+					for i, text := range result {
+						ret = ret.setSingleValue(i, k, text)
+					}
 				}
 			}
 		}
@@ -789,37 +798,37 @@ type mappedScraper struct {
 	Movie     *mappedMovieScraperConfig     `yaml:"movie"`
 }
 
-type mappedResult map[string]string
+type mappedResult map[string]interface{}
 type mappedResults []mappedResult
 
 func (r mappedResult) apply(dest interface{}) {
-	destVal := reflect.ValueOf(dest)
-
-	// dest should be a pointer
-	destVal = destVal.Elem()
+	destVal := reflect.ValueOf(dest).Elem()
 
 	for key, value := range r {
 		field := destVal.FieldByName(key)
+		fieldType := field.Type()
 
-		if field.IsValid() {
-			var reflectValue reflect.Value
-			if field.Kind() == reflect.Ptr {
-				// need to copy the value, otherwise everything is set to the
-				// same pointer
-				localValue := value
-				reflectValue = reflect.ValueOf(&localValue)
-			} else {
-				reflectValue = reflect.ValueOf(value)
+		if field.IsValid() && field.CanSet() {
+			reflectValue := reflect.ValueOf(value)
+			reflectValueType := reflectValue.Type()
+
+			switch {
+			case reflectValueType.ConvertibleTo(fieldType):
+				field.Set(reflectValue.Convert(fieldType))
+			case fieldType.Kind() == reflect.Pointer && reflectValueType.ConvertibleTo(fieldType.Elem()):
+				ptr := reflect.New(fieldType.Elem())
+				ptr.Elem().Set(reflectValue.Convert(fieldType.Elem()))
+				field.Set(ptr)
+			default:
+				logger.Errorf("Cannot convert %T to %s for field %s", value, fieldType, key)
 			}
-
-			field.Set(reflectValue)
 		} else {
-			logger.Errorf("Field %s does not exist in %T", key, dest)
+			logger.Errorf("Field %s does not exist or cannot be set in %T", key, dest)
 		}
 	}
 }
 
-func (r mappedResults) setKey(index int, key string, value string) mappedResults {
+func (r mappedResults) setSingleValue(index int, key string, value string) mappedResults {
 	if index >= len(r) {
 		r = append(r, make(mappedResult))
 	}
@@ -827,6 +836,20 @@ func (r mappedResults) setKey(index int, key string, value string) mappedResults
 	logger.Debugf(`[%d][%s] = %s`, index, key, value)
 	r[index][key] = value
 	return r
+}
+
+func (r mappedResults) setMultiValue(index int, key string, value []string) mappedResults {
+	if index >= len(r) {
+		r = append(r, make(mappedResult))
+	}
+
+	logger.Debugf(`[%d][%s] = %s`, index, key, value)
+	r[index][key] = value
+	return r
+}
+
+func urlsIsMulti(key string) bool {
+	return key == "URLs"
 }
 
 func (s mappedScraper) scrapePerformer(ctx context.Context, q mappedQuery) (*models.ScrapedPerformer, error) {
@@ -839,12 +862,12 @@ func (s mappedScraper) scrapePerformer(ctx context.Context, q mappedQuery) (*mod
 
 	performerTagsMap := performerMap.Tags
 
-	results := performerMap.process(ctx, q, s.Common)
+	results := performerMap.process(ctx, q, s.Common, urlsIsMulti)
 
 	// now apply the tags
 	if performerTagsMap != nil {
 		logger.Debug(`Processing performer tags:`)
-		tagResults := performerTagsMap.process(ctx, q, s.Common)
+		tagResults := performerTagsMap.process(ctx, q, s.Common, nil)
 
 		for _, p := range tagResults {
 			tag := &models.ScrapedTag{}
@@ -872,7 +895,7 @@ func (s mappedScraper) scrapePerformers(ctx context.Context, q mappedQuery) ([]*
 		return nil, nil
 	}
 
-	results := performerMap.process(ctx, q, s.Common)
+	results := performerMap.process(ctx, q, s.Common, nil)
 	for _, r := range results {
 		var p models.ScrapedPerformer
 		r.apply(&p)
@@ -901,7 +924,7 @@ func (s mappedScraper) processSceneRelationships(ctx context.Context, q mappedQu
 
 	if sceneStudioMap != nil {
 		logger.Debug(`Processing scene studio:`)
-		studioResults := sceneStudioMap.process(ctx, q, s.Common)
+		studioResults := sceneStudioMap.process(ctx, q, s.Common, nil)
 
 		if len(studioResults) > 0 && resultIndex < len(studioResults) {
 			studio := &models.ScrapedStudio{}
@@ -925,14 +948,14 @@ func (s mappedScraper) processPerformers(ctx context.Context, performersMap mapp
 	// now apply the performers and tags
 	if performersMap.mappedConfig != nil {
 		logger.Debug(`Processing performers:`)
-		performerResults := performersMap.process(ctx, q, s.Common)
+		performerResults := performersMap.process(ctx, q, s.Common, urlsIsMulti)
 
 		scenePerformerTagsMap := performersMap.Tags
 
 		// process performer tags once
 		var performerTagResults mappedResults
 		if scenePerformerTagsMap != nil {
-			performerTagResults = scenePerformerTagsMap.process(ctx, q, s.Common)
+			performerTagResults = scenePerformerTagsMap.process(ctx, q, s.Common, nil)
 		}
 
 		for _, p := range performerResults {
@@ -955,7 +978,7 @@ func (s mappedScraper) processPerformers(ctx context.Context, performersMap mapp
 func processRelationships[T any](ctx context.Context, s mappedScraper, relationshipMap mappedConfig, q mappedQuery) []*T {
 	var ret []*T
 
-	results := relationshipMap.process(ctx, q, s.Common)
+	results := relationshipMap.process(ctx, q, s.Common, nil)
 
 	for _, p := range results {
 		var value T
@@ -976,7 +999,7 @@ func (s mappedScraper) scrapeScenes(ctx context.Context, q mappedQuery) ([]*Scra
 	}
 
 	logger.Debug(`Processing scenes:`)
-	results := sceneMap.process(ctx, q, s.Common)
+	results := sceneMap.process(ctx, q, s.Common, nil)
 	for i, r := range results {
 		logger.Debug(`Processing scene:`)
 
@@ -998,7 +1021,7 @@ func (s mappedScraper) scrapeScene(ctx context.Context, q mappedQuery) (*Scraped
 	sceneMap := sceneScraperConfig.mappedConfig
 
 	logger.Debug(`Processing scene:`)
-	results := sceneMap.process(ctx, q, s.Common)
+	results := sceneMap.process(ctx, q, s.Common, nil)
 
 	var ret ScrapedScene
 	if len(results) > 0 {
@@ -1031,12 +1054,12 @@ func (s mappedScraper) scrapeGallery(ctx context.Context, q mappedQuery) (*Scrap
 	galleryStudioMap := galleryScraperConfig.Studio
 
 	logger.Debug(`Processing gallery:`)
-	results := galleryMap.process(ctx, q, s.Common)
+	results := galleryMap.process(ctx, q, s.Common, urlsIsMulti)
 
 	// now apply the performers and tags
 	if galleryPerformersMap != nil {
 		logger.Debug(`Processing gallery performers:`)
-		performerResults := galleryPerformersMap.process(ctx, q, s.Common)
+		performerResults := galleryPerformersMap.process(ctx, q, s.Common, urlsIsMulti)
 
 		for _, p := range performerResults {
 			performer := &models.ScrapedPerformer{}
@@ -1047,7 +1070,7 @@ func (s mappedScraper) scrapeGallery(ctx context.Context, q mappedQuery) (*Scrap
 
 	if galleryTagsMap != nil {
 		logger.Debug(`Processing gallery tags:`)
-		tagResults := galleryTagsMap.process(ctx, q, s.Common)
+		tagResults := galleryTagsMap.process(ctx, q, s.Common, nil)
 
 		for _, p := range tagResults {
 			tag := &models.ScrapedTag{}
@@ -1058,7 +1081,7 @@ func (s mappedScraper) scrapeGallery(ctx context.Context, q mappedQuery) (*Scrap
 
 	if galleryStudioMap != nil {
 		logger.Debug(`Processing gallery studio:`)
-		studioResults := galleryStudioMap.process(ctx, q, s.Common)
+		studioResults := galleryStudioMap.process(ctx, q, s.Common, nil)
 
 		if len(studioResults) > 0 {
 			studio := &models.ScrapedStudio{}
@@ -1092,11 +1115,11 @@ func (s mappedScraper) scrapeGroup(ctx context.Context, q mappedQuery) (*models.
 	movieStudioMap := movieScraperConfig.Studio
 	movieTagsMap := movieScraperConfig.Tags
 
-	results := movieMap.process(ctx, q, s.Common)
+	results := movieMap.process(ctx, q, s.Common, urlsIsMulti)
 
 	if movieStudioMap != nil {
 		logger.Debug(`Processing movie studio:`)
-		studioResults := movieStudioMap.process(ctx, q, s.Common)
+		studioResults := movieStudioMap.process(ctx, q, s.Common, nil)
 
 		if len(studioResults) > 0 {
 			studio := &models.ScrapedStudio{}
@@ -1108,7 +1131,7 @@ func (s mappedScraper) scrapeGroup(ctx context.Context, q mappedQuery) (*models.
 	// now apply the tags
 	if movieTagsMap != nil {
 		logger.Debug(`Processing movie tags:`)
-		tagResults := movieTagsMap.process(ctx, q, s.Common)
+		tagResults := movieTagsMap.process(ctx, q, s.Common, nil)
 
 		for _, p := range tagResults {
 			tag := &models.ScrapedTag{}

--- a/pkg/scraper/xpath_test.go
+++ b/pkg/scraper/xpath_test.go
@@ -32,6 +32,7 @@ const htmlDoc1 = `
 							</td>
 							<td class="paramvalue">
 								<a href="/html/m_links/Mia_Malkova/">Mia Malkova</a>&nbsp;
+								<a href="/html/m_links/Mia_Malkova/second_url">Mia Malkova</a>&nbsp;
 							</td>
 						</tr>
 						<tr>
@@ -206,6 +207,8 @@ func makeXPathConfig() mappedPerformerScraperConfig {
 	}
 
 	config.mappedConfig["Name"] = makeSimpleAttrConfig(makeCommonXPath("Babe Name:") + `/a`)
+	config.mappedConfig["URL"] = makeSimpleAttrConfig(makeCommonXPath("Babe Name:") + `/a/@href`)
+	config.mappedConfig["URLs"] = makeSimpleAttrConfig(makeCommonXPath("Babe Name:") + `/a/@href`)
 	config.mappedConfig["Ethnicity"] = makeSimpleAttrConfig(makeCommonXPath("Ethnicity:"))
 	config.mappedConfig["Aliases"] = makeSimpleAttrConfig(makeCommonXPath("Aliases:"))
 	config.mappedConfig["EyeColor"] = makeSimpleAttrConfig(makeCommonXPath("Eye Color:"))
@@ -321,6 +324,8 @@ func TestScrapePerformerXPath(t *testing.T) {
 	}
 
 	const performerName = "Mia Malkova"
+	const url = "/html/m_links/Mia_Malkova/"
+	const secondURL = "/html/m_links/Mia_Malkova/second_url"
 	const ethnicity = "Caucasian"
 	const country = "United States"
 	const birthdate = "1992-07-01"
@@ -338,6 +343,16 @@ func TestScrapePerformerXPath(t *testing.T) {
 	const weight = "57" // 126 lb
 
 	verifyField(t, performerName, performer.Name, "Name")
+	verifyField(t, url, performer.URL, "URL")
+
+	// #5294 - test multiple URLs
+	if len(performer.URLs) != 2 {
+		t.Errorf("Expected 2 URLs, got %d", len(performer.URLs))
+	} else {
+		verifyField(t, url, &performer.URLs[0], "URLs[0]")
+		verifyField(t, secondURL, &performer.URLs[1], "URLs[1]")
+	}
+
 	verifyField(t, gender, performer.Gender, "Gender")
 	verifyField(t, ethnicity, performer.Ethnicity, "Ethnicity")
 	verifyField(t, country, performer.Country, "Country")
@@ -805,7 +820,7 @@ func TestLoadInvalidXPath(t *testing.T) {
 		doc: doc,
 	}
 
-	config.process(context.Background(), q, nil)
+	config.process(context.Background(), q, nil, nil)
 }
 
 type mockGlobalConfig struct{}

--- a/pkg/scraper/xpath_test.go
+++ b/pkg/scraper/xpath_test.go
@@ -584,7 +584,7 @@ func makeSceneXPathConfig() mappedScraper {
 
 	performerConfig := make(mappedConfig)
 	performerConfig["Name"] = makeSimpleAttrConfig(`$performerElem/@data-mxptext`)
-	performerConfig["URL"] = makeSimpleAttrConfig(`$performerElem/@href`)
+	performerConfig["URLs"] = makeSimpleAttrConfig(`$performerElem/@href`)
 	config.Performers.mappedConfig = performerConfig
 
 	studioConfig := make(mappedConfig)
@@ -668,8 +668,8 @@ func verifyPerformers(t *testing.T, expectedNames []string, expectedURLs []strin
 		}
 		if i < len(actualPerformers) {
 			actualName = *actualPerformers[i].Name
-			if actualPerformers[i].URL != nil {
-				actualURL = *actualPerformers[i].URL
+			if len(actualPerformers[i].URLs) == 1 {
+				actualURL = actualPerformers[i].URLs[0]
 			}
 		}
 


### PR DESCRIPTION
The mapped scraper functionality is in sore need of a rework. #5294 has highlighted this with the new `URLs` field. For now, I've hacked in a solution that should correctly convert URLs to a list. 

Notably, this does _not work_ where `URLs` is used in a sub-object scenario. For example, it will populate only a single URL in the `URLs` field of performers within a scene scrape. This is because there is currently no way to determine which performer a given URL value belongs to. Therefore, it follows existing convention and assigns one URL for each performer result. This means that it is not possible to have multiple URLs for any performer within a scene scrape.

Resolves #5294 

For testing, I used the following performer scraper for LinkTree:
```
name: LinkTree
performerByURL:
  - action: scrapeXPath
    url:
      - linktr.ee
    scraper: performerScraper

xPathScrapers:
  performerScraper:
    performer:
      Name: //div[@id='profile-title']/h1/text()
      URLs:
        selector: //div[@id='links-container']//a/@href
```