### PR TITLE
Remove unused stash-box fingerprint queries

### DIFF
--- a/graphql/stash-box/query.graphql
+++ b/graphql/stash-box/query.graphql
@@ -120,12 +120,6 @@ fragment SceneFragment on Scene {
   }
 }
 
-query FindSceneByFingerprint($fingerprint: FingerprintQueryInput!) {
-  findSceneByFingerprint(fingerprint: $fingerprint) {
-    ...SceneFragment
-  }
-}
-
 query FindScenesBySceneFingerprints(
   $fingerprints: [[FingerprintQueryInput!]!]!
 ) {

--- a/graphql/stash-box/query.graphql
+++ b/graphql/stash-box/query.graphql
@@ -126,12 +126,6 @@ query FindSceneByFingerprint($fingerprint: FingerprintQueryInput!) {
   }
 }
 
-query FindScenesByFullFingerprints($fingerprints: [FingerprintQueryInput!]!) {
-  findScenesByFullFingerprints(fingerprints: $fingerprints) {
-    ...SceneFragment
-  }
-}
-
 query FindScenesBySceneFingerprints(
   $fingerprints: [[FingerprintQueryInput!]!]!
 ) {

--- a/pkg/stashbox/graphql/generated_client.go
+++ b/pkg/stashbox/graphql/generated_client.go
@@ -9,7 +9,6 @@ import (
 )
 
 type StashBoxGraphQLClient interface {
-	FindSceneByFingerprint(ctx context.Context, fingerprint FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindSceneByFingerprint, error)
 	FindScenesBySceneFingerprints(ctx context.Context, fingerprints [][]*FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindScenesBySceneFingerprints, error)
 	SearchScene(ctx context.Context, term string, interceptors ...clientv2.RequestInterceptor) (*SearchScene, error)
 	SearchPerformer(ctx context.Context, term string, interceptors ...clientv2.RequestInterceptor) (*SearchPerformer, error)
@@ -535,24 +534,6 @@ func (t *SceneFragment_Studio_StudioFragment_Parent) GetName() string {
 	return t.Name
 }
 
-type FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_StudioFragment_Parent struct {
-	ID   string "json:\"id\" graphql:\"id\""
-	Name string "json:\"name\" graphql:\"name\""
-}
-
-func (t *FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_StudioFragment_Parent) GetID() string {
-	if t == nil {
-		t = &FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_StudioFragment_Parent{}
-	}
-	return t.ID
-}
-func (t *FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_StudioFragment_Parent) GetName() string {
-	if t == nil {
-		t = &FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_StudioFragment_Parent{}
-	}
-	return t.Name
-}
-
 type FindScenesBySceneFingerprints_FindScenesBySceneFingerprints_SceneFragment_Studio_StudioFragment_Parent struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
@@ -674,17 +655,6 @@ func (t *SubmitPerformerDraft_SubmitPerformerDraft) GetID() *string {
 		t = &SubmitPerformerDraft_SubmitPerformerDraft{}
 	}
 	return t.ID
-}
-
-type FindSceneByFingerprint struct {
-	FindSceneByFingerprint []*SceneFragment "json:\"findSceneByFingerprint\" graphql:\"findSceneByFingerprint\""
-}
-
-func (t *FindSceneByFingerprint) GetFindSceneByFingerprint() []*SceneFragment {
-	if t == nil {
-		t = &FindSceneByFingerprint{}
-	}
-	return t.FindSceneByFingerprint
 }
 
 type FindScenesBySceneFingerprints struct {
@@ -817,142 +787,6 @@ func (t *SubmitPerformerDraft) GetSubmitPerformerDraft() *SubmitPerformerDraft_S
 		t = &SubmitPerformerDraft{}
 	}
 	return &t.SubmitPerformerDraft
-}
-
-const FindSceneByFingerprintDocument = `query FindSceneByFingerprint ($fingerprint: FingerprintQueryInput!) {
-	findSceneByFingerprint(fingerprint: $fingerprint) {
-		... SceneFragment
-	}
-}
-fragment SceneFragment on Scene {
-	id
-	title
-	code
-	details
-	director
-	duration
-	date
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	studio {
-		... StudioFragment
-	}
-	tags {
-		... TagFragment
-	}
-	performers {
-		... PerformerAppearanceFragment
-	}
-	fingerprints {
-		... FingerprintFragment
-	}
-}
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment ImageFragment on Image {
-	id
-	url
-	width
-	height
-}
-fragment StudioFragment on Studio {
-	name
-	id
-	aliases
-	urls {
-		... URLFragment
-	}
-	parent {
-		name
-		id
-	}
-	images {
-		... ImageFragment
-	}
-}
-fragment TagFragment on Tag {
-	name
-	id
-}
-fragment PerformerAppearanceFragment on PerformerAppearance {
-	as
-	performer {
-		... PerformerFragment
-	}
-}
-fragment PerformerFragment on Performer {
-	id
-	name
-	disambiguation
-	aliases
-	gender
-	merged_ids
-	deleted
-	merged_into_id
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	birth_date
-	death_date
-	ethnicity
-	country
-	eye_color
-	hair_color
-	height
-	measurements {
-		... MeasurementsFragment
-	}
-	breast_type
-	career_start_year
-	career_end_year
-	tattoos {
-		... BodyModificationFragment
-	}
-	piercings {
-		... BodyModificationFragment
-	}
-}
-fragment MeasurementsFragment on Measurements {
-	band_size
-	cup_size
-	waist
-	hip
-}
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
-}
-fragment FingerprintFragment on Fingerprint {
-	algorithm
-	hash
-	duration
-}
-`
-
-func (c *Client) FindSceneByFingerprint(ctx context.Context, fingerprint FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindSceneByFingerprint, error) {
-	vars := map[string]any{
-		"fingerprint": fingerprint,
-	}
-
-	var res FindSceneByFingerprint
-	if err := c.Client.Post(ctx, "FindSceneByFingerprint", FindSceneByFingerprintDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
 }
 
 const FindScenesBySceneFingerprintsDocument = `query FindScenesBySceneFingerprints ($fingerprints: [[FingerprintQueryInput!]!]!) {
@@ -1724,7 +1558,6 @@ func (c *Client) SubmitPerformerDraft(ctx context.Context, input PerformerDraftI
 }
 
 var DocumentOperationNames = map[string]string{
-	FindSceneByFingerprintDocument:        "FindSceneByFingerprint",
 	FindScenesBySceneFingerprintsDocument: "FindScenesBySceneFingerprints",
 	SearchSceneDocument:                   "SearchScene",
 	SearchPerformerDocument:               "SearchPerformer",

--- a/pkg/stashbox/graphql/generated_client.go
+++ b/pkg/stashbox/graphql/generated_client.go
@@ -10,7 +10,6 @@ import (
 
 type StashBoxGraphQLClient interface {
 	FindSceneByFingerprint(ctx context.Context, fingerprint FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindSceneByFingerprint, error)
-	FindScenesByFullFingerprints(ctx context.Context, fingerprints []*FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindScenesByFullFingerprints, error)
 	FindScenesBySceneFingerprints(ctx context.Context, fingerprints [][]*FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindScenesBySceneFingerprints, error)
 	SearchScene(ctx context.Context, term string, interceptors ...clientv2.RequestInterceptor) (*SearchScene, error)
 	SearchPerformer(ctx context.Context, term string, interceptors ...clientv2.RequestInterceptor) (*SearchPerformer, error)
@@ -554,24 +553,6 @@ func (t *FindSceneByFingerprint_FindSceneByFingerprint_SceneFragment_Studio_Stud
 	return t.Name
 }
 
-type FindScenesByFullFingerprints_FindScenesByFullFingerprints_SceneFragment_Studio_StudioFragment_Parent struct {
-	ID   string "json:\"id\" graphql:\"id\""
-	Name string "json:\"name\" graphql:\"name\""
-}
-
-func (t *FindScenesByFullFingerprints_FindScenesByFullFingerprints_SceneFragment_Studio_StudioFragment_Parent) GetID() string {
-	if t == nil {
-		t = &FindScenesByFullFingerprints_FindScenesByFullFingerprints_SceneFragment_Studio_StudioFragment_Parent{}
-	}
-	return t.ID
-}
-func (t *FindScenesByFullFingerprints_FindScenesByFullFingerprints_SceneFragment_Studio_StudioFragment_Parent) GetName() string {
-	if t == nil {
-		t = &FindScenesByFullFingerprints_FindScenesByFullFingerprints_SceneFragment_Studio_StudioFragment_Parent{}
-	}
-	return t.Name
-}
-
 type FindScenesBySceneFingerprints_FindScenesBySceneFingerprints_SceneFragment_Studio_StudioFragment_Parent struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
@@ -704,17 +685,6 @@ func (t *FindSceneByFingerprint) GetFindSceneByFingerprint() []*SceneFragment {
 		t = &FindSceneByFingerprint{}
 	}
 	return t.FindSceneByFingerprint
-}
-
-type FindScenesByFullFingerprints struct {
-	FindScenesByFullFingerprints []*SceneFragment "json:\"findScenesByFullFingerprints\" graphql:\"findScenesByFullFingerprints\""
-}
-
-func (t *FindScenesByFullFingerprints) GetFindScenesByFullFingerprints() []*SceneFragment {
-	if t == nil {
-		t = &FindScenesByFullFingerprints{}
-	}
-	return t.FindScenesByFullFingerprints
 }
 
 type FindScenesBySceneFingerprints struct {
@@ -975,142 +945,6 @@ func (c *Client) FindSceneByFingerprint(ctx context.Context, fingerprint Fingerp
 
 	var res FindSceneByFingerprint
 	if err := c.Client.Post(ctx, "FindSceneByFingerprint", FindSceneByFingerprintDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
-}
-
-const FindScenesByFullFingerprintsDocument = `query FindScenesByFullFingerprints ($fingerprints: [FingerprintQueryInput!]!) {
-	findScenesByFullFingerprints(fingerprints: $fingerprints) {
-		... SceneFragment
-	}
-}
-fragment SceneFragment on Scene {
-	id
-	title
-	code
-	details
-	director
-	duration
-	date
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	studio {
-		... StudioFragment
-	}
-	tags {
-		... TagFragment
-	}
-	performers {
-		... PerformerAppearanceFragment
-	}
-	fingerprints {
-		... FingerprintFragment
-	}
-}
-fragment URLFragment on URL {
-	url
-	type
-}
-fragment ImageFragment on Image {
-	id
-	url
-	width
-	height
-}
-fragment StudioFragment on Studio {
-	name
-	id
-	aliases
-	urls {
-		... URLFragment
-	}
-	parent {
-		name
-		id
-	}
-	images {
-		... ImageFragment
-	}
-}
-fragment TagFragment on Tag {
-	name
-	id
-}
-fragment PerformerAppearanceFragment on PerformerAppearance {
-	as
-	performer {
-		... PerformerFragment
-	}
-}
-fragment PerformerFragment on Performer {
-	id
-	name
-	disambiguation
-	aliases
-	gender
-	merged_ids
-	deleted
-	merged_into_id
-	urls {
-		... URLFragment
-	}
-	images {
-		... ImageFragment
-	}
-	birth_date
-	death_date
-	ethnicity
-	country
-	eye_color
-	hair_color
-	height
-	measurements {
-		... MeasurementsFragment
-	}
-	breast_type
-	career_start_year
-	career_end_year
-	tattoos {
-		... BodyModificationFragment
-	}
-	piercings {
-		... BodyModificationFragment
-	}
-}
-fragment MeasurementsFragment on Measurements {
-	band_size
-	cup_size
-	waist
-	hip
-}
-fragment BodyModificationFragment on BodyModification {
-	location
-	description
-}
-fragment FingerprintFragment on Fingerprint {
-	algorithm
-	hash
-	duration
-}
-`
-
-func (c *Client) FindScenesByFullFingerprints(ctx context.Context, fingerprints []*FingerprintQueryInput, interceptors ...clientv2.RequestInterceptor) (*FindScenesByFullFingerprints, error) {
-	vars := map[string]any{
-		"fingerprints": fingerprints,
-	}
-
-	var res FindScenesByFullFingerprints
-	if err := c.Client.Post(ctx, "FindScenesByFullFingerprints", FindScenesByFullFingerprintsDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -1891,7 +1725,6 @@ func (c *Client) SubmitPerformerDraft(ctx context.Context, input PerformerDraftI
 
 var DocumentOperationNames = map[string]string{
 	FindSceneByFingerprintDocument:        "FindSceneByFingerprint",
-	FindScenesByFullFingerprintsDocument:  "FindScenesByFullFingerprints",
 	FindScenesBySceneFingerprintsDocument: "FindScenesBySceneFingerprints",
 	SearchSceneDocument:                   "SearchScene",
 	SearchPerformerDocument:               "SearchPerformer",


### PR DESCRIPTION
This query has been deprecated for ages, and is not in use in stash. I'm removing from stash-box, so we should remove it here as well.

EDIT: Also removes `findSceneByFingerprint`. Querying for a single fingerprint is not useful and not in use.