### PR TITLE
Add graphql support for removing custom field keys

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -344,4 +344,6 @@ input CustomFieldsInput {
   full: Map
   "If populated, only the keys in this map will be updated"
   partial: Map
+  "Remove any keys in this list"
+  remove: [String!]
 }

--- a/internal/api/custom_fields.go
+++ b/internal/api/custom_fields.go
@@ -1,0 +1,12 @@
+package api
+
+import "github.com/stashapp/stash/pkg/models"
+
+func handleUpdateCustomFields(input models.CustomFieldsInput) models.CustomFieldsInput {
+	ret := input
+	// convert json.Numbers to int/float
+	ret.Full = convertMapJSONNumbers(ret.Full)
+	ret.Partial = convertMapJSONNumbers(ret.Partial)
+
+	return ret
+}

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -297,10 +297,7 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 		return nil, fmt.Errorf("converting tag ids: %w", err)
 	}
 
-	updatedPerformer.CustomFields = input.CustomFields
-	// convert json.Numbers to int/float
-	updatedPerformer.CustomFields.Full = convertMapJSONNumbers(updatedPerformer.CustomFields.Full)
-	updatedPerformer.CustomFields.Partial = convertMapJSONNumbers(updatedPerformer.CustomFields.Partial)
+	updatedPerformer.CustomFields = handleUpdateCustomFields(input.CustomFields)
 
 	var imageData []byte
 	imageIncluded := translator.hasField("image")
@@ -415,6 +412,10 @@ func (r *mutationResolver) BulkPerformerUpdate(ctx context.Context, input BulkPe
 	updatedPerformer.TagIDs, err = translator.updateIdsBulk(input.TagIds, "tag_ids")
 	if err != nil {
 		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	if input.CustomFields != nil {
+		updatedPerformer.CustomFields = handleUpdateCustomFields(*input.CustomFields)
 	}
 
 	ret := []*models.Performer{}

--- a/pkg/models/custom_fields.go
+++ b/pkg/models/custom_fields.go
@@ -9,6 +9,8 @@ type CustomFieldsInput struct {
 	Full map[string]interface{} `json:"full"`
 	// If populated, only the keys in this map will be updated
 	Partial map[string]interface{} `json:"partial"`
+	// Remove any keys in this list
+	Remove []string `json:"remove"`
 }
 
 type CustomFieldsReader interface {

--- a/pkg/sqlite/custom_fields_test.go
+++ b/pkg/sqlite/custom_fields_test.go
@@ -65,6 +65,18 @@ func TestSetCustomFields(t *testing.T) {
 			false,
 		},
 		{
+			"valid remove",
+			models.CustomFieldsInput{
+				Remove: []string{"real"},
+			},
+			func() map[string]interface{} {
+				m := getPerformerCustomFields(performerIdx)
+				delete(m, "real")
+				return m
+			}(),
+			false,
+		},
+		{
 			"leading space full",
 			models.CustomFieldsInput{
 				Full: map[string]interface{}{
@@ -144,16 +156,38 @@ func TestSetCustomFields(t *testing.T) {
 			nil,
 			true,
 		},
+		{
+			"invalid remove full",
+			models.CustomFieldsInput{
+				Full: map[string]interface{}{
+					"key": "value",
+				},
+				Remove: []string{"key"},
+			},
+			nil,
+			true,
+		},
+		{
+			"invalid remove partial",
+			models.CustomFieldsInput{
+				Partial: map[string]interface{}{
+					"real": float64(4.56),
+				},
+				Remove: []string{"real"},
+			},
+			nil,
+			true,
+		},
 	}
 
 	// use performer custom fields store
 	store := db.Performer
 	id := performerIDs[performerIdx]
 
-	assert := assert.New(t)
-
 	for _, tt := range tests {
 		runWithRollbackTxn(t, tt.name, func(t *testing.T, ctx context.Context) {
+			assert := assert.New(t)
+
 			err := store.SetCustomFields(ctx, id, tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetCustomFields() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Resolves #5931 

Adds optional `remove` field to `CustomFieldsInput`. Any keys in this list will be removed from the custom fields for that object. An error will be returned if the `full` or `partial` maps contain a key that is also in the `remove` list.