### PR TITLE
Feat: Add Performer Scene Toggle on Tag Detail Page

### DIFF
--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -85,6 +85,8 @@ const TagTabs: React.FC<{
   const [showAllDetails, setShowAllDetails] = useState<boolean>(
     showAllCounts && tag.children.length > 0
   );
+  const [showPerformerScenes, setShowPerformerScenes] =
+    useState<boolean>(false);
 
   const sceneCount =
     (showAllDetails ? tag.scene_count_all : tag.scene_count) ?? 0;
@@ -154,6 +156,20 @@ const TagTabs: React.FC<{
       </div>
     );
   }, [showAllDetails, tag.children.length]);
+
+  const performerContentSwitch = useMemo(() => {
+    const performerScenesSwitch = (
+      <Form.Check
+        id="showPerformerScenes"
+        checked={showPerformerScenes}
+        onChange={() => setShowPerformerScenes(!showPerformerScenes)}
+        type="switch"
+        label={<FormattedMessage id="show_performer_scenes" />}
+      />
+    );
+
+    return <div className="item-list-header">{performerScenesSwitch}</div>;
+  }, [showPerformerScenes]);
 
   return (
     <Tabs
@@ -259,10 +275,12 @@ const TagTabs: React.FC<{
         }
       >
         {contentSwitch}
+        {performerContentSwitch}
         <TagPerformersPanel
           active={tabKey === "performers"}
           tag={tag}
           showSubTagContent={showAllDetails}
+          showPerformerScenes={showPerformerScenes}
         />
       </Tab>
       <Tab

--- a/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagPerformersPanel.tsx
@@ -2,23 +2,70 @@ import React from "react";
 import * as GQL from "src/core/generated-graphql";
 import { useTagFilterHook } from "src/core/tags";
 import { PerformerList } from "src/components/Performers/PerformerList";
+import { FilteredSceneList } from "src/components/Scenes/SceneList";
 import { View } from "src/components/List/views";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import {
+  TagsCriterion,
+  PerformerTagsCriterionOption,
+} from "src/models/list-filter/criteria/tags";
 
 interface ITagPerformersPanel {
   active: boolean;
   tag: GQL.TagDataFragment;
   showSubTagContent?: boolean;
+  showPerformerScenes?: boolean;
 }
 
 export const TagPerformersPanel: React.FC<ITagPerformersPanel> = ({
   active,
   tag,
   showSubTagContent,
+  showPerformerScenes,
 }) => {
-  const filterHook = useTagFilterHook(tag, showSubTagContent);
+  // Hook for filtering performers by tag
+  const performerFilterHook = useTagFilterHook(tag, showSubTagContent);
+
+  // Custom filter hook for finding scenes with performers that have this tag
+  const performerScenesFilterHook = (baseFilter: ListFilterModel) => {
+    // Clone to avoid mutating original
+    const newFilter = baseFilter.clone();
+
+    // Remove any existing performer_tags criteria to prevent duplicates
+    newFilter.criteria = newFilter.criteria.filter(
+      (c) => c.criterionOption.type !== "performer_tags"
+    );
+
+    const tagValue = { id: tag.id, label: tag.name };
+
+    const performerTagsCriterion = new TagsCriterion(
+      PerformerTagsCriterionOption
+    );
+    performerTagsCriterion.value = {
+      items: [tagValue],
+      excluded: [],
+      depth: showSubTagContent ? -1 : 0,
+    };
+    performerTagsCriterion.modifier = GQL.CriterionModifier.IncludesAll;
+
+    newFilter.criteria.push(performerTagsCriterion);
+
+    return newFilter;
+  };
+
+  if (showPerformerScenes) {
+    return (
+      <FilteredSceneList
+        filterHook={performerScenesFilterHook}
+        alterQuery={false}
+        view={View.TagScenes}
+      />
+    );
+  }
+
   return (
     <PerformerList
-      filterHook={filterHook}
+      filterHook={performerFilterHook}
       alterQuery={active}
       view={View.TagPerformers}
     />

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1136,6 +1136,7 @@
   "include_sub_studios": "Include subsidiary studios",
   "include_sub_tag_content": "Include sub-tag content",
   "include_sub_tags": "Include sub-tags",
+  "show_performer_scenes": "Show Performer Scenes",
   "index_of_total": "{index} of {total}",
   "instagram": "Instagram",
   "interactive": "Interactive",


### PR DESCRIPTION
This PR introduces a new toggle on the tag detail page within the performer tab. This toggle allows users to easily view all scenes featuring the performers associated with that specific tag, providing a more streamlined way to see a performer's scenes from the tag detail page.

It also works seamlessly with the existing "Include Sub-Tag Content" toggle.

This feature was developed with the assistance of AI and has been tested locally.