### PR TITLE
Change show male performers option into list of gender checkboxes

### DIFF
--- a/ui/v2.5/src/components/Tagger/constants.ts
+++ b/ui/v2.5/src/components/Tagger/constants.ts
@@ -1,4 +1,4 @@
-import { ScraperSourceInput } from "src/core/generated-graphql";
+import { GenderEnum, ScraperSourceInput } from "src/core/generated-graphql";
 
 export const STASH_BOX_PREFIX = "stashbox:";
 export const SCRAPER_PREFIX = "scraper:";
@@ -27,7 +27,6 @@ export const DEFAULT_EXCLUDED_STUDIO_FIELDS = ["name"];
 
 export const initialConfig: ITaggerConfig = {
   blacklist: DEFAULT_BLACKLIST,
-  showMales: true,
   mode: "auto",
   setCoverImage: true,
   setTags: true,
@@ -43,7 +42,7 @@ export type ParseMode = "auto" | "filename" | "dir" | "path" | "metadata";
 export type TagOperation = "merge" | "overwrite";
 export interface ITaggerConfig {
   blacklist: string[];
-  showMales: boolean;
+  performerGenders?: GenderEnum[];
   mode: ParseMode;
   setCoverImage: boolean;
   setTags: boolean;

--- a/ui/v2.5/src/components/Tagger/scenes/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/Config.tsx
@@ -13,6 +13,8 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { Icon } from "src/components/Shared/Icon";
 import { ParseMode, TagOperation } from "../constants";
 import { TaggerStateContext } from "../context";
+import { GenderEnum } from "src/core/generated-graphql";
+import { genderList } from "src/utils/gender";
 
 const Blacklist: React.FC<{
   list: string[];
@@ -118,6 +120,26 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
   const { config, setConfig } = useContext(TaggerStateContext);
   const intl = useIntl();
 
+  function renderGenderCheckbox(gender: GenderEnum) {
+    const performerGenders = config.performerGenders || genderList.slice();
+    return (
+      <Form.Check
+        key={gender}
+        label={<FormattedMessage id={`gender_types.${gender}`} />}
+        checked={performerGenders.includes(gender)}
+        onChange={(e) => {
+          const isChecked = e.currentTarget.checked;
+          setConfig({
+            ...config,
+            performerGenders: isChecked
+              ? [...performerGenders, gender]
+              : performerGenders.filter((g) => g !== gender),
+          });
+        }}
+      />
+    );
+  }
+
   return (
     <Collapse in={show}>
       <Card>
@@ -127,18 +149,16 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
           </h4>
           <hr className="w-100" />
           <Form className="col-md-6">
-            <Form.Group controlId="tag-males" className="align-items-center">
-              <Form.Check
-                label={
-                  <FormattedMessage id="component_tagger.config.show_male_label" />
-                }
-                checked={config.showMales}
-                onChange={(e) =>
-                  setConfig({ ...config, showMales: e.currentTarget.checked })
-                }
-              />
+            <Form.Group
+              controlId="performer-genders"
+              className="align-items-center"
+            >
+              <Form.Label>
+                <FormattedMessage id="component_tagger.config.performer_genders.heading" />
+              </Form.Label>
+              {genderList.map(renderGenderCheckbox)}
               <Form.Text>
-                <FormattedMessage id="component_tagger.config.show_male_desc" />
+                <FormattedMessage id="component_tagger.config.performer_genders.description" />
               </Form.Text>
             </Form.Group>
             <Form.Group controlId="set-cover" className="align-items-center">

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -21,7 +21,7 @@ import { TagSelect } from "src/components/Shared/Select";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { OperationButton } from "src/components/Shared/OperationButton";
 import * as FormUtils from "src/utils/form";
-import { stringToGender } from "src/utils/gender";
+import { genderList, stringToGender } from "src/utils/gender";
 import { IScrapedScene, TaggerStateContext } from "../context";
 import { OptionalField } from "../IncludeButton";
 import { SceneTaggerModalsState } from "./sceneTaggerModals";
@@ -237,17 +237,15 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     saveScene,
   } = React.useContext(TaggerStateContext);
 
+  const performerGenders = config.performerGenders || genderList;
+
   const performers = useMemo(
     () =>
       scene.performers?.filter((p) => {
-        if (!config.showMales) {
-          return (
-            !p.gender || stringToGender(p.gender, true) !== GQL.GenderEnum.Male
-          );
-        }
-        return true;
+        const gender = p.gender ? stringToGender(p.gender, true) : undefined;
+        return !gender || performerGenders.includes(gender);
       }) ?? [],
-    [config, scene]
+    [scene, performerGenders]
   );
 
   const { createPerformerModal, createStudioModal } = React.useContext(

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -189,6 +189,10 @@
       },
       "mark_organized_desc": "Immediately mark the scene as Organized after the Save button is clicked.",
       "mark_organized_label": "Mark as Organized on save",
+      "performer_genders": {
+        "heading": "Performer genders",
+        "description": "Performers with these genders will be shown when tagging scenes."
+      },
       "query_mode_auto": "Auto",
       "query_mode_auto_desc": "Uses metadata if present, or filename",
       "query_mode_dir": "Dir",
@@ -204,8 +208,6 @@
       "set_cover_label": "Set scene cover image",
       "set_tag_desc": "Attach tags to scene, either by overwriting or merging with existing tags on scene.",
       "set_tag_label": "Set tags",
-      "show_male_desc": "Toggle whether male performers will be available to tag.",
-      "show_male_label": "Show male performers",
       "source": "Source"
     },
     "noun_query": "Query",

--- a/ui/v2.5/src/utils/gender.ts
+++ b/ui/v2.5/src/utils/gender.ts
@@ -1,13 +1,22 @@
 import * as GQL from "../core/generated-graphql";
 
 export const stringGenderMap = new Map<string, GQL.GenderEnum>([
-  ["Male", GQL.GenderEnum.Male],
   ["Female", GQL.GenderEnum.Female],
+  ["Male", GQL.GenderEnum.Male],
   ["Transgender Male", GQL.GenderEnum.TransgenderMale],
   ["Transgender Female", GQL.GenderEnum.TransgenderFemale],
   ["Intersex", GQL.GenderEnum.Intersex],
   ["Non-Binary", GQL.GenderEnum.NonBinary],
 ]);
+
+export const genderList = [
+  GQL.GenderEnum.Female,
+  GQL.GenderEnum.Male,
+  GQL.GenderEnum.TransgenderFemale,
+  GQL.GenderEnum.TransgenderMale,
+  GQL.GenderEnum.Intersex,
+  GQL.GenderEnum.NonBinary,
+];
 
 export const genderToString = (value?: GQL.GenderEnum | string | null) => {
   if (!value) {


### PR DESCRIPTION
Resolves #5423

Replaces `Show male performers` checkbox option in the tagger configuration with a list of checkboxes for each gender:

<img width="614" height="373" alt="image" src="https://github.com/user-attachments/assets/a9cbc47a-5aab-4991-85c8-fa6e60164bb0" />
