### PR TITLE
Stash box validation bugfix

### DIFF
--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -249,18 +249,19 @@ func (r *queryResolver) ValidateStashBoxCredentials(ctx context.Context, input c
 	if valid {
 		status = fmt.Sprintf("Successfully authenticated as %s", user.Me.Name)
 	} else {
+		errorStr := strings.ToLower(err.Error())
 		switch {
-		case strings.Contains(strings.ToLower(err.Error()), "doctype"):
+		case strings.Contains(errorStr, "doctype"):
 			// Index file returned rather than graphql
 			status = "Invalid endpoint"
-		case strings.Contains(err.Error(), "request failed"):
+		case strings.Contains(errorStr, "request failed"):
 			status = "No response from server"
-		case strings.HasPrefix(err.Error(), "invalid character") ||
-			strings.HasPrefix(err.Error(), "illegal base64 data") ||
-			err.Error() == "unexpected end of JSON input" ||
-			err.Error() == "token contains an invalid number of segments":
+		case strings.Contains(errorStr, "invalid character") ||
+			strings.Contains(errorStr, "illegal base64 data") ||
+			strings.Contains(errorStr, "unexpected end of json input") ||
+			strings.Contains(errorStr, "token contains an invalid number of segments"):
 			status = "Malformed API key."
-		case err.Error() == "" || err.Error() == "signature is invalid":
+		case strings.Contains(errorStr, "signature is invalid"):
 			status = "Invalid or expired API key."
 		default:
 			status = fmt.Sprintf("Unknown error: %s", err)

--- a/ui/v2.5/src/components/Settings/StashBoxConfiguration.tsx
+++ b/ui/v2.5/src/components/Settings/StashBoxConfiguration.tsx
@@ -139,7 +139,6 @@ export const StashBoxModal: React.FC<IStashBoxModal> = ({ value, close }) => {
                   max_requests_per_minute: parseInt(e.currentTarget.value),
                 })
               }
-              ref={apiKey}
             />
             <div className="sub-heading">
               <FormattedMessage


### PR DESCRIPTION
A user on Discord reported an issue where testing the credentials for a stash-box configuration would return the following error

> Unknown error: {"networkErrors":{"code":500,"message":"Response body token is malformed: token contains an invalid number of segments"},"graphqlErrors":null}

This turns out to be because of the newly introduced field for request rates accidentally overwriting the API key ref that was used to test credentials, but NOT the code that persists these settings to the config which is why this has gone undetected for a few weeks 😅 

In the process of tracking down the bug I also changed the logic that translates these network errors into more user-friendly ones