### PR TITLE
FR: Add Interfaces to Destroy File Database Entries

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -421,6 +421,8 @@ type Mutation {
   """
   moveFiles(input: MoveFilesInput!): Boolean!
   deleteFiles(ids: [ID!]!): Boolean!
+  "Deletes file entries from the database without deleting the files from the filesystem"
+  deleteFileEntries(ids: [ID!]!): Boolean!
 
   fileSetFingerprints(input: FileSetFingerprintsInput!): Boolean!
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -422,7 +422,7 @@ type Mutation {
   moveFiles(input: MoveFilesInput!): Boolean!
   deleteFiles(ids: [ID!]!): Boolean!
   "Deletes file entries from the database without deleting the files from the filesystem"
-  deleteFileEntries(ids: [ID!]!): Boolean!
+  destroyFiles(ids: [ID!]!): Boolean!
 
   fileSetFingerprints(input: FileSetFingerprintsInput!): Boolean!
 

--- a/graphql/schema/types/gallery.graphql
+++ b/graphql/schema/types/gallery.graphql
@@ -100,6 +100,8 @@ input GalleryDestroyInput {
   """
   delete_file: Boolean
   delete_generated: Boolean
+  "If true, delete the file entry from the database if the file is not assigned to any other objects"
+  destroy_file_entry: Boolean
 }
 
 type FindGalleriesResultType {

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -82,12 +82,16 @@ input ImageDestroyInput {
   id: ID!
   delete_file: Boolean
   delete_generated: Boolean
+  "If true, delete the file entry from the database if the file is not assigned to any other objects"
+  destroy_file_entry: Boolean
 }
 
 input ImagesDestroyInput {
   ids: [ID!]!
   delete_file: Boolean
   delete_generated: Boolean
+  "If true, delete the file entry from the database if the file is not assigned to any other objects"
+  destroy_file_entry: Boolean
 }
 
 type FindImagesResultType {

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -196,12 +196,16 @@ input SceneDestroyInput {
   id: ID!
   delete_file: Boolean
   delete_generated: Boolean
+  "If true, delete the file entry from the database if the file is not assigned to any other objects"
+  destroy_file_entry: Boolean
 }
 
 input ScenesDestroyInput {
   ids: [ID!]!
   delete_file: Boolean
   delete_generated: Boolean
+  "If true, delete the file entry from the database if the file is not assigned to any other objects"
+  destroy_file_entry: Boolean
 }
 
 type FindScenesResultType {

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -210,7 +210,7 @@ func (r *mutationResolver) DeleteFiles(ctx context.Context, ids []string) (ret b
 	return true, nil
 }
 
-func (r *mutationResolver) DeleteFileEntries(ctx context.Context, ids []string) (ret bool, err error) {
+func (r *mutationResolver) DestroyFiles(ctx context.Context, ids []string) (ret bool, err error) {
 	fileIDs, err := stringslice.StringSliceToIntSlice(ids)
 	if err != nil {
 		return false, fmt.Errorf("converting ids: %w", err)

--- a/internal/api/resolver_mutation_gallery.go
+++ b/internal/api/resolver_mutation_gallery.go
@@ -346,6 +346,7 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 
 	deleteGenerated := utils.IsTrue(input.DeleteGenerated)
 	deleteFile := utils.IsTrue(input.DeleteFile)
+	destroyFileEntry := utils.IsTrue(input.DestroyFileEntry)
 
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Gallery
@@ -366,7 +367,7 @@ func (r *mutationResolver) GalleryDestroy(ctx context.Context, input models.Gall
 
 			galleries = append(galleries, gallery)
 
-			imgsDestroyed, err = r.galleryService.Destroy(ctx, gallery, fileDeleter, deleteGenerated, deleteFile)
+			imgsDestroyed, err = r.galleryService.Destroy(ctx, gallery, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry)
 			if err != nil {
 				return err
 			}

--- a/internal/api/resolver_mutation_image.go
+++ b/internal/api/resolver_mutation_image.go
@@ -325,7 +325,7 @@ func (r *mutationResolver) ImageDestroy(ctx context.Context, input models.ImageD
 			return fmt.Errorf("image with id %d not found", imageID)
 		}
 
-		return r.imageService.Destroy(ctx, i, fileDeleter, utils.IsTrue(input.DeleteGenerated), utils.IsTrue(input.DeleteFile))
+		return r.imageService.Destroy(ctx, i, fileDeleter, utils.IsTrue(input.DeleteGenerated), utils.IsTrue(input.DeleteFile), utils.IsTrue(input.DestroyFileEntry))
 	}); err != nil {
 		fileDeleter.Rollback()
 		return false, err
@@ -372,7 +372,7 @@ func (r *mutationResolver) ImagesDestroy(ctx context.Context, input models.Image
 
 			images = append(images, i)
 
-			if err := r.imageService.Destroy(ctx, i, fileDeleter, utils.IsTrue(input.DeleteGenerated), utils.IsTrue(input.DeleteFile)); err != nil {
+			if err := r.imageService.Destroy(ctx, i, fileDeleter, utils.IsTrue(input.DeleteGenerated), utils.IsTrue(input.DeleteFile), utils.IsTrue(input.DestroyFileEntry)); err != nil {
 				return err
 			}
 		}

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -440,6 +440,7 @@ func (r *mutationResolver) SceneDestroy(ctx context.Context, input models.SceneD
 
 	deleteGenerated := utils.IsTrue(input.DeleteGenerated)
 	deleteFile := utils.IsTrue(input.DeleteFile)
+	destroyFileEntry := utils.IsTrue(input.DestroyFileEntry)
 
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Scene
@@ -456,7 +457,7 @@ func (r *mutationResolver) SceneDestroy(ctx context.Context, input models.SceneD
 		// kill any running encoders
 		manager.KillRunningStreams(s, fileNamingAlgo)
 
-		return r.sceneService.Destroy(ctx, s, fileDeleter, deleteGenerated, deleteFile)
+		return r.sceneService.Destroy(ctx, s, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry)
 	}); err != nil {
 		fileDeleter.Rollback()
 		return false, err
@@ -494,6 +495,7 @@ func (r *mutationResolver) ScenesDestroy(ctx context.Context, input models.Scene
 
 	deleteGenerated := utils.IsTrue(input.DeleteGenerated)
 	deleteFile := utils.IsTrue(input.DeleteFile)
+	destroyFileEntry := utils.IsTrue(input.DestroyFileEntry)
 
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		qb := r.repository.Scene
@@ -512,7 +514,7 @@ func (r *mutationResolver) ScenesDestroy(ctx context.Context, input models.Scene
 			// kill any running encoders
 			manager.KillRunningStreams(scene, fileNamingAlgo)
 
-			if err := r.sceneService.Destroy(ctx, scene, fileDeleter, deleteGenerated, deleteFile); err != nil {
+			if err := r.sceneService.Destroy(ctx, scene, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry); err != nil {
 				return err
 			}
 		}

--- a/internal/manager/repository.go
+++ b/internal/manager/repository.go
@@ -13,14 +13,14 @@ type SceneService interface {
 	Create(ctx context.Context, input *models.Scene, fileIDs []models.FileID, coverImage []byte) (*models.Scene, error)
 	AssignFile(ctx context.Context, sceneID int, fileID models.FileID) error
 	Merge(ctx context.Context, sourceIDs []int, destinationID int, fileDeleter *scene.FileDeleter, options scene.MergeOptions) error
-	Destroy(ctx context.Context, scene *models.Scene, fileDeleter *scene.FileDeleter, deleteGenerated, deleteFile bool) error
+	Destroy(ctx context.Context, scene *models.Scene, fileDeleter *scene.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
 
 	FindByIDs(ctx context.Context, ids []int, load ...scene.LoadRelationshipOption) ([]*models.Scene, error)
 	sceneFingerprintGetter
 }
 
 type ImageService interface {
-	Destroy(ctx context.Context, image *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) error
+	Destroy(ctx context.Context, image *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
 	DestroyZipImages(ctx context.Context, zipFile models.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 }
 
@@ -31,7 +31,7 @@ type GalleryService interface {
 	SetCover(ctx context.Context, g *models.Gallery, coverImageId int) error
 	ResetCover(ctx context.Context, g *models.Gallery) error
 
-	Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) ([]*models.Image, error)
+	Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) ([]*models.Image, error)
 
 	ValidateImageGalleryChange(ctx context.Context, i *models.Image, updateIDs models.UpdateIDs) error
 

--- a/internal/manager/repository.go
+++ b/internal/manager/repository.go
@@ -13,14 +13,14 @@ type SceneService interface {
 	Create(ctx context.Context, input *models.Scene, fileIDs []models.FileID, coverImage []byte) (*models.Scene, error)
 	AssignFile(ctx context.Context, sceneID int, fileID models.FileID) error
 	Merge(ctx context.Context, sourceIDs []int, destinationID int, fileDeleter *scene.FileDeleter, options scene.MergeOptions) error
-	Destroy(ctx context.Context, scene *models.Scene, fileDeleter *scene.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
+	Destroy(ctx context.Context, scene *models.Scene, fileDeleter *scene.FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error
 
 	FindByIDs(ctx context.Context, ids []int, load ...scene.LoadRelationshipOption) ([]*models.Scene, error)
 	sceneFingerprintGetter
 }
 
 type ImageService interface {
-	Destroy(ctx context.Context, image *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
+	Destroy(ctx context.Context, image *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error
 	DestroyZipImages(ctx context.Context, zipFile models.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 }
 
@@ -31,7 +31,7 @@ type GalleryService interface {
 	SetCover(ctx context.Context, g *models.Gallery, coverImageId int) error
 	ResetCover(ctx context.Context, g *models.Gallery) error
 
-	Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) ([]*models.Image, error)
+	Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) ([]*models.Image, error)
 
 	ValidateImageGalleryChange(ctx context.Context, i *models.Image, updateIDs models.UpdateIDs) error
 

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -300,7 +300,10 @@ func (h *cleanHandler) handleRelatedScenes(ctx context.Context, fileDeleter *fil
 		// only delete if the scene has no other files
 		if len(scene.Files.List()) <= 1 {
 			logger.Infof("Deleting scene %q since it has no other related files", scene.DisplayName())
-			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, true, false); err != nil {
+			const deleteGenerated = true
+			const deleteFile = false
+			const destroyFileEntry = false
+			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, deleteGenerated, deleteFile, destroyFileEntry); err != nil {
 				return err
 			}
 
@@ -421,7 +424,10 @@ func (h *cleanHandler) handleRelatedImages(ctx context.Context, fileDeleter *fil
 
 		if len(i.Files.List()) <= 1 {
 			logger.Infof("Deleting image %q since it has no other related files", i.DisplayName())
-			if err := mgr.ImageService.Destroy(ctx, i, imageFileDeleter, true, false); err != nil {
+			const deleteGenerated = true
+			const deleteFile = false
+			const destroyFileEntry = false
+			if err := mgr.ImageService.Destroy(ctx, i, imageFileDeleter, deleteGenerated, deleteFile, destroyFileEntry); err != nil {
 				return err
 			}
 

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -300,7 +300,7 @@ func (h *cleanHandler) handleRelatedScenes(ctx context.Context, fileDeleter *fil
 		// only delete if the scene has no other files
 		if len(scene.Files.List()) <= 1 {
 			logger.Infof("Deleting scene %q since it has no other related files", scene.DisplayName())
-			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, true, false, false); err != nil {
+			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, true, false); err != nil {
 				return err
 			}
 

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -300,7 +300,7 @@ func (h *cleanHandler) handleRelatedScenes(ctx context.Context, fileDeleter *fil
 		// only delete if the scene has no other files
 		if len(scene.Files.List()) <= 1 {
 			logger.Infof("Deleting scene %q since it has no other related files", scene.DisplayName())
-			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, true, false); err != nil {
+			if err := mgr.SceneService.Destroy(ctx, scene, sceneFileDeleter, true, false, false); err != nil {
 				return err
 			}
 

--- a/pkg/gallery/delete.go
+++ b/pkg/gallery/delete.go
@@ -8,14 +8,13 @@ import (
 	"github.com/stashapp/stash/pkg/models"
 )
 
-func (s *Service) Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) ([]*models.Image, error) {
+func (s *Service) Destroy(ctx context.Context, i *models.Gallery, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) ([]*models.Image, error) {
 	var imgsDestroyed []*models.Image
-	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
 
 	// chapter deletion is done via delete cascade, so we don't need to do anything here
 
 	// if this is a zip-based gallery, delete the images as well first
-	zipImgsDestroyed, err := s.destroyZipFileImages(ctx, i, fileDeleter, deleteGenerated, deleteFile, destroyEntry)
+	zipImgsDestroyed, err := s.destroyZipFileImages(ctx, i, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gallery/service.go
+++ b/pkg/gallery/service.go
@@ -16,7 +16,7 @@ type ImageFinder interface {
 }
 
 type ImageService interface {
-	Destroy(ctx context.Context, i *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) error
+	Destroy(ctx context.Context, i *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
 	DestroyZipImages(ctx context.Context, zipFile models.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 	DestroyFolderImages(ctx context.Context, folderID models.FolderID, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) ([]*models.Image, error)
 }

--- a/pkg/gallery/service.go
+++ b/pkg/gallery/service.go
@@ -16,7 +16,7 @@ type ImageFinder interface {
 }
 
 type ImageService interface {
-	Destroy(ctx context.Context, i *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error
+	Destroy(ctx context.Context, i *models.Image, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error
 	DestroyZipImages(ctx context.Context, zipFile models.File, fileDeleter *image.FileDeleter, deleteGenerated bool) ([]*models.Image, error)
 	DestroyFolderImages(ctx context.Context, folderID models.FolderID, fileDeleter *image.FileDeleter, deleteGenerated, deleteFile bool) ([]*models.Image, error)
 }

--- a/pkg/image/delete.go
+++ b/pkg/image/delete.go
@@ -37,8 +37,9 @@ func (d *FileDeleter) MarkGeneratedFiles(image *models.Image) error {
 }
 
 // Destroy destroys an image, optionally marking the file and generated files for deletion.
-func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool) error {
-	return s.destroyImage(ctx, i, fileDeleter, deleteGenerated, deleteFile)
+func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
+	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
+	return s.destroyImage(ctx, i, fileDeleter, deleteGenerated, deleteFile, destroyEntry)
 }
 
 // DestroyZipImages destroys all images in zip, optionally marking the files and generated files for deletion.
@@ -146,9 +147,15 @@ func (s *Service) DestroyFolderImages(ctx context.Context, folderID models.Folde
 }
 
 // Destroy destroys an image, optionally marking the file and generated files for deletion.
-func (s *Service) destroyImage(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool) error {
+func (s *Service) destroyImage(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
+	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
+
 	if deleteFile {
 		if err := s.deleteFiles(ctx, i, fileDeleter); err != nil {
+			return err
+		}
+	} else if destroyEntry {
+		if err := s.destroyFileEntries(ctx, i); err != nil {
 			return err
 		}
 	}
@@ -185,6 +192,38 @@ func (s *Service) deleteFiles(ctx context.Context, i *models.Image, fileDeleter 
 		if f.Base().ZipFileID == nil {
 			logger.Info("Deleting image file: ", f.Base().Path)
 			if err := file.Destroy(ctx, s.File, f, fileDeleter.Deleter, deleteFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// destroyFileEntries destroys file entries from the database without deleting
+// the files from the filesystem
+func (s *Service) destroyFileEntries(ctx context.Context, i *models.Image) error {
+	if err := i.LoadFiles(ctx, s.Repository); err != nil {
+		return err
+	}
+
+	for _, f := range i.Files.List() {
+		// only destroy file entries where there is no other associated image
+		otherImages, err := s.Repository.FindByFileID(ctx, f.Base().ID)
+		if err != nil {
+			return err
+		}
+
+		if len(otherImages) > 1 {
+			// other image associated, don't remove
+			continue
+		}
+
+		// don't destroy files in zip archives
+		if f.Base().ZipFileID == nil {
+			const deleteFile = false
+			logger.Info("Destroying image file entry: ", f.Base().Path)
+			if err := file.Destroy(ctx, s.File, f, nil, deleteFile); err != nil {
 				return err
 			}
 		}

--- a/pkg/image/delete.go
+++ b/pkg/image/delete.go
@@ -37,9 +37,8 @@ func (d *FileDeleter) MarkGeneratedFiles(image *models.Image) error {
 }
 
 // Destroy destroys an image, optionally marking the file and generated files for deletion.
-func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
-	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
-	return s.destroyImage(ctx, i, fileDeleter, deleteGenerated, deleteFile, destroyEntry)
+func (s *Service) Destroy(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error {
+	return s.destroyImage(ctx, i, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry)
 }
 
 // DestroyZipImages destroys all images in zip, optionally marking the files and generated files for deletion.
@@ -76,7 +75,8 @@ func (s *Service) DestroyZipImages(ctx context.Context, zipFile models.File, fil
 		}
 
 		const deleteFileInZip = false
-		if err := s.destroyImage(ctx, img, fileDeleter, deleteGenerated, deleteFileInZip); err != nil {
+		const destroyFileEntry = false
+		if err := s.destroyImage(ctx, img, fileDeleter, deleteGenerated, deleteFileInZip, destroyFileEntry); err != nil {
 			return nil, err
 		}
 
@@ -136,7 +136,8 @@ func (s *Service) DestroyFolderImages(ctx context.Context, folderID models.Folde
 			continue
 		}
 
-		if err := s.Destroy(ctx, img, fileDeleter, deleteGenerated, deleteFile); err != nil {
+		const destroyFileEntry = false
+		if err := s.Destroy(ctx, img, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry); err != nil {
 			return nil, err
 		}
 
@@ -147,14 +148,12 @@ func (s *Service) DestroyFolderImages(ctx context.Context, folderID models.Folde
 }
 
 // Destroy destroys an image, optionally marking the file and generated files for deletion.
-func (s *Service) destroyImage(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
-	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
-
+func (s *Service) destroyImage(ctx context.Context, i *models.Image, fileDeleter *FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error {
 	if deleteFile {
 		if err := s.deleteFiles(ctx, i, fileDeleter); err != nil {
 			return err
 		}
-	} else if destroyEntry {
+	} else if destroyFileEntry {
 		if err := s.destroyFileEntries(ctx, i); err != nil {
 			return err
 		}

--- a/pkg/models/gallery.go
+++ b/pkg/models/gallery.go
@@ -95,6 +95,7 @@ type GalleryDestroyInput struct {
 	// If true, then the zip file will be deleted if the gallery is zip-file-based.
 	// If gallery is folder-based, then any files not associated with other
 	// galleries will be deleted, along with the folder, if it is not empty.
-	DeleteFile      *bool `json:"delete_file"`
-	DeleteGenerated *bool `json:"delete_generated"`
+	DeleteFile       *bool `json:"delete_file"`
+	DeleteGenerated  *bool `json:"delete_generated"`
+	DestroyFileEntry *bool `json:"destroy_file_entry"`
 }

--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -88,15 +88,17 @@ type ImageUpdateInput struct {
 }
 
 type ImageDestroyInput struct {
-	ID              string `json:"id"`
-	DeleteFile      *bool  `json:"delete_file"`
-	DeleteGenerated *bool  `json:"delete_generated"`
+	ID               string `json:"id"`
+	DeleteFile       *bool  `json:"delete_file"`
+	DeleteGenerated  *bool  `json:"delete_generated"`
+	DestroyFileEntry *bool  `json:"destroy_file_entry"`
 }
 
 type ImagesDestroyInput struct {
-	Ids             []string `json:"ids"`
-	DeleteFile      *bool    `json:"delete_file"`
-	DeleteGenerated *bool    `json:"delete_generated"`
+	Ids              []string `json:"ids"`
+	DeleteFile       *bool    `json:"delete_file"`
+	DeleteGenerated  *bool    `json:"delete_generated"`
+	DestroyFileEntry *bool    `json:"destroy_file_entry"`
 }
 
 type ImageQueryOptions struct {

--- a/pkg/models/scene.go
+++ b/pkg/models/scene.go
@@ -202,15 +202,17 @@ type SceneUpdateInput struct {
 }
 
 type SceneDestroyInput struct {
-	ID              string `json:"id"`
-	DeleteFile      *bool  `json:"delete_file"`
-	DeleteGenerated *bool  `json:"delete_generated"`
+	ID               string `json:"id"`
+	DeleteFile       *bool  `json:"delete_file"`
+	DeleteGenerated  *bool  `json:"delete_generated"`
+	DestroyFileEntry *bool  `json:"destroy_file_entry"`
 }
 
 type ScenesDestroyInput struct {
-	Ids             []string `json:"ids"`
-	DeleteFile      *bool    `json:"delete_file"`
-	DeleteGenerated *bool    `json:"delete_generated"`
+	Ids              []string `json:"ids"`
+	DeleteFile       *bool    `json:"delete_file"`
+	DeleteGenerated  *bool    `json:"delete_generated"`
+	DestroyFileEntry *bool    `json:"destroy_file_entry"`
 }
 
 func NewSceneQueryResult(getter SceneGetter) *SceneQueryResult {

--- a/pkg/scene/delete.go
+++ b/pkg/scene/delete.go
@@ -109,7 +109,7 @@ func (d *FileDeleter) MarkMarkerFiles(scene *models.Scene, seconds int) error {
 
 // Destroy deletes a scene and its associated relationships from the
 // database.
-func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter *FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error {
+func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
 	mqb := s.MarkerRepository
 	markers, err := mqb.FindBySceneID(ctx, scene.ID)
 	if err != nil {
@@ -122,11 +122,13 @@ func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter 
 		}
 	}
 
+	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
+
 	if deleteFile {
 		if err := s.deleteFiles(ctx, scene, fileDeleter); err != nil {
 			return err
 		}
-	} else if destroyFileEntry {
+	} else if destroyEntry {
 		if err := s.destroyFileEntries(ctx, scene); err != nil {
 			return err
 		}

--- a/pkg/scene/delete.go
+++ b/pkg/scene/delete.go
@@ -109,7 +109,7 @@ func (d *FileDeleter) MarkMarkerFiles(scene *models.Scene, seconds int) error {
 
 // Destroy deletes a scene and its associated relationships from the
 // database.
-func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter *FileDeleter, deleteGenerated, deleteFile bool, destroyFileEntry ...bool) error {
+func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter *FileDeleter, deleteGenerated, deleteFile, destroyFileEntry bool) error {
 	mqb := s.MarkerRepository
 	markers, err := mqb.FindBySceneID(ctx, scene.ID)
 	if err != nil {
@@ -122,13 +122,11 @@ func (s *Service) Destroy(ctx context.Context, scene *models.Scene, fileDeleter 
 		}
 	}
 
-	destroyEntry := len(destroyFileEntry) > 0 && destroyFileEntry[0]
-
 	if deleteFile {
 		if err := s.deleteFiles(ctx, scene, fileDeleter); err != nil {
 			return err
 		}
-	} else if destroyEntry {
+	} else if destroyFileEntry {
 		if err := s.destroyFileEntries(ctx, scene); err != nil {
 			return err
 		}

--- a/pkg/scene/merge.go
+++ b/pkg/scene/merge.go
@@ -120,7 +120,8 @@ func (s *Service) Merge(ctx context.Context, sourceIDs []int, destinationID int,
 	for _, src := range sources {
 		const deleteGenerated = true
 		const deleteFile = false
-		if err := s.Destroy(ctx, src, fileDeleter, deleteGenerated, deleteFile); err != nil {
+		const destroyFileEntry = false
+		if err := s.Destroy(ctx, src, fileDeleter, deleteGenerated, deleteFile, destroyFileEntry); err != nil {
 			return fmt.Errorf("deleting scene %d: %w", src.ID, err)
 		}
 	}


### PR DESCRIPTION
This PR allows users to delete database duplicate entries via the playground. I was able to add a dummy secondary data to some images that were located in my database and then delete them accordingly. 

For WP: I changed up the verbage of the variables a little bit as I felt like "DestroyFiles" could be misinterpreted by users. I kept the logic the same but modified it to "DestroyFileEntries"

This example deletes an entry with the ID of 10:

```  
mutation {                                                                                                         
    deleteFileEntries(ids: ["10"])                                                                         
  }  
```

This is an example of removing a primary entry. It should error out and let the user know that it is a primary entry:

```
{
  "errors": [
    {
      "message": "cannot destroy primary file entry /Users/gykes/Desktop/blah.mkv",
      "path": [
        "deleteFileEntries"
      ]
    }
  ],
  "data": null
}
```

Also added `destroy_file_entry` option to SceneDestroyInput, ScenesDestroyInput, ImageDestroyInput, ImagesDestroyInput, and GalleryDestroyInput. This allows deleting the file DB entry (without removing the actual file) when destroying content.   

fixes: https://github.com/stashapp/stash/issues/6355