### PR TITLE
[MediaSession] fall back to performers if studio not available

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -882,11 +882,13 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       if (!player) return;
 
       // set up mediasession plugin
+      // get performer names as array
+      const performers = scene?.performers.map((p) => p.name).join(", ");
       player
         .mediaSession()
         .setMetadata(
           scene?.title ?? "Stash",
-          scene?.studio?.name ?? "Stash",
+          scene?.studio?.name ?? performers ?? "Stash",
           scene.paths.screenshot || ""
         );
     }, [getPlayer, scene]);

--- a/ui/v2.5/src/components/ScenePlayer/media-session.ts
+++ b/ui/v2.5/src/components/ScenePlayer/media-session.ts
@@ -20,11 +20,11 @@ class MediaSessionPlugin extends videojs.getPlugin("plugin") {
   }
 
   // manually set poster since it's only set on useEffect
-  public setMetadata(title: string, studioName: string, poster: string): void {
+  public setMetadata(title: string, artist: string, poster: string): void {
     if ("mediaSession" in navigator) {
       navigator.mediaSession.metadata = new MediaMetadata({
         title,
-        artist: studioName,
+        artist,
         artwork: [
           {
             src: poster || this.player.poster() || "",


### PR DESCRIPTION
follow up to #6298 

> Looks good. A nice addition might be for the artist to fall back to the performers if there is no studio.

