### PR TITLE
Don't trim query string from decoded URL params

### DIFF
--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -183,7 +183,7 @@ export class ListFilterModel {
       ret.disp = Number.parseInt(params.disp, 10);
     }
     if (params.q) {
-      ret.q = params.q.trim();
+      ret.q = params.q;
     }
     if (params.p) {
       ret.p = Number.parseInt(params.p, 10);


### PR DESCRIPTION
Fixes issue introduced in #1263. 

Reported in Discord, a trailing space would be removed from the query string after typing. Pressing space afterwards would keep the space.