### PR TITLE
Remove max-width from StudioTagger styles

### DIFF
--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -286,7 +286,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  max-width: 1600px;
 
   &-header {
     color: white;


### PR DESCRIPTION
Currently the tagger view for studios is not taking the entire space available on the screen. From blame, it looks like it never got changed since the initial implementation of the view. Not sure why it was added in the first place.

<table>
<thead>
<th>Before</th>
<th>After</th>
</thead>
<tbody>
<tr>
<td><img width="3425" height="2044" alt="Before" src="https://github.com/user-attachments/assets/8d8f1cc4-db3b-41f4-8a02-daa2f0e25502" /></td>
<td><img width="3440" height="1287" alt="After" src="https://github.com/user-attachments/assets/c12c5e04-da13-4e5e-8188-b958168bd249" /></td>
</tr>
</table>