### PR TITLE
Show custom fields on compact expanded details

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -29,7 +29,7 @@ const PerformerDetailGroup: React.FC<PropsWithChildren<IPerformerDetails>> =
 
 export const PerformerDetailsPanel: React.FC<IPerformerDetails> =
   PatchComponent("PerformerDetailsPanel", (props) => {
-    const { performer, fullWidth } = props;
+    const { performer, fullWidth, collapsed } = props;
 
     // Network state
     const intl = useIntl();
@@ -177,7 +177,9 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> =
           value={renderStashIDs()}
           fullWidth={fullWidth}
         />
-        {fullWidth && <CustomFields values={performer.custom_fields} />}
+        {(fullWidth || !collapsed) && (
+          <CustomFields values={performer.custom_fields} />
+        )}
       </PerformerDetailGroup>
     );
   });

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -710,6 +710,10 @@ button.btn.favorite-button {
   }
 }
 
+.custom-fields {
+  width: 100%;
+}
+
 .custom-fields .detail-item .detail-item-title {
   max-width: 130px;
   overflow: hidden;


### PR DESCRIPTION
Resolves #5833

Shows custom fields on its own row on compact expanded view:

![image](https://github.com/user-attachments/assets/ddceff10-d960-444b-b665-fa8bf63303d4)
