### PR TITLE
Plugin API - React Font Awesome library

### DIFF
--- a/ui/v2.5/src/pluginApi.d.ts
+++ b/ui/v2.5/src/pluginApi.d.ts
@@ -617,6 +617,7 @@ declare namespace PluginApi {
     const FontAwesomeBrands: typeof import("@fortawesome/free-brands-svg-icons");
     const Intl: typeof import("react-intl");
     const Mousetrap: typeof import("mousetrap");
+    const ReactFontAwesome: typeof import("@fortawesome/react-fontawesome");
     const ReactSelect: typeof import("react-select");
 
     // @ts-expect-error

--- a/ui/v2.5/src/pluginApi.tsx
+++ b/ui/v2.5/src/pluginApi.tsx
@@ -12,6 +12,7 @@ import * as Intl from "react-intl";
 import * as FontAwesomeSolid from "@fortawesome/free-solid-svg-icons";
 import * as FontAwesomeRegular from "@fortawesome/free-regular-svg-icons";
 import * as FontAwesomeBrands from "@fortawesome/free-brands-svg-icons";
+import * as ReactFontAwesome from "@fortawesome/react-fontawesome";
 import * as ReactSelect from "react-select";
 import { useSpriteInfo } from "./hooks/sprite";
 import { useToast } from "./hooks/Toast";
@@ -78,6 +79,7 @@ export const PluginApi = {
     FontAwesomeBrands,
     Mousetrap,
     MousetrapPause,
+    ReactFontAwesome,
     ReactSelect,
   },
   register: {


### PR DESCRIPTION
Makes the `@fortawesome/react-fontawesome` library available via the plugin API under the namespace `ReactFontAwesome`.

The library's `FontAwesomeIcon` component is already exported via the API under `components.Icon`, and this hasn't changed under this PR. However, making the whole library available makes it consistent with other available libraries, and most importantly makes it easier to unit test with. Bundling the library with a plugin adds a significant amount to the bundle size.