### PR TITLE
Don't convert config file location to absolute during setup

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -219,8 +219,11 @@ func (s *Manager) Setup(ctx context.Context, input SetupInput) error {
 		// paths since they must not be relative. The config file property is
 		// resolved to an absolute path when stash is run normally, so convert
 		// relative paths to absolute paths during setup.
-		configFile, _ := filepath.Abs(input.ConfigLocation)
-
+		// #6287 - this should no longer be necessary since the ffmpeg code
+		// converts to absolute paths. Converting the config location to
+		// absolute means that scraper and plugin paths default to absolute
+		// which we don't want.
+		configFile := input.ConfigLocation
 		configDir := filepath.Dir(configFile)
 
 		if exists, _ := fsutil.DirExists(configDir); !exists {


### PR DESCRIPTION
Converting the config file path to absolute during setup was originally done for #3304. The ffmpeg code has been redone since and this is no longer necessary. It was resulting in the scraper and plugin paths being made absolute during setup, despite all the others being relative to the provided config path.

Fixes #6287
Closes https://github.com/stashapp/stash/issues/3029