### PR TITLE
Fix new panic in IsFsPathCaseSensitive: Use filepath operations to check for file system case sensitivity

### DIFF
--- a/pkg/fsutil/fs.go
+++ b/pkg/fsutil/fs.go
@@ -29,7 +29,7 @@ func IsFsPathCaseSensitive(path string) (bool, error) {
 
 	flippedPath := filepath.Join(filepath.Dir(path), fBase)
 
-	fiCase, err := os.Stat(string(flippedPath))
+	fiCase, err := os.Stat(flippedPath)
 	if err != nil { // cannot stat the case flipped path
 		return true, nil // fs of path should be case sensitive
 	}

--- a/pkg/fsutil/fs.go
+++ b/pkg/fsutil/fs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"unicode"
 )
 
@@ -27,18 +26,10 @@ func IsFsPathCaseSensitive(path string) (bool, error) {
 	if err != nil { // cannot be case flipped
 		return false, err
 	}
-	i := strings.LastIndex(path, base)
-	if i < 0 { // shouldn't happen
-		return false, fmt.Errorf("could not case flip path %s", path)
-	}
 
-	flipped := []rune(path)
-	for _, c := range fBase { // replace base of path with the flipped one ( we need to flip the base or last dir part )
-		flipped[i] = c
-		i++
-	}
+	flippedPath := filepath.Join(filepath.Dir(path), fBase)
 
-	fiCase, err := os.Stat(string(flipped))
+	fiCase, err := os.Stat(string(flippedPath))
 	if err != nil { // cannot stat the case flipped path
 		return true, nil // fs of path should be case sensitive
 	}

--- a/pkg/fsutil/fs_test.go
+++ b/pkg/fsutil/fs_test.go
@@ -41,4 +41,15 @@ func TestIsFsPathCaseSensitive_UnicodeByteLength(t *testing.T) {
 	}
 
 	// assert.True(t, r, "expected fs to be case sensitive")
+
+	// Ensure that subfolders of a folder with multi-byte chars is not causing a panic
+	path3 := filepath.Join(dir, "NoPanic ❤️")
+	makeDir(path3)
+	path4 := filepath.Join(path3, "Test")
+	makeDir(path4)
+
+	_, err = IsFsPathCaseSensitive(path4)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
If the path leading to the last component has any multi-byte chars then `IsFsPathCaseSensitive` panics.

Replacing `string` functions with `filepath` functions to address mismatch of indexes.