### PR TITLE
Add swipe navigation to lightbox

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -141,14 +141,15 @@ const LightboxCarousel = forwardRef(function (
   }
 
   function handleReleaseCarousel(
-    event: React.TouchEvent,
-    swipeDuration: number
+    event: React.PointerEvent,
+    swipeDuration: number,
+    cancelled: boolean
   ) {
     const cappedDuration = Math.max(50, Math.min(500, swipeDuration)) / 1000;
     const adjustedShift = carouselShift / (2 * cappedDuration);
-    if (adjustedShift < -window.innerWidth / 2) {
+    if (!cancelled && adjustedShift < -window.innerWidth / 2) {
       handleRight();
-    } else if (adjustedShift > window.innerWidth / 2) {
+    } else if (!cancelled && adjustedShift > window.innerWidth / 2) {
       handleLeft();
     }
     setCarouselShift(0);

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -76,6 +76,7 @@ const CLASSNAME_FOOTER_RIGHT = `${CLASSNAME_FOOTER}-right`;
 const CLASSNAME_DISPLAY = `${CLASSNAME}-display`;
 const CLASSNAME_CAROUSEL = `${CLASSNAME}-carousel`;
 const CLASSNAME_INSTANT = `${CLASSNAME_CAROUSEL}-instant`;
+const CLASSNAME_SWIPE = `${CLASSNAME_CAROUSEL}-swipe`;
 const CLASSNAME_IMAGE = `${CLASSNAME_CAROUSEL}-image`;
 const CLASSNAME_IMAGE_CONTAINER = `${CLASSNAME_CAROUSEL}-image-container`;
 const CLASSNAME_NAVBUTTON = `${CLASSNAME}-navbutton`;
@@ -91,7 +92,7 @@ const SCROLL_ZOOM_TIMEOUT = 250;
 const ZOOM_NONE_EPSILON = 0.015;
 
 interface ILightboxCarouselProps {
-  instantTransition: boolean;
+  transition: string | null;
   currentIndex: number;
   images: ILightboxImage[];
   displayMode: GQL.ImageLightboxDisplayMode;
@@ -107,11 +108,12 @@ interface ILightboxCarouselProps {
   debouncedScrollReset: () => void;
   handleLeft: () => void;
   handleRight: () => void;
+  overrideTransition: (t: string) => void;
 }
 
 const LightboxCarousel = forwardRef(function (
   {
-    instantTransition,
+    transition,
     currentIndex,
     images,
     displayMode,
@@ -127,15 +129,36 @@ const LightboxCarousel = forwardRef(function (
     debouncedScrollReset,
     handleLeft,
     handleRight,
+    overrideTransition,
   }: ILightboxCarouselProps,
   carouselRef: ForwardedRef<HTMLDivElement>
 ) {
+  const [carouselShift, setCarouselShift] = useState(0);
+
+  function handleMoveCarousel(delta: number) {
+    overrideTransition(CLASSNAME_INSTANT);
+    setCarouselShift(carouselShift + delta);
+  }
+
+  function handleReleaseCarousel(
+    event: React.TouchEvent,
+    swipeDuration: number
+  ) {
+    const cappedDuration = Math.max(50, Math.min(500, swipeDuration)) / 1000;
+    const adjustedShift = carouselShift / (2 * cappedDuration);
+    if (adjustedShift < -window.innerWidth / 2) {
+      handleRight();
+    } else if (adjustedShift > window.innerWidth / 2) {
+      handleLeft();
+    }
+    setCarouselShift(0);
+    overrideTransition(CLASSNAME_SWIPE);
+  }
+
   return (
     <div
-      className={cx(CLASSNAME_CAROUSEL, {
-        [CLASSNAME_INSTANT]: instantTransition,
-      })}
-      style={{ left: `${currentIndex * -100}vw` }}
+      className={CLASSNAME_CAROUSEL + (transition ? ` ${transition}` : "")}
+      style={{ left: `calc(${currentIndex * -100}vw + ${carouselShift}px)` }}
       ref={carouselRef}
     >
       {images.map((image, i) => (
@@ -160,6 +183,8 @@ const LightboxCarousel = forwardRef(function (
               onLeft={handleLeft}
               onRight={handleRight}
               isVideo={isVideo(image.visual_files?.[0] ?? {})}
+              moveCarousel={handleMoveCarousel}
+              releaseCarousel={handleReleaseCarousel}
             />
           ) : undefined}
         </div>
@@ -203,7 +228,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [index, setIndex] = useState<number | null>(null);
   const [movingLeft, setMovingLeft] = useState(false);
   const oldIndex = useRef<number | null>(null);
-  const [instantTransition, setInstantTransition] = useState(false);
+  const [transition, setTransition] = useState<string | null>(null);
   const [isSwitchingPage, setIsSwitchingPage] = useState(true);
   const [isFullscreen, setFullscreen] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
@@ -334,15 +359,15 @@ export const LightboxComponent: React.FC<IProps> = ({
     }
   }, [isSwitchingPage, images, index]);
 
-  const disableInstantTransition = useDebounce(
-    () => setInstantTransition(false),
-    400
-  );
+  const restoreTransition = useDebounce(() => setTransition(null), 400);
 
-  const setInstant = useCallback(() => {
-    setInstantTransition(true);
-    disableInstantTransition();
-  }, [disableInstantTransition]);
+  const overrideTransition = useCallback(
+    (t: string) => {
+      setTransition(t);
+      restoreTransition();
+    },
+    [restoreTransition]
+  );
 
   useEffect(() => {
     if (images.length < 2) return;
@@ -524,12 +549,12 @@ export const LightboxComponent: React.FC<IProps> = ({
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
       if (e.repeat && (e.key === "ArrowRight" || e.key === "ArrowLeft"))
-        setInstant();
+        overrideTransition(CLASSNAME_INSTANT);
       if (e.key === "ArrowLeft") handleLeft();
       else if (e.key === "ArrowRight") handleRight();
       else if (e.key === "Escape") close();
     },
-    [setInstant, handleLeft, handleRight, close]
+    [overrideTransition, handleLeft, handleRight, close]
   );
   const handleFullScreenChange = () => {
     if (clearIntervalCallback.current) {
@@ -969,7 +994,7 @@ export const LightboxComponent: React.FC<IProps> = ({
             </Button>
           )}
           <LightboxCarousel
-            instantTransition={instantTransition}
+            transition={transition}
             currentIndex={currentIndex}
             images={images}
             displayMode={displayMode}
@@ -985,6 +1010,7 @@ export const LightboxComponent: React.FC<IProps> = ({
             debouncedScrollReset={debouncedScrollReset}
             handleLeft={handleLeft}
             handleRight={handleRight}
+            overrideTransition={overrideTransition}
           />
           {allowNavigation && (
             <Button

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -144,16 +144,20 @@ const LightboxCarousel = forwardRef(function (
     event: React.PointerEvent,
     swipeDuration: number,
     cancelled: boolean
-  ) {
+  ): boolean {
     const cappedDuration = Math.max(50, Math.min(500, swipeDuration)) / 1000;
     const adjustedShift = carouselShift / (2 * cappedDuration);
+    let changed = false;
     if (!cancelled && adjustedShift < -window.innerWidth / 2) {
       handleRight();
+      changed = true;
     } else if (!cancelled && adjustedShift > window.innerWidth / 2) {
       handleLeft();
+      changed = true;
     }
     setCarouselShift(0);
     overrideTransition(CLASSNAME_SWIPE);
+    return changed;
   }
 
   return (

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   Button,
   Col,
@@ -83,6 +90,84 @@ const MIN_ZOOM = 0.1;
 const SCROLL_ZOOM_TIMEOUT = 250;
 const ZOOM_NONE_EPSILON = 0.015;
 
+interface ILightboxCarouselProps {
+  instantTransition: boolean;
+  currentIndex: number;
+  images: ILightboxImage[];
+  displayMode: GQL.ImageLightboxDisplayMode;
+  scaleUp: boolean;
+  scrollMode: GQL.ImageLightboxScrollMode;
+  resetPosition?: boolean;
+  zoom: number;
+  scrollAttemptsBeforeChange: number;
+  firstScroll: React.MutableRefObject<number | null>;
+  inScrollGroup: React.MutableRefObject<boolean>;
+  movingLeft: boolean;
+  updateZoom: (v: number) => void;
+  debouncedScrollReset: () => void;
+  handleLeft: () => void;
+  handleRight: () => void;
+}
+
+const LightboxCarousel = forwardRef(function (
+  {
+    instantTransition,
+    currentIndex,
+    images,
+    displayMode,
+    scaleUp,
+    scrollMode,
+    resetPosition,
+    zoom,
+    scrollAttemptsBeforeChange,
+    firstScroll,
+    inScrollGroup,
+    movingLeft,
+    updateZoom,
+    debouncedScrollReset,
+    handleLeft,
+    handleRight,
+  }: ILightboxCarouselProps,
+  carouselRef: ForwardedRef<HTMLDivElement>
+) {
+  return (
+    <div
+      className={cx(CLASSNAME_CAROUSEL, {
+        [CLASSNAME_INSTANT]: instantTransition,
+      })}
+      style={{ left: `${currentIndex * -100}vw` }}
+      ref={carouselRef}
+    >
+      {images.map((image, i) => (
+        <div className={`${CLASSNAME_IMAGE_CONTAINER}`} key={image.paths.image}>
+          {i >= currentIndex - 1 && i <= currentIndex + 1 ? (
+            <LightboxImage
+              src={image.paths.image ?? ""}
+              width={image.visual_files?.[0]?.width ?? 0}
+              height={image.visual_files?.[0]?.height ?? 0}
+              displayMode={displayMode}
+              scaleUp={scaleUp}
+              scrollMode={scrollMode}
+              resetPosition={resetPosition}
+              zoom={i === currentIndex ? zoom : 1}
+              scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}
+              firstScroll={firstScroll}
+              inScrollGroup={inScrollGroup}
+              current={i === currentIndex}
+              alignBottom={movingLeft}
+              setZoom={updateZoom}
+              debouncedScrollReset={debouncedScrollReset}
+              onLeft={handleLeft}
+              onRight={handleRight}
+              isVideo={isVideo(image.visual_files?.[0] ?? {})}
+            />
+          ) : undefined}
+        </div>
+      ))}
+    </div>
+  );
+});
+
 interface IProps {
   images: ILightboxImage[];
   isVisible: boolean;
@@ -145,7 +230,6 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const overlayTarget = useRef<HTMLButtonElement | null>(null);
-  const carouselRef = useRef<HTMLDivElement | null>(null);
   const indicatorRef = useRef<HTMLDivElement | null>(null);
   const navRef = useRef<HTMLDivElement | null>(null);
   const clearIntervalCallback = useRef<() => void>();
@@ -884,45 +968,24 @@ export const LightboxComponent: React.FC<IProps> = ({
               <Icon icon={faChevronLeft} />
             </Button>
           )}
-
-          <div
-            className={cx(CLASSNAME_CAROUSEL, {
-              [CLASSNAME_INSTANT]: instantTransition,
-            })}
-            style={{ left: `${currentIndex * -100}vw` }}
-            ref={carouselRef}
-          >
-            {images.map((image, i) => (
-              <div
-                className={`${CLASSNAME_IMAGE_CONTAINER}`}
-                key={image.paths.image}
-              >
-                {i >= currentIndex - 1 && i <= currentIndex + 1 ? (
-                  <LightboxImage
-                    src={image.paths.image ?? ""}
-                    width={image.visual_files?.[0]?.width ?? 0}
-                    height={image.visual_files?.[0]?.height ?? 0}
-                    displayMode={displayMode}
-                    scaleUp={scaleUp}
-                    scrollMode={scrollMode}
-                    resetPosition={resetPosition}
-                    zoom={i === currentIndex ? zoom : 1}
-                    scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}
-                    firstScroll={firstScroll}
-                    inScrollGroup={inScrollGroup}
-                    current={i === currentIndex}
-                    alignBottom={movingLeft}
-                    setZoom={updateZoom}
-                    debouncedScrollReset={debouncedScrollReset}
-                    onLeft={handleLeft}
-                    onRight={handleRight}
-                    isVideo={isVideo(image.visual_files?.[0] ?? {})}
-                  />
-                ) : undefined}
-              </div>
-            ))}
-          </div>
-
+          <LightboxCarousel
+            instantTransition={instantTransition}
+            currentIndex={currentIndex}
+            images={images}
+            displayMode={displayMode}
+            scaleUp={scaleUp}
+            scrollMode={scrollMode}
+            resetPosition={resetPosition}
+            zoom={zoom}
+            scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}
+            firstScroll={firstScroll}
+            inScrollGroup={inScrollGroup}
+            movingLeft={movingLeft}
+            updateZoom={updateZoom}
+            debouncedScrollReset={debouncedScrollReset}
+            handleLeft={handleLeft}
+            handleRight={handleRight}
+          />
           {allowNavigation && (
             <Button
               variant="link"

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -70,6 +70,7 @@ const CLASSNAME_DISPLAY = `${CLASSNAME}-display`;
 const CLASSNAME_CAROUSEL = `${CLASSNAME}-carousel`;
 const CLASSNAME_INSTANT = `${CLASSNAME_CAROUSEL}-instant`;
 const CLASSNAME_IMAGE = `${CLASSNAME_CAROUSEL}-image`;
+const CLASSNAME_IMAGE_CONTAINER = `${CLASSNAME_CAROUSEL}-image-container`;
 const CLASSNAME_NAVBUTTON = `${CLASSNAME}-navbutton`;
 const CLASSNAME_NAV = `${CLASSNAME}-nav`;
 const CLASSNAME_NAVIMAGE = `${CLASSNAME_NAV}-image`;
@@ -892,7 +893,10 @@ export const LightboxComponent: React.FC<IProps> = ({
             ref={carouselRef}
           >
             {images.map((image, i) => (
-              <div className={`${CLASSNAME_IMAGE}`} key={image.paths.image}>
+              <div
+                className={`${CLASSNAME_IMAGE_CONTAINER}`}
+                key={image.paths.image}
+              >
                 {i >= currentIndex - 1 && i <= currentIndex + 1 ? (
                   <LightboxImage
                     src={image.paths.image ?? ""}

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -229,7 +229,6 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [index, setIndex] = useState<number | null>(null);
   const [movingLeft, setMovingLeft] = useState(false);
   const oldIndex = useRef<number | null>(null);
-  const [transition, setTransition] = useState<string | null>(null);
   const [isSwitchingPage, setIsSwitchingPage] = useState(true);
   const [isFullscreen, setFullscreen] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
@@ -312,6 +311,11 @@ export const LightboxComponent: React.FC<IProps> = ({
   );
 
   const disableAnimation = config?.interface.imageLightbox.disableAnimation;
+  const defaultTransition = disableAnimation ? CLASSNAME_INSTANT : null;
+
+  const [transition, setTransition] = useState<string | null>(
+    defaultTransition
+  );
 
   function setSlideshowDelay(v: number) {
     setLightboxSettings({ slideshowDelay: v });
@@ -360,7 +364,10 @@ export const LightboxComponent: React.FC<IProps> = ({
     }
   }, [isSwitchingPage, images, index]);
 
-  const restoreTransition = useDebounce(() => setTransition(null), 400);
+  const restoreTransition = useDebounce(
+    () => setTransition(defaultTransition),
+    400
+  );
 
   const overrideTransition = useCallback(
     (t: string) => {
@@ -470,10 +477,6 @@ export const LightboxComponent: React.FC<IProps> = ({
     (isUserAction = true) => {
       if (isSwitchingPage || index === -1) return;
 
-      if (disableAnimation) {
-        setInstant();
-      }
-
       setShowChapters(false);
       setMovingLeft(true);
 
@@ -491,24 +494,12 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [
-      images,
-      pageCallback,
-      isSwitchingPage,
-      resetIntervalCallback,
-      index,
-      disableAnimation,
-      setInstant,
-    ]
+    [images, pageCallback, isSwitchingPage, resetIntervalCallback, index]
   );
 
   const handleRight = useCallback(
     (isUserAction = true) => {
       if (isSwitchingPage) return;
-
-      if (disableAnimation) {
-        setInstant();
-      }
 
       setMovingLeft(false);
       setShowChapters(false);
@@ -534,8 +525,6 @@ export const LightboxComponent: React.FC<IProps> = ({
       isSwitchingPage,
       resetIntervalCallback,
       index,
-      disableAnimation,
-      setInstant,
     ]
   );
 

--- a/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
@@ -107,7 +107,7 @@ interface IProps {
     ev: React.PointerEvent,
     swipeDuration: number,
     cancelled: boolean
-  ) => void;
+  ) => boolean;
   isVideo: boolean;
 }
 
@@ -501,8 +501,10 @@ export const LightboxImage: React.FC<IProps> = ({
     }
 
     if (ev.pointerType === "touch" && startPoint.current !== null) {
-      // Swipe navigation
-      releaseCarousel(ev, ev.timeStamp - startTime.current, false);
+      // Swipe navigation, returns true if actually moved to another image.
+      if (releaseCarousel(ev, ev.timeStamp - startTime.current, false)) {
+        return;
+      }
     }
 
     if (

--- a/ui/v2.5/src/hooks/Lightbox/lightbox.scss
+++ b/ui/v2.5/src/hooks/Lightbox/lightbox.scss
@@ -144,27 +144,23 @@
       transition-duration: 0ms;
     }
 
-    &-image {
+    &-image-container {
       content-visibility: auto;
-      display: flex;
       width: 100vw;
+    }
 
-      picture {
-        display: flex;
-        margin: auto;
-        position: relative;
-
-        > div {
-          display: flex;
-          height: 100%;
-          position: absolute;
-          width: 100%;
-        }
-      }
+    &-image {
+      height: 100%;
+      width: 100%;
 
       img {
-        cursor: pointer;
         object-fit: contain;
+      }
+
+      &-pan {
+        img {
+          cursor: pointer;
+        }
       }
     }
   }

--- a/ui/v2.5/src/hooks/Lightbox/lightbox.scss
+++ b/ui/v2.5/src/hooks/Lightbox/lightbox.scss
@@ -144,6 +144,11 @@
       transition-duration: 0ms;
     }
 
+    &-swipe {
+      transition-duration: 200ms;
+      transition-timing-function: ease-out;
+    }
+
     &-image-container {
       content-visibility: auto;
       width: 100vw;


### PR DESCRIPTION
Adds swipe navigation to the lightbox on touch devices. Changes the panning behavior to interrupt panning when the edge of the image is reached. In the implementation, an X/Y position of zero now means centered, and a non-zero position is an offset from that.

Relevant to #2538, but that asks for more than just swipe.

Separate from this PR, I have changes to auto-hide the lightbox controls, and to control wake lock, if that is of interest.