### PR TITLE
Backend support for image custom fields

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -765,6 +765,8 @@ input ImageFilterType {
   tags_filter: TagFilterType
   "Filter by related files that meet this criteria"
   files_filter: FileFilterType
+  "Filter by custom fields"
+  custom_fields: [CustomFieldCriterionInput!]
 }
 
 input FileFilterType {

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -21,6 +21,7 @@ type Image {
   studio: Studio
   tags: [Tag!]!
   performers: [Performer!]!
+  custom_fields: Map!
 }
 
 type ImageFileType {
@@ -56,6 +57,7 @@ input ImageUpdateInput {
   gallery_ids: [ID!]
 
   primary_file_id: ID
+  custom_fields: CustomFieldsInput
 }
 
 input BulkImageUpdateInput {
@@ -76,6 +78,7 @@ input BulkImageUpdateInput {
   performer_ids: BulkUpdateIds
   tag_ids: BulkUpdateIds
   gallery_ids: BulkUpdateIds
+  custom_fields: CustomFieldsInput
 }
 
 input ImageDestroyInput {

--- a/internal/api/resolver_model_image.go
+++ b/internal/api/resolver_model_image.go
@@ -161,3 +161,12 @@ func (r *imageResolver) Urls(ctx context.Context, obj *models.Image) ([]string, 
 
 	return obj.URLs.List(), nil
 }
+
+func (r *imageResolver) CustomFields(ctx context.Context, obj *models.Image) (map[string]interface{}, error) {
+	customFields, err := loaders.From(ctx).ImageCustomFields.Load(obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return customFields, nil
+}

--- a/internal/api/resolver_mutation_image.go
+++ b/internal/api/resolver_mutation_image.go
@@ -177,6 +177,13 @@ func (r *mutationResolver) imageUpdate(ctx context.Context, input models.ImageUp
 		return nil, fmt.Errorf("converting tag ids: %w", err)
 	}
 
+	if input.CustomFields != nil {
+		updatedImage.CustomFields = *input.CustomFields
+		// convert json.Numbers to int/float
+		updatedImage.CustomFields.Full = convertMapJSONNumbers(updatedImage.CustomFields.Full)
+		updatedImage.CustomFields.Partial = convertMapJSONNumbers(updatedImage.CustomFields.Partial)
+	}
+
 	qb := r.repository.Image
 	image, err := qb.UpdatePartial(ctx, imageID, updatedImage)
 	if err != nil {
@@ -235,6 +242,13 @@ func (r *mutationResolver) BulkImageUpdate(ctx context.Context, input BulkImageU
 	updatedImage.TagIDs, err = translator.updateIdsBulk(input.TagIds, "tag_ids")
 	if err != nil {
 		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	if input.CustomFields != nil {
+		updatedImage.CustomFields = *input.CustomFields
+		// convert json.Numbers to int/float
+		updatedImage.CustomFields.Full = convertMapJSONNumbers(updatedImage.CustomFields.Full)
+		updatedImage.CustomFields.Partial = convertMapJSONNumbers(updatedImage.CustomFields.Partial)
 	}
 
 	// Start the transaction and save the images

--- a/internal/autotag/integration_test.go
+++ b/internal/autotag/integration_test.go
@@ -365,7 +365,10 @@ func makeImage(expectedResult bool) *models.Image {
 }
 
 func createImage(ctx context.Context, w models.ImageWriter, o *models.Image, f *models.ImageFile) error {
-	err := w.Create(ctx, o, []models.FileID{f.ID})
+	err := w.Create(ctx, &models.CreateImageInput{
+		Image:   o,
+		FileIDs: []models.FileID{f.ID},
+	})
 
 	if err != nil {
 		return fmt.Errorf("Failed to create image with path '%s': %s", f.Path, err.Error())

--- a/pkg/image/import.go
+++ b/pkg/image/import.go
@@ -31,8 +31,9 @@ type Importer struct {
 	Input               jsonschema.Image
 	MissingRefBehaviour models.ImportMissingRefEnum
 
-	ID    int
-	image models.Image
+	ID           int
+	image        models.Image
+	customFields map[string]interface{}
 }
 
 func (i *Importer) PreImport(ctx context.Context) error {
@@ -57,6 +58,8 @@ func (i *Importer) PreImport(ctx context.Context) error {
 	if err := i.populateTags(ctx); err != nil {
 		return err
 	}
+
+	i.customFields = i.Input.CustomFields
 
 	return nil
 }
@@ -344,7 +347,11 @@ func (i *Importer) Create(ctx context.Context) (*int, error) {
 		fileIDs = append(fileIDs, f.Base().ID)
 	}
 
-	err := i.ReaderWriter.Create(ctx, &i.image, fileIDs)
+	err := i.ReaderWriter.Create(ctx, &models.CreateImageInput{
+		Image:        &i.image,
+		FileIDs:      fileIDs,
+		CustomFields: i.customFields,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating image: %v", err)
 	}

--- a/pkg/image/import_test.go
+++ b/pkg/image/import_test.go
@@ -45,7 +45,8 @@ func TestImporterPreImportWithStudio(t *testing.T) {
 	i := Importer{
 		StudioWriter: db.Studio,
 		Input: jsonschema.Image{
-			Studio: existingStudioName,
+			Studio:       existingStudioName,
+			CustomFields: customFields,
 		},
 	}
 
@@ -57,6 +58,7 @@ func TestImporterPreImportWithStudio(t *testing.T) {
 	err := i.PreImport(testCtx)
 	assert.Nil(t, err)
 	assert.Equal(t, existingStudioID, *i.image.StudioID)
+	assert.Equal(t, customFields, i.customFields)
 
 	i.Input.Studio = existingStudioErr
 	err = i.PreImport(testCtx)

--- a/pkg/image/scan.go
+++ b/pkg/image/scan.go
@@ -27,7 +27,7 @@ type ScanCreatorUpdater interface {
 	GetFiles(ctx context.Context, relatedID int) ([]models.File, error)
 	GetGalleryIDs(ctx context.Context, relatedID int) ([]int, error)
 
-	Create(ctx context.Context, newImage *models.Image, fileIDs []models.FileID) error
+	Create(ctx context.Context, newImage *models.CreateImageInput) error
 	UpdatePartial(ctx context.Context, id int, updatedImage models.ImagePartial) (*models.Image, error)
 	AddFileID(ctx context.Context, id int, fileID models.FileID) error
 }
@@ -124,7 +124,10 @@ func (h *ScanHandler) Handle(ctx context.Context, f models.File, oldFile models.
 			logger.Infof("Adding %s to gallery %s", f.Base().Path, g.Path)
 		}
 
-		if err := h.CreatorUpdater.Create(ctx, &newImage, []models.FileID{imageFile.ID}); err != nil {
+		if err := h.CreatorUpdater.Create(ctx, &models.CreateImageInput{
+			Image:   &newImage,
+			FileIDs: []models.FileID{imageFile.ID},
+		}); err != nil {
 			return fmt.Errorf("creating new image: %w", err)
 		}
 

--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -1,6 +1,8 @@
 package models
 
-import "context"
+import (
+	"context"
+)
 
 type ImageFilterType struct {
 	OperatorFilter[ImageFilterType]
@@ -65,25 +67,28 @@ type ImageFilterType struct {
 	CreatedAt *TimestampCriterionInput `json:"created_at"`
 	// Filter by updated at
 	UpdatedAt *TimestampCriterionInput `json:"updated_at"`
+	// Filter by custom fields
+	CustomFields []CustomFieldCriterionInput `json:"custom_fields"`
 }
 
 type ImageUpdateInput struct {
-	ClientMutationID *string  `json:"clientMutationId"`
-	ID               string   `json:"id"`
-	Title            *string  `json:"title"`
-	Code             *string  `json:"code"`
-	Urls             []string `json:"urls"`
-	Date             *string  `json:"date"`
-	Details          *string  `json:"details"`
-	Photographer     *string  `json:"photographer"`
-	Rating100        *int     `json:"rating100"`
-	Organized        *bool    `json:"organized"`
-	SceneIds         []string `json:"scene_ids"`
-	StudioID         *string  `json:"studio_id"`
-	TagIds           []string `json:"tag_ids"`
-	PerformerIds     []string `json:"performer_ids"`
-	GalleryIds       []string `json:"gallery_ids"`
-	PrimaryFileID    *string  `json:"primary_file_id"`
+	ClientMutationID *string            `json:"clientMutationId"`
+	ID               string             `json:"id"`
+	Title            *string            `json:"title"`
+	Code             *string            `json:"code"`
+	Urls             []string           `json:"urls"`
+	Date             *string            `json:"date"`
+	Details          *string            `json:"details"`
+	Photographer     *string            `json:"photographer"`
+	Rating100        *int               `json:"rating100"`
+	Organized        *bool              `json:"organized"`
+	SceneIds         []string           `json:"scene_ids"`
+	StudioID         *string            `json:"studio_id"`
+	TagIds           []string           `json:"tag_ids"`
+	PerformerIds     []string           `json:"performer_ids"`
+	GalleryIds       []string           `json:"gallery_ids"`
+	PrimaryFileID    *string            `json:"primary_file_id"`
+	CustomFields     *CustomFieldsInput `json:"custom_fields"`
 
 	// deprecated
 	URL *string `json:"url"`

--- a/pkg/models/jsonschema/image.go
+++ b/pkg/models/jsonschema/image.go
@@ -18,18 +18,19 @@ type Image struct {
 	// deprecated - for import only
 	URL string `json:"url,omitempty"`
 
-	URLs         []string      `json:"urls,omitempty"`
-	Date         string        `json:"date,omitempty"`
-	Details      string        `json:"details,omitempty"`
-	Photographer string        `json:"photographer,omitempty"`
-	Organized    bool          `json:"organized,omitempty"`
-	OCounter     int           `json:"o_counter,omitempty"`
-	Galleries    []GalleryRef  `json:"galleries,omitempty"`
-	Performers   []string      `json:"performers,omitempty"`
-	Tags         []string      `json:"tags,omitempty"`
-	Files        []string      `json:"files,omitempty"`
-	CreatedAt    json.JSONTime `json:"created_at,omitempty"`
-	UpdatedAt    json.JSONTime `json:"updated_at,omitempty"`
+	URLs         []string               `json:"urls,omitempty"`
+	Date         string                 `json:"date,omitempty"`
+	Details      string                 `json:"details,omitempty"`
+	Photographer string                 `json:"photographer,omitempty"`
+	Organized    bool                   `json:"organized,omitempty"`
+	OCounter     int                    `json:"o_counter,omitempty"`
+	Galleries    []GalleryRef           `json:"galleries,omitempty"`
+	Performers   []string               `json:"performers,omitempty"`
+	Tags         []string               `json:"tags,omitempty"`
+	Files        []string               `json:"files,omitempty"`
+	CreatedAt    json.JSONTime          `json:"created_at,omitempty"`
+	UpdatedAt    json.JSONTime          `json:"updated_at,omitempty"`
+	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
 }
 
 func (s Image) Filename(basename string, hash string) string {

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -137,13 +137,13 @@ func (_m *ImageReaderWriter) CoverByGalleryID(ctx context.Context, galleryId int
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: ctx, newImage, fileIDs
-func (_m *ImageReaderWriter) Create(ctx context.Context, newImage *models.Image, fileIDs []models.FileID) error {
-	ret := _m.Called(ctx, newImage, fileIDs)
+// Create provides a mock function with given fields: ctx, newImage
+func (_m *ImageReaderWriter) Create(ctx context.Context, newImage *models.CreateImageInput) error {
+	ret := _m.Called(ctx, newImage)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *models.Image, []models.FileID) error); ok {
-		r0 = rf(ctx, newImage, fileIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.CreateImageInput) error); ok {
+		r0 = rf(ctx, newImage)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -380,6 +380,52 @@ func (_m *ImageReaderWriter) FindMany(ctx context.Context, ids []int) ([]*models
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*models.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []int) error); ok {
+		r1 = rf(ctx, ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCustomFields provides a mock function with given fields: ctx, id
+func (_m *ImageReaderWriter) GetCustomFields(ctx context.Context, id int) (map[string]interface{}, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(context.Context, int) map[string]interface{}); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCustomFieldsBulk provides a mock function with given fields: ctx, ids
+func (_m *ImageReaderWriter) GetCustomFieldsBulk(ctx context.Context, ids []int) ([]models.CustomFieldMap, error) {
+	ret := _m.Called(ctx, ids)
+
+	var r0 []models.CustomFieldMap
+	if rf, ok := ret.Get(0).(func(context.Context, []int) []models.CustomFieldMap); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.CustomFieldMap)
 		}
 	}
 
@@ -692,6 +738,20 @@ func (_m *ImageReaderWriter) ResetOCounter(ctx context.Context, id int) (int, er
 	}
 
 	return r0, r1
+}
+
+// SetCustomFields provides a mock function with given fields: ctx, id, fields
+func (_m *ImageReaderWriter) SetCustomFields(ctx context.Context, id int, fields models.CustomFieldsInput) error {
+	ret := _m.Called(ctx, id, fields)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, models.CustomFieldsInput) error); ok {
+		r0 = rf(ctx, id, fields)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Size provides a mock function with given fields: ctx

--- a/pkg/models/model_image.go
+++ b/pkg/models/model_image.go
@@ -47,6 +47,13 @@ func NewImage() Image {
 	}
 }
 
+type CreateImageInput struct {
+	*Image
+
+	FileIDs      []FileID
+	CustomFields map[string]interface{} `json:"custom_fields"`
+}
+
 type ImagePartial struct {
 	Title OptionalString
 	Code  OptionalString
@@ -66,6 +73,7 @@ type ImagePartial struct {
 	TagIDs        *UpdateIDs
 	PerformerIDs  *UpdateIDs
 	PrimaryFileID *FileID
+	CustomFields  CustomFieldsInput
 }
 
 func NewImagePartial() ImagePartial {

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -43,7 +43,7 @@ type ImageCounter interface {
 
 // ImageCreator provides methods to create images.
 type ImageCreator interface {
-	Create(ctx context.Context, newImage *Image, fileIDs []FileID) error
+	Create(ctx context.Context, newImage *CreateImageInput) error
 }
 
 // ImageUpdater provides methods to update images.
@@ -78,6 +78,7 @@ type ImageReader interface {
 	FileLoader
 
 	GalleryCoverFinder
+	CustomFieldsReader
 
 	All(ctx context.Context) ([]*Image, error)
 	Size(ctx context.Context) (float64, error)
@@ -88,6 +89,7 @@ type ImageWriter interface {
 	ImageCreator
 	ImageUpdater
 	ImageDestroyer
+	CustomFieldsWriter
 
 	AddFileID(ctx context.Context, id int, fileID FileID) error
 	RemoveFileID(ctx context.Context, id int, fileID FileID) error

--- a/pkg/sqlite/custom_fields.go
+++ b/pkg/sqlite/custom_fields.go
@@ -192,6 +192,10 @@ func (s *customFieldsStore) GetCustomFieldsBulk(ctx context.Context, ids []int) 
 
 	const single = false
 	ret := make([]models.CustomFieldMap, len(ids))
+	// initialise ret with empty maps for each id
+	for i := range ret {
+		ret[i] = make(map[string]interface{})
+	}
 
 	idi := make(map[int]int, len(ids))
 	for i, id := range ids {

--- a/pkg/sqlite/custom_fields_test.go
+++ b/pkg/sqlite/custom_fields_test.go
@@ -247,6 +247,12 @@ func TestGallerySetCustomFields(t *testing.T) {
 	testSetCustomFields(t, "Gallery", db.Gallery, galleryIDs[galleryIdx], getGalleryCustomFields(galleryIdx))
 }
 
+func TestImageSetCustomFields(t *testing.T) {
+	imageIdx := imageIdx2WithGallery
+
+	testSetCustomFields(t, "Image", db.Image, imageIDs[imageIdx], getImageCustomFields(imageIdx))
+}
+
 func TestGroupSetCustomFields(t *testing.T) {
 	groupIdx := groupIdxWithScene
 

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 82
+var appSchemaVersion uint = 83
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/image_filter.go
+++ b/pkg/sqlite/image_filter.go
@@ -100,6 +100,13 @@ func (qb *imageFilterHandler) criterionHandler() criterionHandler {
 		&timestampCriterionHandler{imageFilter.CreatedAt, "images.created_at", nil},
 		&timestampCriterionHandler{imageFilter.UpdatedAt, "images.updated_at", nil},
 
+		&customFieldsFilterHandler{
+			table: imagesCustomFieldsTable.GetTable(),
+			fkCol: imageIDColumn,
+			c:     imageFilter.CustomFields,
+			idCol: "images.id",
+		},
+
 		&relatedFilterHandler{
 			relatedIDCol:   "galleries_images.gallery_id",
 			relatedRepo:    galleryRepository.repository,

--- a/pkg/sqlite/migrations/83_image_custom_fields.up.sql
+++ b/pkg/sqlite/migrations/83_image_custom_fields.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `image_custom_fields` (
+  `image_id` integer NOT NULL,
+  `field` varchar(64) NOT NULL,
+  `value` BLOB NOT NULL,
+  PRIMARY KEY (`image_id`, `field`),
+  foreign key(`image_id`) references `images`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `index_image_custom_fields_field_value` ON `image_custom_fields` (`field`, `value`);

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1247,6 +1247,18 @@ func getImageBasename(index int) string {
 	return getImageStringValue(index, pathField)
 }
 
+func getImageCustomFields(index int) map[string]interface{} {
+	if index%5 == 0 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"string": getImageStringValue(index, "custom"),
+		"int":    int64(index % 5),
+		"real":   float64(index) / 10,
+	}
+}
+
 func makeImageFile(i int) *models.ImageFile {
 	return &models.ImageFile{
 		BaseFile: &models.BaseFile{
@@ -1309,7 +1321,11 @@ func createImages(ctx context.Context, n int) error {
 
 		image := makeImage(i)
 
-		err := qb.Create(ctx, image, []models.FileID{f.ID})
+		err := qb.Create(ctx, &models.CreateImageInput{
+			Image:        image,
+			FileIDs:      []models.FileID{f.ID},
+			CustomFields: getImageCustomFields(i),
+		})
 
 		if err != nil {
 			return fmt.Errorf("Error creating image %v+: %s", image, err.Error())

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -14,6 +14,7 @@ var (
 	performersImagesJoinTable = goqu.T(performersImagesTable)
 	imagesFilesJoinTable      = goqu.T(imagesFilesTable)
 	imagesURLsJoinTable       = goqu.T(imagesURLsTable)
+	imagesCustomFieldsTable   = goqu.T("image_custom_fields")
 
 	galleriesFilesJoinTable      = goqu.T(galleriesFilesTable)
 	galleriesTagsJoinTable       = goqu.T(galleriesTagsTable)


### PR DESCRIPTION
Backend changes for image custom fields. Copilot generated. Manually tested in graphql playground.

Also fixes issue where graphql query would give an error when objects had no custom fields set due to illegal nil value.