### PR TITLE
Add tag count to studio sort whitelist

### DIFF
--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -586,6 +586,7 @@ var studioSortOptions = sortOptions{
 	"scenes_count",
 	"random",
 	"rating",
+	"tag_count",
 	"updated_at",
 }
 


### PR DESCRIPTION
The tag count sort option never got added to the whitelist for the studio sort options, and currently returns `invalid sort: tag_count` in the UI when attempting to sort by Tag Count.