### PR TITLE
Import/export bug fixes

### DIFF
--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -1,6 +1,8 @@
 package fsutil
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -151,7 +153,12 @@ var (
 )
 
 // SanitiseBasename returns a file basename removing any characters that are illegal or problematic to use in the filesystem.
+// It appends a short hash of the original string to ensure uniqueness.
 func SanitiseBasename(v string) string {
+	// Generate a short hash for uniqueness
+	hash := sha1.Sum([]byte(v))
+	shortHash := hex.EncodeToString(hash[:4]) // Use the first 4 bytes of the hash
+
 	v = strings.TrimSpace(v)
 
 	// replace illegal filename characters with -
@@ -163,7 +170,7 @@ func SanitiseBasename(v string) string {
 	// remove multiple hyphens
 	v = multiHyphenRE.ReplaceAllString(v, "-")
 
-	return strings.TrimSpace(v)
+	return strings.TrimSpace(v) + "-" + shortHash
 }
 
 // GetExeName returns the name of the given executable for the current platform.

--- a/pkg/fsutil/file_test.go
+++ b/pkg/fsutil/file_test.go
@@ -8,13 +8,13 @@ func TestSanitiseBasename(t *testing.T) {
 		v    string
 		want string
 	}{
-		{"basic", "basic", "basic"},
-		{"spaces", `spaced name`, "spaced-name"},
-		{"leading/trailing spaces", `  spaced name  `, "spaced-name"},
-		{"hyphen name", `hyphened-name`, "hyphened-name"},
-		{"multi-hyphen", `hyphened--name`, "hyphened-name"},
-		{"replaced characters", `a&b=c\d/:e*"f?_ g`, "a-b-c-d-e-f-g"},
-		{"removed characters", `foo!!bar@@and, more`, "foobarand-more"},
+		{"basic", "basic", "basic-61a7508e"},
+		{"spaces", `spaced name`, "spaced-name-b297cf60"},
+		{"leading/trailing spaces", `  spaced name  `, "spaced-name-175433e9"},
+		{"hyphen name", `hyphened-name`, "hyphened-name-789c55f2"},
+		{"multi-hyphen", `hyphened--name`, "hyphened-name-2da2a58f"},
+		{"replaced characters", `a&b=c\d/:e*"f?_ g`, "a-b-c-d-e-f-g-ffca6fb0"},
+		{"removed characters", `foo!!bar@@and, more`, "foobarand-more-7cee02ab"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/tag/export.go
+++ b/pkg/tag/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/models/json"
 	"github.com/stashapp/stash/pkg/models/jsonschema"
+	"github.com/stashapp/stash/pkg/sliceutil"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -53,6 +54,28 @@ func ToJSON(ctx context.Context, reader FinderAliasImageGetter, tag *models.Tag)
 	newTagJSON.Parents = GetNames(parents)
 
 	return &newTagJSON, nil
+}
+
+// GetDependentTagIDs returns a slice of unique tag IDs that this tag references.
+func GetDependentTagIDs(ctx context.Context, reader FinderAliasImageGetter, tag *models.Tag) ([]int, error) {
+	var ret []int
+
+	parents, err := reader.FindByChildTagID(ctx, tag.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting parents: %v", err)
+	}
+
+	for _, tt := range parents {
+		toAdd, err := GetDependentTagIDs(ctx, reader, tt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting dependent tag IDs: %v", err)
+		}
+
+		ret = sliceutil.AppendUniques(ret, toAdd)
+		ret = sliceutil.AppendUnique(ret, tt.ID)
+	}
+
+	return ret, nil
 }
 
 func GetIDs(tags []*models.Tag) []int {


### PR DESCRIPTION
Fixes some issues while investigating #5775

- includes parent tags in export if including depedencies
I had an issue where the import would fail because the parent tags weren't included in the export.

- add short hash of basename as suffix when sanitising basenames
I had an issue where two tags with names `parent` and `#parent` would end up with the same filename.