### PR TITLE
Make path criterion default modifier includes instead of equals

### DIFF
--- a/ui/v2.5/src/models/list-filter/criteria/country.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/country.ts
@@ -3,11 +3,11 @@ import { CriterionModifier } from "src/core/generated-graphql";
 import { getCountryByISO } from "src/utils/country";
 import { StringCriterion, StringCriterionOption } from "./criterion";
 
-export const CountryCriterionOption = new StringCriterionOption(
-  "country",
-  "country",
-  () => new CountryCriterion()
-);
+export const CountryCriterionOption = new StringCriterionOption({
+  messageID: "country",
+  type: "country",
+  makeCriterion: () => new CountryCriterion(),
+});
 
 export class CountryCriterion extends StringCriterion {
   constructor() {

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -526,13 +526,12 @@ export class IHierarchicalLabeledIdCriterion extends ModifierCriterion<IHierarch
 
 export class StringCriterionOption extends ModifierCriterionOption {
   constructor(
-    messageID: string,
-    value: CriterionType,
-    makeCriterion?: () => ModifierCriterion<CriterionValue>
+    options: Partial<
+      Omit<IModifierCriterionOptionParams, "messageID" | "type">
+    > &
+      Pick<IModifierCriterionOptionParams, "messageID" | "type">
   ) {
     super({
-      messageID,
-      type: value,
       modifierOptions: [
         CriterionModifier.Equals,
         CriterionModifier.NotEquals,
@@ -545,9 +544,8 @@ export class StringCriterionOption extends ModifierCriterionOption {
       ],
       defaultModifier: CriterionModifier.Equals,
       inputType: "text",
-      makeCriterion: makeCriterion
-        ? makeCriterion
-        : () => new StringCriterion(this),
+      makeCriterion: () => new StringCriterion(this),
+      ...options,
     });
   }
 }
@@ -556,7 +554,7 @@ export function createStringCriterionOption(
   type: CriterionType,
   messageID?: string
 ) {
-  return new StringCriterionOption(messageID ?? type, type);
+  return new StringCriterionOption({ messageID: messageID ?? type, type });
 }
 
 export class MandatoryStringCriterionOption extends ModifierCriterionOption {

--- a/ui/v2.5/src/models/list-filter/criteria/path.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/path.ts
@@ -1,10 +1,12 @@
+import { CriterionModifier } from "src/core/generated-graphql";
 import { StringCriterion, StringCriterionOption } from "./criterion";
 
-export const PathCriterionOption = new StringCriterionOption(
-  "path",
-  "path",
-  () => new PathCriterion()
-);
+export const PathCriterionOption = new StringCriterionOption({
+  messageID: "path",
+  type: "path",
+  defaultModifier: CriterionModifier.Includes,
+  makeCriterion: () => new PathCriterion(),
+});
 
 export class PathCriterion extends StringCriterion {
   constructor() {


### PR DESCRIPTION
Fixes longstanding annoying issue where the path criterion would select `equals` as the modifier. Changes this to use `includes` instead, which is the most likely desired default.

Related discussion: https://discourse.stashapp.cc/t/using-the-filter-option-is-not-working-as-i-expect/2277