### PR TITLE
make ImageCard patchable for plugin extensibility

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -252,6 +252,10 @@ Returns `void`.
 - `HoverPopover`
 - `Icon`
 - `ImageCard`
+- `ImageCard.Details`
+- `ImageCard.Image`
+- `ImageCard.Overlays`
+- `ImageCard.Popovers`
 - `ImageDetailPanel`
 - `ImageGridCard`
 - `ImageInput`


### PR DESCRIPTION
## Summary

This PR builds on #6463 (which made `ImageCard` patchable) by adding sub-component granularity for better plugin extensibility.

- Extract sub-components (`ImageCardPopovers`, `ImageCardDetails`, `ImageCardOverlays`, `ImageCardImage`) as separate patchable components
- Follows the same pattern used by `SceneCard`, `GalleryCard`, and `PerformerCard`

## Changes

The refactoring mirrors the structure of other patchable card components:
- `ImageCard` - main component, patchable (from #6463)
- `ImageCard.Popovers` - tag, performer, gallery popovers
- `ImageCard.Details` - date and description
- `ImageCard.Overlays` - studio overlay
- `ImageCard.Image` - image preview and rating banner
