### PR TITLE
fix(scraper): handle base64 data URIs in processImageField

### DIFF
--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -68,6 +68,12 @@ func processImageField(ctx context.Context, imageField *string, client *http.Cli
 		return nil
 	}
 
+	// don't try to get the image if it doesn't appear to be a URL
+	// this allows scrapers to return base64 data URIs directly
+	if !strings.HasPrefix(*imageField, "http") {
+		return nil
+	}
+
 	img, err := getImage(ctx, *imageField, client, globalConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Add check to skip HTTP fetch for non-HTTP URLs in `processImageField()`, matching the existing behavior in `setPerformerImage()` and `setStudioImage()`

## Problem

When a scraper returns a base64 data URI (e.g., `data:image/jpeg;base64,...`) for a scene image, Stash logs warnings like:

```
level=warning msg="Could not set image using URL data:image/jpeg;base64,..."
```

This happens because `processImageField()` unconditionally attempts to fetch the image via HTTP, even when it's already a data URI.

## Root Cause

The `setPerformerImage()` and `setStudioImage()` functions already have protection:

```go
// don't try to get the image if it doesn't appear to be a URL
if !strings.HasPrefix(*p.Image, "http") {
    p.Images = []string{*p.Image}
    return nil
}
```

However, `processImageField()` (used for scene images) was missing this check.

## Solution

Add the same prefix check to `processImageField()` to allow scrapers to return base64 data URIs directly without triggering HTTP fetch errors.