### PR TITLE
Fix duplicate file detection in zip archives

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -895,7 +895,8 @@ func (s *scanJob) getFileFS(f *models.BaseFile) (models.FS, error) {
 	}
 
 	zipPath := f.ZipFile.Base().Path
-	return fs.OpenZip(zipPath, f.Size)
+	zipSize := f.ZipFile.Base().Size
+	return fs.OpenZip(zipPath, zipSize)
 }
 
 func (s *scanJob) handleRename(ctx context.Context, f models.File, fp []models.Fingerprint) (models.File, error) {


### PR DESCRIPTION
When scanning a zip archive duplicate images are being detected as renames rather than duplicates.

This is because in `scanJob.getFileFS` the size of the inner file (`my_archive.zip/001.png`) is being passed to `OpenZip` rather than the size of the zip archive (`my_archive.zip`), causing it to fail when opening the archive. This causes `handleRename` to incorrectly detect it as a rename.

The effects of that are:
- no info on duplicates in the file data
- the file will take the name/path of the final duplicate scanned rather than the first