### PR TITLE
FR: Save & New Button on Objects

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
@@ -34,6 +34,20 @@ const GalleryCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.GalleryCreateInput) {
+    const result = await createGallery({
+      variables: { input },
+    });
+    if (result.data?.galleryCreate) {
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "gallery" }).toLocaleLowerCase() }
+        )
+      );
+    }
+  }
+
   return (
     <div className="row new-view">
       <div className="col-md-6">
@@ -47,6 +61,7 @@ const GalleryCreate: React.FC = () => {
           gallery={gallery}
           isVisible
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
           onDelete={() => {}}
         />
       </div>

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryCreate.tsx
@@ -19,26 +19,14 @@ const GalleryCreate: React.FC = () => {
 
   const [createGallery] = useGalleryCreate();
 
-  async function onSave(input: GQL.GalleryCreateInput) {
+  async function onSave(input: GQL.GalleryCreateInput, andNew?: boolean) {
     const result = await createGallery({
       variables: { input },
     });
     if (result.data?.galleryCreate) {
-      history.push(`/galleries/${result.data.galleryCreate.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          { entity: intl.formatMessage({ id: "gallery" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.GalleryCreateInput) {
-    const result = await createGallery({
-      variables: { input },
-    });
-    if (result.data?.galleryCreate) {
+      if (!andNew) {
+        history.push(`/galleries/${result.data.galleryCreate.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -61,7 +49,6 @@ const GalleryCreate: React.FC = () => {
           gallery={gallery}
           isVisible
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
           onDelete={() => {}}
         />
       </div>

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Prompt } from "react-router-dom";
-import { Button, Form, Col, Row } from "react-bootstrap";
+import { Button, Dropdown, Form, Col, Row, SplitButton } from "react-bootstrap";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
@@ -459,24 +459,29 @@ export const GalleryEditPanel: React.FC<IProps> = ({
       <Form noValidate onSubmit={formik.handleSubmit}>
         <Row className="form-container edit-buttons-container px-3 pt-3">
           <div className="edit-buttons mb-3 pl-0">
-            <Button
-              className="edit-button"
-              variant="primary"
-              disabled={
-                (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
-              }
-              onClick={() => formik.submitForm()}
-            >
-              <FormattedMessage id="actions.save" />
-            </Button>
-            {isNew && onSaveAndNew && (
-              <Button
+            {isNew && onSaveAndNew ? (
+              <SplitButton
+                id="gallery-save-split-button"
                 className="edit-button"
                 variant="primary"
                 disabled={!isEqual(formik.errors, {})}
-                onClick={() => onSaveAndNewClick()}
+                title={intl.formatMessage({ id: "actions.save" })}
+                onClick={() => formik.submitForm()}
               >
-                <FormattedMessage id="actions.save_and_new" />
+                <Dropdown.Item onClick={() => onSaveAndNewClick()}>
+                  <FormattedMessage id="actions.save_and_new" />
+                </Dropdown.Item>
+              </SplitButton>
+            ) : (
+              <Button
+                className="edit-button"
+                variant="primary"
+                disabled={
+                  (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
+                }
+                onClick={() => formik.submitForm()}
+              >
+                <FormattedMessage id="actions.save" />
               </Button>
             )}
             <Button

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -36,6 +36,7 @@ interface IProps {
   gallery: Partial<GQL.GalleryDataFragment>;
   isVisible: boolean;
   onSubmit: (input: GQL.GalleryCreateInput) => Promise<void>;
+  onSaveAndNew?: (input: GQL.GalleryCreateInput) => Promise<void>;
   onDelete: () => void;
 }
 
@@ -43,6 +44,7 @@ export const GalleryEditPanel: React.FC<IProps> = ({
   gallery,
   isVisible,
   onSubmit,
+  onSaveAndNew,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -181,6 +183,18 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     setIsLoading(true);
     try {
       await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
+  async function onSaveAndNewClick() {
+    const input = schema.cast(formik.values);
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -455,6 +469,16 @@ export const GalleryEditPanel: React.FC<IProps> = ({
             >
               <FormattedMessage id="actions.save" />
             </Button>
+            {isNew && onSaveAndNew && (
+              <Button
+                className="edit-button"
+                variant="primary"
+                disabled={!isEqual(formik.errors, {})}
+                onClick={() => onSaveAndNewClick()}
+              >
+                <FormattedMessage id="actions.save_and_new" />
+              </Button>
+            )}
             <Button
               className="edit-button"
               variant="danger"

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -35,8 +35,7 @@ import { ScraperMenu } from "src/components/Shared/ScraperMenu";
 interface IProps {
   gallery: Partial<GQL.GalleryDataFragment>;
   isVisible: boolean;
-  onSubmit: (input: GQL.GalleryCreateInput) => Promise<void>;
-  onSaveAndNew?: (input: GQL.GalleryCreateInput) => Promise<void>;
+  onSubmit: (input: GQL.GalleryCreateInput, andNew?: boolean) => Promise<void>;
   onDelete: () => void;
 }
 
@@ -44,7 +43,6 @@ export const GalleryEditPanel: React.FC<IProps> = ({
   gallery,
   isVisible,
   onSubmit,
-  onSaveAndNew,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -179,10 +177,10 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     return <div></div>;
   }, [gallery?.paths?.cover, intl]);
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -192,14 +190,7 @@ export const GalleryEditPanel: React.FC<IProps> = ({
 
   async function onSaveAndNewClick() {
     const input = schema.cast(formik.values);
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   async function onScrapeClicked(s: GQL.ScraperSourceInput) {
@@ -459,7 +450,7 @@ export const GalleryEditPanel: React.FC<IProps> = ({
       <Form noValidate onSubmit={formik.handleSubmit}>
         <Row className="form-container edit-buttons-container px-3 pt-3">
           <div className="edit-buttons mb-3 pl-0">
-            {isNew && onSaveAndNew ? (
+            {isNew ? (
               <SplitButton
                 id="gallery-save-split-button"
                 className="edit-button"

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupCreate.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupCreate.tsx
@@ -40,6 +40,20 @@ const GroupCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.GroupCreateInput) {
+    const result = await createGroup({
+      variables: { input },
+    });
+    if (result.data?.groupCreate?.id) {
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "group" }).toLocaleLowerCase() }
+        )
+      );
+    }
+  }
+
   function renderFrontImage() {
     if (frontImage) {
       return (
@@ -80,6 +94,7 @@ const GroupCreate: React.FC = () => {
         <GroupEditPanel
           group={group}
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/groups")}
           onDelete={() => {}}
           setFrontImage={setFrontImage}

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupCreate.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupCreate.tsx
@@ -25,26 +25,14 @@ const GroupCreate: React.FC = () => {
 
   const [createGroup] = useGroupCreate();
 
-  async function onSave(input: GQL.GroupCreateInput) {
+  async function onSave(input: GQL.GroupCreateInput, andNew?: boolean) {
     const result = await createGroup({
       variables: { input },
     });
     if (result.data?.groupCreate?.id) {
-      history.push(`/groups/${result.data.groupCreate.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          { entity: intl.formatMessage({ id: "group" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.GroupCreateInput) {
-    const result = await createGroup({
-      variables: { input },
-    });
-    if (result.data?.groupCreate?.id) {
+      if (!andNew) {
+        history.push(`/groups/${result.data.groupCreate.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -94,7 +82,6 @@ const GroupCreate: React.FC = () => {
         <GroupEditPanel
           group={group}
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/groups")}
           onDelete={() => {}}
           setFrontImage={setFrontImage}

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
@@ -32,6 +32,7 @@ import { RelatedGroupTable, IRelatedGroupEntry } from "./RelatedGroupTable";
 interface IGroupEditPanel {
   group: Partial<GQL.GroupDataFragment>;
   onSubmit: (group: GQL.GroupCreateInput) => Promise<void>;
+  onSaveAndNew?: (group: GQL.GroupCreateInput) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setFrontImage: (image?: string | null) => void;
@@ -42,6 +43,7 @@ interface IGroupEditPanel {
 export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
   group,
   onSubmit,
+  onSaveAndNew,
   onCancel,
   onDelete,
   setFrontImage,
@@ -212,6 +214,18 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     setIsLoading(true);
     try {
       await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
+  async function onSaveAndNewClick() {
+    const input = schema.cast(formik.values);
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -462,6 +476,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
         isEditing
         onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
+        onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onFrontImageChange}
         onImageChangeURL={onFrontImageLoad}

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
@@ -31,8 +31,7 @@ import { RelatedGroupTable, IRelatedGroupEntry } from "./RelatedGroupTable";
 
 interface IGroupEditPanel {
   group: Partial<GQL.GroupDataFragment>;
-  onSubmit: (group: GQL.GroupCreateInput) => Promise<void>;
-  onSaveAndNew?: (group: GQL.GroupCreateInput) => Promise<void>;
+  onSubmit: (group: GQL.GroupCreateInput, andNew?: boolean) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setFrontImage: (image?: string | null) => void;
@@ -43,7 +42,6 @@ interface IGroupEditPanel {
 export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
   group,
   onSubmit,
-  onSaveAndNew,
   onCancel,
   onDelete,
   setFrontImage,
@@ -210,10 +208,10 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     }
   }
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -223,14 +221,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
 
   async function onSaveAndNewClick() {
     const input = schema.cast(formik.values);
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   async function onScrapeGroupURL(url: string) {
@@ -476,7 +467,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
         isEditing
         onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
-        onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
+        onSaveAndNew={isNew ? onSaveAndNewClick : undefined}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onFrontImageChange}
         onImageChangeURL={onFrontImageLoad}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerCreate.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerCreate.tsx
@@ -40,6 +40,22 @@ const PerformerCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.PerformerCreateInput) {
+    const result = await createPerformer({
+      variables: { input },
+    });
+    if (result.data?.performerCreate) {
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          {
+            entity: intl.formatMessage({ id: "performer" }).toLocaleLowerCase(),
+          }
+        )
+      );
+    }
+  }
+
   function renderPerformerImage() {
     if (encodingImage) {
       return (
@@ -75,6 +91,7 @@ const PerformerCreate: React.FC = () => {
           performer={performer}
           isVisible
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
           setImage={setImage}
           setEncodingImage={setEncodingImage}
         />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerCreate.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerCreate.tsx
@@ -23,28 +23,14 @@ const PerformerCreate: React.FC = () => {
 
   const [createPerformer] = usePerformerCreate();
 
-  async function onSave(input: GQL.PerformerCreateInput) {
+  async function onSave(input: GQL.PerformerCreateInput, andNew?: boolean) {
     const result = await createPerformer({
       variables: { input },
     });
     if (result.data?.performerCreate) {
-      history.push(`/performers/${result.data.performerCreate.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          {
-            entity: intl.formatMessage({ id: "performer" }).toLocaleLowerCase(),
-          }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.PerformerCreateInput) {
-    const result = await createPerformer({
-      variables: { input },
-    });
-    if (result.data?.performerCreate) {
+      if (!andNew) {
+        history.push(`/performers/${result.data.performerCreate.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -91,7 +77,6 @@ const PerformerCreate: React.FC = () => {
           performer={performer}
           isVisible
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
           setImage={setImage}
           setEncodingImage={setEncodingImage}
         />

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -59,6 +59,7 @@ interface IPerformerDetails {
   performer: Partial<GQL.PerformerDataFragment>;
   isVisible: boolean;
   onSubmit: (performer: GQL.PerformerCreateInput) => Promise<void>;
+  onSaveAndNew?: (performer: GQL.PerformerCreateInput) => Promise<void>;
   onCancel?: () => void;
   setImage: (image?: string | null) => void;
   setEncodingImage: (loading: boolean) => void;
@@ -78,6 +79,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   performer,
   isVisible,
   onSubmit,
+  onSaveAndNew,
   onCancel,
   setImage,
   setEncodingImage,
@@ -356,6 +358,23 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     setIsLoading(false);
   }
 
+  async function onSaveAndNewClick() {
+    const { values } = formik;
+    const input = {
+      ...schema.cast(values),
+      custom_fields: customFieldInput(isNew, values.custom_fields),
+    };
+
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
   // set up hotkeys
   useEffect(() => {
     if (isVisible) {
@@ -604,6 +623,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
           </Button>
         </div>
         <Button
+          className="mr-2"
           variant="success"
           disabled={
             (!isNew && !formik.dirty) ||
@@ -614,6 +634,17 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         >
           <FormattedMessage id="actions.save" />
         </Button>
+        {isNew && onSaveAndNew && (
+          <Button
+            variant="success"
+            disabled={
+              !isEqual(formik.errors, {}) || customFieldsError !== undefined
+            }
+            onClick={() => onSaveAndNewClick()}
+          >
+            <FormattedMessage id="actions.save_and_new" />
+          </Button>
+        )}
       </div>
     );
   }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Button, Form, Dropdown } from "react-bootstrap";
+import { Button, Form, Dropdown, SplitButton } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
@@ -622,27 +622,31 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
             <FormattedMessage id="actions.clear_image" />
           </Button>
         </div>
-        <Button
-          className="mr-2"
-          variant="success"
-          disabled={
-            (!isNew && !formik.dirty) ||
-            !isEqual(formik.errors, {}) ||
-            customFieldsError !== undefined
-          }
-          onClick={() => formik.submitForm()}
-        >
-          <FormattedMessage id="actions.save" />
-        </Button>
-        {isNew && onSaveAndNew && (
-          <Button
+        {isNew && onSaveAndNew ? (
+          <SplitButton
+            id="save-split-button"
             variant="success"
             disabled={
               !isEqual(formik.errors, {}) || customFieldsError !== undefined
             }
-            onClick={() => onSaveAndNewClick()}
+            title={intl.formatMessage({ id: "actions.save" })}
+            onClick={() => formik.submitForm()}
           >
-            <FormattedMessage id="actions.save_and_new" />
+            <Dropdown.Item onClick={() => onSaveAndNewClick()}>
+              <FormattedMessage id="actions.save_and_new" />
+            </Dropdown.Item>
+          </SplitButton>
+        ) : (
+          <Button
+            variant="success"
+            disabled={
+              (!isNew && !formik.dirty) ||
+              !isEqual(formik.errors, {}) ||
+              customFieldsError !== undefined
+            }
+            onClick={() => formik.submitForm()}
+          >
+            <FormattedMessage id="actions.save" />
           </Button>
         )}
       </div>

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -58,7 +58,10 @@ const isScraper = (
 interface IPerformerDetails {
   performer: Partial<GQL.PerformerDataFragment>;
   isVisible: boolean;
-  onSubmit: (performer: GQL.PerformerCreateInput, andNew?: boolean) => Promise<void>;
+  onSubmit: (
+    performer: GQL.PerformerCreateInput,
+    andNew?: boolean
+  ) => Promise<void>;
   onCancel?: () => void;
   setImage: (image?: string | null) => void;
   setEncodingImage: (loading: boolean) => void;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -58,8 +58,7 @@ const isScraper = (
 interface IPerformerDetails {
   performer: Partial<GQL.PerformerDataFragment>;
   isVisible: boolean;
-  onSubmit: (performer: GQL.PerformerCreateInput) => Promise<void>;
-  onSaveAndNew?: (performer: GQL.PerformerCreateInput) => Promise<void>;
+  onSubmit: (performer: GQL.PerformerCreateInput, andNew?: boolean) => Promise<void>;
   onCancel?: () => void;
   setImage: (image?: string | null) => void;
   setEncodingImage: (loading: boolean) => void;
@@ -79,7 +78,6 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   performer,
   isVisible,
   onSubmit,
-  onSaveAndNew,
   onCancel,
   setImage,
   setEncodingImage,
@@ -347,10 +345,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     ImageUtils.onImageChange(event, onImageLoad);
   }
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -364,15 +362,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       ...schema.cast(values),
       custom_fields: customFieldInput(isNew, values.custom_fields),
     };
-
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   // set up hotkeys
@@ -622,7 +612,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
             <FormattedMessage id="actions.clear_image" />
           </Button>
         </div>
-        {isNew && onSaveAndNew ? (
+        {isNew ? (
           <SplitButton
             id="save-split-button"
             variant="success"

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
@@ -74,6 +74,22 @@ const SceneCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.SceneCreateInput) {
+    const fileID = query.get("file_id") ?? undefined;
+    const result = await mutateCreateScene({
+      ...input,
+      file_ids: fileID ? [fileID] : undefined,
+    });
+    if (result.data?.sceneCreate?.id) {
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "scene" }).toLocaleLowerCase() }
+        )
+      );
+    }
+  }
+
   return (
     <div className="row new-view justify-content-center" id="create-scene-page">
       <div className="col-md-8">
@@ -89,6 +105,7 @@ const SceneCreate: React.FC = () => {
           isVisible
           isNew
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
         />
       </div>
     </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
@@ -57,30 +57,16 @@ const SceneCreate: React.FC = () => {
     return <LoadingIndicator />;
   }
 
-  async function onSave(input: GQL.SceneCreateInput) {
+  async function onSave(input: GQL.SceneCreateInput, andNew?: boolean) {
     const fileID = query.get("file_id") ?? undefined;
     const result = await mutateCreateScene({
       ...input,
       file_ids: fileID ? [fileID] : undefined,
     });
     if (result.data?.sceneCreate?.id) {
-      history.push(`/scenes/${result.data.sceneCreate.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          { entity: intl.formatMessage({ id: "scene" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.SceneCreateInput) {
-    const fileID = query.get("file_id") ?? undefined;
-    const result = await mutateCreateScene({
-      ...input,
-      file_ids: fileID ? [fileID] : undefined,
-    });
-    if (result.data?.sceneCreate?.id) {
+      if (!andNew) {
+        history.push(`/scenes/${result.data.sceneCreate.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -105,7 +91,6 @@ const SceneCreate: React.FC = () => {
           isVisible
           isNew
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
         />
       </div>
     </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -52,6 +52,7 @@ interface IProps {
   isNew?: boolean;
   isVisible: boolean;
   onSubmit: (input: GQL.SceneCreateInput) => Promise<void>;
+  onSaveAndNew?: (input: GQL.SceneCreateInput) => Promise<void>;
   onDelete?: () => void;
 }
 
@@ -61,6 +62,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
   isNew = false,
   isVisible,
   onSubmit,
+  onSaveAndNew,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -272,6 +274,18 @@ export const SceneEditPanel: React.FC<IProps> = ({
     setIsLoading(true);
     try {
       await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
+  async function onSaveAndNewClick() {
+    const input = schema.cast(formik.values);
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -746,6 +760,16 @@ export const SceneEditPanel: React.FC<IProps> = ({
             >
               <FormattedMessage id="actions.save" />
             </Button>
+            {isNew && onSaveAndNew && (
+              <Button
+                className="edit-button"
+                variant="primary"
+                disabled={!isEqual(formik.errors, {})}
+                onClick={() => onSaveAndNewClick()}
+              >
+                <FormattedMessage id="actions.save_and_new" />
+              </Button>
+            )}
             {onDelete && (
               <Button
                 className="edit-button"

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Button, Form, Col, Row, ButtonGroup } from "react-bootstrap";
+import {
+  Button,
+  Dropdown,
+  Form,
+  Col,
+  Row,
+  ButtonGroup,
+  SplitButton,
+} from "react-bootstrap";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
@@ -750,24 +758,29 @@ export const SceneEditPanel: React.FC<IProps> = ({
       <Form noValidate onSubmit={formik.handleSubmit}>
         <Row className="form-container edit-buttons-container px-3 pt-3">
           <div className="edit-buttons mb-3 pl-0">
-            <Button
-              className="edit-button"
-              variant="primary"
-              disabled={
-                (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
-              }
-              onClick={() => formik.submitForm()}
-            >
-              <FormattedMessage id="actions.save" />
-            </Button>
-            {isNew && onSaveAndNew && (
-              <Button
+            {isNew && onSaveAndNew ? (
+              <SplitButton
+                id="scene-save-split-button"
                 className="edit-button"
                 variant="primary"
                 disabled={!isEqual(formik.errors, {})}
-                onClick={() => onSaveAndNewClick()}
+                title={intl.formatMessage({ id: "actions.save" })}
+                onClick={() => formik.submitForm()}
               >
-                <FormattedMessage id="actions.save_and_new" />
+                <Dropdown.Item onClick={() => onSaveAndNewClick()}>
+                  <FormattedMessage id="actions.save_and_new" />
+                </Dropdown.Item>
+              </SplitButton>
+            ) : (
+              <Button
+                className="edit-button"
+                variant="primary"
+                disabled={
+                  (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
+                }
+                onClick={() => formik.submitForm()}
+              >
+                <FormattedMessage id="actions.save" />
               </Button>
             )}
             {onDelete && (

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -59,8 +59,7 @@ interface IProps {
   initialCoverImage?: string;
   isNew?: boolean;
   isVisible: boolean;
-  onSubmit: (input: GQL.SceneCreateInput) => Promise<void>;
-  onSaveAndNew?: (input: GQL.SceneCreateInput) => Promise<void>;
+  onSubmit: (input: GQL.SceneCreateInput, andNew?: boolean) => Promise<void>;
   onDelete?: () => void;
 }
 
@@ -70,7 +69,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
   isNew = false,
   isVisible,
   onSubmit,
-  onSaveAndNew,
   onDelete,
 }) => {
   const intl = useIntl();
@@ -278,10 +276,10 @@ export const SceneEditPanel: React.FC<IProps> = ({
     formik.setFieldValue("groups", newGroups);
   }
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -291,14 +289,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   async function onSaveAndNewClick() {
     const input = schema.cast(formik.values);
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   const encodingImage = ImageUtils.usePasteImage(onImageLoad);
@@ -758,7 +749,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       <Form noValidate onSubmit={formik.handleSubmit}>
         <Row className="form-container edit-buttons-container px-3 pt-3">
           <div className="edit-buttons mb-3 pl-0">
-            {isNew && onSaveAndNew ? (
+            {isNew ? (
               <SplitButton
                 id="scene-save-split-button"
                 className="edit-button"

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -10,6 +10,7 @@ interface IProps {
   isEditing: boolean;
   onToggleEdit: () => void;
   onSave: () => void;
+  onSaveAndNew?: () => void;
   saveDisabled?: boolean;
   onDelete: () => void;
   onAutoTag?: () => void;
@@ -49,14 +50,25 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
     if (!props.isEditing) return;
 
     return (
-      <Button
-        variant="success"
-        className="save"
-        disabled={props.saveDisabled}
-        onClick={() => props.onSave()}
-      >
-        <FormattedMessage id="actions.save" />
-      </Button>
+      <>
+        <Button
+          variant="success"
+          className="save mr-2"
+          disabled={props.saveDisabled}
+          onClick={() => props.onSave()}
+        >
+          <FormattedMessage id="actions.save" />
+        </Button>
+        {props.isNew && props.onSaveAndNew && (
+          <Button
+            variant="success"
+            disabled={props.saveDisabled}
+            onClick={() => props.onSaveAndNew!()}
+          >
+            <FormattedMessage id="actions.save_and_new" />
+          </Button>
+        )}
+      </>
     );
   }
 

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from "react-bootstrap";
+import { Button, Dropdown, Modal, SplitButton } from "react-bootstrap";
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ImageInput } from "./ImageInput";
@@ -49,26 +49,32 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
   function renderSaveButton() {
     if (!props.isEditing) return;
 
-    return (
-      <>
-        <Button
+    if (props.isNew && props.onSaveAndNew) {
+      return (
+        <SplitButton
+          id="save-split-button"
           variant="success"
-          className="save mr-2"
+          className="save"
           disabled={props.saveDisabled}
+          title={intl.formatMessage({ id: "actions.save" })}
           onClick={() => props.onSave()}
         >
-          <FormattedMessage id="actions.save" />
-        </Button>
-        {props.isNew && props.onSaveAndNew && (
-          <Button
-            variant="success"
-            disabled={props.saveDisabled}
-            onClick={() => props.onSaveAndNew!()}
-          >
+          <Dropdown.Item onClick={() => props.onSaveAndNew!()}>
             <FormattedMessage id="actions.save_and_new" />
-          </Button>
-        )}
-      </>
+          </Dropdown.Item>
+        </SplitButton>
+      );
+    }
+
+    return (
+      <Button
+        variant="success"
+        className="save"
+        disabled={props.saveDisabled}
+        onClick={() => props.onSave()}
+      >
+        <FormattedMessage id="actions.save" />
+      </Button>
     );
   }
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -62,9 +62,22 @@
   padding: 0;
   row-gap: 0.5rem;
 
-  .btn {
+  > .btn {
     margin-right: 0.5rem;
     white-space: nowrap;
+  }
+
+  > .btn-group {
+    margin-right: 0.5rem;
+
+    .btn {
+      margin-right: 0;
+    }
+
+    // Show caret on split button dropdown toggle
+    .dropdown-toggle-split::after {
+      content: "";
+    }
   }
 }
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
@@ -41,6 +41,20 @@ const StudioCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.StudioCreateInput) {
+    const result = await createStudio({
+      variables: { input },
+    });
+    if (result.data?.studioCreate?.id) {
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+        )
+      );
+    }
+  }
+
   function renderImage() {
     if (image) {
       return <img className="logo" alt="" src={image} />;
@@ -68,6 +82,7 @@ const StudioCreate: React.FC = () => {
         <StudioEditPanel
           studio={studio}
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/studios")}
           onDelete={() => {}}
           setImage={setImage}

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioCreate.tsx
@@ -26,26 +26,14 @@ const StudioCreate: React.FC = () => {
 
   const [createStudio] = useStudioCreate();
 
-  async function onSave(input: GQL.StudioCreateInput) {
+  async function onSave(input: GQL.StudioCreateInput, andNew?: boolean) {
     const result = await createStudio({
       variables: { input },
     });
     if (result.data?.studioCreate?.id) {
-      history.push(`/studios/${result.data.studioCreate.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.StudioCreateInput) {
-    const result = await createStudio({
-      variables: { input },
-    });
-    if (result.data?.studioCreate?.id) {
+      if (!andNew) {
+        history.push(`/studios/${result.data.studioCreate.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -82,7 +70,6 @@ const StudioCreate: React.FC = () => {
         <StudioEditPanel
           studio={studio}
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/studios")}
           onDelete={() => {}}
           setImage={setImage}

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -25,6 +25,7 @@ import StashBoxIDSearchModal from "src/components/Shared/StashBoxIDSearchModal";
 interface IStudioEditPanel {
   studio: Partial<GQL.StudioDataFragment>;
   onSubmit: (studio: GQL.StudioCreateInput) => Promise<void>;
+  onSaveAndNew?: (studio: GQL.StudioCreateInput) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setImage: (image?: string | null) => void;
@@ -34,6 +35,7 @@ interface IStudioEditPanel {
 export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
   studio,
   onSubmit,
+  onSaveAndNew,
   onCancel,
   onDelete,
   setImage,
@@ -136,6 +138,18 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     setIsLoading(true);
     try {
       await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
+  async function onSaveAndNewClick() {
+    const input = schema.cast(formik.values);
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -247,6 +261,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         isEditing
         onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
+        onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onImageChange}
         onImageChangeURL={onImageLoad}

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -24,8 +24,7 @@ import StashBoxIDSearchModal from "src/components/Shared/StashBoxIDSearchModal";
 
 interface IStudioEditPanel {
   studio: Partial<GQL.StudioDataFragment>;
-  onSubmit: (studio: GQL.StudioCreateInput) => Promise<void>;
-  onSaveAndNew?: (studio: GQL.StudioCreateInput) => Promise<void>;
+  onSubmit: (studio: GQL.StudioCreateInput, andNew?: boolean) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setImage: (image?: string | null) => void;
@@ -35,7 +34,6 @@ interface IStudioEditPanel {
 export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
   studio,
   onSubmit,
-  onSaveAndNew,
   onCancel,
   onDelete,
   setImage,
@@ -134,10 +132,10 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     };
   });
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -147,14 +145,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
 
   async function onSaveAndNewClick() {
     const input = schema.cast(formik.values);
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   function onImageLoad(imageData: string | null) {
@@ -261,7 +252,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         isEditing
         onToggleEdit={onCancel}
         onSave={formik.handleSubmit}
-        onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
+        onSaveAndNew={isNew ? onSaveAndNewClick : undefined}
         saveDisabled={(!isNew && !formik.dirty) || !isEqual(formik.errors, {})}
         onImageChange={onImageChange}
         onImageChangeURL={onImageLoad}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagCreate.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagCreate.tsx
@@ -49,6 +49,29 @@ const TagCreate: React.FC = () => {
     }
   }
 
+  async function onSaveAndNew(input: GQL.TagCreateInput) {
+    const oldRelations = {
+      parents: [],
+      children: [],
+    };
+    const result = await createTag({
+      variables: { input },
+    });
+    if (result.data?.tagCreate?.id) {
+      const created = result.data.tagCreate;
+      tagRelationHook(created, oldRelations, {
+        parents: created.parents,
+        children: created.children,
+      });
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.created_entity" },
+          { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
+        )
+      );
+    }
+  }
+
   function renderImage() {
     if (image) {
       return <img className="logo" alt="" src={image} />;
@@ -70,6 +93,7 @@ const TagCreate: React.FC = () => {
         <TagEditPanel
           tag={tag}
           onSubmit={onSave}
+          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/tags")}
           onDelete={() => {}}
           setImage={setImage}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagCreate.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagCreate.tsx
@@ -25,7 +25,7 @@ const TagCreate: React.FC = () => {
 
   const [createTag] = useTagCreate();
 
-  async function onSave(input: GQL.TagCreateInput) {
+  async function onSave(input: GQL.TagCreateInput, andNew?: boolean) {
     const oldRelations = {
       parents: [],
       children: [],
@@ -39,30 +39,9 @@ const TagCreate: React.FC = () => {
         parents: created.parents,
         children: created.children,
       });
-      history.push(`/tags/${created.id}`);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.created_entity" },
-          { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
-
-  async function onSaveAndNew(input: GQL.TagCreateInput) {
-    const oldRelations = {
-      parents: [],
-      children: [],
-    };
-    const result = await createTag({
-      variables: { input },
-    });
-    if (result.data?.tagCreate?.id) {
-      const created = result.data.tagCreate;
-      tagRelationHook(created, oldRelations, {
-        parents: created.parents,
-        children: created.children,
-      });
+      if (!andNew) {
+        history.push(`/tags/${created.id}`);
+      }
       Toast.success(
         intl.formatMessage(
           { id: "toast.created_entity" },
@@ -93,7 +72,6 @@ const TagCreate: React.FC = () => {
         <TagEditPanel
           tag={tag}
           onSubmit={onSave}
-          onSaveAndNew={onSaveAndNew}
           onCancel={() => history.push("/tags")}
           onDelete={() => {}}
           setImage={setImage}

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -24,6 +24,7 @@ import StashBoxIDSearchModal from "src/components/Shared/StashBoxIDSearchModal";
 interface ITagEditPanel {
   tag: Partial<GQL.TagDataFragment>;
   onSubmit: (tag: GQL.TagCreateInput) => Promise<void>;
+  onSaveAndNew?: (tag: GQL.TagCreateInput) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setImage: (image?: string | null) => void;
@@ -33,6 +34,7 @@ interface ITagEditPanel {
 export const TagEditPanel: React.FC<ITagEditPanel> = ({
   tag,
   onSubmit,
+  onSaveAndNew,
   onCancel,
   onDelete,
   setImage,
@@ -126,6 +128,18 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     setIsLoading(true);
     try {
       await onSubmit(input);
+      formik.resetForm();
+    } catch (e) {
+      Toast.error(e);
+    }
+    setIsLoading(false);
+  }
+
+  async function onSaveAndNewClick() {
+    const input = schema.cast(formik.values);
+    setIsLoading(true);
+    try {
+      await onSaveAndNew?.(input);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -271,6 +285,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
           isEditing
           onToggleEdit={onCancel}
           onSave={formik.handleSubmit}
+          onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
           saveDisabled={
             (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
           }

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -23,8 +23,7 @@ import StashBoxIDSearchModal from "src/components/Shared/StashBoxIDSearchModal";
 
 interface ITagEditPanel {
   tag: Partial<GQL.TagDataFragment>;
-  onSubmit: (tag: GQL.TagCreateInput) => Promise<void>;
-  onSaveAndNew?: (tag: GQL.TagCreateInput) => Promise<void>;
+  onSubmit: (tag: GQL.TagCreateInput, andNew?: boolean) => Promise<void>;
   onCancel: () => void;
   onDelete: () => void;
   setImage: (image?: string | null) => void;
@@ -34,7 +33,6 @@ interface ITagEditPanel {
 export const TagEditPanel: React.FC<ITagEditPanel> = ({
   tag,
   onSubmit,
-  onSaveAndNew,
   onCancel,
   onDelete,
   setImage,
@@ -124,10 +122,10 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     };
   });
 
-  async function onSave(input: InputValues) {
+  async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);
     try {
-      await onSubmit(input);
+      await onSubmit(input, andNew);
       formik.resetForm();
     } catch (e) {
       Toast.error(e);
@@ -137,14 +135,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
 
   async function onSaveAndNewClick() {
     const input = schema.cast(formik.values);
-    setIsLoading(true);
-    try {
-      await onSaveAndNew?.(input);
-      formik.resetForm();
-    } catch (e) {
-      Toast.error(e);
-    }
-    setIsLoading(false);
+    onSave(input, true);
   }
 
   const encodingImage = ImageUtils.usePasteImage(onImageLoad);
@@ -285,7 +276,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
           isEditing
           onToggleEdit={onCancel}
           onSave={formik.handleSubmit}
-          onSaveAndNew={onSaveAndNew ? onSaveAndNewClick : undefined}
+          onSaveAndNew={isNew ? onSaveAndNewClick : undefined}
           saveDisabled={
             (!isNew && !formik.dirty) || !isEqual(formik.errors, {})
           }

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -687,6 +687,11 @@ div.dropdown-menu {
 
 .edit-button {
   margin-right: 10px;
+
+  // Show caret on split button dropdown toggle
+  &.btn-group .dropdown-toggle-split::after {
+    content: "";
+  }
 }
 
 .wrap-tags {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -107,6 +107,7 @@
     "reshuffle": "Reshuffle",
     "running": "running",
     "save": "Save",
+    "save_and_new": "Save & New",
     "save_delete_settings": "Use these options by default when deleting",
     "save_filter": "Save filter",
     "scan": "Scan",


### PR DESCRIPTION
This modifies the "Save" button into a split button and adds a "Save & New" option.

Updated: Performers, Studios, Tags, Scenes, Galleries, Groups

UI for Studios: 

<img width="1584" height="1424" alt="Screenshot 2025-12-20 at 18-20-36 Studios Stash" src="https://github.com/user-attachments/assets/ba8b9a29-2a72-48b9-ab4f-4b82c57084db" />

Fixes: https://github.com/stashapp/stash/issues/5921