### PR TITLE
Allow stash path to non-existing directory

### DIFF
--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -85,6 +86,8 @@ func (r *mutationResolver) setConfigFloat(key string, value *float64) {
 func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGeneralInput) (*ConfigGeneralResult, error) {
 	c := config.GetInstance()
 
+	// #4709 - allow stash paths even if they do not exist, so that users may configure stash
+	// for disconnected drives or network storage.
 	existingPaths := c.GetStashPaths()
 	if input.Stashes != nil {
 		for _, s := range input.Stashes {
@@ -97,8 +100,12 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 				}
 			}
 			if isNew {
+				s.Path = filepath.Clean(s.Path)
+
+				// if it exists, it must be directory
 				exists, err := fsutil.DirExists(s.Path)
-				if !exists {
+				// allow it to not exist but if it does exist it must be a directory
+				if !exists && !errors.Is(err, fs.ErrNotExist) {
 					return makeConfigGeneralResult(), err
 				}
 			}


### PR DESCRIPTION
Changed validation behaviour so that it only enforces that the path is a directory if it exists.

Resolves #4709 