### PR TITLE
Add graphql playground link to tools panel

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { Setting } from "./Inputs";
 import { SettingSection } from "./SettingSection";
 import { PatchContainerComponent } from "src/patch";
+import { ExternalLink } from "../Shared/ExternalLink";
 
 const SettingsToolsSection = PatchContainerComponent("SettingsToolsSection");
 
@@ -12,6 +13,15 @@ export const SettingsToolsPanel: React.FC = () => {
   return (
     <SettingSection headingID="config.tools.scene_tools">
       <SettingsToolsSection>
+        <Setting
+          heading={
+            <ExternalLink href="/playground">
+              <Button>
+                <FormattedMessage id="config.tools.graphql_playground" />
+              </Button>
+            </ExternalLink>
+          }
+        />
         <Setting
           heading={
             <Link to="/sceneFilenameParser">

--- a/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
@@ -11,37 +11,43 @@ const SettingsToolsSection = PatchContainerComponent("SettingsToolsSection");
 
 export const SettingsToolsPanel: React.FC = () => {
   return (
-    <SettingSection headingID="config.tools.scene_tools">
-      <SettingsToolsSection>
-        <Setting
-          heading={
-            <ExternalLink href="/playground">
-              <Button>
-                <FormattedMessage id="config.tools.graphql_playground" />
-              </Button>
-            </ExternalLink>
-          }
-        />
-        <Setting
-          heading={
-            <Link to="/sceneFilenameParser">
-              <Button>
-                <FormattedMessage id="config.tools.scene_filename_parser.title" />
-              </Button>
-            </Link>
-          }
-        />
+    <>
+      <SettingSection headingID="config.tools.heading">
+        <SettingsToolsSection>
+          <Setting
+            heading={
+              <ExternalLink href="/playground">
+                <Button>
+                  <FormattedMessage id="config.tools.graphql_playground" />
+                </Button>
+              </ExternalLink>
+            }
+          />
+        </SettingsToolsSection>
+      </SettingSection>
+      <SettingSection headingID="config.tools.scene_tools">
+        <SettingsToolsSection>
+          <Setting
+            heading={
+              <Link to="/sceneFilenameParser">
+                <Button>
+                  <FormattedMessage id="config.tools.scene_filename_parser.title" />
+                </Button>
+              </Link>
+            }
+          />
 
-        <Setting
-          heading={
-            <Link to="/sceneDuplicateChecker">
-              <Button>
-                <FormattedMessage id="config.tools.scene_duplicate_checker" />
-              </Button>
-            </Link>
-          }
-        />
-      </SettingsToolsSection>
-    </SettingSection>
+          <Setting
+            heading={
+              <Link to="/sceneDuplicateChecker">
+                <Button>
+                  <FormattedMessage id="config.tools.scene_duplicate_checker" />
+                </Button>
+              </Link>
+            }
+          />
+        </SettingsToolsSection>
+      </SettingSection>
+    </>
   );
 };

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -562,6 +562,7 @@
     },
     "tools": {
       "graphql_playground": "GraphQL playground",
+      "heading": "Tools",
       "scene_duplicate_checker": "Scene Duplicate Checker",
       "scene_filename_parser": {
         "add_field": "Add Field",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -561,6 +561,7 @@
       "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata"
     },
     "tools": {
+      "graphql_playground": "GraphQL playground",
       "scene_duplicate_checker": "Scene Duplicate Checker",
       "scene_filename_parser": {
         "add_field": "Add Field",


### PR DESCRIPTION
Adds a `GraphQL playground` link to the tools panel.