### PR TITLE
Fix datepicker button border radius

### DIFF
--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -446,6 +446,13 @@ button.collapse-button {
   }
 }
 
+.input-group-append {
+  .btn {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+  }
+}
+
 .ModalComponent .modal-footer {
   justify-content: space-between;
 }


### PR DESCRIPTION
## Summary
- Adds missing `.input-group-append .btn` CSS rule to zero out the left-side border-radius, fixing the datepicker calendar button appearance
- Mirrors the existing `.input-group-prepend .btn` rule for symmetry

Fixes #6518

## Test plan
- [x] Open a form with a datepicker (e.g. `/scenes/new`)
- [x] Verify the calendar button's left border-radius is now flat (0), seamlessly joining the input field
- [x] Compare with other input groups (e.g. URLs) to confirm consistent appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)