### PR TITLE
Add useLightbox and useGalleryLightbox in plugin api

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -83,6 +83,8 @@ Returns a `Promise<void>` that resolves when all of the components have been loa
 ### `hooks`
 
 This namespace provides access to the following core utility hooks:
+- `useGalleryLightbox`
+- `useLightbox`
 - `useSpriteInfo`
 - `useToast`
 

--- a/ui/v2.5/src/pluginApi.d.ts
+++ b/ui/v2.5/src/pluginApi.d.ts
@@ -1046,6 +1046,16 @@ declare namespace PluginApi {
       uploadScript: (funscriptPath: string) => Promise<void>;
       sync: () => Promise<void>;
     };
+
+    function useLightbox(): {
+      state: any;
+      chapters: any;
+    };
+
+    function useGalleryLightbox(): {
+      id: string;
+      chapters: any;
+    };
   }
   namespace patch {
     function before(target: PatchableComponentNames, fn: Function): void;

--- a/ui/v2.5/src/pluginApi.tsx
+++ b/ui/v2.5/src/pluginApi.tsx
@@ -19,6 +19,7 @@ import Event from "./hooks/event";
 import { before, instead, after, components, RegisterComponent } from "./patch";
 import { useSettings } from "./components/Settings/context";
 import { useInteractive } from "./hooks/Interactive/context";
+import { useLightbox, useGalleryLightbox } from "./hooks/Lightbox/hooks";
 
 // due to code splitting, some components may not have been loaded when a plugin
 // page is loaded. This function will load all components passed to it.
@@ -161,6 +162,8 @@ export const PluginApi = {
     useToast,
     useSettings,
     useInteractive,
+    useLightbox,
+    useGalleryLightbox,
   },
   patch: {
     // intercept the arguments of supported functions


### PR DESCRIPTION
Adds useLightbox and useGalleryLightbox hooks to the plugin api. Also added to docs.

Tested with my gallery card plugin.