### PR TITLE
Parse scene t value as number not int

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -720,7 +720,12 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
 
   const _setTimestamp = useRef<(value: number) => void>();
   const initialTimestamp = useMemo(() => {
-    return Number.parseInt(queryParams.get("t") ?? "0", 10);
+    const t = queryParams.get("t");
+    if (!t) return 0;
+
+    const n = Number(t);
+    if (Number.isNaN(n)) return 0;
+    return n;
   }, [queryParams]);
 
   const [queueTotal, setQueueTotal] = useState(0);


### PR DESCRIPTION
Fixes issue reported on Discord:
> I noticed that markers which are played via the "markers" tab are ignoring sub-second precision. The marker starts playing at a different frame compared to playing the same marker via the scene details panel.