### PR TITLE
Fix UNIQUE constraint failure in folder hierarchy correction

### DIFF
--- a/pkg/file/move.go
+++ b/pkg/file/move.go
@@ -189,29 +189,55 @@ func (m *Mover) rollback() {
 }
 
 // correctSubFolderHierarchy sets the path of all contained folders to be relative to the given folder.
+// oldParentPath is the folder's path before it was renamed. Children whose filepath.Dir
+// does not match oldParentPath are mis-parented and skipped.
 // It does not move the folder hierarchy in the filesystem.
-func correctSubFolderHierarchy(ctx context.Context, rw models.FolderReaderWriter, folder *models.Folder) error {
+func correctSubFolderHierarchy(ctx context.Context, rw models.FolderReaderWriter, folder *models.Folder, oldParentPath string) error {
 	folders, err := rw.FindByParentFolderID(ctx, folder.ID)
 	if err != nil {
 		return fmt.Errorf("finding contained folders in folder %s: %w", folder.Path, err)
 	}
 
-	folderPath := folder.Path
-
 	for _, f := range folders {
-		oldPath := f.Path
-		folderBasename := filepath.Base(f.Path)
-		correctPath := filepath.Join(folderPath, folderBasename)
+		oldChildPath := f.Path
 
-		logger.Debugf("updating folder %s to %s", oldPath, correctPath)
+		// validate that this child is actually a direct subdirectory of the old parent path.
+		// if not, the parent_folder_id is incorrect — skip this child.
+		if filepath.Dir(f.Path) != oldParentPath {
+			logger.Warnf("folder %s is not a direct child of %s (parent_folder_id is incorrect), skipping", f.Path, oldParentPath)
+			continue
+		}
+
+		correctPath := filepath.Join(folder.Path, filepath.Base(f.Path))
+
+		// skip if path is already correct
+		if oldChildPath == correctPath {
+			if err := correctSubFolderHierarchy(ctx, rw, f, oldChildPath); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// check if the target path already exists in the database
+		existing, err := rw.FindByPath(ctx, correctPath, true)
+		if err != nil {
+			return fmt.Errorf("checking for existing folder at path %s: %w", correctPath, err)
+		}
+
+		if existing != nil && existing.ID != f.ID {
+			logger.Warnf("cannot update folder path %s -> %s: target path already exists (folder %d), skipping", oldChildPath, correctPath, existing.ID)
+			continue
+		}
+
+		logger.Debugf("updating folder %s to %s", oldChildPath, correctPath)
 
 		f.Path = correctPath
 		if err := rw.Update(ctx, f); err != nil {
-			return fmt.Errorf("updating folder path %s -> %s: %w", oldPath, f.Path, err)
+			return fmt.Errorf("updating folder path %s -> %s: %w", oldChildPath, f.Path, err)
 		}
 
-		// recurse
-		if err := correctSubFolderHierarchy(ctx, rw, f); err != nil {
+		// recurse with the child's old path
+		if err := correctSubFolderHierarchy(ctx, rw, f, oldChildPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/file/move_test.go
+++ b/pkg/file/move_test.go
@@ -1,0 +1,215 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCorrectSubFolderHierarchy(t *testing.T) {
+	ctx := context.Background()
+
+	parentID := models.FolderID(1)
+
+	tests := []struct {
+		name          string
+		setup         func(rw *mocks.FolderReaderWriter)
+		parent        *models.Folder
+		oldParentPath string
+		wantErr       bool
+	}{
+		{
+			name: "updates child folder path",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/parent",
+			},
+			oldParentPath: "/old/parent",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				child := &models.Folder{
+					ID:   2,
+					Path: "/old/parent/child",
+				}
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{child}, nil)
+				rw.On("FindByPath", mock.Anything, "/new/parent/child", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 2 && f.Path == "/new/parent/child"
+				})).Return(nil)
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(2)).Return([]*models.Folder{}, nil)
+			},
+		},
+		{
+			name: "skips when path already correct",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/content",
+			},
+			oldParentPath: "/content",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				child := &models.Folder{
+					ID:   2,
+					Path: "/content/child",
+				}
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{child}, nil)
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(2)).Return([]*models.Folder{}, nil)
+			},
+		},
+		{
+			name: "skips mis-parented child",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/parent",
+			},
+			oldParentPath: "/old/parent",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				misparented := &models.Folder{
+					ID:   2,
+					Path: "/old/parent/sorted/yes",
+				}
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{misparented}, nil)
+			},
+		},
+		{
+			name: "skips when target path already exists",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/parent",
+			},
+			oldParentPath: "/old/parent",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				child := &models.Folder{
+					ID:   2,
+					Path: "/old/parent/child",
+				}
+				preExisting := &models.Folder{
+					ID:   5,
+					Path: "/new/parent/child",
+				}
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{child}, nil)
+				rw.On("FindByPath", mock.Anything, "/new/parent/child", true).Return(preExisting, nil)
+			},
+		},
+		{
+			name: "recurses into sub-folders",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/root",
+			},
+			oldParentPath: "/old/root",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				child := &models.Folder{
+					ID:   2,
+					Path: "/old/root/sorted",
+				}
+				grandchild := &models.Folder{
+					ID:   3,
+					Path: "/old/root/sorted/deep",
+				}
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{child}, nil)
+				rw.On("FindByPath", mock.Anything, "/new/root/sorted", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 2 && f.Path == "/new/root/sorted"
+				})).Return(nil)
+
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(2)).Return([]*models.Folder{grandchild}, nil)
+				rw.On("FindByPath", mock.Anything, "/new/root/sorted/deep", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 3 && f.Path == "/new/root/sorted/deep"
+				})).Return(nil)
+
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(3)).Return([]*models.Folder{}, nil)
+			},
+		},
+		{
+			name: "issue 6427: duplicate basename at different hierarchy levels",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/content",
+			},
+			oldParentPath: "/old/content",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				childYes := &models.Folder{
+					ID:   2,
+					Path: "/old/content/yes",
+				}
+				childSorted := &models.Folder{
+					ID:   3,
+					Path: "/old/content/sorted",
+				}
+				grandchildYes := &models.Folder{
+					ID:   4,
+					Path: "/old/content/sorted/yes",
+				}
+
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{childYes, childSorted}, nil)
+
+				rw.On("FindByPath", mock.Anything, "/new/content/yes", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 2 && f.Path == "/new/content/yes"
+				})).Return(nil)
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(2)).Return([]*models.Folder{}, nil)
+
+				rw.On("FindByPath", mock.Anything, "/new/content/sorted", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 3 && f.Path == "/new/content/sorted"
+				})).Return(nil)
+
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(3)).Return([]*models.Folder{grandchildYes}, nil)
+				rw.On("FindByPath", mock.Anything, "/new/content/sorted/yes", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 4 && f.Path == "/new/content/sorted/yes"
+				})).Return(nil)
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(4)).Return([]*models.Folder{}, nil)
+			},
+		},
+		{
+			name: "issue 6427: conflict from incorrect parent_folder_id",
+			parent: &models.Folder{
+				ID:   parentID,
+				Path: "/new/content",
+			},
+			oldParentPath: "/old/content",
+			setup: func(rw *mocks.FolderReaderWriter) {
+				childYes := &models.Folder{
+					ID:   2,
+					Path: "/old/content/yes",
+				}
+				misparentedYes := &models.Folder{
+					ID:   4,
+					Path: "/old/content/sorted/yes",
+				}
+
+				rw.On("FindByParentFolderID", mock.Anything, parentID).Return([]*models.Folder{childYes, misparentedYes}, nil)
+
+				rw.On("FindByPath", mock.Anything, "/new/content/yes", true).Return(nil, nil)
+				rw.On("Update", mock.Anything, mock.MatchedBy(func(f *models.Folder) bool {
+					return f.ID == 2 && f.Path == "/new/content/yes"
+				})).Return(nil)
+				rw.On("FindByParentFolderID", mock.Anything, models.FolderID(2)).Return([]*models.Folder{}, nil)
+
+				// misparentedYes is skipped — filepath.Dir("/old/content/sorted/yes")
+				// is "/old/content/sorted", not "/old/content"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := &mocks.FolderReaderWriter{}
+			tt.setup(rw)
+
+			err := correctSubFolderHierarchy(ctx, rw, tt.parent, tt.oldParentPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			rw.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -265,6 +265,7 @@ func (s *Scanner) handleFolderRename(ctx context.Context, file ScannedFile) (*mo
 
 	// if the folder was moved, update the existing folder
 	logger.Infof("%s moved to %s. Updating path...", renamedFrom.Path, file.Path)
+	oldPath := renamedFrom.Path
 	renamedFrom.Path = file.Path
 
 	// update the parent folder ID
@@ -281,7 +282,7 @@ func (s *Scanner) handleFolderRename(ctx context.Context, file ScannedFile) (*mo
 	}
 
 	// #4146 - correct sub-folders to have the correct path
-	if err := correctSubFolderHierarchy(ctx, s.Repository.Folder, renamedFrom); err != nil {
+	if err := correctSubFolderHierarchy(ctx, s.Repository.Folder, renamedFrom, oldPath); err != nil {
 		return nil, fmt.Errorf("correcting sub folder hierarchy for %q: %w", renamedFrom.Path, err)
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #6427: `UNIQUE constraint failed: folders.path` when scanning after a folder move (e.g., drive letter change)
- Root cause: `correctSubFolderHierarchy` blindly trusted `parent_folder_id` relationships, so mis-parented children could produce colliding paths
- Adds three guard layers to `correctSubFolderHierarchy`:
  1. **Validate `filepath.Dir(child)` matches old parent path** — skips mis-parented children (root cause)
  2. **Skip children whose path is already correct** — avoids unnecessary DB writes
  3. **Check `FindByPath` before updating** — skips if target path is already taken by another folder

## Test plan
- [x] Added unit tests for `correctSubFolderHierarchy` covering:
  - Basic path update
  - Already-correct path skip
  - Mis-parented child skip
  - Pre-existing target path skip
  - Recursive sub-folder updates
  - Issue #6427 scenario with duplicate basenames at different hierarchy levels
  - Issue #6427 scenario with incorrect `parent_folder_id`
- [ ] Verify scan completes without error after drive letter change with duplicate folder basenames
- [ ] Verify scan completes without error when target folder paths already exist in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)