### PR TITLE
Replace history when merging tag

### DIFF
--- a/ui/v2.5/src/components/Tags/TagDetails/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagMergeDialog.tsx
@@ -55,7 +55,7 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
       if (result.data?.tagsMerge) {
         Toast.success(intl.formatMessage({ id: "toast.merged_tags" }));
         onClose();
-        history.push(`/tags/${destination}`);
+        history.replace(`/tags/${destination}`);
       }
     } catch (e) {
       Toast.error(e);


### PR DESCRIPTION
Prevents backing up to the now non-existing tag page.

1. Go on a tag page
2. Merge ***into*** another tag
3. Backing up returns to the page before the merge instead of 404
