### PR TITLE
Bug Fix: Update Macos Version Check

### DIFF
--- a/internal/api/check_version.go
+++ b/internal/api/check_version.go
@@ -41,7 +41,7 @@ var stashReleases = func() map[string]string {
 // isMacOSBundle checks if the application is running from within a macOS .app bundle
 func isMacOSBundle() bool {
 	exec, err := os.Executable()
-	return err == nil && strings.Contains(exec, ".app/")
+	return err == nil && strings.Contains(exec, "Stash.app/")
 }
 
 // getWantedRelease determines which release variant to download based on platform and bundle type


### PR DESCRIPTION
This adds in a condition for checking if mac users are using the CLI or the .app version and downloads the appropriate version.

I tested this on my macbook and the .app version was downloaded correctly from the .app version of Stash.

Fixes: #4678