### PR TITLE
feat: Auto-tag new files right after scanning

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -91,6 +91,10 @@ input ScanMetadataInput {
   scanGenerateThumbnails: Boolean
   "Generate image clip previews during scan"
   scanGenerateClipPreviews: Boolean
+  "Auto-tag new files during scan"
+  autoTagNewFiles: Boolean
+  "Auto-tag options for new files during scan"
+  autoTagOptions: AutoTagMetadataInput
 
   "Filter options for the scan"
   filter: ScanMetaDataFilterInput
@@ -113,6 +117,8 @@ type ScanMetadataOptions {
   scanGenerateThumbnails: Boolean!
   "Generate image clip previews during scan"
   scanGenerateClipPreviews: Boolean!
+  "Auto-tag new files during scan"
+  autoTagNewFiles: Boolean!
 }
 
 input CleanMetadataInput {

--- a/internal/manager/config/tasks.go
+++ b/internal/manager/config/tasks.go
@@ -17,6 +17,8 @@ type ScanMetadataOptions struct {
 	ScanGenerateThumbnails bool `json:"scanGenerateThumbnails"`
 	// Generate image thumbnails during scan
 	ScanGenerateClipPreviews bool `json:"scanGenerateClipPreviews"`
+	// Auto-tag new files during scan
+	AutoTagNewFiles bool `json:"autoTagNewFiles"`
 }
 
 type AutoTagMetadataOptions struct {

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -85,6 +85,9 @@ type ScanMetadataInput struct {
 
 	config.ScanMetadataOptions `mapstructure:",squash"`
 
+	// Auto-tag options for new files during scan
+	AutoTagOptions *AutoTagMetadataInput `json:"autoTagOptions"`
+
 	// Filter options for the scan
 	Filter *ScanMetaDataFilterInput `json:"filter"`
 }
@@ -124,6 +127,7 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		scanner:       scanner,
 		input:         input,
 		subscriptions: s.scanSubs,
+		repository:    s.Repository,
 	}
 
 	return s.JobManager.Add(ctx, "Scanning...", &scanJob), nil

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -90,6 +90,7 @@ export const LibraryTasks: React.FC = () => {
       scanGeneratePhashes: false,
       scanGenerateThumbnails: false,
       scanGenerateClipPreviews: false,
+      autoTagNewFiles: false,
     };
   }
 
@@ -231,10 +232,14 @@ export const LibraryTasks: React.FC = () => {
 
   async function runScan(paths?: string[]) {
     try {
-      await mutateMetadataScan({
-        ...scanOptions,
-        paths,
-      });
+      const scanRequest = { ...scanOptions, paths };
+      
+      // Dynamically include autoTagOptions if autoTagNewFiles is enabled.
+      if (scanOptions.autoTagNewFiles) {
+        Object.assign(scanRequest, { autoTagOptions });
+      }
+
+      await mutateMetadataScan(scanRequest);
 
       Toast.success(
         intl.formatMessage(

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -233,7 +233,7 @@ export const LibraryTasks: React.FC = () => {
   async function runScan(paths?: string[]) {
     try {
       const scanRequest = { ...scanOptions, paths };
-      
+
       // Dynamically include autoTagOptions if autoTagNewFiles is enabled.
       if (scanOptions.autoTagNewFiles) {
         Object.assign(scanRequest, { autoTagOptions });

--- a/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
@@ -20,6 +20,7 @@ export const ScanOptions: React.FC<IScanOptions> = ({
     scanGenerateThumbnails,
     scanGenerateClipPreviews,
     rescan,
+    autoTagNewFiles,
   } = options;
 
   function setOptions(input: Partial<GQL.ScanMetadataInput>) {
@@ -84,6 +85,12 @@ export const ScanOptions: React.FC<IScanOptions> = ({
         tooltipID="config.tasks.rescan_tooltip"
         checked={rescan ?? false}
         onChange={(v) => setOptions({ rescan: v })}
+      />
+      <BooleanSetting
+        id="auto-tag-new-files"
+        headingID="config.tasks.auto_tag_new_files_during_scan"
+        checked={autoTagNewFiles ?? false}
+        onChange={(v) => setOptions({ autoTagNewFiles: v })}
       />
     </>
   );

--- a/ui/v2.5/src/docs/en/Manual/Tasks.md
+++ b/ui/v2.5/src/docs/en/Manual/Tasks.md
@@ -22,6 +22,7 @@ The scan task accepts the following options:
 | Generate thumbnails for images | Generates thumbnails for image files. | 
 | Generate previews for image clips | Generates a gif/looping video as thumbnail for image clips/gifs. |
 | Rescan | By default, Stash will only rescan existing files if the file's modified date has been updated since its previous scan. Stash will rescan files in the path when this option is enabled, regardless of the file modification time. Only required Stash needs to recalculate video/image metadata, or to rescan gallery zips. |
+| Auto tag new files | Auto-tag new files immediately after scan completion. |
 
 ## Auto Tagging
 See the [Auto Tagging](/help/AutoTagging.md) page.

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -466,6 +466,7 @@
         "auto_tagging_paths": "Auto Tagging the following paths"
       },
       "auto_tag_based_on_filenames": "Auto-tag content based on file paths.",
+      "auto_tag_new_files_during_scan": "Auto tag new files",
       "auto_tagging": "Auto Tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",


### PR DESCRIPTION
This PR adds a new auto-tagging option that kicks in for newly scanned files right after a scan finishes.

The main plus is that it's quick, as it just focuses on tagging these fresh files as they come in.

There's a new setting in the scan options so you can turn this feature on or off.

Quick heads-up: An AI helped get the initial code for this started, and it's working fine on my local server.