### PR TITLE
Backend support for Group custom fields

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -462,6 +462,9 @@ input GroupFilterType {
   scenes_filter: SceneFilterType
   "Filter by related studios that meet this criteria"
   studios_filter: StudioFilterType
+
+  "Filter by custom fields"
+  custom_fields: [CustomFieldCriterionInput!]
 }
 
 input StudioFilterType {

--- a/graphql/schema/types/group.graphql
+++ b/graphql/schema/types/group.graphql
@@ -31,6 +31,7 @@ type Group {
   sub_group_count(depth: Int): Int! # Resolver
   scenes: [Scene!]!
   o_counter: Int # Resolver
+  custom_fields: Map!
 }
 
 input GroupDescriptionInput {
@@ -59,6 +60,8 @@ input GroupCreateInput {
   front_image: String
   "This should be a URL or a base64 encoded data URL"
   back_image: String
+
+  custom_fields: Map
 }
 
 input GroupUpdateInput {
@@ -82,6 +85,8 @@ input GroupUpdateInput {
   front_image: String
   "This should be a URL or a base64 encoded data URL"
   back_image: String
+
+  custom_fields: CustomFieldsInput
 }
 
 input BulkUpdateGroupDescriptionsInput {
@@ -101,6 +106,8 @@ input BulkGroupUpdateInput {
 
   containing_groups: BulkUpdateGroupDescriptionsInput
   sub_groups: BulkUpdateGroupDescriptionsInput
+
+  custom_fields: CustomFieldsInput
 }
 
 input GroupDestroyInput {

--- a/internal/api/loaders/dataloaders.go
+++ b/internal/api/loaders/dataloaders.go
@@ -64,11 +64,12 @@ type Loaders struct {
 	StudioByID         *StudioLoader
 	StudioCustomFields *CustomFieldsLoader
 
-	TagByID         *TagLoader
-	TagCustomFields *CustomFieldsLoader
-	GroupByID       *GroupLoader
-	FileByID        *FileLoader
-	FolderByID      *FolderLoader
+	TagByID           *TagLoader
+	TagCustomFields   *CustomFieldsLoader
+	GroupByID         *GroupLoader
+	GroupCustomFields *CustomFieldsLoader
+	FileByID          *FileLoader
+	FolderByID        *FolderLoader
 }
 
 type Middleware struct {
@@ -138,6 +139,11 @@ func (m Middleware) Middleware(next http.Handler) http.Handler {
 				wait:     wait,
 				maxBatch: maxBatch,
 				fetch:    m.fetchGroups(ctx),
+			},
+			GroupCustomFields: &CustomFieldsLoader{
+				wait:     wait,
+				maxBatch: maxBatch,
+				fetch:    m.fetchGroupCustomFields(ctx),
 			},
 			FileByID: &FileLoader{
 				wait:     wait,
@@ -318,6 +324,18 @@ func (m Middleware) fetchTagCustomFields(ctx context.Context) func(keys []int) (
 		err := m.Repository.WithDB(ctx, func(ctx context.Context) error {
 			var err error
 			ret, err = m.Repository.Tag.GetCustomFieldsBulk(ctx, keys)
+			return err
+		})
+
+		return ret, toErrorSlice(err)
+	}
+}
+
+func (m Middleware) fetchGroupCustomFields(ctx context.Context) func(keys []int) ([]models.CustomFieldMap, []error) {
+	return func(keys []int) (ret []models.CustomFieldMap, errs []error) {
+		err := m.Repository.WithDB(ctx, func(ctx context.Context) error {
+			var err error
+			ret, err = m.Repository.Group.GetCustomFieldsBulk(ctx, keys)
 			return err
 		})
 

--- a/internal/api/resolver_model_movie.go
+++ b/internal/api/resolver_model_movie.go
@@ -215,3 +215,16 @@ func (r *groupResolver) OCounter(ctx context.Context, obj *models.Group) (ret *i
 	}
 	return &count, nil
 }
+
+func (r *groupResolver) CustomFields(ctx context.Context, obj *models.Group) (map[string]interface{}, error) {
+	m, err := loaders.From(ctx).GroupCustomFields.Load(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if m == nil {
+		return make(map[string]interface{}), nil
+	}
+
+	return m, nil
+}

--- a/internal/manager/repository.go
+++ b/internal/manager/repository.go
@@ -39,7 +39,7 @@ type GalleryService interface {
 }
 
 type GroupService interface {
-	Create(ctx context.Context, group *models.Group, frontimageData []byte, backimageData []byte) error
+	Create(ctx context.Context, input *models.CreateGroupInput) error
 	UpdatePartial(ctx context.Context, id int, updatedGroup models.GroupPartial, frontImage group.ImageInput, backImage group.ImageInput) (*models.Group, error)
 
 	AddSubGroups(ctx context.Context, groupID int, subGroups []models.GroupIDDescription, insertIndex *int) error

--- a/pkg/group/create.go
+++ b/pkg/group/create.go
@@ -12,27 +12,37 @@ var (
 	ErrHierarchyLoop = errors.New("a group cannot be contained by one of its subgroups")
 )
 
-func (s *Service) Create(ctx context.Context, group *models.Group, frontimageData []byte, backimageData []byte) error {
+func (s *Service) Create(ctx context.Context, input *models.CreateGroupInput) error {
 	r := s.Repository
+	group := input.Group
 
 	if err := s.validateCreate(ctx, group); err != nil {
 		return err
 	}
 
-	err := r.Create(ctx, group)
+	err := r.Create(ctx, input.Group)
 	if err != nil {
 		return err
 	}
 
-	// update image table
-	if len(frontimageData) > 0 {
-		if err := r.UpdateFrontImage(ctx, group.ID, frontimageData); err != nil {
+	// set custom fields
+	if len(input.CustomFields) > 0 {
+		if err := r.SetCustomFields(ctx, group.ID, models.CustomFieldsInput{
+			Full: input.CustomFields,
+		}); err != nil {
 			return err
 		}
 	}
 
-	if len(backimageData) > 0 {
-		if err := r.UpdateBackImage(ctx, group.ID, backimageData); err != nil {
+	// update image table
+	if len(input.FrontImageData) > 0 {
+		if err := r.UpdateFrontImage(ctx, group.ID, input.FrontImageData); err != nil {
+			return err
+		}
+	}
+
+	if len(input.BackImageData) > 0 {
+		if err := r.UpdateBackImage(ctx, group.ID, input.BackImageData); err != nil {
 			return err
 		}
 	}

--- a/pkg/group/export.go
+++ b/pkg/group/export.go
@@ -11,61 +11,67 @@ import (
 	"github.com/stashapp/stash/pkg/utils"
 )
 
-type ImageGetter interface {
-	GetFrontImage(ctx context.Context, movieID int) ([]byte, error)
-	GetBackImage(ctx context.Context, movieID int) ([]byte, error)
+type GroupExportReader interface {
+	GetFrontImage(ctx context.Context, groupID int) ([]byte, error)
+	GetBackImage(ctx context.Context, groupID int) ([]byte, error)
+	GetCustomFields(ctx context.Context, groupID int) (map[string]interface{}, error)
 }
 
-// ToJSON converts a Movie into its JSON equivalent.
-func ToJSON(ctx context.Context, reader ImageGetter, studioReader models.StudioGetter, movie *models.Group) (*jsonschema.Group, error) {
-	newMovieJSON := jsonschema.Group{
-		Name:      movie.Name,
-		Aliases:   movie.Aliases,
-		Director:  movie.Director,
-		Synopsis:  movie.Synopsis,
-		URLs:      movie.URLs.List(),
-		CreatedAt: json.JSONTime{Time: movie.CreatedAt},
-		UpdatedAt: json.JSONTime{Time: movie.UpdatedAt},
+// ToJSON converts a Group into its JSON equivalent.
+func ToJSON(ctx context.Context, reader GroupExportReader, studioReader models.StudioGetter, group *models.Group) (*jsonschema.Group, error) {
+	newGroupJSON := jsonschema.Group{
+		Name:      group.Name,
+		Aliases:   group.Aliases,
+		Director:  group.Director,
+		Synopsis:  group.Synopsis,
+		URLs:      group.URLs.List(),
+		CreatedAt: json.JSONTime{Time: group.CreatedAt},
+		UpdatedAt: json.JSONTime{Time: group.UpdatedAt},
 	}
 
-	if movie.Date != nil {
-		newMovieJSON.Date = movie.Date.String()
+	if group.Date != nil {
+		newGroupJSON.Date = group.Date.String()
 	}
-	if movie.Rating != nil {
-		newMovieJSON.Rating = *movie.Rating
+	if group.Rating != nil {
+		newGroupJSON.Rating = *group.Rating
 	}
-	if movie.Duration != nil {
-		newMovieJSON.Duration = *movie.Duration
+	if group.Duration != nil {
+		newGroupJSON.Duration = *group.Duration
 	}
 
-	if movie.StudioID != nil {
-		studio, err := studioReader.Find(ctx, *movie.StudioID)
+	if group.StudioID != nil {
+		studio, err := studioReader.Find(ctx, *group.StudioID)
 		if err != nil {
 			return nil, fmt.Errorf("error getting movie studio: %v", err)
 		}
 
 		if studio != nil {
-			newMovieJSON.Studio = studio.Name
+			newGroupJSON.Studio = studio.Name
 		}
 	}
 
-	frontImage, err := reader.GetFrontImage(ctx, movie.ID)
+	frontImage, err := reader.GetFrontImage(ctx, group.ID)
 	if err != nil {
 		logger.Errorf("Error getting movie front image: %v", err)
 	}
 
 	if len(frontImage) > 0 {
-		newMovieJSON.FrontImage = utils.GetBase64StringFromData(frontImage)
+		newGroupJSON.FrontImage = utils.GetBase64StringFromData(frontImage)
 	}
 
-	backImage, err := reader.GetBackImage(ctx, movie.ID)
+	backImage, err := reader.GetBackImage(ctx, group.ID)
 	if err != nil {
 		logger.Errorf("Error getting movie back image: %v", err)
 	}
 
 	if len(backImage) > 0 {
-		newMovieJSON.BackImage = utils.GetBase64StringFromData(backImage)
+		newGroupJSON.BackImage = utils.GetBase64StringFromData(backImage)
 	}
 
-	return &newMovieJSON, nil
+	newGroupJSON.CustomFields, err = reader.GetCustomFields(ctx, group.ID)
+	if err != nil {
+		return nil, fmt.Errorf("getting group custom fields: %v", err)
+	}
+
+	return &newGroupJSON, nil
 }

--- a/pkg/group/import.go
+++ b/pkg/group/import.go
@@ -14,6 +14,7 @@ import (
 
 type ImporterReaderWriter interface {
 	models.GroupCreatorUpdater
+	models.CustomFieldsWriter
 	FindByName(ctx context.Context, name string, nocase bool) (*models.Group, error)
 }
 
@@ -230,6 +231,14 @@ func (i *Importer) PostImport(ctx context.Context, id int) error {
 			},
 		}); err != nil {
 			return fmt.Errorf("error setting parents: %v", err)
+		}
+	}
+
+	if len(i.Input.CustomFields) > 0 {
+		if err := i.ReaderWriter.SetCustomFields(ctx, id, models.CustomFieldsInput{
+			Full: i.Input.CustomFields,
+		}); err != nil {
+			return fmt.Errorf("error setting custom fields: %v", err)
 		}
 	}
 

--- a/pkg/group/service.go
+++ b/pkg/group/service.go
@@ -10,6 +10,7 @@ type CreatorUpdater interface {
 	models.GroupGetter
 	models.GroupCreator
 	models.GroupUpdater
+	models.CustomFieldsWriter
 
 	models.ContainingGroupLoader
 	models.SubGroupLoader

--- a/pkg/models/group.go
+++ b/pkg/models/group.go
@@ -43,4 +43,6 @@ type GroupFilterType struct {
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at
 	UpdatedAt *TimestampCriterionInput `json:"updated_at"`
+	// Filter by custom fields
+	CustomFields []CustomFieldCriterionInput `json:"custom_fields"`
 }

--- a/pkg/models/jsonschema/group.go
+++ b/pkg/models/jsonschema/group.go
@@ -33,6 +33,8 @@ type Group struct {
 	CreatedAt  json.JSONTime         `json:"created_at,omitempty"`
 	UpdatedAt  json.JSONTime         `json:"updated_at,omitempty"`
 
+	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
+
 	// deprecated - for import only
 	URL string `json:"url,omitempty"`
 }

--- a/pkg/models/mocks/GroupReaderWriter.go
+++ b/pkg/models/mocks/GroupReaderWriter.go
@@ -312,6 +312,52 @@ func (_m *GroupReaderWriter) GetContainingGroupDescriptions(ctx context.Context,
 	return r0, r1
 }
 
+// GetCustomFields provides a mock function with given fields: ctx, id
+func (_m *GroupReaderWriter) GetCustomFields(ctx context.Context, id int) (map[string]interface{}, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(context.Context, int) map[string]interface{}); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCustomFieldsBulk provides a mock function with given fields: ctx, ids
+func (_m *GroupReaderWriter) GetCustomFieldsBulk(ctx context.Context, ids []int) ([]models.CustomFieldMap, error) {
+	ret := _m.Called(ctx, ids)
+
+	var r0 []models.CustomFieldMap
+	if rf, ok := ret.Get(0).(func(context.Context, []int) []models.CustomFieldMap); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.CustomFieldMap)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []int) error); ok {
+		r1 = rf(ctx, ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetFrontImage provides a mock function with given fields: ctx, groupID
 func (_m *GroupReaderWriter) GetFrontImage(ctx context.Context, groupID int) ([]byte, error) {
 	ret := _m.Called(ctx, groupID)
@@ -495,6 +541,20 @@ func (_m *GroupReaderWriter) QueryCount(ctx context.Context, groupFilter *models
 	}
 
 	return r0, r1
+}
+
+// SetCustomFields provides a mock function with given fields: ctx, id, fields
+func (_m *GroupReaderWriter) SetCustomFields(ctx context.Context, id int, fields models.CustomFieldsInput) error {
+	ret := _m.Called(ctx, id, fields)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, models.CustomFieldsInput) error); ok {
+		r0 = rf(ctx, id, fields)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Update provides a mock function with given fields: ctx, updatedGroup

--- a/pkg/models/model_group.go
+++ b/pkg/models/model_group.go
@@ -34,6 +34,14 @@ func NewGroup() Group {
 	}
 }
 
+type CreateGroupInput struct {
+	*Group
+
+	CustomFields   map[string]interface{} `json:"custom_fields"`
+	FrontImageData []byte
+	BackImageData  []byte
+}
+
 func (m *Group) LoadURLs(ctx context.Context, l URLLoader) error {
 	return m.URLs.load(func() ([]string, error) {
 		return l.GetURLs(ctx, m.ID)
@@ -74,6 +82,8 @@ type GroupPartial struct {
 	SubGroups        *UpdateGroupDescriptions
 	CreatedAt        OptionalTime
 	UpdatedAt        OptionalTime
+
+	CustomFields CustomFieldsInput
 }
 
 func NewGroupPartial() GroupPartial {

--- a/pkg/models/repository_group.go
+++ b/pkg/models/repository_group.go
@@ -68,6 +68,7 @@ type GroupReader interface {
 	TagIDLoader
 	ContainingGroupLoader
 	SubGroupLoader
+	CustomFieldsReader
 
 	All(ctx context.Context) ([]*Group, error)
 	GetFrontImage(ctx context.Context, groupID int) ([]byte, error)
@@ -81,6 +82,7 @@ type GroupWriter interface {
 	GroupCreator
 	GroupUpdater
 	GroupDestroyer
+	CustomFieldsWriter
 }
 
 // GroupReaderWriter provides all group methods.

--- a/pkg/sqlite/anonymise.go
+++ b/pkg/sqlite/anonymise.go
@@ -964,6 +964,10 @@ func (db *Anonymiser) anonymiseGroups(ctx context.Context) error {
 		return err
 	}
 
+	if err := db.anonymiseCustomFields(ctx, goqu.T(groupsCustomFieldsTable.GetTable()), "group_id"); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/sqlite/custom_fields_test.go
+++ b/pkg/sqlite/custom_fields_test.go
@@ -242,7 +242,13 @@ func TestSceneSetCustomFields(t *testing.T) {
 }
 
 func TestGallerySetCustomFields(t *testing.T) {
-	galleryIdx := galleryIdxWithScene
+	galleryIdx := galleryIdxWithChapters
 
 	testSetCustomFields(t, "Gallery", db.Gallery, galleryIDs[galleryIdx], getGalleryCustomFields(galleryIdx))
+}
+
+func TestGroupSetCustomFields(t *testing.T) {
+	groupIdx := groupIdxWithScene
+
+	testSetCustomFields(t, "Group", db.Group, groupIDs[groupIdx], getGroupCustomFields(groupIdx))
 }

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 81
+var appSchemaVersion uint = 82
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/group.go
+++ b/pkg/sqlite/group.go
@@ -131,6 +131,7 @@ var (
 
 type GroupStore struct {
 	blobJoinQueryBuilder
+	customFieldsStore
 	tagRelationshipStore
 	groupRelationshipStore
 
@@ -142,6 +143,10 @@ func NewGroupStore(blobStore *BlobStore) *GroupStore {
 		blobJoinQueryBuilder: blobJoinQueryBuilder{
 			blobStore: blobStore,
 			joinTable: groupTable,
+		},
+		customFieldsStore: customFieldsStore{
+			table: groupsCustomFieldsTable,
+			fk:    groupsCustomFieldsTable.Col(groupIDColumn),
 		},
 		tagRelationshipStore: tagRelationshipStore{
 			idRelationshipStore: idRelationshipStore{
@@ -232,6 +237,10 @@ func (qb *GroupStore) UpdatePartial(ctx context.Context, id int, partial models.
 	}
 
 	if err := qb.groupRelationshipStore.modifySubRelationships(ctx, id, partial.SubGroups); err != nil {
+		return nil, err
+	}
+
+	if err := qb.SetCustomFields(ctx, id, partial.CustomFields); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sqlite/group_filter.go
+++ b/pkg/sqlite/group_filter.go
@@ -84,6 +84,13 @@ func (qb *groupFilterHandler) criterionHandler() criterionHandler {
 		&timestampCriterionHandler{groupFilter.CreatedAt, "groups.created_at", nil},
 		&timestampCriterionHandler{groupFilter.UpdatedAt, "groups.updated_at", nil},
 
+		&customFieldsFilterHandler{
+			table: groupsCustomFieldsTable.GetTable(),
+			fkCol: groupIDColumn,
+			c:     groupFilter.CustomFields,
+			idCol: "groups.id",
+		},
+
 		&relatedFilterHandler{
 			relatedIDCol:   "groups_scenes.scene_id",
 			relatedRepo:    sceneRepository.repository,

--- a/pkg/sqlite/migrations/82_group_custom_fields.up.sql
+++ b/pkg/sqlite/migrations/82_group_custom_fields.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `group_custom_fields` (
+  `group_id` integer NOT NULL,
+  `field` varchar(64) NOT NULL,
+  `value` BLOB NOT NULL,
+  PRIMARY KEY (`group_id`, `field`),
+  foreign key(`group_id`) references `groups`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `index_group_custom_fields_field_value` ON `group_custom_fields` (`field`, `value`);

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1457,6 +1457,18 @@ func getGroupEmptyString(index int, field string) string {
 	return v.String
 }
 
+func getGroupCustomFields(index int) map[string]interface{} {
+	if index%5 == 0 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"string": getGroupStringValue(index, "custom"),
+		"int":    int64(index % 5),
+		"real":   float64(index) / 10,
+	}
+}
+
 // createGroups creates n groups with plain Name and o groups with camel cased NaMe included
 func createGroups(ctx context.Context, mqb models.GroupReaderWriter, n int, o int) error {
 	const namePlain = "Name"
@@ -1487,6 +1499,13 @@ func createGroups(ctx context.Context, mqb models.GroupReaderWriter, n int, o in
 
 		if err != nil {
 			return fmt.Errorf("Error creating group [%d] %v+: %s", i, group, err.Error())
+		}
+
+		customFields := getGroupCustomFields(i)
+		if customFields != nil {
+			if err := mqb.SetCustomFields(ctx, group.ID, models.CustomFieldsInput{Full: customFields}); err != nil {
+				return fmt.Errorf("Error setting custom fields for group %d: %s", group.ID, err.Error())
+			}
 		}
 
 		groupIDs = append(groupIDs, group.ID)

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -47,6 +47,7 @@ var (
 	groupsURLsJoinTable     = goqu.T(groupURLsTable)
 	groupsTagsJoinTable     = goqu.T(groupsTagsTable)
 	groupRelationsJoinTable = goqu.T(groupRelationsTable)
+	groupsCustomFieldsTable = goqu.T("group_custom_fields")
 
 	tagsAliasesJoinTable  = goqu.T(tagAliasesTable)
 	tagRelationsJoinTable = goqu.T(tagRelationsTable)


### PR DESCRIPTION
Support for group custom fields, with assistance from copilot. Backend only. Tested manually using graphql playground.

There's a bit of inconsistency between the various sqlite store implementations that should ideally be addressed at some point.