### PR TITLE
Remember the selected stash box in scene tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -174,13 +174,30 @@ export const TaggerContext: React.FC = ({ children }) => {
   }, [Scrapers.data, stashConfig]);
 
   useEffect(() => {
-    if (sources.length && !currentSource) {
+    if (!sources.length) {
+      return;
+    }
+    if (config.selectedEndpoint) {
+      let source = sources.find((s) => s.sourceInput.stash_box_endpoint == config.selectedEndpoint);
+      if (source) {
+        setCurrentSource(source);
+        return;
+      }
+    }
+    if (!currentSource) {
       setCurrentSource(sources[0]);
     }
-  }, [sources, currentSource]);
+  }, [sources, config]);
 
   useEffect(() => {
     setSearchResults({});
+    const selectedEndpoint = currentSource?.sourceInput.stash_box_endpoint;
+    if (selectedEndpoint && selectedEndpoint !== config.selectedEndpoint) {
+      setConfig({
+        ...config,
+        selectedEndpoint,
+      });
+    }
   }, [currentSource]);
 
   function getPendingFingerprints() {

--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -174,9 +174,10 @@ export const TaggerContext: React.FC = ({ children }) => {
   }, [Scrapers.data, stashConfig]);
 
   useEffect(() => {
-    if (!sources.length) {
+    if (!sources.length || currentSource) {
       return;
     }
+    // First, see if we have a saved endpoint.
     if (config.selectedEndpoint) {
       let source = sources.find((s) => s.sourceInput.stash_box_endpoint == config.selectedEndpoint);
       if (source) {
@@ -184,10 +185,9 @@ export const TaggerContext: React.FC = ({ children }) => {
         return;
       }
     }
-    if (!currentSource) {
-      setCurrentSource(sources[0]);
-    }
-  }, [sources, config]);
+    // Otherwise, just use the first source.
+    setCurrentSource(sources[0]);
+  }, [sources, currentSource, config]);
 
   useEffect(() => {
     setSearchResults({});
@@ -198,7 +198,7 @@ export const TaggerContext: React.FC = ({ children }) => {
         selectedEndpoint,
       });
     }
-  }, [currentSource]);
+  }, [currentSource, config, setConfig]);
 
   function getPendingFingerprints() {
     const endpoint = currentSource?.sourceInput.stash_box_endpoint;

--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -179,7 +179,9 @@ export const TaggerContext: React.FC = ({ children }) => {
     }
     // First, see if we have a saved endpoint.
     if (config.selectedEndpoint) {
-      let source = sources.find((s) => s.sourceInput.stash_box_endpoint == config.selectedEndpoint);
+      let source = sources.find(
+        (s) => s.sourceInput.stash_box_endpoint == config.selectedEndpoint
+      );
       if (source) {
         setCurrentSource(source);
         return;


### PR DESCRIPTION
This stores the selected stash box in the config, the same way that studio and performer tagger do (it uses the same setting).

If a non-stashbox source (scraper) is selected, this is not remembered.

I have removed the `currentSource` dependency because there is no need to
re-run this code when the selected source changes and it caused issues
during testing at one point.

Resolves #6191
Related https://github.com/stashapp/stash/issues/2858