### PR TITLE
feat: add Cup Size sort option for performers

### DIFF
--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -778,11 +778,23 @@ func (qb *PerformerStore) sortByScenesDuration(direction string) string {
 	return " ORDER BY (" + selectPerformerScenesDurationSQL + ") " + direction
 }
 
+func (qb *PerformerStore) sortByCupSize(direction string) string {
+	direction = getSortDirection(direction)
+	return " ORDER BY CASE" +
+		" WHEN performers.measurements IS NULL OR performers.measurements = '' THEN NULL" +
+		" WHEN INSTR(performers.measurements, '-') = 0 THEN NULL" +
+		" ELSE REPLACE(REPLACE(" +
+		"LTRIM(SUBSTR(performers.measurements, 1, INSTR(performers.measurements, '-') - 1), '0123456789')," +
+		" 'DDD', 'F'), 'DD', 'E')" +
+		" END " + direction
+}
+
 var performerSortOptions = sortOptions{
 	"birthdate",
 	"career_start",
 	"career_end",
 	"created_at",
+	"cup_size",
 	"galleries_count",
 	"height",
 	"id",
@@ -828,6 +840,8 @@ func (qb *PerformerStore) getPerformerSort(findFilter *models.FindFilterType) (s
 		sortQuery += getCountSort(performerTable, performersScenesTable, performerIDColumn, direction)
 	case "scenes_duration":
 		sortQuery += qb.sortByScenesDuration(direction)
+	case "cup_size":
+		sortQuery += qb.sortByCupSize(direction)
 	case "images_count":
 		sortQuery += getCountSort(performerTable, performersImagesTable, performerIDColumn, direction)
 	case "galleries_count":

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -2532,6 +2532,37 @@ func TestPerformerQuerySortScenesCount(t *testing.T) {
 	})
 }
 
+func TestPerformerQuerySortCupSize(t *testing.T) {
+	sort := "cup_size"
+	direction := models.SortDirectionEnumDesc
+	findFilter := &models.FindFilterType{
+		Sort:      &sort,
+		Direction: &direction,
+	}
+
+	withTxn(func(ctx context.Context) error {
+		// just ensure it queries without error
+		performers, _, err := db.Performer.Query(ctx, nil, findFilter)
+		if err != nil {
+			t.Errorf("Error querying performers: %s", err.Error())
+		}
+
+		assert.True(t, len(performers) > 0)
+
+		// sort in ascending order
+		direction = models.SortDirectionEnumAsc
+
+		performers, _, err = db.Performer.Query(ctx, nil, findFilter)
+		if err != nil {
+			t.Errorf("Error querying performers: %s", err.Error())
+		}
+
+		assert.True(t, len(performers) > 0)
+
+		return nil
+	})
+}
+
 func TestPerformerCountByTagID(t *testing.T) {
 	withTxn(func(ctx context.Context) error {
 		sqb := db.Performer

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -948,6 +948,7 @@
     "none": "None",
     "only": "Only"
   },
+  "cup_size": "Cup Size",
   "custom": "Custom",
   "custom_fields": {
     "criteria_format_string": "{criterion} (custom field) {modifierString} {valueString}",

--- a/ui/v2.5/src/models/list-filter/performers.ts
+++ b/ui/v2.5/src/models/list-filter/performers.ts
@@ -25,6 +25,7 @@ const sortByOptions = [
   "name",
   "height",
   "birthdate",
+  "cup_size",
   "tag_count",
   "random",
   "rating",


### PR DESCRIPTION
## Summary
- Adds a "Cup Size" sort option to the Performers page, extracting cup size from the `measurements` string field (e.g. `34DD-24-34` → `DD` → normalized to `E`)
- Normalizes equivalent cup sizes: DD→E, DDD→F so they sort together
- Handles NULL, empty, and malformed measurements gracefully (sort to end)

Closes #4831

## Implementation
- **Computed SQL sort** — no schema migration needed, follows existing pattern for custom sorts (`sortByScenesDuration`, `sortByPlayCount`, etc.)
- SQL extracts cup letters via `LTRIM(SUBSTR(...), '0123456789')`, then normalizes with `REPLACE`
- Backend: new `sortByCupSize()` method + whitelist entry + switch case in `getPerformerSort()`
- Frontend: sort option added to performer list + `en-GB.json` translation

## Test plan
- [x] Go code compiles without errors
- [x] `TestPerformerQuerySortCupSize` test added (ASC + DESC, verifies no query errors)
- [ ] Manual: Performers page → Sort dropdown → "Cup Size" appears
- [ ] Manual: Sort ASC orders A < B < C < D < E (DD) < F (DDD) < G < ...
- [ ] Manual: Performers with no measurements sort to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)