### PR TITLE
Correct sidebar styling on details pages

### DIFF
--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -929,7 +929,6 @@ $sticky-header-height: calc(50px + 3.3rem);
     align-self: flex-start;
 
     // take a further 15px padding to match the detail body
-    height: calc(100vh - $sticky-header-height - 15px);
     margin-top: -15px;
     max-height: calc(100vh - $sticky-header-height - 15px);
     overflow-y: auto;
@@ -941,6 +940,10 @@ $sticky-header-height: calc(50px + 3.3rem);
     .sidebar-toolbar {
       padding-top: 15px;
     }
+  }
+
+  .sidebar-pane:not(.hide-sidebar) .sidebar {
+    height: calc(100vh - $sticky-header-height - 15px);
   }
 
   .sidebar-pane.hide-sidebar .sidebar {


### PR DESCRIPTION
Attempt at resolving #6375 

Appears to fix some of the styling issues on sub-pages with sidebar. It is still not stickying correctly on `xs` viewports. Input welcomed on how to fix this.

I'll take a further look tomorrow.

Fixes #6375 