### PR TITLE
Feature Request: Show Submit Fingerprints Button when 0 Scenes Visable

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -206,7 +206,7 @@ const SceneList: React.FC<{
 }> = ({ scenes, filter, selectedIds, onSelectChange, fromGroupId }) => {
   const queue = useMemo(() => SceneQueue.fromListFilterModel(filter), [filter]);
 
-  if (scenes.length === 0) {
+  if (scenes.length === 0 && filter.displayMode !== DisplayMode.Tagger) {
     return null;
   }
 

--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -211,6 +211,10 @@ export const Tagger: React.FC<ITaggerProps> = ({ scenes, queue }) => {
       return;
     }
 
+    if (scenes.length === 0) {
+      return;
+    }
+
     if (loadingMulti) {
       return (
         <Button


### PR DESCRIPTION
Changes up the UI so that the submit fingerprints button is visible if there are fingerprints to submit  and there are no scenes present in the tagger view.

Fixes: https://github.com/stashapp/stash/issues/5852
Fixes: https://github.com/stashapp/stash/issues/6314


UI: 
<img width="1036" height="354" alt="Screenshot 2025-11-24 at 18 30 43" src="https://github.com/user-attachments/assets/c00d93a7-21e6-4742-96c8-838aa0aee594" />
