### PR TITLE
Pagination styling

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -984,7 +984,7 @@ input[type="range"].zoom-slider {
 .pagination-footer {
   background-color: transparent;
   bottom: $navbar-height;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem 0.75rem;
   position: sticky;
   z-index: 10;
 

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -984,12 +984,18 @@ input[type="range"].zoom-slider {
 .pagination-footer {
   background-color: transparent;
   bottom: $navbar-height;
+  margin: auto;
   padding: 0.5rem 1rem 0.75rem;
   position: sticky;
+  width: fit-content;
   z-index: 10;
 
   @include media-breakpoint-up(sm) {
     bottom: 0;
+  }
+
+  .pagination.btn-group {
+    box-shadow: 0 8px 10px 2px rgb(0 0 0 / 30%);
   }
 
   .pagination {


### PR DESCRIPTION
In addition to the shadow styling provided by @cj12312021, I've also raised the bar slightly so that it is no longer completely occluded by the link bar when hovering over a link.

Before: 
![image](https://github.com/user-attachments/assets/e0d87104-d369-4b9f-ad60-2d64288e2f2f)

After:
![image](https://github.com/user-attachments/assets/89728dd4-7747-4ac1-b4ee-e90803abd388)
