### PR TITLE
Filter performers/tags/studios list by current filter

### DIFF
--- a/ui/v2.5/src/components/List/Filters/StudiosFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/StudiosFilter.tsx
@@ -1,11 +1,19 @@
 import React, { ReactNode, useMemo } from "react";
-import { useFindStudiosForSelectQuery } from "src/core/generated-graphql";
+import {
+  StudioDataFragment,
+  StudioFilterType,
+  useFindStudiosForSelectQuery,
+} from "src/core/generated-graphql";
 import { HierarchicalObjectsFilter } from "./SelectableFilter";
 import { StudiosCriterion } from "src/models/list-filter/criteria/studios";
 import { sortByRelevance } from "src/utils/query";
 import { CriterionOption } from "src/models/list-filter/criteria/criterion";
 import { ListFilterModel } from "src/models/list-filter/filter";
-import { useLabeledIdFilterState } from "./LabeledIdFilter";
+import {
+  makeQueryVariables,
+  setObjectFilter,
+  useLabeledIdFilterState,
+} from "./LabeledIdFilter";
 import { SidebarListFilter } from "./SidebarListFilter";
 
 interface IStudiosFilter {
@@ -13,32 +21,61 @@ interface IStudiosFilter {
   setCriterion: (c: StudiosCriterion) => void;
 }
 
-function useStudioQuery(query: string, skip?: boolean) {
+function queryVariables(query: string, f?: ListFilterModel) {
+  const studioFilter: StudioFilterType = {};
+
+  if (f) {
+    const filterOutput = f.makeFilter();
+
+    // always remove studio filter from the filter
+    // since modifier is includes
+    delete filterOutput.studios;
+
+    // TODO - look for same in AND?
+
+    setObjectFilter(studioFilter, f.mode, filterOutput);
+  }
+
+  return makeQueryVariables(query, { studio_filter: studioFilter });
+}
+
+function sortResults(
+  query: string,
+  studios: Pick<StudioDataFragment, "id" | "name" | "aliases">[]
+) {
+  return sortByRelevance(
+    query,
+    studios ?? [],
+    (s) => s.name,
+    (s) => s.aliases
+  ).map((p) => {
+    return {
+      id: p.id,
+      label: p.name,
+    };
+  });
+}
+
+function useStudioQueryFilter(
+  query: string,
+  filter?: ListFilterModel,
+  skip?: boolean
+) {
   const { data, loading } = useFindStudiosForSelectQuery({
-    variables: {
-      filter: {
-        q: query,
-        per_page: 200,
-      },
-    },
+    variables: queryVariables(query, filter),
     skip,
   });
 
-  const results = useMemo(() => {
-    return sortByRelevance(
-      query,
-      data?.findStudios.studios ?? [],
-      (s) => s.name,
-      (s) => s.aliases
-    ).map((p) => {
-      return {
-        id: p.id,
-        label: p.name,
-      };
-    });
-  }, [data, query]);
+  const results = useMemo(
+    () => sortResults(query, data?.findStudios.studios ?? []),
+    [data?.findStudios.studios, query]
+  );
 
   return { results, loading };
+}
+
+function useStudioQuery(query: string, skip?: boolean) {
+  return useStudioQueryFilter(query, undefined, skip);
 }
 
 const StudiosFilter: React.FC<IStudiosFilter> = ({
@@ -65,7 +102,7 @@ export const SidebarStudiosFilter: React.FC<{
     filter,
     setFilter,
     option,
-    useQuery: useStudioQuery,
+    useQuery: useStudioQueryFilter,
     singleValue: true,
     hierarchical: true,
     includeSubMessageID: "subsidiary_studios",


### PR DESCRIPTION
This PR builds on the sidebar filter work by filtering out studios/performers/tags from the list based on the current filter.

For example, when selecting Studio `X`, the tags filter list will only show tags from scenes that have that studio. The only current limitation is that it does not take the search query into account. This is due to the search query field being on a separate input type and not on the studio/performer/tag filter input type. This will be addressed in another PR.