### PR TITLE
Add search term filter tag to scene list filter tags

### DIFF
--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -9,31 +9,37 @@ import { Badge, BadgeProps, Button, Overlay, Popover } from "react-bootstrap";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "../Shared/Icon";
-import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faMagnifyingGlass, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { BsPrefixProps, ReplaceProps } from "react-bootstrap/esm/helpers";
 import { CustomFieldsCriterion } from "src/models/list-filter/criteria/custom-fields";
 import { useDebounce } from "src/hooks/debounce";
+import cx from "classnames";
 
 type TagItemProps = PropsWithChildren<
   ReplaceProps<"span", BsPrefixProps<"span"> & BadgeProps>
 >;
 
 export const TagItem: React.FC<TagItemProps> = (props) => {
-  const { children } = props;
+  const { className, children, ...others } = props;
   return (
-    <Badge className="tag-item" variant="secondary" {...props}>
+    <Badge
+      className={cx("tag-item", className)}
+      variant="secondary"
+      {...others}
+    >
       {children}
     </Badge>
   );
 };
 
 export const FilterTag: React.FC<{
+  className?: string;
   label: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLSpanElement>;
   onRemove: React.MouseEventHandler<HTMLElement>;
-}> = ({ label, onClick, onRemove }) => {
+}> = ({ className, label, onClick, onRemove }) => {
   return (
-    <TagItem onClick={onClick}>
+    <TagItem className={className} onClick={onClick}>
       {label}
       <Button
         variant="secondary"
@@ -96,18 +102,24 @@ const MoreFilterTags: React.FC<{
 };
 
 interface IFilterTagsProps {
+  searchTerm?: string;
   criteria: Criterion[];
+  onEditSearchTerm?: () => void;
   onEditCriterion: (c: Criterion) => void;
   onRemoveCriterion: (c: Criterion, valueIndex?: number) => void;
   onRemoveAll: () => void;
+  onRemoveSearchTerm?: () => void;
   truncateOnOverflow?: boolean;
 }
 
 export const FilterTags: React.FC<IFilterTagsProps> = ({
+  searchTerm,
   criteria,
   onEditCriterion,
   onRemoveCriterion,
   onRemoveAll,
+  onEditSearchTerm,
+  onRemoveSearchTerm,
   truncateOnOverflow = false,
 }) => {
   const intl = useIntl();
@@ -265,7 +277,7 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     );
   }
 
-  if (criteria.length === 0) {
+  if (criteria.length === 0 && !searchTerm) {
     return null;
   }
 
@@ -273,31 +285,31 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
 
   const filterTags = criteria.map((c) => getFilterTags(c)).flat();
 
-  if (cutoff && filterTags.length > cutoff) {
-    const visibleCriteria = filterTags.slice(0, cutoff);
-    const hiddenCriteria = filterTags.slice(cutoff);
-
-    return (
-      <div className={className} ref={ref}>
-        {visibleCriteria}
-        <MoreFilterTags tags={hiddenCriteria} />
-        {criteria.length >= 3 && (
-          <Button
-            variant="minimal"
-            className="clear-all-button"
-            onClick={() => onRemoveAll()}
-          >
-            <FormattedMessage id="actions.clear" />
-          </Button>
-        )}
-      </div>
+  if (searchTerm && searchTerm.length > 0) {
+    filterTags.unshift(
+      <FilterTag
+        key="search-term"
+        className="search-term-filter-tag"
+        label={
+          <span className="search-term">
+            <Icon icon={faMagnifyingGlass} />
+            {searchTerm}
+          </span>
+        }
+        onClick={() => onEditSearchTerm?.()}
+        onRemove={() => onRemoveSearchTerm?.()}
+      />
     );
   }
 
+  const visibleCriteria = cutoff ? filterTags.slice(0, cutoff) : filterTags;
+  const hiddenCriteria = cutoff ? filterTags.slice(cutoff) : [];
+
   return (
     <div className={className} ref={ref}>
-      {filterTags}
-      {criteria.length >= 3 && (
+      {visibleCriteria}
+      <MoreFilterTags tags={hiddenCriteria} />
+      {filterTags.length >= 3 && (
         <Button
           variant="minimal"
           className="clear-all-button"

--- a/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
+++ b/ui/v2.5/src/components/List/Filters/FilterSidebar.tsx
@@ -16,8 +16,17 @@ export const FilteredSidebarHeader: React.FC<{
   filter: ListFilterModel;
   setFilter: (filter: ListFilterModel) => void;
   view?: View;
-}> = ({ sidebarOpen, showEditFilter, filter, setFilter, view }) => {
-  const focus = useFocus();
+  focus?: ReturnType<typeof useFocus>;
+}> = ({
+  sidebarOpen,
+  showEditFilter,
+  filter,
+  setFilter,
+  view,
+  focus: providedFocus,
+}) => {
+  const localFocus = useFocus();
+  const focus = providedFocus ?? localFocus;
   const [, setFocus] = focus;
 
   // Set the focus on the input field when the sidebar is opened

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -196,9 +196,12 @@ export function useFilterOperations(props: {
     [setFilter]
   );
 
-  const clearAllCriteria = useCallback(() => {
-    setFilter((cv) => cv.clearCriteria());
-  }, [setFilter]);
+  const clearAllCriteria = useCallback(
+    (includeSearchTerm = false) => {
+      setFilter((cv) => cv.clearCriteria(includeSearchTerm));
+    },
+    [setFilter]
+  );
 
   return {
     setPage,

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -63,6 +63,7 @@ import { Icon } from "../Shared/Icon";
 import { ListViewOptions } from "../List/ListViewOptions";
 import { PageSizeSelector, SortBySelect } from "../List/ListFilter";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
+import useFocus from "src/utils/focus";
 
 function renderMetadataByline(result: GQL.FindScenesQueryResult) {
   const duration = result?.data?.findScenes?.duration;
@@ -247,6 +248,7 @@ const SidebarContent: React.FC<{
   onClose?: () => void;
   showEditFilter: (editingCriterion?: string) => void;
   count?: number;
+  focus?: ReturnType<typeof useFocus>;
 }> = ({
   filter,
   setFilter,
@@ -256,6 +258,7 @@ const SidebarContent: React.FC<{
   sidebarOpen,
   onClose,
   count,
+  focus,
 }) => {
   const showResultsId =
     count !== undefined ? "actions.show_count_results" : "actions.show_results";
@@ -270,6 +273,7 @@ const SidebarContent: React.FC<{
         filter={filter}
         setFilter={setFilter}
         view={view}
+        focus={focus}
       />
 
       <ScenesFilterSidebarSections>
@@ -332,6 +336,7 @@ interface IOperations {
 }
 
 const ListToolbarContent: React.FC<{
+  searchTerm: string;
   criteria: Criterion[];
   items: GQL.SlimSceneDataFragment[];
   selectedIds: Set<string>;
@@ -340,6 +345,8 @@ const ListToolbarContent: React.FC<{
   onEditCriterion: (c: Criterion) => void;
   onRemoveCriterion: (criterion: Criterion, valueIndex?: number) => void;
   onRemoveAllCriterion: () => void;
+  onEditSearchTerm: () => void;
+  onRemoveSearchTerm: () => void;
   onSelectAll: () => void;
   onSelectNone: () => void;
   onEdit: () => void;
@@ -347,6 +354,7 @@ const ListToolbarContent: React.FC<{
   onPlay: () => void;
   onCreateNew: () => void;
 }> = ({
+  searchTerm,
   criteria,
   items,
   selectedIds,
@@ -355,6 +363,8 @@ const ListToolbarContent: React.FC<{
   onEditCriterion,
   onRemoveCriterion,
   onRemoveAllCriterion,
+  onEditSearchTerm,
+  onRemoveSearchTerm,
   onSelectAll,
   onSelectNone,
   onEdit,
@@ -376,10 +386,13 @@ const ListToolbarContent: React.FC<{
             title={intl.formatMessage({ id: "actions.sidebar.toggle" })}
           />
           <FilterTags
+            searchTerm={searchTerm}
             criteria={criteria}
             onEditCriterion={onEditCriterion}
             onRemoveCriterion={onRemoveCriterion}
             onRemoveAll={onRemoveAllCriterion}
+            onEditSearchTerm={onEditSearchTerm}
+            onRemoveSearchTerm={onRemoveSearchTerm}
             truncateOnOverflow
           />
         </div>
@@ -525,6 +538,9 @@ interface IFilteredScenes {
 export const FilteredSceneList = (props: IFilteredScenes) => {
   const intl = useIntl();
   const history = useHistory();
+
+  const searchFocus = useFocus();
+  const [, setSearchFocus] = searchFocus;
 
   const { filterHook, defaultSort, view, alterQuery, fromGroupId } = props;
 
@@ -780,6 +796,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               sidebarOpen={showSidebar}
               onClose={() => setShowSidebar(false)}
               count={cachedResult.loading ? undefined : totalCount}
+              focus={searchFocus}
             />
           </Sidebar>
           <div>
@@ -789,6 +806,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
               })}
             >
               <ListToolbarContent
+                searchTerm={filter.searchTerm}
                 criteria={filter.criteria}
                 items={items}
                 selectedIds={selectedIds}
@@ -797,6 +815,11 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}
                 onRemoveAllCriterion={() => clearAllCriteria()}
+                onEditSearchTerm={() => {
+                  setShowSidebar(true);
+                  setSearchFocus(true);
+                }}
+                onRemoveSearchTerm={() => setFilter(filter.clearSearchTerm())}
                 onSelectAll={() => onSelectAll()}
                 onSelectNone={() => onSelectNone()}
                 onEdit={onEdit}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -814,7 +814,7 @@ export const FilteredSceneList = (props: IFilteredScenes) => {
                 onToggleSidebar={() => setShowSidebar(!showSidebar)}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}
-                onRemoveAllCriterion={() => clearAllCriteria()}
+                onRemoveAllCriterion={() => clearAllCriteria(true)}
                 onEditSearchTerm={() => {
                   setShowSidebar(true);
                   setSearchFocus(true);

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -1121,6 +1121,21 @@ input[type="range"].blue-slider {
   }
 }
 
+// hide the search term tag item when the search box is visible
+@include media-breakpoint-up(lg) {
+  .scene-list-toolbar .filter-tags .search-term-filter-tag {
+    display: none;
+  }
+}
+@include media-breakpoint-down(md) {
+  .sidebar-pane:not(.hide-sidebar)
+    .scene-list-toolbar
+    .filter-tags
+    .search-term-filter-tag {
+    display: none;
+  }
+}
+
 .scene-list-header {
   flex-wrap: wrap-reverse;
   gap: 0.5rem;

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -698,8 +698,10 @@ div.dropdown-menu {
 }
 
 .tag-item {
+  align-items: center;
   background-color: $muted-gray;
   color: $dark-text;
+  display: flex;
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
@@ -710,17 +712,20 @@ div.dropdown-menu {
     cursor: pointer;
   }
 
+  .search-term svg {
+    margin-left: 0;
+  }
+
   .btn {
     background: none;
     border: none;
     bottom: 2px;
     color: $dark-text;
     font-size: 12px;
-    line-height: 1rem;
+    line-height: 16px;
     margin-right: -0.5rem;
     opacity: 0.5;
     padding: 0 0.5rem;
-    position: relative;
 
     &:active,
     &:hover {

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -701,7 +701,7 @@ div.dropdown-menu {
   align-items: center;
   background-color: $muted-gray;
   color: $dark-text;
-  display: flex;
+  display: inline-flex;
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -478,8 +478,16 @@ export class ListFilterModel {
 
   public clearCriteria() {
     const ret = this.clone();
+    ret.searchTerm = "";
     ret.criteria = [];
     ret.currentPage = 1;
+    return ret;
+  }
+
+  public clearSearchTerm() {
+    const ret = this.clone();
+    ret.searchTerm = "";
+    ret.currentPage = 1; // reset to first page
     return ret;
   }
 

--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -476,9 +476,11 @@ export class ListFilterModel {
     return this.setCriteria(criteria);
   }
 
-  public clearCriteria() {
+  public clearCriteria(clearSearchTerm = false) {
     const ret = this.clone();
-    ret.searchTerm = "";
+    if (clearSearchTerm) {
+      ret.searchTerm = "";
+    }
     ret.criteria = [];
     ret.currentPage = 1;
     return ret;

--- a/ui/v2.5/src/utils/focus.ts
+++ b/ui/v2.5/src/utils/focus.ts
@@ -2,10 +2,14 @@ import { useRef, useEffect, useCallback } from "react";
 
 const useFocus = () => {
   const htmlElRef = useRef<HTMLInputElement | null>(null);
-  const setFocus = useCallback(() => {
+  const setFocus = useCallback((selectAll?: boolean) => {
     const currentEl = htmlElRef.current;
     if (currentEl) {
-      currentEl.focus();
+      if (selectAll) {
+        currentEl.select();
+      } else {
+        currentEl.focus();
+      }
     }
   }, []);
 


### PR DESCRIPTION
Resubmission of #5991.

Addresses styling bug that occurred on details pages.

With #6079 merged, I also changed the styling to hide the search term filter tag when the search input field is visible.

<img width="223" height="76" alt="image" src="https://github.com/user-attachments/assets/2e70ffc7-9302-4ec8-ae03-571b867aab93" />
<img width="519" height="75" alt="image" src="https://github.com/user-attachments/assets/8cc12e4a-ec15-47f6-a14c-6c143f608560" />
