### PR TITLE
Fix scaling of scrubber sprites

### DIFF
--- a/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
+++ b/ui/v2.5/src/components/Scenes/PreviewScrubber.tsx
@@ -73,11 +73,11 @@ export const PreviewScrubber: React.FC<IScenePreviewProps> = ({
     spriteSheet.src = sprite.url;
 
     setStyle({
-      backgroundPosition: `${-sprite.x}px ${-sprite.y}px`,
-      backgroundImage: `url(${sprite.url})`,
-      width: `${sprite.w}px`,
-      height: `${sprite.h}px`,
-      transform: `scale(${scale})`,
+      backgroundPosition: `${-sprite.x * scale}px ${-sprite.y * scale}px`,
+      backgroundImage: `url(${spriteSheet.src})`,
+      backgroundSize: `${spriteSheet.naturalWidth * scale}px ${spriteSheet.naturalHeight * scale}px`,
+      width: `${sprite.w * scale}px`,
+      height: `${sprite.h * scale}px`,
     });
   }, [sprite]);
 


### PR DESCRIPTION
My PR fixes a scaling issue introduced with #6588 which superseded #6522 but failed to apply the changed scrubber scaling of the original PR. 

The Scenescrubber now looks like this, when using custom sprite generation:
<img width="321" height="275" alt="Screenshot From 2026-03-03 13-01-01" src="https://github.com/user-attachments/assets/1194f610-6167-485f-9bc9-a5173d5006d9" />

This small change fixes the scaling:
<img width="321" height="275" alt="Screenshot From 2026-03-03 13-04-28" src="https://github.com/user-attachments/assets/363dc772-2ddd-4fbc-b6d1-9199fb84eedc" />

