### PR TITLE
Partial fix for #2761 - Add reverse proxy prefix to HLS links

### DIFF
--- a/pkg/ffmpeg/stream_segmented.go
+++ b/pkg/ffmpeg/stream_segmented.go
@@ -426,7 +426,7 @@ func serveHLSManifest(sm *StreamManager, w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	prefix := strings.TrimRight(r.Header.Get("X-Forwarded-Prefix"), "")
+	prefix := r.Header.Get("X-Forwarded-Prefix")
 
 	baseUrl := *r.URL
 	baseUrl.RawQuery = ""
@@ -561,7 +561,7 @@ func serveDASHManifest(sm *StreamManager, w http.ResponseWriter, r *http.Request
 	mediaDuration := mpd.Duration(time.Duration(probeResult.FileDuration * float64(time.Second)))
 	m := mpd.NewMPD(mpd.DASH_PROFILE_LIVE, mediaDuration.String(), "PT4.0S")
 
-	prefix := strings.TrimRight(r.Header.Get("X-Forwarded-Prefix"), "")
+	prefix := r.Header.Get("X-Forwarded-Prefix")
 
 	baseUrl := r.URL.JoinPath("/")
 	baseUrl.RawQuery = ""

--- a/pkg/ffmpeg/stream_segmented.go
+++ b/pkg/ffmpeg/stream_segmented.go
@@ -426,9 +426,11 @@ func serveHLSManifest(sm *StreamManager, w http.ResponseWriter, r *http.Request,
 		return
 	}
 
+	prefix := strings.TrimRight(r.Header.Get("X-Forwarded-Prefix"), "")
+
 	baseUrl := *r.URL
 	baseUrl.RawQuery = ""
-	baseURL := baseUrl.String()
+	baseURL := prefix + baseUrl.String()
 
 	urlQuery := url.Values{}
 	apikey := r.URL.Query().Get(apiKeyParamKey)
@@ -559,9 +561,11 @@ func serveDASHManifest(sm *StreamManager, w http.ResponseWriter, r *http.Request
 	mediaDuration := mpd.Duration(time.Duration(probeResult.FileDuration * float64(time.Second)))
 	m := mpd.NewMPD(mpd.DASH_PROFILE_LIVE, mediaDuration.String(), "PT4.0S")
 
+	prefix := strings.TrimRight(r.Header.Get("X-Forwarded-Prefix"), "")
+
 	baseUrl := r.URL.JoinPath("/")
 	baseUrl.RawQuery = ""
-	m.BaseURL = baseUrl.String()
+	m.BaseURL = prefix + baseUrl.String()
 
 	video, _ := m.AddNewAdaptationSetVideo(MimeWebmVideo, "progressive", true, 1)
 


### PR DESCRIPTION
Adds prefix from X-Forwarded-Prefix to links generated in HLS file. Partial fix for issue #2761 