### PR TITLE
Image count on GalleryData

### DIFF
--- a/ui/v2.5/graphql/data/gallery.graphql
+++ b/ui/v2.5/graphql/data/gallery.graphql
@@ -22,7 +22,7 @@ fragment GalleryData on Gallery {
   folder {
     ...FolderData
   }
-
+  image_count
   chapters {
     ...GalleryChapterData
   }


### PR DESCRIPTION
Image count data added to `GalleryData` fragment for use by UI plugins.