### PR TITLE
Treat images with no exif metadata as well-oriented

### DIFF
--- a/pkg/file/image/orientation.go
+++ b/pkg/file/image/orientation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/rwcarlsen/goexif/exif"
 	"github.com/stashapp/stash/pkg/logger"
@@ -33,7 +34,7 @@ func areDimensionsFlipped(fs models.FS, path string) (bool, error) {
 
 	x, err := exif.Decode(r)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
+		if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "failed to find exif") {
 			// no exif data
 			return false, nil
 		}


### PR DESCRIPTION
Some images fail to be loaded by `goexif`, but the error raised is not `EOF` -- it's a [hard-coded "failed to find exif intro marker"](https://github.com/rwcarlsen/goexif/blob/9e8deecbddbd4989a3e8d003684b783412b41e7a/exif/exif.go#L645-L653). In turn, the images are falsely assigned width and height of 0, and this causes the `ImageWall` view to fail the [`getCommonHeight` helper](https://github.com/neptunian/react-photo-gallery/blob/0bb8e4c4a027c021f8a5a06de71e89026596fd95/src/layouts/justified.js#L9-L13) returning NaN. In turn, this leaves all images on any `ImageWall` including at least one bad-EXIF image with width and height of `NaN`.