### PR TITLE
Ignore empty studio alias in ScrapedStudio

### DIFF
--- a/pkg/models/model_scraped_item.go
+++ b/pkg/models/model_scraped_item.go
@@ -62,7 +62,7 @@ func (s *ScrapedStudio) ToStudio(endpoint string, excluded map[string]bool) *Stu
 		ret.Details = *s.Details
 	}
 
-	if s.Aliases != nil && !excluded["aliases"] {
+	if s.Aliases != nil && *s.Aliases != "" && !excluded["aliases"] {
 		ret.Aliases = NewRelatedStrings(stringslice.FromString(*s.Aliases, ","))
 	}
 


### PR DESCRIPTION
Omits parsing the `Aliases` field if it is not nil but empty. Fixes issue where studios could not be batch added from stash-box.

Related: https://discourse.stashapp.cc/t/failure-to-bulk-add-studios-from-stash-box-studio-alias-must-not-be-empty/4481