### PR TITLE
Scene list toolbar

### DIFF
--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -101,6 +101,10 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     );
   }
 
+  if (criteria.length === 0) {
+    return null;
+  }
+
   return (
     <div className="d-flex justify-content-center mb-2 wrap-tags filter-tags">
       {criteria.map(renderFilterTags)}

--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -106,7 +106,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   }
 
   return (
-    <div className="d-flex justify-content-center mb-2 wrap-tags filter-tags">
+    <div className="wrap-tags filter-tags">
       {criteria.map(renderFilterTags)}
       {criteria.length >= 3 && (
         <Button

--- a/ui/v2.5/src/components/List/Filters/FilterButton.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterButton.tsx
@@ -7,20 +7,26 @@ import { useIntl } from "react-intl";
 interface IFilterButtonProps {
   count?: number;
   onClick: () => void;
+  title?: string;
 }
 
 export const FilterButton: React.FC<IFilterButtonProps> = ({
   count = 0,
   onClick,
+  title,
 }) => {
   const intl = useIntl();
+
+  if (!title) {
+    title = intl.formatMessage({ id: "search_filter.edit_filter" });
+  }
 
   return (
     <Button
       variant="secondary"
       className="filter-button"
       onClick={onClick}
-      title={intl.formatMessage({ id: "search_filter.edit_filter" })}
+      title={title}
     >
       <Icon icon={faFilter} />
       {count ? (

--- a/ui/v2.5/src/components/List/Filters/FilterButton.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterButton.tsx
@@ -1,21 +1,19 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Badge, Button } from "react-bootstrap";
-import { ListFilterModel } from "src/models/list-filter/filter";
 import { faFilter } from "@fortawesome/free-solid-svg-icons";
 import { Icon } from "src/components/Shared/Icon";
 import { useIntl } from "react-intl";
 
 interface IFilterButtonProps {
-  filter: ListFilterModel;
+  count?: number;
   onClick: () => void;
 }
 
 export const FilterButton: React.FC<IFilterButtonProps> = ({
-  filter,
+  count = 0,
   onClick,
 }) => {
   const intl = useIntl();
-  const count = useMemo(() => filter.count(), [filter]);
 
   return (
     <Button

--- a/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
@@ -44,7 +44,7 @@ export const FilteredSidebarHeader: React.FC<{
           onFilterUpdate={setFilter}
           focus={focus}
         />
-        <FilterButton onClick={() => showEditFilter()} filter={filter} />
+        <FilterButton onClick={() => showEditFilter()} count={filter.count()} />
       </div>
       <SidebarSection
         className="sidebar-saved-filters"

--- a/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
@@ -2,13 +2,13 @@ import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { SidebarSection } from "src/components/Shared/Sidebar";
 import { ListFilterModel } from "src/models/list-filter/filter";
-import { FilterButton } from "./FilterButton";
 import { SearchTermInput } from "../ListFilter";
 import { SidebarSavedFilterList } from "../SavedFilterList";
 import { View } from "../views";
 import useFocus from "src/utils/focus";
 import ScreenUtils from "src/utils/screen";
 import Mousetrap from "mousetrap";
+import { Button } from "react-bootstrap";
 
 export const FilteredSidebarHeader: React.FC<{
   sidebarOpen: boolean;
@@ -36,8 +36,18 @@ export const FilteredSidebarHeader: React.FC<{
           onFilterUpdate={setFilter}
           focus={focus}
         />
-        <FilterButton onClick={() => showEditFilter()} count={filter.count()} />
       </div>
+
+      <div>
+        <Button
+          className="edit-filter-button"
+          size="sm"
+          onClick={() => showEditFilter()}
+        >
+          <FormattedMessage id="search_filter.edit_filter" />
+        </Button>
+      </div>
+
       <SidebarSection
         className="sidebar-saved-filters"
         text={<FormattedMessage id="search_filter.saved_filters" />}

--- a/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
-import { SidebarSection, SidebarToolbar } from "src/components/Shared/Sidebar";
+import { SidebarSection } from "src/components/Shared/Sidebar";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { FilterButton } from "./FilterButton";
 import { SearchTermInput } from "../ListFilter";
@@ -10,20 +10,13 @@ import useFocus from "src/utils/focus";
 import ScreenUtils from "src/utils/screen";
 import Mousetrap from "mousetrap";
 
-export const FilteredSidebarToolbar: React.FC<{
-  onClose?: () => void;
-}> = ({ onClose, children }) => {
-  return <SidebarToolbar onClose={onClose}>{children}</SidebarToolbar>;
-};
-
 export const FilteredSidebarHeader: React.FC<{
   sidebarOpen: boolean;
-  onClose?: () => void;
   showEditFilter: () => void;
   filter: ListFilterModel;
   setFilter: (filter: ListFilterModel) => void;
   view?: View;
-}> = ({ sidebarOpen, onClose, showEditFilter, filter, setFilter, view }) => {
+}> = ({ sidebarOpen, showEditFilter, filter, setFilter, view }) => {
   const focus = useFocus();
   const [, setFocus] = focus;
 
@@ -37,7 +30,6 @@ export const FilteredSidebarHeader: React.FC<{
 
   return (
     <>
-      <FilteredSidebarToolbar onClose={onClose} />
       <div className="sidebar-search-container">
         <SearchTermInput
           filter={filter}

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -232,6 +232,7 @@ export const PageSizeSelector: React.FC<{
 };
 
 export const SortBySelect: React.FC<{
+  className?: string;
   sortBy: string | undefined;
   sortDirection: SortDirectionEnum;
   options: ISortByOption[];
@@ -239,6 +240,7 @@ export const SortBySelect: React.FC<{
   onChangeSortDirection: () => void;
   onReshuffleRandomSort: () => void;
 }> = ({
+  className,
   sortBy,
   sortDirection,
   options,
@@ -272,7 +274,7 @@ export const SortBySelect: React.FC<{
   }
 
   return (
-    <Dropdown as={ButtonGroup} className="mr-2">
+    <Dropdown as={ButtonGroup} className={className}>
       <InputGroup.Prepend>
         <Dropdown.Toggle variant="secondary">
           {currentSortBy
@@ -409,6 +411,7 @@ export const ListFilter: React.FC<IListFilterProps> = ({
         )}
 
         <SortBySelect
+          className="mr-2"
           sortBy={filter.sortBy}
           sortDirection={filter.sortDirection}
           options={filterOptions.sortByOptions}

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -342,7 +342,7 @@ export const ListFilter: React.FC<IListFilterProps> = ({
             >
               <FilterButton
                 onClick={() => openFilterDialog()}
-                filter={filter}
+                count={filter.count()}
               />
             </OverlayTrigger>
           </ButtonGroup>

--- a/ui/v2.5/src/components/List/ListOperationButtons.tsx
+++ b/ui/v2.5/src/components/List/ListOperationButtons.tsx
@@ -33,6 +33,17 @@ export const OperationDropdown: React.FC<PropsWithChildren<{}>> = ({
   );
 };
 
+export const OperationDropdownItem: React.FC<{
+  text: string;
+  onClick: () => void;
+}> = ({ text, onClick }) => {
+  return (
+    <Dropdown.Item className="bg-secondary text-white" onClick={onClick}>
+      {text}
+    </Dropdown.Item>
+  );
+};
+
 export interface IListFilterOperation {
   text: string;
   onClick: () => void;

--- a/ui/v2.5/src/components/List/ListOperationButtons.tsx
+++ b/ui/v2.5/src/components/List/ListOperationButtons.tsx
@@ -15,14 +15,17 @@ import {
   faPencilAlt,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
+import cx from "classnames";
 
-export const OperationDropdown: React.FC<PropsWithChildren<{}>> = ({
-  children,
-}) => {
+export const OperationDropdown: React.FC<
+  PropsWithChildren<{
+    className?: string;
+  }>
+> = ({ className, children }) => {
   if (!children) return null;
 
   return (
-    <Dropdown as={ButtonGroup}>
+    <Dropdown className={className} as={ButtonGroup}>
       <Dropdown.Toggle variant="secondary" id="more-menu">
         <Icon icon={faEllipsisH} />
       </Dropdown.Toggle>
@@ -36,9 +39,13 @@ export const OperationDropdown: React.FC<PropsWithChildren<{}>> = ({
 export const OperationDropdownItem: React.FC<{
   text: string;
   onClick: () => void;
-}> = ({ text, onClick }) => {
+  className?: string;
+}> = ({ text, onClick, className }) => {
   return (
-    <Dropdown.Item className="bg-secondary text-white" onClick={onClick}>
+    <Dropdown.Item
+      className={cx("bg-secondary text-white", className)}
+      onClick={onClick}
+    >
       {text}
     </Dropdown.Item>
   );

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -938,19 +938,19 @@ input[type="range"].zoom-slider {
   .sidebar-search-container {
     display: flex;
     margin-bottom: 0.5rem;
-
-    .filter-button {
-      display: none;
-    }
   }
 
   .search-term-input {
     flex-grow: 1;
-    margin-right: 0.25rem;
+    margin-right: 0;
 
     .clearable-text-field {
       height: 100%;
     }
+  }
+
+  .edit-filter-button {
+    width: 100%;
   }
 
   .sidebar-footer {
@@ -970,14 +970,6 @@ input[type="range"].zoom-slider {
 @include media-breakpoint-down(xs) {
   .sidebar .sidebar-search-container {
     margin-top: 0.25rem;
-
-    .filter-button {
-      display: block;
-    }
-  }
-
-  .sidebar .search-term-input {
-    margin-right: 0.5rem;
   }
 }
 

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -932,7 +932,10 @@ input[type="range"].zoom-slider {
   .sidebar-search-container {
     display: flex;
     margin-bottom: 0.5rem;
-    margin-top: 0.25rem;
+
+    .filter-button {
+      display: none;
+    }
   }
 
   .search-term-input {
@@ -943,9 +946,30 @@ input[type="range"].zoom-slider {
       height: 100%;
     }
   }
+
+  .sidebar-footer {
+    background-color: $body-bg;
+    bottom: 0;
+    display: none;
+    padding: 0.5rem;
+    position: sticky;
+
+    @include media-breakpoint-down(xs) {
+      display: flex;
+      justify-content: center;
+    }
+  }
 }
 
 @include media-breakpoint-down(xs) {
+  .sidebar .sidebar-search-container {
+    margin-top: 0.25rem;
+
+    .filter-button {
+      display: block;
+    }
+  }
+
   .sidebar .search-term-input {
     margin-right: 0.5rem;
   }

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -412,6 +412,12 @@ input[type="range"].zoom-slider {
   }
 }
 
+.filter-tags {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+}
+
 .filter-tags .clear-all-button {
   color: $text-color;
   // to match filter pills

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -935,6 +935,14 @@ input[type="range"].zoom-slider {
 }
 
 .sidebar {
+  // make controls slightly larger on mobile
+  @include media-breakpoint-down(xs) {
+    .btn,
+    .form-control {
+      font-size: 1.25rem;
+    }
+  }
+
   .sidebar-search-container {
     display: flex;
     margin-bottom: 0.5rem;

--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -103,7 +103,6 @@ const allMenuItems: IMenuItem[] = [
     href: "/scenes",
     icon: faPlayCircle,
     hotkey: "g s",
-    userCreatable: true,
   },
   {
     name: "images",

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -19,7 +19,7 @@ import { SceneCardsGrid } from "./SceneCardsGrid";
 import { TaggerContext } from "../Tagger/context";
 import { IdentifyDialog } from "../Dialogs/IdentifyDialog/IdentifyDialog";
 import { ConfigurationContext } from "src/hooks/Config";
-import { faEllipsisH, faPlay, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlay, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { SceneMergeModal } from "./SceneMergeDialog";
 import { objectTitle } from "src/core/files";
 import TextUtils from "src/utils/text";
@@ -27,7 +27,10 @@ import { View } from "../List/views";
 import { FileSize } from "../Shared/FileSize";
 import { LoadedContent } from "../List/PagedList";
 import { useCloseEditDelete, useFilterOperations } from "../List/util";
-import { IListFilterOperation } from "../List/ListOperationButtons";
+import {
+  OperationDropdown,
+  OperationDropdownItem,
+} from "../List/ListOperationButtons";
 import { useFilteredItemList } from "../List/ItemList";
 import { FilterTags } from "../List/FilterTags";
 import {
@@ -423,16 +426,11 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
     history.push("/scenes/new");
   }
 
-  const otherOperations: IListFilterOperation[] = [
-    {
-      text: intl.formatMessage({ id: "actions.play_selected" }),
-      onClick: playSelected,
-      isDisplayed: () => hasSelection,
-      icon: faPlay,
-    },
+  const otherOperations = [
     {
       text: intl.formatMessage({ id: "actions.play_random" }),
       onClick: playRandom,
+      isDisplayed: () => totalCount > 1,
     },
     {
       text: `${intl.formatMessage({ id: "actions.generate" })}…`,
@@ -518,9 +516,22 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
                   <Button variant="secondary" onClick={() => onCreateNew()}>
                     <Icon icon={faPlus} />
                   </Button>
-                  <Button variant="secondary">
-                    <Icon icon={faEllipsisH} />
-                  </Button>
+                  <OperationDropdown>
+                    {otherOperations.map((o) => {
+                      if (o.isDisplayed && !o.isDisplayed()) {
+                        return null;
+                      }
+
+                      return (
+                        <OperationDropdownItem
+                          key={o.text}
+                          onClick={o.onClick}
+                          text={o.text}
+                        />
+                      );
+                    })}
+                  </OperationDropdown>
+
                   <Button
                     variant="secondary"
                     onClick={() => setShowSidebar(!showSidebar)}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -465,7 +465,10 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
           <div>
             <ButtonToolbar className="scene-list-toolbar">
               <div>
-                <FilterButton onClick={() => showEditFilter()} />
+                <FilterButton
+                  onClick={() => showEditFilter()}
+                  count={filter.count()}
+                />
               </div>
               <div>
                 <ButtonGroup>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -446,7 +446,11 @@ const ListToolbarContent: React.FC<{
             })}
           </OperationDropdown>
 
-          <Button className="toggle-sidebar-button" variant="secondary" onClick={() => onToggleSidebar()}>
+          <Button
+            className="toggle-sidebar-button"
+            variant="secondary"
+            onClick={() => onToggleSidebar()}
+          >
             <SidebarIcon />
           </Button>
         </ButtonGroup>
@@ -708,7 +712,11 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
             />
           </Sidebar>
           <div>
-            <ButtonToolbar className={cx("scene-list-toolbar", { "has-selection": hasSelection })}>
+            <ButtonToolbar
+              className={cx("scene-list-toolbar", {
+                "has-selection": hasSelection,
+              })}
+            >
               <ListToolbarContent
                 criteriaCount={filter.count()}
                 items={items}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -439,14 +439,6 @@ const ListToolbarContent: React.FC<{
               );
             })}
           </OperationDropdown>
-
-          {/* <Button
-            className="toggle-sidebar-button"
-            variant="secondary"
-            onClick={() => onToggleSidebar()}
-          >
-            <SidebarIcon />
-          </Button> */}
         </ButtonGroup>
       </div>
     </>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -39,12 +39,7 @@ import {
 } from "../List/ListOperationButtons";
 import { useFilteredItemList } from "../List/ItemList";
 import { FilterTags } from "../List/FilterTags";
-import {
-  Sidebar,
-  SidebarIcon,
-  SidebarPane,
-  useSidebarState,
-} from "../Shared/Sidebar";
+import { Sidebar, SidebarPane, useSidebarState } from "../Shared/Sidebar";
 import { SidebarPerformersFilter } from "../List/Filters/PerformersFilter";
 import { SidebarStudiosFilter } from "../List/Filters/StudiosFilter";
 import { PerformersCriterionOption } from "src/models/list-filter/criteria/performers";
@@ -326,7 +321,6 @@ const ListToolbarContent: React.FC<{
   selectedIds: Set<string>;
   operations: IOperations[];
   onToggleSidebar: () => void;
-  onFilterButtonClick: () => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
   onEdit: () => void;
@@ -338,7 +332,6 @@ const ListToolbarContent: React.FC<{
   queue,
   operations,
   onToggleSidebar,
-  onFilterButtonClick,
   onSelectAll,
   onSelectNone,
   onEdit,
@@ -377,8 +370,9 @@ const ListToolbarContent: React.FC<{
       {!hasSelection && (
         <div>
           <FilterButton
-            onClick={() => onFilterButtonClick()}
+            onClick={() => onToggleSidebar()}
             count={criteriaCount}
+            title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
           />
         </div>
       )}
@@ -388,7 +382,7 @@ const ListToolbarContent: React.FC<{
             variant="secondary"
             className="minimal"
             onClick={() => onSelectNone()}
-            title={intl.formatMessage({ id: "actions.clear_selection" })}
+            title={intl.formatMessage({ id: "actions.select_none" })}
           >
             <Icon icon={faTimes} />
           </Button>
@@ -446,13 +440,13 @@ const ListToolbarContent: React.FC<{
             })}
           </OperationDropdown>
 
-          <Button
+          {/* <Button
             className="toggle-sidebar-button"
             variant="secondary"
             onClick={() => onToggleSidebar()}
           >
             <SidebarIcon />
-          </Button>
+          </Button> */}
         </ButtonGroup>
       </div>
     </>
@@ -724,7 +718,6 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
                 selectedIds={selectedIds}
                 operations={otherOperations}
                 onToggleSidebar={() => setShowSidebar(!showSidebar)}
-                onFilterButtonClick={() => showEditFilter()}
                 onSelectAll={() => onSelectAll()}
                 onSelectNone={() => onSelectNone()}
                 onEdit={onEdit}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -446,7 +446,7 @@ const ListToolbarContent: React.FC<{
             })}
           </OperationDropdown>
 
-          <Button variant="secondary" onClick={() => onToggleSidebar()}>
+          <Button className="toggle-sidebar-button" variant="secondary" onClick={() => onToggleSidebar()}>
             <SidebarIcon />
           </Button>
         </ButtonGroup>
@@ -708,7 +708,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
             />
           </Sidebar>
           <div>
-            <ButtonToolbar className="scene-list-toolbar">
+            <ButtonToolbar className={cx("scene-list-toolbar", { "has-selection": hasSelection })}>
               <ListToolbarContent
                 criteriaCount={filter.count()}
                 items={items}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -28,7 +28,6 @@ import { FileSize } from "../Shared/FileSize";
 import { LoadedContent } from "../List/PagedList";
 import { useCloseEditDelete, useFilterOperations } from "../List/util";
 import { IListFilterOperation } from "../List/ListOperationButtons";
-import { FilteredListToolbar } from "../List/FilteredListToolbar";
 import { useFilteredItemList } from "../List/ItemList";
 import { FilterTags } from "../List/FilterTags";
 import {
@@ -472,16 +471,16 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               </div>
               <div>
                 <ButtonGroup>
-                  <Button>
+                  {!!items.length && <Button variant="secondary">
                     <Icon icon={faPlay} />
-                  </Button>
+                  </Button>}
                   <Button variant="secondary">
                     <Icon icon={faPlus} />
                   </Button>
                   <Button variant="secondary">
                     <Icon icon={faEllipsisH} />
                   </Button>
-                  <Button variant="secondary">
+                  <Button variant="secondary" onClick={() => setShowSidebar(!showSidebar)}>
                     <SidebarIcon />
                   </Button>
                 </ButtonGroup>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -419,6 +419,10 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
     );
   }
 
+  function onCreateNew() {
+    history.push("/scenes/new");
+  }
+
   const otherOperations: IListFilterOperation[] = [
     {
       text: intl.formatMessage({ id: "actions.play_selected" }),
@@ -503,15 +507,15 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               <div>
                 <ButtonGroup>
                   {!!items.length && (
-                    <Button 
-                      variant="secondary" 
-                      onClick={() => onPlay()} 
+                    <Button
+                      variant="secondary"
+                      onClick={() => onPlay()}
                       title={intl.formatMessage({ id: "actions.play" })}
                     >
                       <Icon icon={faPlay} />
                     </Button>
                   )}
-                  <Button variant="secondary">
+                  <Button variant="secondary" onClick={() => onCreateNew()}>
                     <Icon icon={faPlus} />
                   </Button>
                   <Button variant="secondary">

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -241,12 +241,23 @@ const SidebarContent: React.FC<{
   sidebarOpen: boolean;
   onClose?: () => void;
   showEditFilter: (editingCriterion?: string) => void;
-}> = ({ filter, setFilter, view, showEditFilter, sidebarOpen, onClose }) => {
+  count?: number;
+}> = ({
+  filter,
+  setFilter,
+  view,
+  showEditFilter,
+  sidebarOpen,
+  onClose,
+  count,
+}) => {
+  const showResultsId =
+    count !== undefined ? "actions.show_count_results" : "actions.show_results";
+
   return (
     <>
       <FilteredSidebarHeader
         sidebarOpen={sidebarOpen}
-        onClose={onClose}
         showEditFilter={showEditFilter}
         filter={filter}
         setFilter={setFilter}
@@ -290,6 +301,12 @@ const SidebarContent: React.FC<{
           setFilter={setFilter}
         />
       </ScenesFilterSidebarSections>
+
+      <div className="sidebar-footer">
+        <Button className="sidebar-close-button" onClick={onClose}>
+          <FormattedMessage id={showResultsId} values={{ count }} />
+        </Button>
+      </div>
     </>
   );
 };
@@ -634,6 +651,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               view={view}
               sidebarOpen={showSidebar}
               onClose={() => setShowSidebar(false)}
+              count={cachedResult.loading ? undefined : totalCount}
             />
           </Sidebar>
           <div>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -19,7 +19,7 @@ import { SceneCardsGrid } from "./SceneCardsGrid";
 import { TaggerContext } from "../Tagger/context";
 import { IdentifyDialog } from "../Dialogs/IdentifyDialog/IdentifyDialog";
 import { ConfigurationContext } from "src/hooks/Config";
-import { faPlay } from "@fortawesome/free-solid-svg-icons";
+import { faEllipsisH, faPlay, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { SceneMergeModal } from "./SceneMergeDialog";
 import { objectTitle } from "src/core/files";
 import TextUtils from "src/utils/text";
@@ -31,7 +31,12 @@ import { IListFilterOperation } from "../List/ListOperationButtons";
 import { FilteredListToolbar } from "../List/FilteredListToolbar";
 import { useFilteredItemList } from "../List/ItemList";
 import { FilterTags } from "../List/FilterTags";
-import { Sidebar, SidebarPane, useSidebarState } from "../Shared/Sidebar";
+import {
+  Sidebar,
+  SidebarIcon,
+  SidebarPane,
+  useSidebarState,
+} from "../Shared/Sidebar";
 import { SidebarPerformersFilter } from "../List/Filters/PerformersFilter";
 import { SidebarStudiosFilter } from "../List/Filters/StudiosFilter";
 import { PerformersCriterionOption } from "src/models/list-filter/criteria/performers";
@@ -49,6 +54,9 @@ import {
 } from "../List/Filters/FilterSidebar";
 import { PatchContainerComponent } from "src/patch";
 import { Pagination, PaginationIndex } from "../List/Pagination";
+import { Button, ButtonGroup, ButtonToolbar } from "react-bootstrap";
+import { FilterButton } from "../List/Filters/FilterButton";
+import { Icon } from "../Shared/Icon";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -455,32 +463,27 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
             />
           </Sidebar>
           <div>
-            <FilteredListToolbar
-              filter={filter}
-              setFilter={setFilter}
-              showEditFilter={showEditFilter}
-              view={view}
-              listSelect={listSelect}
-              onEdit={() =>
-                showModal(
-                  <EditScenesDialog
-                    selected={selectedItems}
-                    onClose={onCloseEditDelete}
-                  />
-                )
-              }
-              onDelete={() => {
-                showModal(
-                  <DeleteScenesDialog
-                    selected={selectedItems}
-                    onClose={onCloseEditDelete}
-                  />
-                );
-              }}
-              operations={otherOperations}
-              onToggleSidebar={() => setShowSidebar((v) => !v)}
-              zoomable
-            />
+            <ButtonToolbar className="scene-list-toolbar">
+              <div>
+                <FilterButton onClick={() => showEditFilter()} />
+              </div>
+              <div>
+                <ButtonGroup>
+                  <Button>
+                    <Icon icon={faPlay} />
+                  </Button>
+                  <Button variant="secondary">
+                    <Icon icon={faPlus} />
+                  </Button>
+                  <Button variant="secondary">
+                    <Icon icon={faEllipsisH} />
+                  </Button>
+                  <Button variant="secondary">
+                    <SidebarIcon />
+                  </Button>
+                </ButtonGroup>
+              </div>
+            </ButtonToolbar>
 
             <FilterTags
               criteria={filter.criteria}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1053,3 +1053,11 @@ input[type="range"].blue-slider {
     margin: 0;
   }
 }
+
+.detail-body .scene-list-toolbar {
+  top: calc($sticky-detail-header-height + $navbar-height);
+
+  @include media-breakpoint-down(xs) {
+    top: 0;
+  }
+}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1042,21 +1042,6 @@ input[type="range"].blue-slider {
   .selected-items-info .btn {
     margin-right: 0.5rem;
   }
-
-  .filter-tags {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    margin-bottom: 0;
-    margin-left: 0.5rem;
-
-    @include media-breakpoint-down(xs) {
-      display: none;
-    }
-
-    .tag-item {
-      white-space: nowrap;
-    }
-  }
 }
 
 .scene-list-header {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1004,13 +1004,29 @@ input[type="range"].blue-slider {
   }
 }
 
-.scene-list-toolbar {
+.scene-list-toolbar,
+.scene-list-header {
   align-items: center;
   background-color: $body-bg;
   display: flex;
-  flex-wrap: nowrap;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+
+  > div {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-start;
+
+    &:last-child {
+      flex-shrink: 0;
+      justify-content: flex-end;
+      margin-left: auto;
+    }
+  }
+}
+
+.scene-list-toolbar {
+  flex-wrap: nowrap;
   // offset the main padding
   margin-top: -0.5rem;
   padding-bottom: 0.5rem;
@@ -1027,18 +1043,6 @@ input[type="range"].blue-slider {
     margin-right: 0.5rem;
   }
 
-  > div {
-    align-items: center;
-    display: flex;
-    justify-content: flex-start;
-
-    &:last-child {
-      flex-shrink: 0;
-      justify-content: flex-end;
-      margin-left: 1rem;
-    }
-  }
-
   .filter-tags {
     flex-wrap: nowrap;
     justify-content: flex-start;
@@ -1052,5 +1056,14 @@ input[type="range"].blue-slider {
     .tag-item {
       white-space: nowrap;
     }
+  }
+}
+
+.scene-list-header {
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  .paginationIndex {
+    margin: 0;
   }
 }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1059,6 +1059,17 @@ input[type="range"].blue-slider {
   .paginationIndex {
     margin: 0;
   }
+
+  // center the header on smaller screens
+  @include media-breakpoint-down(sm) {
+    & > div,
+    & > div:last-child {
+      flex-basis: 100%;
+      justify-content: center;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
 }
 
 .detail-body .scene-list-toolbar {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1043,9 +1043,22 @@ input[type="range"].blue-slider {
     margin-right: 0.5rem;
   }
 
-  // on mobile, hide sidebar toggle button when something is selected
+  // hide drop down menu items for play and create new
+  // when the buttons are visible
+  @include media-breakpoint-up(sm) {
+    .scene-list-operations {
+      .play-item,
+      .create-new-item {
+        display: none;
+      }
+    }
+  }
+
+  // hide play and create new buttons on xs screens
+  // show these in the drop down menu instead
   @include media-breakpoint-down(xs) {
-    &.has-selection .toggle-sidebar-button {
+    .play-button,
+    .create-new-button {
       display: none;
     }
   }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1026,7 +1026,7 @@ input[type="range"].blue-slider {
 }
 
 .scene-list-toolbar {
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   // offset the main padding
   margin-top: -0.5rem;
   padding-bottom: 0.5rem;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1003,3 +1003,54 @@ input[type="range"].blue-slider {
     }
   }
 }
+
+.scene-list-toolbar {
+  align-items: center;
+  background-color: $body-bg;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  // offset the main padding
+  margin-top: -0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  position: sticky;
+  top: $navbar-height;
+  z-index: 10;
+
+  @include media-breakpoint-down(xs) {
+    top: 0;
+  }
+
+  .slick-slider {
+    width: 50vw;
+  }
+
+  > div {
+    align-items: center;
+    display: flex;
+    justify-content: flex-start;
+
+    &:last-child {
+      flex-shrink: 0;
+      margin-left: 1rem;
+      justify-content: flex-end;
+    }
+  }
+
+  .filter-tags {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    margin-bottom: 0;
+    margin-left: 0.5rem;
+
+    @include media-breakpoint-down(xs) {
+      display: none;
+    }
+
+    .tag-item {
+      white-space: nowrap;
+    }
+  }
+}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1013,8 +1013,8 @@ input[type="range"].blue-slider {
   margin-bottom: 0.5rem;
   // offset the main padding
   margin-top: -0.5rem;
-  padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
   position: sticky;
   top: $navbar-height;
   z-index: 10;
@@ -1023,8 +1023,8 @@ input[type="range"].blue-slider {
     top: 0;
   }
 
-  .slick-slider {
-    width: 50vw;
+  .selected-items-info .btn {
+    margin-right: 0.5rem;
   }
 
   > div {
@@ -1034,8 +1034,8 @@ input[type="range"].blue-slider {
 
     &:last-child {
       flex-shrink: 0;
-      margin-left: 1rem;
       justify-content: flex-end;
+      margin-left: 1rem;
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1045,6 +1045,7 @@ input[type="range"].blue-slider {
 }
 
 .scene-list-header {
+  flex-wrap: wrap-reverse;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1042,6 +1042,13 @@ input[type="range"].blue-slider {
   .selected-items-info .btn {
     margin-right: 0.5rem;
   }
+
+  // on mobile, hide sidebar toggle button when something is selected
+  @include media-breakpoint-down(xs) {
+    &.has-selection .toggle-sidebar-button {
+      display: none;
+    }
+  }
 }
 
 .scene-list-header {

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -770,8 +770,9 @@ $sidebar-width: 250px;
   .sidebar {
     bottom: 0;
     left: 0;
-    margin-top: 4rem;
+    margin-top: $navbar-height;
     overflow-y: auto;
+    padding-top: 0.5rem;
     position: fixed;
     scrollbar-gutter: stable;
     top: 0;

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -887,8 +887,7 @@ $sticky-header-height: calc(50px + 3.3rem);
     padding-left: 0;
     position: sticky;
 
-    // sticky detail header is 50px + 3.3rem
-    top: calc(50px + 3.3rem);
+    top: calc($sticky-detail-header-height + $navbar-height);
 
     .sidebar-toolbar {
       padding-top: 15px;
@@ -915,7 +914,6 @@ $sticky-header-height: calc(50px + 3.3rem);
       flex: 100% 0 0;
       height: calc(100vh - 4rem);
       max-height: calc(100vh - 4rem);
-      padding-top: 0;
       top: 0;
     }
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -55,7 +55,7 @@ body {
 
   @include media-breakpoint-down(xs) {
     @media (orientation: portrait) {
-      padding: 1rem 0 $navbar-height;
+      padding: 0.5rem 0 $navbar-height;
     }
   }
 }
@@ -692,8 +692,7 @@ div.dropdown-menu {
 
   .badge {
     margin: unset;
-    // stylelint-disable declaration-no-important
-    white-space: normal !important;
+    white-space: normal;
   }
 }
 
@@ -1014,6 +1013,7 @@ div.dropdown-menu {
 }
 
 .top-nav {
+  height: $navbar-height;
   justify-content: start;
   padding: 0.25rem 1rem;
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -1,8 +1,9 @@
 // variables required by other scss files
 
 // this is calculated from the existing height
-// TODO: we should set this explicitly in the navbar
 $navbar-height: 48.75px;
+
+$sticky-detail-header-height: 50px;
 
 @import "styles/theme";
 @import "styles/range";
@@ -85,10 +86,10 @@ dd {
 
 .sticky.detail-header {
   display: block;
-  min-height: 50px;
+  min-height: $sticky-detail-header-height;
   padding: unset;
   position: fixed;
-  top: 3.3rem;
+  top: $navbar-height;
   z-index: 10;
 
   @media (max-width: 576px) {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -1013,7 +1013,6 @@ div.dropdown-menu {
 }
 
 .top-nav {
-  height: $navbar-height;
   justify-content: start;
   padding: 0.25rem 1rem;
 
@@ -1024,6 +1023,9 @@ div.dropdown-menu {
       bottom: 0;
       top: auto;
     }
+  }
+  @include media-breakpoint-up(xl) {
+    height: $navbar-height;
   }
 
   .navbar-toggler {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -81,6 +81,7 @@
     "open_random": "Open Random",
     "optimise_database": "Optimise Database",
     "overwrite": "Overwrite",
+    "play": "Play",
     "play_random": "Play Random",
     "play_selected": "Play selected",
     "preview": "Preview",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -129,7 +129,8 @@
     "show_count_results": "Show {count} results",
     "sidebar": {
       "close": "Close sidebar",
-      "open": "Open sidebar"
+      "open": "Open sidebar",
+      "toggle": "Toggle sidebar"
     },
     "skip": "Skip",
     "split": "Split",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -125,6 +125,8 @@
     "set_image": "Set image…",
     "show": "Show",
     "show_configuration": "Show Configuration",
+    "show_results": "Show results",
+    "show_count_results": "Show {count} results",
     "sidebar": {
       "close": "Close sidebar",
       "open": "Open sidebar"

--- a/ui/v2.5/src/models/list-filter/filter-options.ts
+++ b/ui/v2.5/src/models/list-filter/filter-options.ts
@@ -1,7 +1,7 @@
 import { CriterionOption } from "./criteria/criterion";
 import { DisplayMode } from "./types";
 
-interface ISortByOption {
+export interface ISortByOption {
   messageID: string;
   value: string;
 }

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -521,6 +521,34 @@ export class ListFilterModel {
   public setPageSize(pageSize: number) {
     const ret = this.clone();
     ret.itemsPerPage = pageSize;
+    ret.currentPage = 1; // reset to first page
+    return ret;
+  }
+
+  public setSortBy(sortBy: string | undefined) {
+    const ret = this.clone();
+    ret.sortBy = sortBy;
+    ret.currentPage = 1; // reset to first page
+    return ret;
+  }
+
+  public toggleSortDirection() {
+    const ret = this.clone();
+
+    if (ret.sortDirection === SortDirectionEnum.Asc) {
+      ret.sortDirection = SortDirectionEnum.Desc;
+    } else {
+      ret.sortDirection = SortDirectionEnum.Asc;
+    }
+
+    ret.currentPage = 1; // reset to first page
+    return ret;
+  }
+
+  public reshuffleRandomSort() {
+    const ret = this.clone();
+    ret.currentPage = 1;
+    ret.randomSeed = -1;
     return ret;
   }
 


### PR DESCRIPTION
Adds a sticky top toolbar to the scenes query page. The sticky toolbar includes buttons to edit the filter, toggle the sidebar, 

![image](https://github.com/user-attachments/assets/d6133157-efb4-48f6-a8b4-5c4ff75c6218)
![image](https://github.com/user-attachments/assets/f647d68c-938e-44a1-97c5-185333107f87)

The results summary has been moved to be left-justified on the same row as the sort, page and display mode selectors. This row is _not_ stickied.

A play button is included, and the new Scene button is moved from the navbar to the toolbar. 

The toggle sidebar button has been moved to the right side of the toolbar, and removed from the sidebar.

On mobile viewports, the sidebar includes a button to close the sidebar at the bottom:

![image](https://github.com/user-attachments/assets/139c90bc-3cee-4ba0-9955-d02c328adf2a)

When an item is selected, the toolbar changes to show the number selected, with buttons to select all or none:

![image](https://github.com/user-attachments/assets/feaa4763-a372-4d8d-97cd-35fa40a8250f)

Related discussion here: https://discourse.stashapp.cc/t/query-page-redesign/2064/27
