### PR TITLE
Add Selective generate

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -26,7 +26,7 @@ input GenerateMetadataInput {
   imageIDs: [ID!]
   "gallery ids to generate for"
   galleryIDs: [ID!]
-
+  "paths to run generate on, in addition to the other ID lists"
   paths: [String!]
 
   "overwrite existing media"

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -29,7 +29,6 @@ input GenerateMetadataInput {
 
   paths: [String!]
 
-
   "overwrite existing media"
   overwrite: Boolean
 }

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -27,6 +27,9 @@ input GenerateMetadataInput {
   "gallery ids to generate for"
   galleryIDs: [ID!]
 
+  paths: [String!]
+
+
   "overwrite existing media"
   overwrite: Boolean
 }

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -74,6 +74,28 @@ func getScanPaths(inputPaths []string) []*config.StashConfig {
 	return ret
 }
 
+// Filters the input array for paths that are within the paths managed by stash
+func filterStashPaths(inputPaths []string) []string {
+	if len(inputPaths) == 0 {
+		return inputPaths
+	}
+
+	stashPaths := config.GetInstance().GetStashPaths()
+
+	var ret []string
+	for _, p := range inputPaths {
+		s := stashPaths.GetStashFromDirPath(p)
+		if s == nil {
+			logger.Warnf("%s is not in the configured stash paths", p)
+			continue
+		}
+
+		ret = append(ret, p)
+	}
+
+	return ret
+}
+
 // ScanSubscribe subscribes to a notification that is triggered when a
 // scan or clean is complete.
 func (s *Manager) ScanSubscribe(ctx context.Context) <-chan bool {

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -65,7 +65,6 @@ const generateQueueSize = 200000
 type GenerateJob struct {
 	repository models.Repository
 	input      GenerateMetadataInput
-	paths      []string
 
 	overwrite      bool
 	fileNamingAlgo models.HashAlgorithm
@@ -103,14 +102,6 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 
 	logger.Infof("Generate started with %d parallel tasks", parallelTasks)
 
-	if len(j.input.Paths) > 0 {
-		sp := getScanPaths(j.input.Paths)
-		j.paths = make([]string, len(sp))
-		for i, p := range sp {
-			j.paths[i] = p.Path
-		}
-	}
-
 	queue := make(chan Task, generateQueueSize)
 	go func() {
 		defer close(queue)
@@ -144,8 +135,13 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 		r := j.repository
 		if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
 			qb := r.Scene
-			if len(j.input.SceneIDs) == 0 && len(j.input.MarkerIDs) == 0 && len(j.input.ImageIDs) == 0 && len(j.input.GalleryIDs) == 0 {
-				j.queueTasks(ctx, g, queue)
+			if len(j.input.SceneIDs) == 0 &&
+				len(j.input.MarkerIDs) == 0 &&
+				len(j.input.ImageIDs) == 0 &&
+				len(j.input.GalleryIDs) == 0 &&
+				len(j.input.Paths) == 0 {
+
+				j.queueTasks(ctx, g, nil, queue)
 			} else {
 				if len(j.input.SceneIDs) > 0 {
 					scenes, err = qb.FindMany(ctx, sceneIDs)
@@ -196,7 +192,8 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 				}
 
 				if len(j.input.Paths) > 0 {
-					j.queueTasks(ctx, g, queue)
+					paths := filterStashPaths(j.input.Paths)
+					j.queueTasks(ctx, g, paths, queue)
 				}
 			}
 
@@ -291,18 +288,18 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 	return nil
 }
 
-func (j *GenerateJob) queueTasks(ctx context.Context, g *generate.Generator, queue chan<- Task) {
+func (j *GenerateJob) queueTasks(ctx context.Context, g *generate.Generator, paths []string, queue chan<- Task) {
 	j.totals = totalsGenerate{}
 
-	j.queueScenesTasks(ctx, g, queue)
-	j.queueImagesTasks(ctx, g, queue)
+	j.queueScenesTasks(ctx, g, paths, queue)
+	j.queueImagesTasks(ctx, g, paths, queue)
 }
 
-func (j *GenerateJob) queueScenesTasks(ctx context.Context, g *generate.Generator, queue chan<- Task) {
+func (j *GenerateJob) queueScenesTasks(ctx context.Context, g *generate.Generator, paths []string, queue chan<- Task) {
 	const batchSize = 1000
 
 	findFilter := models.BatchFindFilter(batchSize)
-	sceneFilter := scene.FilterFromPaths(j.paths)
+	sceneFilter := scene.FilterFromPaths(paths)
 
 	r := j.repository
 
@@ -338,11 +335,11 @@ func (j *GenerateJob) queueScenesTasks(ctx context.Context, g *generate.Generato
 	}
 }
 
-func (j *GenerateJob) queueImagesTasks(ctx context.Context, g *generate.Generator, queue chan<- Task) {
+func (j *GenerateJob) queueImagesTasks(ctx context.Context, g *generate.Generator, paths []string, queue chan<- Task) {
 	const batchSize = 1000
 
 	findFilter := models.BatchFindFilter(batchSize)
-	imageFilter := image.FilterFromPaths(j.paths)
+	imageFilter := image.FilterFromPaths(paths)
 
 	r := j.repository
 

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -43,6 +43,8 @@ type GenerateMetadataInput struct {
 	GalleryIDs []string `json:"galleryIDs"`
 	// overwrite existing media
 	Overwrite bool `json:"overwrite"`
+	// paths
+	Paths []string `json:"paths"`
 }
 
 type GeneratePreviewOptionsInput struct {
@@ -63,6 +65,7 @@ const generateQueueSize = 200000
 type GenerateJob struct {
 	repository models.Repository
 	input      GenerateMetadataInput
+	paths      []string
 
 	overwrite      bool
 	fileNamingAlgo models.HashAlgorithm
@@ -99,6 +102,12 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 	parallelTasks := config.GetParallelTasksWithAutoDetection()
 
 	logger.Infof("Generate started with %d parallel tasks", parallelTasks)
+
+	sp := getScanPaths(j.input.Paths)
+	j.paths = make([]string, len(sp))
+	for i, p := range sp {
+		j.paths[i] = p.Path
+	}
 
 	queue := make(chan Task, generateQueueSize)
 	go func() {
@@ -182,6 +191,10 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 							j.queueImageJob(g, img, queue)
 						}
 					}
+				}
+
+				if len(j.input.Paths) > 0 {
+					j.queueTasks(ctx, g, queue)
 				}
 			}
 
@@ -287,6 +300,7 @@ func (j *GenerateJob) queueScenesTasks(ctx context.Context, g *generate.Generato
 	const batchSize = 1000
 
 	findFilter := models.BatchFindFilter(batchSize)
+	sceneFilter := scene.FilterFromPaths(j.paths)
 
 	r := j.repository
 
@@ -295,7 +309,7 @@ func (j *GenerateJob) queueScenesTasks(ctx context.Context, g *generate.Generato
 			return
 		}
 
-		scenes, err := scene.Query(ctx, r.Scene, nil, findFilter)
+		scenes, err := scene.Query(ctx, r.Scene, sceneFilter, findFilter)
 		if err != nil {
 			logger.Errorf("Error encountered queuing files to scan: %s", err.Error())
 			return
@@ -326,6 +340,7 @@ func (j *GenerateJob) queueImagesTasks(ctx context.Context, g *generate.Generato
 	const batchSize = 1000
 
 	findFilter := models.BatchFindFilter(batchSize)
+	imageFilter := image.FilterFromPaths(j.paths)
 
 	r := j.repository
 
@@ -334,7 +349,7 @@ func (j *GenerateJob) queueImagesTasks(ctx context.Context, g *generate.Generato
 			return
 		}
 
-		images, err := image.Query(ctx, r.Image, nil, findFilter)
+		images, err := image.Query(ctx, r.Image, imageFilter, findFilter)
 		if err != nil {
 			logger.Errorf("Error encountered queuing files to scan: %s", err.Error())
 			return

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -43,7 +43,7 @@ type GenerateMetadataInput struct {
 	GalleryIDs []string `json:"galleryIDs"`
 	// overwrite existing media
 	Overwrite bool `json:"overwrite"`
-	// paths
+	// paths to run generate on, in addition to the other ID lists
 	Paths []string `json:"paths"`
 }
 

--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -103,10 +103,12 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 
 	logger.Infof("Generate started with %d parallel tasks", parallelTasks)
 
-	sp := getScanPaths(j.input.Paths)
-	j.paths = make([]string, len(sp))
-	for i, p := range sp {
-		j.paths[i] = p.Path
+	if len(j.input.Paths) > 0 {
+		sp := getScanPaths(j.input.Paths)
+		j.paths = make([]string, len(sp))
+		for i, p := range sp {
+			j.paths[i] = p.Path
+		}
 	}
 
 	queue := make(chan Task, generateQueueSize)

--- a/pkg/image/query.go
+++ b/pkg/image/query.go
@@ -2,7 +2,9 @@ package image
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -44,6 +46,35 @@ func Query(ctx context.Context, qb Queryer, imageFilter *models.ImageFilterType,
 	}
 
 	return images, nil
+}
+
+// FilterFromPaths creates a ImageFilterType that filters using the provided
+// paths.
+func FilterFromPaths(paths []string) *models.ImageFilterType {
+	ret := &models.ImageFilterType{}
+	or := ret
+	sep := string(filepath.Separator)
+
+	for _, p := range paths {
+		if !strings.HasSuffix(p, sep) {
+			p += sep
+		}
+
+		if ret.Path == nil {
+			or = ret
+		} else {
+			newOr := &models.ImageFilterType{}
+			or.Or = newOr
+			or = newOr
+		}
+
+		or.Path = &models.StringCriterionInput{
+			Modifier: models.CriterionModifierEquals,
+			Value:    p + "%",
+		}
+	}
+
+	return ret
 }
 
 func CountByPerformerID(ctx context.Context, r QueryCounter, id int) (int, error) {

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -79,6 +79,7 @@ export const LibraryTasks: React.FC = () => {
     scan: false,
     autoTag: false,
     identify: false,
+    generate: false,
   });
 
   function getDefaultScanOptions(): GQL.ScanMetadataInput {
@@ -265,6 +266,41 @@ export const LibraryTasks: React.FC = () => {
     );
   }
 
+  function renderGenerateDialog() {
+    if (!dialogOpen.generate) {
+      return;
+    }
+
+    return <DirectorySelectionDialog onClose={onGenerateDialogClosed} />;
+  }
+
+  function onGenerateDialogClosed(paths?: string[]) {
+    if (paths) {
+      runGenerate(paths);
+    }
+
+    setDialogOpen({ generate: false });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async function runGenerate(paths?: string[]) {
+    try {
+      await mutateMetadataGenerate({
+        ...generateOptions,
+        paths,
+      });
+
+      Toast.success(
+        intl.formatMessage(
+          { id: "config.tasks.added_job_to_queue" },
+          { operation_name: intl.formatMessage({ id: "actions.generate" }) }
+        )
+      );
+    } catch (e) {
+      Toast.error(e);
+    }
+  }
+
   async function onGenerateClicked() {
     try {
       // insert preview options here instead of loading them
@@ -307,6 +343,7 @@ export const LibraryTasks: React.FC = () => {
       {renderScanDialog()}
       {renderAutoTagDialog()}
       {maybeRenderIdentifyDialog()}
+      {renderGenerateDialog()}
 
       <SettingSection headingID="library">
         <SettingGroup
@@ -425,13 +462,23 @@ export const LibraryTasks: React.FC = () => {
             subHeadingID: "config.tasks.generate_desc",
           }}
           topLevel={
-            <Button
-              variant="secondary"
-              type="submit"
-              onClick={() => onGenerateClicked()}
-            >
-              <FormattedMessage id="actions.generate" />
-            </Button>
+            <>
+              <Button
+                variant="secondary"
+                type="submit"
+                onClick={() => onGenerateClicked()}
+              >
+                <FormattedMessage id="actions.generate" />
+              </Button>
+              <Button
+                variant="secondary"
+                type="submit"
+                className="mr-2"
+                onClick={() => setDialogOpen({ generate: true })}
+              >
+                <FormattedMessage id="actions.selective_generate" />…
+              </Button>
+            </>
           }
           collapsible
         >

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -123,6 +123,7 @@
     "invert_selection": "Invert Selection",
     "selective_auto_tag": "Selective auto tag",
     "selective_clean": "Selective clean",
+    "selective_generate": "Selective generate",
     "selective_scan": "Selective scan",
     "set_as_default": "Set as default",
     "set_back_image": "Back image…",


### PR DESCRIPTION
As the title says, I've added the `Selective generate...` button and it functions the same as the other `Selective` buttons.

<img width="800" height="135" alt="image" src="https://github.com/user-attachments/assets/1ef32c10-2078-4057-b089-52283cc5c683" />


This closes #3287 but not its sub issue. I've built this for myself and only now, when creating the PR, I noticed the feature request.

The proposed workaround in issue #3287 is not ideal, IMHO, when you have considerably more than 1000 items that you wish to run generate on, so I think that the feature is still useful as implemented.

For example, you scan for new files and only generate scene and image phashes to quickly identify dups and only then you run the slower generation on the same folders.
