### PR TITLE
perf: use useMemo to cache performer sorting in Scene Tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/scenes/TaggerScene.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/TaggerScene.tsx
@@ -28,8 +28,7 @@ interface ITaggerSceneDetails {
 
 const TaggerSceneDetails: React.FC<ITaggerSceneDetails> = ({ scene }) => {
   const [open, setOpen] = useState(false);
-  const sorted = sortPerformers(scene.performers);
-
+  const sorted = useMemo(() => sortPerformers(scene.performers), [scene.performers]);
   return (
     <div className="original-scene-details">
       <Collapse in={open}>


### PR DESCRIPTION
This PR fixes performance issue in Scene Tagger when creating performers. The issue was that performer sorting was executed on every render, causing UI to hang. Fixed by wrapping sorting in useMemo.