### PR TITLE
specify URL for stash ID endpoint

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1461,7 +1461,7 @@
     "welcome_to_stash": "Welcome to Stash"
   },
   "stash_id": "Stash ID",
-  "stash_id_endpoint": "Stash ID Endpoint",
+  "stash_id_endpoint": "Stash ID Endpoint URL",
   "stash_ids": "Stash IDs",
   "stashbox_search": {
     "header": "Search {entityType} from StashBox",


### PR DESCRIPTION
Has been a persistent confusion/pain point [1](https://discord.com/channels/559159668438728723/559159931505213440/1455468288845938700) [2](https://discord.com/channels/559159668438728723/559159931505213440/1331461772434997300) [3](https://discord.com/channels/559159668438728723/559159931505213440/1202720555598356630) which should be cleared up with this fix