### PR TITLE
fix: Prevent generating invalid link on empty scraper response

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/PerformerResult.tsx
@@ -165,6 +165,12 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
 
   const selectedSource = !selectedID ? "skip" : "existing";
 
+  const safeBuildPerformerScraperLink = (id: string | null | undefined) => {
+    return stashboxPerformerPrefix && id
+      ? `${stashboxPerformerPrefix}${id}`
+      : undefined;
+  };
+
   return (
     <div className="row no-gutters align-items-center mt-2">
       <div className="entity-name">
@@ -172,7 +178,7 @@ const PerformerResult: React.FC<IPerformerResultProps> = ({
         <b className="ml-2">
           <PerformerLink
             performer={performer}
-            url={`${stashboxPerformerPrefix}${performer.remote_site_id}`}
+            url={safeBuildPerformerScraperLink(performer.remote_site_id)}
           />
         </b>
       </div>

--- a/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioResult.tsx
@@ -134,6 +134,12 @@ const StudioResult: React.FC<IStudioResultProps> = ({
 
   const selectedSource = !selectedID ? "skip" : "existing";
 
+  const safeBuildStudioScraperLink = (id: string | null | undefined) => {
+    return stashboxStudioPrefix && id
+      ? `${stashboxStudioPrefix}${id}`
+      : undefined;
+  };
+
   return (
     <div className="row no-gutters align-items-center mt-2">
       <div className="entity-name">
@@ -141,7 +147,7 @@ const StudioResult: React.FC<IStudioResultProps> = ({
         <b className="ml-2">
           <StudioLink
             studio={studio}
-            url={`${stashboxStudioPrefix}${studio.remote_site_id}`}
+            url={safeBuildStudioScraperLink(studio.remote_site_id)}
           />
         </b>
       </div>


### PR DESCRIPTION
## Old behaviour

When using a scraper that doesn't return an ID for studios or performers, the current version of stash generates an invalid link due to unsafe string building.

URL generated: `https://${STASH_BASE_URL}/undefinednull`

## Fixed behaviour

A check has been added that prevents generating such links and keeping it a bolded text element instead.
