### PR TITLE
Add zoomIndex to SceneGalleriesPanel GalleryCard

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneGalleriesPanel.tsx
@@ -10,7 +10,12 @@ export const SceneGalleriesPanel: React.FC<ISceneGalleriesPanelProps> = ({
   galleries,
 }) => {
   const cards = galleries.map((gallery) => (
-    <GalleryCard key={gallery.id} gallery={gallery} selecting={false} />
+    <GalleryCard
+      key={gallery.id}
+      gallery={gallery}
+      selecting={false}
+      zoomIndex={2}
+    />
   ));
 
   return <div className="container scene-galleries">{cards}</div>;


### PR DESCRIPTION
Adding a zoomIndex fixes the height of the thumbnail and prevents the card resizing when scrubbing. Fixes #5814