### PR TITLE
Fix missing saved filter overwrite translation

### DIFF
--- a/ui/v2.5/src/components/List/SavedFilterList.tsx
+++ b/ui/v2.5/src/components/List/SavedFilterList.tsx
@@ -222,7 +222,7 @@ const OverwriteAlert: React.FC<{
     <Modal show>
       <Modal.Body>
         <FormattedMessage
-          id="dialogs.overwrite_filter_confirm"
+          id="dialogs.overwrite_filter_warning"
           values={{
             entityName: overwritingFilter.name,
           }}


### PR DESCRIPTION
This translation was renamed from _confirm to _warning.