### PR TITLE
Fix: Add Try/Catch to Filters for Depreciated Career_Length Criterion

### DIFF
--- a/ui/v2.5/src/models/list-filter/filter.ts
+++ b/ui/v2.5/src/models/list-filter/filter.ts
@@ -313,9 +313,14 @@ export class ListFilterModel {
     this.criteria = [];
     if (objectFilter) {
       for (const [k, v] of Object.entries(objectFilter)) {
-        const criterion = this.makeCriterion(k as CriterionType);
-        criterion.setFromSavedCriterion(v);
-        this.criteria.push(criterion);
+        try {
+          const criterion = this.makeCriterion(k as CriterionType);
+          criterion.setFromSavedCriterion(v);
+          this.criteria.push(criterion);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("Failed to load saved filter criterion:", err);
+        }
       }
     }
   }


### PR DESCRIPTION
A user on Discord reported that their UI would crash with the error: `Error: Unknown criterion parameter name: career_length` when a filter contained the old career_length field.

With the try/catch, the unknown criterion is silently skipped (with a console error logged) instead of crashing the page. The career_length filter will no longer be applied, but the rest of the saved filter will load and function normally. Users can then update their filters to add in the new fields as they see fit. This matches the existing error handling pattern used for URL-encoded filter parameters. 

Edit: Didn't do any legit testing. I believe the only way to test would be to create a filter, modify the DB to add in the old career_length field, and make sure that the UI no longer crashes.