### PR TITLE
install python packages system-wide

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 
 RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg tzdata vips vips-tools \
-    && pip install --user --break-system-packages mechanicalsoup cloudscraper stashapp-tools
+    && pip install --break-system-packages mechanicalsoup cloudscraper stashapp-tools
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 # Basic build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys


### PR DESCRIPTION
Installing pip packages with `--user` as root means only root can use these packages and they need to be installed twice if running as a non-root user. Installing them system wide allows them to be accessed regardless of which user the container is run as.