### PR TITLE
add content-disposition filename header to streams

### DIFF
--- a/internal/manager/running_streams.go
+++ b/internal/manager/running_streams.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"mime"
 	"net/http"
-	"path"
+	"path/filepath"
 
 	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/internal/static"
@@ -48,17 +48,17 @@ func (s *SceneServer) StreamSceneDirect(scene *models.Scene, w http.ResponseWrit
 
 	sceneHash := scene.GetHash(config.GetInstance().GetVideoFileNamingAlgorithm())
 
-	filepath := GetInstance().Paths.Scene.GetStreamPath(scene.Path, sceneHash)
+	fp := GetInstance().Paths.Scene.GetStreamPath(scene.Path, sceneHash)
 	streamRequestCtx := ffmpeg.NewStreamRequestContext(w, r)
 
 	// #2579 - hijacking and closing the connection here causes video playback to fail in Safari
 	// We trust that the request context will be closed, so we don't need to call Cancel on the
 	// returned context here.
-	_ = GetInstance().ReadLockManager.ReadLock(streamRequestCtx, filepath)
-	_, filename := path.Split(filepath)
+	_ = GetInstance().ReadLockManager.ReadLock(streamRequestCtx, fp)
+	_, filename := filepath.Split(fp)
 	contentDisposition := mime.FormatMediaType("inline", map[string]string{"filename": filename})
 	w.Header().Set("Content-Disposition", contentDisposition)
-	http.ServeFile(w, r, filepath)
+	http.ServeFile(w, r, fp)
 }
 
 func (s *SceneServer) ServeScreenshot(scene *models.Scene, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Add Content-Disposition filename header to streams so they can be saved with their original filename

Closes #627