### PR TITLE
Bugfix: Fix New Tagger Gender Setting Select

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/Config.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/Config.tsx
@@ -124,6 +124,7 @@ const Config: React.FC<IConfigProps> = ({ show }) => {
     const performerGenders = config.performerGenders || genderList.slice();
     return (
       <Form.Check
+        id={`gender-${gender}`}
         key={gender}
         label={<FormattedMessage id={`gender_types.${gender}`} />}
         checked={performerGenders.includes(gender)}


### PR DESCRIPTION
Adds an ID to the check. I believe bootstrap was auto generating the same ID for each of the toggles so when you clicked the various names it always selected the first option. 

Was able to test in dev and this fixed the issue. 

Fixes: https://github.com/stashapp/stash/issues/6350