### PR TITLE
Set default card width before container width is calculated

### DIFF
--- a/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
+++ b/ui/v2.5/src/components/Shared/GridCard/GridCard.tsx
@@ -89,14 +89,21 @@ export function useCardWidth(
   zoomWidths: number[]
 ) {
   return useMemo(() => {
+    if (ScreenUtils.isMobile()) {
+      return;
+    }
+
     if (
-      !containerWidth ||
       zoomIndex === undefined ||
       zoomIndex < 0 ||
-      zoomIndex >= zoomWidths.length ||
-      ScreenUtils.isMobile()
+      zoomIndex >= zoomWidths.length
     )
       return;
+
+    // use a default card width if we don't have the container width yet
+    if (!containerWidth) {
+      return zoomWidths[zoomIndex];
+    }
 
     let zoomValue = zoomIndex;
     const preferredCardWidth = zoomWidths[zoomValue];


### PR DESCRIPTION
Fixes issue where cards would appear without a maximum width briefly before the container width is calculated.