### PR TITLE
Truncate custom field display to 5 lines

### DIFF
--- a/ui/v2.5/src/components/Shared/CustomFields.tsx
+++ b/ui/v2.5/src/components/Shared/CustomFields.tsx
@@ -8,6 +8,7 @@ import { Icon } from "./Icon";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import { PatchComponent } from "src/patch";
+import { TruncatedText } from "./TruncatedText";
 
 const maxFieldNameLength = 64;
 
@@ -47,7 +48,7 @@ const CustomField: React.FC<{ field: string; value: unknown }> = ({
       id={id}
       label={field}
       labelTitle={field}
-      value={valueStr}
+      value={<TruncatedText lineCount={5} text={<>{valueStr}</>} />}
       fullWidth={true}
       showEmpty
     />

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -712,6 +712,10 @@ button.btn.favorite-button {
 
 .custom-fields {
   width: 100%;
+
+  .detail-item {
+    max-width: 100%;
+  }
 }
 
 .custom-fields .detail-item .detail-item-title {
@@ -719,6 +723,14 @@ button.btn.favorite-button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.custom-fields .detail-item .detail-item-value {
+  word-break: break-word;
+
+  .TruncatedText {
+    white-space: pre-line;
+  }
 }
 
 .custom-fields-input > .collapse-button {


### PR DESCRIPTION
Truncates custom field values to a maximum of 5 lines, and sets the max width so that long custom field values don't overflow out of the page bounds.

Screenshot:

<img width="1504" height="746" alt="image" src="https://github.com/user-attachments/assets/00f45f88-742e-4666-88e7-b8baabf99687" />

Resolves #5937 