### PR TITLE
docs: Add note on Chrome 136 requirements for remote debugging

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -111,6 +111,8 @@ Some scrapers require a Chrome instance to function correctly. If left empty, st
 
 `Chrome CDP path` can be set to a path to the chrome executable, or an http(s) address to remote chrome instance (for example: `http://localhost:9222/json/version`).
 
+> **Important**: As of Chrome 136 or higher you need to specify `--user-data-dir` alongisde `--remote-debugging-port`. Read more on their [official post](https://developer.chrome.com/blog/remote-debugging-port). 
+
 ## Authentication
 
 By default, stash is not configured with any sort of password protection. To enable password protection, both `Username` and `Password` must be populated. Note that when entering a new username and password where none was set previously, the system will immediately request these credentials to log you in.


### PR DESCRIPTION
Credit to https://discord.com/channels/559159668438728723/559159931505213440/1374803050291527680 for noticing. 