### PR TITLE
fix: retry JSON unmarshal after fixing invalid backslash escapes

### DIFF
--- a/pkg/plugin/raw.go
+++ b/pkg/plugin/raw.go
@@ -86,7 +86,7 @@ func (t *rawPluginTask) Start() error {
 				nextCh := rune(inStr[i+1])
 				// Valid JSON escape chars: " \ / b f n r t u
 				validEscape := false
-				for _, validCh := range "\"\\\/bfnrtu" {
+				for _, validCh := range `"\/bfnrtu` {
 					if nextCh == validCh {
 						validEscape = true
 						break


### PR DESCRIPTION
Attempt to recover from plugin outputs containing invalid backslash escapes by fixing and retrying JSON unmarshal in pkg/plugin/raw.go and pkg/javascript/gql.go.