### PR TITLE
Error loading plugins

### DIFF
--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -103,6 +103,14 @@ const AppContainer: React.FC<React.PropsWithChildren<{}>> = PatchFunction(
   }
 ) as React.FC;
 
+const MainContainer: React.FC = ({ children }) => {
+  return (
+    <div className={`main container-fluid ${appleRendering ? "apple" : ""}`}>
+      {children}
+    </div>
+  );
+};
+
 function translateLanguageLocale(l: string) {
   // intl doesn't support all locales, so we need to map some to supported ones
   switch (l) {
@@ -299,15 +307,17 @@ export const App: React.FC = () => {
         messages={messages}
         formats={intlFormats}
       >
-        <ErrorMessage
-          message={
-            <FormattedMessage
-              id="errors.loading_type"
-              values={{ type: "configuration" }}
-            />
-          }
-          error={config.error.message}
-        />
+        <MainContainer>
+          <ErrorMessage
+            message={
+              <FormattedMessage
+                id="errors.loading_type"
+                values={{ type: "configuration" }}
+              />
+            }
+            error={config.error.message}
+          />
+        </MainContainer>
       </IntlProvider>
     );
   }
@@ -334,13 +344,7 @@ export const App: React.FC = () => {
                       <InteractiveProvider>
                         <Helmet {...titleProps} />
                         {maybeRenderNavbar()}
-                        <div
-                          className={`main container-fluid ${
-                            appleRendering ? "apple" : ""
-                          }`}
-                        >
-                          {renderContent()}
-                        </div>
+                        <MainContainer>{renderContent()}</MainContainer>
                       </InteractiveProvider>
                     </ManualProvider>
                   </LightboxProvider>

--- a/ui/v2.5/src/components/List/PagedList.tsx
+++ b/ui/v2.5/src/components/List/PagedList.tsx
@@ -3,6 +3,8 @@ import { QueryResult } from "@apollo/client";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { Pagination, PaginationIndex } from "./Pagination";
 import { LoadingIndicator } from "../Shared/LoadingIndicator";
+import { ErrorMessage } from "../Shared/ErrorMessage";
+import { FormattedMessage } from "react-intl";
 
 export const PagedList: React.FC<
   PropsWithChildren<{
@@ -65,7 +67,17 @@ export const PagedList: React.FC<
       return <LoadingIndicator />;
     }
     if (result.error) {
-      return <h1>{result.error.message}</h1>;
+      return (
+        <ErrorMessage
+          message={
+            <FormattedMessage
+              id="errors.loading_type"
+              values={{ type: "items" }}
+            />
+          }
+          error={result.error.message}
+        />
+      );
     }
 
     return (

--- a/ui/v2.5/src/components/Shared/ErrorMessage.tsx
+++ b/ui/v2.5/src/components/Shared/ErrorMessage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { Alert } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 
 interface IProps {
@@ -10,10 +11,11 @@ export const ErrorMessage: React.FC<IProps> = (props) => {
   const { error, message = <FormattedMessage id="errors.header" /> } = props;
 
   return (
-    <div className="row ErrorMessage">
-      <h2 className="ErrorMessage-content">
-        {message}: {error}
-      </h2>
+    <div className="ErrorMessage-container">
+      <Alert variant="danger" className="ErrorMessage">
+        <Alert.Heading className="ErrorMessage-header">{message}</Alert.Heading>
+        <div className="ErrorMessage-content code">{error}</div>
+      </Alert>
     </div>
   );
 };

--- a/ui/v2.5/src/components/Shared/ErrorMessage.tsx
+++ b/ui/v2.5/src/components/Shared/ErrorMessage.tsx
@@ -1,6 +1,8 @@
+import { faWarning } from "@fortawesome/free-solid-svg-icons";
 import React, { ReactNode } from "react";
 import { Alert } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
+import { Icon } from "./Icon";
 
 interface IProps {
   message?: React.ReactNode;
@@ -13,7 +15,10 @@ export const ErrorMessage: React.FC<IProps> = (props) => {
   return (
     <div className="ErrorMessage-container">
       <Alert variant="danger" className="ErrorMessage">
-        <Alert.Heading className="ErrorMessage-header">{message}</Alert.Heading>
+        <Alert.Heading className="ErrorMessage-header">
+          <Icon icon={faWarning} />
+          {message}
+        </Alert.Heading>
         <div className="ErrorMessage-content code">{error}</div>
       </Alert>
     </div>

--- a/ui/v2.5/src/components/Shared/ErrorMessage.tsx
+++ b/ui/v2.5/src/components/Shared/ErrorMessage.tsx
@@ -1,11 +1,19 @@
 import React, { ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
 
 interface IProps {
+  message?: React.ReactNode;
   error: string | ReactNode;
 }
 
-export const ErrorMessage: React.FC<IProps> = ({ error }) => (
-  <div className="row ErrorMessage">
-    <h2 className="ErrorMessage-content">Error: {error}</h2>
-  </div>
-);
+export const ErrorMessage: React.FC<IProps> = (props) => {
+  const { error, message = <FormattedMessage id="errors.header" /> } = props;
+
+  return (
+    <div className="row ErrorMessage">
+      <h2 className="ErrorMessage-content">
+        {message}: {error}
+      </h2>
+    </div>
+  );
+};

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -213,13 +213,22 @@ button.collapse-button {
   text-align: center;
 }
 
-.ErrorMessage {
-  align-items: center;
-  height: 20rem;
+.ErrorMessage-container {
+  display: flex;
   justify-content: center;
+  width: 100%;
+}
 
-  &-content {
-    display: inline-block;
+.ErrorMessage {
+  background-color: initial;
+  border-color: $danger;
+  color: $text-color;
+  margin: 1rem;
+  text-align: left;
+  width: 500px;
+
+  @include media-breakpoint-down(xs) {
+    width: 100%;
   }
 }
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -220,6 +220,13 @@ button.collapse-button {
 }
 
 .ErrorMessage {
+  .fa-icon {
+    color: $warning;
+    font-size: 1.5em;
+    margin-right: 0.3em;
+    vertical-align: middle;
+  }
+
   background-color: initial;
   border-color: $danger;
   color: $text-color;

--- a/ui/v2.5/src/hooks/Toast.tsx
+++ b/ui/v2.5/src/hooks/Toast.tsx
@@ -28,7 +28,9 @@ const errorDelay = 5000;
 
 let toastID = 0;
 
-const ToastContext = createContext<(item: IToast) => void>(() => {});
+type ToastFn = (item: IToast) => void;
+
+const ToastContext = createContext<ToastFn | null>(null);
 
 export const ToastProvider: React.FC = ({ children }) => {
   const [toast, setToast] = useState<IActiveToast>();
@@ -120,6 +122,10 @@ export const ToastProvider: React.FC = ({ children }) => {
 
 export const useToast = () => {
   const addToast = useContext(ToastContext);
+
+  if (!addToast) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
 
   return useMemo(
     () => ({


### PR DESCRIPTION
This PR fixes a nasty but unlikely bug where if the configuration query fails for any reason, then the UI configuration will be clobbered by the front page initialisation.

This also revamps the `ErrorMessage` component to present more like a typical error message:

![image](https://github.com/user-attachments/assets/53d5dccd-0335-4be7-a326-ac48bab7e152)
![image](https://github.com/user-attachments/assets/6ee99e85-31ac-4080-ac70-034c95d48e97)
![image](https://github.com/user-attachments/assets/31f33e20-abf8-42b3-86f0-0653d01c4fc2)

TODO: test these with longer error messages