### PR TITLE
feat: Allow multiple aliases for groups

### DIFF
--- a/graphql/schema/types/group.graphql
+++ b/graphql/schema/types/group.graphql
@@ -7,7 +7,7 @@ type GroupDescription {
 type Group {
   id: ID!
   name: String!
-  aliases: String
+  aliases: [String!]
   "Duration in seconds"
   duration: Int
   date: String
@@ -38,7 +38,7 @@ input GroupDescriptionInput {
 
 input GroupCreateInput {
   name: String!
-  aliases: String
+  aliases: [String!]
   "Duration in seconds"
   duration: Int
   date: String
@@ -62,7 +62,7 @@ input GroupCreateInput {
 input GroupUpdateInput {
   id: ID!
   name: String
-  aliases: String
+  aliases: [String!]
   duration: Int
   date: String
   # rating expressed as 1-100

--- a/internal/api/changeset_translator.go
+++ b/internal/api/changeset_translator.go
@@ -293,6 +293,19 @@ func (t changesetTranslator) optionalURLs(value []string, legacyValue *string) *
 	return nil
 }
 
+func (t changesetTranslator) optionalAliases(value *string, field string) *models.UpdateStrings {
+	if !t.hasField(field) {
+		return nil
+	}
+
+	var valueSlice []string
+	if value != nil {
+		valueSlice = []string{*value}
+	}
+
+	return t.updateStrings(valueSlice, field)
+}
+
 func (t changesetTranslator) optionalURLsBulk(value *BulkUpdateStrings, legacyValue *string) *models.UpdateStrings {
 	const (
 		legacyField = "url"

--- a/internal/api/resolver_model_movie.go
+++ b/internal/api/resolver_model_movie.go
@@ -22,6 +22,37 @@ func (r *groupResolver) Rating100(ctx context.Context, obj *models.Group) (*int,
 	return obj.Rating, nil
 }
 
+// Movie resolver - returns single alias as *string
+func (r *movieResolver) Aliases(ctx context.Context, obj *models.Group) (*string, error) {
+	if !obj.Aliases.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadAliases(ctx, r.repository.Group)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	aliases := obj.Aliases.List()
+	if len(aliases) == 0 {
+		return nil, nil
+	}
+
+	return &aliases[0], nil
+}
+
+// Group resolver - returns all aliases as []string
+func (r *groupResolver) Aliases(ctx context.Context, obj *models.Group) ([]string, error) {
+	if !obj.Aliases.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadAliases(ctx, r.repository.Group)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return obj.Aliases.List(), nil
+}
+
 func (r *groupResolver) URL(ctx context.Context, obj *models.Group) (*string, error) {
 	if !obj.URLs.Loaded() {
 		if err := r.withReadTxn(ctx, func(ctx context.Context) error {

--- a/internal/api/resolver_mutation_group.go
+++ b/internal/api/resolver_mutation_group.go
@@ -22,7 +22,6 @@ func groupFromGroupCreateInput(ctx context.Context, input GroupCreateInput) (*mo
 	newGroup := models.NewGroup()
 
 	newGroup.Name = input.Name
-	newGroup.Aliases = translator.string(input.Aliases)
 	newGroup.Duration = input.Duration
 	newGroup.Rating = input.Rating100
 	newGroup.Director = translator.string(input.Director)
@@ -56,6 +55,10 @@ func groupFromGroupCreateInput(ctx context.Context, input GroupCreateInput) (*mo
 
 	if input.Urls != nil {
 		newGroup.URLs = models.NewRelatedStrings(input.Urls)
+	}
+
+	if input.Aliases != nil {
+		newGroup.Aliases = models.NewRelatedStrings(input.Aliases)
 	}
 
 	return &newGroup, nil
@@ -113,7 +116,7 @@ func groupPartialFromGroupUpdateInput(translator changesetTranslator, input Grou
 	updatedGroup := models.NewGroupPartial()
 
 	updatedGroup.Name = translator.optionalString(input.Name, "name")
-	updatedGroup.Aliases = translator.optionalString(input.Aliases, "aliases")
+	updatedGroup.Aliases = translator.updateStrings(input.Aliases, "aliases")
 	updatedGroup.Duration = translator.optionalInt(input.Duration, "duration")
 	updatedGroup.Rating = translator.optionalInt(input.Rating100, "rating100")
 	updatedGroup.Director = translator.optionalString(input.Director, "director")

--- a/internal/api/resolver_mutation_movie.go
+++ b/internal/api/resolver_mutation_movie.go
@@ -33,7 +33,6 @@ func (r *mutationResolver) MovieCreate(ctx context.Context, input MovieCreateInp
 	newGroup := models.NewGroup()
 
 	newGroup.Name = input.Name
-	newGroup.Aliases = translator.string(input.Aliases)
 	newGroup.Duration = input.Duration
 	newGroup.Rating = input.Rating100
 	newGroup.Director = translator.string(input.Director)
@@ -53,6 +52,10 @@ func (r *mutationResolver) MovieCreate(ctx context.Context, input MovieCreateInp
 	newGroup.TagIDs, err = translator.relatedIds(input.TagIds)
 	if err != nil {
 		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	if input.Aliases != nil {
+		newGroup.Aliases = models.NewRelatedStrings([]string{*input.Aliases})
 	}
 
 	if input.Urls != nil {
@@ -132,7 +135,6 @@ func (r *mutationResolver) MovieUpdate(ctx context.Context, input MovieUpdateInp
 	updatedGroup := models.NewGroupPartial()
 
 	updatedGroup.Name = translator.optionalString(input.Name, "name")
-	updatedGroup.Aliases = translator.optionalString(input.Aliases, "aliases")
 	updatedGroup.Duration = translator.optionalInt(input.Duration, "duration")
 	updatedGroup.Rating = translator.optionalInt(input.Rating100, "rating100")
 	updatedGroup.Director = translator.optionalString(input.Director, "director")
@@ -153,6 +155,7 @@ func (r *mutationResolver) MovieUpdate(ctx context.Context, input MovieUpdateInp
 	}
 
 	updatedGroup.URLs = translator.optionalURLs(input.Urls, input.URL)
+	updatedGroup.Aliases = translator.optionalAliases(input.Aliases, "aliases")
 
 	var frontimageData []byte
 	frontImageIncluded := translator.hasField("front_image")

--- a/internal/manager/task_export.go
+++ b/internal/manager/task_export.go
@@ -1161,6 +1161,10 @@ func (t *ExportTask) exportGroup(ctx context.Context, wg *sync.WaitGroup, jobCha
 	tagReader := r.Tag
 
 	for m := range jobChan {
+		if err := m.LoadAliases(ctx, r.Group); err != nil {
+			logger.Errorf("[groups] <%s> error getting group aliases: %v", m.Name, err)
+			continue
+		}
 		if err := m.LoadURLs(ctx, r.Group); err != nil {
 			logger.Errorf("[groups] <%s> error getting group urls: %v", m.Name, err)
 			continue

--- a/pkg/group/export.go
+++ b/pkg/group/export.go
@@ -20,7 +20,7 @@ type ImageGetter interface {
 func ToJSON(ctx context.Context, reader ImageGetter, studioReader models.StudioGetter, movie *models.Group) (*jsonschema.Group, error) {
 	newMovieJSON := jsonschema.Group{
 		Name:      movie.Name,
-		Aliases:   movie.Aliases,
+		Aliases:   movie.Aliases.List(),
 		Director:  movie.Director,
 		Synopsis:  movie.Synopsis,
 		URLs:      movie.URLs.List(),

--- a/pkg/group/export_test.go
+++ b/pkg/group/export_test.go
@@ -29,7 +29,8 @@ const (
 )
 
 const movieName = "testMovie"
-const movieAliases = "aliases"
+
+var movieAliases = []string{"aliases", "alias2"}
 
 var (
 	date       = "2001-01-01"
@@ -66,7 +67,7 @@ func createFullMovie(id int, studioID int) models.Group {
 	return models.Group{
 		ID:        id,
 		Name:      movieName,
-		Aliases:   movieAliases,
+		Aliases:   models.NewRelatedStrings(movieAliases),
 		Date:      &dateObj,
 		Rating:    &rating,
 		Duration:  &duration,
@@ -83,6 +84,7 @@ func createEmptyMovie(id int) models.Group {
 	return models.Group{
 		ID:        id,
 		URLs:      models.NewRelatedStrings([]string{}),
+		Aliases:   models.NewRelatedStrings([]string{}),
 		CreatedAt: createTime,
 		UpdatedAt: updateTime,
 	}
@@ -112,7 +114,8 @@ func createFullJSONMovie(studio, frontImage, backImage string) *jsonschema.Group
 
 func createEmptyJSONMovie() *jsonschema.Group {
 	return &jsonschema.Group{
-		URLs: []string{},
+		URLs:    []string{},
+		Aliases: []string{},
 		CreatedAt: json.JSONTime{
 			Time: createTime,
 		},

--- a/pkg/group/import.go
+++ b/pkg/group/import.go
@@ -140,13 +140,17 @@ func createTags(ctx context.Context, tagWriter models.TagFinderCreator, names []
 func (i *Importer) groupJSONToGroup(groupJSON jsonschema.Group) models.Group {
 	newGroup := models.Group{
 		Name:      groupJSON.Name,
-		Aliases:   groupJSON.Aliases,
 		Director:  groupJSON.Director,
 		Synopsis:  groupJSON.Synopsis,
 		CreatedAt: groupJSON.CreatedAt.GetTime(),
 		UpdatedAt: groupJSON.UpdatedAt.GetTime(),
 
 		TagIDs: models.NewRelatedIDs([]int{}),
+	}
+
+	// Convert aliases array to RelatedStrings
+	if len(groupJSON.Aliases) > 0 {
+		newGroup.Aliases = models.NewRelatedStrings(groupJSON.Aliases)
 	}
 
 	if len(groupJSON.URLs) > 0 {

--- a/pkg/models/jsonschema/group.go
+++ b/pkg/models/jsonschema/group.go
@@ -18,7 +18,7 @@ type SubGroupDescription struct {
 
 type Group struct {
 	Name       string                `json:"name,omitempty"`
-	Aliases    string                `json:"aliases,omitempty"`
+	Aliases    []string              `json:"aliases,omitempty"`
 	Duration   int                   `json:"duration,omitempty"`
 	Date       string                `json:"date,omitempty"`
 	Rating     int                   `json:"rating,omitempty"`

--- a/pkg/models/mocks/GroupReaderWriter.go
+++ b/pkg/models/mocks/GroupReaderWriter.go
@@ -266,6 +266,29 @@ func (_m *GroupReaderWriter) FindMany(ctx context.Context, ids []int) ([]*models
 	return r0, r1
 }
 
+// GetAliases provides a mock function with given fields: ctx, relatedID
+func (_m *GroupReaderWriter) GetAliases(ctx context.Context, relatedID int) ([]string, error) {
+	ret := _m.Called(ctx, relatedID)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context, int) []string); ok {
+		r0 = rf(ctx, relatedID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, relatedID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetBackImage provides a mock function with given fields: ctx, groupID
 func (_m *GroupReaderWriter) GetBackImage(ctx context.Context, groupID int) ([]byte, error) {
 	ret := _m.Called(ctx, groupID)

--- a/pkg/models/model_group.go
+++ b/pkg/models/model_group.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Group struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	Aliases  string `json:"aliases"`
-	Duration *int   `json:"duration"`
-	Date     *Date  `json:"date"`
+	ID       int            `json:"id"`
+	Name     string         `json:"name"`
+	Aliases  RelatedStrings `json:"aliases"`
+	Duration *int           `json:"duration"`
+	Date     *Date          `json:"date"`
 	// Rating expressed in 1-100 scale
 	Rating    *int      `json:"rating"`
 	StudioID  *int      `json:"studio_id"`
@@ -32,6 +32,12 @@ func NewGroup() Group {
 		CreatedAt: currentTime,
 		UpdatedAt: currentTime,
 	}
+}
+
+func (m *Group) LoadAliases(ctx context.Context, l AliasLoader) error {
+	return m.Aliases.load(func() ([]string, error) {
+		return l.GetAliases(ctx, m.ID)
+	})
 }
 
 func (m *Group) LoadURLs(ctx context.Context, l URLLoader) error {
@@ -60,7 +66,7 @@ func (m *Group) LoadSubGroupIDs(ctx context.Context, l SubGroupLoader) error {
 
 type GroupPartial struct {
 	Name     OptionalString
-	Aliases  OptionalString
+	Aliases  *UpdateStrings
 	Duration OptionalInt
 	Date     OptionalDate
 	// Rating expressed in 1-100 scale

--- a/pkg/models/repository_group.go
+++ b/pkg/models/repository_group.go
@@ -64,6 +64,7 @@ type GroupReader interface {
 	GroupFinder
 	GroupQueryer
 	GroupCounter
+	AliasLoader
 	URLLoader
 	TagIDLoader
 	ContainingGroupLoader

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 72
+var appSchemaVersion uint = 73
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/73_group_aliases.up.sql
+++ b/pkg/sqlite/migrations/73_group_aliases.up.sql
@@ -1,0 +1,80 @@
+PRAGMA foreign_keys=OFF;
+
+-- Create groups_aliases table
+CREATE TABLE `groups_aliases` (
+  `group_id` integer NOT NULL,
+  `alias` varchar(255) NOT NULL,
+  foreign key(`group_id`) references `groups`(`id`) on delete CASCADE,
+  PRIMARY KEY(`group_id`, `alias`)
+);
+
+CREATE INDEX `groups_aliases_alias` on `groups_aliases` (`alias`);
+
+-- Migrate existing aliases data
+INSERT INTO `groups_aliases`
+  (
+    `group_id`,
+    `alias`
+  )
+  SELECT 
+    `id`,
+    `aliases`
+  FROM `groups`
+  WHERE `groups`.`aliases` IS NOT NULL AND `groups`.`aliases` != '';
+
+-- Create new groups table without aliases column
+CREATE TABLE `groups_new` (
+  `id` integer not null primary key autoincrement,
+  `name` varchar(255) not null,
+  `duration` integer,
+  `date` date,
+  `rating` tinyint,
+  `studio_id` integer REFERENCES `studios`(`id`) ON DELETE SET NULL,
+  `director` varchar(255),
+  `description` text,
+  `created_at` datetime not null,
+  `updated_at` datetime not null,
+  `front_image_blob` varchar(255) REFERENCES `blobs`(`checksum`),
+  `back_image_blob` varchar(255) REFERENCES `blobs`(`checksum`)
+);
+
+-- Copy data from old table to new table (excluding aliases)
+INSERT INTO `groups_new`
+  (
+    `id`,
+    `name`,
+    `duration`,
+    `date`,
+    `rating`,
+    `studio_id`,
+    `director`,
+    `description`,
+    `created_at`,
+    `updated_at`,
+    `front_image_blob`,
+    `back_image_blob`
+  )
+  SELECT 
+    `id`,
+    `name`,
+    `duration`,
+    `date`,
+    `rating`,
+    `studio_id`,
+    `director`,
+    `description`,
+    `created_at`,
+    `updated_at`,
+    `front_image_blob`,
+    `back_image_blob`
+  FROM `groups`;
+
+-- Drop old table and rename new one
+DROP TABLE `groups`;
+ALTER TABLE `groups_new` rename to `groups`;
+
+-- Recreate indexes
+CREATE INDEX `index_groups_on_name` ON `groups`(`name`);
+CREATE INDEX `index_groups_on_studio_id` on `groups` (`studio_id`);
+
+PRAGMA foreign_keys=ON; 

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -44,6 +44,8 @@ var (
 
 	tagsAliasesJoinTable  = goqu.T(tagAliasesTable)
 	tagRelationsJoinTable = goqu.T(tagRelationsTable)
+
+	groupsAliasesJoinTable = goqu.T(groupsAliasesTable)
 )
 
 var (
@@ -368,6 +370,14 @@ var (
 
 	groupRelationshipTableMgr = &table{
 		table: groupRelationsJoinTable,
+	}
+
+	groupsAliasesTableMgr = &stringTable{
+		table: table{
+			table:    groupsAliasesJoinTable,
+			idColumn: groupsAliasesJoinTable.Col(groupIDColumn),
+		},
+		stringColumn: groupsAliasesJoinTable.Col("alias"),
 	}
 )
 

--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -146,7 +146,7 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
   const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
   const aliases = useMemo(
-    () => (group.aliases ? [group.aliases] : []),
+    () => (group.aliases ? group.aliases : []),
     [group.aliases]
   );
 

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
@@ -66,7 +66,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
 
   const schema = yup.object({
     name: yup.string().required(),
-    aliases: yup.string().ensure(),
+    aliases: yupUniqueStringList(intl),
     duration: yup.number().integer().min(0).nullable().defined(),
     date: yupDateString(intl),
     studio_id: yup.string().required().nullable(),
@@ -88,7 +88,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
 
   const initialValues = {
     name: group?.name ?? "",
-    aliases: group?.aliases ?? "",
+    aliases: group?.aliases ?? [],
     duration: group?.duration ?? null,
     date: group?.date ?? "",
     studio_id: group?.studio?.id ?? null,
@@ -165,7 +165,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     }
 
     if (state.aliases) {
-      formik.setFieldValue("aliases", state.aliases);
+      formik.setFieldValue("aliases", state.aliases ? [state.aliases] : []);
     }
 
     if (state.duration) {
@@ -376,6 +376,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     renderDateField,
     renderDurationField,
     renderURLListField,
+    renderStringListField,
   } = formikUtils(intl, formik);
 
   function renderStudioField() {
@@ -444,7 +445,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
 
       <Form noValidate onSubmit={formik.handleSubmit} id="group-edit">
         {renderInputField("name")}
-        {renderInputField("aliases")}
+        {renderStringListField("aliases")}
         {renderDurationField("duration")}
         {renderDateField("date")}
         {renderContainingGroupsField()}

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupScrapeDialog.tsx
@@ -43,7 +43,9 @@ export const GroupScrapeDialog: React.FC<IGroupScrapeDialogProps> = ({
   );
   const [aliases, setAliases] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(
-      group.aliases && group.aliases.length > 0 ? group.aliases.join(", ") : undefined,
+      group.aliases && group.aliases.length > 0
+        ? group.aliases.join(", ")
+        : undefined,
       scraped.aliases
     )
   );

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupScrapeDialog.tsx
@@ -42,7 +42,10 @@ export const GroupScrapeDialog: React.FC<IGroupScrapeDialogProps> = ({
     new ScrapeResult<string>(group.name, scraped.name)
   );
   const [aliases, setAliases] = useState<ScrapeResult<string>>(
-    new ScrapeResult<string>(group.aliases, scraped.aliases)
+    new ScrapeResult<string>(
+      group.aliases && group.aliases.length > 0 ? group.aliases.join(", ") : undefined,
+      scraped.aliases
+    )
   );
   const [duration, setDuration] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(

--- a/ui/v2.5/src/components/Groups/GroupSelect.tsx
+++ b/ui/v2.5/src/components/Groups/GroupSelect.tsx
@@ -111,7 +111,7 @@ export const GroupSelect: React.FC<
     const { inputValue } = optionProps.selectProps;
     let alias: string | undefined = "";
     if (!title.toLowerCase().includes(inputValue.toLowerCase())) {
-      const matchingAlias = object.aliases?.find(a => 
+      const matchingAlias = object.aliases?.find((a) =>
         a.toLowerCase().includes(inputValue.toLowerCase())
       );
       alias = matchingAlias;
@@ -219,7 +219,10 @@ export const GroupSelect: React.FC<
       options.some((o) => {
         return (
           o.name.toLowerCase() === inputValue.toLowerCase() ||
-          (o.aliases && o.aliases.some(alias => alias.toLowerCase() === inputValue.toLowerCase()))
+          (o.aliases &&
+            o.aliases.some(
+              (alias) => alias.toLowerCase() === inputValue.toLowerCase()
+            ))
         );
       })
     ) {

--- a/ui/v2.5/src/components/Groups/GroupSelect.tsx
+++ b/ui/v2.5/src/components/Groups/GroupSelect.tsx
@@ -47,7 +47,7 @@ function sortGroupsByRelevance(input: string, groups: FindGroupsResult) {
     input,
     groups,
     (m) => m.name,
-    (m) => (m.aliases ? [m.aliases] : [])
+    (m) => m.aliases ?? []
   );
 }
 
@@ -111,7 +111,10 @@ export const GroupSelect: React.FC<
     const { inputValue } = optionProps.selectProps;
     let alias: string | undefined = "";
     if (!title.toLowerCase().includes(inputValue.toLowerCase())) {
-      alias = object.aliases || undefined;
+      const matchingAlias = object.aliases?.find(a => 
+        a.toLowerCase().includes(inputValue.toLowerCase())
+      );
+      alias = matchingAlias;
     }
 
     thisOptionProps = {
@@ -216,7 +219,7 @@ export const GroupSelect: React.FC<
       options.some((o) => {
         return (
           o.name.toLowerCase() === inputValue.toLowerCase() ||
-          o.aliases?.toLowerCase() === inputValue.toLowerCase()
+          (o.aliases && o.aliases.some(alias => alias.toLowerCase() === inputValue.toLowerCase()))
         );
       })
     ) {

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -221,7 +221,13 @@ export const ScrapedGroupsRow: React.FC<
     const value = resultValue ?? [];
 
     const selectValue = value.map((p) => {
-      const aliases: string = "";
+      // Convert ScrapedGroup's single aliases string to Group's aliases array
+      const aliases: string[] = p.aliases
+        ? p.aliases
+            .split(",")
+            .map((a) => a.trim())
+            .filter((a) => a)
+        : [];
       return {
         id: p.stored_id ?? "",
         name: p.name ?? "",
@@ -236,8 +242,16 @@ export const ScrapedGroupsRow: React.FC<
         isDisabled={!isNew}
         onSelect={(items) => {
           if (onChangeFn) {
-            // map the id back to stored_id
-            onChangeFn(items.map((p) => ({ ...p, stored_id: p.id })));
+            // map the id back to stored_id and convert aliases array back to comma-separated string
+            onChangeFn(
+              items.map((p) => ({
+                ...p,
+                stored_id: p.id,
+                aliases: Array.isArray(p.aliases)
+                  ? p.aliases.join(", ")
+                  : p.aliases,
+              }))
+            );
           }
         }}
         values={selectValue}

--- a/ui/v2.5/src/core/groups.ts
+++ b/ui/v2.5/src/core/groups.ts
@@ -5,7 +5,12 @@ export const scrapedGroupToCreateInput = (toCreate: GQL.ScrapedGroup) => {
   const input: GQL.GroupCreateInput = {
     name: toCreate.name ?? "",
     urls: toCreate.urls,
-    aliases: toCreate.aliases,
+    aliases: toCreate.aliases
+      ? toCreate.aliases
+          .split(",")
+          .map((a) => a.trim())
+          .filter((a) => a)
+      : undefined,
     front_image: toCreate.front_image,
     back_image: toCreate.back_image,
     synopsis: toCreate.synopsis,


### PR DESCRIPTION
This PR updates groups to support multiple aliases, making their behavior consistent with other entity types.
This change includes a database migration to update the schema.
The initial code was drafted with AI assistance.
Confirmed working as expected on my local server.