### PR TITLE
Handle marshalling scraped movie to group

### DIFF
--- a/internal/api/scraped_content.go
+++ b/internal/api/scraped_content.go
@@ -135,6 +135,13 @@ func marshalScrapedGroups(content []scraper.ScrapedContent) ([]*models.ScrapedGr
 			ret = append(ret, m)
 		case models.ScrapedGroup:
 			ret = append(ret, &m)
+		// it's possible that a scraper returns models.ScrapedMovie
+		case *models.ScrapedMovie:
+			g := m.ScrapedGroup()
+			ret = append(ret, &g)
+		case models.ScrapedMovie:
+			g := m.ScrapedGroup()
+			ret = append(ret, &g)
 		default:
 			return nil, fmt.Errorf("%w: cannot turn ScrapedContent into ScrapedGroup", models.ErrConversion)
 		}


### PR DESCRIPTION
Fixes error message: `scrapeGroupURL: input: scrapeGroupURL conversion error: cannot turn ScrapedContent into ScrapedGroup` when scraping groups using URL.