### PR TITLE
FR: Hide Already Installed Plugins or Scrapers

### DIFF
--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -100,6 +100,12 @@ export const AvailablePluginPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
+  // Get installed packages to filter them out from available list
+  const { data: installedData } = useInstalledPluginPackages();
+  const installedPackageIds = new Set(
+    installedData?.installedPackages?.map((p) => p.package_id) ?? []
+  );
+
   async function onInstallPackages(packages: GQL.PackageSpecInput[]) {
     const r = await mutateInstallPluginPackages(packages);
 
@@ -114,7 +120,10 @@ export const AvailablePluginPackages: React.FC = () => {
 
   async function loadSource(source: string): Promise<RemotePackage[]> {
     const { data } = await queryAvailablePluginPackages(source);
-    return data.availablePackages;
+    // Filter out already installed packages
+    return data.availablePackages.filter(
+      (pkg) => !installedPackageIds.has(pkg.package_id)
+    );
   }
 
   function addSource(source: GQL.PackageSource) {

--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -101,7 +101,7 @@ export const AvailablePluginPackages: React.FC = () => {
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
   // Get installed packages to filter them out from available list
-  const { data: installedData } = useInstalledPluginPackages();
+  const { data: installedData } = useInstalledPluginPackages(false);
   const installedPackageIds = new Set(
     installedData?.installedPackages?.map((p) => p.package_id) ?? []
   );

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -101,7 +101,7 @@ export const AvailableScraperPackages: React.FC = () => {
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
   // Get installed packages to filter them out from available list
-  const { data: installedData } = useInstalledScraperPackages();
+  const { data: installedData } = useInstalledScraperPackages(false);
   const installedPackageIds = new Set(
     installedData?.installedPackages?.map((p) => p.package_id) ?? []
   );

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -100,6 +100,12 @@ export const AvailableScraperPackages: React.FC = () => {
   const [jobID, setJobID] = useState<string>();
   const { job } = useMonitorJob(jobID, () => onPackageChanges());
 
+  // Get installed packages to filter them out from available list
+  const { data: installedData } = useInstalledScraperPackages();
+  const installedPackageIds = new Set(
+    installedData?.installedPackages?.map((p) => p.package_id) ?? []
+  );
+
   async function onInstallPackages(packages: GQL.PackageSpecInput[]) {
     const r = await mutateInstallScraperPackages(packages);
 
@@ -114,7 +120,10 @@ export const AvailableScraperPackages: React.FC = () => {
 
   async function loadSource(source: string): Promise<RemotePackage[]> {
     const { data } = await queryAvailableScraperPackages(source);
-    return data.availablePackages;
+    // Filter out already installed packages
+    return data.availablePackages.filter(
+      (pkg) => !installedPackageIds.has(pkg.package_id)
+    );
   }
 
   function addSource(source: GQL.PackageSource) {


### PR DESCRIPTION
Very small UX change. If a scraper or plugin is already installed it should be removed from the available plugins list. 

Fixes: https://github.com/stashapp/stash/issues/5640