### PR TITLE
Allow scan to continue when encountering an error

### DIFF
--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -107,7 +107,8 @@ func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.
 
 		info, err := d.Info()
 		if err != nil {
-			return fmt.Errorf("reading info for %q: %w", path, err)
+			logger.Errorf("reading info for %q: %v", path, err)
+			return nil
 		}
 
 		if !s.acceptEntry(ctx, path, info) {


### PR DESCRIPTION
I noticed hundreds of files weren't being scanned because there was a corrupted file in one of the top level directories which was killing the scan process.