### PR TITLE
Add colon to death date in the expanded performer details

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerDetailsPanel.tsx
@@ -94,7 +94,11 @@ export const PerformerDetailsPanel: React.FC<IPerformerDetails> =
           }
           fullWidth={fullWidth}
         />
-        <DetailItem id="death_date" value={performer.death_date} />
+        <DetailItem
+          id="death_date"
+          value={performer.death_date}
+          fullWidth={fullWidth}
+        />
         {performer.country ? (
           <DetailItem
             id="country"


### PR DESCRIPTION
It's a trivial thing but this colon is currently missing ![Screenshot 2025-06-22](https://github.com/user-attachments/assets/9421d081-f8ec-4a00-a34f-255040a0fd3f)
