### PR TITLE
Feature Request: Allow Partial Dates in the UI

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1563,7 +1563,7 @@
   "urls": "URLs",
   "validation": {
     "blank": "${path} must not be blank",
-    "date_invalid_form": "${path} must be in YYYY-MM-DD form",
+    "date_invalid_form": "${path} must be in YYYY, YYYY-MM, or YYYY-MM-DD form",
     "end_time_before_start_time": "End time must be greater than or equal to start time",
     "required": "${path} is a required field",
     "unique": "${path} must be unique"

--- a/ui/v2.5/src/utils/yup.ts
+++ b/ui/v2.5/src/utils/yup.ts
@@ -139,8 +139,22 @@ export function yupDateString(intl: IntlShape) {
       name: "date",
       test(value) {
         if (!value) return true;
-        if (!value.match(/^\d{4}-\d{2}-\d{2}$/)) return false;
-        if (Number.isNaN(Date.parse(value))) return false;
+        // Allow YYYY, YYYY-MM, or YYYY-MM-DD formats
+        if (!value.match(/^\d{4}(-\d{2}(-\d{2})?)?$/)) return false;
+        // Validate the date components
+        const parts = value.split("-");
+        const year = parseInt(parts[0], 10);
+        if (year < 1 || year > 9999) return false;
+        if (parts.length >= 2) {
+          const month = parseInt(parts[1], 10);
+          if (month < 1 || month > 12) return false;
+        }
+        if (parts.length === 3) {
+          const day = parseInt(parts[2], 10);
+          if (day < 1 || day > 31) return false;
+          // Full date - validate it parses correctly
+          if (Number.isNaN(Date.parse(value))) return false;
+        }
         return true;
       },
       message: intl.formatMessage({ id: "validation.date_invalid_form" }),


### PR DESCRIPTION
With the addition of https://github.com/stashapp/stash/pull/6305 this current PR allows users to input partial dates in the frontend in the follow formats: 

- YYYY
- YYYY-MM

Any missing information will be converted to `01` as default. It will apply to all major areas to include Scenes, Images, Galleries, Groups and Performers. The new warning seems a little long but if someone has a better alteration then please let me know.

Fixes: https://github.com/stashapp/stash/issues/6330