### PR TITLE
i18n: Change 'Has Chapters' to 'Chapters'

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1134,7 +1134,7 @@
     "syncing": "Syncing with server",
     "uploading": "Uploading script"
   },
-  "hasChapters": "Has Chapters",
+  "hasChapters": "Chapters",
   "hasMarkers": "Has Markers",
   "height": "Height",
   "height_cm": "Height (cm)",


### PR DESCRIPTION
Only used in gallery filter, removing "Has" offers better sorting order and maintains uniformity with other filters. 

https://github.com/stashapp/stash/pull/6270 is also removing "Has" from the scene filter.