### PR TITLE
Fix capitalization in custom localisation heading

### DIFF
--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -669,7 +669,7 @@
       },
       "custom_locales": {
         "description": "Override individual locale strings. See https://github.com/stashapp/stash/blob/develop/ui/v2.5/src/locales/en-GB.json for the master list. Page must be reloaded for changes to take effect.",
-        "heading": "Custom Localisation",
+        "heading": "Custom localisation",
         "option_label": "Custom localisation enabled"
       },
       "custom_title": {


### PR DESCRIPTION
Missed one in https://github.com/stashapp/stash/pull/6548.