### PR TITLE
[Feature] Reveal file in system file manager from file info panel

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -426,6 +426,10 @@ type Mutation {
   destroyFiles(ids: [ID!]!): Boolean!
 
   fileSetFingerprints(input: FileSetFingerprintsInput!): Boolean!
+  "Reveal the file in the system file manager"
+  revealFileInFileManager(id: ID!): Boolean!
+  "Reveal the folder in the system file manager"
+  revealFolderInFileManager(id: ID!): Boolean!
 
   # Saved filters
   saveFilter(input: SaveFilterInput!): SavedFilter!

--- a/internal/api/authentication.go
+++ b/internal/api/authentication.go
@@ -40,6 +40,8 @@ func authenticateHandler() func(http.Handler) http.Handler {
 				return
 			}
 
+			r = session.SetLocalRequest(r)
+
 			userID, err := manager.GetInstance().SessionStore.Authenticate(w, r)
 			if err != nil {
 				if !errors.Is(err, session.ErrUnauthorized) {

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/stashapp/stash/internal/desktop"
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/fsutil"
@@ -324,5 +325,55 @@ func (r *mutationResolver) FileSetFingerprints(ctx context.Context, input FileSe
 		return false, err
 	}
 
+	return true, nil
+}
+
+func (r *mutationResolver) RevealFileInFileManager(ctx context.Context, id string) (bool, error) {
+	fileIDInt, err := strconv.Atoi(id)
+	if err != nil {
+		return false, fmt.Errorf("converting id: %w", err)
+	}
+
+	var filePath string
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		files, err := r.repository.File.Find(ctx, models.FileID(fileIDInt))
+		if err != nil {
+			return fmt.Errorf("finding file: %w", err)
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("file with id %d not found", fileIDInt)
+		}
+		filePath = files[0].Base().Path
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	desktop.RevealInFileManager(filePath)
+	return true, nil
+}
+
+func (r *mutationResolver) RevealFolderInFileManager(ctx context.Context, id string) (bool, error) {
+	folderIDInt, err := strconv.Atoi(id)
+	if err != nil {
+		return false, fmt.Errorf("converting id: %w", err)
+	}
+
+	var folderPath string
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		folder, err := r.repository.Folder.Find(ctx, models.FolderID(folderIDInt))
+		if err != nil {
+			return fmt.Errorf("finding folder: %w", err)
+		}
+		if folder == nil {
+			return fmt.Errorf("folder with id %d not found", folderIDInt)
+		}
+		folderPath = folder.Path
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	desktop.RevealInFileManager(folderPath)
 	return true, nil
 }

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/fsutil"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/session"
 	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 )
 
@@ -329,6 +331,12 @@ func (r *mutationResolver) FileSetFingerprints(ctx context.Context, input FileSe
 }
 
 func (r *mutationResolver) RevealFileInFileManager(ctx context.Context, id string) (bool, error) {
+	// disallow if request did not come from localhost
+	if !session.IsLocalRequest(ctx) {
+		logger.Warnf("Attempt to reveal file in file manager from non-local request")
+		return false, fmt.Errorf("access denied")
+	}
+
 	fileIDInt, err := strconv.Atoi(id)
 	if err != nil {
 		return false, fmt.Errorf("converting id: %w", err)
@@ -354,6 +362,12 @@ func (r *mutationResolver) RevealFileInFileManager(ctx context.Context, id strin
 }
 
 func (r *mutationResolver) RevealFolderInFileManager(ctx context.Context, id string) (bool, error) {
+	// disallow if request did not come from localhost
+	if !session.IsLocalRequest(ctx) {
+		logger.Warnf("Attempt to reveal folder in file manager from non-local request")
+		return false, fmt.Errorf("access denied")
+	}
+
 	folderIDInt, err := strconv.Atoi(id)
 	if err != nil {
 		return false, fmt.Errorf("converting id: %w", err)

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -357,7 +357,10 @@ func (r *mutationResolver) RevealFileInFileManager(ctx context.Context, id strin
 		return false, err
 	}
 
-	desktop.RevealInFileManager(filePath)
+	if err := desktop.RevealInFileManager(filePath); err != nil {
+		return false, err
+	}
+
 	return true, nil
 }
 
@@ -388,6 +391,9 @@ func (r *mutationResolver) RevealFolderInFileManager(ctx context.Context, id str
 		return false, err
 	}
 
-	desktop.RevealInFileManager(folderPath)
+	if err := desktop.RevealInFileManager(folderPath); err != nil {
+		return false, err
+	}
+
 	return true, nil
 }

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -156,14 +156,14 @@ func getIconPath() string {
 }
 
 func RevealInFileManager(path string) {
-	exists, err := fsutil.FileExists(path)
-	if err != nil {
-		logger.Errorf("Error checking file: %s", err)
+	if !IsDesktop() {
 		return
 	}
-	if exists && IsDesktop() {
-		revealInFileManager(path)
+	if _, err := os.Stat(path); err != nil {
+		logger.Errorf("Error checking path: %s", err)
+		return
 	}
+	revealInFileManager(path)
 }
 
 func getServerURL(path string) string {

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -156,7 +156,8 @@ func getIconPath() string {
 }
 
 func RevealInFileManager(path string) {
-	if _, err := os.Stat(path); err != nil {
+	info, err := os.Stat(path)
+	if err != nil {
 		logger.Errorf("Error checking path: %s", err)
 		return
 	}
@@ -166,7 +167,7 @@ func RevealInFileManager(path string) {
 		logger.Errorf("Error getting absolute path: %s", err)
 		return
 	}
-	revealInFileManager(absPath)
+	revealInFileManager(absPath, info)
 }
 
 func getServerURL(path string) string {

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -156,14 +156,17 @@ func getIconPath() string {
 }
 
 func RevealInFileManager(path string) {
-	if !IsDesktop() {
-		return
-	}
 	if _, err := os.Stat(path); err != nil {
 		logger.Errorf("Error checking path: %s", err)
 		return
 	}
-	revealInFileManager(path)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		logger.Errorf("Error getting absolute path: %s", err)
+		return
+	}
+	revealInFileManager(absPath)
 }
 
 func getServerURL(path string) string {

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -2,6 +2,7 @@
 package desktop
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -155,19 +156,17 @@ func getIconPath() string {
 	return path.Join(config.GetInstance().GetConfigPath(), "icon.png")
 }
 
-func RevealInFileManager(path string) {
+func RevealInFileManager(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
-		logger.Errorf("Error checking path: %s", err)
-		return
+		return fmt.Errorf("error checking path: %w", err)
 	}
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		logger.Errorf("Error getting absolute path: %s", err)
-		return
+		return fmt.Errorf("error getting absolute path: %w", err)
 	}
-	revealInFileManager(absPath, info)
+	return revealInFileManager(absPath, info)
 }
 
 func getServerURL(path string) string {

--- a/internal/desktop/desktop_platform_darwin.go
+++ b/internal/desktop/desktop_platform_darwin.go
@@ -4,10 +4,11 @@
 package desktop
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
-	"github.com/kermieisinthehouse/gosx-notifier"
+	gosxnotifier "github.com/kermieisinthehouse/gosx-notifier"
 	"github.com/stashapp/stash/pkg/logger"
 )
 
@@ -33,10 +34,11 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string, _ os.FileInfo) {
+func revealInFileManager(path string, _ os.FileInfo) error {
 	if err := exec.Command(`open`, `-R`, path).Run(); err != nil {
-		logger.Errorf("Error revealing path in Finder: %s", err.Error())
+		return fmt.Errorf("error revealing path in Finder: %w", err)
 	}
+	return nil
 }
 
 func isDoubleClickLaunched() bool {

--- a/internal/desktop/desktop_platform_darwin.go
+++ b/internal/desktop/desktop_platform_darwin.go
@@ -4,6 +4,7 @@
 package desktop
 
 import (
+	"os"
 	"os/exec"
 
 	"github.com/kermieisinthehouse/gosx-notifier"
@@ -32,7 +33,7 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string) {
+func revealInFileManager(path string, _ os.FileInfo) {
 	if err := exec.Command(`open`, `-R`, path).Run(); err != nil {
 		logger.Errorf("Error revealing path in Finder: %s", err.Error())
 	}

--- a/internal/desktop/desktop_platform_darwin.go
+++ b/internal/desktop/desktop_platform_darwin.go
@@ -33,7 +33,9 @@ func sendNotification(notificationTitle string, notificationText string) {
 }
 
 func revealInFileManager(path string) {
-	exec.Command(`open`, `-R`, path)
+	if err := exec.Command(`open`, `-R`, path).Run(); err != nil {
+		logger.Errorf("Error revealing path in Finder: %s", err.Error())
+	}
 }
 
 func isDoubleClickLaunched() bool {

--- a/internal/desktop/desktop_platform_nixes.go
+++ b/internal/desktop/desktop_platform_nixes.go
@@ -4,6 +4,7 @@
 package desktop
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,14 +35,15 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string, info os.FileInfo) {
+func revealInFileManager(path string, info os.FileInfo) error {
 	dir := path
 	if !info.IsDir() {
 		dir = filepath.Dir(path)
 	}
 	if err := exec.Command("xdg-open", dir).Run(); err != nil {
-		logger.Errorf("Error opening directory in file manager: %s", err.Error())
+		return fmt.Errorf("error opening directory in file manager: %w", err)
 	}
+	return nil
 }
 
 func isDoubleClickLaunched() bool {

--- a/internal/desktop/desktop_platform_nixes.go
+++ b/internal/desktop/desktop_platform_nixes.go
@@ -34,9 +34,9 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string) {
+func revealInFileManager(path string, info os.FileInfo) {
 	dir := path
-	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+	if !info.IsDir() {
 		dir = filepath.Dir(path)
 	}
 	if err := exec.Command("xdg-open", dir).Run(); err != nil {

--- a/internal/desktop/desktop_platform_nixes.go
+++ b/internal/desktop/desktop_platform_nixes.go
@@ -6,6 +6,7 @@ package desktop
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/stashapp/stash/pkg/logger"
@@ -34,7 +35,13 @@ func sendNotification(notificationTitle string, notificationText string) {
 }
 
 func revealInFileManager(path string) {
-
+	dir := path
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		dir = filepath.Dir(path)
+	}
+	if err := exec.Command("xdg-open", dir).Run(); err != nil {
+		logger.Errorf("Error opening directory in file manager: %s", err.Error())
+	}
 }
 
 func isDoubleClickLaunched() bool {

--- a/internal/desktop/desktop_platform_windows.go
+++ b/internal/desktop/desktop_platform_windows.go
@@ -84,7 +84,8 @@ func sendNotification(notificationTitle string, notificationText string) {
 }
 
 func revealInFileManager(path string) {
-	if err := exec.Command(`explorer`, `/select,`+path).Run(); err != nil {
-		logger.Errorf("Error revealing path in Explorer: %s", err.Error())
-	}
+	c := exec.Command(`explorer`, `/select,`, path)
+	logger.Debugf("Running: %s", c.String())
+	// explorer seems to return an error code even when it works, so ignore the error
+	_ = c.Run()
 }

--- a/internal/desktop/desktop_platform_windows.go
+++ b/internal/desktop/desktop_platform_windows.go
@@ -84,9 +84,10 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string, _ os.FileInfo) {
+func revealInFileManager(path string, _ os.FileInfo) error {
 	c := exec.Command(`explorer`, `/select,`, path)
 	logger.Debugf("Running: %s", c.String())
 	// explorer seems to return an error code even when it works, so ignore the error
 	_ = c.Run()
+	return nil
 }

--- a/internal/desktop/desktop_platform_windows.go
+++ b/internal/desktop/desktop_platform_windows.go
@@ -4,6 +4,7 @@
 package desktop
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 	"unsafe"
@@ -83,7 +84,7 @@ func sendNotification(notificationTitle string, notificationText string) {
 	}
 }
 
-func revealInFileManager(path string) {
+func revealInFileManager(path string, _ os.FileInfo) {
 	c := exec.Command(`explorer`, `/select,`, path)
 	logger.Debugf("Running: %s", c.String())
 	// explorer seems to return an error code even when it works, so ignore the error

--- a/internal/desktop/desktop_platform_windows.go
+++ b/internal/desktop/desktop_platform_windows.go
@@ -84,5 +84,7 @@ func sendNotification(notificationTitle string, notificationText string) {
 }
 
 func revealInFileManager(path string) {
-	exec.Command(`explorer`, `\select`, path)
+	if err := exec.Command(`explorer`, `/select,`+path).Run(); err != nil {
+		logger.Errorf("Error revealing path in Explorer: %s", err.Error())
+	}
 }

--- a/pkg/session/local.go
+++ b/pkg/session/local.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/stashapp/stash/pkg/logger"
+)
+
+// SetLocalRequest checks if the request is from localhost and sets the context value accordingly.
+// It returns the modified request with the updated context, or the original request if it did
+// not come from localhost or if there was an error parsing the remote address.
+func SetLocalRequest(r *http.Request) *http.Request {
+	// determine if request is from localhost
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		logger.Errorf("Error parsing remote address: %v", err)
+		return r
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		logger.Errorf("Error parsing IP address: %s", host)
+		return r
+	}
+
+	if ip.IsLoopback() {
+		ctx := context.WithValue(r.Context(), contextLocalRequest, true)
+		r = r.WithContext(ctx)
+	}
+
+	return r
+}
+
+// IsLocalRequest returns true if the request is from localhost, as determined by the context value set by SetLocalRequest.
+// If the context value is not set, it returns false.
+func IsLocalRequest(ctx context.Context) bool {
+	val := ctx.Value(contextLocalRequest)
+	if val == nil {
+		return false
+	}
+	return val.(bool)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -15,6 +15,7 @@ type key int
 const (
 	contextUser key = iota
 	contextVisitedPlugins
+	contextLocalRequest
 )
 
 const (

--- a/ui/v2.5/graphql/mutations/file.graphql
+++ b/ui/v2.5/graphql/mutations/file.graphql
@@ -1,3 +1,11 @@
 mutation DeleteFiles($ids: [ID!]!) {
   deleteFiles(ids: $ids)
 }
+
+mutation RevealFileInFileManager($id: ID!) {
+  revealFileInFileManager(id: $id)
+}
+
+mutation RevealFolderInFileManager($id: ID!) {
+  revealFolderInFileManager(id: $id)
+}

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
@@ -1,16 +1,11 @@
 import React, { useMemo, useState } from "react";
 import { Accordion, Button, Card } from "react-bootstrap";
 import { FormattedMessage, FormattedTime } from "react-intl";
-import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
-import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
+import { RevealInFilesystemButton } from "src/components/Shared/RevealInFilesystemButton";
 import * as GQL from "src/core/generated-graphql";
-import {
-  mutateGallerySetPrimaryFile,
-  mutateRevealFileInFileManager,
-  mutateRevealFolderInFileManager,
-} from "src/core/StashService";
+import { mutateGallerySetPrimaryFile } from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import TextUtils from "src/utils/text";
 import { TextField, URLsField } from "src/utils/field";
@@ -47,19 +42,10 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
         <TextField id={id}>
           <span className="d-flex align-items-center">
             <TruncatedText text={path} />
-            <Button
-              className="minimal ml-1"
-              title="Reveal in file manager"
-              onClick={() => {
-                if (props.folder) {
-                  mutateRevealFolderInFileManager(props.folder.id);
-                } else if (props.file) {
-                  mutateRevealFileInFileManager(props.file.id);
-                }
-              }}
-            >
-              <Icon icon={faFolderOpen} />
-            </Button>
+            <RevealInFilesystemButton
+              folderId={props.folder?.id}
+              fileId={props.file?.id}
+            />
           </span>
         </TextField>
         {props.file && (

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryFileInfoPanel.tsx
@@ -1,13 +1,19 @@
 import React, { useMemo, useState } from "react";
 import { Accordion, Button, Card } from "react-bootstrap";
 import { FormattedMessage, FormattedTime } from "react-intl";
+import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
+import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
 import * as GQL from "src/core/generated-graphql";
-import { mutateGallerySetPrimaryFile } from "src/core/StashService";
+import {
+  mutateGallerySetPrimaryFile,
+  mutateRevealFileInFileManager,
+  mutateRevealFolderInFileManager,
+} from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import TextUtils from "src/utils/text";
-import { TextField, URLField, URLsField } from "src/utils/field";
+import { TextField, URLsField } from "src/utils/field";
 
 interface IFileInfoPanelProps {
   folder?: Pick<GQL.Folder, "id" | "path">;
@@ -38,12 +44,24 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
           </>
         )}
         <TextField id="media_info.checksum" value={checksum?.value} truncate />
-        <URLField
-          id={id}
-          url={`file://${path}`}
-          value={`file://${path}`}
-          truncate
-        />
+        <TextField id={id}>
+          <span className="d-flex align-items-center">
+            <TruncatedText text={path} />
+            <Button
+              className="minimal ml-1"
+              title="Reveal in file manager"
+              onClick={() => {
+                if (props.folder) {
+                  mutateRevealFolderInFileManager(props.folder.id);
+                } else if (props.file) {
+                  mutateRevealFileInFileManager(props.file.id);
+                }
+              }}
+            >
+              <Icon icon={faFolderOpen} />
+            </Button>
+          </span>
+        </TextField>
         {props.file && (
           <TextField id="file_mod_time">
             <FormattedTime

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageFileInfoPanel.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from "react";
 import { Accordion, Button, Card } from "react-bootstrap";
 import { FormattedMessage, FormattedTime } from "react-intl";
+import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
+import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
 import * as GQL from "src/core/generated-graphql";
-import { mutateImageSetPrimaryFile } from "src/core/StashService";
+import {
+  mutateImageSetPrimaryFile,
+  mutateRevealFileInFileManager,
+} from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import TextUtils from "src/utils/text";
 import { TextField, URLField, URLsField } from "src/utils/field";
@@ -47,12 +52,18 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
           truncate
           internal
         />
-        <URLField
-          id="path"
-          url={`file://${props.file.path}`}
-          value={`file://${props.file.path}`}
-          truncate
-        />
+        <TextField id="path">
+          <span className="d-flex align-items-center">
+            <TruncatedText text={props.file.path} />
+            <Button
+              className="minimal ml-1"
+              title="Reveal in file manager"
+              onClick={() => mutateRevealFileInFileManager(props.file.id)}
+            >
+              <Icon icon={faFolderOpen} />
+            </Button>
+          </span>
+        </TextField>
         <TextField id="filesize">
           <span className="text-truncate">
             <FileSize size={props.file.size} />

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageFileInfoPanel.tsx
@@ -1,15 +1,11 @@
 import React, { useState } from "react";
 import { Accordion, Button, Card } from "react-bootstrap";
 import { FormattedMessage, FormattedTime } from "react-intl";
-import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
-import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
+import { RevealInFilesystemButton } from "src/components/Shared/RevealInFilesystemButton";
 import * as GQL from "src/core/generated-graphql";
-import {
-  mutateImageSetPrimaryFile,
-  mutateRevealFileInFileManager,
-} from "src/core/StashService";
+import { mutateImageSetPrimaryFile } from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import TextUtils from "src/utils/text";
 import { TextField, URLField, URLsField } from "src/utils/field";
@@ -55,13 +51,7 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
         <TextField id="path">
           <span className="d-flex align-items-center">
             <TruncatedText text={props.file.path} />
-            <Button
-              className="minimal ml-1"
-              title="Reveal in file manager"
-              onClick={() => mutateRevealFileInFileManager(props.file.id)}
-            >
-              <Icon icon={faFolderOpen} />
-            </Button>
+            <RevealInFilesystemButton fileId={props.file.id} />
           </span>
         </TextField>
         <TextField id="filesize">

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -7,11 +7,16 @@ import {
   useIntl,
 } from "react-intl";
 import { useHistory } from "react-router-dom";
+import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
+import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
 import { ReassignFilesDialog } from "src/components/Shared/ReassignFilesDialog";
 import * as GQL from "src/core/generated-graphql";
-import { mutateSceneSetPrimaryFile } from "src/core/StashService";
+import {
+  mutateSceneSetPrimaryFile,
+  mutateRevealFileInFileManager,
+} from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
@@ -70,12 +75,18 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
           truncate
           internal
         />
-        <URLField
-          id="path"
-          url={`file://${props.file.path}`}
-          value={`file://${props.file.path}`}
-          truncate
-        />
+        <TextField id="path">
+          <span className="d-flex align-items-center">
+            <TruncatedText text={props.file.path} />
+            <Button
+              className="minimal ml-1"
+              title="Reveal in file manager"
+              onClick={() => mutateRevealFileInFileManager(props.file.id)}
+            >
+              <Icon icon={faFolderOpen} />
+            </Button>
+          </span>
+        </TextField>
         <TextField id="filesize">
           <span className="text-truncate">
             <FileSize size={props.file.size} />

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -7,16 +7,12 @@ import {
   useIntl,
 } from "react-intl";
 import { useHistory } from "react-router-dom";
-import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
-import { Icon } from "src/components/Shared/Icon";
 import { DeleteFilesDialog } from "src/components/Shared/DeleteFilesDialog";
+import { RevealInFilesystemButton } from "src/components/Shared/RevealInFilesystemButton";
 import { ReassignFilesDialog } from "src/components/Shared/ReassignFilesDialog";
 import * as GQL from "src/core/generated-graphql";
-import {
-  mutateSceneSetPrimaryFile,
-  mutateRevealFileInFileManager,
-} from "src/core/StashService";
+import { mutateSceneSetPrimaryFile } from "src/core/StashService";
 import { useToast } from "src/hooks/Toast";
 import NavUtils from "src/utils/navigation";
 import TextUtils from "src/utils/text";
@@ -78,13 +74,7 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
         <TextField id="path">
           <span className="d-flex align-items-center">
             <TruncatedText text={props.file.path} />
-            <Button
-              className="minimal ml-1"
-              title="Reveal in file manager"
-              onClick={() => mutateRevealFileInFileManager(props.file.id)}
-            >
-              <Icon icon={faFolderOpen} />
-            </Button>
+            <RevealInFilesystemButton fileId={props.file.id} />
           </span>
         </TextField>
         <TextField id="filesize">

--- a/ui/v2.5/src/components/Shared/RevealInFilesystemButton.tsx
+++ b/ui/v2.5/src/components/Shared/RevealInFilesystemButton.tsx
@@ -38,7 +38,7 @@ export const RevealInFilesystemButton: React.FC<
 
   return (
     <Button
-      className="minimal ml-1"
+      className="minimal reveal-in-filesystem-button"
       title={intl.formatMessage({ id: "actions.reveal_in_file_manager" })}
       onClick={onClick}
     >

--- a/ui/v2.5/src/components/Shared/RevealInFilesystemButton.tsx
+++ b/ui/v2.5/src/components/Shared/RevealInFilesystemButton.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
+import { useIntl } from "react-intl";
+import { Icon } from "./Icon";
+import {
+  mutateRevealFileInFileManager,
+  mutateRevealFolderInFileManager,
+} from "src/core/StashService";
+import { getPlatformURL } from "src/core/createClient";
+
+interface IRevealInFilesystemButtonProps {
+  fileId?: string;
+  folderId?: string;
+}
+
+function isLocalhost(): boolean {
+  const { hostname } = getPlatformURL();
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+}
+
+export const RevealInFilesystemButton: React.FC<
+  IRevealInFilesystemButtonProps
+> = ({ fileId, folderId }) => {
+  const intl = useIntl();
+
+  if (!isLocalhost()) return null;
+
+  function onClick() {
+    if (folderId) {
+      mutateRevealFolderInFileManager(folderId);
+    } else if (fileId) {
+      mutateRevealFileInFileManager(fileId);
+    }
+  }
+
+  return (
+    <Button
+      className="minimal ml-1"
+      title={intl.formatMessage({ id: "actions.reveal_in_file_manager" })}
+      onClick={onClick}
+    >
+      <Icon icon={faFolderOpen} />
+    </Button>
+  );
+};

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -1204,3 +1204,8 @@ input[type="range"].double-range-slider-max {
     overflow-y: auto;
   }
 }
+
+.reveal-in-filesystem-button {
+  margin-left: 0.25rem;
+  padding: 0 0.25rem;
+}

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2248,6 +2248,18 @@ export const mutateDeleteFiles = (ids: string[]) =>
     },
   });
 
+export const mutateRevealFileInFileManager = (id: string) =>
+  client.mutate<GQL.RevealFileInFileManagerMutation>({
+    mutation: GQL.RevealFileInFileManagerDocument,
+    variables: { id },
+  });
+
+export const mutateRevealFolderInFileManager = (id: string) =>
+  client.mutate<GQL.RevealFolderInFileManagerMutation>({
+    mutation: GQL.RevealFolderInFileManagerDocument,
+    variables: { id },
+  });
+
 /// Scrapers
 
 export const useListSceneScrapers = () => GQL.useListSceneScrapersQuery();

--- a/ui/v2.5/src/docs/en/Manual/Browsing.md
+++ b/ui/v2.5/src/docs/en/Manual/Browsing.md
@@ -50,3 +50,9 @@ Saved filters are sorted alphabetically by title with capitalized titles sorted 
 ### Default filter
 
 The default filter for the top-level pages may be set to the current filter by clicking the `Set as default` button in the saved filter menu.
+
+## Reveal file in file manager
+
+The `Reveal in file manager` action is available for file-based scenes, galleries and images in the `File Info` tab. This action will open the file manager to the location of the file on disk. The file will be selected if supported by the file manager.
+
+This button will only be available when accessing stash from a local loopback address (e.g. `localhost` or `127.0.0.1`), and will not be shown when accessing stash from a remote address.

--- a/ui/v2.5/src/index.scss
+++ b/ui/v2.5/src/index.scss
@@ -84,6 +84,7 @@ code,
 }
 
 dd {
+  overflow: hidden;
   white-space: pre-line;
 }
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -98,6 +98,7 @@
     "remove_from_containing_group": "Remove from Group",
     "remove_from_gallery": "Remove from Gallery",
     "rename_gen_files": "Rename generated files",
+    "reveal_in_file_manager": "Reveal in File Manager",
     "rescan": "Rescan",
     "reset_play_duration": "Reset play duration",
     "reset_resume_time": "Reset resume time",


### PR DESCRIPTION
# Scope

Adds a folder icon button next to the path field in the Scene, Image, and Gallery file info panels. Clicking it opens the file's enclosing directory in the system file manager (Finder on macOS, Explorer on Windows, xdg-open on Linux).

The path field previously rendered a `file://` URL link which browsers block for security reasons, making it non-functional. It is now plain text with the reveal button alongside it.

The button is only shown when accessing Stash from localhost, since the feature requires a local GUI file manager. It is hidden when accessed remotely.

The mutations are guarded so they only run if the request came from a loopback address.

Also fixes the existing `revealInFileManager` platform implementations which were constructing `exec.Command` but never calling `.Run()`, making them silent no-ops:

- **darwin**: add `.Run()` to `open -R`
- **windows**: add `.Run()` and fix flag to `/select,` with path as a separate argument
- **linux**: implement using `xdg-open` on the parent directory (was an empty stub)
- **desktop.go**: thread `os.FileInfo` through to platform implementations to avoid a redundant `os.Stat` call on Linux

## Closes/Fixes Issues

N/A

## Other testing QA Notes

- Open a scene/image/gallery detail page from localhost and click the folder icon next to the path field — the enclosing directory should open in the system file manager
- The button does not appear when accessing Stash from a non-localhost address
- Linux requires `xdg-open` to be available