### PR TITLE
Bugfix: Add defaultExcludes List 

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -296,6 +296,9 @@ var (
 	defaultImageExtensions   = []string{"png", "jpg", "jpeg", "gif", "webp"}
 	defaultGalleryExtensions = []string{"zip", "cbz"}
 	defaultMenuItems         = []string{"scenes", "images", "groups", "markers", "galleries", "performers", "studios", "tags"}
+	// defaultExcludes contains default regex patterns to exclude from scanning
+	// @eaDir is a Synology NAS metadata folder that should be ignored
+	defaultExcludes = []string{`(?i)/@eaDir/`}
 )
 
 type MissingConfigError struct {
@@ -753,11 +756,13 @@ func (i *Config) GetDefaultScrapersPath() string {
 }
 
 func (i *Config) GetExcludes() []string {
-	return i.getStringSlice(Exclude)
+	ret := i.getStringSlice(Exclude)
+	return append(defaultExcludes, ret...)
 }
 
 func (i *Config) GetImageExcludes() []string {
-	return i.getStringSlice(ImageExclude)
+	ret := i.getStringSlice(ImageExclude)
+	return append(defaultExcludes, ret...)
 }
 
 func (i *Config) GetVideoExtensions() []string {


### PR DESCRIPTION
This add a defaultExcludes list. Currently it only contains a way to block out the Synology hidden folder but it can be expanded to include other patters if there are any.

Added to video and image scanner

I don't have a way to test this on Synology systems so this is 50% "that looks good" and 50% hopes and prayers. Hoping that some Synology users are willing to test this for me

Fixes: #3171 