### PR TITLE
Clear markers on unmount

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -705,7 +705,6 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
     }));
 
     const markers = player!.markers();
-    markers.clearMarkers();
 
     const uniqueTagNames = markerData
       .map((marker) => marker.primaryTag.name)
@@ -771,6 +770,8 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = ({
 
     return () => {
       player.off("loadedmetadata", handleLoadMetadata);
+      const markers = player!.markers();
+      markers.clearMarkers();
     };
   }, [getPlayer, scene, loadMarkers]);
 


### PR DESCRIPTION
Related to #5671

Clears markers when unmounting scene player. Should hopefully address markers remaining when navigating quickly between scenes.

Pinging @SyZeeGee for possible testing.