### PR TITLE
Sort duplicate scene groups by total filesize descending

### DIFF
--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -79,7 +79,24 @@ export const SceneDuplicateChecker: React.FC = () => {
     },
   });
 
-  const scenes = data?.findDuplicateScenes ?? [];
+  const getGroupTotalSize = (group: GQL.SlimSceneDataFragment[]) => {
+    // Sum all file sizes across all scenes in the group
+    return group.reduce((groupTotal, scene) => {
+      const sceneTotal = scene.files.reduce(
+        (fileTotal, file) => fileTotal + file.size,
+        0
+      );
+      return groupTotal + sceneTotal;
+    }, 0);
+  };
+
+  const scenes = useMemo(() => {
+    const groups = data?.findDuplicateScenes ?? [];
+    // Sort by total file size descending (largest groups first)
+    return [...groups].sort((a, b) => {
+      return getGroupTotalSize(b) - getGroupTotalSize(a);
+    });
+  }, [data?.findDuplicateScenes]);
 
   const { data: missingPhash } = GQL.useFindScenesQuery({
     variables: {


### PR DESCRIPTION
This is a new feature I would find personally helpful - I did not see any existing issues or PRs for it, but it looked simple so I just implemented it myself.

This adds a default sort to the Scene Duplicate Checker screen, sorting (in descending order) by the total filesize of all scenes in that duplicate group. Given that there did not appear to be a default sort already, it seemed safe to add one.

I believe that this sort behavior makes the most sense as this allows the end user to easily identify the duplicate groups that would potentially free the most disk space if addressed, which seems like it would be one of the primary use cases (certainly the one I find myself using it for).

Related https://github.com/stashapp/stash/issues/1220