### PR TITLE
FR: Autopopulate Stash-ID Search Box

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -681,6 +681,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
             onStashIDSelected(item);
             setIsStashIDSearchOpen(false);
           }}
+          initialQuery={performer.name ?? ""}
         />
       )}
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -731,6 +731,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
             onStashIDSelected(item);
             setIsStashIDSearchOpen(false);
           }}
+          initialQuery={scene.title ?? ""}
         />
       )}
       <Form noValidate onSubmit={formik.handleSubmit}>

--- a/ui/v2.5/src/components/Shared/StashBoxIDSearchModal.tsx
+++ b/ui/v2.5/src/components/Shared/StashBoxIDSearchModal.tsx
@@ -33,6 +33,7 @@ interface IProps {
   stashBoxes: GQL.StashBox[];
   excludedStashBoxEndpoints?: string[];
   onSelectItem: (item?: GQL.StashIdInput) => void;
+  initialQuery?: string;
 }
 
 const CLASSNAME = "StashBoxIDSearchModal";
@@ -289,6 +290,7 @@ export const StashBoxIDSearchModal: React.FC<IProps> = ({
   stashBoxes,
   excludedStashBoxEndpoints = [],
   onSelectItem,
+  initialQuery = "",
 }) => {
   const intl = useIntl();
   const Toast = useToast();
@@ -297,7 +299,7 @@ export const StashBoxIDSearchModal: React.FC<IProps> = ({
   const [selectedStashBox, setSelectedStashBox] = useState<GQL.StashBox | null>(
     null
   );
-  const [query, setQuery] = useState<string>("");
+  const [query, setQuery] = useState<string>(initialQuery);
   const [results, setResults] = useState<SearchResultItem[] | undefined>(
     undefined
   );

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -200,6 +200,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
             onStashIDSelected(item);
             setIsStashIDSearchOpen(false);
           }}
+          initialQuery={studio.name ?? ""}
         />
       )}
 

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -213,6 +213,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
             onStashIDSelected(item);
             setIsStashIDSearchOpen(false);
           }}
+          initialQuery={tag?.name ?? ""}
         />
       )}
 


### PR DESCRIPTION
Recently, the ability to manually search for a Stash Id was added to all objects that support them. This makes it so that the title/name is auto populated in the search box to make it a little easier when searching.

Fixes: https://github.com/stashapp/stash/issues/6426