### PR TITLE
Add marker end seconds import/export

### DIFF
--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -709,6 +709,11 @@ func (t *ImportTask) ImportScenes(ctx context.Context) {
 				return err
 			}
 
+			// skip importing markers if the scene was not created
+			if sceneImporter.ID == 0 {
+				return nil
+			}
+
 			// import the scene markers
 			for _, m := range sceneJSON.Markers {
 				markerImporter := &scene.MarkerImporter{

--- a/pkg/models/jsonschema/scene.go
+++ b/pkg/models/jsonschema/scene.go
@@ -14,6 +14,7 @@ import (
 type SceneMarker struct {
 	Title      string        `json:"title,omitempty"`
 	Seconds    string        `json:"seconds,omitempty"`
+	EndSeconds string        `json:"end_seconds,omitempty"`
 	PrimaryTag string        `json:"primary_tag,omitempty"`
 	Tags       []string      `json:"tags,omitempty"`
 	CreatedAt  json.JSONTime `json:"created_at,omitempty"`

--- a/pkg/scene/export.go
+++ b/pkg/scene/export.go
@@ -229,7 +229,6 @@ func GetSceneMarkersJSON(ctx context.Context, markerReader models.SceneMarkerFin
 		sceneMarkerJSON := jsonschema.SceneMarker{
 			Title:      sceneMarker.Title,
 			Seconds:    getDecimalString(sceneMarker.Seconds),
-			EndSeconds: "",
 			PrimaryTag: primaryTag.Name,
 			Tags:       getTagNames(sceneMarkerTags),
 			CreatedAt:  json.JSONTime{Time: sceneMarker.CreatedAt},

--- a/pkg/scene/export.go
+++ b/pkg/scene/export.go
@@ -229,10 +229,15 @@ func GetSceneMarkersJSON(ctx context.Context, markerReader models.SceneMarkerFin
 		sceneMarkerJSON := jsonschema.SceneMarker{
 			Title:      sceneMarker.Title,
 			Seconds:    getDecimalString(sceneMarker.Seconds),
+			EndSeconds: "",
 			PrimaryTag: primaryTag.Name,
 			Tags:       getTagNames(sceneMarkerTags),
 			CreatedAt:  json.JSONTime{Time: sceneMarker.CreatedAt},
 			UpdatedAt:  json.JSONTime{Time: sceneMarker.UpdatedAt},
+		}
+
+		if sceneMarker.EndSeconds != nil {
+			sceneMarkerJSON.EndSeconds = getDecimalString(*sceneMarker.EndSeconds)
 		}
 
 		results = append(results, sceneMarkerJSON)

--- a/pkg/scene/marker_import.go
+++ b/pkg/scene/marker_import.go
@@ -27,12 +27,20 @@ type MarkerImporter struct {
 
 func (i *MarkerImporter) PreImport(ctx context.Context) error {
 	seconds, _ := strconv.ParseFloat(i.Input.Seconds, 64)
+
+	var endSeconds *float64
+	if i.Input.EndSeconds != "" {
+		parsedEndSeconds, _ := strconv.ParseFloat(i.Input.EndSeconds, 64)
+		endSeconds = &parsedEndSeconds
+	}
+
 	i.marker = models.SceneMarker{
-		Title:     i.Input.Title,
-		Seconds:   seconds,
-		SceneID:   i.SceneID,
-		CreatedAt: i.Input.CreatedAt.GetTime(),
-		UpdatedAt: i.Input.UpdatedAt.GetTime(),
+		Title:      i.Input.Title,
+		Seconds:    seconds,
+		EndSeconds: endSeconds,
+		SceneID:    i.SceneID,
+		CreatedAt:  i.Input.CreatedAt.GetTime(),
+		UpdatedAt:  i.Input.UpdatedAt.GetTime(),
 	}
 
 	if err := i.populateTags(ctx); err != nil {


### PR DESCRIPTION
Addresses part of #5775

Error mentioned in #5775 occurs when attempting to import a new marker to an already existing scene with `Duplicate object handling` set to Ignore (the default value). That is not currently addressed in this PR.