### PR TITLE
Bring back select all/none to scene list

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -670,6 +670,16 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
       className: "create-new-item",
     },
     {
+      text: intl.formatMessage({ id: "actions.select_all" }),
+      onClick: () => onSelectAll(),
+      isDisplayed: () => totalCount > 0,
+    },
+    {
+      text: intl.formatMessage({ id: "actions.select_none" }),
+      onClick: () => onSelectNone(),
+      isDisplayed: () => hasSelection,
+    },
+    {
       text: intl.formatMessage({ id: "actions.play_random" }),
       onClick: playRandom,
       isDisplayed: () => totalCount > 1,


### PR DESCRIPTION
Select all is now available in the overflow list. Select none is also available if there is a selection.