### PR TITLE
Give bottom pagination bar transparent background

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -952,7 +952,7 @@ input[type="range"].zoom-slider {
 }
 
 .pagination-footer {
-  background-color: $body-bg;
+  background-color: transparent;
   bottom: $navbar-height;
   padding: 0.5rem 1rem;
   position: sticky;
@@ -964,5 +964,10 @@ input[type="range"].zoom-slider {
 
   .pagination {
     margin-bottom: 0;
+
+    .btn:disabled {
+      color: #888;
+      opacity: 1;
+    }
   }
 }


### PR DESCRIPTION
Feedback on the pagination bottom bar was that the bar used up too much space. Made the bar transparent so only the paging controls are visible.

![image](https://github.com/user-attachments/assets/de7c17ad-4886-4d57-9bf9-d48efacd09e6)
