### PR TITLE
Add keyboard shortcuts for Scene Cover generation

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -247,6 +247,8 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
     Mousetrap.bind("p p", () => onQueuePrevious());
     Mousetrap.bind("p r", () => onQueueRandom());
     Mousetrap.bind(",", () => setCollapsed(!collapsed));
+    Mousetrap.bind("c c", () => onGenerateScreenshot(getPlayerPosition()));
+    Mousetrap.bind("c d", () => onGenerateScreenshot());
 
     return () => {
       Mousetrap.unbind("a");
@@ -260,6 +262,8 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       Mousetrap.unbind("p p");
       Mousetrap.unbind("p r");
       Mousetrap.unbind(",");
+      Mousetrap.unbind("c c");
+      Mousetrap.unbind("c d");
     };
   });
 

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -67,6 +67,9 @@
 | `r 0` | Unset rating (stars) |
 | `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
 | ``r ` `` | Unset rating (decimal) |
+| Cover generation ||
+| `c c` | Generate screenshot at current time |
+| `c d` | Generate default screenshot |
 | Playback ||
 | `p n` | Play next scene in queue |
 | `p p` | Play previous scene in queue |


### PR DESCRIPTION
### DESCRIPTION:

I like using custom cover screenshots for my scenes.  When playing a video, I will often spot a good place to pause to generate the screenshot, but then the button to "Generate screenshot from current" is buried under a submenu in the scene details tab and requires a few clicks.
 
This adds 1 shortcut to generate the screenshot at current time, and 1 screenshot to re-generate a default screenshot.   I tried to ensure the shortcuts follow the conventions of existing shortcuts and do not conflict with any existing shortcuts.
 
Ideally a system to define any custom shortcuts could be cool, but that's a much larger effort. 

### CHANGES:

- Add 'c c' shortcut to generate screenshot at current time
- Add 'c d' shortcut to generate default screenshot
- Update keyboard shortcuts documentation