### PR TITLE
Optimize Groups List Page Performance

### DIFF
--- a/ui/v2.5/graphql/data/group.graphql
+++ b/ui/v2.5/graphql/data/group.graphql
@@ -1,3 +1,4 @@
+# Full fragment for detail views - includes recursive counts
 fragment GroupData on Group {
   id
   name
@@ -32,6 +33,47 @@ fragment GroupData on Group {
   performer_count_all: performer_count(depth: -1)
   sub_group_count
   sub_group_count_all: sub_group_count(depth: -1)
+  o_counter
+
+  scenes {
+    id
+    title
+  }
+}
+
+# Lightweight fragment for list views - excludes expensive recursive counts
+# The _all fields (depth: -1) cause 10+ second queries on large databases
+fragment ListGroupData on Group {
+  id
+  name
+  aliases
+  duration
+  date
+  rating100
+  director
+
+  studio {
+    ...SlimStudioData
+  }
+
+  tags {
+    ...SlimTagData
+  }
+
+  containing_groups {
+    group {
+      ...SlimGroupData
+    }
+    description
+  }
+
+  synopsis
+  urls
+  front_image_path
+  back_image_path
+  scene_count
+  performer_count
+  sub_group_count
   o_counter
 
   scenes {

--- a/ui/v2.5/graphql/queries/movie.graphql
+++ b/ui/v2.5/graphql/queries/movie.graphql
@@ -2,7 +2,7 @@ query FindGroups($filter: FindFilterType, $group_filter: GroupFilterType) {
   findGroups(filter: $filter, group_filter: $group_filter) {
     count
     groups {
-      ...GroupData
+      ...ListGroupData
     }
   }
 }

--- a/ui/v2.5/src/components/Groups/EditGroupsDialog.tsx
+++ b/ui/v2.5/src/components/Groups/EditGroupsDialog.tsx
@@ -23,12 +23,12 @@ import { ContainingGroupsMultiSet } from "./ContainingGroupsMultiSet";
 import { IRelatedGroupEntry } from "./GroupDetails/RelatedGroupTable";
 
 interface IListOperationProps {
-  selected: GQL.GroupDataFragment[];
+  selected: GQL.ListGroupDataFragment[];
   onClose: (applied: boolean) => void;
 }
 
 export function getAggregateContainingGroups(
-  state: Pick<GQL.GroupDataFragment, "containing_groups">[]
+  state: Pick<GQL.ListGroupDataFragment, "containing_groups">[]
 ) {
   const sortedLists: IRelatedGroupEntry[][] = state.map((o) =>
     o.containing_groups
@@ -144,7 +144,7 @@ export const EditGroupsDialog: React.FC<IListOperationProps> = (
     let updateDirector: string | undefined;
     let first = true;
 
-    state.forEach((group: GQL.GroupDataFragment) => {
+    state.forEach((group: GQL.ListGroupDataFragment) => {
       const groupTagIDs = (group.tags ?? []).map((p) => p.id).sort();
       const groupContainingGroupIDs = (group.containing_groups ?? []).sort(
         (a, b) => a.group.id.localeCompare(b.group.id)

--- a/ui/v2.5/src/components/Groups/GroupCard.tsx
+++ b/ui/v2.5/src/components/Groups/GroupCard.tsx
@@ -36,7 +36,7 @@ const Description: React.FC<{
 };
 
 interface IProps {
-  group: GQL.GroupDataFragment;
+  group: GQL.ListGroupDataFragment;
   cardWidth?: number;
   sceneNumber?: number;
   selecting?: boolean;

--- a/ui/v2.5/src/components/Groups/GroupCardGrid.tsx
+++ b/ui/v2.5/src/components/Groups/GroupCardGrid.tsx
@@ -7,7 +7,7 @@ import {
 } from "../Shared/GridCard/GridCard";
 
 interface IGroupCardGrid {
-  groups: GQL.GroupDataFragment[];
+  groups: GQL.ListGroupDataFragment[];
   selectedIds: Set<string>;
   zoomIndex: number;
   onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -199,7 +199,7 @@ export const GroupList: React.FC<IGroupList> = PatchComponent(
     }
 
     function renderEditDialog(
-      selectedGroups: GQL.GroupDataFragment[],
+      selectedGroups: GQL.ListGroupDataFragment[],
       onClose: (applied: boolean) => void
     ) {
       return <EditGroupsDialog selected={selectedGroups} onClose={onClose} />;

--- a/ui/v2.5/src/components/Groups/RelatedGroupPopover.tsx
+++ b/ui/v2.5/src/components/Groups/RelatedGroupPopover.tsx
@@ -16,7 +16,7 @@ import { GroupTag } from "./GroupTag";
 
 interface IProps {
   group: Pick<
-    GQL.GroupDataFragment,
+    GQL.ListGroupDataFragment,
     "id" | "name" | "containing_groups" | "sub_group_count"
   >;
 }


### PR DESCRIPTION
Similar change to https://github.com/stashapp/stash/pull/6398

## Summary
   - Adds a new `ListGroupData` GraphQL fragment for list views that excludes expensive recursive count fields
   - The `_all` fields (with `depth: -1`) cause 10+ second queries on large databases when loading the groups list      
   page
   - Updates `FindGroups` query and related components to use the lightweight fragment
   - Preserves full `GroupData` fragment for detail views where recursive counts are needed

Improves FindGroups query on my groups list page from 10.79 seconds to 0.16 seconds.