### PR TITLE
Fix custom field numbers not filtering correctly

### DIFF
--- a/internal/api/json.go
+++ b/internal/api/json.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/stashapp/stash/pkg/models"
 )
 
-// JSONNumberToNumber converts a JSON number to either a float64 or int64.
+// jsonNumberToNumber converts a JSON number to either a float64 or int64.
 func jsonNumberToNumber(n json.Number) interface{} {
 	if strings.Contains(string(n), ".") {
 		f, _ := n.Float64()
@@ -13,6 +15,15 @@ func jsonNumberToNumber(n json.Number) interface{} {
 	}
 	ret, _ := n.Int64()
 	return ret
+}
+
+// anyJSONNumberToNumber converts a JSON number using jsonNumberToNumber, otherwise it returns the existing value
+func anyJSONNumberToNumber(v any) any {
+	if n, ok := v.(json.Number); ok {
+		return jsonNumberToNumber(n)
+	}
+
+	return v
 }
 
 // ConvertMapJSONNumbers converts all JSON numbers in a map to either float64 or int64.
@@ -30,6 +41,24 @@ func convertMapJSONNumbers(m map[string]interface{}) (ret map[string]interface{}
 		} else {
 			ret[k] = v
 		}
+	}
+
+	return ret
+}
+
+func convertCustomFieldCriterionValues(c models.CustomFieldCriterionInput) models.CustomFieldCriterionInput {
+	nv := make([]any, len(c.Value))
+	for i, v := range c.Value {
+		nv[i] = anyJSONNumberToNumber(v)
+	}
+	c.Value = nv
+	return c
+}
+
+func convertCustomFieldCriterionInputJSONNumbers(c []models.CustomFieldCriterionInput) []models.CustomFieldCriterionInput {
+	ret := make([]models.CustomFieldCriterionInput, len(c))
+	for i, v := range c {
+		ret[i] = convertCustomFieldCriterionValues(v)
 	}
 
 	return ret

--- a/internal/api/resolver_query_find_performer.go
+++ b/internal/api/resolver_query_find_performer.go
@@ -32,6 +32,9 @@ func (r *queryResolver) FindPerformers(ctx context.Context, performerFilter *mod
 		}
 	}
 
+	// #5682 - convert JSON numbers to float64 or int64
+	performerFilter.CustomFields = convertCustomFieldCriterionInputJSONNumbers(performerFilter.CustomFields)
+
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 		var performers []*models.Performer
 		var err error


### PR DESCRIPTION
Number filter values were passed in as `json.Number`. This issue has arisen before when setting custom fields, but was missed for filtering.

Fixes #5682