### PR TITLE
add MediaSession plugin

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -22,6 +22,7 @@ import "./vtt-thumbnails";
 import "./big-buttons";
 import "./track-activity";
 import "./vrmode";
+import "./media-session";
 import cx from "classnames";
 import {
   useSceneSaveActivity,
@@ -395,6 +396,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
             pauseBeforeLooping: false,
             createButtons: uiConfig?.showAbLoopControls ?? false,
           },
+          mediaSession: {},
         },
       };
 
@@ -871,6 +873,21 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
 
       return () => player.off("ended");
     }, [getPlayer, onComplete]);
+
+    // set up mediaSession plugin
+    useEffect(() => {
+      const player = getPlayer();
+      if (!player) return;
+
+      // set up mediasession plugin
+      player
+        .mediaSession()
+        .setMetadata(
+          scene?.title ?? "Stash",
+          scene?.studio?.name ?? "Stash",
+          scene.paths.screenshot || ""
+        );
+    }, [getPlayer, scene]);
 
     function onScrubberScroll() {
       if (started.current) {

--- a/ui/v2.5/src/components/ScenePlayer/media-session.ts
+++ b/ui/v2.5/src/components/ScenePlayer/media-session.ts
@@ -1,0 +1,71 @@
+import videojs, { VideoJsPlayer } from "video.js";
+
+class MediaSessionPlugin extends videojs.getPlugin("plugin") {
+  constructor(player: VideoJsPlayer) {
+    super(player);
+
+    player.ready(() => {
+      player.addClass("vjs-media-session");
+      this.setActionHandlers();
+    });
+
+    player.on("play", () => {
+      this.updatePlaybackState();
+    });
+
+    player.on("pause", () => {
+      this.updatePlaybackState();
+    });
+    this.updatePlaybackState();
+  }
+
+  // manually set poster since it's only set on useEffect
+  public setMetadata(title: string, studioName: string, poster: string): void {
+    if ("mediaSession" in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title,
+        artist: studioName,
+        artwork: [
+          {
+            src: poster || this.player.poster() || "",
+            type: "image/jpeg",
+          },
+        ],
+      });
+    }
+  }
+
+  private updatePlaybackState(): void {
+    if ("mediaSession" in navigator) {
+      const playbackState = this.player.paused() ? "paused" : "playing";
+      navigator.mediaSession.playbackState = playbackState;
+    }
+  }
+
+  private setActionHandlers(): void {
+    // method initialization
+    navigator.mediaSession.setActionHandler("play", () => {
+      this.player.play();
+    });
+    navigator.mediaSession.setActionHandler("pause", () => {
+      this.player.pause();
+    });
+    navigator.mediaSession.setActionHandler("nexttrack", () => {
+      this.player.skipButtons()?.handleForward();
+    });
+    navigator.mediaSession.setActionHandler("previoustrack", () => {
+      this.player.skipButtons()?.handleBackward();
+    });
+  }
+}
+
+videojs.registerPlugin("mediaSession", MediaSessionPlugin);
+
+/* eslint-disable @typescript-eslint/naming-convention */
+declare module "video.js" {
+  interface VideoJsPlayer {
+    mediaSession: () => MediaSessionPlugin;
+  }
+}
+
+export default MediaSessionPlugin;


### PR DESCRIPTION
closes #5508 

To validate on desktop
1. make sure the tab is NOT MUTED, otherwise the media button will not show up
2. click the 🎵 icon on brave, the Media Control button on chrome <img width="18" height="18" alt="unnamed" src="https://github.com/user-attachments/assets/bcdd8dcc-1cae-4dbf-a10d-d748a96f40fe" /> or see the help guide https://support.google.com/chrome/answer/9692215?hl=en

Next/Previous are tied to playlist, skipping intervals are determined by the browser, as is scrubbing.
Play/Pause is implemented
Title reflects the title, Studio is the Artist and Groups (Album) was not implemented