### PR TITLE
Fix various migration issues

### DIFF
--- a/internal/manager/task/migrate.go
+++ b/internal/manager/task/migrate.go
@@ -169,7 +169,9 @@ func (s *MigrateJob) postMigrate(ctx context.Context, progress *job.Progress) er
 	// optimise the database
 	var err error
 	progress.ExecuteTask("Optimising database", func() {
-		err = database.Optimise(ctx)
+		// don't use Optimize/vacuum as this adds a significant amount of time
+		// to the migration
+		err = database.Analyze(ctx)
 	})
 
 	if err != nil {

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -425,6 +425,15 @@ func (db *Database) Optimise(ctx context.Context) error {
 // Vacuum runs a VACUUM on the database, rebuilding the database file into a minimal amount of disk space.
 func (db *Database) Vacuum(ctx context.Context) error {
 	_, err := db.writeDB.ExecContext(ctx, "VACUUM")
+
+	// toggle journal_mode to flush the wal file
+	if _, err := db.writeDB.Exec("PRAGMA journal_mode=DELETE"); err != nil {
+		return err
+	}
+	if _, err := db.writeDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		return err
+	}
+
 	return err
 }
 

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -425,15 +425,6 @@ func (db *Database) Optimise(ctx context.Context) error {
 // Vacuum runs a VACUUM on the database, rebuilding the database file into a minimal amount of disk space.
 func (db *Database) Vacuum(ctx context.Context) error {
 	_, err := db.writeDB.ExecContext(ctx, "VACUUM")
-
-	// toggle journal_mode to flush the wal file
-	if _, err := db.writeDB.Exec("PRAGMA journal_mode=DELETE"); err != nil {
-		return err
-	}
-	if _, err := db.writeDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return err
-	}
-
 	return err
 }
 

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -430,7 +430,19 @@ func (db *Database) Vacuum(ctx context.Context) error {
 
 // Analyze runs an ANALYZE on the database to improve query performance.
 func (db *Database) Analyze(ctx context.Context) error {
-	_, err := db.writeDB.ExecContext(ctx, "ANALYZE")
+	return analyze(ctx, db.writeDB)
+}
+
+// analyze runs an ANALYZE on the database to improve query performance.
+func analyze(ctx context.Context, db *sqlx.DB) error {
+	_, err := db.ExecContext(ctx, "ANALYZE")
+	return err
+}
+
+// flushWAL flushes the Write-Ahead Log (WAL) to the main database file.
+// It also truncates the WAL file to 0 bytes.
+func flushWAL(ctx context.Context, db *sqlx.DB) error {
+	_, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
 	return err
 }
 

--- a/pkg/sqlite/migrate.go
+++ b/pkg/sqlite/migrate.go
@@ -39,6 +39,12 @@ func NewMigrator(db *Database) (*Migrator, error) {
 	m.conn.SetConnMaxIdleTime(dbConnTimeout)
 
 	m.m, err = m.getMigrate()
+
+	// if error encountered, close the connection
+	if err != nil {
+		m.Close()
+	}
+
 	return m, err
 }
 


### PR DESCRIPTION
Thanks to @cj12312021 for the massive database to test the migration process against. Resolves the following issues found while testing:
- UI now shows when the database is being backed up in the first step
- close the migration connection to the database before re-connecting the main database. This should hopefully address the `database locked` and database corruption issues that were encountered
- ~~when running a vacuum, the wal file is now flushed so that we're not left with a wal file the size of the whole database file~~
- removed the post-migrate vacuum. In many cases this isn't necessary, and it takes a very long time on larger databases. In future it might be worth adding an option to enable it, or to automatically do it after large schema restructures. Alternatively, we can just recommend it as a user-initiated post-migrate step.