### PR TITLE
Fix panic in IsFsPathCaseSensitive

### DIFF
--- a/pkg/fsutil/fs.go
+++ b/pkg/fsutil/fs.go
@@ -32,8 +32,8 @@ func IsFsPathCaseSensitive(path string) (bool, error) {
 		return false, fmt.Errorf("could not case flip path %s", path)
 	}
 
-	flipped := []byte(path)
-	for _, c := range []byte(fBase) { // replace base of path with the flipped one ( we need to flip the base or last dir part )
+	flipped := []rune(path)
+	for _, c := range fBase { // replace base of path with the flipped one ( we need to flip the base or last dir part )
 		flipped[i] = c
 		i++
 	}
@@ -43,7 +43,7 @@ func IsFsPathCaseSensitive(path string) (bool, error) {
 		return true, nil // fs of path should be case sensitive
 	}
 
-	if fiCase.ModTime() == fi.ModTime() { // file path exists and is the same
+	if fiCase.ModTime().Equal(fi.ModTime()) { // file path exists and is the same
 		return false, nil // fs of path is not case sensitive
 	}
 	return false, fmt.Errorf("can not determine case sensitivity of path %s", path)

--- a/pkg/fsutil/fs_test.go
+++ b/pkg/fsutil/fs_test.go
@@ -1,0 +1,44 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsFsPathCaseSensitive_UnicodeByteLength(t *testing.T) {
+	// Ⱥ (U+023A) is 2 bytes in UTF-8
+	// Its lowercase ⱥ (U+2C65) is 3 bytes in UTF-8
+
+	dir := t.TempDir()
+	makeDir := func(path string) {
+		// Create the directory so os.Stat succeeds
+		if err := os.Mkdir(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	path := filepath.Join(dir, "Ⱥtest")
+	makeDir(path)
+
+	// ensure the test does not panic due to byte length differences in the case flipped path
+	_, err := IsFsPathCaseSensitive(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// no guarantee about case sensitivity of the fs running the tests,
+	// so we just want to ensure the function works and does not panic
+	// assert.True(t, r, "expected fs to be case sensitive")
+
+	// test regular ASCII paths still work
+	path2 := filepath.Join(dir, "Test")
+	makeDir(path2)
+
+	_, err = IsFsPathCaseSensitive(path2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert.True(t, r, "expected fs to be case sensitive")
+}


### PR DESCRIPTION
Fixes #6571

Verified the result of `IsFsPathCaseSensistive` manually on linux and windows.