### PR TITLE
Fix incorrect URL field in studio exclusions

### DIFF
--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -81,4 +81,4 @@ export const PERFORMER_FIELDS = [
   "details",
 ];
 
-export const STUDIO_FIELDS = ["name", "image", "urls", "parent_studio"];
+export const STUDIO_FIELDS = ["name", "image", "url", "parent_studio"];

--- a/ui/v2.5/src/components/Tagger/studios/StudioFieldSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioFieldSelector.tsx
@@ -20,7 +20,10 @@ const StudioFieldSelect: React.FC<IProps> = ({
 }) => {
   const intl = useIntl();
   const [excluded, setExcluded] = useState<Record<string, boolean>>(
-    excludedFields.reduce((dict, field) => ({ ...dict, [field]: true }), {})
+    // filter out fields that aren't in STUDIO_FIELDS
+    excludedFields
+      .filter((field) => STUDIO_FIELDS.includes(field))
+      .reduce((dict, field) => ({ ...dict, [field]: true }), {})
   );
 
   const toggleField = (field: string) =>


### PR DESCRIPTION
Fixes issue reported on Discord:
> In the Studio tagger, when you click "show configuration" and then choose "excluded fields" it will start off by default by excluding the studio "name" from the auto tag. If you attempt to select "URLs" so that it does not automatically scrape the URL for a studio it will show that URLs are excluded but will continue scraping URLs anyway. This means that after scraping a Studio you have to manually uncheck the URL every time. I did not attempt to do a "Batch Update Studios" for fear of the auto tagger overwriting the URLS for every studio.

This was caused by an incorrect field name in the studio tagger excluded field candidates, introduced with the performer urls change.