### PR TITLE
Refactor file scanning and handling logic

### DIFF
--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -100,6 +100,8 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		return 0, err
 	}
 
+	cfg := config.GetInstance()
+
 	scanner := &file.Scanner{
 		Repository: file.NewRepository(s.Repository),
 		FileDecorators: []file.Decorator{
@@ -118,6 +120,10 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		},
 		FingerprintCalculator: &fingerprintCalculator{s.Config},
 		FS:                    &file.OsFS{},
+		ZipFileExtensions:     cfg.GetGalleryExtensions(),
+		// ScanFilters is set in ScanJob.Execute
+		// HandlerRequiredFilters is set in ScanJob.Execute
+		Rescan: input.Rescan,
 	}
 
 	scanJob := ScanJob{

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -3,6 +3,10 @@ package file
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"time"
 
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/txn"
@@ -34,4 +38,24 @@ func (r *Repository) WithReadTxn(ctx context.Context, fn txn.TxnFunc) error {
 
 func (r *Repository) WithDB(ctx context.Context, fn txn.TxnFunc) error {
 	return txn.WithDatabase(ctx, r.TxnManager, fn)
+}
+
+// ModTime returns the modification time truncated to seconds.
+func ModTime(info fs.FileInfo) time.Time {
+	// truncate to seconds, since we don't store beyond that in the database
+	return info.ModTime().Truncate(time.Second)
+}
+
+// GetFileSize gets the size of the file, taking into account symlinks.
+func GetFileSize(f models.FS, path string, info fs.FileInfo) (int64, error) {
+	// #2196/#3042 - replace size with target size if file is a symlink
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		targetInfo, err := f.Stat(path)
+		if err != nil {
+			return 0, fmt.Errorf("reading info for symlink %q: %w", path, err)
+		}
+		return targetInfo.Size(), nil
+	}
+
+	return info.Size(), nil
 }

--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -75,7 +75,7 @@ func (d *folderRenameDetector) bestCandidate() *models.Folder {
 	return best.folder
 }
 
-func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.Folder, error) {
+func (s *Scanner) detectFolderMove(ctx context.Context, file ScannedFile) (*models.Folder, error) {
 	// in order for a folder to be considered moved, the existing folder must be
 	// missing, and the majority of the old folder's files must be present, unchanged,
 	// in the new folder.
@@ -88,7 +88,7 @@ func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.
 
 	r := s.Repository
 
-	if err := symWalk(file.fs, file.Path, func(path string, d fs.DirEntry, err error) error {
+	if err := SymWalk(file.FS, file.Path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// don't let errors prevent scanning
 			logger.Errorf("error scanning %s: %v", path, err)
@@ -111,11 +111,11 @@ func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.
 			return nil
 		}
 
-		if !s.acceptEntry(ctx, path, info) {
+		if !s.AcceptEntry(ctx, path, info) {
 			return nil
 		}
 
-		size, err := getFileSize(file.fs, path, info)
+		size, err := GetFileSize(file.FS, path, info)
 		if err != nil {
 			return fmt.Errorf("getting file size for %q: %w", path, err)
 		}
@@ -154,7 +154,7 @@ func (s *scanJob) detectFolderMove(ctx context.Context, file scanFile) (*models.
 				}
 
 				// parent folder must be missing
-				_, err = file.fs.Lstat(pf.Path)
+				_, err = file.FS.Lstat(pf.Path)
 				if err == nil {
 					// parent folder exists, not a candidate
 					detector.reject(parentFolderID)

--- a/pkg/file/walk.go
+++ b/pkg/file/walk.go
@@ -81,8 +81,8 @@ func walkSym(f models.FS, filename string, linkDirname string, walkFn fs.WalkDir
 	return fsWalk(f, filename, symWalkFunc)
 }
 
-// symWalk extends filepath.Walk to also follow symlinks
-func symWalk(fs models.FS, path string, walkFn fs.WalkDirFunc) error {
+// SymWalk extends filepath.Walk to also follow symlinks
+func SymWalk(fs models.FS, path string, walkFn fs.WalkDirFunc) error {
 	return walkSym(fs, path, path, walkFn)
 }
 

--- a/pkg/file/zip.go
+++ b/pkg/file/zip.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	errNotReaderAt  = errors.New("not a ReaderAt")
+	ErrNotReaderAt  = errors.New("invalid reader: does not implement io.ReaderAt")
 	errZipFSOpenZip = errors.New("cannot open zip file inside zip file")
 )
 
@@ -38,7 +38,7 @@ func newZipFS(fs models.FS, path string, size int64) (*zipFS, error) {
 	asReaderAt, _ := reader.(io.ReaderAt)
 	if asReaderAt == nil {
 		reader.Close()
-		return nil, errNotReaderAt
+		return nil, ErrNotReaderAt
 	}
 
 	zipReader, err := zip.NewReader(asReaderAt, size)


### PR DESCRIPTION
This is preparatory work for a future synchronous `scanFile` graphql interface. This PR moves the directory walking and queuing functionality out of the `file` package and into the calling scan task code. Includes removal of some vestigial functionality and some refactoring. No specific regressions are expected, but given the complexity of the scan code some regression testing will be necessary.

Closes #3800