### PR TITLE
Feature: Sort by Studio in scenes/performers

### DIFF
--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1096,6 +1096,7 @@ var sceneSortOptions = sortOptions{
 	"perceptual_similarity",
 	"random",
 	"rating",
+	"studio",
 	"tag_count",
 	"title",
 	"updated_at",
@@ -1208,6 +1209,9 @@ func (qb *SceneStore) setSceneSort(query *queryBuilder, findFilter *models.FindF
 		query.sortAndPagination += fmt.Sprintf(" ORDER BY (SELECT MAX(o_date) FROM %s AS sort WHERE sort.%s = %s.id) %s", scenesODatesTable, sceneIDColumn, sceneTable, getSortDirection(direction))
 	case "o_counter":
 		query.sortAndPagination += getCountSort(sceneTable, scenesODatesTable, sceneIDColumn, direction)
+	case "studio":
+		query.join(studioTable, "", "scenes.studio_id = studios.id")
+		query.sortAndPagination += getSort("name", direction, studioTable)
 	default:
 		query.sortAndPagination += getSort(sort, direction, "scenes")
 	}

--- a/ui/v2.5/src/models/list-filter/scenes.ts
+++ b/ui/v2.5/src/models/list-filter/scenes.ts
@@ -53,6 +53,7 @@ const sortByOptions = [
   "interactive",
   "interactive_speed",
   "perceptual_similarity",
+  "studio",
   ...MediaSortByOptions,
 ]
   .map(ListFilterOptions.createSortBy)


### PR DESCRIPTION
Adds the ability to sort by Studio in scenes pages and on performer pages. 

Tested in dev with 3 studios. `2 Chicks Same Time`, `Brazzers`, and `Our Little Secret`. 

Ascending:  2 Chicks Same Time -> Brazzers -> Our Little Secret. 
Descending : Our Little Secret -> Brazzers -> 2 Chicks Same Time

Fixes: #5480 