### PR TITLE
add image scraping to built-in Auto-Tag scraper

### DIFF
--- a/pkg/scraper/autotag.go
+++ b/pkg/scraper/autotag.go
@@ -90,6 +90,11 @@ func autotagMatchTags(ctx context.Context, path string, tagReader models.TagAuto
 }
 
 func (s autotagScraper) viaImage(ctx context.Context, _client *http.Client, image *models.Image) (*models.ScrapedImage, error) {
+	path := image.Path
+	if path == "" {
+		return nil, nil
+	}
+
 	var ret *models.ScrapedImage
 
 	// only trim extension if image is file-based
@@ -97,11 +102,6 @@ func (s autotagScraper) viaImage(ctx context.Context, _client *http.Client, imag
 
 	// populate performers, studio and tags based on image path
 	if err := txn.WithReadTxn(ctx, s.txnManager, func(ctx context.Context) error {
-		path := image.Path
-		if path == "" {
-			return nil
-		}
-
 		performers, err := autotagMatchPerformers(ctx, path, s.performerReader, trimExt)
 		if err != nil {
 			return fmt.Errorf("autotag scraper viaImage: %w", err)

--- a/pkg/scraper/autotag.go
+++ b/pkg/scraper/autotag.go
@@ -89,11 +89,13 @@ func autotagMatchTags(ctx context.Context, path string, tagReader models.TagAuto
 	return ret, nil
 }
 
-func (s autotagScraper) viaImage(ctx context.Context, client *http.Client, image *models.Image) (*models.ScrapedImage, error) {
+func (s autotagScraper) viaImage(ctx context.Context, _client *http.Client, image *models.Image) (*models.ScrapedImage, error) {
 	var ret *models.ScrapedImage
-	const trimExt = false
 
-	// populate performers, studio and tags based on scene path
+	// only trim extension if image is file-based
+	trimExt := image.PrimaryFileID != nil
+
+	// populate performers, studio and tags based on image path
 	if err := txn.WithReadTxn(ctx, s.txnManager, func(ctx context.Context) error {
 		path := image.Path
 		if path == "" {

--- a/pkg/scraper/autotag.go
+++ b/pkg/scraper/autotag.go
@@ -89,6 +89,47 @@ func autotagMatchTags(ctx context.Context, path string, tagReader models.TagAuto
 	return ret, nil
 }
 
+func (s autotagScraper) viaImage(ctx context.Context, client *http.Client, image *models.Image) (*models.ScrapedImage, error) {
+	var ret *models.ScrapedImage
+	const trimExt = false
+
+	// populate performers, studio and tags based on scene path
+	if err := txn.WithReadTxn(ctx, s.txnManager, func(ctx context.Context) error {
+		path := image.Path
+		if path == "" {
+			return nil
+		}
+
+		performers, err := autotagMatchPerformers(ctx, path, s.performerReader, trimExt)
+		if err != nil {
+			return fmt.Errorf("autotag scraper viaImage: %w", err)
+		}
+		studio, err := autotagMatchStudio(ctx, path, s.studioReader, trimExt)
+		if err != nil {
+			return fmt.Errorf("autotag scraper viaImage: %w", err)
+		}
+
+		tags, err := autotagMatchTags(ctx, path, s.tagReader, trimExt)
+		if err != nil {
+			return fmt.Errorf("autotag scraper viaImage: %w", err)
+		}
+
+		if len(performers) > 0 || studio != nil || len(tags) > 0 {
+			ret = &models.ScrapedImage{
+				Performers: performers,
+				Studio:     studio,
+				Tags:       tags,
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
 func (s autotagScraper) viaScene(ctx context.Context, _client *http.Client, scene *models.Scene) (*models.ScrapedScene, error) {
 	var ret *models.ScrapedScene
 	const trimExt = false
@@ -181,6 +222,8 @@ func (s autotagScraper) supports(ty ScrapeContentType) bool {
 		return true
 	case ScrapeContentTypeGallery:
 		return true
+	case ScrapeContentTypeImage:
+		return true
 	}
 
 	return false
@@ -202,6 +245,9 @@ func (s autotagScraper) spec() Scraper {
 			SupportedScrapes: supportedScrapes,
 		},
 		Gallery: &ScraperSpec{
+			SupportedScrapes: supportedScrapes,
+		},
+		Image: &ScraperSpec{
 			SupportedScrapes: supportedScrapes,
 		},
 	}


### PR DESCRIPTION
The bulk Auto-Tag operations already supported images, but the built-in Auto-Tag scraper did not support them, therefore the option was missing in the image details scrape menu. It was already available for galleries and scenes, images just seem to have just slipped through. Seems to work fine, not sure if there was a reason why this wasn't implemented already.

Hopefully, this can be a first step in making Images a first class citizen in terms of scraping UI. But one step at a time.

![Screenshot_20260320_001151](https://github.com/user-attachments/assets/51220c22-84c6-4233-886c-47f7092ec180)
![Screenshot_20260320_002326](https://github.com/user-attachments/assets/dff4c439-85c5-403b-9e4a-ec88ec77fefd)
