### PR TITLE
Update Yarn installation link

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 * [Go](https://golang.org/dl/)
 * [GolangCI](https://golangci-lint.run/) - A meta-linter which runs several linters in parallel
   * To install, follow the [local installation instructions](https://golangci-lint.run/welcome/install/#local-installation)
-* [Yarn](https://yarnpkg.com/en/docs/install) - Yarn package manager
+* [Yarn](https://yarnpkg.com/getting-started/install) - Yarn package manager
 
 ## Environment
 


### PR DESCRIPTION
The existing link goes to a page that says:
```
These instructions only cover Yarn versions prior to 2.0. Those versions entered maintenance mode in January 2020 and will eventually reach their end-of-life in terms of support. Please see the main website for the most up-to-date documentation: yarnpkg.com/getting-started/migration.
```

This PR updates the link to go to the current installation instructions.