### PR TITLE
fix(scene_merge): Retain source's preview when merge target's file is deleted

### DIFF
--- a/pkg/scene/merge.go
+++ b/pkg/scene/merge.go
@@ -118,7 +118,7 @@ func (s *Service) Merge(ctx context.Context, sourceIDs []int, destinationID int,
 
 	// delete old scenes
 	for _, src := range sources {
-		const deleteGenerated = true
+		const deleteGenerated = false
 		const deleteFile = false
 		if err := s.Destroy(ctx, src, fileDeleter, deleteGenerated, deleteFile); err != nil {
 			return fmt.Errorf("deleting scene %d: %w", src.ID, err)


### PR DESCRIPTION
This fixes a quirk with scene merge previews.
Previously, if you merged Scene A into Scene B, then deleted Scene B's original file (making Scene A's file the primary one for the merged scene), Scene A's existing preview wouldn't stick, often forcing a regeneration.
Now, Scene A's preview is correctly kept and used in this specific scenario.
Quick heads-up: An AI helped draft the code for this fix, and it's been working fine on my local server.