### PR TITLE
Fix stale browser-cached thumbnails after file content changes during scan.

### DIFF
--- a/pkg/gallery/scan.go
+++ b/pkg/gallery/scan.go
@@ -135,13 +135,14 @@ func (h *ScanHandler) associateExisting(ctx context.Context, existing []*models.
 			if err := h.CreatorUpdater.AddFileID(ctx, i.ID, f.Base().ID); err != nil {
 				return fmt.Errorf("adding file to gallery: %w", err)
 			}
-			// update updated_at time
-			if _, err := h.CreatorUpdater.UpdatePartial(ctx, i.ID, models.NewGalleryPartial()); err != nil {
-				return fmt.Errorf("updating gallery: %w", err)
-			}
 		}
 
 		if !found || updateExisting {
+			// update updated_at time when file association or content changes
+			if _, err := h.CreatorUpdater.UpdatePartial(ctx, i.ID, models.NewGalleryPartial()); err != nil {
+				return fmt.Errorf("updating gallery: %w", err)
+			}
+
 			h.PluginCache.RegisterPostHooks(ctx, i.ID, hook.GalleryUpdatePost, nil, nil)
 		}
 	}

--- a/pkg/gallery/scan_test.go
+++ b/pkg/gallery/scan_test.go
@@ -2,67 +2,14 @@ package gallery
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
 	"github.com/stashapp/stash/pkg/plugin"
-	"github.com/stashapp/stash/pkg/txn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-var errRollback = errors.New("rollback")
-
-type mockGalleryScanCU struct {
-	mock.Mock
-}
-
-func (m *mockGalleryScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Gallery, error) {
-	args := m.Called(ctx, fileID)
-	return args.Get(0).([]*models.Gallery), args.Error(1)
-}
-
-func (m *mockGalleryScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Gallery, error) {
-	args := m.Called(ctx, fp)
-	return args.Get(0).([]*models.Gallery), args.Error(1)
-}
-
-func (m *mockGalleryScanCU) GetFiles(ctx context.Context, relatedID int) ([]models.File, error) {
-	args := m.Called(ctx, relatedID)
-	return args.Get(0).([]models.File), args.Error(1)
-}
-
-func (m *mockGalleryScanCU) Create(ctx context.Context, input *models.CreateGalleryInput) error {
-	args := m.Called(ctx, input)
-	return args.Error(0)
-}
-
-func (m *mockGalleryScanCU) UpdatePartial(ctx context.Context, id int, updatedGallery models.GalleryPartial) (*models.Gallery, error) {
-	args := m.Called(ctx, id, updatedGallery)
-	return args.Get(0).(*models.Gallery), args.Error(1)
-}
-
-func (m *mockGalleryScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
-	args := m.Called(ctx, id, fileID)
-	return args.Error(0)
-}
-
-type noopTxnManager struct{}
-
-func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
-	return ctx, nil
-}
-func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
-func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
-func (m *noopTxnManager) IsLocked(err error) bool            { return false }
-
-func withTxnCtx(fn func(ctx context.Context)) {
-	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
-		fn(ctx)
-		return errRollback
-	})
-}
 
 func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 	const (
@@ -98,28 +45,28 @@ func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cu := &mockGalleryScanCU{}
-			cu.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
+			db := mocks.NewDatabase()
+			db.Gallery.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
 
 			if tt.expectUpdate {
-				cu.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
+				db.Gallery.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
 					Return(&models.Gallery{ID: testGalleryID}, nil)
 			}
 
 			h := &ScanHandler{
-				CreatorUpdater: cu,
+				CreatorUpdater: db.Gallery,
 				PluginCache:    &plugin.Cache{},
 			}
 
-			withTxnCtx(func(ctx context.Context) {
+			db.WithTxnCtx(func(ctx context.Context) {
 				err := h.associateExisting(ctx, []*models.Gallery{makeGallery()}, existingFile, tt.updateExisting)
 				assert.NoError(t, err)
 			})
 
 			if tt.expectUpdate {
-				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
+				db.Gallery.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
 			} else {
-				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+				db.Gallery.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
 			}
 		})
 	}
@@ -140,22 +87,22 @@ func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
 		Files: models.NewRelatedFiles([]models.File{existingFile}),
 	}
 
-	cu := &mockGalleryScanCU{}
-	cu.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
-	cu.On("AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID)).Return(nil)
-	cu.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
+	db := mocks.NewDatabase()
+	db.Gallery.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
+	db.Gallery.On("AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID)).Return(nil)
+	db.Gallery.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
 		Return(&models.Gallery{ID: testGalleryID}, nil)
 
 	h := &ScanHandler{
-		CreatorUpdater: cu,
+		CreatorUpdater: db.Gallery,
 		PluginCache:    &plugin.Cache{},
 	}
 
-	withTxnCtx(func(ctx context.Context) {
+	db.WithTxnCtx(func(ctx context.Context) {
 		err := h.associateExisting(ctx, []*models.Gallery{gallery}, newFile, false)
 		assert.NoError(t, err)
 	})
 
-	cu.AssertCalled(t, "AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID))
-	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
+	db.Gallery.AssertCalled(t, "AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID))
+	db.Gallery.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
 }

--- a/pkg/gallery/scan_test.go
+++ b/pkg/gallery/scan_test.go
@@ -1,0 +1,161 @@
+package gallery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/plugin"
+	"github.com/stashapp/stash/pkg/txn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var errRollback = errors.New("rollback")
+
+type mockGalleryScanCU struct {
+	mock.Mock
+}
+
+func (m *mockGalleryScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Gallery, error) {
+	args := m.Called(ctx, fileID)
+	return args.Get(0).([]*models.Gallery), args.Error(1)
+}
+
+func (m *mockGalleryScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Gallery, error) {
+	args := m.Called(ctx, fp)
+	return args.Get(0).([]*models.Gallery), args.Error(1)
+}
+
+func (m *mockGalleryScanCU) GetFiles(ctx context.Context, relatedID int) ([]models.File, error) {
+	args := m.Called(ctx, relatedID)
+	return args.Get(0).([]models.File), args.Error(1)
+}
+
+func (m *mockGalleryScanCU) Create(ctx context.Context, input *models.CreateGalleryInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *mockGalleryScanCU) UpdatePartial(ctx context.Context, id int, updatedGallery models.GalleryPartial) (*models.Gallery, error) {
+	args := m.Called(ctx, id, updatedGallery)
+	return args.Get(0).(*models.Gallery), args.Error(1)
+}
+
+func (m *mockGalleryScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
+	args := m.Called(ctx, id, fileID)
+	return args.Error(0)
+}
+
+type noopTxnManager struct{}
+
+func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
+	return ctx, nil
+}
+func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
+func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
+func (m *noopTxnManager) IsLocked(err error) bool            { return false }
+
+func withTxnCtx(fn func(ctx context.Context)) {
+	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
+		fn(ctx)
+		return errRollback
+	})
+}
+
+func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
+	const (
+		testGalleryID = 1
+		testFileID    = 100
+	)
+
+	existingFile := &models.BaseFile{ID: models.FileID(testFileID), Path: "test.zip"}
+
+	makeGallery := func() *models.Gallery {
+		return &models.Gallery{
+			ID:    testGalleryID,
+			Files: models.NewRelatedFiles([]models.File{existingFile}),
+		}
+	}
+
+	tests := []struct {
+		name           string
+		updateExisting bool
+		expectUpdate   bool
+	}{
+		{
+			name:           "calls UpdatePartial when file content changed",
+			updateExisting: true,
+			expectUpdate:   true,
+		},
+		{
+			name:           "skips UpdatePartial when file unchanged and already associated",
+			updateExisting: false,
+			expectUpdate:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cu := &mockGalleryScanCU{}
+			cu.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
+
+			if tt.expectUpdate {
+				cu.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
+					Return(&models.Gallery{ID: testGalleryID}, nil)
+			}
+
+			h := &ScanHandler{
+				CreatorUpdater: cu,
+				PluginCache:    &plugin.Cache{},
+			}
+
+			withTxnCtx(func(ctx context.Context) {
+				err := h.associateExisting(ctx, []*models.Gallery{makeGallery()}, existingFile, tt.updateExisting)
+				assert.NoError(t, err)
+			})
+
+			if tt.expectUpdate {
+				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
+			} else {
+				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
+	const (
+		testGalleryID = 1
+		existFileID   = 100
+		newFileID     = 200
+	)
+
+	existingFile := &models.BaseFile{ID: models.FileID(existFileID), Path: "existing.zip"}
+	newFile := &models.BaseFile{ID: models.FileID(newFileID), Path: "new.zip"}
+
+	gallery := &models.Gallery{
+		ID:    testGalleryID,
+		Files: models.NewRelatedFiles([]models.File{existingFile}),
+	}
+
+	cu := &mockGalleryScanCU{}
+	cu.On("GetFiles", mock.Anything, testGalleryID).Return([]models.File{existingFile}, nil)
+	cu.On("AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID)).Return(nil)
+	cu.On("UpdatePartial", mock.Anything, testGalleryID, mock.Anything).
+		Return(&models.Gallery{ID: testGalleryID}, nil)
+
+	h := &ScanHandler{
+		CreatorUpdater: cu,
+		PluginCache:    &plugin.Cache{},
+	}
+
+	withTxnCtx(func(ctx context.Context) {
+		err := h.associateExisting(ctx, []*models.Gallery{gallery}, newFile, false)
+		assert.NoError(t, err)
+	})
+
+	cu.AssertCalled(t, "AddFileID", mock.Anything, testGalleryID, models.FileID(newFileID))
+	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testGalleryID, mock.Anything)
+}

--- a/pkg/image/scan.go
+++ b/pkg/image/scan.go
@@ -210,8 +210,8 @@ func (h *ScanHandler) associateExisting(ctx context.Context, existing []*models.
 			changed = true
 		}
 
-		if changed {
-			// always update updated_at time
+		if changed || updateExisting {
+			// update updated_at time when file association or content changes
 			imagePartial := models.NewImagePartial()
 			imagePartial.GalleryIDs = galleryIDs
 
@@ -229,9 +229,7 @@ func (h *ScanHandler) associateExisting(ctx context.Context, existing []*models.
 					return fmt.Errorf("updating gallery updated at timestamp: %w", err)
 				}
 			}
-		}
 
-		if changed || updateExisting {
 			h.PluginCache.RegisterPostHooks(ctx, i.ID, hook.ImageUpdatePost, nil, nil)
 		}
 	}

--- a/pkg/image/scan_test.go
+++ b/pkg/image/scan_test.go
@@ -1,0 +1,207 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/plugin"
+	"github.com/stashapp/stash/pkg/txn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var errRollback = errors.New("rollback")
+
+type mockImageScanCU struct {
+	mock.Mock
+}
+
+func (m *mockImageScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Image, error) {
+	args := m.Called(ctx, fileID)
+	return args.Get(0).([]*models.Image), args.Error(1)
+}
+
+func (m *mockImageScanCU) FindByFolderID(ctx context.Context, folderID models.FolderID) ([]*models.Image, error) {
+	args := m.Called(ctx, folderID)
+	return args.Get(0).([]*models.Image), args.Error(1)
+}
+
+func (m *mockImageScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Image, error) {
+	args := m.Called(ctx, fp)
+	return args.Get(0).([]*models.Image), args.Error(1)
+}
+
+func (m *mockImageScanCU) GetFiles(ctx context.Context, relatedID int) ([]models.File, error) {
+	args := m.Called(ctx, relatedID)
+	return args.Get(0).([]models.File), args.Error(1)
+}
+
+func (m *mockImageScanCU) GetGalleryIDs(ctx context.Context, relatedID int) ([]int, error) {
+	args := m.Called(ctx, relatedID)
+	return args.Get(0).([]int), args.Error(1)
+}
+
+func (m *mockImageScanCU) Create(ctx context.Context, newImage *models.CreateImageInput) error {
+	args := m.Called(ctx, newImage)
+	return args.Error(0)
+}
+
+func (m *mockImageScanCU) UpdatePartial(ctx context.Context, id int, updatedImage models.ImagePartial) (*models.Image, error) {
+	args := m.Called(ctx, id, updatedImage)
+	return args.Get(0).(*models.Image), args.Error(1)
+}
+
+func (m *mockImageScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
+	args := m.Called(ctx, id, fileID)
+	return args.Error(0)
+}
+
+type mockScanConfig struct{}
+
+func (m *mockScanConfig) GetCreateGalleriesFromFolders() bool { return false }
+
+type noopTxnManager struct{}
+
+func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
+	return ctx, nil
+}
+func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
+func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
+func (m *noopTxnManager) IsLocked(err error) bool            { return false }
+
+func withTxnCtx(fn func(ctx context.Context)) {
+	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
+		fn(ctx)
+		return errRollback
+	})
+}
+
+type mockGalleryFinderCreator struct {
+	mock.Mock
+}
+
+func (m *mockGalleryFinderCreator) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Gallery, error) {
+	args := m.Called(ctx, fileID)
+	return args.Get(0).([]*models.Gallery), args.Error(1)
+}
+
+func (m *mockGalleryFinderCreator) FindByFolderID(ctx context.Context, folderID models.FolderID) ([]*models.Gallery, error) {
+	args := m.Called(ctx, folderID)
+	return args.Get(0).([]*models.Gallery), args.Error(1)
+}
+
+func (m *mockGalleryFinderCreator) Create(ctx context.Context, input *models.CreateGalleryInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *mockGalleryFinderCreator) UpdatePartial(ctx context.Context, id int, updatedGallery models.GalleryPartial) (*models.Gallery, error) {
+	args := m.Called(ctx, id, updatedGallery)
+	return args.Get(0).(*models.Gallery), args.Error(1)
+}
+
+func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
+	const (
+		testImageID = 1
+		testFileID  = 100
+	)
+
+	existingFile := &models.BaseFile{ID: models.FileID(testFileID), Path: "/images/test.jpg"}
+
+	makeImage := func() *models.Image {
+		return &models.Image{
+			ID:         testImageID,
+			Files:      models.NewRelatedFiles([]models.File{existingFile}),
+			GalleryIDs: models.NewRelatedIDs([]int{}),
+		}
+	}
+
+	tests := []struct {
+		name           string
+		updateExisting bool
+		expectUpdate   bool
+	}{
+		{
+			name:           "calls UpdatePartial when file content changed",
+			updateExisting: true,
+			expectUpdate:   true,
+		},
+		{
+			name:           "skips UpdatePartial when file unchanged and already associated",
+			updateExisting: false,
+			expectUpdate:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cu := &mockImageScanCU{}
+			cu.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
+			cu.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
+
+			if tt.expectUpdate {
+				cu.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
+					Return(&models.Image{ID: testImageID}, nil)
+			}
+
+			h := &ScanHandler{
+				CreatorUpdater: cu,
+				GalleryFinder:  &mockGalleryFinderCreator{},
+				ScanConfig:     &mockScanConfig{},
+				PluginCache:    &plugin.Cache{},
+			}
+
+			withTxnCtx(func(ctx context.Context) {
+				err := h.associateExisting(ctx, []*models.Image{makeImage()}, existingFile, tt.updateExisting)
+				assert.NoError(t, err)
+			})
+
+			if tt.expectUpdate {
+				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
+			} else {
+				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
+	const (
+		testImageID = 1
+		existFileID = 100
+		newFileID   = 200
+	)
+
+	existingFile := &models.BaseFile{ID: models.FileID(existFileID), Path: "/images/existing.jpg"}
+	newFile := &models.BaseFile{ID: models.FileID(newFileID), Path: "/images/new.jpg"}
+
+	image := &models.Image{
+		ID:         testImageID,
+		Files:      models.NewRelatedFiles([]models.File{existingFile}),
+		GalleryIDs: models.NewRelatedIDs([]int{}),
+	}
+
+	cu := &mockImageScanCU{}
+	cu.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
+	cu.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
+	cu.On("AddFileID", mock.Anything, testImageID, models.FileID(newFileID)).Return(nil)
+	cu.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
+		Return(&models.Image{ID: testImageID}, nil)
+
+	h := &ScanHandler{
+		CreatorUpdater: cu,
+		GalleryFinder:  &mockGalleryFinderCreator{},
+		ScanConfig:     &mockScanConfig{},
+		PluginCache:    &plugin.Cache{},
+	}
+
+	withTxnCtx(func(ctx context.Context) {
+		err := h.associateExisting(ctx, []*models.Image{image}, newFile, false)
+		assert.NoError(t, err)
+	})
+
+	cu.AssertCalled(t, "AddFileID", mock.Anything, testImageID, models.FileID(newFileID))
+	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
+}

--- a/pkg/image/scan_test.go
+++ b/pkg/image/scan_test.go
@@ -2,105 +2,18 @@ package image
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
 	"github.com/stashapp/stash/pkg/plugin"
-	"github.com/stashapp/stash/pkg/txn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-var errRollback = errors.New("rollback")
-
-type mockImageScanCU struct {
-	mock.Mock
-}
-
-func (m *mockImageScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Image, error) {
-	args := m.Called(ctx, fileID)
-	return args.Get(0).([]*models.Image), args.Error(1)
-}
-
-func (m *mockImageScanCU) FindByFolderID(ctx context.Context, folderID models.FolderID) ([]*models.Image, error) {
-	args := m.Called(ctx, folderID)
-	return args.Get(0).([]*models.Image), args.Error(1)
-}
-
-func (m *mockImageScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Image, error) {
-	args := m.Called(ctx, fp)
-	return args.Get(0).([]*models.Image), args.Error(1)
-}
-
-func (m *mockImageScanCU) GetFiles(ctx context.Context, relatedID int) ([]models.File, error) {
-	args := m.Called(ctx, relatedID)
-	return args.Get(0).([]models.File), args.Error(1)
-}
-
-func (m *mockImageScanCU) GetGalleryIDs(ctx context.Context, relatedID int) ([]int, error) {
-	args := m.Called(ctx, relatedID)
-	return args.Get(0).([]int), args.Error(1)
-}
-
-func (m *mockImageScanCU) Create(ctx context.Context, newImage *models.CreateImageInput) error {
-	args := m.Called(ctx, newImage)
-	return args.Error(0)
-}
-
-func (m *mockImageScanCU) UpdatePartial(ctx context.Context, id int, updatedImage models.ImagePartial) (*models.Image, error) {
-	args := m.Called(ctx, id, updatedImage)
-	return args.Get(0).(*models.Image), args.Error(1)
-}
-
-func (m *mockImageScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
-	args := m.Called(ctx, id, fileID)
-	return args.Error(0)
-}
-
 type mockScanConfig struct{}
 
 func (m *mockScanConfig) GetCreateGalleriesFromFolders() bool { return false }
-
-type noopTxnManager struct{}
-
-func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
-	return ctx, nil
-}
-func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
-func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
-func (m *noopTxnManager) IsLocked(err error) bool            { return false }
-
-func withTxnCtx(fn func(ctx context.Context)) {
-	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
-		fn(ctx)
-		return errRollback
-	})
-}
-
-type mockGalleryFinderCreator struct {
-	mock.Mock
-}
-
-func (m *mockGalleryFinderCreator) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Gallery, error) {
-	args := m.Called(ctx, fileID)
-	return args.Get(0).([]*models.Gallery), args.Error(1)
-}
-
-func (m *mockGalleryFinderCreator) FindByFolderID(ctx context.Context, folderID models.FolderID) ([]*models.Gallery, error) {
-	args := m.Called(ctx, folderID)
-	return args.Get(0).([]*models.Gallery), args.Error(1)
-}
-
-func (m *mockGalleryFinderCreator) Create(ctx context.Context, input *models.CreateGalleryInput) error {
-	args := m.Called(ctx, input)
-	return args.Error(0)
-}
-
-func (m *mockGalleryFinderCreator) UpdatePartial(ctx context.Context, id int, updatedGallery models.GalleryPartial) (*models.Gallery, error) {
-	args := m.Called(ctx, id, updatedGallery)
-	return args.Get(0).(*models.Gallery), args.Error(1)
-}
 
 func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 	const (
@@ -137,31 +50,31 @@ func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cu := &mockImageScanCU{}
-			cu.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
-			cu.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
+			db := mocks.NewDatabase()
+			db.Image.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
+			db.Image.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
 
 			if tt.expectUpdate {
-				cu.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
+				db.Image.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
 					Return(&models.Image{ID: testImageID}, nil)
 			}
 
 			h := &ScanHandler{
-				CreatorUpdater: cu,
-				GalleryFinder:  &mockGalleryFinderCreator{},
+				CreatorUpdater: db.Image,
+				GalleryFinder:  db.Gallery,
 				ScanConfig:     &mockScanConfig{},
 				PluginCache:    &plugin.Cache{},
 			}
 
-			withTxnCtx(func(ctx context.Context) {
+			db.WithTxnCtx(func(ctx context.Context) {
 				err := h.associateExisting(ctx, []*models.Image{makeImage()}, existingFile, tt.updateExisting)
 				assert.NoError(t, err)
 			})
 
 			if tt.expectUpdate {
-				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
+				db.Image.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
 			} else {
-				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+				db.Image.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
 			}
 		})
 	}
@@ -183,25 +96,25 @@ func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
 		GalleryIDs: models.NewRelatedIDs([]int{}),
 	}
 
-	cu := &mockImageScanCU{}
-	cu.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
-	cu.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
-	cu.On("AddFileID", mock.Anything, testImageID, models.FileID(newFileID)).Return(nil)
-	cu.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
+	db := mocks.NewDatabase()
+	db.Image.On("GetFiles", mock.Anything, testImageID).Return([]models.File{existingFile}, nil)
+	db.Image.On("GetGalleryIDs", mock.Anything, testImageID).Return([]int{}, nil)
+	db.Image.On("AddFileID", mock.Anything, testImageID, models.FileID(newFileID)).Return(nil)
+	db.Image.On("UpdatePartial", mock.Anything, testImageID, mock.Anything).
 		Return(&models.Image{ID: testImageID}, nil)
 
 	h := &ScanHandler{
-		CreatorUpdater: cu,
-		GalleryFinder:  &mockGalleryFinderCreator{},
+		CreatorUpdater: db.Image,
+		GalleryFinder:  db.Gallery,
 		ScanConfig:     &mockScanConfig{},
 		PluginCache:    &plugin.Cache{},
 	}
 
-	withTxnCtx(func(ctx context.Context) {
+	db.WithTxnCtx(func(ctx context.Context) {
 		err := h.associateExisting(ctx, []*models.Image{image}, newFile, false)
 		assert.NoError(t, err)
 	})
 
-	cu.AssertCalled(t, "AddFileID", mock.Anything, testImageID, models.FileID(newFileID))
-	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
+	db.Image.AssertCalled(t, "AddFileID", mock.Anything, testImageID, models.FileID(newFileID))
+	db.Image.AssertCalled(t, "UpdatePartial", mock.Anything, testImageID, mock.Anything)
 }

--- a/pkg/models/mocks/database.go
+++ b/pkg/models/mocks/database.go
@@ -3,6 +3,7 @@ package mocks
 
 import (
 	"context"
+	"errors"
 
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/txn"
@@ -87,6 +88,16 @@ func (db *Database) AssertExpectations(t mock.TestingT) {
 	db.Studio.AssertExpectations(t)
 	db.Tag.AssertExpectations(t)
 	db.SavedFilter.AssertExpectations(t)
+}
+
+// WithTxnCtx runs fn with a context that has a transaction hook manager registered,
+// so code that calls txn.AddPostCommitHook (e.g. plugin cache) won't nil-panic.
+// Always rolls back to avoid executing the registered hooks.
+func (db *Database) WithTxnCtx(fn func(ctx context.Context)) {
+	_ = txn.WithTxn(context.Background(), db, func(ctx context.Context) error {
+		fn(ctx)
+		return errors.New("rollback")
+	})
 }
 
 func (db *Database) Repository() models.Repository {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -160,15 +160,15 @@ func (h *ScanHandler) associateExisting(ctx context.Context, existing []*models.
 			if err := h.CreatorUpdater.AddFileID(ctx, s.ID, f.ID); err != nil {
 				return fmt.Errorf("adding file to scene: %w", err)
 			}
+		}
 
-			// update updated_at time
+		if !found || updateExisting {
+			// update updated_at time when file association or content changes
 			scenePartial := models.NewScenePartial()
 			if _, err := h.CreatorUpdater.UpdatePartial(ctx, s.ID, scenePartial); err != nil {
 				return fmt.Errorf("updating scene: %w", err)
 			}
-		}
 
-		if !found || updateExisting {
 			h.PluginCache.RegisterPostHooks(ctx, s.ID, hook.SceneUpdatePost, nil, nil)
 		}
 	}

--- a/pkg/scene/scan_test.go
+++ b/pkg/scene/scan_test.go
@@ -1,0 +1,171 @@
+package scene
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/plugin"
+	"github.com/stashapp/stash/pkg/txn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// sentinel error to force rollback, preventing post-commit hooks from
+// trying to execute plugins on the zero-value Cache in tests.
+var errRollback = errors.New("rollback")
+
+type mockSceneScanCU struct {
+	mock.Mock
+}
+
+func (m *mockSceneScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Scene, error) {
+	args := m.Called(ctx, fileID)
+	return args.Get(0).([]*models.Scene), args.Error(1)
+}
+
+func (m *mockSceneScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Scene, error) {
+	args := m.Called(ctx, fp)
+	return args.Get(0).([]*models.Scene), args.Error(1)
+}
+
+func (m *mockSceneScanCU) GetFiles(ctx context.Context, relatedID int) ([]*models.VideoFile, error) {
+	args := m.Called(ctx, relatedID)
+	return args.Get(0).([]*models.VideoFile), args.Error(1)
+}
+
+func (m *mockSceneScanCU) Create(ctx context.Context, newScene *models.Scene, fileIDs []models.FileID) error {
+	args := m.Called(ctx, newScene, fileIDs)
+	return args.Error(0)
+}
+
+func (m *mockSceneScanCU) UpdatePartial(ctx context.Context, id int, updatedScene models.ScenePartial) (*models.Scene, error) {
+	args := m.Called(ctx, id, updatedScene)
+	return args.Get(0).(*models.Scene), args.Error(1)
+}
+
+func (m *mockSceneScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
+	args := m.Called(ctx, id, fileID)
+	return args.Error(0)
+}
+
+type noopTxnManager struct{}
+
+func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
+	return ctx, nil
+}
+func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
+func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
+func (m *noopTxnManager) IsLocked(err error) bool            { return false }
+
+// withTxnCtx runs fn inside a transaction context so that txn.AddPostCommitHook
+// (called by plugin.Cache.RegisterPostHooks) doesn't panic on a nil hookManager.
+func withTxnCtx(fn func(ctx context.Context)) {
+	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
+		fn(ctx)
+		return errRollback
+	})
+}
+
+func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
+	const (
+		testSceneID = 1
+		testFileID  = 100
+	)
+
+	existingFile := &models.VideoFile{
+		BaseFile: &models.BaseFile{ID: models.FileID(testFileID), Path: "test.mp4"},
+	}
+
+	makeScene := func() *models.Scene {
+		return &models.Scene{
+			ID:    testSceneID,
+			Files: models.NewRelatedVideoFiles([]*models.VideoFile{existingFile}),
+		}
+	}
+
+	tests := []struct {
+		name           string
+		updateExisting bool
+		expectUpdate   bool
+	}{
+		{
+			name:           "calls UpdatePartial when file content changed",
+			updateExisting: true,
+			expectUpdate:   true,
+		},
+		{
+			name:           "skips UpdatePartial when file unchanged and already associated",
+			updateExisting: false,
+			expectUpdate:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cu := &mockSceneScanCU{}
+			cu.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
+
+			if tt.expectUpdate {
+				cu.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
+					Return(&models.Scene{ID: testSceneID}, nil)
+			}
+
+			h := &ScanHandler{
+				CreatorUpdater: cu,
+				PluginCache:    &plugin.Cache{},
+			}
+
+			withTxnCtx(func(ctx context.Context) {
+				err := h.associateExisting(ctx, []*models.Scene{makeScene()}, existingFile, tt.updateExisting)
+				assert.NoError(t, err)
+			})
+
+			if tt.expectUpdate {
+				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
+			} else {
+				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
+	const (
+		testSceneID = 1
+		existFileID = 100
+		newFileID   = 200
+	)
+
+	existingFile := &models.VideoFile{
+		BaseFile: &models.BaseFile{ID: models.FileID(existFileID), Path: "existing.mp4"},
+	}
+	newFile := &models.VideoFile{
+		BaseFile: &models.BaseFile{ID: models.FileID(newFileID), Path: "new.mp4"},
+	}
+
+	scene := &models.Scene{
+		ID:    testSceneID,
+		Files: models.NewRelatedVideoFiles([]*models.VideoFile{existingFile}),
+	}
+
+	cu := &mockSceneScanCU{}
+	cu.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
+	cu.On("AddFileID", mock.Anything, testSceneID, models.FileID(newFileID)).Return(nil)
+	cu.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
+		Return(&models.Scene{ID: testSceneID}, nil)
+
+	h := &ScanHandler{
+		CreatorUpdater: cu,
+		PluginCache:    &plugin.Cache{},
+	}
+
+	withTxnCtx(func(ctx context.Context) {
+		err := h.associateExisting(ctx, []*models.Scene{scene}, newFile, false)
+		assert.NoError(t, err)
+	})
+
+	cu.AssertCalled(t, "AddFileID", mock.Anything, testSceneID, models.FileID(newFileID))
+	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
+}

--- a/pkg/scene/scan_test.go
+++ b/pkg/scene/scan_test.go
@@ -2,71 +2,14 @@ package scene
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
 	"github.com/stashapp/stash/pkg/plugin"
-	"github.com/stashapp/stash/pkg/txn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-// sentinel error to force rollback, preventing post-commit hooks from
-// trying to execute plugins on the zero-value Cache in tests.
-var errRollback = errors.New("rollback")
-
-type mockSceneScanCU struct {
-	mock.Mock
-}
-
-func (m *mockSceneScanCU) FindByFileID(ctx context.Context, fileID models.FileID) ([]*models.Scene, error) {
-	args := m.Called(ctx, fileID)
-	return args.Get(0).([]*models.Scene), args.Error(1)
-}
-
-func (m *mockSceneScanCU) FindByFingerprints(ctx context.Context, fp []models.Fingerprint) ([]*models.Scene, error) {
-	args := m.Called(ctx, fp)
-	return args.Get(0).([]*models.Scene), args.Error(1)
-}
-
-func (m *mockSceneScanCU) GetFiles(ctx context.Context, relatedID int) ([]*models.VideoFile, error) {
-	args := m.Called(ctx, relatedID)
-	return args.Get(0).([]*models.VideoFile), args.Error(1)
-}
-
-func (m *mockSceneScanCU) Create(ctx context.Context, newScene *models.Scene, fileIDs []models.FileID) error {
-	args := m.Called(ctx, newScene, fileIDs)
-	return args.Error(0)
-}
-
-func (m *mockSceneScanCU) UpdatePartial(ctx context.Context, id int, updatedScene models.ScenePartial) (*models.Scene, error) {
-	args := m.Called(ctx, id, updatedScene)
-	return args.Get(0).(*models.Scene), args.Error(1)
-}
-
-func (m *mockSceneScanCU) AddFileID(ctx context.Context, id int, fileID models.FileID) error {
-	args := m.Called(ctx, id, fileID)
-	return args.Error(0)
-}
-
-type noopTxnManager struct{}
-
-func (m *noopTxnManager) Begin(ctx context.Context, writable bool) (context.Context, error) {
-	return ctx, nil
-}
-func (m *noopTxnManager) Commit(ctx context.Context) error   { return nil }
-func (m *noopTxnManager) Rollback(ctx context.Context) error { return nil }
-func (m *noopTxnManager) IsLocked(err error) bool            { return false }
-
-// withTxnCtx runs fn inside a transaction context so that txn.AddPostCommitHook
-// (called by plugin.Cache.RegisterPostHooks) doesn't panic on a nil hookManager.
-func withTxnCtx(fn func(ctx context.Context)) {
-	_ = txn.WithTxn(context.Background(), &noopTxnManager{}, func(ctx context.Context) error {
-		fn(ctx)
-		return errRollback
-	})
-}
 
 func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 	const (
@@ -104,28 +47,28 @@ func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cu := &mockSceneScanCU{}
-			cu.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
+			db := mocks.NewDatabase()
+			db.Scene.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
 
 			if tt.expectUpdate {
-				cu.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
+				db.Scene.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
 					Return(&models.Scene{ID: testSceneID}, nil)
 			}
 
 			h := &ScanHandler{
-				CreatorUpdater: cu,
+				CreatorUpdater: db.Scene,
 				PluginCache:    &plugin.Cache{},
 			}
 
-			withTxnCtx(func(ctx context.Context) {
+			db.WithTxnCtx(func(ctx context.Context) {
 				err := h.associateExisting(ctx, []*models.Scene{makeScene()}, existingFile, tt.updateExisting)
 				assert.NoError(t, err)
 			})
 
 			if tt.expectUpdate {
-				cu.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
+				db.Scene.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
 			} else {
-				cu.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
+				db.Scene.AssertNotCalled(t, "UpdatePartial", mock.Anything, mock.Anything, mock.Anything)
 			}
 		})
 	}
@@ -150,22 +93,22 @@ func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
 		Files: models.NewRelatedVideoFiles([]*models.VideoFile{existingFile}),
 	}
 
-	cu := &mockSceneScanCU{}
-	cu.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
-	cu.On("AddFileID", mock.Anything, testSceneID, models.FileID(newFileID)).Return(nil)
-	cu.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
+	db := mocks.NewDatabase()
+	db.Scene.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{existingFile}, nil)
+	db.Scene.On("AddFileID", mock.Anything, testSceneID, models.FileID(newFileID)).Return(nil)
+	db.Scene.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
 		Return(&models.Scene{ID: testSceneID}, nil)
 
 	h := &ScanHandler{
-		CreatorUpdater: cu,
+		CreatorUpdater: db.Scene,
 		PluginCache:    &plugin.Cache{},
 	}
 
-	withTxnCtx(func(ctx context.Context) {
+	db.WithTxnCtx(func(ctx context.Context) {
 		err := h.associateExisting(ctx, []*models.Scene{scene}, newFile, false)
 		assert.NoError(t, err)
 	})
 
-	cu.AssertCalled(t, "AddFileID", mock.Anything, testSceneID, models.FileID(newFileID))
-	cu.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
+	db.Scene.AssertCalled(t, "AddFileID", mock.Anything, testSceneID, models.FileID(newFileID))
+	db.Scene.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
 }


### PR DESCRIPTION
### Problem

When a file's content changes (e.g. renaming files within a gallery zip), the scan handler updates fingerprints but never bumps the entity's `updated_at` timestamp. Since thumbnail URLs use `updated_at` as a cache buster and are served with
`immutable`/1-year cache headers, browsers indefinitely serve the old cached thumbnail.

### Solution

In the `associateExisting` method for scenes, images, and galleries, `UpdatePartial` was previously only called when a **new file association** was created (`!found`). This change extends it to also run when `updateExisting` is true (i.e.
`oldFile != nil` — the file existed before but its content changed). This bumps `updated_at`, invalidating the browser cache.

The fix restructures the existing conditional blocks so that `UpdatePartial` and the post-update plugin hook share the same `!found || updateExisting` guard, rather than having `UpdatePartial` nested only inside the `!found` branch.

### Testing

Added unit tests for `associateExisting` across all three packages (`pkg/scene`, `pkg/image`, `pkg/gallery`) covering:

- **Content change path** — `UpdatePartial` is called when the file is already associated but content has changed
- **No-op path** — `UpdatePartial` is *not* called when the file is already associated and unchanged
- **New file path** — `UpdatePartial` is called when a previously unknown file is added

Tests use the existing `mocks.Database` infrastructure. Added a `WithTxnCtx` helper to `mocks.Database` to provide a transaction context for code that registers plugin hooks.