### PR TITLE
Add separate sidebar toggle button

### DIFF
--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -167,7 +167,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
         return (child as HTMLElement).classList.contains("more-tags");
       });
 
-      if (moreTags && !!cutoff) {
+      if (moreTags && cutoff !== undefined) {
         return;
       }
 
@@ -273,7 +273,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
 
   const filterTags = criteria.map((c) => getFilterTags(c)).flat();
 
-  if (cutoff && filterTags.length > cutoff) {
+  if (cutoff !== undefined && filterTags.length > cutoff) {
     const visibleCriteria = filterTags.slice(0, cutoff);
     const hiddenCriteria = filterTags.slice(cutoff);
 

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -368,7 +368,11 @@ const ListToolbarContent: React.FC<{
             onRemoveAll={onRemoveAllCriterion}
             truncateOnOverflow
           />
-          <Button className="minimal sidebar-toggle-button" variant="secondary" onClick={() => onToggleSidebar()}>
+          <Button
+            className="minimal sidebar-toggle-button"
+            variant="secondary"
+            onClick={() => onToggleSidebar()}
+          >
             <Icon icon={faSliders} />
           </Button>
         </div>
@@ -386,6 +390,13 @@ const ListToolbarContent: React.FC<{
           <span>{selectedIds.size} selected</span>
           <Button variant="link" onClick={() => onSelectAll()}>
             <FormattedMessage id="actions.select_all" />
+          </Button>
+          <Button
+            className="minimal sidebar-toggle-button"
+            variant="secondary"
+            onClick={() => onToggleSidebar()}
+          >
+            <Icon icon={faSliders} />
           </Button>
         </div>
       )}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -357,6 +357,7 @@ const ListToolbarContent: React.FC<{
       className="minimal sidebar-toggle-button ignore-sidebar-outside-click"
       variant="secondary"
       onClick={() => onToggleSidebar()}
+      title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
     >
       <Icon icon={faSliders} />
     </Button>
@@ -369,7 +370,6 @@ const ListToolbarContent: React.FC<{
           <FilterButton
             onClick={() => onEditCriterion()}
             count={criteria.length}
-            title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
           />
           <FilterTags
             criteria={criteria}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -352,6 +352,16 @@ const ListToolbarContent: React.FC<{
 
   const hasSelection = selectedIds.size > 0;
 
+  const sidebarToggle = (
+    <Button
+      className="minimal sidebar-toggle-button ignore-sidebar-outside-click"
+      variant="secondary"
+      onClick={() => onToggleSidebar()}
+    >
+      <Icon icon={faSliders} />
+    </Button>
+  );
+
   return (
     <>
       {!hasSelection && (
@@ -368,13 +378,7 @@ const ListToolbarContent: React.FC<{
             onRemoveAll={onRemoveAllCriterion}
             truncateOnOverflow
           />
-          <Button
-            className="minimal sidebar-toggle-button"
-            variant="secondary"
-            onClick={() => onToggleSidebar()}
-          >
-            <Icon icon={faSliders} />
-          </Button>
+          {sidebarToggle}
         </div>
       )}
       {hasSelection && (
@@ -391,13 +395,7 @@ const ListToolbarContent: React.FC<{
           <Button variant="link" onClick={() => onSelectAll()}>
             <FormattedMessage id="actions.select_all" />
           </Button>
-          <Button
-            className="minimal sidebar-toggle-button"
-            variant="secondary"
-            onClick={() => onToggleSidebar()}
-          >
-            <Icon icon={faSliders} />
-          </Button>
+          {sidebarToggle}
         </div>
       )}
       <div>

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -23,6 +23,7 @@ import {
   faPencil,
   faPlay,
   faPlus,
+  faSliders,
   faTimes,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
@@ -322,7 +323,7 @@ const ListToolbarContent: React.FC<{
   selectedIds: Set<string>;
   operations: IOperations[];
   onToggleSidebar: () => void;
-  onEditCriterion: (c: Criterion) => void;
+  onEditCriterion: (c?: Criterion) => void;
   onRemoveCriterion: (criterion: Criterion, valueIndex?: number) => void;
   onRemoveAllCriterion: () => void;
   onSelectAll: () => void;
@@ -354,9 +355,9 @@ const ListToolbarContent: React.FC<{
   return (
     <>
       {!hasSelection && (
-        <div>
+        <div className="filter-toolbar">
           <FilterButton
-            onClick={() => onToggleSidebar()}
+            onClick={() => onEditCriterion()}
             count={criteria.length}
             title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
           />
@@ -367,6 +368,9 @@ const ListToolbarContent: React.FC<{
             onRemoveAll={onRemoveAllCriterion}
             truncateOnOverflow
           />
+          <Button className="minimal sidebar-toggle-button" variant="secondary" onClick={() => onToggleSidebar()}>
+            <Icon icon={faSliders} />
+          </Button>
         </div>
       )}
       {hasSelection && (
@@ -749,7 +753,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
                 selectedIds={selectedIds}
                 operations={otherOperations}
                 onToggleSidebar={() => setShowSidebar(!showSidebar)}
-                onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
+                onEditCriterion={(c) => showEditFilter(c?.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}
                 onRemoveAllCriterion={() => clearAllCriteria()}
                 onSelectAll={() => onSelectAll()}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1147,6 +1147,19 @@ input[type="range"].blue-slider {
   }
 }
 
+// move the sidebar toggle to the left on xl viewports
+@include media-breakpoint-up(xl) {
+  .scene-list .scene-list-toolbar .filter-section {
+    .sidebar-toggle-button {
+      margin-left: 0;
+    }
+
+    .filter-tags {
+      order: 2;
+    }
+  }
+}
+
 .scene-list-header {
   flex-wrap: wrap-reverse;
   gap: 0.5rem;

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -942,11 +942,6 @@ input[type="range"].blue-slider {
   transition-property: opacity;
 }
 
-.scene-list:not(.hide-sidebar) .sidebar-toggle-button {
-  opacity: 0;
-  pointer-events: none;
-}
-
 .scene-wall,
 .marker-wall {
   .wall-item {
@@ -1063,7 +1058,7 @@ input[type="range"].blue-slider {
     }
   }
 
-  > div:first-child {
+  > div.filter-toolbar {
     border: 1px solid $secondary;
     border-radius: 0.25rem;
     flex-grow: 1;
@@ -1072,6 +1067,10 @@ input[type="range"].blue-slider {
     .filter-button {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
+    }
+
+    .sidebar-toggle-button {
+      margin-left: auto;
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1102,7 +1102,9 @@ input[type="range"].blue-slider {
     flex-wrap: nowrap;
     justify-content: flex-start;
     margin-bottom: 0;
-    width: calc(100% - 35px - 0.5rem);
+
+    // account for filter button, and toggle sidebar buttons with gaps
+    width: calc(100% - 70px - 1rem);
 
     @include media-breakpoint-down(xs) {
       overflow-x: auto;
@@ -1123,6 +1125,25 @@ input[type="range"].blue-slider {
 @include media-breakpoint-down(md) {
   .sidebar-pane.hide-sidebar .scene-list-toolbar .search-container {
     display: none;
+  }
+}
+
+// hide Edit Filter button on larger screens
+@include media-breakpoint-up(lg) {
+  .scene-list .sidebar .edit-filter-button {
+    display: none;
+  }
+}
+
+// hide the filter icon button when sidebar is shown on smaller screens
+@include media-breakpoint-down(md) {
+  .sidebar-pane:not(.hide-sidebar) .scene-list-toolbar .filter-button {
+    display: none;
+  }
+
+  // adjust the width of the filter-tags as well
+  .sidebar-pane:not(.hide-sidebar) .scene-list-toolbar .filter-tags {
+    width: calc(100% - 35px - 0.5rem);
   }
 }
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1058,20 +1058,24 @@ input[type="range"].blue-slider {
     }
   }
 
+  .selected-items-info,
+  > div.filter-toolbar {
+    flex-grow: 1;
+    overflow-x: hidden;
+  }
+
   > div.filter-toolbar {
     border: 1px solid $secondary;
     border-radius: 0.25rem;
-    flex-grow: 1;
-    overflow-x: hidden;
 
     .filter-button {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
     }
+  }
 
-    .sidebar-toggle-button {
-      margin-left: auto;
-    }
+  .sidebar-toggle-button {
+    margin-left: auto;
   }
 
   .filter-tags {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1084,8 +1084,8 @@ input[type="range"].blue-slider {
     border-right: 1px solid $secondary;
     display: block;
     margin-right: -0.5rem;
+    min-width: calc($sidebar-width - 15px);
     padding-right: 10px;
-    width: calc($sidebar-width - 15px);
 
     .search-term-input {
       margin-right: 0;


### PR DESCRIPTION
Related Discourse post: https://discourse.stashapp.cc/t/query-page-redesign/2064/79?u=withoutpants

- changes the behaviour of the filter icon button on the scene query page to show the filter dialog
- adds a sidebar toggle button to the right sidebar of the scene query page toolbar

<img width="1462" height="70" alt="image" src="https://github.com/user-attachments/assets/97347786-b2a1-40cf-a852-cb1b88fd46f9" />
