### PR TITLE
Generate screenshot task: return if primary file failed to load

### DIFF
--- a/internal/manager/task_generate_screenshot.go
+++ b/internal/manager/task_generate_screenshot.go
@@ -32,6 +32,7 @@ func (t *GenerateCoverTask) Start(ctx context.Context) {
 		return t.Scene.LoadPrimaryFile(ctx, r.File)
 	}); err != nil {
 		logger.Error(err)
+		return
 	}
 
 	if !required {


### PR DESCRIPTION
Related to #6194

Fixes panic if the primary file fails to load during the generate screenshot task.