### PR TITLE
Bugfix: Tagger Ignoing Disambiguation When Linking Performer

### DIFF
--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -670,12 +670,7 @@ export const TaggerContext: React.FC = ({ children }) => {
           return {
             ...r,
             performers: r.performers.map((p) => {
-              // Match by remote_site_id if available, otherwise fall back to name
-              const matches = performer.remote_site_id
-                ? p.remote_site_id === performer.remote_site_id
-                : p.name === performer.name;
-
-              if (matches) {
+              if (p.remote_site_id === performer.remote_site_id) {
                 return {
                   ...p,
                   stored_id: performerID,


### PR DESCRIPTION
Changed the performer matching logic in `createNewPerformer` to use `remote_site_id` instead of name when updating search results. This ensures only the specific performer being created gets updated with the new `stored_id`, preventing the previous performer from being unmatched between performers with matching names

Fixes: https://github.com/stashapp/stash/issues/6038