### PR TITLE
FR: Add Generate Task to Galleries

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -20,10 +20,12 @@ input GenerateMetadataInput {
 
   "scene ids to generate for"
   sceneIDs: [ID!]
-  "image ids to generate for"
-  imageIDs: [ID!]
   "marker ids to generate for"
   markerIDs: [ID!]
+  "image ids to generate for"
+  imageIDs: [ID!]
+  "gallery ids to generate for"
+  galleryIDs: [ID!]
 
   "overwrite existing media"
   overwrite: Boolean

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -35,10 +35,12 @@ type GenerateMetadataInput struct {
 	ImageThumbnails           bool `json:"imageThumbnails"`
 	// scene ids to generate for
 	SceneIDs []string `json:"sceneIDs"`
-	// image ids to generate for
-	ImageIDs []string `json:"imageIDs"`
 	// marker ids to generate for
 	MarkerIDs []string `json:"markerIDs"`
+	// image ids to generate for
+	ImageIDs []string `json:"imageIDs"`
+	// gallery ids to generate for
+	GalleryIDs []string `json:"galleryIDs"`
 	// overwrite existing media
 	Overwrite bool `json:"overwrite"`
 }
@@ -114,6 +116,10 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 		if err != nil {
 			logger.Error(err.Error())
 		}
+		galleryIDs, err := stringslice.StringSliceToIntSlice(j.input.GalleryIDs)
+		if err != nil {
+			logger.Error(err.Error())
+		}
 
 		g := &generate.Generator{
 			Encoder:      instance.FFMpeg,
@@ -127,7 +133,7 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 		r := j.repository
 		if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
 			qb := r.Scene
-			if len(j.input.SceneIDs) == 0 && len(j.input.MarkerIDs) == 0 && len(j.input.ImageIDs) == 0 {
+			if len(j.input.SceneIDs) == 0 && len(j.input.MarkerIDs) == 0 && len(j.input.ImageIDs) == 0 && len(j.input.GalleryIDs) == 0 {
 				j.queueTasks(ctx, g, queue)
 			} else {
 				if len(j.input.SceneIDs) > 0 {
@@ -159,6 +165,22 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 						}
 
 						j.queueImageJob(g, i, queue)
+					}
+				}
+
+				if len(j.input.GalleryIDs) > 0 {
+					for _, galleryID := range galleryIDs {
+						imgs, err := r.Image.FindByGalleryID(ctx, galleryID)
+						if err != nil {
+							return err
+						}
+						for _, img := range imgs {
+							if err := img.LoadFiles(ctx, r.Image); err != nil {
+								return err
+							}
+
+							j.queueImageJob(g, img, queue)
+						}
 					}
 				}
 			}

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -183,6 +183,22 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 						}
 					}
 				}
+
+				if len(j.input.GalleryIDs) > 0 {
+					for _, galleryID := range galleryIDs {
+						imgs, err := r.Image.FindByGalleryID(ctx, galleryID)
+						if err != nil {
+							return err
+						}
+						for _, img := range imgs {
+							if err := img.LoadFiles(ctx, r.Image); err != nil {
+								return err
+							}
+
+							j.queueImageJob(g, img, queue)
+						}
+					}
+				}
 			}
 
 			return nil

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -183,22 +183,6 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 						}
 					}
 				}
-
-				if len(j.input.GalleryIDs) > 0 {
-					for _, galleryID := range galleryIDs {
-						imgs, err := r.Image.FindByGalleryID(ctx, galleryID)
-						if err != nil {
-							return err
-						}
-						for _, img := range imgs {
-							if err := img.LoadFiles(ctx, r.Image); err != nil {
-								return err
-							}
-
-							j.queueImageJob(g, img, queue)
-						}
-					}
-				}
 			}
 
 			return nil

--- a/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
+++ b/ui/v2.5/src/components/Dialogs/GenerateDialog.tsx
@@ -14,19 +14,20 @@ import { SettingSection } from "../Settings/SettingSection";
 import { faCogs, faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { SettingsContext } from "../Settings/context";
 
-interface ISceneGenerateDialog {
+interface IGenerateDialog {
   selectedIds?: string[];
   onClose: () => void;
-  type: "scene" | "image";
+  type: "scene" | "image" | "gallery";
 }
 
-export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
+export const GenerateDialog: React.FC<IGenerateDialog> = ({
   selectedIds,
   onClose,
   type,
 }) => {
   const sceneIDs = type === "scene" ? selectedIds : undefined;
   const imageIDs = type === "image" ? selectedIds : undefined;
+  const galleryIDs = type === "gallery" ? selectedIds : undefined;
 
   const { configuration } = useConfigurationContext();
 
@@ -92,6 +93,13 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
   }, [configuration, configRead]);
 
   const selectionStatus = useMemo(() => {
+    const countableIds: Record<typeof type, string> = {
+      scene: "countables.scenes",
+      image: "countables.images",
+      gallery: "countables.galleries",
+    };
+    const countableId = countableIds[type];
+
     if (selectedIds) {
       return (
         <Form.Group id="selected-generate-ids">
@@ -101,7 +109,7 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
               num: selectedIds.length,
               scene: intl.formatMessage(
                 {
-                  id: "countables.scenes",
+                  id: countableId,
                 },
                 {
                   count: selectedIds.length,
@@ -121,7 +129,7 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
             num: intl.formatMessage({ id: "all" }),
             scene: intl.formatMessage(
               {
-                id: "countables.scenes",
+                id: countableId,
               },
               {
                 count: 0,
@@ -138,7 +146,7 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
         <div>{message}</div>
       </Form.Group>
     );
-  }, [selectedIds, intl]);
+  }, [selectedIds, intl, type]);
 
   async function onGenerate() {
     try {
@@ -146,6 +154,7 @@ export const GenerateDialog: React.FC<ISceneGenerateDialog> = ({
         ...options,
         sceneIDs,
         imageIDs,
+        galleryIDs,
       });
       Toast.success(
         intl.formatMessage(

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -257,7 +257,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
             className="bg-secondary text-white"
             onClick={() => onGenerate()}
           >
-            <FormattedMessage id="actions.generate" />
+            {`${intl.formatMessage({ id: "actions.generate" })}…`}
           </Dropdown.Item>
           <Dropdown.Item
             className="bg-secondary text-white"

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -15,6 +15,11 @@ import {
   useFindGallery,
   useGalleryUpdate,
 } from "src/core/StashService";
+import { lazyComponent } from "src/utils/lazyComponent";
+
+const GenerateDialog = lazyComponent(
+  () => import("../../Dialogs/GenerateDialog")
+);
 import { ErrorMessage } from "src/components/Shared/ErrorMessage";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { Icon } from "src/components/Shared/Icon";
@@ -165,11 +170,37 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
   }
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+  const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
+  const [generateImageIds, setGenerateImageIds] = useState<string[]>([]);
+
+  const [fetchGalleryImages] = GQL.useFindImagesLazyQuery();
 
   function onDeleteDialogClosed(deleted: boolean) {
     setIsDeleteAlertOpen(false);
     if (deleted) {
       goBackOrReplace(history, "/galleries");
+    }
+  }
+
+  async function onGenerate() {
+    const result = await fetchGalleryImages({
+      variables: {
+        image_filter: {
+          galleries: {
+            modifier: GQL.CriterionModifier.Includes,
+            value: [gallery.id],
+          },
+        },
+        filter: {
+          per_page: -1,
+        },
+      },
+    });
+
+    if (result.data?.findImages?.images) {
+      const imageIds = result.data.findImages.images.map((img) => img.id);
+      setGenerateImageIds(imageIds);
+      setIsGenerateDialogOpen(true);
     }
   }
 
@@ -179,6 +210,18 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
         <DeleteGalleriesDialog
           selected={[{ ...gallery, image_count: NaN }]}
           onClose={onDeleteDialogClosed}
+        />
+      );
+    }
+  }
+
+  function maybeRenderGenerateDialog() {
+    if (isGenerateDialogOpen) {
+      return (
+        <GenerateDialog
+          selectedIds={generateImageIds}
+          onClose={() => setIsGenerateDialogOpen(false)}
+          type="image"
         />
       );
     }
@@ -209,6 +252,12 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
             onClick={() => onResetCover()}
           >
             <FormattedMessage id="actions.reset_cover" />
+          </Dropdown.Item>
+          <Dropdown.Item
+            className="bg-secondary text-white"
+            onClick={() => onGenerate()}
+          >
+            <FormattedMessage id="actions.generate" />
           </Dropdown.Item>
           <Dropdown.Item
             className="bg-secondary text-white"
@@ -387,6 +436,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
         <title>{title}</title>
       </Helmet>
       {maybeRenderDeleteDialog()}
+      {maybeRenderGenerateDialog()}
       <div className={`gallery-tabs ${collapsed ? "collapsed" : ""}`}>
         <div>
           <div className="gallery-header-container">

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -171,36 +171,11 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
   const [isGenerateDialogOpen, setIsGenerateDialogOpen] = useState(false);
-  const [generateImageIds, setGenerateImageIds] = useState<string[]>([]);
-
-  const [fetchGalleryImages] = GQL.useFindImagesLazyQuery();
 
   function onDeleteDialogClosed(deleted: boolean) {
     setIsDeleteAlertOpen(false);
     if (deleted) {
       goBackOrReplace(history, "/galleries");
-    }
-  }
-
-  async function onGenerate() {
-    const result = await fetchGalleryImages({
-      variables: {
-        image_filter: {
-          galleries: {
-            modifier: GQL.CriterionModifier.Includes,
-            value: [gallery.id],
-          },
-        },
-        filter: {
-          per_page: -1,
-        },
-      },
-    });
-
-    if (result.data?.findImages?.images) {
-      const imageIds = result.data.findImages.images.map((img) => img.id);
-      setGenerateImageIds(imageIds);
-      setIsGenerateDialogOpen(true);
     }
   }
 
@@ -219,9 +194,9 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
     if (isGenerateDialogOpen) {
       return (
         <GenerateDialog
-          selectedIds={generateImageIds}
+          selectedIds={[gallery.id]}
           onClose={() => setIsGenerateDialogOpen(false)}
-          type="image"
+          type="gallery"
         />
       );
     }
@@ -255,7 +230,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
           </Dropdown.Item>
           <Dropdown.Item
             className="bg-secondary text-white"
-            onClick={() => onGenerate()}
+            onClick={() => setIsGenerateDialogOpen(true)}
           >
             {`${intl.formatMessage({ id: "actions.generate" })}…`}
           </Dropdown.Item>

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -12,11 +12,13 @@ import GalleryWallCard from "./GalleryWallCard";
 import { EditGalleriesDialog } from "./EditGalleriesDialog";
 import { DeleteGalleriesDialog } from "./DeleteGalleriesDialog";
 import { ExportDialog } from "../Shared/ExportDialog";
+import { GenerateDialog } from "../Dialogs/GenerateDialog";
 import { GalleryListTable } from "./GalleryListTable";
 import { GalleryCardGrid } from "./GalleryCardGrid";
 import { View } from "../List/views";
 import { PatchComponent } from "src/patch";
 import { IItemListOperation } from "../List/FilteredListToolbar";
+import { useModal } from "src/hooks/modal";
 
 function getItems(result: GQL.FindGalleriesQueryResult) {
   return result?.data?.findGalleries?.galleries ?? [];
@@ -40,6 +42,7 @@ export const GalleryList: React.FC<IGalleryList> = PatchComponent(
     const history = useHistory();
     const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
     const [isExportAll, setIsExportAll] = useState(false);
+    const { modal, showModal, closeModal } = useModal();
 
     const filterMode = GQL.FilterMode.Galleries;
 
@@ -48,6 +51,24 @@ export const GalleryList: React.FC<IGalleryList> = PatchComponent(
       {
         text: intl.formatMessage({ id: "actions.view_random" }),
         onClick: viewRandom,
+      },
+      {
+        text: `${intl.formatMessage({ id: "actions.generate" })}…`,
+        onClick: (
+          _result: GQL.FindGalleriesQueryResult,
+          _filter: ListFilterModel,
+          selectedIds: Set<string>
+        ) => {
+          showModal(
+            <GenerateDialog
+              type="gallery"
+              selectedIds={Array.from(selectedIds.values())}
+              onClose={() => closeModal()}
+            />
+          );
+          return Promise.resolve();
+        },
+        isDisplayed: showWhenSelected,
       },
       {
         text: intl.formatMessage({ id: "actions.export" }),
@@ -172,6 +193,7 @@ export const GalleryList: React.FC<IGalleryList> = PatchComponent(
       return (
         <>
           {maybeRenderGalleryExportDialog()}
+          {modal}
           {renderGalleries()}
         </>
       );

--- a/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/GenerateOptions.tsx
@@ -7,7 +7,7 @@ import {
 } from "../GeneratePreviewOptions";
 
 interface IGenerateOptions {
-  type?: "scene" | "image";
+  type?: "scene" | "image" | "gallery";
   selection?: boolean;
   options: GQL.GenerateMetadataInput;
   setOptions: (s: GQL.GenerateMetadataInput) => void;
@@ -27,7 +27,7 @@ export const GenerateOptions: React.FC<IGenerateOptions> = ({
   }
 
   const showSceneOptions = !type || type === "scene";
-  const showImageOptions = !type || type === "image";
+  const showImageOptions = !type || type === "image" || type === "gallery";
 
   return (
     <>


### PR DESCRIPTION
This PR adds a "Generate" option to the gallery detail page overflow menu, addressing the issue where users had no way to regenerate broken image thumbnails for specific galleries. When a user clicks "Generate" from a gallery's overflow menu, the system queries for all image IDs within that gallery and opens the Generate dialog with those images pre-selected. 

Tested by deleting my image previews and then regenerating with this feature

Dropdown: 

<img width="970" height="592" alt="Screenshot 2025-12-20 at 23-03-47 AVIF Galleries Stash" src="https://github.com/user-attachments/assets/9fb2a73f-bd49-4fe0-926c-a18f7224151a" />

Modal: 

<img width="1700" height="752" alt="Screenshot 2025-12-20 at 23-03-59 AVIF Galleries Stash" src="https://github.com/user-attachments/assets/58ecc29d-1ae4-4c32-8720-bade7574245c" />

Fixes: https://github.com/stashapp/stash/issues/5756