### PR TITLE
Fix panic when library path has trailing path separator

### DIFF
--- a/internal/manager/config/stash_config.go
+++ b/internal/manager/config/stash_config.go
@@ -42,7 +42,8 @@ func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
 func (s StashConfigs) Paths() []string {
 	paths := make([]string, len(s))
 	for i, c := range s {
-		paths[i] = c.Path
+		// #6618 - clean the path to ensure comparison works correctly
+		paths[i] = filepath.Clean(c.Path)
 	}
 	return paths
 }

--- a/pkg/file/folder.go
+++ b/pkg/file/folder.go
@@ -33,7 +33,10 @@ func GetOrCreateFolderHierarchy(ctx context.Context, fc models.FolderFinderCreat
 			// safety check - don't allow parent path to be the same as the current path,
 			// otherwise we could end up in an infinite loop
 			if parentPath == path {
-				panic(fmt.Sprintf("parent path is the same as the current path: %s", path))
+				// #6618 - log a warning and return nil for the parent ID,
+				// which will cause the folder to be created with no parent
+				logger.Warnf("parent path is the same as the current path: %s", path)
+				return nil, nil
 			}
 
 			parent, err := GetOrCreateFolderHierarchy(ctx, fc, parentPath, rootPaths)


### PR DESCRIPTION
Resolves #6618
Closes #6615

Cleans the stash directory paths so that they are compared correctly when determining how high up the filesystem hierarchy to create folder entries for, and replaces the panic with a warning when creating folder hierarchies.