### PR TITLE
optimised dockerfiles for faster rebuilds and image size

### DIFF
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -3,27 +3,29 @@
 # Build GQL
 FROM node:lts AS gqlgen
 RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
-WORKDIR /stash/ui/v2.5
+WORKDIR /stash
 RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
     --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
     --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
-    yarn install --frozen-lockfile
-RUN --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    make pre-ui
+RUN --mount=type=bind,source=./Makefile,target=/stash/Makefile \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
     --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
     --mount=type=bind,source=./graphql/,target=/stash/graphql \
     --mount=type=bind,source=./ui/v2.5/graphql/,target=/stash/ui/v2.5/graphql \
     --mount=type=bind,source=./ui/v2.5/codegen.ts,target=/stash/ui/v2.5/codegen.ts \
-    yarn run gqlgen
+    make generate-ui
 
 # Build Frontend
 FROM node:lts AS frontend
 RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
-WORKDIR /stash/ui/v2.5
+WORKDIR /stash
 RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
     --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
     --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
-    yarn install --frozen-lockfile
-WORKDIR /stash
+    make pre-ui
 ARG GITHASH
 ARG STASH_VERSION
 COPY ./ui/v2.5/src /stash/ui/v2.5/src/
@@ -39,11 +41,13 @@ RUN --mount=type=bind,source=./.git,target=/stash/.git \
     BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui
 
 # Build Backend
-FROM golang:1.24 AS backend
+FROM golang:1.24-alpine AS backend
+RUN apk add --no-cache git gcc libc-dev make
 WORKDIR /stash
 COPY go.mod go.sum /stash/
 COPY ./internal /stash/internal
 RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
     --mount=type=bind,source=./gqlgen.yml,target=/stash/gqlgen.yml \
     --mount=type=bind,source=./.gqlgenc.yml,target=/stash/.gqlgenc.yml \
     --mount=type=bind,source=./cmd,target=/stash/cmd \
@@ -54,18 +58,20 @@ RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
 ARG GITHASH
 ARG STASH_VERSION
 COPY --from=frontend /stash/ui/v2.5/build /stash/ui/v2.5/build
-RUN --mount=type=bind,source=./.git,target=/stash/.git \
+RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
+    --mount=type=bind,source=./.git,target=/stash/.git \
     --mount=type=bind,source=./Makefile,target=/stash/Makefile \
     --mount=type=bind,source=./scripts,target=/stash/scripts \
     --mount=type=bind,source=./pkg,target=/stash/pkg \
     --mount=type=bind,source=./cmd,target=/stash/cmd \
     --mount=type=bind,source=./ui/login,target=/stash/ui/login \
     --mount=type=bind,source=./ui/ui.go,target=/stash/ui/ui.go \
-    CGO_ENABLED=0 make flags-release flags-pie stash
+    make flags-release flags-pie stash
 
 # Final Runnable Image
-FROM gcr.io/distroless/base-nossl
-COPY --link --from=backend /stash/stash /usr/bin/stash
+FROM alpine:latest
+RUN apk add --no-cache py3-requests
+COPY --link --from=backend /stash/stash /usr/bin/
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999
-CMD ["/usr/bin/stash"]
+CMD ["stash"]

--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -1,39 +1,71 @@
-# This dockerfile should be built with `make docker-build` from the stash root.
+# This dockerfile should be built with `make docker-cuda-build` from the stash root.
+
+# Build GQL
+FROM node:lts AS gqlgen
+RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
+WORKDIR /stash/ui/v2.5
+RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    yarn install --frozen-lockfile
+RUN --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    --mount=type=bind,source=./graphql/,target=/stash/graphql \
+    --mount=type=bind,source=./ui/v2.5/graphql/,target=/stash/ui/v2.5/graphql \
+    --mount=type=bind,source=./ui/v2.5/codegen.ts,target=/stash/ui/v2.5/codegen.ts \
+    yarn run gqlgen
 
 # Build Frontend
-FROM node:alpine as frontend
-RUN apk add --no-cache make git
-## cache node_modules separately
-COPY ./ui/v2.5/package.json ./ui/v2.5/yarn.lock /stash/ui/v2.5/
+FROM node:lts AS frontend
+RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
+WORKDIR /stash/ui/v2.5
+RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    yarn install --frozen-lockfile
 WORKDIR /stash
-COPY Makefile /stash/
-COPY ./graphql /stash/graphql/
-COPY ./ui /stash/ui/
-RUN make pre-ui
-RUN make generate-ui
 ARG GITHASH
 ARG STASH_VERSION
-RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui
+COPY ./ui/v2.5/src /stash/ui/v2.5/src/
+RUN --mount=type=bind,source=./.git,target=/stash/.git \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
+    --mount=type=bind,source=./ui/v2.5/public,target=/stash/ui/v2.5/public \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    --mount=type=bind,source=./ui/v2.5/index.html,target=/stash/ui/v2.5/index.html \
+    --mount=type=bind,source=./ui/v2.5/vite.config.js,target=/stash/ui/v2.5/vite.config.js \
+    --mount=type=bind,source=./ui/v2.5/tsconfig.json,target=/stash/ui/v2.5/tsconfig.json \
+    --mount=type=bind,from=gqlgen,source=/stash/ui/v2.5/src/core/generated-graphql.ts,target=/stash/ui/v2.5/src/core/generated-graphql.ts \
+    BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui
 
 # Build Backend
-FROM golang:1.22-alpine as backend
-RUN apk add --no-cache make alpine-sdk
+FROM golang:1.24 AS backend
 WORKDIR /stash
-COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/
-COPY ./scripts /stash/scripts/
-COPY ./pkg /stash/pkg/
-COPY ./cmd /stash/cmd
+COPY go.mod go.sum /stash/
 COPY ./internal /stash/internal
-COPY --from=frontend /stash /stash/
-RUN make generate-backend
+RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
+    --mount=type=bind,source=./gqlgen.yml,target=/stash/gqlgen.yml \
+    --mount=type=bind,source=./.gqlgenc.yml,target=/stash/.gqlgenc.yml \
+    --mount=type=bind,source=./cmd,target=/stash/cmd \
+    --mount=type=bind,source=./pkg,target=/stash/pkg \
+    --mount=type=bind,source=./ui,target=/stash/ui \
+    --mount=type=bind,source=./graphql/,target=/stash/graphql \
+    go generate ./cmd/stash
 ARG GITHASH
 ARG STASH_VERSION
-RUN make flags-release flags-pie stash
+COPY --from=frontend /stash/ui/v2.5/build /stash/ui/v2.5/build
+RUN --mount=type=bind,source=./.git,target=/stash/.git \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
+    --mount=type=bind,source=./scripts,target=/stash/scripts \
+    --mount=type=bind,source=./pkg,target=/stash/pkg \
+    --mount=type=bind,source=./cmd,target=/stash/cmd \
+    --mount=type=bind,source=./ui/login,target=/stash/ui/login \
+    --mount=type=bind,source=./ui/ui.go,target=/stash/ui/ui.go \
+    CGO_ENABLED=0 make flags-release flags-pie stash
 
 # Final Runnable Image
-FROM alpine:latest
-RUN apk add --no-cache ca-certificates vips-tools ffmpeg
-COPY --from=backend /stash/stash /usr/bin/
+FROM gcr.io/distroless/base-nossl
+COPY --link --from=backend /stash/stash /usr/bin/stash
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999
-ENTRYPOINT ["stash"]
+CMD ["/usr/bin/stash"]

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -1,49 +1,83 @@
 # This dockerfile should be built with `make docker-cuda-build` from the stash root.
 
+# Build GQL
+FROM node:lts AS gqlgen
+RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
+WORKDIR /stash/ui/v2.5
+RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    yarn install --frozen-lockfile
+RUN --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    --mount=type=bind,source=./graphql/,target=/stash/graphql \
+    --mount=type=bind,source=./ui/v2.5/graphql/,target=/stash/ui/v2.5/graphql \
+    --mount=type=bind,source=./ui/v2.5/codegen.ts,target=/stash/ui/v2.5/codegen.ts \
+    yarn run gqlgen
+
 # Build Frontend
-FROM node:alpine as frontend
-RUN apk add --no-cache make git
-## cache node_modules separately
-COPY ./ui/v2.5/package.json ./ui/v2.5/yarn.lock /stash/ui/v2.5/
+FROM node:lts AS frontend
+RUN npm i -g corepack --force && corepack install -g yarn && corepack enable
+WORKDIR /stash/ui/v2.5
+RUN --mount=type=cache,id=yarn,target=/home/root/.yarn \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    yarn install --frozen-lockfile
 WORKDIR /stash
-COPY Makefile /stash/
-COPY ./graphql /stash/graphql/
-COPY ./ui /stash/ui/
-RUN make pre-ui
-RUN make generate-ui
 ARG GITHASH
 ARG STASH_VERSION
-RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui
+COPY ./ui/v2.5/src /stash/ui/v2.5/src/
+RUN --mount=type=bind,source=./.git,target=/stash/.git \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
+    --mount=type=bind,source=./ui/v2.5/public,target=/stash/ui/v2.5/public \
+    --mount=type=bind,source=./ui/v2.5/package.json,target=/stash/ui/v2.5/package.json \
+    --mount=type=bind,source=./ui/v2.5/yarn.lock,target=/stash/ui/v2.5/yarn.lock \
+    --mount=type=bind,source=./ui/v2.5/index.html,target=/stash/ui/v2.5/index.html \
+    --mount=type=bind,source=./ui/v2.5/vite.config.js,target=/stash/ui/v2.5/vite.config.js \
+    --mount=type=bind,source=./ui/v2.5/tsconfig.json,target=/stash/ui/v2.5/tsconfig.json \
+    --mount=type=bind,from=gqlgen,source=/stash/ui/v2.5/src/core/generated-graphql.ts,target=/stash/ui/v2.5/src/core/generated-graphql.ts \
+    BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui
 
 # Build Backend
-FROM golang:1.22-bullseye as backend
-RUN apt update && apt install -y build-essential golang
+FROM golang:1.24 AS backend
 WORKDIR /stash
-COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/
-COPY ./scripts /stash/scripts/
-COPY ./pkg /stash/pkg/
-COPY ./cmd /stash/cmd
+COPY go.mod go.sum /stash/
 COPY ./internal /stash/internal
-COPY --from=frontend /stash /stash/
-RUN make generate-backend
+RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
+    --mount=type=bind,source=./gqlgen.yml,target=/stash/gqlgen.yml \
+    --mount=type=bind,source=./.gqlgenc.yml,target=/stash/.gqlgenc.yml \
+    --mount=type=bind,source=./cmd,target=/stash/cmd \
+    --mount=type=bind,source=./pkg,target=/stash/pkg \
+    --mount=type=bind,source=./ui,target=/stash/ui \
+    --mount=type=bind,source=./graphql/,target=/stash/graphql \
+    go generate ./cmd/stash
 ARG GITHASH
 ARG STASH_VERSION
-RUN make flags-release flags-pie stash
+COPY --from=frontend /stash/ui/v2.5/build /stash/ui/v2.5/build
+RUN --mount=type=bind,source=./.git,target=/stash/.git \
+    --mount=type=bind,source=./Makefile,target=/stash/Makefile \
+    --mount=type=bind,source=./scripts,target=/stash/scripts \
+    --mount=type=bind,source=./pkg,target=/stash/pkg \
+    --mount=type=bind,source=./cmd,target=/stash/cmd \
+    --mount=type=bind,source=./ui/login,target=/stash/ui/login \
+    --mount=type=bind,source=./ui/ui.go,target=/stash/ui/ui.go \
+    make flags-release flags-pie stash
 
 # Final Runnable Image
-FROM nvidia/cuda:12.0.1-base-ubuntu22.04
-RUN apt update && apt upgrade -y && apt install -y ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo
-RUN rm -rf /var/lib/apt/lists/*
-COPY --from=backend /stash/stash /usr/bin/
+FROM nvidia/cuda:12.8.0-base-ubuntu24.04
+RUN apt update -y && apt install -y --no-install-recommends ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo python3-pip \
+    && pip install requests --break-system-packages \
+    && rm -rf /var/lib/apt/lists/*
+COPY --link --from=backend /stash/stash /usr/bin/
 
 # NVENC Patch
-RUN mkdir -p /usr/local/bin /patched-lib
-RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh
-RUN wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
+RUN mkdir -p /usr/local/bin /patched-lib \
+    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh \
+    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh \
+    && chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
 
-ENV LANG C.UTF-8
-ENV NVIDIA_VISIBLE_DEVICES all
+ENV LANG=C.UTF-8
+ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999

--- a/docker/build/x86_64/Dockerfile-distroless
+++ b/docker/build/x86_64/Dockerfile-distroless
@@ -67,23 +67,17 @@ RUN --mount=type=cache,id=go,target=/root/.cache/go-build \
     --mount=type=bind,source=./ui/ui.go,target=/stash/ui/ui.go \
     CGO_ENABLED=0 make flags-release flags-pie stash
 
+# Build a virtualenv using the appropriate Debian release
+FROM debian:12-slim AS build-venv
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip setuptools wheel requests
+
 # Final Runnable Image
-FROM nvidia/cuda:12.8.0-base-ubuntu24.04
-RUN apt update -y && apt install -y --no-install-recommends ca-certificates libvips-tools ffmpeg wget intel-media-va-driver-non-free vainfo python3-requests \
-    && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/python3-debian12
+COPY --link --from=build-venv /venv /venv
 COPY --link --from=backend /stash/stash /usr/bin/
-
-# NVENC Patch
-RUN mkdir -p /usr/local/bin /patched-lib \
-    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh -O /usr/local/bin/patch.sh \
-    && wget https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh \
-    && chmod +x /usr/local/bin/patch.sh /usr/local/bin/docker-entrypoint.sh /usr/bin/stash
-
-ENV LANG=C.UTF-8
-ENV NVIDIA_VISIBLE_DEVICES=all
-ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 EXPOSE 9999
-ENTRYPOINT ["docker-entrypoint.sh", "stash"]
-
-# vim: ft=dockerfile
+ENTRYPOINT ["stash"]

--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -131,5 +131,6 @@
     "vite": "^4.5.6",
     "vite-plugin-compression": "^0.5.1",
     "vite-tsconfig-paths": "^4.0.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
I have used the preexisting makefile where possible.
The image sizes are:
 - alpine: 158 MB down from 309 MB
 - cuda: 1.25 GB down from 1.81 GB
 
 Added a distroless variant with a size of 204 MB.