### PR TITLE
Fix handy not working correctly

### DIFF
--- a/ui/v2.5/src/hooks/Interactive/interactive.ts
+++ b/ui/v2.5/src/hooks/Interactive/interactive.ts
@@ -178,7 +178,7 @@ export class Interactive {
     this._connected = await this._handy
       .setHsspSetup(funscriptUrl)
       .then((result) => result === HsspSetupResult.downloaded);
-    
+
     // for some reason we need to call getStatus after setup to ensure proper state
     // see https://github.com/defucilis/thehandy/issues/3
     await this._handy.getStatus();


### PR DESCRIPTION
Related to upstream bug: https://github.com/defucilis/thehandy/issues/3

Fixes error message when trying to play a video with Handy:
```
Error: Need to setup the Handy with a script before calling HSSP Play!
```

Works around this by calling `getStatus()` to set the status correctly.