### PR TITLE
Vacuum into database directory then move file if backup dir different

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -350,10 +350,28 @@ func (db *Database) Backup(backupPath string) (err error) {
 		defer thisDB.Close()
 	}
 
-	logger.Infof("Backing up database into: %s", backupPath)
-	_, err = thisDB.Exec(`VACUUM INTO "` + backupPath + `"`)
+	// if backup path is not in the same directory as the database,
+	// then backup to the same directory first, then move to the final location.
+	// This is to prevent errors if the backup directory is over a network share.
+	dbDir := filepath.Dir(db.dbPath)
+	moveAfter := filepath.Dir(backupPath) != dbDir
+	vacuumOut := backupPath
+	if moveAfter {
+		vacuumOut = filepath.Join(dbDir, filepath.Base(backupPath))
+	}
+
+	logger.Infof("Backing up database into: %s", vacuumOut)
+	_, err = thisDB.Exec(`VACUUM INTO "` + vacuumOut + `"`)
 	if err != nil {
 		return fmt.Errorf("vacuum failed: %w", err)
+	}
+
+	if moveAfter {
+		logger.Infof("Moving database backup to: %s", backupPath)
+		err = os.Rename(vacuumOut, backupPath)
+		if err != nil {
+			return fmt.Errorf("moving database backup failed: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If the backup directory is not the same directory as the database, then vacuum into the same directory then move it to its destination. This is to prevent issues vacuuming over a network share.