### PR TITLE
Show filter tags in scene list toolbar

### DIFF
--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -60,6 +60,7 @@
     "react-datepicker": "^4.10.0",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
+    "react-intersection-observer": "^9.16.0",
     "react-intl": "^6.2.8",
     "react-photo-gallery": "^8.0.0",
     "react-remark": "^2.1.0",

--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -1,5 +1,6 @@
 import React, {
   PropsWithChildren,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useReducer,
@@ -95,6 +96,7 @@ const MoreFilterTags: React.FC<{
 };
 
 interface IFilterTagsProps {
+  inViewRef?: (node?: Element | null) => void;
   criteria: Criterion[];
   onEditCriterion: (c: Criterion) => void;
   onRemoveCriterion: (c: Criterion, valueIndex?: number) => void;
@@ -103,6 +105,7 @@ interface IFilterTagsProps {
 }
 
 export const FilterTags: React.FC<IFilterTagsProps> = ({
+  inViewRef,
   criteria,
   onEditCriterion,
   onRemoveCriterion,
@@ -110,13 +113,23 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   truncateOnOverflow = false,
 }) => {
   const intl = useIntl();
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>();
 
   const [cutoff, setCutoff] = React.useState<number | undefined>();
   const elementGap = 10; // Adjust this value based on your CSS gap or margin
   const moreTagWidth = 80; // reserve space for the "more" tag
 
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  const setRefs = useCallback(
+    (node) => {
+      // Ref's from useRef needs to have the node assigned to `current`
+      ref.current = node;
+      // Callback refs, like the one from `useInView`, is a function that takes the node as an argument
+      if (inViewRef) inViewRef(node);
+    },
+    [inViewRef]
+  );
 
   const debounceResetCutoff = useDebounce(
     () => {
@@ -277,7 +290,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     const hiddenCriteria = filterTags.slice(cutoff);
 
     return (
-      <div className={className} ref={ref}>
+      <div className={className} ref={setRefs}>
         {visibleCriteria}
         <MoreFilterTags tags={hiddenCriteria} />
         {criteria.length >= 3 && (
@@ -294,7 +307,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   }
 
   return (
-    <div className={className} ref={ref}>
+    <div className={className} ref={setRefs}>
       {filterTags}
       {criteria.length >= 3 && (
         <Button

--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -1,11 +1,17 @@
-import React, { PropsWithChildren } from "react";
-import { Badge, BadgeProps, Button } from "react-bootstrap";
+import React, {
+  PropsWithChildren,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import { Badge, BadgeProps, Button, Overlay, Tooltip } from "react-bootstrap";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "../Shared/Icon";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { BsPrefixProps, ReplaceProps } from "react-bootstrap/esm/helpers";
 import { CustomFieldsCriterion } from "src/models/list-filter/criteria/custom-fields";
+import { useCompare } from "src/hooks/state";
 
 type TagItemProps = PropsWithChildren<
   ReplaceProps<"span", BsPrefixProps<"span"> & BadgeProps>
@@ -41,11 +47,58 @@ export const FilterTag: React.FC<{
   );
 };
 
+const MoreFilterTags: React.FC<{
+  tags: React.ReactNode[];
+}> = ({ tags }) => {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+  const target = useRef(null);
+
+  if (!tags.length) {
+    return null;
+  }
+
+  function handleMouseEnter() {
+    setShowTooltip(true);
+  }
+
+  function handleMouseLeave() {
+    setShowTooltip(false);
+  }
+
+  return (
+    <>
+      <Overlay target={target.current} placement="bottom" show={showTooltip}>
+        <Tooltip
+          id="more-criteria-tooltip"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onClick={handleMouseLeave}
+        >
+          {tags}
+        </Tooltip>
+      </Overlay>
+      <Badge
+        ref={target}
+        className={"tag-item more-tags"}
+        variant="secondary"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <FormattedMessage
+          id="search_filter.more_filter_criteria"
+          values={{ count: tags.length }}
+        />
+      </Badge>
+    </>
+  );
+};
+
 interface IFilterTagsProps {
   criteria: Criterion[];
   onEditCriterion: (c: Criterion) => void;
   onRemoveCriterion: (c: Criterion, valueIndex?: number) => void;
   onRemoveAll: () => void;
+  truncateOnOverflow?: boolean;
 }
 
 export const FilterTags: React.FC<IFilterTagsProps> = ({
@@ -53,8 +106,105 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
   onEditCriterion,
   onRemoveCriterion,
   onRemoveAll,
+  truncateOnOverflow = false,
 }) => {
   const intl = useIntl();
+  const criteriaChanged = useCompare(criteria);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [cutoff, setCutoff] = React.useState<number | undefined>();
+  const elementGap = 10; // Adjust this value based on your CSS gap or margin
+  const moreTagWidth = 80; // reserve space for the "more" tag
+
+  // trigger recalculation of cutoff when control resizes
+  useEffect(() => {
+    if (!truncateOnOverflow || !ref.current) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      setCutoff(undefined);
+    });
+
+    const { current } = ref;
+    resizeObserver.observe(current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [truncateOnOverflow]);
+
+  useLayoutEffect(() => {
+    // if criteria changed, set the cutoff to undefined to recalculate it
+    if (!truncateOnOverflow || criteriaChanged) {
+      setCutoff(undefined);
+      return;
+    }
+
+    const { current } = ref;
+
+    if (current) {
+      // calculate the number of tags that can fit in the container
+      const containerWidth = current.clientWidth;
+      const children = Array.from(current.children);
+
+      // don't recalculate anything if the more tag is visible and cutoff is already set
+      const moreTags = children.find((child) => {
+        return (child as HTMLElement).classList.contains("more-tags");
+      });
+
+      if (moreTags && !!cutoff) {
+        return;
+      }
+
+      const childTags = children.filter((child) => {
+        return (
+          (child as HTMLElement).classList.contains("tag-item") ||
+          (child as HTMLElement).classList.contains("clear-all-button")
+        );
+      });
+
+      const clearAllButton = children.find((child) => {
+        return (child as HTMLElement).classList.contains("clear-all-button");
+      });
+
+      // calculate the total width without the more tag
+      const defaultTotalWidth = childTags.reduce((total, child, idx) => {
+        return (
+          total +
+          ((child as HTMLElement).offsetWidth ?? 0) +
+          (idx === childTags.length - 1 ? 0 : elementGap)
+        );
+      }, 0);
+
+      if (containerWidth >= defaultTotalWidth) {
+        // if the container is wide enough to fit all tags, reset cutoff
+        setCutoff(undefined);
+        return;
+      }
+
+      let totalWidth = 0;
+      let visibleCount = 0;
+
+      // reserve space for the more tags control
+      totalWidth += moreTagWidth;
+
+      // reserve space for the clear all button if present
+      if (clearAllButton) {
+        totalWidth += (clearAllButton as HTMLElement).offsetWidth ?? 0;
+      }
+
+      for (const child of children) {
+        totalWidth += ((child as HTMLElement).offsetWidth ?? 0) + elementGap;
+        if (totalWidth > containerWidth) {
+          break;
+        }
+        visibleCount++;
+      }
+
+      setCutoff(visibleCount);
+    }
+  });
 
   function onRemoveCriterionTag(
     criterion: Criterion,
@@ -72,7 +222,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     onEditCriterion(criterion);
   }
 
-  function renderFilterTags(criterion: Criterion) {
+  function getFilterTags(criterion: Criterion) {
     if (
       criterion instanceof CustomFieldsCriterion &&
       criterion.value.length > 1
@@ -105,9 +255,34 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     return null;
   }
 
+  const className = "wrap-tags filter-tags";
+
+  const filterTags = criteria.map((c) => getFilterTags(c)).flat();
+
+  if (cutoff && filterTags.length > cutoff) {
+    const visibleCriteria = filterTags.slice(0, cutoff);
+    const hiddenCriteria = filterTags.slice(cutoff);
+
+    return (
+      <div className={className}>
+        {visibleCriteria}
+        <MoreFilterTags tags={hiddenCriteria} />
+        {criteria.length >= 3 && (
+          <Button
+            variant="minimal"
+            className="clear-all-button"
+            onClick={() => onRemoveAll()}
+          >
+            <FormattedMessage id="actions.clear" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div className="wrap-tags filter-tags">
-      {criteria.map(renderFilterTags)}
+    <div className={className} ref={ref}>
+      {filterTags}
       {criteria.length >= 3 && (
         <Button
           variant="minimal"

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -416,13 +416,18 @@ input[type="range"].zoom-slider {
   display: flex;
   justify-content: center;
   margin-bottom: 0.5rem;
-}
 
-.filter-tags .clear-all-button {
-  color: $text-color;
-  // to match filter pills
-  line-height: 16px;
-  padding: 0;
+  .more-tags {
+    background-color: transparent;
+    color: #fff;
+  }
+
+  .clear-all-button {
+    color: $text-color;
+    // to match filter pills
+    line-height: 16px;
+    padding: 0;
+  }
 }
 
 .filter-button {

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -63,6 +63,7 @@ import { Icon } from "../Shared/Icon";
 import { ListViewOptions } from "../List/ListViewOptions";
 import { PageSizeSelector, SortBySelect } from "../List/ListFilter";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
+import ScreenUtils from "src/utils/screen";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -350,6 +351,7 @@ const ListToolbarContent: React.FC<{
   const intl = useIntl();
 
   const hasSelection = selectedIds.size > 0;
+  const isMobile = ScreenUtils.isMobile();
 
   return (
     <>
@@ -365,6 +367,7 @@ const ListToolbarContent: React.FC<{
             onEditCriterion={onEditCriterion}
             onRemoveCriterion={onRemoveCriterion}
             onRemoveAll={onRemoveAllCriterion}
+            truncateOnOverflow={!isMobile}
           />
         </div>
       )}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -62,6 +62,7 @@ import { FilterButton } from "../List/Filters/FilterButton";
 import { Icon } from "../Shared/Icon";
 import { ListViewOptions } from "../List/ListViewOptions";
 import { PageSizeSelector, SortBySelect } from "../List/ListFilter";
+import { Criterion } from "src/models/list-filter/criteria/criterion";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -316,11 +317,14 @@ interface IOperations {
 }
 
 const ListToolbarContent: React.FC<{
-  criteriaCount: number;
+  criteria: Criterion[];
   items: GQL.SlimSceneDataFragment[];
   selectedIds: Set<string>;
   operations: IOperations[];
   onToggleSidebar: () => void;
+  onEditCriterion: (c: Criterion) => void;
+  onRemoveCriterion: (criterion: Criterion, valueIndex?: number) => void;
+  onRemoveAllCriterion: () => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
   onEdit: () => void;
@@ -328,11 +332,14 @@ const ListToolbarContent: React.FC<{
   onPlay: () => void;
   onCreateNew: () => void;
 }> = ({
-  criteriaCount,
+  criteria,
   items,
   selectedIds,
   operations,
   onToggleSidebar,
+  onEditCriterion,
+  onRemoveCriterion,
+  onRemoveAllCriterion,
   onSelectAll,
   onSelectNone,
   onEdit,
@@ -350,8 +357,14 @@ const ListToolbarContent: React.FC<{
         <div>
           <FilterButton
             onClick={() => onToggleSidebar()}
-            count={criteriaCount}
+            count={criteria.length}
             title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
+          />
+          <FilterTags
+            criteria={criteria}
+            onEditCriterion={onEditCriterion}
+            onRemoveCriterion={onRemoveCriterion}
+            onRemoveAll={onRemoveAllCriterion}
           />
         </div>
       )}
@@ -730,11 +743,14 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               })}
             >
               <ListToolbarContent
-                criteriaCount={filter.count()}
+                criteria={filter.criteria}
                 items={items}
                 selectedIds={selectedIds}
                 operations={otherOperations}
                 onToggleSidebar={() => setShowSidebar(!showSidebar)}
+                onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
+                onRemoveCriterion={removeCriterion}
+                onRemoveAllCriterion={() => clearAllCriteria()}
                 onSelectAll={() => onSelectAll()}
                 onSelectNone={() => onSelectNone()}
                 onEdit={onEdit}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -69,7 +69,6 @@ import { Icon } from "../Shared/Icon";
 import { ListViewOptions } from "../List/ListViewOptions";
 import { PageSizeSelector, SortBySelect } from "../List/ListFilter";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
-import ScreenUtils from "src/utils/screen";
 import { useInView } from "react-intersection-observer";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
@@ -358,7 +357,6 @@ const ListToolbarContent: React.FC<{
   const intl = useIntl();
 
   const hasSelection = selectedIds.size > 0;
-  const isMobile = ScreenUtils.isMobile();
 
   return (
     <>
@@ -374,7 +372,7 @@ const ListToolbarContent: React.FC<{
             onEditCriterion={onEditCriterion}
             onRemoveCriterion={onRemoveCriterion}
             onRemoveAll={onRemoveAllCriterion}
-            truncateOnOverflow={!isMobile}
+            truncateOnOverflow
           />
         </div>
       )}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1112,3 +1112,7 @@ input[type="range"].blue-slider {
     top: 0;
   }
 }
+
+#more-criteria-tooltip .tooltip-inner {
+  max-width: 400px;
+}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1064,10 +1064,12 @@ input[type="range"].blue-slider {
   }
 
   > div:first-child {
+    flex-grow: 1;
     overflow-x: hidden;
   }
 
   .filter-tags {
+    flex-grow: 1;
     flex-wrap: nowrap;
     justify-content: flex-start;
     margin-bottom: 0;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1020,13 +1020,13 @@ input[type="range"].blue-slider {
     &:last-child {
       flex-shrink: 0;
       justify-content: flex-end;
-      margin-left: auto;
     }
   }
 }
 
 .scene-list-toolbar {
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  gap: 1rem;
   // offset the main padding
   margin-top: -0.5rem;
   padding-bottom: 0.5rem;
@@ -1060,6 +1060,25 @@ input[type="range"].blue-slider {
     .play-button,
     .create-new-button {
       display: none;
+    }
+  }
+
+  > div:first-child {
+    overflow-x: hidden;
+  }
+
+  .filter-tags {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    margin-bottom: 0;
+    width: calc(100% - 35px - 0.5rem);
+
+    @include media-breakpoint-down(xs) {
+      scrollbar-width: none;
+    }
+
+    .tag-item {
+      white-space: nowrap;
     }
   }
 }

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1074,7 +1074,8 @@ input[type="range"].blue-slider {
     width: calc(100% - 35px - 0.5rem);
 
     @include media-breakpoint-down(xs) {
-      scrollbar-width: none;
+      overflow-x: auto;
+      scrollbar-width: thin;
     }
 
     .tag-item {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1073,6 +1073,8 @@ input[type="range"].blue-slider {
     flex-wrap: nowrap;
     justify-content: flex-start;
     margin-bottom: 0;
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
     width: calc(100% - 35px - 0.5rem);
 
     @include media-breakpoint-down(xs) {
@@ -1082,6 +1084,13 @@ input[type="range"].blue-slider {
 
     .tag-item {
       white-space: nowrap;
+    }
+  }
+
+  &.hide-filter-tags {
+    .filter-tags {
+      opacity: 0;
+      pointer-events: none;
     }
   }
 }

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -788,6 +788,14 @@ $sidebar-width: 250px;
     margin-left: -$sidebar-width;
   }
 
+  &.hide-sidebar .sidebar + div {
+    width: 100%;
+  }
+
+  &:not(.hide-sidebar) .sidebar + div {
+    width: calc(100% - $sidebar-width);
+  }
+
   > :nth-child(2) {
     flex-grow: 1;
     padding-left: 0.5rem;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1316,7 +1316,7 @@
     "name": "Filter",
     "saved_filters": "Saved filters",
     "update_filter": "Update Filter",
-    "more_filter_criteria": "+{count} others"
+    "more_filter_criteria": "+{count} more"
   },
   "second": "Second",
   "seconds": "Seconds",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1315,7 +1315,8 @@
     "edit_filter": "Edit Filter",
     "name": "Filter",
     "saved_filters": "Saved filters",
-    "update_filter": "Update Filter"
+    "update_filter": "Update Filter",
+    "more_filter_criteria": "+{count} others"
   },
   "second": "Second",
   "seconds": "Seconds",

--- a/ui/v2.5/yarn.lock
+++ b/ui/v2.5/yarn.lock
@@ -6475,6 +6475,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-intersection-observer@^9.16.0:
+  version "9.16.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz#7376d54edc47293300961010844d53b273ee0fb9"
+  integrity sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==
+
 react-intl@^6.2.8:
   version "6.2.8"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-6.2.8.tgz#f61fffc14e69490607d3be9253704ac5afc49d56"


### PR DESCRIPTION
Adds the current filter tags to the scene list toolbar. If the tags don't fit in the available space, then the list is truncated, with the overflow accessible in a toolbar by hovering over (or clicking on touch devices) the `+x more` tooltip:

![image](https://github.com/user-attachments/assets/9989e361-8493-4388-8f47-f402adc7b450)
![image](https://github.com/user-attachments/assets/f14840a9-438d-46ce-a2ef-16fedbba049c)

The tags in the tooltip can be interacted with to edit or remove them.

When scrolled to the top of the page, the filter tags are shown as usual and the tags in the toolbar are hidden, only appearing once the tags at the top of the page are out of view:


https://github.com/user-attachments/assets/173a6bbe-484d-4dd4-a0a6-076b4ebce7c7










