### PR TITLE
Use existing formats for saved filters

### DIFF
--- a/ui/v2.5/src/components/List/SavedFilterList.tsx
+++ b/ui/v2.5/src/components/List/SavedFilterList.tsx
@@ -67,7 +67,7 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
             mode: filter.mode,
             name,
             find_filter: filterCopy.makeFindFilter(),
-            object_filter: filterCopy.makeFilter(),
+            object_filter: filterCopy.makeSavedFilter(),
             ui_options: filterCopy.makeSavedUIOptions(),
           },
         },
@@ -142,7 +142,7 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
           value: {
             mode: filter.mode,
             find_filter: filterCopy.makeFindFilter(),
-            object_filter: filterCopy.makeFilter(),
+            object_filter: filterCopy.makeSavedFilter(),
             ui_options: filterCopy.makeSavedUIOptions(),
           },
         },

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -7,6 +7,7 @@ import {
   MultiCriterionInput,
   TimestampCriterionInput,
   ConfigDataFragment,
+  DateCriterionInput,
 } from "src/core/generated-graphql";
 import TextUtils from "src/utils/text";
 import {
@@ -1034,6 +1035,14 @@ export class DateCriterion extends ModifierCriterion<IDateValue> {
 
   protected encodeValue(): unknown {
     return encodeRangeValue(this.modifier, this.value);
+  }
+
+  public toCriterionInput(): DateCriterionInput {
+    return {
+      modifier: this.modifier,
+      value: this.value?.value ?? "",
+      value2: this.value?.value2,
+    };
   }
 
   protected getLabelValue() {

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -5,7 +5,6 @@ import {
   HierarchicalMultiCriterionInput,
   IntCriterionInput,
   MultiCriterionInput,
-  DateCriterionInput,
   TimestampCriterionInput,
   ConfigDataFragment,
 } from "src/core/generated-graphql";
@@ -21,11 +20,13 @@ import {
   ITimestampValue,
   ILabeledValueListValue,
   IPhashDistanceValue,
+  IRangeValue,
 } from "../types";
 
 export type Option = string | number | IOptionType;
 export type CriterionValue =
   | string
+  | boolean
   | string[]
   | ILabeledId[]
   | IHierarchicalLabelValue
@@ -36,7 +37,7 @@ export type CriterionValue =
   | ITimestampValue
   | IPhashDistanceValue;
 
-export interface ISavedCriterion<T extends CriterionValue> {
+export interface ISavedCriterion<T> {
   modifier: CriterionModifier;
   value: T | undefined;
 }
@@ -82,9 +83,15 @@ export abstract class Criterion {
     return `${this.criterionOption.type}`;
   }
 
-  public abstract toJSON(): string;
+  public abstract toQueryParams(): Record<string, unknown>;
+
+  // fromDecodedParams is used to set the criterion from the query string
+  // i is the decoded parameter object
+  public abstract fromDecodedParams(i: Record<string, unknown>): void;
 
   public abstract applyToCriterionInput(input: Record<string, unknown>): void;
+
+  public abstract applyToSavedCriterion(input: Record<string, unknown>): void;
   public abstract setFromSavedCriterion(criterion: unknown): void;
 }
 
@@ -164,38 +171,61 @@ export abstract class ModifierCriterion<
     );
   }
 
-  public toJSON() {
-    let encodedCriterion;
+  public toQueryParams(): Record<string, unknown> {
+    let encodedCriterion: Record<string, unknown> = {
+      type: this.criterionOption.type,
+      modifier: this.modifier,
+    };
+
     if (
-      this.modifier === CriterionModifier.IsNull ||
-      this.modifier === CriterionModifier.NotNull
+      this.modifier !== CriterionModifier.IsNull &&
+      this.modifier !== CriterionModifier.NotNull
     ) {
-      encodedCriterion = {
-        type: this.criterionOption.type,
-        modifier: this.modifier,
-      };
-    } else {
-      encodedCriterion = {
-        type: this.criterionOption.type,
-        value: this.value,
-        modifier: this.modifier,
-      };
+      encodedCriterion.value = this.encodeValue();
     }
-    return JSON.stringify(encodedCriterion);
+
+    return encodedCriterion;
   }
 
-  public setFromSavedCriterion(criterion: ISavedCriterion<V>) {
-    if (criterion.value !== undefined && criterion.value !== null) {
-      this.value = criterion.value;
+  protected encodeValue(): unknown {
+    return this.value;
+  }
+
+  protected decodeValue(v: unknown) {
+    if (v !== undefined && v !== null) {
+      this.value = v as V;
     }
-    this.modifier = criterion.modifier;
+  }
+
+  public fromDecodedParams(i: unknown): void {
+    // use same logic as from saved criterion by default
+    const c = i as ISavedCriterion<V>;
+    this.modifier = c.modifier;
+    this.decodeValue(c.value);
+  }
+
+  public setFromSavedCriterion(criterion: unknown) {
+    const c = criterion as ISavedCriterion<V>;
+    if (c.value !== undefined && c.value !== null) {
+      this.value = c.value;
+    }
+    this.modifier = c.modifier;
   }
 
   public applyToCriterionInput(input: Record<string, unknown>) {
     input[this.criterionOption.type] = this.toCriterionInput();
   }
 
-  public toCriterionInput(): unknown {
+  // TODO - saved criterion _should_ be criterion input
+  // kicking this can down the road a little further
+  public applyToSavedCriterion(input: Record<string, unknown>): void {
+    input[this.criterionOption.type] = {
+      value: this.value,
+      modifier: this.modifier,
+    };
+  }
+
+  protected toCriterionInput(): unknown {
     return {
       value: this.value,
       modifier: this.modifier,
@@ -755,6 +785,33 @@ export function createMandatoryNumberCriterionOption(
   return new MandatoryNumberCriterionOption(messageID ?? value, value);
 }
 
+export function encodeRangeValue<V>(
+  modifier: CriterionModifier,
+  value: IRangeValue<V>
+): unknown {
+  // only encode value2 if modifier is between/not between
+  if (
+    modifier === CriterionModifier.Between ||
+    modifier === CriterionModifier.NotBetween
+  ) {
+    return { value: value.value, value2: value.value2 };
+  }
+
+  return { value: value.value };
+}
+
+export function decodeRangeValue<V>(v: {
+  value: V | IRangeValue<V>;
+  value2?: V;
+}): IRangeValue<V> {
+  // handle backwards compatible value
+  if (typeof v.value === "object") {
+    return v.value as IRangeValue<V>;
+  } else {
+    return { value: v.value, value2: v.value2 };
+  }
+}
+
 export class NumberCriterion extends ModifierCriterion<INumberValue> {
   constructor(type: ModifierCriterionOption) {
     super(type, { value: undefined, value2: undefined });
@@ -785,6 +842,19 @@ export class NumberCriterion extends ModifierCriterion<INumberValue> {
       value: this.value?.value ?? 0,
       value2: this.value?.value2,
     };
+  }
+
+  public setFromSavedCriterion(c: {
+    modifier: CriterionModifier;
+    value: number | INumberValue;
+    value2?: number;
+  }) {
+    super.setFromSavedCriterion(c);
+    // this.value = decodeRangeValue(c);
+  }
+
+  protected encodeValue(): unknown {
+    return encodeRangeValue(this.modifier, this.value);
   }
 
   protected getLabelValue(_intl: IntlShape) {
@@ -867,6 +937,19 @@ export class DurationCriterion extends ModifierCriterion<INumberValue> {
     };
   }
 
+  public setFromSavedCriterion(c: {
+    modifier: CriterionModifier;
+    value: number | INumberValue;
+    value2?: number;
+  }) {
+    super.setFromSavedCriterion(c);
+    // this.value = decodeRangeValue(c);
+  }
+
+  protected encodeValue(): unknown {
+    return encodeRangeValue(this.modifier, this.value);
+  }
+
   protected getLabelValue(_intl: IntlShape) {
     const value = TextUtils.secondsToTimestamp(this.value.value ?? 0);
     const value2 = TextUtils.secondsToTimestamp(this.value.value2 ?? 0);
@@ -940,19 +1023,17 @@ export class DateCriterion extends ModifierCriterion<IDateValue> {
     this.value = { ...this.value };
   }
 
-  public encodeValue() {
-    return {
-      value: this.value.value,
-      value2: this.value.value2,
-    };
+  public setFromSavedCriterion(c: {
+    modifier: CriterionModifier;
+    value: string | IDateValue;
+    value2?: string;
+  }) {
+    super.setFromSavedCriterion(c);
+    // this.value = decodeRangeValue(c);
   }
 
-  public toCriterionInput(): DateCriterionInput {
-    return {
-      modifier: this.modifier,
-      value: this.value?.value,
-      value2: this.value?.value2,
-    };
+  protected encodeValue(): unknown {
+    return encodeRangeValue(this.modifier, this.value);
   }
 
   protected getLabelValue() {
@@ -1043,21 +1124,27 @@ export class TimestampCriterion extends ModifierCriterion<ITimestampValue> {
     this.value = { ...this.value };
   }
 
-  public encodeValue() {
-    return {
-      value: this.value?.value,
-      value2: this.value?.value2,
-    };
-  }
-
   public toCriterionInput(): TimestampCriterionInput {
     return {
       modifier: this.modifier,
-      value: this.transformValueToInput(this.value.value),
+      value: this.transformValueToInput(this.value.value ?? ""),
       value2: this.value.value2
         ? this.transformValueToInput(this.value.value2)
         : null,
     };
+  }
+
+  public setFromSavedCriterion(c: {
+    modifier: CriterionModifier;
+    value: string | ITimestampValue;
+    value2?: string;
+  }) {
+    this.setFromSavedCriterion(c);
+    // this.value = decodeRangeValue(c);
+  }
+
+  protected encodeValue(): unknown {
+    return encodeRangeValue(this.modifier, this.value);
   }
 
   protected getLabelValue() {

--- a/ui/v2.5/src/models/list-filter/criteria/custom-fields.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/custom-fields.ts
@@ -27,6 +27,10 @@ export class CustomFieldsCriterion extends Criterion {
     input.custom_fields = cloneDeep(this.value);
   }
 
+  public applyToSavedCriterion(input: Record<string, unknown>): void {
+    input.custom_fields = cloneDeep(this.value);
+  }
+
   public getLabel(intl: IntlShape): string {
     // show first criterion
     if (this.value.length === 0) {
@@ -91,19 +95,20 @@ export class CustomFieldsCriterion extends Criterion {
     );
   }
 
-  public toJSON(): string {
+  public toQueryParams(): Record<string, unknown> {
     const encodedCriterion = {
       type: this.criterionOption.type,
       value: this.value,
     };
-    return JSON.stringify(encodedCriterion);
+    return encodedCriterion;
   }
 
-  public setFromSavedCriterion(criterion: {
-    type: string;
-    value: CustomFieldCriterionInput[];
-  }): void {
-    const { value } = criterion;
-    this.value = cloneDeep(value);
+  public fromDecodedParams(i: unknown): void {
+    const criterion = i as { value: CustomFieldCriterionInput[] };
+    this.value = cloneDeep(criterion.value);
+  }
+
+  public setFromSavedCriterion(input: CustomFieldCriterionInput[]): void {
+    this.value = cloneDeep(input);
   }
 }

--- a/ui/v2.5/src/models/list-filter/criteria/rating.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/rating.ts
@@ -10,7 +10,11 @@ import {
   IntCriterionInput,
 } from "src/core/generated-graphql";
 import { INumberValue } from "../types";
-import { ModifierCriterion, ModifierCriterionOption } from "./criterion";
+import {
+  encodeRangeValue,
+  ModifierCriterion,
+  ModifierCriterionOption,
+} from "./criterion";
 
 const modifierOptions = [
   CriterionModifier.Equals,
@@ -70,6 +74,19 @@ export class RatingCriterion extends ModifierCriterion<INumberValue> {
       value: this.value.value ?? 0,
       value2: this.value.value2,
     };
+  }
+
+  public setFromSavedCriterion(c: {
+    modifier: CriterionModifier;
+    value: number | INumberValue;
+    value2?: number;
+  }) {
+    super.setFromSavedCriterion(c);
+    // this.value = decodeRangeValue(c);
+  }
+
+  protected encodeValue(): unknown {
+    return encodeRangeValue(this.modifier, this.value);
   }
 
   protected getLabelValue() {

--- a/ui/v2.5/src/models/list-filter/criteria/stash-ids.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/stash-ids.ts
@@ -5,7 +5,11 @@ import {
   StashIdCriterionInput,
 } from "src/core/generated-graphql";
 import { IStashIDValue } from "../types";
-import { ModifierCriterion, ModifierCriterionOption } from "./criterion";
+import {
+  ISavedCriterion,
+  ModifierCriterion,
+  ModifierCriterionOption,
+} from "./criterion";
 
 export const StashIDCriterionOption = new ModifierCriterionOption({
   messageID: "stash_id",
@@ -90,7 +94,29 @@ export class StashIDCriterion extends ModifierCriterion<IStashIDValue> {
     return ret;
   }
 
-  public toJSON() {
+  public setFromSavedCriterion(
+    criterion: StashIdCriterionInput | ISavedCriterion<StashIdCriterionInput>
+  ) {
+    super.setFromSavedCriterion(criterion);
+
+    // const asStashIDValue = criterion as StashIdCriterionInput;
+    // const asSavedCriterion =
+    //   criterion as ISavedCriterion<StashIdCriterionInput>;
+    // if (asStashIDValue.endpoint || asStashIDValue.stash_id) {
+    //   this.value = {
+    //     endpoint: asStashIDValue.endpoint ?? "",
+    //     stashID: asStashIDValue.stash_id ?? "",
+    //   };
+    // } else if (asSavedCriterion.value) {
+    //   this.value = {
+    //     endpoint: asSavedCriterion.value.endpoint ?? "",
+    //     stashID: asSavedCriterion.value.stash_id ?? "",
+    //   };
+    // }
+  }
+
+  public toQueryParams(): Record<string, unknown> {
+    super.toQueryParams();
     let encodedCriterion;
     if (
       (this.modifier === CriterionModifier.IsNull ||
@@ -108,7 +134,7 @@ export class StashIDCriterion extends ModifierCriterion<IStashIDValue> {
         modifier: this.modifier,
       };
     }
-    return JSON.stringify(encodedCriterion);
+    return encodedCriterion;
   }
 
   public isValid(): boolean {

--- a/ui/v2.5/src/models/list-filter/types.ts
+++ b/ui/v2.5/src/models/list-filter/types.ts
@@ -39,11 +39,14 @@ export interface IHierarchicalLabelValue {
   depth: number;
 }
 
-export interface INumberValue {
-  value: number | undefined;
-  value2: number | undefined;
+export interface IRangeValue<V> {
+  value: V | undefined;
+  value2: V | undefined;
 }
 
+export type INumberValue = IRangeValue<number>;
+export type IDateValue = IRangeValue<string>;
+export type ITimestampValue = IRangeValue<string>;
 export interface IPHashDuplicationValue {
   duplicated: boolean;
   distance?: number; // currently not implemented
@@ -52,16 +55,6 @@ export interface IPHashDuplicationValue {
 export interface IStashIDValue {
   endpoint: string;
   stashID: string;
-}
-
-export interface IDateValue {
-  value: string;
-  value2: string | undefined;
-}
-
-export interface ITimestampValue {
-  value: string;
-  value2: string | undefined;
 }
 
 export interface IPhashDistanceValue {


### PR DESCRIPTION
#5632 introduced some changes around the format of the saved filters that wasn't fully ready. This existing saved filter format is currently not correct. It's supposed to follow the format of the graphql filter inputs, but instead it's following the schema of the UI object model. Fixing that issue will require a migration to massage the saved filter formats. This PR rolls back the changes to the saved filter format.

Note that this will not fix corrupted saved filters created after the #5632 build.

Resolves #5690