### PR TITLE
BugFix: Remove style for Studio URLs

### DIFF
--- a/ui/v2.5/src/components/Studios/styles.scss
+++ b/ui/v2.5/src/components/Studios/styles.scss
@@ -49,5 +49,9 @@
       display: none;
     }
   }
+
+  .detail-item.urls ul {
+    list-style-type: none;
+  }
   /* stylelint-enable selector-class-pattern */
 }


### PR DESCRIPTION
Removes the style from the list of studio URLs to match the expectation on discourse and keep it in line other URL lists.

<https://discourse.stashapp.cc/t/studio-urls-list-style/4360>