### PR TITLE
Implement stash_ids_endpoint for the SceneFilterType

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -84,10 +84,20 @@ input PHashDuplicationCriterionInput {
 input StashIDCriterionInput {
   """
   If present, this value is treated as a predicate.
-  That is, it will filter based on stash_ids with the matching endpoint
+  That is, it will filter based on stash_id with the matching endpoint
   """
   endpoint: String
   stash_id: String
+  modifier: CriterionModifier!
+}
+
+input StashIDsCriterionInput {
+  """
+  If present, this value is treated as a predicate.
+  That is, it will filter based on stash_ids with the matching endpoint
+  """
+  endpoint: String
+  stash_ids: [String]
   modifier: CriterionModifier!
 }
 
@@ -156,6 +166,8 @@ input PerformerFilterType {
   o_counter: IntCriterionInput
   "Filter by StashID"
   stash_id_endpoint: StashIDCriterionInput
+  "Filter by StashIDs"
+  stash_ids_endpoint: StashIDsCriterionInput
   # rating expressed as 1-100
   rating100: IntCriterionInput
   "Filter by url"
@@ -292,6 +304,8 @@ input SceneFilterType {
   performer_count: IntCriterionInput
   "Filter by StashID"
   stash_id_endpoint: StashIDCriterionInput
+  "Filter by StashIDs"
+  stash_ids_endpoint: StashIDsCriterionInput
   "Filter by url"
   url: StringCriterionInput
   "Filter by interactive"
@@ -432,6 +446,8 @@ input StudioFilterType {
   parents: MultiCriterionInput
   "Filter by StashID"
   stash_id_endpoint: StashIDCriterionInput
+  "Filter by StashIDs"
+  stash_ids_endpoint: StashIDsCriterionInput
   "Filter to only include studios with these tags"
   tags: HierarchicalMultiCriterionInput
   "Filter to only include studios missing this property"

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -165,7 +165,7 @@ input PerformerFilterType {
   "Filter by o count"
   o_counter: IntCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput
+  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   # rating expressed as 1-100
@@ -303,7 +303,7 @@ input SceneFilterType {
   "Filter by performer count"
   performer_count: IntCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput
+  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   "Filter by url"
@@ -445,7 +445,7 @@ input StudioFilterType {
   "Filter to only include studios with this parent studio"
   parents: MultiCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput
+  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   "Filter to only include studios with these tags"

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -165,7 +165,8 @@ input PerformerFilterType {
   "Filter by o count"
   o_counter: IntCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
+  stash_id_endpoint: StashIDCriterionInput
+    @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   # rating expressed as 1-100
@@ -303,7 +304,8 @@ input SceneFilterType {
   "Filter by performer count"
   performer_count: IntCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
+  stash_id_endpoint: StashIDCriterionInput
+    @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   "Filter by url"
@@ -445,7 +447,8 @@ input StudioFilterType {
   "Filter to only include studios with this parent studio"
   parents: MultiCriterionInput
   "Filter by StashID"
-  stash_id_endpoint: StashIDCriterionInput @deprecated(reason: "use stash_ids_endpoint instead")
+  stash_id_endpoint: StashIDCriterionInput
+    @deprecated(reason: "use stash_ids_endpoint instead")
   "Filter by StashIDs"
   stash_ids_endpoint: StashIDsCriterionInput
   "Filter to only include studios with these tags"

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -627,6 +627,10 @@ input TagFilterType {
 
   "Filter by StashID"
   stash_id_endpoint: StashIDCriterionInput
+    @deprecated(reason: "use stash_ids_endpoint instead")
+
+  "Filter by StashID"
+  stash_ids_endpoint: StashIDsCriterionInput
 
   "Filter by related scenes that meet this criteria"
   scenes_filter: SceneFilterType

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -166,6 +166,8 @@ type PerformerFilterType struct {
 	StashID *StringCriterionInput `json:"stash_id"`
 	// Filter by StashID Endpoint
 	StashIDEndpoint *StashIDCriterionInput `json:"stash_id_endpoint"`
+	// Filter by StashIDs Endpoint
+	StashIDsEndpoint *StashIDsCriterionInput `json:"stash_ids_endpoint"`
 	// Filter by rating expressed as 1-100
 	Rating100 *IntCriterionInput `json:"rating100"`
 	// Filter by url

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -79,6 +79,8 @@ type SceneFilterType struct {
 	StashID *StringCriterionInput `json:"stash_id"`
 	// Filter by StashID Endpoint
 	StashIDEndpoint *StashIDCriterionInput `json:"stash_id_endpoint"`
+	// Filter by StashIDs Endpoint
+	StashIDsEndpoint *StashIDsCriterionInput `json:"stash_ids_endpoint"`
 	// Filter by url
 	URL *StringCriterionInput `json:"url"`
 	// Filter by interactive

--- a/pkg/models/stash_ids.go
+++ b/pkg/models/stash_ids.go
@@ -129,8 +129,16 @@ func (u *UpdateStashIDs) Set(v StashID) {
 
 type StashIDCriterionInput struct {
 	// If present, this value is treated as a predicate.
-	// That is, it will filter based on stash_ids with the matching endpoint
+	// That is, it will filter based on stash_id with the matching endpoint
 	Endpoint *string           `json:"endpoint"`
 	StashID  *string           `json:"stash_id"`
+	Modifier CriterionModifier `json:"modifier"`
+}
+
+type StashIDsCriterionInput struct {
+	// If present, this value is treated as a predicate.
+	// That is, it will filter based on stash_ids with the matching endpoint
+	Endpoint *string           `json:"endpoint"`
+	StashIDs []*string         `json:"stash_ids"`
 	Modifier CriterionModifier `json:"modifier"`
 }

--- a/pkg/models/studio.go
+++ b/pkg/models/studio.go
@@ -10,6 +10,8 @@ type StudioFilterType struct {
 	StashID *StringCriterionInput `json:"stash_id"`
 	// Filter by StashID Endpoint
 	StashIDEndpoint *StashIDCriterionInput `json:"stash_id_endpoint"`
+	// Filter by StashIDs Endpoint
+	StashIDsEndpoint *StashIDsCriterionInput `json:"stash_ids_endpoint"`
 	// Filter to only include studios missing this property
 	IsMissing *string `json:"is_missing"`
 	// Filter by rating expressed as 1-100

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -42,6 +42,8 @@ type TagFilterType struct {
 	IgnoreAutoTag *bool `json:"ignore_auto_tag"`
 	// Filter by StashID Endpoint
 	StashIDEndpoint *StashIDCriterionInput `json:"stash_id_endpoint"`
+	// Filter by StashIDs Endpoint
+	StashIDsEndpoint *StashIDsCriterionInput `json:"stash_ids_endpoint"`
 	// Filter by related scenes that meet this criteria
 	ScenesFilter *SceneFilterType `json:"scenes_filter"`
 	// Filter by related images that meet this criteria

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1012,28 +1012,25 @@ func (h *stashIDCriterionHandler) handle(ctx context.Context, f *filterBuilder) 
 		return
 	}
 
-	stashIDRepo := h.stashIDRepository
-	t := stashIDRepo.tableName
-	if h.stashIDTableAs != "" {
-		t = h.stashIDTableAs
-	}
-
-	joinClause := fmt.Sprintf("%s.%s = %s", t, stashIDRepo.idColumn, h.parentIDCol)
-	if h.c.Endpoint != nil && *h.c.Endpoint != "" {
-		joinClause += fmt.Sprintf(" AND %s.endpoint = '%s'", t, *h.c.Endpoint)
-	}
-
-	f.addLeftJoin(stashIDRepo.tableName, h.stashIDTableAs, joinClause)
-
-	v := ""
+	var stashIDs []*string
 	if h.c.StashID != nil {
-		v = *h.c.StashID
+		stashIDs = []*string{h.c.StashID}
 	}
 
-	stringCriterionHandler(&models.StringCriterionInput{
-		Value:    v,
+	convertedInput := &models.StashIDsCriterionInput{
+		Endpoint: h.c.Endpoint,
+		StashIDs: stashIDs,
 		Modifier: h.c.Modifier,
-	}, t+".stash_id")(ctx, f)
+	}
+
+	convertedHandler := stashIDsCriterionHandler{
+		c:                 convertedInput,
+		stashIDRepository: h.stashIDRepository,
+		stashIDTableAs:    h.stashIDTableAs,
+		parentIDCol:       h.parentIDCol,
+	}
+
+	convertedHandler.handle(ctx, f)
 }
 
 type stashIDsCriterionHandler struct {

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1060,7 +1060,7 @@ func (h *stashIDsCriterionHandler) handle(ctx context.Context, f *filterBuilder)
 
 	f.addLeftJoin(stashIDRepo.tableName, h.stashIDTableAs, joinClause)
 
-	if h.c.StashIDs == nil || len(h.c.StashIDs) == 0 {
+	if len(h.c.StashIDs) == 0 {
 		stringCriterionHandler(&models.StringCriterionInput{
 			Value:    "",
 			Modifier: h.c.Modifier,

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1015,6 +1015,8 @@ func (h *stashIDCriterionHandler) handle(ctx context.Context, f *filterBuilder) 
 	var stashIDs []*string
 	if h.c.StashID != nil {
 		stashIDs = []*string{h.c.StashID}
+	} else {
+		stashIDs = nil
 	}
 
 	convertedInput := &models.StashIDsCriterionInput{
@@ -1058,21 +1060,28 @@ func (h *stashIDsCriterionHandler) handle(ctx context.Context, f *filterBuilder)
 
 	f.addLeftJoin(stashIDRepo.tableName, h.stashIDTableAs, joinClause)
 
-	b := f
-	for _, n := range h.c.StashIDs {
-		query := &filterBuilder{}
-		v := ""
-		if n != nil {
-			v = *n
-		}
-
+	if h.c.StashIDs == nil || len(h.c.StashIDs) == 0 {
 		stringCriterionHandler(&models.StringCriterionInput{
-			Value:    v,
+			Value:    "",
 			Modifier: h.c.Modifier,
-		}, t+".stash_id")(ctx, query)
+		}, t+".stash_id")(ctx, f)
+	} else {
+		b := f
+		for _, n := range h.c.StashIDs {
+			query := &filterBuilder{}
+			v := ""
+			if n != nil {
+				v = *n
+			}
 
-		b.or(query)
-		b = query
+			stringCriterionHandler(&models.StringCriterionInput{
+				Value:    v,
+				Modifier: h.c.Modifier,
+			}, t+".stash_id")(ctx, query)
+
+			b.or(query)
+			b = query
+		}
 	}
 }
 

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1079,7 +1079,11 @@ func (h *stashIDsCriterionHandler) handle(ctx context.Context, f *filterBuilder)
 				Modifier: h.c.Modifier,
 			}, t+".stash_id")(ctx, query)
 
-			b.or(query)
+			if h.c.Modifier == models.CriterionModifierNotEquals {
+				b.and(query)
+			} else {
+				b.or(query)
+			}
 			b = query
 		}
 	}

--- a/pkg/sqlite/performer_filter.go
+++ b/pkg/sqlite/performer_filter.go
@@ -148,6 +148,12 @@ func (qb *performerFilterHandler) criterionHandler() criterionHandler {
 			stashIDTableAs:    "performer_stash_ids",
 			parentIDCol:       "performers.id",
 		},
+		&stashIDsCriterionHandler{
+			c:                 filter.StashIDsEndpoint,
+			stashIDRepository: &performerRepository.stashIDs,
+			stashIDTableAs:    "performer_stash_ids",
+			parentIDCol:       "performers.id",
+		},
 
 		qb.aliasCriterionHandler(filter.Aliases),
 

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -1069,6 +1069,8 @@ func TestPerformerQuery(t *testing.T) {
 	var (
 		endpoint = performerStashID(performerIdxWithGallery).Endpoint
 		stashID  = performerStashID(performerIdxWithGallery).StashID
+		stashID2 = performerStashID(performerIdx1WithGallery).StashID
+		stashIDs = []*string{&stashID, &stashID2}
 	)
 
 	tests := []struct {
@@ -1130,6 +1132,60 @@ func TestPerformerQuery(t *testing.T) {
 				},
 			},
 			[]int{performerIdxWithGallery},
+			nil,
+			false,
+		},
+		{
+			"stash ids with endpoint",
+			nil,
+			&models.PerformerFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierEquals,
+				},
+			},
+			[]int{performerIdxWithGallery, performerIdx1WithGallery},
+			nil,
+			false,
+		},
+		{
+			"exclude stash ids with endpoint",
+			nil,
+			&models.PerformerFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierNotEquals,
+				},
+			},
+			nil,
+			[]int{performerIdxWithGallery, performerIdx1WithGallery},
+			false,
+		},
+		{
+			"null stash ids with endpoint",
+			nil,
+			&models.PerformerFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+			nil,
+			[]int{performerIdxWithGallery, performerIdx1WithGallery},
+			false,
+		},
+		{
+			"not null stash ids with endpoint",
+			nil,
+			&models.PerformerFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierNotNull,
+				},
+			},
+			[]int{performerIdxWithGallery, performerIdx1WithGallery},
 			nil,
 			false,
 		},

--- a/pkg/sqlite/scene_filter.go
+++ b/pkg/sqlite/scene_filter.go
@@ -114,9 +114,14 @@ func (qb *sceneFilterHandler) criterionHandler() criterionHandler {
 				stringCriterionHandler(sceneFilter.StashID, "scene_stash_ids.stash_id")(ctx, f)
 			}
 		}),
-
 		&stashIDCriterionHandler{
 			c:                 sceneFilter.StashIDEndpoint,
+			stashIDRepository: &sceneRepository.stashIDs,
+			stashIDTableAs:    "scene_stash_ids",
+			parentIDCol:       "scenes.id",
+		},
+		&stashIDsCriterionHandler{
+			c:                 sceneFilter.StashIDsEndpoint,
 			stashIDRepository: &sceneRepository.stashIDs,
 			stashIDTableAs:    "scene_stash_ids",
 			parentIDCol:       "scenes.id",

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2098,6 +2098,8 @@ func TestSceneQuery(t *testing.T) {
 	var (
 		endpoint = sceneStashID(sceneIdxWithGallery).Endpoint
 		stashID  = sceneStashID(sceneIdxWithGallery).StashID
+		stashID2 = sceneStashID(sceneIdxWithPerformer).StashID
+		stashIDs = []*string{&stashID, &stashID2}
 
 		depth = -1
 	)
@@ -2200,6 +2202,60 @@ func TestSceneQuery(t *testing.T) {
 				},
 			},
 			[]int{sceneIdxWithGallery},
+			nil,
+			false,
+		},
+		{
+			"stash ids with endpoint",
+			nil,
+			&models.SceneFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierEquals,
+				},
+			},
+			[]int{sceneIdxWithGallery, sceneIdxWithPerformer},
+			nil,
+			false,
+		},
+		{
+			"exclude stash ids with endpoint",
+			nil,
+			&models.SceneFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierNotEquals,
+				},
+			},
+			nil,
+			[]int{sceneIdxWithGallery, sceneIdxWithPerformer},
+			false,
+		},
+		{
+			"null stash ids with endpoint",
+			nil,
+			&models.SceneFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+			nil,
+			[]int{sceneIdxWithGallery, sceneIdxWithPerformer},
+			false,
+		},
+		{
+			"not null stash ids with endpoint",
+			nil,
+			&models.SceneFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierNotNull,
+				},
+			},
+			[]int{sceneIdxWithGallery, sceneIdxWithPerformer},
 			nil,
 			false,
 		},

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1547,7 +1547,7 @@ func getIgnoreAutoTag(index int) bool {
 func performerStashID(i int) models.StashID {
 	return models.StashID{
 		StashID:  getPerformerStringValue(i, "stashid"),
-		Endpoint: getPerformerStringValue(i, "endpoint"),
+		Endpoint: getPerformerStringValue(0, "endpoint"),
 	}
 }
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1079,7 +1079,7 @@ func getObjectDate(index int) *models.Date {
 func sceneStashID(i int) models.StashID {
 	return models.StashID{
 		StashID:   getSceneStringValue(i, "stashid"),
-		Endpoint:  getSceneStringValue(i, "endpoint"),
+		Endpoint:  getSceneStringValue(0, "endpoint"),
 		UpdatedAt: epochTime,
 	}
 }

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1700,7 +1700,7 @@ func getTagChildCount(id int) int {
 func tagStashID(i int) models.StashID {
 	return models.StashID{
 		StashID:  getTagStringValue(i, "stashid"),
-		Endpoint: getTagStringValue(i, "endpoint"),
+		Endpoint: getTagStringValue(0, "endpoint"),
 	}
 }
 

--- a/pkg/sqlite/studio_filter.go
+++ b/pkg/sqlite/studio_filter.go
@@ -72,6 +72,12 @@ func (qb *studioFilterHandler) criterionHandler() criterionHandler {
 			stashIDTableAs:    "studio_stash_ids",
 			parentIDCol:       "studios.id",
 		},
+		&stashIDsCriterionHandler{
+			c:                 studioFilter.StashIDsEndpoint,
+			stashIDRepository: &studioRepository.stashIDs,
+			stashIDTableAs:    "studio_stash_ids",
+			parentIDCol:       "studios.id",
+		},
 
 		qb.isMissingCriterionHandler(studioFilter.IsMissing),
 		qb.tagCountCriterionHandler(studioFilter.TagCount),

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -91,6 +91,12 @@ func (qb *tagFilterHandler) criterionHandler() criterionHandler {
 			stashIDTableAs:    "tag_stash_ids",
 			parentIDCol:       "tags.id",
 		},
+		&stashIDsCriterionHandler{
+			c:                 tagFilter.StashIDsEndpoint,
+			stashIDRepository: &tagRepository.stashIDs,
+			stashIDTableAs:    "tag_stash_ids",
+			parentIDCol:       "tags.id",
+		},
 
 		&timestampCriterionHandler{tagFilter.CreatedAt, "tags.created_at", nil},
 		&timestampCriterionHandler{tagFilter.UpdatedAt, "tags.updated_at", nil},

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -356,6 +356,8 @@ func TestTagQuery(t *testing.T) {
 	var (
 		endpoint = tagStashID(tagIdxWithPerformer).Endpoint
 		stashID  = tagStashID(tagIdxWithPerformer).StashID
+		stashID2 = tagStashID(tagIdx1WithPerformer).StashID
+		stashIDs = []*string{&stashID, &stashID2}
 	)
 
 	tests := []struct {
@@ -417,6 +419,60 @@ func TestTagQuery(t *testing.T) {
 				},
 			},
 			[]int{tagIdxWithPerformer},
+			nil,
+			false,
+		},
+		{
+			"stash ids with endpoint",
+			nil,
+			&models.TagFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierEquals,
+				},
+			},
+			[]int{tagIdxWithPerformer, tagIdx1WithPerformer},
+			nil,
+			false,
+		},
+		{
+			"exclude stash ids with endpoint",
+			nil,
+			&models.TagFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					StashIDs: stashIDs,
+					Modifier: models.CriterionModifierNotEquals,
+				},
+			},
+			nil,
+			[]int{tagIdxWithPerformer, tagIdx1WithPerformer},
+			false,
+		},
+		{
+			"null stash ids with endpoint",
+			nil,
+			&models.TagFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+			nil,
+			[]int{tagIdxWithPerformer, tagIdx1WithPerformer},
+			false,
+		},
+		{
+			"not null stash ids with endpoint",
+			nil,
+			&models.TagFilterType{
+				StashIDsEndpoint: &models.StashIDsCriterionInput{
+					Endpoint: &endpoint,
+					Modifier: models.CriterionModifierNotNull,
+				},
+			},
+			[]int{tagIdxWithPerformer, tagIdx1WithPerformer},
 			nil,
 			false,
 		},


### PR DESCRIPTION
As mentioned in Issue #6400, I propose this change to allow to query an entire list of stash ids against the scenes in the database.

I have applied it to scenes, performers, and studios.

Resolves #6400