### PR TITLE
docker documentation update

### DIFF
--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -1,11 +1,13 @@
 # Docker Installation (for most 64-bit GNU/Linux systems)
-StashApp is supported on most systems that support Docker and docker-compose. Your OS likely ships with or makes available the necessary packages.
+StashApp is supported on most systems that support Docker. Your OS likely ships with or makes available the necessary packages.
 
 ## Dependencies
-Only `docker` and `docker-compose` are required. For the most part your understanding of the technologies can be superficial. So long as you can follow commands and are open to reading a bit, you should be fine.
+Only `docker` is required. For the most part your understanding of the technologies can be superficial. So long as you can follow commands and are open to reading a bit, you should be fine.
 
-Installation instructions are available below, and if your distrobution's repository ships a current version of docker, you may use that.
+Installation instructions are available below, and if your distributions's repository ships a current version of docker, you may use that.
 https://docs.docker.com/engine/install/
+
+On some distributions, `docker compose` is shipped seperately, usually as `docker-cli-compose`. docker-compose is not recommended.
 
 ### Get the docker-compose.yml file
 
@@ -19,7 +21,7 @@ curl -o docker-compose.yml https://raw.githubusercontent.com/stashapp/stash/deve
 Once you have that file where you want it, modify the settings as you please, and then run:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 Installing StashApp this way will by default bind stash to port 9999. This is available in your web browser locally at http://localhost:9999 or on your network as http://YOUR-LOCAL-IP:9999
@@ -29,9 +31,9 @@ Good luck and have fun!
 ### Docker
 Docker is effectively a cross-platform software package repository. It allows you to ship an entire environment in what's referred to as a container. Containers are intended to hold everything that is needed to run an application from one place to another, making it easy for everyone along the way to reproduce the environment.
 
-The StashApp docker container ships with everything you need to automatically build and run stash, including ffmpeg.
+The StashApp docker container ships with everything you need to automatically run stash, including ffmpeg.
 
-### docker-compose
-Docker Compose lets you specify how and where to run your containers, and to manage their environment. The docker-compose.yml file in this folder gets you a fully working instance of StashApp exactly as you would need it to have a reasonable instance for testing / developing on. If you are deploying a live instance for production, a reverse proxy (such as NGINX or Traefik) is recommended, but not required.
+### docker compose
+Docker Compose lets you specify how and where to run your containers, and to manage their environment. The docker-compose.yml file in this folder gets you a fully working instance of StashApp exactly as you would need it to have a reasonable instance for testing / developing on. If you are deploying a live instance for production, a [reverse proxy](https://docs.stashapp.cc/guides/reverse-proxy/) (such as NGINX or Traefik) is recommended, but not required.
 
 The latest version is always recommended.

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,6 +1,5 @@
 # APPNICENAME=Stash
 # APPDESCRIPTION=An organizer for your porn, written in Go
-version: '3.4'
 services:
   stash:
     image: stashapp/stash:latest
@@ -27,10 +26,12 @@ services:
       - /etc/localtime:/etc/localtime:ro
       ## Adjust below paths (the left part) to your liking.
       ## E.g. you can change ./config:/root/.stash to ./stash:/root/.stash
-      
+      ## The left part is the path on your host, the right part is the path in the stash container.
+
       ## Keep configs, scrapers, and plugins here.
       - ./config:/root/.stash
       ## Point this at your collection.
+      ## The left side is where your collection is on your host, the right side is where it will be in stash.
       - ./data:/data
       ## This is where your stash's metadata lives
       - ./metadata:/metadata


### PR DESCRIPTION
- use docker compose instead of deprecated docker-compose
- add note for package as docker-cli-compose
- add link for reverse proxy
- remove obselete version string
- fixed distrobution typo (likely distro) expanded improperly