### PR TITLE
Resume after scrubbing, hide player UI faster

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -360,7 +360,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
         },
         nativeControlsForTouch: false,
         playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
-        inactivityTimeout: 2000,
+        inactivityTimeout: 700,
         preload: "none",
         playsinline: true,
         techOrder: ["chromecast", "html5"],
@@ -893,15 +893,23 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
         );
     }, [getPlayer, scene]);
 
+    const pausedBeforeScrubber = useRef(true);
+
     function onScrubberScroll() {
-      if (started.current) {
-        getPlayer()?.pause();
+      const player = getPlayer();
+      if (started.current && player) {
+        pausedBeforeScrubber.current = player.paused();
+        player.pause();
       }
     }
 
     function onScrubberSeek(seconds: number) {
-      if (started.current) {
-        getPlayer()?.currentTime(seconds);
+      const player = getPlayer();
+      if (started.current && player) {
+        player.currentTime(seconds);
+        if (!pausedBeforeScrubber.current) {
+          player.play();
+        }
       } else {
         setTime(seconds);
       }


### PR DESCRIPTION
This PR includes 2 improvements to the scene player:
1. After scrubbing, it resumes the video playback if it was playing before the scrub
2. Reduces the timeout for hiding the video UI from 2000ms to 700ms