### PR TITLE
Captions on SlimSceneData

### DIFF
--- a/ui/v2.5/graphql/data/scene-slim.graphql
+++ b/ui/v2.5/graphql/data/scene-slim.graphql
@@ -11,6 +11,10 @@ fragment SlimSceneData on Scene {
   organized
   interactive
   interactive_speed
+  captions {
+    language_code
+    caption_type
+  }
   resume_time
   play_duration
   play_count


### PR DESCRIPTION
Captions data added to `SlimSceneData` fragment.
Added to allow card UI plugins to check for captions data and add a relevant icon.