### PR TITLE
Set organised flag in gallery create

### DIFF
--- a/internal/api/resolver_mutation_gallery.go
+++ b/internal/api/resolver_mutation_gallery.go
@@ -49,6 +49,7 @@ func (r *mutationResolver) GalleryCreate(ctx context.Context, input GalleryCreat
 	newGallery.Details = translator.string(input.Details)
 	newGallery.Photographer = translator.string(input.Photographer)
 	newGallery.Rating = input.Rating100
+	newGallery.Organized = translator.bool(input.Organized)
 
 	var err error
 


### PR DESCRIPTION
Fixes issue reported in Discord - organized flag was not being read when creating gallery using graphql.