### PR TITLE
Fix caption handling during scan and check before correcting path

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stashapp/stash/pkg/scene"
 	"github.com/stashapp/stash/pkg/scene/generate"
 	"github.com/stashapp/stash/pkg/txn"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 type ScanJob struct {
@@ -35,6 +36,8 @@ type ScanJob struct {
 
 	fileQueue chan file.ScannedFile
 	count     int
+
+	unmatchedCaptionFiles utils.MutexField[[]string]
 }
 
 func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
@@ -174,6 +177,22 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 				return fs.SkipDir
 			}
 
+			// we don't include caption files in the file scan, but we do need
+			// to handle them
+			if fsutil.MatchExtension(path, video.CaptionExts) {
+				fileRepo := j.scanner.Repository.File
+				matched := video.AssociateCaptions(ctx, path, j.scanner.Repository.TxnManager, fileRepo, fileRepo)
+
+				if !matched {
+					logger.Debugf("No matching video file found for caption file %s", path)
+					j.unmatchedCaptionFiles.SetFunc(func(files []string) []string {
+						return append(files, path)
+					})
+				}
+
+				return nil
+			}
+
 			logger.Debugf("Skipping file %s", path)
 			return nil
 		}
@@ -311,6 +330,45 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 		return err
 	}
 
+	// if this is a new video file, match it with any unmatched caption files
+	if r.New && len(j.unmatchedCaptionFiles.Get()) > 0 {
+		videoFile, _ := r.File.(*models.VideoFile)
+
+		if videoFile != nil {
+			// try to match any unmatched caption files to this video file
+			for _, captionPath := range j.unmatchedCaptionFiles.Get() {
+				if video.MatchesCaption(videoFile.Path, captionPath) {
+					video.AssociateCaptions(ctx, captionPath, j.scanner.Repository.TxnManager, j.scanner.Repository.File, j.scanner.Repository.File)
+
+					// remove from the unmatched list
+					j.unmatchedCaptionFiles.SetFunc(func(files []string) []string {
+						newFiles := make([]string, 0, len(files)-1)
+						for _, f := range files {
+							if f != captionPath {
+								newFiles = append(newFiles, f)
+							}
+						}
+						return newFiles
+					})
+				}
+			}
+		}
+	}
+
+	// clean captions - scene handler handles this as well, but
+	// unchanged files aren't processed by the scene handler
+	if r.IsUnchanged() {
+		videoFile, _ := r.File.(*models.VideoFile)
+
+		if videoFile != nil {
+			txnMgr := j.scanner.Repository.TxnManager
+			fileRepo := j.scanner.Repository.File
+			if err := video.CleanCaptions(ctx, videoFile, txnMgr, fileRepo); err != nil {
+				logger.Errorf("Error cleaning captions: %v", err)
+			}
+		}
+	}
+
 	// handle rename should have already handled the contents of the zip file
 	// so shouldn't need to scan it again
 
@@ -380,11 +438,10 @@ type sceneFinder interface {
 // handlerRequiredFilter returns true if a File's handler needs to be executed despite the file not being updated.
 type handlerRequiredFilter struct {
 	extensionConfig
-	txnManager     txn.Manager
-	SceneFinder    sceneFinder
-	ImageFinder    fileCounter
-	GalleryFinder  galleryFinder
-	CaptionUpdater video.CaptionUpdater
+	txnManager    txn.Manager
+	SceneFinder   sceneFinder
+	ImageFinder   fileCounter
+	GalleryFinder galleryFinder
 
 	FolderCache *lru.LRU[bool]
 
@@ -400,7 +457,6 @@ func newHandlerRequiredFilter(c *config.Config, repo models.Repository) *handler
 		SceneFinder:              repo.Scene,
 		ImageFinder:              repo.Image,
 		GalleryFinder:            repo.Gallery,
-		CaptionUpdater:           repo.File,
 		FolderCache:              lru.New[bool](processes * 2),
 		videoFileNamingAlgorithm: c.GetVideoFileNamingAlgorithm(),
 	}
@@ -475,42 +531,12 @@ func (f *handlerRequiredFilter) Accept(ctx context.Context, ff models.File) bool
 		}
 	}
 
-	if isVideoFile {
-		// TODO - check if the cover exists
-		// hash := scene.GetHash(ff, f.videoFileNamingAlgorithm)
-		// ssPath := instance.Paths.Scene.GetScreenshotPath(hash)
-		// if exists, _ := fsutil.FileExists(ssPath); !exists {
-		// 	// if not, check if the file is a primary file for a scene
-		// 	scenes, err := f.SceneFinder.FindByPrimaryFileID(ctx, ff.Base().ID)
-		// 	if err != nil {
-		// 		// just ignore
-		// 		return false
-		// 	}
-
-		// 	if len(scenes) > 0 {
-		// 		// if it is, then it needs to be re-generated
-		// 		return true
-		// 	}
-		// }
-
-		// clean captions - scene handler handles this as well, but
-		// unchanged files aren't processed by the scene handler
-		videoFile, _ := ff.(*models.VideoFile)
-		if videoFile != nil {
-			if err := video.CleanCaptions(ctx, videoFile, f.txnManager, f.CaptionUpdater); err != nil {
-				logger.Errorf("Error cleaning captions: %v", err)
-			}
-		}
-	}
-
 	return false
 }
 
 type scanFilter struct {
 	extensionConfig
-	txnManager     txn.Manager
-	FileFinder     models.FileFinder
-	CaptionUpdater video.CaptionUpdater
+	txnManager txn.Manager
 
 	stashPaths        config.StashConfigs
 	generatedPath     string
@@ -523,8 +549,6 @@ func newScanFilter(c *config.Config, repo models.Repository, minModTime time.Tim
 	return &scanFilter{
 		extensionConfig:   newExtensionConfig(c),
 		txnManager:        repo.TxnManager,
-		FileFinder:        repo.File,
-		CaptionUpdater:    repo.File,
 		stashPaths:        c.GetStashPaths(),
 		generatedPath:     c.GetGeneratedPath(),
 		videoExcludeRegex: generateRegexps(c.GetExcludes()),
@@ -553,15 +577,6 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo) 
 	isVideoFile := useAsVideo(path)
 	isImageFile := useAsImage(path)
 	isZipFile := fsutil.MatchExtension(path, f.zipExt)
-
-	// handle caption files
-	if fsutil.MatchExtension(path, video.CaptionExts) {
-		// we don't include caption files in the file scan, but we do need
-		// to handle them
-		video.AssociateCaptions(ctx, path, f.txnManager, f.FileFinder, f.CaptionUpdater)
-
-		return false
-	}
 
 	if !info.IsDir() && !isVideoFile && !isImageFile && !isZipFile {
 		logger.Debugf("Skipping %s as it does not match any known file extensions", path)

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -73,6 +73,8 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	j.scanner.ScanFilters = []file.PathFilter{newScanFilter(c, repo, minModTime)}
 	j.scanner.HandlerRequiredFilters = []file.Filter{newHandlerRequiredFilter(cfg, repo)}
 
+	logger.Infof("Starting scan of %d paths with %d parallel tasks", len(paths), nTasks)
+
 	j.runJob(ctx, paths, nTasks, progress)
 
 	taskQueue.Close()
@@ -83,7 +85,7 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	}
 
 	elapsed := time.Since(start)
-	logger.Info(fmt.Sprintf("Scan finished (%s)", elapsed))
+	logger.Infof("Scan finished (%s)", elapsed)
 
 	j.subscriptions.notify()
 	return nil

--- a/pkg/file/move.go
+++ b/pkg/file/move.go
@@ -205,6 +205,25 @@ func correctSubFolderHierarchy(ctx context.Context, rw models.FolderReaderWriter
 
 		logger.Debugf("updating folder %s to %s", oldPath, correctPath)
 
+		// #6427 - ensure folder entry with new path doesn't already exist
+		const caseSensitive = true
+		existing, err := rw.FindByPath(ctx, correctPath, caseSensitive)
+		if err != nil {
+			return fmt.Errorf("finding folder by path %s: %w", correctPath, err)
+		}
+
+		if existing != nil {
+			// this should no longer be possible, but if it does happen, log a warning
+			// and skip updating this folder and its subfolders
+			logger.Warnf("folder with path %s already exists, setting parent_folder_id of %s to NULL and skipping", correctPath, oldPath)
+			f.ParentFolderID = nil
+			if err := rw.Update(ctx, f); err != nil {
+				return fmt.Errorf("updating folder parent id to NULL for folder %s: %w", oldPath, err)
+			}
+
+			continue
+		}
+
 		f.Path = correctPath
 		if err := rw.Update(ctx, f); err != nil {
 			return fmt.Errorf("updating folder path %s -> %s: %w", oldPath, f.Path, err)

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -349,6 +349,10 @@ type ScanFileResult struct {
 	Updated bool
 }
 
+func (r ScanFileResult) IsUnchanged() bool {
+	return !r.New && !r.Renamed && !r.Updated
+}
+
 // ScanFile scans the provided file into the database, returning the scan result.
 func (s *Scanner) ScanFile(ctx context.Context, f ScannedFile) (*ScanFileResult, error) {
 	var r *ScanFileResult

--- a/pkg/file/video/caption.go
+++ b/pkg/file/video/caption.go
@@ -90,11 +90,20 @@ type CaptionUpdater interface {
 	UpdateCaptions(ctx context.Context, fileID models.FileID, captions []*models.VideoCaption) error
 }
 
+// MatchesCaption returns true if the caption file matches the video file based on the filename
+func MatchesCaption(videoPath, captionPath string) bool {
+	captionPrefix := getCaptionPrefix(captionPath)
+	videoPrefix := strings.TrimSuffix(videoPath, filepath.Ext(videoPath)) + "."
+	return captionPrefix == videoPrefix
+}
+
 // associates captions to scene/s with the same basename
-func AssociateCaptions(ctx context.Context, captionPath string, txnMgr txn.Manager, fqb models.FileFinder, w CaptionUpdater) {
+// returns true if the caption file was matched to a video file and processed, false otherwise
+func AssociateCaptions(ctx context.Context, captionPath string, txnMgr txn.Manager, fqb models.FileFinder, w CaptionUpdater) bool {
 	captionLang := getCaptionsLangFromPath(captionPath)
 
 	captionPrefix := getCaptionPrefix(captionPath)
+	matched := false
 	if err := txn.WithTxn(ctx, txnMgr, func(ctx context.Context) error {
 		var err error
 		files, er := fqb.FindAllByPath(ctx, captionPrefix+"*", true)
@@ -117,6 +126,8 @@ func AssociateCaptions(ctx context.Context, captionPath string, txnMgr txn.Manag
 			path := f.Base().Path
 
 			logger.Debugf("Matched captions to file %s", path)
+			matched = true
+
 			captions, er := w.GetCaptions(ctx, fileID)
 			if er == nil {
 				fileExt := filepath.Ext(captionPath)
@@ -139,6 +150,8 @@ func AssociateCaptions(ctx context.Context, captionPath string, txnMgr txn.Manag
 	}); err != nil {
 		logger.Error(err.Error())
 	}
+
+	return matched
 }
 
 // CleanCaptions removes non existent/accessible language codes from captions

--- a/pkg/utils/mutex.go
+++ b/pkg/utils/mutex.go
@@ -1,5 +1,7 @@
 package utils
 
+import "sync"
+
 // MutexManager manages access to mutexes using a mutex type and key.
 type MutexManager struct {
 	mapChan chan map[string]<-chan struct{}
@@ -61,4 +63,27 @@ func (csm *MutexManager) Claim(mutexType string, key string, done <-chan struct{
 
 		csm.mapChan <- m
 	}()
+}
+
+type MutexField[T any] struct {
+	mutex sync.RWMutex
+	value T
+}
+
+func (mf *MutexField[T]) Get() T {
+	mf.mutex.RLock()
+	defer mf.mutex.RUnlock()
+	return mf.value
+}
+
+func (mf *MutexField[T]) Set(value T) {
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+	mf.value = value
+}
+
+func (mf *MutexField[T]) SetFunc(f func(T) T) {
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+	mf.value = f(mf.value)
 }


### PR DESCRIPTION
Resolves #6427 
Resolves #3800 

Performs a check before setting the path during `correctSubFolderHierarchy`. If a folder already exists then it sets parent folder id of the corrected folder to `NULL` and skips processing for that folder and it's subdirectories. It should no longer hit this code, and this is only a sanity check.

Changes the caption handling code so that captions are matched in a single scan, rather than requiring multiple scans. This addresses a panic during scanning due to the accept handler performing caption mutations which would start a transaction, when in some cases a transaction was already opened. It moves the caption handling code out of the accept handler altogether. If it scans the caption file before the matching video file is scanned, then it adds the caption file to a list, which is subsequently checked after a new video file is scanned, at which point it is matched with the video file.