### PR TITLE
Redirect to previous page on delete to preserve filters

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -167,7 +167,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
   function onDeleteDialogClosed(deleted: boolean) {
     setIsDeleteAlertOpen(false);
     if (deleted) {
-      history.push("/galleries");
+      history.goBack();
     }
   }
 

--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -252,10 +252,10 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
       await deleteGroup();
     } catch (e) {
       Toast.error(e);
+      return;
     }
 
-    // redirect to groups page
-    history.push(`/groups`);
+    history.goBack();
   }
 
   function toggleEditing(value?: boolean) {

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -156,7 +156,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
   function onDeleteDialogClosed(deleted: boolean) {
     setIsDeleteAlertOpen(false);
     if (deleted) {
-      history.push("/images");
+      history.goBack();
     }
   }
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -298,10 +298,10 @@ const PerformerPage: React.FC<IProps> = PatchComponent(
         await deletePerformer({ variables: { id: performer.id } });
       } catch (e) {
         Toast.error(e);
+        return;
       }
 
-      // redirect to performers page
-      history.push("/performers");
+      history.goBack();
     }
 
     function toggleEditing(value?: boolean) {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -909,7 +909,7 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
     ) {
       loadScene(queueScenes[currentQueueIndex + 1].id);
     } else {
-      history.push("/scenes");
+      history.goBack();
     }
   }
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -375,10 +375,10 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
       await deleteStudio();
     } catch (e) {
       Toast.error(e);
+      return;
     }
 
-    // redirect to studios page
-    history.push(`/studios`);
+    history.goBack();
   }
 
   function renderDeleteAlert() {

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -417,10 +417,10 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
       });
     } catch (e) {
       Toast.error(e);
+      return;
     }
 
-    // redirect to tags page
-    history.push(`/tags`);
+    history.goBack();
   }
 
   function renderDeleteAlert() {


### PR DESCRIPTION
Similar to #5712, small QoL patch to allow for quicker transition between views when deleting items (gallery, group, image, performer, scene, studio, tag).

UI will now return to previous page, thus getting back all filters and sort settings without user interaction (previously required backing up 2 times in history).

I tried looking at deleting the deleted view from the history but it seems way too complicated and tricky for what it is.