### PR TITLE
Initialise IsDesktop early to avoid confusion due to ffmpeg checks

### DIFF
--- a/cmd/stash/main.go
+++ b/cmd/stash/main.go
@@ -76,6 +76,10 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
+	// initialise desktop.IsDesktop here so that it doesn't get affected by
+	// ffmpeg hardware checks later on
+	desktop.InitIsDesktop()
+
 	mgr, err := manager.Initialize(cfg, l)
 	if err != nil {
 		exitError(fmt.Errorf("manager initialization error: %w", err))


### PR DESCRIPTION
This will go into a bugfix release.

Fixes issue where the ffmpeg hardware tests would prevent the desktop features from being activated (system tray and browser open).