### PR TITLE
Custom favicon and title

### DIFF
--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -307,7 +307,8 @@ export const App: React.FC = () => {
     );
   }
 
-  const titleProps = makeTitleProps();
+  const title = config.data?.configuration.ui.title || "Stash";
+  const titleProps = makeTitleProps(title);
 
   if (!messages) {
     return null;

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -248,6 +248,14 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             onChange={(v) => saveInterface({ sfwContentMode: v })}
           />
 
+          <StringSetting
+            id="custom-title"
+            headingID="config.ui.custom_title.heading"
+            subHeadingID="config.ui.custom_title.description"
+            value={ui.title ?? ""}
+            onChange={(v) => saveUI({ title: v })}
+          />
+
           <div className="setting-group">
             <div className="setting">
               <div>

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -103,6 +103,8 @@ export interface IUIConfig {
   defaultFilters?: DefaultFilters;
 
   taggerConfig?: ITaggerConfig;
+
+  title?: string;
 }
 
 export function getFrontPageContent(

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -165,6 +165,12 @@ The following environment variables are also supported:
 |----------------------|---------|
 | `STASH_SQLITE_CACHE_SIZE` | Sets the SQLite cache size. See https://www.sqlite.org/pragma.html#pragma_cache_size. Default is `-2000` which is 2MB. |
 
+### Custom favicon
+
+You can provide a custom favicon by placing a `favicon.ico` file in the configuration directory. The configuration directory is located alongside the `config.yml` file.
+
+When a custom favicon is provided, it will be served instead of the default embedded favicon.
+
 ### Custom served folders
 
 Custom served folders are served when the server handles a request with the `/custom` URL prefix. The following is an example configuration:

--- a/ui/v2.5/src/hooks/title.ts
+++ b/ui/v2.5/src/hooks/title.ts
@@ -1,10 +1,13 @@
 import { MessageDescriptor, useIntl } from "react-intl";
+import { useConfigurationContext } from "./Config";
 
 export const TITLE = "Stash";
 export const TITLE_SEPARATOR = " | ";
 
 export function useTitleProps(...messages: (string | MessageDescriptor)[]) {
   const intl = useIntl();
+  const config = useConfigurationContext();
+  const title = config.configuration.ui.title || TITLE;
 
   const parts = messages.map((msg) => {
     if (typeof msg === "object") {
@@ -14,13 +17,13 @@ export function useTitleProps(...messages: (string | MessageDescriptor)[]) {
     }
   });
 
-  return makeTitleProps(...parts);
+  return makeTitleProps(title, ...parts);
 }
 
-export function makeTitleProps(...parts: string[]) {
-  const title = [...parts, TITLE].join(TITLE_SEPARATOR);
+export function makeTitleProps(title: string, ...parts: string[]) {
+  const fullTitle = [...parts, title].join(TITLE_SEPARATOR);
   return {
-    titleTemplate: `%s | ${title}`,
-    defaultTitle: title,
+    titleTemplate: `%s | ${fullTitle}`,
+    defaultTitle: fullTitle,
   };
 }

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -621,6 +621,10 @@
         "heading": "Custom localisation",
         "option_label": "Custom localisation enabled"
       },
+      "custom_title": {
+        "description": "Custom text to append to the page title. If empty, defaults to 'Stash'.",
+        "heading": "Custom Title"
+      },
       "delete_options": {
         "description": "Default settings when deleting images, galleries, and scenes.",
         "heading": "Delete Options",


### PR DESCRIPTION
Adds support for custom favicon by reading from `favicon.ico` from the config directory. Uses the custom favicon if it is present at startup.

Adds `Custom Title` setting to the interface settings. Replaces `Stash` with whatever is in the custom title. Defaults to `Stash` if empty.

Resolves #5072
