### PR TITLE
Disable links on wall items when selecting

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
@@ -132,7 +132,13 @@ const GalleryWallCard: React.FC<IProps> = ({
           <footer className={CLASSNAME_FOOTER}>
             <Link
               to={`/galleries/${gallery.id}`}
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                if (selecting) {
+                  e.preventDefault();
+                  handleCardClick(e);
+                }
+                e.stopPropagation();
+              }}
             >
               {title && (
                 <TruncatedText

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -131,7 +131,16 @@ export const SceneWallItem: React.FC<
       />
       <div className="lineargradient">
         <footer className="wall-item-footer">
-          <Link to={props.photo.link} onClick={(e) => e.stopPropagation()}>
+          <Link
+            to={props.photo.link}
+            onClick={(e) => {
+              if (props.selecting) {
+                e.preventDefault();
+                handleClick(e);
+              }
+              e.stopPropagation();
+            }}
+          >
             {title && (
               <TruncatedText
                 text={title}


### PR DESCRIPTION
Resolves #6026 

Plugs some more link actions when selecting, this time for wall items. Gallery preview scrubber is left as is, since clicking on it doesn't navigate to a new page.