### PR TITLE
get sidebar to use all available vertical space

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -214,6 +214,10 @@ input[type="range"].zoom-slider {
   }
 }
 
+.sidebar-saved-filter-list-container .saved-filter-list {
+  max-height: unset;
+}
+
 .sidebar-saved-filter-list-container .toolbar {
   align-items: center;
   display: flex;
@@ -618,8 +622,6 @@ ul.selectable-list {
 .folder-filter ul {
   list-style-type: none;
   margin-bottom: 0.25rem;
-  max-height: 300px;
-  overflow-y: auto;
   // to prevent unnecessary vertical scrollbar
   padding-inline-start: 0;
   padding-bottom: 0.15rem;

--- a/ui/v2.5/src/components/Shared/CollapseButton.tsx
+++ b/ui/v2.5/src/components/Shared/CollapseButton.tsx
@@ -44,8 +44,8 @@ export const CollapseButton: React.FC<React.PropsWithChildren<IProps>> = (
           <Icon icon={open ? faChevronDown : faChevronRight} fixedWidth />
           <span>{props.text}</span>
         </Button>
+        {props.outsideCollapse}
       </div>
-      {props.outsideCollapse}
       <Collapse in={open} {...props.collapseProps}>
         <div>{props.children}</div>
       </Collapse>

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -1006,9 +1006,11 @@ button.btn.favorite-button {
   border-bottom: 1px solid $secondary;
 
   .collapse-header {
-    // background-color: $secondary;
-
+    background-color: $body-bg;
     padding: 0.25rem;
+    position: sticky;
+    top: -0.5rem;
+    z-index: 1;
 
     .collapse-button {
       font-weight: bold;


### PR DESCRIPTION
The sidebar uses the full vertical space now if needed. The current solution is rather simple, long selectable option lists like tags or performers are show in full, and the whole sidebar is just scrollable (no more sub-scrolling). the section header and active inclussions and exclussions are sticky, so in the list currently scrolled out of, it's always visible whats currently being scrolled and what's already selected.

<img width="249" height="699" alt="Screenshot_20260531_144331" src="https://github.com/user-attachments/assets/26ce7221-6f14-4894-bde3-3fad5b34459b" />

The search input is really hard to get sticky, and would probably only be possible through Javascript nightmares.

I've tried keeping to individual lists scrollable, but that comes at various prices like lists getting tiny when multiple lists are open on small screens, or elements with only a few entries getting stretched when multiple are open (because they will always size equally through flexbox).
