### PR TITLE
Show the stash box for each stash ID in the scene merge dialog

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -51,7 +51,7 @@ const StashIDsField: React.FC<IStashIDsField> = ({ values }) => {
   if (!values.length) return null;
 
   return (
-    <ul className="pl-0">
+    <ul className="pl-0 mw-100">
       {values.map((v) => (
         <li key={v.stash_id} className="row no-gutters">
           <StashIDPill linkType="scenes" stashID={v} />

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -11,6 +11,7 @@ import {
   mutateSceneMerge,
   queryFindFullScenesByID,
 } from "src/core/StashService";
+import { useConfigurationContext } from "src/hooks/Config";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useToast } from "src/hooks/Toast";
 import { faExchangeAlt, faSignInAlt } from "@fortawesome/free-solid-svg-icons";
@@ -47,7 +48,23 @@ interface IStashIDsField {
 }
 
 const StashIDsField: React.FC<IStashIDsField> = ({ values }) => {
-  return <StringListSelect value={values.map((v) => v.stash_id)} />;
+  const { configuration } = useConfigurationContext();
+
+  function getEndpointName(stash_id: GQL.StashId) {
+    return (
+      configuration?.general.stashBoxes.find(
+        (sb) => sb.endpoint === stash_id.endpoint
+      )?.name ?? stash_id.endpoint
+    );
+  }
+
+  function getStashIdDisplayName(stash_id: GQL.StashId) {
+    return `${getEndpointName(stash_id)} | ${stash_id.stash_id}`;
+  }
+
+  return (
+    <StringListSelect value={values.map((v) => getStashIdDisplayName(v))} />
+  );
 };
 
 type MergeOptions = {

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { Icon } from "../Shared/Icon";
 import { LoadingIndicator } from "../Shared/LoadingIndicator";
-import { StringListSelect, GallerySelect } from "../Shared/Select";
+import { GallerySelect } from "../Shared/Select";
 import * as FormUtils from "src/utils/form";
 import ImageUtils from "src/utils/image";
 import TextUtils from "src/utils/text";
@@ -11,7 +11,6 @@ import {
   mutateSceneMerge,
   queryFindFullScenesByID,
 } from "src/core/StashService";
-import { useConfigurationContext } from "src/hooks/Config";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useToast } from "src/hooks/Toast";
 import { faExchangeAlt, faSignInAlt } from "@fortawesome/free-solid-svg-icons";
@@ -42,28 +41,23 @@ import {
   ScrapedTagsRow,
 } from "../Shared/ScrapeDialog/ScrapedObjectsRow";
 import { Scene, SceneSelect } from "src/components/Scenes/SceneSelect";
+import { StashIDPill } from "src/components/Shared/StashID";
 
 interface IStashIDsField {
   values: GQL.StashId[];
 }
 
 const StashIDsField: React.FC<IStashIDsField> = ({ values }) => {
-  const { configuration } = useConfigurationContext();
-
-  function getEndpointName(stash_id: GQL.StashId) {
-    return (
-      configuration?.general.stashBoxes.find(
-        (sb) => sb.endpoint === stash_id.endpoint
-      )?.name ?? stash_id.endpoint
-    );
-  }
-
-  function getStashIdDisplayName(stash_id: GQL.StashId) {
-    return `${getEndpointName(stash_id)} | ${stash_id.stash_id}`;
-  }
+  if (!values.length) return null;
 
   return (
-    <StringListSelect value={values.map((v) => getStashIdDisplayName(v))} />
+    <ul className="pl-0">
+      {values.map((v) => (
+        <li key={v.stash_id} className="row no-gutters">
+          <StashIDPill linkType="scenes" stashID={v} />
+        </li>
+      ))}
+    </ul>
   );
 };
 

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -666,10 +666,11 @@ div.react-datepicker {
 }
 
 .stash-id-pill {
-  display: inline-block;
+  display: inline-flex;
   font-size: 90%;
   font-weight: 700;
   line-height: 1;
+  max-width: 100%;
   padding-bottom: 0.25em;
   padding-top: 0.25em;
   text-align: center;
@@ -685,12 +686,15 @@ div.react-datepicker {
   span {
     background-color: $primary;
     border-radius: 0.25rem 0 0 0.25rem;
+    flex-shrink: 0;
     min-width: 5em;
   }
 
   a {
     background-color: $secondary;
     border-radius: 0 0.25rem 0.25rem 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
Currently, this dialog only shows the ID but not the stash box it corresponds to. This is not very useful because the ID does not mean anything to a user.

This changes the dialog to use the standard Stash ID pill.