### PR TITLE
Fix missing folder corruption during scanning

### DIFF
--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stashapp/stash/internal/desktop"
 	"github.com/stashapp/stash/internal/manager"
+	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/file"
 	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
@@ -19,7 +20,7 @@ func (r *mutationResolver) MoveFiles(ctx context.Context, input MoveFilesInput) 
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		fileStore := r.repository.File
 		folderStore := r.repository.Folder
-		mover := file.NewMover(fileStore, folderStore)
+		mover := file.NewMover(fileStore, folderStore, manager.GetInstance().Config.GetStashPaths().Paths())
 		mover.RegisterHooks(ctx)
 
 		var (
@@ -57,13 +58,14 @@ func (r *mutationResolver) MoveFiles(ctx context.Context, input MoveFilesInput) 
 			folderPath := *input.DestinationFolder
 
 			// ensure folder path is within the library
-			if err := r.validateFolderPath(folderPath); err != nil {
+			stashPaths := manager.GetInstance().Config.GetStashPaths()
+			if err := r.validateFolderPath(stashPaths, folderPath); err != nil {
 				return err
 			}
 
 			// get or create folder hierarchy
 			var err error
-			folder, err = file.GetOrCreateFolderHierarchy(ctx, folderStore, folderPath)
+			folder, err = file.GetOrCreateFolderHierarchy(ctx, folderStore, folderPath, stashPaths.Paths())
 			if err != nil {
 				return fmt.Errorf("getting or creating folder hierarchy: %w", err)
 			}
@@ -112,8 +114,7 @@ func (r *mutationResolver) MoveFiles(ctx context.Context, input MoveFilesInput) 
 	return true, nil
 }
 
-func (r *mutationResolver) validateFolderPath(folderPath string) error {
-	paths := manager.GetInstance().Config.GetStashPaths()
+func (r *mutationResolver) validateFolderPath(paths config.StashConfigs, folderPath string) error {
 	if l := paths.GetStashFromDirPath(folderPath); l == nil {
 		return fmt.Errorf("folder path %s must be within a stash library path", folderPath)
 	}

--- a/internal/manager/config/stash_config.go
+++ b/internal/manager/config/stash_config.go
@@ -38,3 +38,11 @@ func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
 	}
 	return nil
 }
+
+func (s StashConfigs) Paths() []string {
+	paths := make([]string, len(s))
+	for i, c := range s {
+		paths[i] = c.Path
+	}
+	return paths
+}

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -123,7 +123,8 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		ZipFileExtensions:     cfg.GetGalleryExtensions(),
 		// ScanFilters is set in ScanJob.Execute
 		// HandlerRequiredFilters is set in ScanJob.Execute
-		Rescan: input.Rescan,
+		RootPaths: cfg.GetStashPaths().Paths(),
+		Rescan:    input.Rescan,
 	}
 
 	scanJob := ScanJob{

--- a/pkg/file/folder.go
+++ b/pkg/file/folder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,8 +13,9 @@ import (
 )
 
 // GetOrCreateFolderHierarchy gets the folder for the given path, or creates a folder hierarchy for the given path if one if no existing folder is found.
-// Does not create any folders in the file system
-func GetOrCreateFolderHierarchy(ctx context.Context, fc models.FolderFinderCreator, path string) (*models.Folder, error) {
+// Creates folder entries for each level of the hierarchy that doesn't already exist, up to the provided root paths.
+// Does not create any folders in the file system.
+func GetOrCreateFolderHierarchy(ctx context.Context, fc models.FolderFinderCreator, path string, rootPaths []string) (*models.Folder, error) {
 	// get or create folder hierarchy
 	// assume case sensitive when searching for the folder
 	const caseSensitive = true
@@ -23,23 +25,38 @@ func GetOrCreateFolderHierarchy(ctx context.Context, fc models.FolderFinderCreat
 	}
 
 	if folder == nil {
-		parentPath := filepath.Dir(path)
-		parent, err := GetOrCreateFolderHierarchy(ctx, fc, parentPath)
-		if err != nil {
-			return nil, err
+		var parentID *models.FolderID
+
+		if !slices.Contains(rootPaths, path) {
+			parentPath := filepath.Dir(path)
+
+			// safety check - don't allow parent path to be the same as the current path,
+			// otherwise we could end up in an infinite loop
+			if parentPath == path {
+				panic(fmt.Sprintf("parent path is the same as the current path: %s", path))
+			}
+
+			parent, err := GetOrCreateFolderHierarchy(ctx, fc, parentPath, rootPaths)
+			if err != nil {
+				return nil, err
+			}
+
+			parentID = &parent.ID
 		}
 
 		now := time.Now()
 
 		folder = &models.Folder{
 			Path:           path,
-			ParentFolderID: &parent.ID,
+			ParentFolderID: parentID,
 			DirEntry:       models.DirEntry{
 				// leave mod time empty for now - it will be updated when the folder is scanned
 			},
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
+
+		logger.Infof("%s doesn't exist. Creating new folder entry...", path)
 
 		if err = fc.Create(ctx, folder); err != nil {
 			return nil, fmt.Errorf("creating folder %s: %w", path, err)
@@ -49,12 +66,18 @@ func GetOrCreateFolderHierarchy(ctx context.Context, fc models.FolderFinderCreat
 	return folder, nil
 }
 
-func transferZipHierarchy(ctx context.Context, folderStore models.FolderReaderWriter, files models.FileFinderUpdater, zipFileID models.FileID, oldPath string, newPath string) error {
-	if err := transferZipFolderHierarchy(ctx, folderStore, zipFileID, oldPath, newPath); err != nil {
+type zipHierarchyMover struct {
+	folderStore models.FolderReaderWriter
+	files       models.FileFinderUpdater
+	rootPaths   []string
+}
+
+func (m zipHierarchyMover) transferZipHierarchy(ctx context.Context, zipFileID models.FileID, oldPath string, newPath string) error {
+	if err := m.transferZipFolderHierarchy(ctx, zipFileID, oldPath, newPath); err != nil {
 		return fmt.Errorf("moving folder hierarchy for file %s: %w", oldPath, err)
 	}
 
-	if err := transferZipFileEntries(ctx, folderStore, files, zipFileID, oldPath, newPath); err != nil {
+	if err := m.transferZipFileEntries(ctx, zipFileID, oldPath, newPath); err != nil {
 		return fmt.Errorf("moving zip file contents for file %s: %w", oldPath, err)
 	}
 
@@ -63,8 +86,8 @@ func transferZipHierarchy(ctx context.Context, folderStore models.FolderReaderWr
 
 // transferZipFolderHierarchy creates the folder hierarchy for zipFileID under newPath, and removes
 // ZipFileID from folders under oldPath.
-func transferZipFolderHierarchy(ctx context.Context, folderStore models.FolderReaderWriter, zipFileID models.FileID, oldPath string, newPath string) error {
-	zipFolders, err := folderStore.FindByZipFileID(ctx, zipFileID)
+func (m zipHierarchyMover) transferZipFolderHierarchy(ctx context.Context, zipFileID models.FileID, oldPath string, newPath string) error {
+	zipFolders, err := m.folderStore.FindByZipFileID(ctx, zipFileID)
 	if err != nil {
 		return err
 	}
@@ -83,7 +106,7 @@ func transferZipFolderHierarchy(ctx context.Context, folderStore models.FolderRe
 		}
 		newZfPath := filepath.Join(newPath, relZfPath)
 
-		newFolder, err := GetOrCreateFolderHierarchy(ctx, folderStore, newZfPath)
+		newFolder, err := GetOrCreateFolderHierarchy(ctx, m.folderStore, newZfPath, m.rootPaths)
 		if err != nil {
 			return err
 		}
@@ -91,14 +114,14 @@ func transferZipFolderHierarchy(ctx context.Context, folderStore models.FolderRe
 		// add ZipFileID to new folder
 		logger.Debugf("adding zip file %s to folder %s", zipFileID, newFolder.Path)
 		newFolder.ZipFileID = &zipFileID
-		if err = folderStore.Update(ctx, newFolder); err != nil {
+		if err = m.folderStore.Update(ctx, newFolder); err != nil {
 			return err
 		}
 
 		// remove ZipFileID from old folder
 		logger.Debugf("removing zip file %s from folder %s", zipFileID, oldFolder.Path)
 		oldFolder.ZipFileID = nil
-		if err = folderStore.Update(ctx, oldFolder); err != nil {
+		if err = m.folderStore.Update(ctx, oldFolder); err != nil {
 			return err
 		}
 	}
@@ -106,9 +129,9 @@ func transferZipFolderHierarchy(ctx context.Context, folderStore models.FolderRe
 	return nil
 }
 
-func transferZipFileEntries(ctx context.Context, folders models.FolderFinderCreator, files models.FileFinderUpdater, zipFileID models.FileID, oldPath, newPath string) error {
+func (m zipHierarchyMover) transferZipFileEntries(ctx context.Context, zipFileID models.FileID, oldPath, newPath string) error {
 	// move contained files if file is a zip file
-	zipFiles, err := files.FindByZipFileID(ctx, zipFileID)
+	zipFiles, err := m.files.FindByZipFileID(ctx, zipFileID)
 	if err != nil {
 		return fmt.Errorf("finding contained files in file %s: %w", oldPath, err)
 	}
@@ -129,7 +152,7 @@ func transferZipFileEntries(ctx context.Context, folders models.FolderFinderCrea
 		newZfDir := filepath.Join(newPath, relZfDir)
 
 		// folder should have been created by transferZipFolderHierarchy
-		newZfFolder, err := GetOrCreateFolderHierarchy(ctx, folders, newZfDir)
+		newZfFolder, err := GetOrCreateFolderHierarchy(ctx, m.folderStore, newZfDir, m.rootPaths)
 		if err != nil {
 			return fmt.Errorf("getting or creating folder hierarchy: %w", err)
 		}
@@ -137,7 +160,7 @@ func transferZipFileEntries(ctx context.Context, folders models.FolderFinderCrea
 		// update file parent folder
 		zfBase.ParentFolderID = newZfFolder.ID
 		logger.Debugf("moving %s to folder %s", zfBase.Path, newZfFolder.Path)
-		if err := files.Update(ctx, zf); err != nil {
+		if err := m.files.Update(ctx, zf); err != nil {
 			return fmt.Errorf("updating file %s: %w", oldZfPath, err)
 		}
 	}

--- a/pkg/file/move.go
+++ b/pkg/file/move.go
@@ -45,9 +45,12 @@ type Mover struct {
 
 	moved          map[string]string
 	foldersCreated []string
+
+	// needed for creating folder hierarchy when moving zip file entries
+	rootPaths []string
 }
 
-func NewMover(fileStore models.FileFinderUpdater, folderStore models.FolderReaderWriter) *Mover {
+func NewMover(fileStore models.FileFinderUpdater, folderStore models.FolderReaderWriter, rootPaths []string) *Mover {
 	return &Mover{
 		Files:   fileStore,
 		Folders: folderStore,
@@ -55,6 +58,7 @@ func NewMover(fileStore models.FileFinderUpdater, folderStore models.FolderReade
 			renamerRemoverImpl: newRenamerRemoverImpl(),
 			mkDirFn:            os.Mkdir,
 		},
+		rootPaths: rootPaths,
 	}
 }
 
@@ -87,7 +91,13 @@ func (m *Mover) Move(ctx context.Context, f models.File, folder *models.Folder, 
 		return fmt.Errorf("file %s already exists", newPath)
 	}
 
-	if err := transferZipHierarchy(ctx, m.Folders, m.Files, fBase.ID, oldPath, newPath); err != nil {
+	zipMover := zipHierarchyMover{
+		folderStore: m.Folders,
+		files:       m.Files,
+		rootPaths:   m.rootPaths,
+	}
+
+	if err := zipMover.transferZipHierarchy(ctx, fBase.ID, oldPath, newPath); err != nil {
 		return fmt.Errorf("moving folder hierarchy for file %s: %w", fBase.Path, err)
 	}
 

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -197,6 +198,10 @@ func (s *Scanner) ScanFolder(ctx context.Context, file ScannedFile) (*models.Fol
 	return f, err
 }
 
+func (s *Scanner) isRootPath(path string) bool {
+	return path == "." || slices.Contains(s.RootPaths, path)
+}
+
 func (s *Scanner) onNewFolder(ctx context.Context, file ScannedFile) (*models.Folder, error) {
 	renamed, err := s.handleFolderRename(ctx, file)
 	if err != nil {
@@ -216,18 +221,16 @@ func (s *Scanner) onNewFolder(ctx context.Context, file ScannedFile) (*models.Fo
 		UpdatedAt: now,
 	}
 
+	if !s.isRootPath(file.Path) {
 	dir := filepath.Dir(file.Path)
-	if dir != "." {
-		parentFolderID, err := s.getFolderID(ctx, dir)
+
+		// create full folder hierarchy if parent folder doesn't exist, and set parent folder ID
+		parentFolder, err := GetOrCreateFolderHierarchy(ctx, s.Repository.Folder, dir, s.RootPaths)
 		if err != nil {
 			return nil, fmt.Errorf("getting parent folder %q: %w", dir, err)
 		}
 
-		// if parent folder doesn't exist, assume it's a top-level folder
-		// this may not be true if we're using multiple goroutines
-		if parentFolderID != nil {
-			toCreate.ParentFolderID = parentFolderID
-		}
+		toCreate.ParentFolderID = &parentFolder.ID
 	}
 
 	txn.AddPostCommitHook(ctx, func(ctx context.Context) {

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -222,7 +222,7 @@ func (s *Scanner) onNewFolder(ctx context.Context, file ScannedFile) (*models.Fo
 	}
 
 	if !s.isRootPath(file.Path) {
-	dir := filepath.Dir(file.Path)
+		dir := filepath.Dir(file.Path)
 
 		// create full folder hierarchy if parent folder doesn't exist, and set parent folder ID
 		parentFolder, err := GetOrCreateFolderHierarchy(ctx, s.Repository.Folder, dir, s.RootPaths)
@@ -317,6 +317,19 @@ func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing 
 			existing.ZipFileID = fZfID
 			update = true
 		}
+	}
+
+	// handle case where parent folder was not previously set
+	if existing.ParentFolderID == nil && !s.isRootPath(existing.Path) {
+		logger.Infof("Existing folder entry %q has no parent folder. Creating folder hierarchy and setting parent ID...", existing.Path)
+
+		// create full folder hierarchy if parent folder doesn't exist, and set parent folder ID
+		parentFolder, err := GetOrCreateFolderHierarchy(ctx, s.Repository.Folder, filepath.Dir(f.Path), s.RootPaths)
+		if err != nil {
+			return nil, fmt.Errorf("getting parent folder for %q: %w", f.Path, err)
+		}
+		existing.ParentFolderID = &parentFolder.ID
+		update = true
 	}
 
 	if update {

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -60,6 +60,10 @@ type Scanner struct {
 	// handlers are called after a file has been scanned.
 	FileHandlers []Handler
 
+	// RootPaths form the top-level paths for the library.
+	// Used to determine the root of the folder hierarchy when creating folders.
+	RootPaths []string
+
 	// Rescan indicates whether files should be rescanned even if they haven't changed.
 	Rescan bool
 
@@ -604,13 +608,19 @@ func (s *Scanner) handleRename(ctx context.Context, f models.File, fp []models.F
 	fBaseCopy.Fingerprints = updatedBase.Fingerprints
 	*updatedBase = fBaseCopy
 
+	zipMover := zipHierarchyMover{
+		folderStore: s.Repository.Folder,
+		files:       s.Repository.File,
+		rootPaths:   s.RootPaths,
+	}
+
 	if err := s.Repository.WithTxn(ctx, func(ctx context.Context) error {
 		if err := s.Repository.File.Update(ctx, updated); err != nil {
 			return fmt.Errorf("updating file for rename %q: %w", newPath, err)
 		}
 
 		if s.IsZipFile(updatedBase.Basename) {
-			if err := transferZipHierarchy(ctx, s.Repository.Folder, s.Repository.File, updatedBase.ID, oldPath, newPath); err != nil {
+			if err := zipMover.transferZipHierarchy(ctx, updatedBase.ID, oldPath, newPath); err != nil {
 				return fmt.Errorf("moving zip hierarchy for renamed zip file %q: %w", newPath, err)
 			}
 		}

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -400,13 +400,31 @@ func (s *Scanner) onNewFile(ctx context.Context, f ScannedFile) (*ScanFileResult
 	baseFile.UpdatedAt = now
 
 	// find the parent folder
-	parentFolderID, err := s.getFolderID(ctx, filepath.Dir(path))
+	folderPath := filepath.Dir(path)
+	parentFolderID, err := s.getFolderID(ctx, folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting parent folder for %q: %w", path, err)
 	}
 
 	if parentFolderID == nil {
-		return nil, fmt.Errorf("parent folder for %q doesn't exist", path)
+		// parent folders should have been created before scanning this file in a recursive scan
+		// assume that we are scanning specifically and only this file,
+		// so we should create the parent folder hierarchy if it doesn't exist
+		if err := s.Repository.WithTxn(ctx, func(ctx context.Context) error {
+			parentFolder, err := GetOrCreateFolderHierarchy(ctx, s.Repository.Folder, folderPath, s.RootPaths)
+			if err != nil {
+				return fmt.Errorf("getting parent folder for %q: %w", f.Path, err)
+			}
+
+			parentFolderID = &parentFolder.ID
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if parentFolderID == nil {
+		// shouldn't happen
+		return nil, fmt.Errorf("parent folder ID is nil for %q", path)
 	}
 
 	baseFile.ParentFolderID = *parentFolderID


### PR DESCRIPTION
This PR addresses corruption that may occur when scanning specific paths, and fixes existing corrupt folder entries.

Fixes the following scenarios:
- scanning a specific folder where the parent folder has not been scanned resulted in the scanned folder entry being created without a parent folder. Scanning a specific folder will now create the folder hierarchy up to the root library folders. Scanning existing folders will now check for folders without parent folders and create the folder hierarchy.
- scanning a specific file where the parent folder has not been scanned resulted in an error about the parent folder not existing, as reported in #3342. Scanning a specific file will now create the necessary folder hierarchy.

Resolves #3342 