### PR TITLE
Create aliases when merging performers

### DIFF
--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -939,6 +939,16 @@ AND NOT EXISTS(SELECT 1 FROM `+table+` o WHERE o.`+idColumn+` = `+table+`.`+idCo
 		}
 	}
 
+	_, err := dbWrapper.Exec(ctx, "INSERT INTO "+performersAliasesTable+" (performer_id, alias) SELECT ?, name FROM "+performerTable+" WHERE id IN "+inBinding, args...)
+	if err != nil {
+		return err
+	}
+
+	_, err = dbWrapper.Exec(ctx, "UPDATE "+performersAliasesTable+" SET performer_id = ? WHERE performer_id IN "+inBinding, args...)
+	if err != nil {
+		return err
+	}
+
 	for _, id := range source {
 		err := qb.Destroy(ctx, id)
 		if err != nil {

--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -206,13 +206,11 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
       )
     );
 
-    // default alias list should be the existing aliases, plus the names of all sources,
-    // plus all source aliases, deduplicated
+    // Default alias list should be the existing aliases, plus all source
+    // aliases, deduplicated. The backend will add the source names as
+    // aliases.
     const allAliases = uniq(
-      dest.alias_list.concat(
-        sources.map((s) => s.name),
-        sources.flatMap((s) => s.alias_list)
-      )
+      dest.alias_list.concat(sources.flatMap((s) => s.alias_list))
     );
 
     setAliases(


### PR DESCRIPTION
Follow-up to #5910. Honestly, I'm not sure why the previous way didn't work, but the new way matches how it's handled for tag merges.