### PR TITLE
Fix edit modal not opening inside gallery view

### DIFF
--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -587,25 +587,6 @@ export const FilteredImageList = PatchComponent(
       setShowSidebar,
     });
 
-    useEffect(() => {
-      Mousetrap.bind("e", () => {
-        if (hasSelection) {
-          onEdit?.();
-        }
-      });
-
-      Mousetrap.bind("d d", () => {
-        if (hasSelection) {
-          onDelete?.();
-        }
-      });
-
-      return () => {
-        Mousetrap.unbind("e");
-        Mousetrap.unbind("d d");
-      };
-    });
-
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,
       onSelectNone,
@@ -628,23 +609,42 @@ export const FilteredImageList = PatchComponent(
       );
     }
 
-    function onEdit() {
+    const onEdit = useCallback(() => {
       showModal(
         <EditImagesDialog
           selected={selectedItems}
           onClose={onCloseEditDelete}
         />
       );
-    }
+    }, [showModal, selectedItems, onCloseEditDelete]);
 
-    function onDelete() {
+    const onDelete = useCallback(() => {
       showModal(
         <DeleteImagesDialog
           selected={selectedItems}
           onClose={onCloseEditDelete}
         />
       );
-    }
+    }, [showModal, selectedItems, onCloseEditDelete]);
+
+    useEffect(() => {
+      Mousetrap.bind("e", () => {
+        if (hasSelection) {
+          onEdit?.();
+        }
+      });
+
+      Mousetrap.bind("d d", () => {
+        if (hasSelection) {
+          onDelete?.();
+        }
+      });
+
+      return () => {
+        Mousetrap.unbind("e");
+        Mousetrap.unbind("d d");
+      };
+    }, [hasSelection, onEdit, onDelete]);
 
     const convertedExtraOperations: IListFilterOperation[] =
       providedOperations.map((o) => ({
@@ -787,7 +787,12 @@ export const FilteredImageList = PatchComponent(
     );
 
     if (!withSidebar) {
-      return content;
+      return (
+        <>
+          {modal}
+          {content}
+        </>
+      );
     }
 
     return (

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -786,46 +786,47 @@ export const FilteredImageList = PatchComponent(
       </>
     );
 
-    if (!withSidebar) {
-      return (
-        <>
-          {modal}
-          {content}
-        </>
-      );
-    }
-
     return (
-      <div
-        className={cx("item-list-container image-list", {
-          "hide-sidebar": !showSidebar,
-        })}
-      >
+      <>
         {modal}
-
-        <SidebarStateContext.Provider value={{ sectionOpen, setSectionOpen }}>
-          <SidebarPane hideSidebar={!showSidebar}>
-            <Sidebar hide={!showSidebar} onHide={() => setShowSidebar(false)}>
-              <SidebarContent
-                filter={filter}
-                setFilter={setFilter}
-                filterHook={filterHook}
-                showEditFilter={showEditFilter}
-                view={view}
-                sidebarOpen={showSidebar}
-                onClose={() => setShowSidebar(false)}
-                count={cachedResult.loading ? undefined : totalCount}
-                focus={searchFocus}
-              />
-            </Sidebar>
-            <SidebarPaneContent
-              onSidebarToggle={() => setShowSidebar(!showSidebar)}
+        {!withSidebar ? (
+          content
+        ) : (
+          <div
+            className={cx("item-list-container image-list", {
+              "hide-sidebar": !showSidebar,
+            })}
+          >
+            <SidebarStateContext.Provider
+              value={{ sectionOpen, setSectionOpen }}
             >
-              {content}
-            </SidebarPaneContent>
-          </SidebarPane>
-        </SidebarStateContext.Provider>
-      </div>
+              <SidebarPane hideSidebar={!showSidebar}>
+                <Sidebar
+                  hide={!showSidebar}
+                  onHide={() => setShowSidebar(false)}
+                >
+                  <SidebarContent
+                    filter={filter}
+                    setFilter={setFilter}
+                    filterHook={filterHook}
+                    showEditFilter={showEditFilter}
+                    view={view}
+                    sidebarOpen={showSidebar}
+                    onClose={() => setShowSidebar(false)}
+                    count={cachedResult.loading ? undefined : totalCount}
+                    focus={searchFocus}
+                  />
+                </Sidebar>
+                <SidebarPaneContent
+                  onSidebarToggle={() => setShowSidebar(!showSidebar)}
+                >
+                  {content}
+                </SidebarPaneContent>
+              </SidebarPane>
+            </SidebarStateContext.Provider>
+          </div>
+        )}
+      </>
     );
   }
 );


### PR DESCRIPTION
## Summary
- Fix the edit/delete modal not appearing when images are selected inside a gallery
- The `{modal}` element was only rendered in the sidebar layout branch, but gallery images use the non-sidebar code path (`View.GalleryImages`), which returned content without rendering the modal to the DOM
- Also wrapped `onEdit`/`onDelete` in `useCallback` and added the missing dependency array to the Mousetrap `useEffect`, matching the pattern used in `SceneList` and other list components

Closes #6624

## Checklist
- [x] Reviewed existing PRs and issues to avoid duplicates
- [x] Code is readable and adequately commented
- [x] Evaluated impact on long-term maintainability
- [x] Minimal change — no unnecessary dependencies or scope creep

## Test plan
- [x] Go to a gallery containing images
- [x] Select one or more images
- [x] Click the Edit toolbar button — modal should now open
- [x] Press `e` keyboard shortcut — modal should now open
- [x] Press `d d` keyboard shortcut — delete dialog should open
- [x] Verify edit/delete modals still work on the standalone Images list page