### PR TITLE
Fix setFromSavedCriterion for TimestampCriterion

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -1148,8 +1148,8 @@ export class TimestampCriterion extends ModifierCriterion<ITimestampValue> {
     value: string | ITimestampValue;
     value2?: string;
   }) {
-    this.setFromSavedCriterion(c);
-    // this.value = decodeRangeValue(c);
+    super.setFromSavedCriterion(c);
+    this.value = decodeRangeValue(c);
   }
 
   protected encodeValue(): unknown {


### PR DESCRIPTION
Fixes #5737 and a bunch of other UI crashes when using a saved filter with timestamp criteria.