### PR TITLE
Quick fix for front page card styling

### DIFF
--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -492,3 +492,10 @@
   color: white;
   opacity: 0.75;
 }
+
+// HACK: compatibility with existing behaviour after removed width from zoom-1 class
+// this should really be changed to use the specific card types instead of a generic zoom-1 class,
+// but this is a quick fix to prevent breaking existing styles
+.recommendation-row .zoom-1 {
+  width: 320px;
+}


### PR DESCRIPTION
Fixes broken card sizing on front page. This is a quick fix as I didn't want to hunt down the specific classes and risk missing one.