### PR TITLE
[SFW] Show Performer Age in Performer Card when SFW turned on

### DIFF
--- a/ui/v2.5/src/sfw-mode.scss
+++ b/ui/v2.5/src/sfw-mode.scss
@@ -83,9 +83,4 @@
       display: none;
     }
   }
-
-  // hide performer age on performer cards
-  .performer-card__age {
-    display: none;
-  }
 }


### PR DESCRIPTION
## Description

This simple PR removes the explicit hiding of performer age from SFW.

I understand why `penis length` and `fake tits` are hidden in SFW, but `age` IS considered SFW (it is an editable field on performer pages). Thus I think it should be shown in SFW performer cards.

## User Story

* IWT: see the age of my family member in old footage.
    * PROBLEM: Must switch from SFW to NSFW to do so

