### PR TITLE
Feature: Add Tagger Shortcut

### DIFF
--- a/ui/v2.5/src/components/List/ListViewOptions.tsx
+++ b/ui/v2.5/src/components/List/ListViewOptions.tsx
@@ -84,11 +84,17 @@ export const ListViewOptions: React.FC<IListViewOptionsProps> = ({
         onSetDisplayMode(DisplayMode.Wall);
       }
     });
+    Mousetrap.bind("v t", () => {
+      if (displayModeOptions.includes(DisplayMode.Tagger)) {
+        onSetDisplayMode(DisplayMode.Tagger);
+      }
+    });
 
     return () => {
       Mousetrap.unbind("v g");
       Mousetrap.unbind("v l");
       Mousetrap.unbind("v w");
+      Mousetrap.unbind("v t");
     };
   });
 

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -30,6 +30,7 @@
 | `v g` | Set view to grid |
 | `v l` | Set view to list |
 | `v w` | Set view to wall |
+| `v t` | Set view to tagger |
 | `+` | Increase zoom slider |
 | `-` | Decrease zoom slider |
 | `←` | Previous page of results |


### PR DESCRIPTION
This allows users to select v + t from the scene page to take them to the tagger similar to the other available shortcuts