### PR TITLE
Fix scrape result row showing when results are same

### DIFF
--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -184,7 +184,7 @@ export const ScrapedObjectsRow = <T,>(props: IScrapedObjectsRow<T>) => {
     field,
     result,
     onChange,
-    newObjects,
+    newObjects = [],
     onCreateNew,
     onLinkExisting,
     renderObjects,
@@ -202,7 +202,7 @@ export const ScrapedObjectsRow = <T,>(props: IScrapedObjectsRow<T>) => {
       )}
       onChange={onChange}
       newValues={
-        onCreateNew ? (
+        onCreateNew && newObjects.length > 0 ? (
           <NewScrapedObjects
             newValues={newObjects ?? []}
             onCreateNew={onCreateNew}


### PR DESCRIPTION
Fixes issue reported in Discourse: https://discourse.stashapp.cc/t/stash-v0-30-is-in-rc-state-and-ready-for-testing/4712/5?u=withoutpants