### PR TITLE
Hide zoom slider in xs viewports

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -91,6 +91,13 @@
   }
 }
 
+// hide zoom slider in xs viewport
+@include media-breakpoint-down(xs) {
+  .display-mode-menu .zoom-slider-container {
+    display: none;
+  }
+}
+
 .display-mode-popover {
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
The zoom slider doesn't function in this viewport so it shouldn't be shown.