### PR TITLE
Always show search field on larger viewports in scene query page 

### DIFF
--- a/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
@@ -68,20 +68,6 @@ export function useFilteredSidebarKeybinds(props: {
 }) {
   const { showSidebar, setShowSidebar } = props;
 
-  // Show the sidebar when the user presses the "/" key
-  useEffect(() => {
-    Mousetrap.bind("/", (e) => {
-      if (!showSidebar) {
-        setShowSidebar(true);
-        e.preventDefault();
-      }
-    });
-
-    return () => {
-      Mousetrap.unbind("/");
-    };
-  }, [showSidebar, setShowSidebar]);
-
   // Hide the sidebar when the user presses the "Esc" key
   useEffect(() => {
     Mousetrap.bind("esc", (e) => {

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -61,7 +61,11 @@ import { Button, ButtonGroup, ButtonToolbar } from "react-bootstrap";
 import { FilterButton } from "../List/Filters/FilterButton";
 import { Icon } from "../Shared/Icon";
 import { ListViewOptions } from "../List/ListViewOptions";
-import { PageSizeSelector, SortBySelect } from "../List/ListFilter";
+import {
+  PageSizeSelector,
+  SearchTermInput,
+  SortBySelect,
+} from "../List/ListFilter";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
@@ -326,11 +330,12 @@ interface IOperations {
 }
 
 const ListToolbarContent: React.FC<{
-  criteria: Criterion[];
+  filter: ListFilterModel;
   items: GQL.SlimSceneDataFragment[];
   selectedIds: Set<string>;
   operations: IOperations[];
   onToggleSidebar: () => void;
+  onSetFilter: (filter: ListFilterModel) => void;
   onEditCriterion: (c: Criterion) => void;
   onRemoveCriterion: (criterion: Criterion, valueIndex?: number) => void;
   onRemoveAllCriterion: () => void;
@@ -341,11 +346,12 @@ const ListToolbarContent: React.FC<{
   onPlay: () => void;
   onCreateNew: () => void;
 }> = ({
-  criteria,
+  filter,
   items,
   selectedIds,
   operations,
   onToggleSidebar,
+  onSetFilter,
   onEditCriterion,
   onRemoveCriterion,
   onRemoveAllCriterion,
@@ -358,25 +364,31 @@ const ListToolbarContent: React.FC<{
 }) => {
   const intl = useIntl();
 
+  const { criteria } = filter;
   const hasSelection = selectedIds.size > 0;
 
   return (
     <>
       {!hasSelection && (
-        <div>
-          <FilterButton
-            onClick={() => onToggleSidebar()}
-            count={criteria.length}
-            title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
-          />
-          <FilterTags
-            criteria={criteria}
-            onEditCriterion={onEditCriterion}
-            onRemoveCriterion={onRemoveCriterion}
-            onRemoveAll={onRemoveAllCriterion}
-            truncateOnOverflow
-          />
-        </div>
+        <>
+          <div className="search-container">
+            <SearchTermInput filter={filter} onFilterUpdate={onSetFilter} />
+          </div>
+          <div className="filter-section">
+            <FilterButton
+              onClick={() => onToggleSidebar()}
+              count={criteria.length}
+              title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
+            />
+            <FilterTags
+              criteria={criteria}
+              onEditCriterion={onEditCriterion}
+              onRemoveCriterion={onRemoveCriterion}
+              onRemoveAll={onRemoveAllCriterion}
+              truncateOnOverflow
+            />
+          </div>
+        </>
       )}
       {hasSelection && (
         <div className="selected-items-info">
@@ -783,7 +795,8 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               })}
             >
               <ListToolbarContent
-                criteria={filter.criteria}
+                filter={filter}
+                onSetFilter={setFilter}
                 items={items}
                 selectedIds={selectedIds}
                 operations={otherOperations}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1063,7 +1063,7 @@ input[type="range"].blue-slider {
     }
   }
 
-  > div:first-child {
+  > div.filter-section {
     border: 1px solid $secondary;
     border-radius: 0.25rem;
     flex-grow: 1;
@@ -1072,6 +1072,23 @@ input[type="range"].blue-slider {
     .filter-button {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
+    }
+  }
+
+  .search-container {
+    border-right: 1px solid $secondary;
+    display: block;
+    margin-right: -0.5rem;
+    padding-right: 10px;
+    width: calc($sidebar-width - 15px);
+
+    .search-term-input {
+      margin-right: 0;
+      width: 100%;
+
+      .clearable-text-field {
+        height: 100%;
+      }
     }
   }
 
@@ -1090,6 +1107,17 @@ input[type="range"].blue-slider {
     .tag-item {
       white-space: nowrap;
     }
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .sidebar-pane:not(.hide-sidebar) .scene-list-toolbar .search-container {
+    display: none;
+  }
+}
+@include media-breakpoint-down(md) {
+  .sidebar-pane.hide-sidebar .scene-list-toolbar .search-container {
+    display: none;
   }
 }
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -755,8 +755,6 @@ button.btn.favorite-button {
   }
 }
 
-$sidebar-width: 250px;
-
 .sidebar-pane {
   display: flex;
 

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -5,6 +5,8 @@ $navbar-height: 48.75px;
 
 $sticky-detail-header-height: 50px;
 
+$sidebar-width: 250px;
+
 @import "styles/theme";
 @import "styles/range";
 @import "styles/scrollbars";


### PR DESCRIPTION
Related Discourse post: https://discourse.stashapp.cc/t/query-page-redesign/2064/79?u=withoutpants

Restores the search term input to the scenes query page, for viewports with width > 991px.

<img width="1472" height="84" alt="image" src="https://github.com/user-attachments/assets/f3e57653-c7b9-4ae7-8ebb-516388f6f0fa" />

The input is hidden when the sidebar is visible, since the sidebar includes the search term input as well.