### PR TITLE
Bugfix: Scene Cover Merge Removing Covers

### DIFF
--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -624,7 +624,12 @@ func (r *mutationResolver) SceneMerge(ctx context.Context, input SceneMergeInput
 			return fmt.Errorf("scene with id %d not found", destID)
 		}
 
-		return r.sceneUpdateCoverImage(ctx, ret, coverImageData)
+		// only update cover image if one was provided
+		if len(coverImageData) > 0 {
+			return r.sceneUpdateCoverImage(ctx, ret, coverImageData)
+		}
+
+		return nil
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A bug was brought up in Discord.

`
Just updated overnight and for some reason I'm losing the cover image after merging scenes together. Not sure if this has been documented yet.
`

Was confirmed by another user as well. 

Was able to fix and use the same GQL command and the cover was not deleted (expected).
