### PR TITLE
Add latest scene sort for performers and studios.

### DIFF
--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -706,6 +706,28 @@ func (qb *PerformerStore) sortByLastOAt(direction string) string {
 	return " ORDER BY (" + selectPerformerLastOAtSQL + ") " + direction
 }
 
+// used for sorting on performer latest scene
+var selectPerformerLatestSceneSQL = utils.StrFormat(
+	"SELECT MAX(date) FROM ("+
+		"SELECT {date} FROM {performers_scenes} s "+
+		"LEFT JOIN {scenes} ON {scenes}.id = s.{scene_id} "+
+		"WHERE s.{performer_id} = {performers}.id"+
+		")",
+	map[string]interface{}{
+		"performer_id":      performerIDColumn,
+		"performers":        performerTable,
+		"performers_scenes": performersScenesTable,
+		"scenes":            sceneTable,
+		"scene_id":          sceneIDColumn,
+		"date":              sceneDateColumn,
+	},
+)
+
+func (qb *PerformerStore) sortByLatestScene(direction string) string {
+	// need to get the latest date from scenes
+	return " ORDER BY (" + selectPerformerLatestSceneSQL + ") " + direction
+}
+
 // used for sorting on performer last view_date
 var selectPerformerLastPlayedAtSQL = utils.StrFormat(
 	"SELECT MAX(view_date) FROM ("+
@@ -762,6 +784,7 @@ var performerSortOptions = sortOptions{
 	"images_count",
 	"last_o_at",
 	"last_played_at",
+	"latest_scene",
 	"measurements",
 	"name",
 	"o_counter",
@@ -812,6 +835,8 @@ func (qb *PerformerStore) getPerformerSort(findFilter *models.FindFilterType) (s
 		sortQuery += qb.sortByLastPlayedAt(direction)
 	case "last_o_at":
 		sortQuery += qb.sortByLastOAt(direction)
+	case "latest_scene":
+		sortQuery += qb.sortByLatestScene(direction)
 	default:
 		sortQuery += getSort(sort, direction, "performers")
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -26,6 +26,7 @@ const (
 	sceneTable            = "scenes"
 	scenesFilesTable      = "scenes_files"
 	sceneIDColumn         = "scene_id"
+	sceneDateColumn       = "date"
 	performersScenesTable = "performers_scenes"
 	scenesTagsTable       = "scenes_tags"
 	scenesGalleriesTable  = "scenes_galleries"

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1185,6 +1185,7 @@
   "last_o_at": "Last O At",
   "last_o_at_sfw": "Last Like At",
   "last_played_at": "Last Played At",
+  "latest_scene": "Latest Scene",
   "library": "Library",
   "loading": {
     "generic": "Loading…",

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -31,6 +31,7 @@ const sortByOptions = [
   "penis_length",
   "play_count",
   "last_played_at",
+  "latest_scene",
   "career_length",
   "weight",
   "measurements",

--- a/ui/v2.5/src/models/list-filter/studios.ts
+++ b/ui/v2.5/src/models/list-filter/studios.ts
@@ -21,6 +21,7 @@ const sortByOptions = [
   "random",
   "rating",
   "scenes_duration",
+  "latest_scene",
 ]
   .map(ListFilterOptions.createSortBy)
   .concat([


### PR DESCRIPTION
This adds a "Latest Scene" sort option for Studios and Performers (a similar option is already present in stash-box for Performers). This sorting is based on the max `date` value on associated Scenes - null values are effectively sorted as the earliest/lowest values.