### PR TITLE
Hang-proof ffmpeg hardware codec checks

### DIFF
--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -313,6 +313,7 @@ func (s *Manager) RefreshFFMpeg(ctx context.Context) {
 		s.FFMpeg = ffmpeg.NewEncoder(ffmpegPath)
 		s.FFProbe = ffmpeg.NewFFProbe(ffprobePath)
 
-		s.FFMpeg.InitHWSupport(ctx)
+		// initialise hardware support with background context
+		s.FFMpeg.InitHWSupport(context.Background())
 	}
 }

--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -36,6 +36,32 @@ const minHeight int = 480
 
 // Tests all (given) hardware codec's
 func (f *FFMpeg) InitHWSupport(ctx context.Context) {
+	// do the hardware codec tests in a separate goroutine to avoid blocking
+	done := make(chan struct{})
+	go func() {
+		f.initHWSupport(ctx)
+		close(done)
+	}()
+
+	// log if the initialization takes too long
+	const hwInitLogTimeoutSecondsDefault = 5
+	hwInitLogTimeoutSeconds := hwInitLogTimeoutSecondsDefault * time.Second
+	timer := time.NewTimer(hwInitLogTimeoutSeconds)
+
+	go func() {
+		select {
+		case <-timer.C:
+			logger.Warnf("[InitHWSupport] Hardware codec initialization is taking longer than %s...", hwInitLogTimeoutSeconds)
+			logger.Info("[InitHWSupport] Hardware encoding will not be available until initialization is complete.")
+		case <-done:
+			if !timer.Stop() {
+				<-timer.C
+			}
+		}
+	}()
+}
+
+func (f *FFMpeg) initHWSupport(ctx context.Context) {
 	var hwCodecSupport []VideoCodec
 
 	// Note that the first compatible codec is returned, so order is important
@@ -83,6 +109,7 @@ func (f *FFMpeg) InitHWSupport(ctx context.Context) {
 		defer cancel()
 
 		cmd := f.Command(testCtx, args)
+		cmd.WaitDelay = time.Second
 		logger.Tracef("[InitHWSupport] Testing codec %s: %v", codec, cmd.Args)
 
 		var stderr bytes.Buffer
@@ -112,6 +139,8 @@ func (f *FFMpeg) InitHWSupport(ctx context.Context) {
 	}
 	logger.Info(outstr)
 
+	f.hwCodecSupportMutex.Lock()
+	defer f.hwCodecSupportMutex.Unlock()
 	f.hwCodecSupport = hwCodecSupport
 }
 
@@ -411,7 +440,7 @@ func (f *FFMpeg) hwMaxResFilter(toCodec VideoCodec, vf *models.VideoFile, reqHei
 
 // Return if a hardware accelerated for HLS is available
 func (f *FFMpeg) hwCodecHLSCompatible() *VideoCodec {
-	for _, element := range f.hwCodecSupport {
+	for _, element := range f.getHWCodecSupport() {
 		switch element {
 		case VideoCodecN264,
 			VideoCodecN264H,
@@ -429,7 +458,7 @@ func (f *FFMpeg) hwCodecHLSCompatible() *VideoCodec {
 
 // Return if a hardware accelerated codec for MP4 is available
 func (f *FFMpeg) hwCodecMP4Compatible() *VideoCodec {
-	for _, element := range f.hwCodecSupport {
+	for _, element := range f.getHWCodecSupport() {
 		switch element {
 		case VideoCodecN264,
 			VideoCodecN264H,
@@ -445,7 +474,7 @@ func (f *FFMpeg) hwCodecMP4Compatible() *VideoCodec {
 
 // Return if a hardware accelerated codec for WebM is available
 func (f *FFMpeg) hwCodecWEBMCompatible() *VideoCodec {
-	for _, element := range f.hwCodecSupport {
+	for _, element := range f.getHWCodecSupport() {
 		switch element {
 		case VideoCodecIVP9,
 			VideoCodecVVP9:

--- a/pkg/ffmpeg/ffmpeg.go
+++ b/pkg/ffmpeg/ffmpeg.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	stashExec "github.com/stashapp/stash/pkg/exec"
 	"github.com/stashapp/stash/pkg/fsutil"
@@ -216,9 +217,10 @@ func (v Version) String() string {
 
 // FFMpeg provides an interface to ffmpeg.
 type FFMpeg struct {
-	ffmpeg         string
-	version        Version
-	hwCodecSupport []VideoCodec
+	ffmpeg              string
+	version             Version
+	hwCodecSupport      []VideoCodec
+	hwCodecSupportMutex sync.RWMutex
 }
 
 // Creates a new FFMpeg encoder
@@ -240,4 +242,10 @@ func (f *FFMpeg) Command(ctx context.Context, args []string) *exec.Cmd {
 
 func (f *FFMpeg) Path() string {
 	return f.ffmpeg
+}
+
+func (f *FFMpeg) getHWCodecSupport() []VideoCodec {
+	f.hwCodecSupportMutex.RLock()
+	defer f.hwCodecSupportMutex.RUnlock()
+	return f.hwCodecSupport
 }


### PR DESCRIPTION
- add `WaitDelay` to ffmpeg command to kill the process if it hangs
- perform hardware codec tests in a separate goroutine so that ffmpeg initialisation can return immediately, hardware encoding will be disabled until the tests are completed
- added warning log if initialisation takes more than 5 seconds

Related: https://discourse.stashapp.cc/t/initial-installation-hangs-on-optimizing-database/4739

I was unable to reproduce the hanging ffmpeg issue, even after installing ffmpeg 8.0.0 from chocolatey, so I created a hanging ffmpeg instance in go:
```
package main

import (
	"fmt"
	"os"
	"time"
)

func main() {

	if len(os.Args) > 1 && os.Args[1] == "-version" {
		fmt.Println("ffmpeg version 8.0-essentials_build-www.gyan.dev Copyright (c) 2000-2025 the FFmpeg developers")
		os.Exit(0)
	}

	if len(os.Args) > 1 && os.Args[1] == "-h" {
		fmt.Println("--enable-libopus --enable-libvpx --enable-libx264 --enable-libx265 --enable-libwebp")
		os.Exit(0)
	}

	time.Sleep(1 * time.Minute)
}
```