### PR TITLE
Wall item height fix

### DIFF
--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -20,7 +20,7 @@ import { ImageWallItem } from "./ImageWallItem";
 import { EditImagesDialog } from "./EditImagesDialog";
 import { DeleteImagesDialog } from "./DeleteImagesDialog";
 import "flexbin/flexbin.css";
-import Gallery from "react-photo-gallery";
+import Gallery, { RenderImageProps } from "react-photo-gallery";
 import { ExportDialog } from "../Shared/ExportDialog";
 import { objectTitle } from "src/core/files";
 import { ConfigurationContext } from "src/hooks/Config";
@@ -53,6 +53,8 @@ const ImageWall: React.FC<IImageWallProps> = ({
 }) => {
   const { configuration } = useContext(ConfigurationContext);
   const uiConfig = configuration?.ui;
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   let photos: {
     src: string;
@@ -94,22 +96,37 @@ const ImageWall: React.FC<IImageWallProps> = ({
     return Math.round(columnCount);
   }
 
-  function targetRowHeight(containerWidth: number) {
-    let zoomHeight = 280;
-    breakpointZoomHeights.forEach((e) => {
-      if (containerWidth >= e.minWidth) {
-        zoomHeight = e.heights[zoomIndex];
-      }
-    });
-    return zoomHeight;
-  }
+  const targetRowHeight = useCallback(
+    (containerWidth: number) => {
+      let zoomHeight = 280;
+      breakpointZoomHeights.forEach((e) => {
+        if (containerWidth >= e.minWidth) {
+          zoomHeight = e.heights[zoomIndex];
+        }
+      });
+      return zoomHeight;
+    },
+    [zoomIndex]
+  );
+
+  const renderImage = useCallback(
+    (props: RenderImageProps) => {
+      return (
+        <ImageWallItem
+          {...props}
+          maxHeight={targetRowHeight(containerRef.current?.offsetWidth ?? 0)}
+        />
+      );
+    },
+    [targetRowHeight]
+  );
 
   return (
-    <div className="gallery">
+    <div className="gallery" ref={containerRef}>
       {photos.length ? (
         <Gallery
           photos={photos}
-          renderImage={ImageWallItem}
+          renderImage={renderImage}
           onClick={showLightboxOnClick}
           margin={uiConfig?.imageWallOptions?.margin!}
           direction={uiConfig?.imageWallOptions?.direction!}

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -109,12 +109,20 @@ const ImageWall: React.FC<IImageWallProps> = ({
     [zoomIndex]
   );
 
+  // set the max height as a factor of the targetRowHeight
+  // this allows some images to be taller than the target row height
+  // but prevents images from becoming too tall when there is a small number of items
+  const maxHeightFactor = 1.3;
+
   const renderImage = useCallback(
     (props: RenderImageProps) => {
       return (
         <ImageWallItem
           {...props}
-          maxHeight={targetRowHeight(containerRef.current?.offsetWidth ?? 0)}
+          maxHeight={
+            targetRowHeight(containerRef.current?.offsetWidth ?? 0) *
+            maxHeightFactor
+          }
         />
       );
     },

--- a/ui/v2.5/src/components/Images/ImageWallItem.tsx
+++ b/ui/v2.5/src/components/Images/ImageWallItem.tsx
@@ -1,23 +1,17 @@
 import React from "react";
-import type {
-  RenderImageProps,
-  renderImageClickHandler,
-  PhotoProps,
-} from "react-photo-gallery";
+import type { RenderImageProps } from "react-photo-gallery";
 
-interface IImageWallProps {
-  margin?: string;
-  index: number;
-  photo: PhotoProps;
-  onClick: renderImageClickHandler | null;
-  direction: "row" | "column";
-  top?: number;
-  left?: number;
+interface IExtraProps {
+  maxHeight: number;
 }
 
-export const ImageWallItem: React.FC<RenderImageProps> = (
-  props: IImageWallProps
+export const ImageWallItem: React.FC<RenderImageProps & IExtraProps> = (
+  props: RenderImageProps & IExtraProps
 ) => {
+  const height = Math.min(props.maxHeight, props.photo.height);
+  const zoomFactor = height / props.photo.height;
+  const width = props.photo.width * zoomFactor;
+
   type style = Record<string, string | number | undefined>;
   var imgStyle: style = {
     margin: props.margin,
@@ -49,8 +43,8 @@ export const ImageWallItem: React.FC<RenderImageProps> = (
       key={props.photo.key}
       style={imgStyle}
       src={props.photo.src}
-      width={props.photo.width}
-      height={props.photo.height}
+      width={width}
+      height={height}
       alt={props.photo.alt}
       onClick={handleClick}
     />

--- a/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
@@ -231,12 +231,20 @@ const MarkerWall: React.FC<IMarkerWallProps> = ({ markers, zoomIndex }) => {
     [zoomIndex]
   );
 
+  // set the max height as a factor of the targetRowHeight
+  // this allows some images to be taller than the target row height
+  // but prevents images from becoming too tall when there is a small number of items
+  const maxHeightFactor = 1.3;
+
   const renderImage = useCallback(
     (props: RenderImageProps<IMarkerPhoto>) => {
       return (
         <MarkerWallItem
           {...props}
-          maxHeight={targetRowHeight(containerRef.current?.offsetWidth ?? 0)}
+          maxHeight={
+            targetRowHeight(containerRef.current?.offsetWidth ?? 0) *
+            maxHeightFactor
+          }
         />
       );
     },

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -219,12 +219,20 @@ const SceneWall: React.FC<ISceneWallProps> = ({
     [zoomIndex]
   );
 
+  // set the max height as a factor of the targetRowHeight
+  // this allows some images to be taller than the target row height
+  // but prevents images from becoming too tall when there is a small number of items
+  const maxHeightFactor = 1.3;
+
   const renderImage = useCallback(
     (props: RenderImageProps<IScenePhoto>) => {
       return (
         <SceneWallItem
           {...props}
-          maxHeight={targetRowHeight(containerRef.current?.offsetWidth ?? 0)}
+          maxHeight={
+            targetRowHeight(containerRef.current?.offsetWidth ?? 0) *
+            maxHeightFactor
+          }
         />
       );
     },

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -26,14 +26,22 @@ interface IScenePhoto {
   onError?: (photo: PhotoProps<IScenePhoto>) => void;
 }
 
-export const SceneWallItem: React.FC<RenderImageProps<IScenePhoto>> = (
-  props: RenderImageProps<IScenePhoto>
-) => {
+interface IExtraProps {
+  maxHeight: number;
+}
+
+export const SceneWallItem: React.FC<
+  RenderImageProps<IScenePhoto> & IExtraProps
+> = (props: RenderImageProps<IScenePhoto> & IExtraProps) => {
   const intl = useIntl();
 
   const { configuration } = useContext(ConfigurationContext);
   const playSound = configuration?.interface.soundOnPreview ?? false;
   const showTitle = configuration?.interface.wallShowTitle ?? false;
+
+  const height = Math.min(props.maxHeight, props.photo.height);
+  const zoomFactor = height / props.photo.height;
+  const width = props.photo.width * zoomFactor;
 
   const [active, setActive] = useState(false);
 
@@ -72,8 +80,8 @@ export const SceneWallItem: React.FC<RenderImageProps<IScenePhoto>> = (
       role="button"
       style={{
         ...divStyle,
-        width: props.photo.width,
-        height: props.photo.height,
+        width,
+        height,
       }}
     >
       <ImagePreview
@@ -83,8 +91,8 @@ export const SceneWallItem: React.FC<RenderImageProps<IScenePhoto>> = (
         autoPlay={video}
         key={props.photo.key}
         src={props.photo.src}
-        width={props.photo.width}
-        height={props.photo.height}
+        width={width}
+        height={height}
         alt={props.photo.alt}
         onMouseEnter={() => setActive(true)}
         onMouseLeave={() => setActive(false)}
@@ -146,6 +154,8 @@ const SceneWall: React.FC<ISceneWallProps> = ({
 }) => {
   const history = useHistory();
 
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   const margin = 3;
   const direction = "row";
 
@@ -196,22 +206,33 @@ const SceneWall: React.FC<ISceneWallProps> = ({
     return Math.round(columnCount);
   }
 
-  function targetRowHeight(containerWidth: number) {
-    let zoomHeight = 280;
-    breakpointZoomHeights.forEach((e) => {
-      if (containerWidth >= e.minWidth) {
-        zoomHeight = e.heights[zoomIndex];
-      }
-    });
-    return zoomHeight;
-  }
+  const targetRowHeight = useCallback(
+    (containerWidth: number) => {
+      let zoomHeight = 280;
+      breakpointZoomHeights.forEach((e) => {
+        if (containerWidth >= e.minWidth) {
+          zoomHeight = e.heights[zoomIndex];
+        }
+      });
+      return zoomHeight;
+    },
+    [zoomIndex]
+  );
 
-  const renderImage = useCallback((props: RenderImageProps<IScenePhoto>) => {
-    return <SceneWallItem {...props} />;
-  }, []);
+  const renderImage = useCallback(
+    (props: RenderImageProps<IScenePhoto>) => {
+      return (
+        <SceneWallItem
+          {...props}
+          maxHeight={targetRowHeight(containerRef.current?.offsetWidth ?? 0)}
+        />
+      );
+    },
+    [targetRowHeight]
+  );
 
   return (
-    <div className="scene-wall">
+    <div className={`scene-wall`} ref={containerRef}>
       {photos.length ? (
         <SceneGallery
           photos={photos}


### PR DESCRIPTION
Fixes #6096

Sets the maximum height of wall items so that pages with low item counts don't result in large images. Some leeway is given during calculation of the maximum height so that the layout ends up utilising the maximum space. A factor of 1.3 of the target height seemed to give the best result. This means that for results with a single item, the image will end up being a maximum of 1.3 times larger than normal.