### PR TITLE
Fix: Custom Field Filtering

### DIFF
--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1129,7 +1129,7 @@ func (h *relatedFilterHandler) handle(ctx context.Context, f *filterBuilder) {
 		return
 	}
 
-	f.addWhere(fmt.Sprintf("%s IN ("+subQuery.toSQL(false)+")", h.relatedIDCol), subQuery.args...)
+	f.addWhere(fmt.Sprintf("%s IN ("+subQuery.toSQL(false)+")", h.relatedIDCol), subQuery.allArgs()...)
 }
 
 type phashDistanceCriterionHandler struct {

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -975,7 +975,7 @@ func (qb *FileStore) queryGroupedFields(ctx context.Context, options models.File
 		Megapixels float64
 		Size       int64
 	}{}
-	if err := qb.repository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.args, &out); err != nil {
+	if err := qb.repository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.allArgs(), &out); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sqlite/folder.go
+++ b/pkg/sqlite/folder.go
@@ -513,7 +513,7 @@ func (qb *FolderStore) queryGroupedFields(ctx context.Context, options models.Fo
 		Megapixels float64
 		Size       int64
 	}{}
-	if err := qb.repository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.args, &out); err != nil {
+	if err := qb.repository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.allArgs(), &out); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -926,7 +926,7 @@ func (qb *ImageStore) queryGroupedFields(ctx context.Context, options models.Ima
 		Megapixels null.Float
 		Size       null.Float
 	}{}
-	if err := imageRepository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.args, &out); err != nil {
+	if err := imageRepository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.allArgs(), &out); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -17,11 +17,24 @@ type queryBuilder struct {
 	joins         joins
 	whereClauses  []string
 	havingClauses []string
-	args          []interface{}
 	withClauses   []string
 	recursiveWith bool
 
+	withArgs   []interface{}
+	joinArgs   []interface{}
+	whereArgs  []interface{}
+	havingArgs []interface{}
+
 	sortAndPagination string
+}
+
+func (qb queryBuilder) allArgs() []interface{} {
+	var args []interface{}
+	args = append(args, qb.withArgs...)
+	args = append(args, qb.joinArgs...)
+	args = append(args, qb.whereArgs...)
+	args = append(args, qb.havingArgs...)
+	return args
 }
 
 func (qb queryBuilder) body(includeSortPagination bool) string {
@@ -55,13 +68,13 @@ func (qb queryBuilder) toSQL(includeSortPagination bool) string {
 func (qb queryBuilder) findIDs(ctx context.Context) ([]int, error) {
 	const includeSortPagination = true
 	sql := qb.toSQL(includeSortPagination)
-	return qb.repository.runIdsQuery(ctx, sql, qb.args)
+	return qb.repository.runIdsQuery(ctx, sql, qb.allArgs())
 }
 
 func (qb queryBuilder) executeFind(ctx context.Context) ([]int, int, error) {
 	const includeSortPagination = true
 	body := qb.body(includeSortPagination)
-	return qb.repository.executeFindQuery(ctx, body, qb.args, qb.sortAndPagination, qb.whereClauses, qb.havingClauses, qb.withClauses, qb.recursiveWith)
+	return qb.repository.executeFindQuery(ctx, body, qb.allArgs(), qb.sortAndPagination, qb.whereClauses, qb.havingClauses, qb.withClauses, qb.recursiveWith)
 }
 
 func (qb queryBuilder) executeCount(ctx context.Context) (int, error) {
@@ -79,7 +92,7 @@ func (qb queryBuilder) executeCount(ctx context.Context) (int, error) {
 
 	body = qb.repository.buildQueryBody(body, qb.whereClauses, qb.havingClauses)
 	countQuery := withClause + qb.repository.buildCountQuery(body)
-	return qb.repository.runCountQuery(ctx, countQuery, qb.args)
+	return qb.repository.runCountQuery(ctx, countQuery, qb.allArgs())
 }
 
 func (qb *queryBuilder) addWhere(clauses ...string) {
@@ -109,7 +122,11 @@ func (qb *queryBuilder) addWith(recursive bool, clauses ...string) {
 }
 
 func (qb *queryBuilder) addArg(args ...interface{}) {
-	qb.args = append(qb.args, args...)
+	qb.whereArgs = append(qb.whereArgs, args...)
+}
+
+func (qb *queryBuilder) addHavingArg(args ...interface{}) {
+	qb.havingArgs = append(qb.havingArgs, args...)
 }
 
 func (qb *queryBuilder) hasJoin(alias string) bool {
@@ -148,7 +165,7 @@ func (qb *queryBuilder) joinSort(table, as, onClause string) {
 func (qb *queryBuilder) addJoins(joins ...join) {
 	for _, j := range joins {
 		if qb.joins.addUnique(j) {
-			qb.args = append(qb.args, j.args...)
+			qb.joinArgs = append(qb.joinArgs, j.args...)
 		}
 	}
 }
@@ -163,40 +180,16 @@ func (qb *queryBuilder) addFilter(f *filterBuilder) error {
 	if len(clause) > 0 {
 		qb.addWith(f.recursiveWith, clause)
 	}
-
-	withArgCount := 0
 	if len(args) > 0 {
-		// WITH clause always comes first and thus precedes all args
-		qb.args = append(args, qb.args...)
-		withArgCount = len(args)
+		qb.withArgs = append(qb.withArgs, args...)
 	}
 
-	// Collect join args separately instead of using addJoins directly,
-	// which appends args at the end. This causes ordering issues when
-	// parseQueryString has already added WHERE args to qb.args.
-	allJoins := f.getAllJoins()
-	var joinArgs []interface{}
-	for _, j := range allJoins {
-		if qb.joins.addUnique(j) {
-			joinArgs = append(joinArgs, j.args...)
-		}
-	}
-
-	// Insert join args after WITH args but before any existing WHERE args,
-	// because JOINs precede WHERE in SQL and args are positional.
-	if len(joinArgs) > 0 {
-		newArgs := make([]interface{}, 0, len(qb.args)+len(joinArgs))
-		newArgs = append(newArgs, qb.args[:withArgCount]...)
-		newArgs = append(newArgs, joinArgs...)
-		newArgs = append(newArgs, qb.args[withArgCount:]...)
-		qb.args = newArgs
-	}
+	qb.addJoins(f.getAllJoins()...)
 
 	clause, args = f.generateWhereClauses()
 	if len(clause) > 0 {
 		qb.addWhere(clause)
 	}
-
 	if len(args) > 0 {
 		qb.addArg(args...)
 	}
@@ -205,9 +198,8 @@ func (qb *queryBuilder) addFilter(f *filterBuilder) error {
 	if len(clause) > 0 {
 		qb.addHaving(clause)
 	}
-
 	if len(args) > 0 {
-		qb.addArg(args...)
+		qb.addHavingArg(args...)
 	}
 
 	return nil

--- a/pkg/sqlite/query.go
+++ b/pkg/sqlite/query.go
@@ -164,13 +164,33 @@ func (qb *queryBuilder) addFilter(f *filterBuilder) error {
 		qb.addWith(f.recursiveWith, clause)
 	}
 
+	withArgCount := 0
 	if len(args) > 0 {
-		// WITH clause always comes first and thus precedes alk args
+		// WITH clause always comes first and thus precedes all args
 		qb.args = append(args, qb.args...)
+		withArgCount = len(args)
 	}
 
-	// add joins here to insert args
-	qb.addJoins(f.getAllJoins()...)
+	// Collect join args separately instead of using addJoins directly,
+	// which appends args at the end. This causes ordering issues when
+	// parseQueryString has already added WHERE args to qb.args.
+	allJoins := f.getAllJoins()
+	var joinArgs []interface{}
+	for _, j := range allJoins {
+		if qb.joins.addUnique(j) {
+			joinArgs = append(joinArgs, j.args...)
+		}
+	}
+
+	// Insert join args after WITH args but before any existing WHERE args,
+	// because JOINs precede WHERE in SQL and args are positional.
+	if len(joinArgs) > 0 {
+		newArgs := make([]interface{}, 0, len(qb.args)+len(joinArgs))
+		newArgs = append(newArgs, qb.args[:withArgCount]...)
+		newArgs = append(newArgs, joinArgs...)
+		newArgs = append(newArgs, qb.args[withArgCount:]...)
+		qb.args = newArgs
+	}
 
 	clause, args = f.generateWhereClauses()
 	if len(clause) > 0 {

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1097,7 +1097,7 @@ func (qb *SceneStore) queryGroupedFields(ctx context.Context, options models.Sce
 		Duration null.Float
 		Size     null.Float
 	}{}
-	if err := sceneRepository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.args, &out); err != nil {
+	if err := sceneRepository.queryStruct(ctx, aggregateQuery.toSQL(includeSortPagination), query.allArgs(), &out); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -1889,6 +1889,65 @@ func TestTagQueryCustomFields(t *testing.T) {
 			}
 		})
 	}
+
+	// Test combining text search (findFilter.Q) with custom field filters.
+	// This verifies that positional args are bound in the correct order
+	// when JOINs (from custom fields) and WHERE (from text search) both
+	// have parameterized placeholders.
+	runWithRollbackTxn(t, "equals with text search", func(t *testing.T, ctx context.Context) {
+		assert := assert.New(t)
+
+		tagName := getTagStringValue(tagIdxWithGallery, "Name")
+		q := tagName
+		findFilter := &models.FindFilterType{Q: &q}
+
+		tagFilter := &models.TagFilterType{
+			CustomFields: []models.CustomFieldCriterionInput{
+				{
+					Field:    "string",
+					Modifier: models.CriterionModifierEquals,
+					Value:    []any{getTagStringValue(tagIdxWithGallery, "custom")},
+				},
+			},
+		}
+
+		tags, _, err := db.Tag.Query(ctx, tagFilter, findFilter)
+		if err != nil {
+			t.Errorf("TagStore.Query() error = %v", err)
+			return
+		}
+
+		ids := tagsToIDs(tags)
+		assert.Contains(ids, tagIDs[tagIdxWithGallery])
+		assert.Len(tags, 1)
+	})
+
+	runWithRollbackTxn(t, "is_null with text search", func(t *testing.T, ctx context.Context) {
+		assert := assert.New(t)
+
+		tagName := getTagStringValue(tagIdxWithGallery, "Name")
+		q := tagName
+		findFilter := &models.FindFilterType{Q: &q}
+
+		tagFilter := &models.TagFilterType{
+			CustomFields: []models.CustomFieldCriterionInput{
+				{
+					Field:    "not existing",
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+		}
+
+		tags, _, err := db.Tag.Query(ctx, tagFilter, findFilter)
+		if err != nil {
+			t.Errorf("TagStore.Query() error = %v", err)
+			return
+		}
+
+		ids := tagsToIDs(tags)
+		assert.Contains(ids, tagIDs[tagIdxWithGallery])
+		assert.Len(tags, 1)
+	})
 }
 
 // TODO Destroy


### PR DESCRIPTION
When combining a text search with a custom field filter, positional SQL args get bound in the wrong order an JOIN args end up after WHERE args even though JOINs come first in the query. This causes custom field filters to silently break when a search term is also present.
                                                                                                                                                                                 
The fix inserts JOIN args before existing WHERE args in addFilter() so the arg order matches the SQL clause order.

  - Searching "Alpha" with color Equals red returns only Alpha
  - Searching "Beta" with color Equals red returns nothing
  - Searching "Gamma" with color Is Null returns only Gamma
  - Searching "Alpha" with color Is Null returns nothing
  
  
  Fixes: https://github.com/stashapp/stash/issues/6613