### PR TITLE
Slightly simplify code after PR #5894

### DIFF
--- a/pkg/stashbox/scene.go
+++ b/pkg/stashbox/scene.go
@@ -287,10 +287,7 @@ func newSceneDraftInput(d SceneDraft, endpoint string) graphql.SceneDraftInput {
 	if scene.Director != "" {
 		draft.Director = &scene.Director
 	}
-	draft.Urls = make([]string, len(scene.URLs.List()))
-	for i, v := range scene.URLs.List() {
-		draft.Urls[i] = v
-	}
+	draft.Urls = scene.URLs.List()
 
 	if scene.Date != nil {
 		v := scene.Date.String()


### PR DESCRIPTION
The code looks like it does because it initially used string pointers; however, the version that landed used a regular string array, so we can just the = operator.