### PR TITLE
Refactor scene list to not use ItemList component

### DIFF
--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupScenesPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupScenesPanel.tsx
@@ -5,7 +5,7 @@ import {
   GroupsCriterionOption,
 } from "src/models/list-filter/criteria/groups";
 import { ListFilterModel } from "src/models/list-filter/filter";
-import { SceneList } from "src/components/Scenes/SceneList";
+import { FilteredSceneList } from "src/components/Scenes/SceneList";
 import { View } from "src/components/List/views";
 
 interface IGroupScenesPanel {
@@ -64,7 +64,7 @@ export const GroupScenesPanel: React.FC<IGroupScenesPanel> = ({
 
   if (group && group.id) {
     return (
-      <SceneList
+      <FilteredSceneList
         filterHook={filterHook}
         defaultSort="group_scene_number"
         alterQuery={active}

--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -488,3 +488,33 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
     </>
   );
 };
+
+export function useShowEditFilter(props: {
+  filter: ListFilterModel;
+  setFilter: (f: ListFilterModel) => void;
+  showModal: (content: React.ReactNode) => void;
+  closeModal: () => void;
+}) {
+  const { filter, setFilter, showModal, closeModal } = props;
+
+  const showEditFilter = useCallback(
+    (editingCriterion?: string) => {
+      function onApplyEditFilter(f: ListFilterModel) {
+        closeModal();
+        setFilter(f);
+      }
+
+      showModal(
+        <EditFilterDialog
+          filter={filter}
+          onApply={onApplyEditFilter}
+          onCancel={() => closeModal()}
+          editingCriterion={editingCriterion}
+        />
+      );
+    },
+    [filter, setFilter, showModal, closeModal]
+  );
+
+  return showEditFilter;
+}

--- a/ui/v2.5/src/components/List/FilteredListToolbar.tsx
+++ b/ui/v2.5/src/components/List/FilteredListToolbar.tsx
@@ -8,11 +8,9 @@ import {
   IListFilterOperation,
   ListOperationButtons,
 } from "./ListOperationButtons";
-import { DisplayMode } from "src/models/list-filter/types";
 import { ButtonToolbar } from "react-bootstrap";
 import { View } from "./views";
-import { useListContext } from "./ListProvider";
-import { useFilter } from "./FilterProvider";
+import { IListSelect, useFilterOperations } from "./util";
 
 export interface IItemListOperation<T extends QueryResult> {
   text: string;
@@ -32,8 +30,13 @@ export interface IItemListOperation<T extends QueryResult> {
 }
 
 export interface IFilteredListToolbar {
-  showEditFilter?: (editingCriterion?: string) => void;
+  filter: ListFilterModel;
+  setFilter: (
+    value: ListFilterModel | ((prevState: ListFilterModel) => ListFilterModel)
+  ) => void;
+  showEditFilter: () => void;
   view?: View;
+  listSelect: IListSelect;
   onEdit?: () => void;
   onDelete?: () => void;
   operations?: IListFilterOperation[];
@@ -41,25 +44,22 @@ export interface IFilteredListToolbar {
 }
 
 export const FilteredListToolbar: React.FC<IFilteredListToolbar> = ({
+  filter,
+  setFilter,
   showEditFilter,
   view,
+  listSelect,
   onEdit,
   onDelete,
   operations,
   zoomable = false,
 }) => {
-  const { getSelected, onSelectAll, onSelectNone } = useListContext();
-  const { filter, setFilter } = useFilter();
-
   const filterOptions = filter.options;
-
-  function onChangeDisplayMode(displayMode: DisplayMode) {
-    setFilter(filter.setDisplayMode(displayMode));
-  }
-
-  function onChangeZoom(newZoomIndex: number) {
-    setFilter(filter.setZoom(newZoomIndex));
-  }
+  const { setDisplayMode, setZoom } = useFilterOperations({
+    filter,
+    setFilter,
+  });
+  const { selectedIds, onSelectAll, onSelectNone } = listSelect;
 
   return (
     <ButtonToolbar className="filtered-list-toolbar">
@@ -75,16 +75,16 @@ export const FilteredListToolbar: React.FC<IFilteredListToolbar> = ({
         onSelectAll={onSelectAll}
         onSelectNone={onSelectNone}
         otherOperations={operations}
-        itemsSelected={getSelected().length > 0}
+        itemsSelected={selectedIds.size > 0}
         onEdit={onEdit}
         onDelete={onDelete}
       />
       <ListViewOptions
         displayMode={filter.displayMode}
         displayModeOptions={filterOptions.displayModeOptions}
-        onSetDisplayMode={onChangeDisplayMode}
+        onSetDisplayMode={setDisplayMode}
         zoomIndex={zoomable ? filter.zoomIndex : undefined}
-        onSetZoom={zoomable ? onChangeZoom : undefined}
+        onSetZoom={zoomable ? setZoom : undefined}
       />
     </ButtonToolbar>
   );

--- a/ui/v2.5/src/components/List/ItemList.tsx
+++ b/ui/v2.5/src/components/List/ItemList.tsx
@@ -83,13 +83,14 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
   const { filter, setFilter: updateFilter } = useFilter();
   const { effectiveFilter, result, cachedResult, totalCount } =
     useQueryResultContext<T, E>();
+  const listSelect = useListContext<E>();
   const {
     selectedIds,
     getSelected,
     onSelectChange,
     onSelectAll,
     onSelectNone,
-  } = useListContext<E>();
+  } = listSelect;
 
   // scroll to the top of the page when the page changes
   useScrollToTopOnPageChange(filter.currentPage, result.loading);
@@ -236,7 +237,10 @@ export const ItemList = <T extends QueryResult, E extends IHasID>(
     updateFilter(filter.clearCriteria());
   }
 
-  const filterListToolbarProps = {
+  const filterListToolbarProps: IFilteredListToolbar = {
+    filter,
+    setFilter: updateFilter,
+    listSelect,
     showEditFilter,
     view: view,
     operations: operations,

--- a/ui/v2.5/src/components/List/ListProvider.tsx
+++ b/ui/v2.5/src/components/List/ListProvider.tsx
@@ -29,22 +29,12 @@ export const ListContext = <T extends IHasID = IHasID>(
 ) => {
   const { selectable = false, items, children } = props;
 
-  const {
-    selectedIds,
-    getSelected,
-    onSelectChange,
-    onSelectAll,
-    onSelectNone,
-  } = useListSelect(items);
+  const listSelect = useListSelect(items);
 
   const state: IListContextState<T> = {
     selectable,
-    selectedIds,
-    getSelected,
-    onSelectChange,
-    onSelectAll,
-    onSelectNone,
     items,
+    ...listSelect,
   };
 
   return (
@@ -74,6 +64,8 @@ const emptyState: IListContextState = {
   onSelectAll: () => {},
   onSelectNone: () => {},
   items: [],
+  hasSelection: false,
+  selectedItems: [],
 };
 
 export function useListContextOptional<T extends IHasID = IHasID>() {

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -126,13 +126,18 @@ function useEmptyFilter(props: {
   return emptyFilter;
 }
 
-export function useFilterState(props: {
+export interface IFilterStateHook {
   filterMode: GQL.FilterMode;
   defaultSort?: string;
-  config?: GQL.ConfigDataFragment;
   view?: View;
   useURL?: boolean;
-}) {
+}
+
+export function useFilterState(
+  props: IFilterStateHook & {
+    config?: GQL.ConfigDataFragment;
+  }
+) {
   const { filterMode, defaultSort, config, view, useURL } = props;
 
   const [filter, setFilterState] = useState<ListFilterModel>(
@@ -445,16 +450,24 @@ export function useCachedQueryResult<T extends QueryResult>(
   return cachedResult;
 }
 
-export function useQueryResult<
+export interface IQueryResultHook<
   T extends QueryResult,
   E extends IHasID = IHasID
->(props: {
-  filter: ListFilterModel;
+> {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   useResult: (filter: ListFilterModel) => T;
   getCount: (data: T) => number;
   getItems: (data: T) => E[];
-}) {
+}
+
+export function useQueryResult<
+  T extends QueryResult,
+  E extends IHasID = IHasID
+>(
+  props: IQueryResultHook<T, E> & {
+    filter: ListFilterModel;
+  }
+) {
   const { filter, filterHook, useResult, getItems, getCount } = props;
 
   const effectiveFilter = useMemo(() => {

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -194,6 +194,7 @@ export function useListSelect<T extends { id: string }>(items: T[]) {
   const [itemsSelected, setItemsSelected] = useState<T[]>([]);
   const [lastClickedId, setLastClickedId] = useState<string>();
 
+  // TODO - this doesn't get updated when items changes
   const selectedIds = useMemo(() => {
     const newSelectedIds = new Set<string>();
     itemsSelected.forEach((item) => {
@@ -303,14 +304,20 @@ export function useListSelect<T extends { id: string }>(items: T[]) {
     setLastClickedId(undefined);
   }
 
+  // TODO - this is for backwards compatibility
   const getSelected = useCallback(() => itemsSelected, [itemsSelected]);
 
+  // convenience state
+  const hasSelection = itemsSelected.length > 0;
+
   return {
+    selectedItems: itemsSelected,
     selectedIds,
     getSelected,
     onSelectChange,
     onSelectAll,
     onSelectNone,
+    hasSelection,
   };
 }
 

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -10,6 +10,7 @@ import { View } from "./views";
 import { usePrevious } from "src/hooks/state";
 import * as GQL from "src/core/generated-graphql";
 import { DisplayMode } from "src/models/list-filter/types";
+import { Criterion } from "src/models/list-filter/criteria/criterion";
 
 export function useFilterURL(
   filter: ListFilterModel,
@@ -186,7 +187,26 @@ export function useFilterOperations(props: {
     [setFilter]
   );
 
-  return { setPage, setDisplayMode, setZoom };
+  const removeCriterion = useCallback(
+    (removedCriterion: Criterion) => {
+      setFilter((cv) =>
+        cv.removeCriterion(removedCriterion.criterionOption.type)
+      );
+    },
+    [setFilter]
+  );
+
+  const clearAllCriteria = useCallback(() => {
+    setFilter((cv) => cv.clearCriteria());
+  }, [setFilter]);
+
+  return {
+    setPage,
+    setDisplayMode,
+    setZoom,
+    removeCriterion,
+    clearAllCriteria,
+  };
 }
 
 export function useListKeyboardShortcuts(props: {

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -487,6 +487,31 @@ export function useQueryResult<
   };
 }
 
+// this hook collects the common logic when closing the edit/delete dialog
+// if applied is true, then the list should be refetched and selection cleared
+export function useCloseEditDelete(props: {
+  onSelectNone: () => void;
+  closeModal: () => void;
+  result: QueryResult;
+}) {
+  const { onSelectNone, closeModal, result } = props;
+
+  const onCloseEditDelete = useCallback(
+    (applied?: boolean) => {
+      closeModal();
+      if (applied) {
+        onSelectNone();
+
+        // refetch
+        result.refetch();
+      }
+    },
+    [onSelectNone, closeModal, result]
+  );
+
+  return onCloseEditDelete;
+}
+
 export function useScrollToTopOnPageChange(
   currentPage: number,
   loading: boolean

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScenesPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
-import { SceneList } from "src/components/Scenes/SceneList";
+import { FilteredSceneList } from "src/components/Scenes/SceneList";
 import { usePerformerFilterHook } from "src/core/performers";
 import { View } from "src/components/List/views";
 import { PatchComponent } from "src/patch";
@@ -14,7 +14,7 @@ export const PerformerScenesPanel: React.FC<IPerformerDetailsProps> =
   PatchComponent("PerformerScenesPanel", ({ active, performer }) => {
     const filterHook = usePerformerFilterHook(performer);
     return (
-      <SceneList
+      <FilteredSceneList
         filterHook={filterHook}
         alterQuery={active}
         view={View.PerformerScenes}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -370,6 +370,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
             );
           }}
           operations={otherOperations}
+          zoomable
         />
 
         <FilterTags

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -30,6 +30,7 @@ import { useCloseEditDelete, useFilterOperations } from "../List/util";
 import { IListFilterOperation } from "../List/ListOperationButtons";
 import { FilteredListToolbar } from "../List/FilteredListToolbar";
 import { useFilteredItemList } from "../List/ItemList";
+import { FilterTags } from "../List/FilterTags";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -230,7 +231,10 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
   const { modal, showModal, closeModal } = modalState;
 
   // Utility hooks
-  const { setPage } = useFilterOperations({ filter, setFilter });
+  const { setPage, removeCriterion, clearAllCriteria } = useFilterOperations({
+    filter,
+    setFilter,
+  });
 
   useAddKeybinds(filter, totalCount);
 
@@ -366,6 +370,13 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
             );
           }}
           operations={otherOperations}
+        />
+
+        <FilterTags
+          criteria={filter.criteria}
+          onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
+          onRemoveCriterion={removeCriterion}
+          onRemoveAll={() => clearAllCriteria()}
         />
 
         <PagedList

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo } from "react";
 import cloneDeep from "lodash-es/cloneDeep";
 import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import { queryFindScenes, useFindScenes } from "src/core/StashService";
-import { ItemList, ItemListContext, showWhenSelected } from "../List/ItemList";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { Tagger } from "../Tagger/scenes/SceneTagger";
@@ -26,14 +25,21 @@ import { objectTitle } from "src/core/files";
 import TextUtils from "src/utils/text";
 import { View } from "../List/views";
 import { FileSize } from "../Shared/FileSize";
-
-function getItems(result: GQL.FindScenesQueryResult) {
-  return result?.data?.findScenes?.scenes ?? [];
-}
-
-function getCount(result: GQL.FindScenesQueryResult) {
-  return result?.data?.findScenes?.count ?? 0;
-}
+import { PagedList } from "../List/PagedList";
+import { useModal } from "src/hooks/modal";
+import {
+  useCloseEditDelete,
+  useEnsureValidPage,
+  useFilterOperations,
+  useFilterState,
+  useListKeyboardShortcuts,
+  useListSelect,
+  useQueryResult,
+  useScrollToTopOnPageChange,
+} from "../List/util";
+import { useShowEditFilter } from "../List/EditFilterDialog";
+import { IListFilterOperation } from "../List/ListOperationButtons";
+import { FilteredListToolbar } from "../List/FilteredListToolbar";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -64,7 +70,130 @@ function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   );
 }
 
-interface ISceneList {
+function usePlayScene() {
+  const history = useHistory();
+
+  const playScene = useCallback(
+    (queue: SceneQueue, sceneID: string, options: IPlaySceneOptions) => {
+      history.push(queue.makeLink(sceneID, options));
+    },
+    [history]
+  );
+
+  return playScene;
+}
+
+function usePlaySelected(selectedIds: Set<string>) {
+  const { configuration: config } = useContext(ConfigurationContext);
+  const playScene = usePlayScene();
+
+  const playSelected = useCallback(() => {
+    // populate queue and go to first scene
+    const sceneIDs = Array.from(selectedIds.values());
+    const queue = SceneQueue.fromSceneIDList(sceneIDs);
+    const autoPlay = config?.interface.autostartVideoOnPlaySelected ?? false;
+    playScene(queue, sceneIDs[0], { autoPlay });
+  }, [selectedIds, config?.interface.autostartVideoOnPlaySelected, playScene]);
+
+  return playSelected;
+}
+
+function usePlayRandom(filter: ListFilterModel, count: number) {
+  const { configuration: config } = useContext(ConfigurationContext);
+  const playScene = usePlayScene();
+
+  const playRandom = useCallback(async () => {
+    // query for a random scene
+    if (count === 0) {
+      return;
+    }
+
+    const pages = Math.ceil(count / filter.itemsPerPage);
+    const page = Math.floor(Math.random() * pages) + 1;
+
+    const indexMax = Math.min(filter.itemsPerPage, count);
+    const index = Math.floor(Math.random() * indexMax);
+    const filterCopy = cloneDeep(filter);
+    filterCopy.currentPage = page;
+    filterCopy.sortBy = "random";
+    const queryResults = await queryFindScenes(filterCopy);
+    const scene = queryResults.data.findScenes.scenes[index];
+    if (scene) {
+      // navigate to the image player page
+      const queue = SceneQueue.fromListFilterModel(filterCopy);
+      const autoPlay = config?.interface.autostartVideoOnPlaySelected ?? false;
+      playScene(queue, scene.id, { sceneIndex: index, autoPlay });
+    }
+  }, [
+    filter,
+    count,
+    config?.interface.autostartVideoOnPlaySelected,
+    playScene,
+  ]);
+
+  return playRandom;
+}
+
+function useAddKeybinds(filter: ListFilterModel, count: number) {
+  const playRandom = usePlayRandom(filter, count);
+
+  useEffect(() => {
+    Mousetrap.bind("p r", () => {
+      playRandom();
+    });
+
+    return () => {
+      Mousetrap.unbind("p r");
+    };
+  }, [playRandom]);
+}
+
+const SceneList: React.FC<{
+  scenes: GQL.SlimSceneDataFragment[];
+  filter: ListFilterModel;
+  selectedIds: Set<string>;
+  onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+  fromGroupId?: string;
+}> = ({ scenes, filter, selectedIds, onSelectChange, fromGroupId }) => {
+  const queue = useMemo(() => SceneQueue.fromListFilterModel(filter), [filter]);
+
+  if (scenes.length === 0) {
+    return null;
+  }
+
+  if (filter.displayMode === DisplayMode.Grid) {
+    return (
+      <SceneCardsGrid
+        scenes={scenes}
+        queue={queue}
+        zoomIndex={filter.zoomIndex}
+        selectedIds={selectedIds}
+        onSelectChange={onSelectChange}
+        fromGroupId={fromGroupId}
+      />
+    );
+  }
+  if (filter.displayMode === DisplayMode.List) {
+    return (
+      <SceneListTable
+        scenes={scenes}
+        queue={queue}
+        selectedIds={selectedIds}
+        onSelectChange={onSelectChange}
+      />
+    );
+  }
+  if (filter.displayMode === DisplayMode.Wall) {
+    return <SceneWallPanel scenes={scenes} sceneQueue={queue} />;
+  }
+  if (filter.displayMode === DisplayMode.Tagger) {
+    return <Tagger scenes={scenes} queue={queue} />;
+  }
+
+  return null;
+};
+
+interface IFilteredScenes {
   filterHook?: (filter: ListFilterModel) => ListFilterModel;
   defaultSort?: string;
   view?: View;
@@ -72,30 +201,132 @@ interface ISceneList {
   fromGroupId?: string;
 }
 
-export const SceneList: React.FC<ISceneList> = ({
-  filterHook,
-  defaultSort,
-  view,
-  alterQuery,
-  fromGroupId,
-}) => {
+export const FilteredSceneList = (props: IFilteredScenes) => {
   const intl = useIntl();
   const history = useHistory();
-  const config = React.useContext(ConfigurationContext);
-  const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
-  const [mergeScenes, setMergeScenes] =
-    useState<{ id: string; title: string }[]>();
-  const [isIdentifyDialogOpen, setIsIdentifyDialogOpen] = useState(false);
-  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
-  const [isExportAll, setIsExportAll] = useState(false);
 
+  const { filterHook, defaultSort, view, alterQuery, fromGroupId } = props;
   const filterMode = GQL.FilterMode.Scenes;
 
-  const otherOperations = [
+  const { configuration: config } = useContext(ConfigurationContext);
+
+  // States
+  const {
+    filter,
+    setFilter,
+    loading: filterLoading,
+  } = useFilterState({
+    filterMode,
+    defaultSort,
+    config,
+    view,
+    useURL: alterQuery,
+  });
+
+  const { effectiveFilter, result, cachedResult, items, totalCount, pages } =
+    useQueryResult({
+      filter,
+      filterHook,
+      useResult: useFindScenes,
+      getCount: (r) => r.data?.findScenes.count ?? 0,
+      getItems: (r) => r.data?.findScenes.scenes ?? [],
+    });
+
+  const listSelect = useListSelect(items);
+  const {
+    selectedIds,
+    selectedItems,
+    onSelectChange,
+    onSelectAll,
+    onSelectNone,
+    hasSelection,
+  } = listSelect;
+
+  const { modal, showModal, closeModal } = useModal();
+
+  // Utility hooks
+  const { setPage } = useFilterOperations({ filter, setFilter });
+
+  // scroll to the top of the page when the page changes
+  useScrollToTopOnPageChange(filter.currentPage, result.loading);
+
+  // ensure that the current page is valid
+  useEnsureValidPage(filter, totalCount, setFilter);
+
+  const showEditFilter = useShowEditFilter({
+    showModal,
+    closeModal,
+    filter,
+    setFilter,
+  });
+
+  useListKeyboardShortcuts({
+    currentPage: filter.currentPage,
+    onChangePage: setPage,
+    onSelectAll,
+    onSelectNone,
+    pages,
+    showEditFilter,
+  });
+
+  useAddKeybinds(filter, totalCount);
+
+  const onCloseEditDelete = useCloseEditDelete({
+    closeModal,
+    onSelectNone,
+    result,
+  });
+
+  const metadataByline = useMemo(() => {
+    if (cachedResult.loading) return "";
+
+    return renderMetadataByline(cachedResult) ?? "";
+  }, [cachedResult]);
+
+  const playSelected = usePlaySelected(selectedIds);
+  const playRandom = usePlayRandom(filter, totalCount);
+
+  function onExport(all: boolean) {
+    showModal(
+      <ExportDialog
+        exportInput={{
+          scenes: {
+            ids: Array.from(selectedIds.values()),
+            all: all,
+          },
+        }}
+        onClose={() => closeModal()}
+      />
+    );
+  }
+
+  function onMerge() {
+    const selected =
+      selectedItems.map((s) => {
+        return {
+          id: s.id,
+          title: objectTitle(s),
+        };
+      }) ?? [];
+    showModal(
+      <SceneMergeModal
+        scenes={selected}
+        onClose={(mergedID?: string) => {
+          closeModal();
+          if (mergedID) {
+            history.push(`/scenes/${mergedID}`);
+          }
+        }}
+        show
+      />
+    );
+  }
+
+  const otherOperations: IListFilterOperation[] = [
     {
       text: intl.formatMessage({ id: "actions.play_selected" }),
       onClick: playSelected,
-      isDisplayed: showWhenSelected,
+      isDisplayed: () => hasSelection,
       icon: faPlay,
     },
     {
@@ -104,273 +335,95 @@ export const SceneList: React.FC<ISceneList> = ({
     },
     {
       text: `${intl.formatMessage({ id: "actions.generate" })}…`,
-      onClick: async () => setIsGenerateDialogOpen(true),
-      isDisplayed: showWhenSelected,
-    },
-    {
-      text: `${intl.formatMessage({ id: "actions.identify" })}…`,
-      onClick: async () => setIsIdentifyDialogOpen(true),
-      isDisplayed: showWhenSelected,
-    },
-    {
-      text: `${intl.formatMessage({ id: "actions.merge" })}…`,
-      onClick: onMerge,
-      isDisplayed: showWhenSelected,
-    },
-    {
-      text: intl.formatMessage({ id: "actions.export" }),
-      onClick: onExport,
-      isDisplayed: showWhenSelected,
-    },
-    {
-      text: intl.formatMessage({ id: "actions.export_all" }),
-      onClick: onExportAll,
-    },
-  ];
-
-  function addKeybinds(
-    result: GQL.FindScenesQueryResult,
-    filter: ListFilterModel
-  ) {
-    Mousetrap.bind("p r", () => {
-      playRandom(result, filter);
-    });
-
-    return () => {
-      Mousetrap.unbind("p r");
-    };
-  }
-
-  function playScene(
-    queue: SceneQueue,
-    sceneID: string,
-    options: IPlaySceneOptions
-  ) {
-    history.push(queue.makeLink(sceneID, options));
-  }
-
-  async function playSelected(
-    result: GQL.FindScenesQueryResult,
-    filter: ListFilterModel,
-    selectedIds: Set<string>
-  ) {
-    // populate queue and go to first scene
-    const sceneIDs = Array.from(selectedIds.values());
-    const queue = SceneQueue.fromSceneIDList(sceneIDs);
-    const autoPlay =
-      config.configuration?.interface.autostartVideoOnPlaySelected ?? false;
-    playScene(queue, sceneIDs[0], { autoPlay });
-  }
-
-  async function playRandom(
-    result: GQL.FindScenesQueryResult,
-    filter: ListFilterModel
-  ) {
-    // query for a random scene
-    if (result.data?.findScenes) {
-      const { count } = result.data.findScenes;
-
-      const pages = Math.ceil(count / filter.itemsPerPage);
-      const page = Math.floor(Math.random() * pages) + 1;
-
-      const indexMax = Math.min(filter.itemsPerPage, count);
-      const index = Math.floor(Math.random() * indexMax);
-      const filterCopy = cloneDeep(filter);
-      filterCopy.currentPage = page;
-      filterCopy.sortBy = "random";
-      const queryResults = await queryFindScenes(filterCopy);
-      const scene = queryResults.data.findScenes.scenes[index];
-      if (scene) {
-        // navigate to the image player page
-        const queue = SceneQueue.fromListFilterModel(filterCopy);
-        const autoPlay =
-          config.configuration?.interface.autostartVideoOnPlaySelected ?? false;
-        playScene(queue, scene.id, { sceneIndex: index, autoPlay });
-      }
-    }
-  }
-
-  async function onMerge(
-    result: GQL.FindScenesQueryResult,
-    filter: ListFilterModel,
-    selectedIds: Set<string>
-  ) {
-    const selected =
-      result.data?.findScenes.scenes
-        .filter((s) => selectedIds.has(s.id))
-        .map((s) => {
-          return {
-            id: s.id,
-            title: objectTitle(s),
-          };
-        }) ?? [];
-
-    setMergeScenes(selected);
-  }
-
-  async function onExport() {
-    setIsExportAll(false);
-    setIsExportDialogOpen(true);
-  }
-
-  async function onExportAll() {
-    setIsExportAll(true);
-    setIsExportDialogOpen(true);
-  }
-
-  function renderContent(
-    result: GQL.FindScenesQueryResult,
-    filter: ListFilterModel,
-    selectedIds: Set<string>,
-    onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void
-  ) {
-    function maybeRenderSceneGenerateDialog() {
-      if (isGenerateDialogOpen) {
-        return (
+      onClick: () =>
+        showModal(
           <GenerateDialog
             type="scene"
             selectedIds={Array.from(selectedIds.values())}
-            onClose={() => setIsGenerateDialogOpen(false)}
+            onClose={() => closeModal()}
           />
-        );
-      }
-    }
-
-    function maybeRenderSceneIdentifyDialog() {
-      if (isIdentifyDialogOpen) {
-        return (
+        ),
+      isDisplayed: () => hasSelection,
+    },
+    {
+      text: `${intl.formatMessage({ id: "actions.identify" })}…`,
+      onClick: () =>
+        showModal(
           <IdentifyDialog
             selectedIds={Array.from(selectedIds.values())}
-            onClose={() => setIsIdentifyDialogOpen(false)}
+            onClose={() => closeModal()}
           />
-        );
-      }
-    }
+        ),
+      isDisplayed: () => hasSelection,
+    },
+    {
+      text: `${intl.formatMessage({ id: "actions.merge" })}…`,
+      onClick: () => onMerge(),
+      isDisplayed: () => hasSelection,
+    },
+    {
+      text: intl.formatMessage({ id: "actions.export" }),
+      onClick: () => onExport(false),
+      isDisplayed: () => hasSelection,
+    },
+    {
+      text: intl.formatMessage({ id: "actions.export_all" }),
+      onClick: () => onExport(true),
+    },
+  ];
 
-    function maybeRenderSceneExportDialog() {
-      if (isExportDialogOpen) {
-        return (
-          <ExportDialog
-            exportInput={{
-              scenes: {
-                ids: Array.from(selectedIds.values()),
-                all: isExportAll,
-              },
-            }}
-            onClose={() => setIsExportDialogOpen(false)}
-          />
-        );
-      }
-    }
+  // render
+  if (filterLoading) return null;
 
-    function renderMergeDialog() {
-      if (mergeScenes) {
-        return (
-          <SceneMergeModal
-            scenes={mergeScenes}
-            onClose={(mergedID?: string) => {
-              setMergeScenes(undefined);
-              if (mergedID) {
-                history.push(`/scenes/${mergedID}`);
-              }
-            }}
-            show
-          />
-        );
-      }
-    }
+  return (
+    <TaggerContext>
+      <div className="item-list-container">
+        {modal}
 
-    function renderScenes() {
-      if (!result.data?.findScenes) return;
+        <FilteredListToolbar
+          filter={filter}
+          setFilter={setFilter}
+          showEditFilter={showEditFilter}
+          view={view}
+          listSelect={listSelect}
+          onEdit={() =>
+            showModal(
+              <EditScenesDialog
+                selected={selectedItems}
+                onClose={onCloseEditDelete}
+              />
+            )
+          }
+          onDelete={() => {
+            showModal(
+              <DeleteScenesDialog
+                selected={selectedItems}
+                onClose={onCloseEditDelete}
+              />
+            );
+          }}
+          operations={otherOperations}
+        />
 
-      const queue = SceneQueue.fromListFilterModel(filter);
-
-      if (filter.displayMode === DisplayMode.Grid) {
-        return (
-          <SceneCardsGrid
-            scenes={result.data.findScenes.scenes}
-            queue={queue}
-            zoomIndex={filter.zoomIndex}
+        <PagedList
+          result={result}
+          cachedResult={cachedResult}
+          filter={filter}
+          totalCount={totalCount}
+          onChangePage={setPage}
+          metadataByline={metadataByline}
+        >
+          <SceneList
+            filter={effectiveFilter}
+            scenes={items}
             selectedIds={selectedIds}
             onSelectChange={onSelectChange}
             fromGroupId={fromGroupId}
           />
-        );
-      }
-      if (filter.displayMode === DisplayMode.List) {
-        return (
-          <SceneListTable
-            scenes={result.data.findScenes.scenes}
-            queue={queue}
-            selectedIds={selectedIds}
-            onSelectChange={onSelectChange}
-          />
-        );
-      }
-      if (filter.displayMode === DisplayMode.Wall) {
-        return (
-          <SceneWallPanel
-            scenes={result.data.findScenes.scenes}
-            sceneQueue={queue}
-          />
-        );
-      }
-      if (filter.displayMode === DisplayMode.Tagger) {
-        return <Tagger scenes={result.data.findScenes.scenes} queue={queue} />;
-      }
-    }
-
-    return (
-      <>
-        {maybeRenderSceneGenerateDialog()}
-        {maybeRenderSceneIdentifyDialog()}
-        {maybeRenderSceneExportDialog()}
-        {renderMergeDialog()}
-        {renderScenes()}
-      </>
-    );
-  }
-
-  function renderEditDialog(
-    selectedScenes: GQL.SlimSceneDataFragment[],
-    onClose: (applied: boolean) => void
-  ) {
-    return <EditScenesDialog selected={selectedScenes} onClose={onClose} />;
-  }
-
-  function renderDeleteDialog(
-    selectedScenes: GQL.SlimSceneDataFragment[],
-    onClose: (confirmed: boolean) => void
-  ) {
-    return <DeleteScenesDialog selected={selectedScenes} onClose={onClose} />;
-  }
-
-  return (
-    <TaggerContext>
-      <ItemListContext
-        filterMode={filterMode}
-        defaultSort={defaultSort}
-        useResult={useFindScenes}
-        getItems={getItems}
-        getCount={getCount}
-        alterQuery={alterQuery}
-        filterHook={filterHook}
-        view={view}
-        selectable
-      >
-        <ItemList
-          zoomable
-          view={view}
-          otherOperations={otherOperations}
-          addKeybinds={addKeybinds}
-          renderContent={renderContent}
-          renderEditDialog={renderEditDialog}
-          renderDeleteDialog={renderDeleteDialog}
-          renderMetadataByline={renderMetadataByline}
-        />
-      </ItemListContext>
+        </PagedList>
+      </div>
     </TaggerContext>
   );
 };
 
-export default SceneList;
+export default FilteredSceneList;

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -5,7 +5,7 @@ import { useTitleProps } from "src/hooks/title";
 import { lazyComponent } from "src/utils/lazyComponent";
 import { View } from "../List/views";
 
-const SceneList = lazyComponent(() => import("./SceneList"));
+const SceneList = lazyComponent(() => import("./FilteredScenes"));
 const SceneMarkerList = lazyComponent(() => import("./SceneMarkerList"));
 const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
 const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));

--- a/ui/v2.5/src/components/Scenes/Scenes.tsx
+++ b/ui/v2.5/src/components/Scenes/Scenes.tsx
@@ -5,7 +5,7 @@ import { useTitleProps } from "src/hooks/title";
 import { lazyComponent } from "src/utils/lazyComponent";
 import { View } from "../List/views";
 
-const SceneList = lazyComponent(() => import("./FilteredScenes"));
+const SceneList = lazyComponent(() => import("./SceneList"));
 const SceneMarkerList = lazyComponent(() => import("./SceneMarkerList"));
 const Scene = lazyComponent(() => import("./SceneDetails/Scene"));
 const SceneCreate = lazyComponent(() => import("./SceneDetails/SceneCreate"));

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioScenesPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
-import { SceneList } from "src/components/Scenes/SceneList";
+import { FilteredSceneList } from "src/components/Scenes/SceneList";
 import { useStudioFilterHook } from "src/core/studios";
 import { View } from "src/components/List/views";
 
@@ -17,7 +17,7 @@ export const StudioScenesPanel: React.FC<IStudioScenesPanel> = ({
 }) => {
   const filterHook = useStudioFilterHook(studio, showChildStudioContent);
   return (
-    <SceneList
+    <FilteredSceneList
       filterHook={filterHook}
       alterQuery={active}
       view={View.StudioScenes}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagScenesPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
-import { SceneList } from "src/components/Scenes/SceneList";
+import { FilteredSceneList } from "src/components/Scenes/SceneList";
 import { useTagFilterHook } from "src/core/tags";
 import { View } from "src/components/List/views";
 
@@ -17,7 +17,7 @@ export const TagScenesPanel: React.FC<ITagScenesPanel> = ({
 }) => {
   const filterHook = useTagFilterHook(tag, showSubTagContent);
   return (
-    <SceneList
+    <FilteredSceneList
       filterHook={filterHook}
       alterQuery={active}
       view={View.TagScenes}


### PR DESCRIPTION
Replaces #5745 
Related to sidebar work (#5714)

Refactors the `SceneList` (renaming to `FilteredSceneList`) to not use the `ItemList` component. The eventual aim is to remove the `ItemList` usage from all list components. For now, this will enable me to work on sidebar changes on the scene page in isolation.

- adds `useShowEditFilter` utility hook to show the edit filter dialog using the provided modal
- changes `FilteredListToolbar` to not use contexts
- adds utility hook: `useFilteredItemList` which consolidates the state and usual behaviour for filtered item lists as performed by `ItemList`
- adds utility hook: `useEmptyFilter` which provides an empty filter
- adds utility hook: `useFilterState` which handles the filter state while also dealing with URL setting
- adds utility hook: `useFilterOperations` which provides a number of functions to alter the filter state
- adds utility hook: `useCloseEditDelete` which handles unselecting and refetching when the edit or delete dialog is closed
- added more fields to `useListSelect`

