### PR TITLE
Bugfix: Set Performers to Use InitialState

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -292,9 +292,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   );
 
   // map of original performer to id
-  const [performerIDs, setPerformerIDs] = useState<(string | undefined)[]>(
-    getInitialPerformers()
-  );
+  const [performerIDs, setPerformerIDs, setInitialPerformerIDs] =
+    useInitialState<(string | undefined)[]>(getInitialPerformers());
 
   const [studioID, setStudioID] = useState<string | undefined>(
     getInitialStudio()
@@ -305,8 +304,8 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   }, [getInitialTags, setInitialTagIDs]);
 
   useEffect(() => {
-    setPerformerIDs(getInitialPerformers());
-  }, [getInitialPerformers]);
+    setInitialPerformerIDs(getInitialPerformers());
+  }, [getInitialPerformers, setInitialPerformerIDs]);
 
   useEffect(() => {
     setStudioID(getInitialStudio());


### PR DESCRIPTION
Sets performers to use initial state to prevent performer tagger results from resetting upon save of another scene.

This is untested

Fixes: https://github.com/stashapp/stash/issues/6324