### PR TITLE
Add search term input to edit filter dialog

### DIFF
--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -34,6 +34,7 @@ import { FilterMode } from "src/core/generated-graphql";
 import { useFocusOnce } from "src/utils/focus";
 import Mousetrap from "mousetrap";
 import ScreenUtils from "src/utils/screen";
+import { SearchTermInput } from "./ListFilter";
 
 interface ICriterionList {
   criteria: string[];
@@ -453,6 +454,15 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
               "criterion-selected": !!criterion,
             })}
           >
+            <div className="search-term-row">
+              <span>
+                <FormattedMessage id="search_filter.search_term" />
+              </span>
+              <SearchTermInput
+                filter={currentFilter}
+                onFilterUpdate={setCurrentFilter}
+              />
+            </div>
             <CriterionOptionList
               criteria={criteriaList}
               currentCriterion={criterion}

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -312,6 +312,32 @@ input[type="range"].zoom-slider {
     padding-right: 0;
   }
 
+  .search-term-row {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+    margin-left: 1.5rem;
+    margin-right: 1rem;
+
+    .search-term-input {
+      flex-basis: 75%;
+    }
+
+    @include media-breakpoint-down(xs) {
+      flex-wrap: wrap;
+
+      > span {
+        width: 100%;
+      }
+
+      .search-term-input {
+        flex-basis: 100%;
+      }
+    }
+  }
+
   .filter-tags {
     border-top: 1px solid rgb(16 22 26 / 40%);
     padding: 1rem 1rem 0 1rem;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1317,6 +1317,7 @@
     "edit_filter": "Edit Filter",
     "name": "Filter",
     "saved_filters": "Saved filters",
+    "search_term": "Search term",
     "update_filter": "Update Filter",
     "more_filter_criteria": "+{count} more"
   },


### PR DESCRIPTION
Related Discourse post: https://discourse.stashapp.cc/t/query-page-redesign/2064/79?u=withoutpants

Adds the search term input as the top field in the Edit Filter dialog:

<img width="760" height="1013" alt="image" src="https://github.com/user-attachments/assets/48479a8c-36d1-4000-b768-2add0454e18c" />

With the recent and planned changes to the query pages, the search term may not always be visible on some viewports. Having the search term on the edit filter page provides a consistent place for it on all viewports.