### PR TITLE
Add support to filter out short video clips in scan

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -517,6 +517,7 @@ type ConfigScrapingResult {
 
 type ConfigDefaultSettingsResult {
   scan: ScanMetadataOptions
+  filter: ScanMetaDataFilterOptions
   identify: IdentifyMetadataTaskOptions
   autoTag: AutoTagMetadataOptions
   generate: GenerateMetadataOptions

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -70,6 +70,15 @@ type GeneratePreviewOptions {
 input ScanMetaDataFilterInput {
   "If set, files with a modification time before this time point are ignored by the scan"
   minModTime: Timestamp
+  "If set, video files with a duration lower than this threshold are ignored by the scan"
+  minDuration: Float
+}
+
+type ScanMetaDataFilterOptions {
+  "If set, files with a modification time before this time point are ignored by the scan"
+  minModTime: Timestamp!
+  "If set, video files with a duration lower than this threshold are ignored by the scan"
+  minDuration: Float!
 }
 
 input ScanMetadataInput {

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -89,10 +89,12 @@ type ScanMetadataInput struct {
 	Filter *ScanMetaDataFilterInput `json:"filter"`
 }
 
-// Filter options for meta data scannning
+// ScanMetaDataFilterInput Filter options for meta data scannning
 type ScanMetaDataFilterInput struct {
 	// If set, files with a modification time before this time point are ignored by the scan
 	MinModTime *time.Time `json:"minModTime"`
+	// If set, video files with a duration lower than this threshold are ignored by the scan
+	MinDuration *float64 `json:"minDuration"`
 }
 
 func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error) {

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -59,8 +59,14 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	taskQueue := job.NewTaskQueue(ctx, progress, taskQueueSize, cfg.GetParallelTasksWithAutoDetection())
 
 	var minModTime time.Time
-	if j.input.Filter != nil && j.input.Filter.MinModTime != nil {
-		minModTime = *j.input.Filter.MinModTime
+	var minDuration *float64
+	if j.input.Filter != nil {
+		if j.input.Filter.MinModTime != nil {
+			minModTime = *j.input.Filter.MinModTime
+		}
+		if j.input.Filter.MinDuration != nil {
+			minDuration = j.input.Filter.MinDuration
+		}
 	}
 
 	j.scanner.Scan(ctx, getScanHandlers(j.input, taskQueue, progress), file.ScanOptions{
@@ -70,6 +76,7 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 		ParallelTasks:          cfg.GetParallelTasksWithAutoDetection(),
 		HandlerRequiredFilters: []file.Filter{newHandlerRequiredFilter(cfg, repo)},
 		Rescan:                 j.input.Rescan,
+		DurationFilter:         minDuration,
 	}, progress)
 
 	taskQueue.Close()

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -161,6 +161,9 @@ fragment ConfigDefaultSettingsData on ConfigDefaultSettingsResult {
     scanGenerateThumbnails
     scanGenerateClipPreviews
   }
+  filter {
+    minDuration
+  }
 
   identify {
     sources {

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -96,6 +96,18 @@ export const LibraryTasks: React.FC = () => {
   const [scanOptions, setScanOptions] = useState<GQL.ScanMetadataInput>(
     getDefaultScanOptions()
   );
+
+  function getDefaultScanFilters(): GQL.ScanMetaDataFilterInput {
+    return {
+      minDuration: null,
+      minModTime: null,
+    };
+  }
+
+  const [scanFilters, setScanFilters] = useState<GQL.ScanMetaDataFilterInput>(
+    getDefaultScanFilters()
+  );
+
   const [autoTagOptions, setAutoTagOptions] =
     useState<GQL.AutoTagMetadataInput>({
       performers: ["*"],
@@ -131,7 +143,7 @@ export const LibraryTasks: React.FC = () => {
       return;
     }
 
-    const { scan, autoTag } = configuration.defaults;
+    const { scan, filter, autoTag } = configuration.defaults;
 
     // prefer UI defaults over system defaults
     // other defaults should be deprecated
@@ -139,6 +151,11 @@ export const LibraryTasks: React.FC = () => {
       setScanOptions(taskDefaults.scan);
     } else if (scan) {
       setScanOptions(withoutTypename(scan));
+    }
+    if (taskDefaults?.filter) {
+      setScanFilters(taskDefaults.filter);
+    } else if (filter) {
+      setScanFilters(withoutTypename(filter));
     }
 
     if (taskDefaults?.autoTag) {
@@ -197,6 +214,11 @@ export const LibraryTasks: React.FC = () => {
     setScanOptions(s);
   }
 
+  function onSetScanFilters(s: GQL.ScanMetaDataFilterInput) {
+    configureDefaults({ filter: s });
+    setScanFilters(s);
+  }
+
   function onSetGenerateOptions(s: GQL.GenerateMetadataInput) {
     configureDefaults({ generate: s });
     setGenerateOptions(s);
@@ -234,6 +256,7 @@ export const LibraryTasks: React.FC = () => {
       await mutateMetadataScan({
         ...scanOptions,
         paths,
+        filter: scanFilters,
       });
 
       Toast.success(
@@ -345,7 +368,12 @@ export const LibraryTasks: React.FC = () => {
           }
           collapsible
         >
-          <ScanOptions options={scanOptions} setOptions={onSetScanOptions} />
+          <ScanOptions
+            options={scanOptions}
+            filters={scanFilters}
+            setOptions={onSetScanOptions}
+            setFilters={onSetScanFilters}
+          />
         </SettingGroup>
       </SettingSection>
 

--- a/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/ScanOptions.tsx
@@ -1,15 +1,21 @@
 import React from "react";
 import * as GQL from "src/core/generated-graphql";
-import { BooleanSetting } from "../Inputs";
+import { BooleanSetting, ModalSetting } from "../Inputs";
+import { DurationInput } from "../../Shared/DurationInput";
+import TextUtils from "../../../utils/text";
 
 interface IScanOptions {
   options: GQL.ScanMetadataInput;
+  filters: GQL.ScanMetaDataFilterInput;
   setOptions: (s: GQL.ScanMetadataInput) => void;
+  setFilters: (s: GQL.ScanMetaDataFilterInput) => void;
 }
 
 export const ScanOptions: React.FC<IScanOptions> = ({
   options,
+  filters,
   setOptions: setOptionsState,
+  setFilters: setFiltersState,
 }) => {
   const {
     scanGenerateCovers,
@@ -22,8 +28,14 @@ export const ScanOptions: React.FC<IScanOptions> = ({
     rescan,
   } = options;
 
+  const { minDuration } = filters;
+
   function setOptions(input: Partial<GQL.ScanMetadataInput>) {
     setOptionsState({ ...options, ...input });
+  }
+
+  function setFilters(input: Partial<GQL.ScanMetaDataFilterInput>) {
+    setFiltersState({ ...filters, ...input });
   }
 
   return (
@@ -84,6 +96,22 @@ export const ScanOptions: React.FC<IScanOptions> = ({
         tooltipID="config.tasks.rescan_tooltip"
         checked={rescan ?? false}
         onChange={(v) => setOptions({ rescan: v })}
+      />
+      <ModalSetting<number>
+        id="duration-filter"
+        headingID="config.tasks.filter_duration_during_scan"
+        tooltipID="config.tasks.filter_duration_during_scan_tooltip"
+        value={minDuration ?? undefined}
+        onChange={(v) => setFilters({ minDuration: v })}
+        renderField={(value, setValue) => (
+          <DurationInput
+            value={value}
+            setValue={(duration) => setValue(duration ?? 0)}
+          />
+        )}
+        renderValue={(v) => {
+          return <span>{TextUtils.secondsToTimestamp(v ?? 0)}</span>;
+        }}
       />
     </>
   );

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -495,6 +495,8 @@
       "dont_include_file_extension_as_part_of_the_title": "Don't include file extension as part of the title",
       "empty_queue": "No tasks are currently running.",
       "export_to_json": "Exports the database content into JSON format in the metadata directory.",
+      "filter_duration_during_scan": "Minimum duration filter",
+      "filter_duration_during_scan_tooltip": "Skips scanning videos below a specified length.",
       "generate": {
         "generating_from_paths": "Generating for scenes from the following paths",
         "generating_scenes": "Generating for {num} {scene}"


### PR DESCRIPTION
Resolves #3160. Tested working locally, there is an associated UI change that looks like so:

<img width="500" alt="Screenshot 2025-06-20 at 6 49 33 PM" src="https://github.com/user-attachments/assets/ef371d0e-2dad-4cf3-b788-c6a323ac54a1" />

The implementation is slightly complicated by #5949 , all three scan paths for a file (`onExistingFile`, `onUnchangedFile`, `onNewFile`) need to support the filtering. 