### PR TITLE
Bugfix: Update Markers to % Base Calc

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/markers.ts
+++ b/ui/v2.5/src/components/ScenePlayer/markers.ts
@@ -158,10 +158,7 @@ class MarkersPlugin extends videojs.getPlugin("plugin") {
       startPercent * 0.3
     }px)`;
 
-    // minimum width of 8px, using calc for percentage-based width
-    rangeDiv.style.width = `max(calc(${widthPercent}% - ${
-      widthPercent * 0.3
-    }px), 8px)`;
+    rangeDiv.style.width = `calc(${widthPercent}% - ${widthPercent * 0.3}px)`;
     rangeDiv.style.bottom = `${layer * this.layerHeight}px`; // Adjust height based on layer
     rangeDiv.style.display = "none"; // Initially hidden
 

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -271,6 +271,7 @@ $sceneTabWidth: 450px;
     border-radius: 2px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     height: 8px;
+    min-width: 8px;
     position: absolute;
     transform: translateY(-28px);
     transition: none;


### PR DESCRIPTION
Fixes range markers (markers with end times) displaying at incorrect positions in fullscreen mode. The issue was that range markers used fixed pixel positioning calculated at render time, which didn't scale when the player resized. Changed to percentage-based calc() positioning to match how dot markers work. Added in a bunch of comments so I could track my math lol.

Tested on my Mac with Waterfox:
Created a marker at 1sec-10minutes. Pre fix there was an offset due to the bug. After the fix the marker was in the expected location when going fullscreen.


Fixes #6286