### PR TITLE
Moved getFileSize from scan.go into standalone util

### DIFF
--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -114,7 +115,7 @@ func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.
 			return nil
 		}
 
-		size, err := getFileSize(file.fs, path, info)
+		size, err := fsutil.GetFileSize(file.fs, path, info)
 		if err != nil {
 			return fmt.Errorf("getting file size for %q: %w", path, err)
 		}

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/remeh/sizedwaitgroup"
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/txn"
@@ -250,7 +250,7 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *scanF
 			return nil
 		}
 
-		size, err := getFileSize(f, path, info)
+		size, err := fsutil.GetFileSize(f, path, info)
 		if err != nil {
 			return err
 		}
@@ -311,19 +311,6 @@ func (s *scanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *scanF
 
 		return nil
 	}
-}
-
-func getFileSize(f models.FS, path string, info fs.FileInfo) (int64, error) {
-	// #2196/#3042 - replace size with target size if file is a symlink
-	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
-		targetInfo, err := f.Stat(path)
-		if err != nil {
-			return 0, fmt.Errorf("reading info for symlink %q: %w", path, err)
-		}
-		return targetInfo.Size(), nil
-	}
-
-	return info.Size(), nil
 }
 
 func (s *scanJob) acceptEntry(ctx context.Context, path string, info fs.FileInfo) bool {

--- a/pkg/fsutil/file_size.go
+++ b/pkg/fsutil/file_size.go
@@ -1,0 +1,22 @@
+package fsutil
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func GetFileSize(f models.FS, path string, info fs.FileInfo) (int64, error) {
+	// #2196/#3042 - replace size with target size if file is a symlink
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		targetInfo, err := f.Stat(path)
+		if err != nil {
+			return 0, fmt.Errorf("reading info for symlink %q: %w", path, err)
+		}
+		return targetInfo.Size(), nil
+	}
+
+	return info.Size(), nil
+}


### PR DESCRIPTION
Small change here. Moved `getFileSize` from `scan.go` into the fsutil package since it looks like it's also being called externally. Also, since `scan.go` is currently at 1200+ lines I thought it might help simplify things a bit.