### PR TITLE
Improve stars rating component with half-star precision

### DIFF
--- a/ui/v2.5/src/components/Shared/Rating/RatingStars.tsx
+++ b/ui/v2.5/src/components/Shared/Rating/RatingStars.tsx
@@ -20,11 +20,17 @@ export interface IRatingStarsProps {
   valueRequired?: boolean;
 }
 
+type HoverState = {
+  star: number;
+  fraction: number;
+};
+
 export const RatingStars: React.FC<IRatingStarsProps> = (
   props: IRatingStarsProps
 ) => {
   const intl = useIntl();
-  const [hoverRating, setHoverRating] = useState<number | undefined>();
+  const [hoverRating, setHoverRating] = useState<HoverState | undefined>();
+  const [hoveredStar, setHoveredStar] = useState<number | undefined>();
   const disabled = props.disabled || !props.onSetRating;
 
   const rating = convertToRatingFormat(props.value, {
@@ -50,35 +56,52 @@ export const RatingStars: React.FC<IRatingStarsProps> = (
     }
   }
 
-  function setRating(thisStar: number) {
+  function setRating(thisStar: number, clickFraction?: number) {
     if (!props.onSetRating) {
       return;
     }
 
     let newRating: number | undefined = thisStar;
 
-    // toggle rating fraction if we're clicking on the current rating
-    if (
-      (stars === thisStar && !fraction) ||
-      (stars + 1 === thisStar && fraction)
-    ) {
-      const f = newToggleFraction();
-      if (!f) {
+    // if we have a click fraction (from half-star clicking), use it directly
+    if (clickFraction !== undefined && precision !== 1) {
+      const targetRating = thisStar - 1 + clickFraction;
+
+      // check if clicking on the same rating to toggle/unset
+      const currentTotal = stars + fraction;
+      if (Math.abs(currentTotal - targetRating) < 0.01) {
         if (props.valueRequired) {
-          if (fraction) {
-            newRating = stars + 1;
-          } else {
-            newRating = stars;
-          }
+          newRating = targetRating;
         } else {
           newRating = undefined;
         }
-      } else if (fraction) {
-        // we're toggling from an existing fraction so use the stars value
-        newRating = stars + f;
       } else {
-        // we're toggling from a whole value, so decrement from current rating
-        newRating = stars - 1 + f;
+        newRating = targetRating;
+      }
+    } else {
+      // original toggle logic for non-half-star clicks or full precision
+      if (
+        (stars === thisStar && !fraction) ||
+        (stars + 1 === thisStar && fraction)
+      ) {
+        const f = newToggleFraction();
+        if (!f) {
+          if (props.valueRequired) {
+            if (fraction) {
+              newRating = stars + 1;
+            } else {
+              newRating = stars;
+            }
+          } else {
+            newRating = undefined;
+          }
+        } else if (fraction) {
+          // we're toggling from an existing fraction so use the stars value
+          newRating = stars + f;
+        } else {
+          // we're toggling from a whole value, so decrement from current rating
+          newRating = stars - 1 + f;
+        }
       }
     }
 
@@ -96,24 +119,127 @@ export const RatingStars: React.FC<IRatingStarsProps> = (
     );
   }
 
-  function onMouseOver(thisStar: number) {
-    if (!disabled) {
-      setHoverRating(thisStar);
+  function getNextRatingForStar(
+    thisStar: number,
+    mouseX?: number
+  ): { star: number; fraction: number } | null {
+    // for half precision with mouse position, detect which half
+    if (precision === 0.5 && mouseX !== undefined) {
+      const isRightHalf = mouseX > 0.5; // mouseX should be normalized 0-1
+      const hoverFraction = isRightHalf ? 1 : 0.5;
+      return { star: thisStar, fraction: hoverFraction };
+    }
+
+    // for other precisions, use the original toggle logic
+    let nextRating = thisStar;
+    let nextFraction = 0;
+
+    if (
+      (stars === thisStar && !fraction) ||
+      (stars + 1 === thisStar && fraction)
+    ) {
+      const f = newToggleFraction();
+      if (!f) {
+        if (props.valueRequired) {
+          if (fraction) {
+            nextRating = stars + 1;
+            nextFraction = 0;
+          } else {
+            nextRating = stars;
+            nextFraction = 0;
+          }
+        } else {
+          // unset rating
+          return null;
+        }
+      } else if (fraction) {
+        nextRating = stars;
+        nextFraction = f;
+      } else {
+        nextRating = stars - 1;
+        nextFraction = f;
+      }
+    } else {
+      nextRating = thisStar - 1;
+      nextFraction = 1;
+    }
+
+    return { star: nextRating + 1, fraction: nextFraction };
+  }
+
+  function updateHoverRating(
+    thisStar: number,
+    event?: React.MouseEvent<HTMLButtonElement>
+  ) {
+    if (disabled) return;
+
+    setHoveredStar(thisStar);
+
+    let mouseX: number | undefined;
+    if (event && precision === 0.5) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      mouseX = (event.clientX - rect.left) / rect.width;
+    }
+
+    const nextRating = getNextRatingForStar(thisStar, mouseX);
+    if (nextRating) {
+      setHoverRating(nextRating);
+    } else {
+      setHoverRating({ star: 0, fraction: 0 }); // unset
+    }
+  }
+
+  function handleClick(
+    event: React.MouseEvent<HTMLButtonElement>,
+    thisStar: number
+  ) {
+    // for half precision, detect which half of the button was clicked
+    if (precision === 0.5) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const clickX = event.clientX - rect.left;
+      const buttonWidth = rect.width;
+      const isRightHalf = clickX > buttonWidth / 2;
+
+      const clickFraction = isRightHalf ? 1 : 0.5;
+      setRating(thisStar, clickFraction);
+    } else {
+      setRating(thisStar);
+    }
+  }
+
+  function onMouseOver(
+    event: React.MouseEvent<HTMLButtonElement>,
+    thisStar: number
+  ) {
+    updateHoverRating(thisStar, event);
+  }
+
+  function onMouseMove(
+    event: React.MouseEvent<HTMLButtonElement>,
+    thisStar: number
+  ) {
+    if (precision === 0.5) {
+      updateHoverRating(thisStar, event);
     }
   }
 
   function onMouseOut(thisStar: number) {
-    if (!disabled && hoverRating === thisStar) {
+    if (!disabled && hoveredStar === thisStar) {
       setHoverRating(undefined);
+      setHoveredStar(undefined);
     }
   }
 
   function getClassName(thisStar: number) {
-    if (hoverRating && hoverRating >= thisStar) {
-      if (hoverRating === stars) {
+    const hoverTotal = hoverRating
+      ? hoverRating.star - 1 + hoverRating.fraction
+      : undefined;
+    const currentTotal = stars + fraction;
+
+    if (hoverTotal !== undefined && hoverTotal >= thisStar) {
+      if (Math.abs(hoverTotal - currentTotal) < 0.01) {
         return "unsetting";
       }
-
       return "setting";
     }
 
@@ -148,38 +274,27 @@ export const RatingStars: React.FC<IRatingStarsProps> = (
   };
 
   function getCurrentSelectedRating(): RatingFraction | undefined {
-    let r: number = hoverRating ? hoverRating : stars;
-    let f: number | undefined = fraction;
-
     if (hoverRating) {
-      if (hoverRating === stars && precision === 1) {
-        if (props.valueRequired) {
-          return { rating: r, fraction: 0 };
-        }
-
-        // unsetting
-        return undefined;
-      }
-      if (hoverRating === stars + 1 && fraction && fraction === precision) {
-        if (props.valueRequired) {
-          return { rating: r, fraction: 0 };
-        }
-        // unsetting
+      // star 0 means unset
+      if (hoverRating.star === 0) {
         return undefined;
       }
 
-      if (f && hoverRating === stars + 1) {
-        f = newToggleFraction();
-        r--;
-      } else if (!f && hoverRating === stars) {
-        f = newToggleFraction();
-        r--;
-      } else {
-        f = 0;
+      const hoverTotal = hoverRating.star - 1 + hoverRating.fraction;
+      const currentTotal = stars + fraction;
+
+      // check if hovering over current rating (for unsetting)
+      if (Math.abs(hoverTotal - currentTotal) < 0.01 && !props.valueRequired) {
+        return undefined;
       }
+
+      return {
+        rating: hoverRating.star - 1,
+        fraction: hoverRating.fraction,
+      };
     }
 
-    return { rating: r, fraction: f ?? 0 };
+    return { rating: stars, fraction: fraction };
   }
 
   function getButtonClassName(
@@ -205,11 +320,18 @@ export const RatingStars: React.FC<IRatingStarsProps> = (
       <Button
         disabled={disabled}
         className={`minimal ${getButtonClassName(thisStar, ratingFraction)}`}
-        onClick={() => setRating(thisStar)}
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+          handleClick(event, thisStar)
+        }
         variant="secondary"
-        onMouseEnter={() => onMouseOver(thisStar)}
+        onMouseEnter={(event: React.MouseEvent<HTMLButtonElement>) =>
+          onMouseOver(event, thisStar)
+        }
+        onMouseMove={(event: React.MouseEvent<HTMLButtonElement>) =>
+          onMouseMove(event, thisStar)
+        }
         onMouseLeave={() => onMouseOut(thisStar)}
-        onFocus={() => onMouseOver(thisStar)}
+        onFocus={() => updateHoverRating(thisStar)}
         onBlur={() => onMouseOut(thisStar)}
         title={getTooltip(thisStar, ratingFraction)}
         key={`star-${thisStar}`}


### PR DESCRIPTION
Ever since i started using stash it always annoyed me that i need to press a star twice in order to rate half star.
This PR makes it so that if you have half precision selected you can instantly rate a image half a rating:


![Kooha-2025-06-02-22-22-32](https://github.com/user-attachments/assets/5edf142d-99ca-4b35-9054-d452660d9b24)

quarter and tenth precision logic remains unchanged

I did run `make validate` to make sure all if fine