### PR TITLE
Update marker background color logic to use primaryTag name instead of title

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/markers.ts
+++ b/ui/v2.5/src/components/ScenePlayer/markers.ts
@@ -86,8 +86,13 @@ class MarkersPlugin extends videojs.getPlugin("plugin") {
     markerSet.dot.toggleAttribute("marker-tooltip-shown", true);
 
     // Set background color based on tag (if available)
-    if (marker.primaryTag && marker.primaryTag.name && this.tagColors[marker.primaryTag.name]) {
-      markerSet.dot.style.backgroundColor = this.tagColors[marker.primaryTag.name];
+    if (
+      marker.primaryTag &&
+      marker.primaryTag.name &&
+      this.tagColors[marker.primaryTag.name]
+    ) {
+      markerSet.dot.style.backgroundColor =
+        this.tagColors[marker.primaryTag.name];
     }
     markerSet.dot.addEventListener("mouseenter", () => {
       this.showMarkerTooltip(marker.title);
@@ -153,7 +158,11 @@ class MarkersPlugin extends videojs.getPlugin("plugin") {
     rangeDiv.style.display = "none"; // Initially hidden
 
     // Set background color based on tag (if available)
-    if (marker.primaryTag && marker.primaryTag.name && this.tagColors[marker.primaryTag.name]) {
+    if (
+      marker.primaryTag &&
+      marker.primaryTag.name &&
+      this.tagColors[marker.primaryTag.name]
+    ) {
       rangeDiv.style.backgroundColor = this.tagColors[marker.primaryTag.name];
     }
 


### PR DESCRIPTION
Currently marker colors are generated based on unique primary tags in `ScenePlayer.tsx`, but then the colors are fetched based on the title. this changes `markers.ts` to get the color by primary tag