### PR TITLE
Skip scanning zip contents when fingerprint is unchanged

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -312,7 +312,7 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	// handle rename should have already handled the contents of the zip file
 	// so shouldn't need to scan it again
 
-	if (r.New || r.FingerprintChanged) && j.scanner.IsZipFile(f.Info.Name()) {
+	if (r.New || r.FingerprintChanged || (r.Updated && j.scanner.Rescan)) && j.scanner.IsZipFile(f.Info.Name()) {
 		ff := r.File
 		f.BaseFile = ff.Base()
 
@@ -324,6 +324,8 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 		if err := j.scanZipFile(zipCtx, f, progress); err != nil {
 			logger.Errorf("Error scanning zip file %q: %v", f.Path, err)
 		}
+	} else if r.Updated && j.scanner.IsZipFile(f.Info.Name()) {
+		logger.Debugf("Skipping zip file scan for %q: fingerprint unchanged", f.Path)
 	}
 
 	return nil

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -312,7 +312,7 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	// handle rename should have already handled the contents of the zip file
 	// so shouldn't need to scan it again
 
-	if (r.New || r.Updated) && j.scanner.IsZipFile(f.Info.Name()) {
+	if (r.New || r.FingerprintChanged) && j.scanner.IsZipFile(f.Info.Name()) {
 		ff := r.File
 		f.BaseFile = ff.Base()
 

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -310,7 +310,9 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	}
 
 	// handle rename should have already handled the contents of the zip file
-	// so shouldn't need to scan it again
+	// so shouldn't need to scan it again.
+	// Only scan zip contents if the file is new, the fingerprint changed,
+	// or if a force rescan was requested.
 
 	if (r.New || r.FingerprintChanged || (r.Updated && j.scanner.Rescan)) && j.scanner.IsZipFile(f.Info.Name()) {
 		ff := r.File

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -374,7 +374,7 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	// Only scan zip contents if the file is new, the fingerprint changed,
 	// or if a force rescan was requested.
 
-	if (r.New || r.FingerprintChanged || (r.Updated && j.scanner.Rescan)) && j.scanner.IsZipFile(f.Info.Name()) {
+	if j.scanner.IsZipFile(f.Info.Name()) && (r.New || r.FingerprintChanged || j.scanner.Rescan) {
 		ff := r.File
 		f.BaseFile = ff.Base()
 

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -343,10 +343,11 @@ func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing 
 }
 
 type ScanFileResult struct {
-	File    models.File
-	New     bool
-	Renamed bool
-	Updated bool
+	File               models.File
+	New                bool
+	Renamed            bool
+	Updated            bool
+	FingerprintChanged bool
 }
 
 // ScanFile scans the provided file into the database, returning the scan result.
@@ -787,6 +788,9 @@ func (s *Scanner) onExistingFile(ctx context.Context, f ScannedFile, existing mo
 		return nil, err
 	}
 
+	oldFingerprints := existing.Base().Fingerprints
+	fingerprintChanged := fp.ContentsChanged(oldFingerprints)
+
 	s.removeOutdatedFingerprints(existing, fp)
 	existing.SetFingerprints(fp)
 
@@ -810,8 +814,9 @@ func (s *Scanner) onExistingFile(ctx context.Context, f ScannedFile, existing mo
 		return nil, err
 	}
 	return &ScanFileResult{
-		File:    existing,
-		Updated: true,
+		File:               existing,
+		Updated:            true,
+		FingerprintChanged: fingerprintChanged,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- When a zip-based gallery's modification time changes but its content fingerprint (oshash/md5) remains the same, skip walking and rescanning every file inside the zip
- Adds a `FingerprintChanged` field to `ScanFileResult` to track whether the file's content hash actually changed during rescan
- Uses the existing `Fingerprints.ContentsChanged()` method to compare old vs new fingerprints before deciding to walk zip contents

## Test plan
- [ ] Scan a library containing zip-based galleries
- [ ] `touch` a zip file (changes modtime but not content) and rescan — contents should be skipped
- [ ] Modify a zip file's contents and rescan — contents should be walked and updated
- [ ] Add a new zip file and scan — contents should be walked as before
- [ ] Force rescan with the rescan option — verify behavior is consistent

Closes #6512

🤖 Generated with [Claude Code](https://claude.com/claude-code)