### PR TITLE
Fix: Maximum update depth exceeded Error on Gallery

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryAddPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryAddPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GalleriesCriterion } from "src/models/list-filter/criteria/galleries";
 import { ListFilterModel } from "src/models/list-filter/filter";
@@ -24,40 +24,43 @@ export const GalleryAddPanel: React.FC<IGalleryAddProps> = PatchComponent(
     const Toast = useToast();
     const intl = useIntl();
 
-    function filterHook(filter: ListFilterModel) {
-      const galleryValue = {
-        id: gallery.id,
-        label: galleryTitle(gallery),
-      };
-      // if galleries is already present, then we modify it, otherwise add
-      let galleryCriterion = filter.criteria.find((c) => {
-        return c.criterionOption.type === "galleries";
-      }) as GalleriesCriterion | undefined;
+    const filterHook = useCallback(
+      (filter: ListFilterModel) => {
+        const galleryValue = {
+          id: gallery.id,
+          label: galleryTitle(gallery),
+        };
+        // if galleries is already present, then we modify it, otherwise add
+        let galleryCriterion = filter.criteria.find((c) => {
+          return c.criterionOption.type === "galleries";
+        }) as GalleriesCriterion | undefined;
 
-      if (
-        galleryCriterion &&
-        galleryCriterion.modifier === GQL.CriterionModifier.Excludes
-      ) {
-        // add the gallery if not present
         if (
-          !galleryCriterion.value.find((p) => {
-            return p.id === gallery.id;
-          })
+          galleryCriterion &&
+          galleryCriterion.modifier === GQL.CriterionModifier.Excludes
         ) {
-          galleryCriterion.value.push(galleryValue);
+          // add the gallery if not present
+          if (
+            !galleryCriterion.value.find((p) => {
+              return p.id === gallery.id;
+            })
+          ) {
+            galleryCriterion.value.push(galleryValue);
+          }
+
+          galleryCriterion.modifier = GQL.CriterionModifier.Excludes;
+        } else {
+          // overwrite
+          galleryCriterion = new GalleriesCriterion();
+          galleryCriterion.modifier = GQL.CriterionModifier.Excludes;
+          galleryCriterion.value = [galleryValue];
+          filter.criteria.push(galleryCriterion);
         }
 
-        galleryCriterion.modifier = GQL.CriterionModifier.Excludes;
-      } else {
-        // overwrite
-        galleryCriterion = new GalleriesCriterion();
-        galleryCriterion.modifier = GQL.CriterionModifier.Excludes;
-        galleryCriterion.value = [galleryValue];
-        filter.criteria.push(galleryCriterion);
-      }
-
-      return filter;
-    }
+        return filter;
+      },
+      [gallery]
+    );
 
     async function addImages(
       result: GQL.FindImagesQueryResult,

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryImagesPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GalleriesCriterion } from "src/models/list-filter/criteria/galleries";
 import { ListFilterModel } from "src/models/list-filter/filter";
@@ -32,40 +32,43 @@ export const GalleryImagesPanel: React.FC<IGalleryDetailsProps> =
       const intl = useIntl();
       const Toast = useToast();
 
-      function filterHook(filter: ListFilterModel) {
-        const galleryValue = {
-          id: gallery.id!,
-          label: galleryTitle(gallery),
-        };
-        // if galleries is already present, then we modify it, otherwise add
-        let galleryCriterion = filter.criteria.find((c) => {
-          return c.criterionOption.type === "galleries";
-        }) as GalleriesCriterion | undefined;
+      const filterHook = useCallback(
+        (filter: ListFilterModel) => {
+          const galleryValue = {
+            id: gallery.id!,
+            label: galleryTitle(gallery),
+          };
+          // if galleries is already present, then we modify it, otherwise add
+          let galleryCriterion = filter.criteria.find((c) => {
+            return c.criterionOption.type === "galleries";
+          }) as GalleriesCriterion | undefined;
 
-        if (
-          galleryCriterion &&
-          (galleryCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
-            galleryCriterion.modifier === GQL.CriterionModifier.Includes)
-        ) {
-          // add the gallery if not present
           if (
-            !galleryCriterion.value.find((p) => {
-              return p.id === gallery.id;
-            })
+            galleryCriterion &&
+            (galleryCriterion.modifier === GQL.CriterionModifier.IncludesAll ||
+              galleryCriterion.modifier === GQL.CriterionModifier.Includes)
           ) {
-            galleryCriterion.value.push(galleryValue);
+            // add the gallery if not present
+            if (
+              !galleryCriterion.value.find((p) => {
+                return p.id === gallery.id;
+              })
+            ) {
+              galleryCriterion.value.push(galleryValue);
+            }
+
+            galleryCriterion.modifier = GQL.CriterionModifier.IncludesAll;
+          } else {
+            // overwrite
+            galleryCriterion = new GalleriesCriterion();
+            galleryCriterion.value = [galleryValue];
+            filter.criteria.push(galleryCriterion);
           }
 
-          galleryCriterion.modifier = GQL.CriterionModifier.IncludesAll;
-        } else {
-          // overwrite
-          galleryCriterion = new GalleriesCriterion();
-          galleryCriterion.value = [galleryValue];
-          filter.criteria.push(galleryCriterion);
-        }
-
-        return filter;
-      }
+          return filter;
+        },
+        [gallery]
+      );
 
       async function setCover(
         result: GQL.FindImagesQueryResult,

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -751,7 +751,7 @@ export const FilteredImageList = PatchComponent(
             currentPage={filter.currentPage}
             itemsPerPage={filter.itemsPerPage}
             totalItems={totalCount}
-            onChangePage={(page) => setFilter(filter.changePage(page))}
+            onChangePage={setPage}
           />
           <PaginationIndex
             loading={cachedResult.loading}
@@ -766,7 +766,7 @@ export const FilteredImageList = PatchComponent(
           <ImageList
             filter={filter}
             images={items}
-            onChangePage={(page) => setFilter(filter.changePage(page))}
+            onChangePage={setPage}
             onSelectChange={onSelectChange}
             pageCount={pageCount}
             selectedIds={selectedIds}

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Mousetrap from "mousetrap";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { useHistory, useLocation } from "react-router-dom";
@@ -489,20 +489,20 @@ export function useCachedQueryResult<T extends QueryResult>(
   result: T
 ) {
   const [cachedResult, setCachedResult] = useState(result);
-  const [lastFilter, setLastFilter] = useState(filter);
+  const lastFilterRef = useRef(filter);
 
   // if we are only changing the page or sort, don't update the result count
   useEffect(() => {
     if (!result.loading) {
       setCachedResult(result);
     } else {
-      if (totalCountImpacted(lastFilter, filter)) {
+      if (totalCountImpacted(lastFilterRef.current, filter)) {
         setCachedResult(result);
       }
     }
 
-    setLastFilter(filter);
-  }, [filter, result, lastFilter]);
+    lastFilterRef.current = filter;
+  }, [filter, result]);
 
   return cachedResult;
 }


### PR DESCRIPTION
Issue raised in discord [here](https://discord.com/channels/559159668438728723/559159910550732809/1479254683804631102)

`GalleryPage` subscribes to the lightbox context via `useGalleryLightbox`. When `ImageList` updates lightbox state via `useLightbox`, the context change re-renders GalleryPage, which cascades to `GalleryImagesPanel` -> `FilteredImageList` -> `ImageList`. Unstable function references (`filterHook`, `onChangePage`) caused dependencies to appear changed on each pass, re-triggering the lightbox effect and creating an infinite loop.

The same inline `onChangePage` pattern exists in the top pagination of other list components. Those don't trigger infinite loops since their parent pages don't consume lightbox context, but could be updated to use `setPage` for consistency in a follow-up.

Fixes: #6652
