### PR TITLE
Use StashIDPill in the performer modal dialog

### DIFF
--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -15,10 +15,10 @@ import {
   faArrowLeft,
   faArrowRight,
   faCheck,
-  faExternalLinkAlt,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
 import { ExternalLink } from "../Shared/ExternalLink";
+import { StashIDPill } from "../Shared/StashID";
 
 interface IPerformerModalProps {
   performer: GQL.ScrapedScenePerformerDataFragment;
@@ -208,15 +208,13 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
 
   function maybeRenderStashBoxLink() {
     const base = endpoint?.match(/https?:\/\/.*?\//)?.[0];
-    if (!base) return;
+    if (!base || !performer.remote_site_id) return;
 
     return (
-      <h6 className="mt-2">
-        <ExternalLink href={`${base}performers/${performer.remote_site_id}`}>
-          <FormattedMessage id="stashbox.source" />
-          <Icon icon={faExternalLinkAlt} className="ml-2" />
-        </ExternalLink>
-      </h6>
+      <StashIDPill
+        linkType="performers"
+        stashID={{ endpoint: endpoint, stash_id: performer.remote_site_id }}
+      />
     );
   }
 


### PR DESCRIPTION
Currently, this dialog just shows a text "Stash-Box Source". This change instead re-uses the StashIDPill, with the main advantage that you can immediately tell which stash box is being used.

The studio modal has a similar issue, but it is harder to make this change because it does not have the link broken down into an endpoint and stash ID part.