### PR TITLE
Initialise UpdatedAt for stash ids

### DIFF
--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -121,12 +121,14 @@ func Test_PerformerStore_Create(t *testing.T) {
 					Aliases:        models.NewRelatedStrings(aliases),
 					StashIDs: models.NewRelatedStashIDs([]models.StashID{
 						{
-							StashID:  stashID1,
-							Endpoint: endpoint1,
+							StashID:   stashID1,
+							Endpoint:  endpoint1,
+							UpdatedAt: epochTime,
 						},
 						{
-							StashID:  stashID2,
-							Endpoint: endpoint2,
+							StashID:   stashID2,
+							Endpoint:  endpoint2,
+							UpdatedAt: epochTime,
 						},
 					}),
 					CreatedAt: createdAt,
@@ -283,12 +285,14 @@ func Test_PerformerStore_Update(t *testing.T) {
 					TagIDs:         models.NewRelatedIDs([]int{tagIDs[tagIdx1WithPerformer], tagIDs[tagIdx1WithDupName]}),
 					StashIDs: models.NewRelatedStashIDs([]models.StashID{
 						{
-							StashID:  stashID1,
-							Endpoint: endpoint1,
+							StashID:   stashID1,
+							Endpoint:  endpoint1,
+							UpdatedAt: epochTime,
 						},
 						{
-							StashID:  stashID2,
-							Endpoint: endpoint2,
+							StashID:   stashID2,
+							Endpoint:  endpoint2,
+							UpdatedAt: epochTime,
 						},
 					}),
 					CreatedAt: createdAt,
@@ -518,12 +522,14 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 				StashIDs: &models.UpdateStashIDs{
 					StashIDs: []models.StashID{
 						{
-							StashID:  stashID1,
-							Endpoint: endpoint1,
+							StashID:   stashID1,
+							Endpoint:  endpoint1,
+							UpdatedAt: epochTime,
 						},
 						{
-							StashID:  stashID2,
-							Endpoint: endpoint2,
+							StashID:   stashID2,
+							Endpoint:  endpoint2,
+							UpdatedAt: epochTime,
 						},
 					},
 					Mode: models.RelationshipUpdateModeSet,
@@ -560,12 +566,14 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 				TagIDs:         models.NewRelatedIDs([]int{tagIDs[tagIdx1WithPerformer], tagIDs[tagIdx1WithDupName]}),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
-						StashID:  stashID1,
-						Endpoint: endpoint1,
+						StashID:   stashID1,
+						Endpoint:  endpoint1,
+						UpdatedAt: epochTime,
 					},
 					{
-						StashID:  stashID2,
-						Endpoint: endpoint2,
+						StashID:   stashID2,
+						Endpoint:  endpoint2,
+						UpdatedAt: epochTime,
 					},
 				}),
 				CreatedAt: createdAt,
@@ -2075,8 +2083,9 @@ func testPerformerStashIDs(ctx context.Context, t *testing.T, s *models.Performe
 	const stashIDStr = "stashID"
 	const endpoint = "endpoint"
 	stashID := models.StashID{
-		StashID:  stashIDStr,
-		Endpoint: endpoint,
+		StashID:   stashIDStr,
+		Endpoint:  endpoint,
+		UpdatedAt: epochTime,
 	}
 
 	qb := db.Performer

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -133,12 +133,14 @@ func Test_sceneQueryBuilder_Create(t *testing.T) {
 				}),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
-						StashID:  stashID1,
-						Endpoint: endpoint1,
+						StashID:   stashID1,
+						Endpoint:  endpoint1,
+						UpdatedAt: epochTime,
 					},
 					{
-						StashID:  stashID2,
-						Endpoint: endpoint2,
+						StashID:   stashID2,
+						Endpoint:  endpoint2,
+						UpdatedAt: epochTime,
 					},
 				}),
 				ResumeTime:   float64(resumeTime),
@@ -178,12 +180,14 @@ func Test_sceneQueryBuilder_Create(t *testing.T) {
 				}),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
-						StashID:  stashID1,
-						Endpoint: endpoint1,
+						StashID:   stashID1,
+						Endpoint:  endpoint1,
+						UpdatedAt: epochTime,
 					},
 					{
-						StashID:  stashID2,
-						Endpoint: endpoint2,
+						StashID:   stashID2,
+						Endpoint:  endpoint2,
+						UpdatedAt: epochTime,
 					},
 				}),
 				ResumeTime:   resumeTime,
@@ -362,12 +366,14 @@ func Test_sceneQueryBuilder_Update(t *testing.T) {
 				}),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
-						StashID:  stashID1,
-						Endpoint: endpoint1,
+						StashID:   stashID1,
+						Endpoint:  endpoint1,
+						UpdatedAt: epochTime,
 					},
 					{
-						StashID:  stashID2,
-						Endpoint: endpoint2,
+						StashID:   stashID2,
+						Endpoint:  endpoint2,
+						UpdatedAt: epochTime,
 					},
 				}),
 				ResumeTime:   resumeTime,
@@ -590,12 +596,14 @@ func Test_sceneQueryBuilder_UpdatePartial(t *testing.T) {
 				StashIDs: &models.UpdateStashIDs{
 					StashIDs: []models.StashID{
 						{
-							StashID:  stashID1,
-							Endpoint: endpoint1,
+							StashID:   stashID1,
+							Endpoint:  endpoint1,
+							UpdatedAt: epochTime,
 						},
 						{
-							StashID:  stashID2,
-							Endpoint: endpoint2,
+							StashID:   stashID2,
+							Endpoint:  endpoint2,
+							UpdatedAt: epochTime,
 						},
 					},
 					Mode: models.RelationshipUpdateModeSet,
@@ -634,12 +642,14 @@ func Test_sceneQueryBuilder_UpdatePartial(t *testing.T) {
 				}),
 				StashIDs: models.NewRelatedStashIDs([]models.StashID{
 					{
-						StashID:  stashID1,
-						Endpoint: endpoint1,
+						StashID:   stashID1,
+						Endpoint:  endpoint1,
+						UpdatedAt: epochTime,
 					},
 					{
-						StashID:  stashID2,
-						Endpoint: endpoint2,
+						StashID:   stashID2,
+						Endpoint:  endpoint2,
+						UpdatedAt: epochTime,
 					},
 				}),
 				ResumeTime:   resumeTime,
@@ -741,12 +751,14 @@ func Test_sceneQueryBuilder_UpdatePartialRelationships(t *testing.T) {
 
 		stashIDs = []models.StashID{
 			{
-				StashID:  stashID1,
-				Endpoint: endpoint1,
+				StashID:   stashID1,
+				Endpoint:  endpoint1,
+				UpdatedAt: epochTime,
 			},
 			{
-				StashID:  stashID2,
-				Endpoint: endpoint2,
+				StashID:   stashID2,
+				Endpoint:  endpoint2,
+				UpdatedAt: epochTime,
 			},
 		}
 	)
@@ -4377,8 +4389,9 @@ func testSceneStashIDs(ctx context.Context, t *testing.T, s *models.Scene) {
 	const stashIDStr = "stashID"
 	const endpoint = "endpoint"
 	stashID := models.StashID{
-		StashID:  stashIDStr,
-		Endpoint: endpoint,
+		StashID:   stashIDStr,
+		Endpoint:  endpoint,
+		UpdatedAt: epochTime,
 	}
 
 	qb := db.Scene

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -24,6 +24,8 @@ import (
 	_ "github.com/stashapp/stash/pkg/sqlite/migrations"
 )
 
+var epochTime = time.Unix(0, 0).UTC()
+
 const (
 	spacedSceneTitle = "zzz yyy xxx"
 )
@@ -1028,8 +1030,9 @@ func getObjectDate(index int) *models.Date {
 
 func sceneStashID(i int) models.StashID {
 	return models.StashID{
-		StashID:  getSceneStringValue(i, "stashid"),
-		Endpoint: getSceneStringValue(i, "endpoint"),
+		StashID:   getSceneStringValue(i, "stashid"),
+		Endpoint:  getSceneStringValue(i, "endpoint"),
+		UpdatedAt: epochTime,
 	}
 }
 

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -618,6 +618,9 @@ func testStudioStashIDs(ctx context.Context, t *testing.T, s *models.Studio) {
 		return
 	}
 
+	// #5563 - set the UpdatedAt field to epoch
+	stashID.UpdatedAt = epochTime
+
 	assert.Equal(t, []models.StashID{stashID}, s.StashIDs.List())
 
 	// remove stash ids and ensure was updated

--- a/pkg/sqlite/table.go
+++ b/pkg/sqlite/table.go
@@ -309,7 +309,15 @@ func (t *stashIDTable) get(ctx context.Context, id int) ([]models.StashID, error
 	return ret, nil
 }
 
+var epochTime = time.Unix(0, 0).UTC()
+
 func (t *stashIDTable) insertJoin(ctx context.Context, id int, v models.StashID) (sql.Result, error) {
+	// #5563 - it's possible that zero-value updated at timestamps are provided via import
+	// replace them with the epoch time
+	if v.UpdatedAt.IsZero() {
+		v.UpdatedAt = epochTime
+	}
+
 	var q = dialect.Insert(t.table.table).Cols(t.idColumn.GetCol(), "endpoint", "stash_id", "updated_at").Vals(
 		goqu.Vals{id, v.Endpoint, v.StashID, v.UpdatedAt},
 	)


### PR DESCRIPTION
If a stash ids are imported and the `updatedAt` field is not set, then this field is initialised at zero time, which graphql interprets as null, causing a UI error. This PR initialises the field when inserting rows to epoch time if it is not set.

Resolves #5563 