### PR TITLE
FR: Allow Marker Screenshot Generation Unconditionally

### DIFF
--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -411,12 +411,13 @@ func (j *GenerateJob) queueSceneJobs(ctx context.Context, g *generate.Generator,
 		}
 	}
 
-	if j.input.Markers {
+	if j.input.Markers || j.input.MarkerImagePreviews || j.input.MarkerScreenshots {
 		task := &GenerateMarkersTask{
 			repository:          r,
 			Scene:               scene,
 			Overwrite:           j.overwrite,
 			fileNamingAlgorithm: j.fileNamingAlgo,
+			VideoPreview:        j.input.Markers,
 			ImagePreview:        j.input.MarkerImagePreviews,
 			Screenshot:          j.input.MarkerScreenshots,
 
@@ -488,6 +489,9 @@ func (j *GenerateJob) queueMarkerJob(g *generate.Generator, marker *models.Scene
 		Marker:              marker,
 		Overwrite:           j.overwrite,
 		fileNamingAlgorithm: j.fileNamingAlgo,
+		VideoPreview:        j.input.Markers,
+		ImagePreview:        j.input.MarkerImagePreviews,
+		Screenshot:          j.input.MarkerScreenshots,
 		generator:           g,
 	}
 	j.totals.markers++

--- a/internal/manager/task_generate_markers.go
+++ b/internal/manager/task_generate_markers.go
@@ -18,6 +18,7 @@ type GenerateMarkersTask struct {
 	Overwrite           bool
 	fileNamingAlgorithm models.HashAlgorithm
 
+	VideoPreview bool
 	ImagePreview bool
 	Screenshot   bool
 
@@ -115,9 +116,11 @@ func (t *GenerateMarkersTask) generateMarker(videoFile *models.VideoFile, scene 
 
 	g := t.generator
 
-	if err := g.MarkerPreviewVideo(context.TODO(), videoFile.Path, sceneHash, seconds, sceneMarker.EndSeconds, instance.Config.GetPreviewAudio()); err != nil {
-		logger.Errorf("[generator] failed to generate marker video: %v", err)
-		logErrorOutput(err)
+	if t.VideoPreview {
+		if err := g.MarkerPreviewVideo(context.TODO(), videoFile.Path, sceneHash, seconds, sceneMarker.EndSeconds, instance.Config.GetPreviewAudio()); err != nil {
+			logger.Errorf("[generator] failed to generate marker video: %v", err)
+			logErrorOutput(err)
+		}
 	}
 
 	if t.ImagePreview {
@@ -164,7 +167,7 @@ func (t *GenerateMarkersTask) markerExists(sceneChecksum string, seconds int) bo
 		return false
 	}
 
-	videoExists := t.videoExists(sceneChecksum, seconds)
+	videoExists := !t.VideoPreview || t.videoExists(sceneChecksum, seconds)
 	imageExists := !t.ImagePreview || t.imageExists(sceneChecksum, seconds)
 	screenshotExists := !t.Screenshot || t.screenshotExists(sceneChecksum, seconds)
 

--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -100,7 +100,6 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
             id="marker-image-preview-task"
             className="sub-setting"
             checked={options.markerImagePreviews ?? false}
-            disabled={!options.markers}
             headingID="dialogs.scene_gen.marker_image_previews"
             tooltipID="dialogs.scene_gen.marker_image_previews_tooltip"
             onChange={(v) =>
@@ -112,7 +111,6 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
           <BooleanSetting
             id="marker-screenshot-task"
             checked={options.markerScreenshots ?? false}
-            disabled={!options.markers}
             headingID="dialogs.scene_gen.marker_screenshots"
             tooltipID="dialogs.scene_gen.marker_screenshots_tooltip"
             onChange={(v) => setOptions({ markerScreenshots: v })}


### PR DESCRIPTION
 This change allows users to generate marker screenshots independently from marker video previews. Previously, the "Marker Screenshots" option was disabled unless "Marker Previews" was also enabled, forcing users who only wanted static marker screenshots to also generate video preview files.                                                                    
                                                                                                                                                      
The implementation adds a `VideoPreview` flag to `GenerateMarkersTask` to make video preview generation conditional, matching how `ImagePreview` and `Screenshot` already worked. The task queuing logic now triggers when either option is selected, and the `markerExists()` check was updated to correctly handle the case where only screenshots are requested. 

On the UI side, the disabled dependency was removed from the marker screenshot checkbox.   

Fixes: https://github.com/stashapp/stash/issues/5841