### PR TITLE
Add sfw label for o-count in stats page

### DIFF
--- a/ui/v2.5/src/components/Stats.tsx
+++ b/ui/v2.5/src/components/Stats.tsx
@@ -4,8 +4,16 @@ import { FormattedMessage, FormattedNumber } from "react-intl";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import TextUtils from "src/utils/text";
 import { FileSize } from "./Shared/FileSize";
+import { useConfigurationContext } from "src/hooks/Config";
 
 export const Stats: React.FC = () => {
+  const { configuration } = useConfigurationContext();
+  const { sfwContentMode } = configuration.interface;
+
+  const oCountID = sfwContentMode
+    ? "stats.total_o_count_sfw"
+    : "stats.total_o_count";
+
   const { data, error, loading } = useStats();
 
   if (error) return <span>{error.message}</span>;
@@ -111,7 +119,7 @@ export const Stats: React.FC = () => {
             <FormattedNumber value={data.stats.total_o_count} />
           </p>
           <p className="heading">
-            <FormattedMessage id="stats.total_o_count" />
+            <FormattedMessage id={oCountID} />
           </p>
         </div>
         <div className="stats-element">

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1484,6 +1484,7 @@
     "scenes_played": "Scenes Played",
     "scenes_size": "Scenes size",
     "total_o_count": "Total O-Count",
+    "total_o_count_sfw": "Total Likes",
     "total_play_count": "Total Play Count",
     "total_play_duration": "Total Play Duration"
   },


### PR DESCRIPTION
Fixes issue mentioned in the Discourse feedback thread (https://discourse.stashapp.cc/t/stash-v0-30-is-in-rc-state-and-ready-for-testing/4712/3). Provides SFW label for total o-count in the stats page: `Total Likes`