### PR TITLE
Delete temp file before running backup

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -322,6 +322,11 @@ func (s *Manager) BackupDatabase(download bool) (string, string, error) {
 		backupPath = f.Name()
 		backupName = s.Database.DatabaseBackupPath("")
 		f.Close()
+
+		// delete the temp file so that the backup operation can create it
+		if err := os.Remove(backupPath); err != nil {
+			return "", "", fmt.Errorf("could not remove temporary backup file %v: %w", backupPath, err)
+		}
 	} else {
 		backupDir := s.Config.GetBackupDirectoryPathOrDefault()
 		if backupDir != "" {


### PR DESCRIPTION
Deletes the created temporary file before running backup so that the backup file can be moved to its location.

Fixes #6244 
This should be backported to 0.29.x as well.