### PR TITLE
feat: add image details to search filter

### DIFF
--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -170,6 +170,12 @@ input AutoTagMetadataInput {
   IDs of tags to tag files with, or "*" for all
   """
   tags: [String!]
+  "If true, will also match performer aliases"
+  performerAliases: Boolean
+  "If true, will also match studio aliases"
+  studioAliases: Boolean
+  "If true, will also match tag aliases"
+  tagAliases: Boolean
 }
 
 type AutoTagMetadataOptions {
@@ -185,6 +191,12 @@ type AutoTagMetadataOptions {
   IDs of tags to tag files with, or "*" for all
   """
   tags: [String!]
+  "If true, will also match performer aliases"
+  performerAliases: Boolean
+  "If true, will also match studio aliases"
+  studioAliases: Boolean
+  "If true, will also match tag aliases"
+  tagAliases: Boolean
 }
 
 enum IdentifyFieldStrategy {

--- a/internal/autotag/gallery.go
+++ b/internal/autotag/gallery.go
@@ -44,7 +44,7 @@ func getGalleryFileTagger(s *models.Gallery, cache *match.Cache) tagger {
 }
 
 // GalleryPerformers tags the provided gallery with performers whose name matches the gallery's path.
-func GalleryPerformers(ctx context.Context, s *models.Gallery, rw GalleryPerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache) error {
+func GalleryPerformers(ctx context.Context, s *models.Gallery, rw GalleryPerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getGalleryFileTagger(s, cache)
 
 	return t.tagPerformers(ctx, performerReader, func(subjectID, otherID int) (bool, error) {
@@ -62,13 +62,13 @@ func GalleryPerformers(ctx context.Context, s *models.Gallery, rw GalleryPerform
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }
 
 // GalleryStudios tags the provided gallery with the first studio whose name matches the gallery's path.
 //
 // Gallerys will not be tagged if studio is already set.
-func GalleryStudios(ctx context.Context, s *models.Gallery, rw GalleryFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache) error {
+func GalleryStudios(ctx context.Context, s *models.Gallery, rw GalleryFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	if s.StudioID != nil {
 		// don't modify
 		return nil
@@ -78,11 +78,11 @@ func GalleryStudios(ctx context.Context, s *models.Gallery, rw GalleryFinderUpda
 
 	return t.tagStudios(ctx, studioReader, func(subjectID, otherID int) (bool, error) {
 		return addGalleryStudio(ctx, rw, s, otherID)
-	})
+	}, matchAliases)
 }
 
 // GalleryTags tags the provided gallery with tags whose name matches the gallery's path.
-func GalleryTags(ctx context.Context, s *models.Gallery, rw GalleryTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache) error {
+func GalleryTags(ctx context.Context, s *models.Gallery, rw GalleryTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getGalleryFileTagger(s, cache)
 
 	return t.tagTags(ctx, tagReader, func(subjectID, otherID int) (bool, error) {
@@ -100,5 +100,5 @@ func GalleryTags(ctx context.Context, s *models.Gallery, rw GalleryTagUpdater, t
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }

--- a/internal/autotag/gallery_test.go
+++ b/internal/autotag/gallery_test.go
@@ -55,7 +55,7 @@ func TestGalleryPerformers(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
 
 		if test.Matches {
 			matchPartial := mock.MatchedBy(func(got models.GalleryPartial) bool {
@@ -76,7 +76,42 @@ func TestGalleryPerformers(t *testing.T) {
 			Path:         test.Path,
 			PerformerIDs: models.NewRelatedIDs([]int{}),
 		}
-		err := GalleryPerformers(testCtx, &gallery, db.Gallery, db.Performer, nil)
+		err := GalleryPerformers(testCtx, &gallery, db.Gallery, db.Performer, nil, true)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedStrings([]string{performerName})
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.GalleryPartial) bool {
+				expected := models.GalleryPartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return galleryPartialsEqual(got, expected)
+			})
+			db.Gallery.On("UpdatePartial", testCtx, galleryID, matchPartial).Return(nil, nil).Once()
+		}
+
+		gallery := models.Gallery{
+			ID:           galleryID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
+		err := GalleryPerformers(testCtx, &gallery, db.Gallery, db.Performer, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -121,7 +156,7 @@ func TestGalleryStudios(t *testing.T) {
 			ID:   galleryID,
 			Path: test.Path,
 		}
-		err := GalleryStudios(testCtx, &gallery, db.Gallery, db.Studio, nil)
+		err := GalleryStudios(testCtx, &gallery, db.Gallery, db.Studio, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -131,7 +166,7 @@ func TestGalleryStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -145,7 +180,7 @@ func TestGalleryStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, studioID).Return([]string{
 			studioName,
 		}, nil).Once()
@@ -197,7 +232,7 @@ func TestGalleryTags(t *testing.T) {
 			Path:   test.Path,
 			TagIDs: models.NewRelatedIDs([]int{}),
 		}
-		err := GalleryTags(testCtx, &gallery, db.Gallery, db.Tag, nil)
+		err := GalleryTags(testCtx, &gallery, db.Gallery, db.Tag, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -207,7 +242,7 @@ func TestGalleryTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -220,7 +255,7 @@ func TestGalleryTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, tagID).Return([]string{
 			tagName,
 		}, nil).Once()

--- a/internal/autotag/image.go
+++ b/internal/autotag/image.go
@@ -35,7 +35,7 @@ func getImageFileTagger(s *models.Image, cache *match.Cache) tagger {
 }
 
 // ImagePerformers tags the provided image with performers whose name matches the image's path.
-func ImagePerformers(ctx context.Context, s *models.Image, rw ImagePerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache) error {
+func ImagePerformers(ctx context.Context, s *models.Image, rw ImagePerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getImageFileTagger(s, cache)
 
 	return t.tagPerformers(ctx, performerReader, func(subjectID, otherID int) (bool, error) {
@@ -53,13 +53,13 @@ func ImagePerformers(ctx context.Context, s *models.Image, rw ImagePerformerUpda
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }
 
 // ImageStudios tags the provided image with the first studio whose name matches the image's path.
 //
 // Images will not be tagged if studio is already set.
-func ImageStudios(ctx context.Context, s *models.Image, rw ImageFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache) error {
+func ImageStudios(ctx context.Context, s *models.Image, rw ImageFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	if s.StudioID != nil {
 		// don't modify
 		return nil
@@ -69,11 +69,11 @@ func ImageStudios(ctx context.Context, s *models.Image, rw ImageFinderUpdater, s
 
 	return t.tagStudios(ctx, studioReader, func(subjectID, otherID int) (bool, error) {
 		return addImageStudio(ctx, rw, s, otherID)
-	})
+	}, matchAliases)
 }
 
 // ImageTags tags the provided image with tags whose name matches the image's path.
-func ImageTags(ctx context.Context, s *models.Image, rw ImageTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache) error {
+func ImageTags(ctx context.Context, s *models.Image, rw ImageTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getImageFileTagger(s, cache)
 
 	return t.tagTags(ctx, tagReader, func(subjectID, otherID int) (bool, error) {
@@ -91,5 +91,5 @@ func ImageTags(ctx context.Context, s *models.Image, rw ImageTagUpdater, tagRead
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }

--- a/internal/autotag/image_test.go
+++ b/internal/autotag/image_test.go
@@ -52,7 +52,7 @@ func TestImagePerformers(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
 
 		if test.Matches {
 			matchPartial := mock.MatchedBy(func(got models.ImagePartial) bool {
@@ -73,7 +73,42 @@ func TestImagePerformers(t *testing.T) {
 			Path:         test.Path,
 			PerformerIDs: models.NewRelatedIDs([]int{}),
 		}
-		err := ImagePerformers(testCtx, &image, db.Image, db.Performer, nil)
+		err := ImagePerformers(testCtx, &image, db.Image, db.Performer, nil, true)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedStrings([]string{performerName})
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.ImagePartial) bool {
+				expected := models.ImagePartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return imagePartialsEqual(got, expected)
+			})
+			db.Image.On("UpdatePartial", testCtx, imageID, matchPartial).Return(nil, nil).Once()
+		}
+
+		image := models.Image{
+			ID:           imageID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
+		err := ImagePerformers(testCtx, &image, db.Image, db.Performer, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -118,7 +153,7 @@ func TestImageStudios(t *testing.T) {
 			ID:   imageID,
 			Path: test.Path,
 		}
-		err := ImageStudios(testCtx, &image, db.Image, db.Studio, nil)
+		err := ImageStudios(testCtx, &image, db.Image, db.Studio, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -128,7 +163,7 @@ func TestImageStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -142,7 +177,7 @@ func TestImageStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, studioID).Return([]string{
 			studioName,
 		}, nil).Once()
@@ -194,7 +229,7 @@ func TestImageTags(t *testing.T) {
 			Path:   test.Path,
 			TagIDs: models.NewRelatedIDs([]int{}),
 		}
-		err := ImageTags(testCtx, &image, db.Image, db.Tag, nil)
+		err := ImageTags(testCtx, &image, db.Image, db.Tag, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -204,7 +239,7 @@ func TestImageTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -218,7 +253,7 @@ func TestImageTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, tagID).Return([]string{
 			tagName,
 		}, nil).Once()

--- a/internal/autotag/integration_test.go
+++ b/internal/autotag/integration_test.go
@@ -558,7 +558,7 @@ func TestParsePerformerScenes(t *testing.T) {
 			if err := p.LoadAliases(ctx, r.Performer); err != nil {
 				return err
 			}
-			return tagger.PerformerScenes(ctx, p, nil, r.Scene)
+			return tagger.PerformerScenes(ctx, p, nil, r.Scene, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -614,7 +614,7 @@ func TestParseStudioScenes(t *testing.T) {
 				return err
 			}
 
-			return tagger.StudioScenes(ctx, s, nil, aliases, r.Scene)
+			return tagger.StudioScenes(ctx, s, nil, aliases, r.Scene, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -674,7 +674,7 @@ func TestParseTagScenes(t *testing.T) {
 				return err
 			}
 
-			return tagger.TagScenes(ctx, s, nil, aliases, r.Scene)
+			return tagger.TagScenes(ctx, s, nil, aliases, r.Scene, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -728,7 +728,7 @@ func TestParsePerformerImages(t *testing.T) {
 			if err := p.LoadAliases(ctx, r.Performer); err != nil {
 				return err
 			}
-			return tagger.PerformerImages(ctx, p, nil, r.Image)
+			return tagger.PerformerImages(ctx, p, nil, r.Image, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -785,7 +785,7 @@ func TestParseStudioImages(t *testing.T) {
 				return err
 			}
 
-			return tagger.StudioImages(ctx, s, nil, aliases, r.Image)
+			return tagger.StudioImages(ctx, s, nil, aliases, r.Image, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -845,7 +845,7 @@ func TestParseTagImages(t *testing.T) {
 				return err
 			}
 
-			return tagger.TagImages(ctx, s, nil, aliases, r.Image)
+			return tagger.TagImages(ctx, s, nil, aliases, r.Image, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -900,7 +900,7 @@ func TestParsePerformerGalleries(t *testing.T) {
 			if err := p.LoadAliases(ctx, r.Performer); err != nil {
 				return err
 			}
-			return tagger.PerformerGalleries(ctx, p, nil, r.Gallery)
+			return tagger.PerformerGalleries(ctx, p, nil, r.Gallery, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -957,7 +957,7 @@ func TestParseStudioGalleries(t *testing.T) {
 				return err
 			}
 
-			return tagger.StudioGalleries(ctx, s, nil, aliases, r.Gallery)
+			return tagger.StudioGalleries(ctx, s, nil, aliases, r.Gallery, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}
@@ -1017,7 +1017,7 @@ func TestParseTagGalleries(t *testing.T) {
 				return err
 			}
 
-			return tagger.TagGalleries(ctx, s, nil, aliases, r.Gallery)
+			return tagger.TagGalleries(ctx, s, nil, aliases, r.Gallery, true)
 		}); err != nil {
 			t.Errorf("Error auto-tagging performers: %s", err)
 		}

--- a/internal/autotag/performer.go
+++ b/internal/autotag/performer.go
@@ -30,7 +30,7 @@ type GalleryQueryPerformerUpdater interface {
 	models.GalleryUpdater
 }
 
-func getPerformerTaggers(p *models.Performer, cache *match.Cache) []tagger {
+func getPerformerTaggers(p *models.Performer, cache *match.Cache, matchAliases bool) []tagger {
 	ret := []tagger{{
 		ID:    p.ID,
 		Type:  "performer",
@@ -38,23 +38,24 @@ func getPerformerTaggers(p *models.Performer, cache *match.Cache) []tagger {
 		cache: cache,
 	}}
 
-	// TODO - disabled until we can have finer control over alias matching
-	// for _, a := range p.Aliases.List() {
-	// 	ret = append(ret, tagger{
-	// 		ID:    p.ID,
-	// 		Type:  "performer",
-	// 		Name:  a,
-	// 		cache: cache,
-	// 	})
-	// }
+	if matchAliases {
+		for _, a := range p.Aliases.List() {
+			ret = append(ret, tagger{
+				ID:    p.ID,
+				Type:  "performer",
+				Name:  a,
+				cache: cache,
+			})
+		}
+	}
 
 	return ret
 }
 
 // PerformerScenes searches for scenes whose path matches the provided performer name and tags the scene with the performer.
 // Performer aliases must be loaded.
-func (tagger *Tagger) PerformerScenes(ctx context.Context, p *models.Performer, paths []string, rw SceneQueryPerformerUpdater) error {
-	t := getPerformerTaggers(p, tagger.Cache)
+func (tagger *Tagger) PerformerScenes(ctx context.Context, p *models.Performer, paths []string, rw SceneQueryPerformerUpdater, matchAliases bool) error {
+	t := getPerformerTaggers(p, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagScenes(ctx, paths, rw, func(o *models.Scene) (bool, error) {
@@ -82,8 +83,8 @@ func (tagger *Tagger) PerformerScenes(ctx context.Context, p *models.Performer, 
 }
 
 // PerformerImages searches for images whose path matches the provided performer name and tags the image with the performer.
-func (tagger *Tagger) PerformerImages(ctx context.Context, p *models.Performer, paths []string, rw ImageQueryPerformerUpdater) error {
-	t := getPerformerTaggers(p, tagger.Cache)
+func (tagger *Tagger) PerformerImages(ctx context.Context, p *models.Performer, paths []string, rw ImageQueryPerformerUpdater, matchAliases bool) error {
+	t := getPerformerTaggers(p, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagImages(ctx, paths, rw, func(o *models.Image) (bool, error) {
@@ -111,8 +112,8 @@ func (tagger *Tagger) PerformerImages(ctx context.Context, p *models.Performer, 
 }
 
 // PerformerGalleries searches for galleries whose path matches the provided performer name and tags the gallery with the performer.
-func (tagger *Tagger) PerformerGalleries(ctx context.Context, p *models.Performer, paths []string, rw GalleryQueryPerformerUpdater) error {
-	t := getPerformerTaggers(p, tagger.Cache)
+func (tagger *Tagger) PerformerGalleries(ctx context.Context, p *models.Performer, paths []string, rw GalleryQueryPerformerUpdater, matchAliases bool) error {
+	t := getPerformerTaggers(p, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagGalleries(ctx, paths, rw, func(o *models.Gallery) (bool, error) {

--- a/internal/autotag/performer_test.go
+++ b/internal/autotag/performer_test.go
@@ -107,7 +107,7 @@ func testPerformerScenes(t *testing.T, performerName, expectedRegex string) {
 		TxnManager: db,
 	}
 
-	err := tagger.PerformerScenes(testCtx, &performer, nil, db.Scene)
+	err := tagger.PerformerScenes(testCtx, &performer, nil, db.Scene, true)
 
 	assert := assert.New(t)
 
@@ -202,7 +202,7 @@ func testPerformerImages(t *testing.T, performerName, expectedRegex string) {
 		TxnManager: db,
 	}
 
-	err := tagger.PerformerImages(testCtx, &performer, nil, db.Image)
+	err := tagger.PerformerImages(testCtx, &performer, nil, db.Image, true)
 
 	assert := assert.New(t)
 
@@ -297,7 +297,7 @@ func testPerformerGalleries(t *testing.T, performerName, expectedRegex string) {
 		TxnManager: db,
 	}
 
-	err := tagger.PerformerGalleries(testCtx, &performer, nil, db.Gallery)
+	err := tagger.PerformerGalleries(testCtx, &performer, nil, db.Gallery, true)
 
 	assert := assert.New(t)
 

--- a/internal/autotag/scene.go
+++ b/internal/autotag/scene.go
@@ -35,7 +35,7 @@ func getSceneFileTagger(s *models.Scene, cache *match.Cache) tagger {
 }
 
 // ScenePerformers tags the provided scene with performers whose name matches the scene's path.
-func ScenePerformers(ctx context.Context, s *models.Scene, rw ScenePerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache) error {
+func ScenePerformers(ctx context.Context, s *models.Scene, rw ScenePerformerUpdater, performerReader models.PerformerAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getSceneFileTagger(s, cache)
 
 	return t.tagPerformers(ctx, performerReader, func(subjectID, otherID int) (bool, error) {
@@ -53,13 +53,13 @@ func ScenePerformers(ctx context.Context, s *models.Scene, rw ScenePerformerUpda
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }
 
 // SceneStudios tags the provided scene with the first studio whose name matches the scene's path.
 //
 // Scenes will not be tagged if studio is already set.
-func SceneStudios(ctx context.Context, s *models.Scene, rw SceneFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache) error {
+func SceneStudios(ctx context.Context, s *models.Scene, rw SceneFinderUpdater, studioReader models.StudioAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	if s.StudioID != nil {
 		// don't modify
 		return nil
@@ -69,11 +69,11 @@ func SceneStudios(ctx context.Context, s *models.Scene, rw SceneFinderUpdater, s
 
 	return t.tagStudios(ctx, studioReader, func(subjectID, otherID int) (bool, error) {
 		return addSceneStudio(ctx, rw, s, otherID)
-	})
+	}, matchAliases)
 }
 
 // SceneTags tags the provided scene with tags whose name matches the scene's path.
-func SceneTags(ctx context.Context, s *models.Scene, rw SceneTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache) error {
+func SceneTags(ctx context.Context, s *models.Scene, rw SceneTagUpdater, tagReader models.TagAutoTagQueryer, cache *match.Cache, matchAliases bool) error {
 	t := getSceneFileTagger(s, cache)
 
 	return t.tagTags(ctx, tagReader, func(subjectID, otherID int) (bool, error) {
@@ -91,5 +91,5 @@ func SceneTags(ctx context.Context, s *models.Scene, rw SceneTagUpdater, tagRead
 		}
 
 		return true, nil
-	})
+	}, matchAliases)
 }

--- a/internal/autotag/scene_test.go
+++ b/internal/autotag/scene_test.go
@@ -185,7 +185,7 @@ func TestScenePerformers(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
 
 		scene := models.Scene{
 			ID:           sceneID,
@@ -207,7 +207,42 @@ func TestScenePerformers(t *testing.T) {
 			db.Scene.On("UpdatePartial", testCtx, sceneID, matchPartial).Return(nil, nil).Once()
 		}
 
-		err := ScenePerformers(testCtx, &scene, db.Scene, db.Performer, nil)
+		err := ScenePerformers(testCtx, &scene, db.Scene, db.Performer, nil, true)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedStrings([]string{performerName})
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.ScenePartial) bool {
+				expected := models.ScenePartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return scenePartialsEqual(got, expected)
+			})
+			db.Scene.On("UpdatePartial", testCtx, sceneID, matchPartial).Return(nil, nil).Once()
+		}
+
+		scene := models.Scene{
+			ID:           sceneID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
+		err := ScenePerformers(testCtx, &scene, db.Scene, db.Performer, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -254,7 +289,7 @@ func TestSceneStudios(t *testing.T) {
 			ID:   sceneID,
 			Path: test.Path,
 		}
-		err := SceneStudios(testCtx, &scene, db.Scene, db.Studio, nil)
+		err := SceneStudios(testCtx, &scene, db.Scene, db.Studio, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -264,7 +299,7 @@ func TestSceneStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -278,7 +313,7 @@ func TestSceneStudios(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Studio.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
+		db.Studio.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Studio{&studio, &reversedStudio}, nil).Once()
 		db.Studio.On("GetAliases", testCtx, studioID).Return([]string{
 			studioName,
 		}, nil).Once()
@@ -330,7 +365,7 @@ func TestSceneTags(t *testing.T) {
 			Path:   test.Path,
 			TagIDs: models.NewRelatedIDs([]int{}),
 		}
-		err := SceneTags(testCtx, &scene, db.Scene, db.Tag, nil)
+		err := SceneTags(testCtx, &scene, db.Scene, db.Tag, nil, true)
 
 		assert.Nil(err)
 		db.AssertExpectations(t)
@@ -340,7 +375,7 @@ func TestSceneTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, mock.Anything).Return([]string{}, nil).Maybe()
 
 		doTest(db, test)
@@ -354,7 +389,7 @@ func TestSceneTags(t *testing.T) {
 		db := mocks.NewDatabase()
 
 		db.Tag.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
-		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
+		db.Tag.On("QueryForAutoTag", testCtx, mock.Anything, mock.Anything).Return([]*models.Tag{&tag, &reversedTag}, nil).Once()
 		db.Tag.On("GetAliases", testCtx, tagID).Return([]string{
 			tagName,
 		}, nil).Once()

--- a/internal/autotag/studio.go
+++ b/internal/autotag/studio.go
@@ -59,7 +59,7 @@ func addGalleryStudio(ctx context.Context, galleryWriter GalleryFinderUpdater, o
 	return true, nil
 }
 
-func getStudioTagger(p *models.Studio, aliases []string, cache *match.Cache) []tagger {
+func getStudioTagger(p *models.Studio, aliases []string, cache *match.Cache, matchAliases bool) []tagger {
 	ret := []tagger{{
 		ID:    p.ID,
 		Type:  "studio",
@@ -67,20 +67,22 @@ func getStudioTagger(p *models.Studio, aliases []string, cache *match.Cache) []t
 		cache: cache,
 	}}
 
-	for _, a := range aliases {
-		ret = append(ret, tagger{
-			ID:   p.ID,
-			Type: "studio",
-			Name: a,
-		})
+	if matchAliases {
+		for _, a := range aliases {
+			ret = append(ret, tagger{
+				ID:   p.ID,
+				Type: "studio",
+				Name: a,
+			})
+		}
 	}
 
 	return ret
 }
 
 // StudioScenes searches for scenes whose path matches the provided studio name and tags the scene with the studio, if studio is not already set on the scene.
-func (tagger *Tagger) StudioScenes(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw SceneFinderUpdater) error {
-	t := getStudioTagger(p, aliases, tagger.Cache)
+func (tagger *Tagger) StudioScenes(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw SceneFinderUpdater, matchAliases bool) error {
+	t := getStudioTagger(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagScenes(ctx, paths, rw, func(o *models.Scene) (bool, error) {
@@ -109,8 +111,8 @@ func (tagger *Tagger) StudioScenes(ctx context.Context, p *models.Studio, paths 
 }
 
 // StudioImages searches for images whose path matches the provided studio name and tags the image with the studio, if studio is not already set on the image.
-func (tagger *Tagger) StudioImages(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw ImageFinderUpdater) error {
-	t := getStudioTagger(p, aliases, tagger.Cache)
+func (tagger *Tagger) StudioImages(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw ImageFinderUpdater, matchAliases bool) error {
+	t := getStudioTagger(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagImages(ctx, paths, rw, func(i *models.Image) (bool, error) {
@@ -139,8 +141,8 @@ func (tagger *Tagger) StudioImages(ctx context.Context, p *models.Studio, paths 
 }
 
 // StudioGalleries searches for galleries whose path matches the provided studio name and tags the gallery with the studio, if studio is not already set on the gallery.
-func (tagger *Tagger) StudioGalleries(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw GalleryFinderUpdater) error {
-	t := getStudioTagger(p, aliases, tagger.Cache)
+func (tagger *Tagger) StudioGalleries(ctx context.Context, p *models.Studio, paths []string, aliases []string, rw GalleryFinderUpdater, matchAliases bool) error {
+	t := getStudioTagger(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagGalleries(ctx, paths, rw, func(o *models.Gallery) (bool, error) {

--- a/internal/autotag/studio_test.go
+++ b/internal/autotag/studio_test.go
@@ -166,7 +166,7 @@ func testStudioScenes(t *testing.T, tc testStudioCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.StudioScenes(testCtx, &studio, nil, aliases, db.Scene)
+	err := tagger.StudioScenes(testCtx, &studio, nil, aliases, db.Scene, true)
 
 	assert := assert.New(t)
 
@@ -269,7 +269,7 @@ func testStudioImages(t *testing.T, tc testStudioCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.StudioImages(testCtx, &studio, nil, aliases, db.Image)
+	err := tagger.StudioImages(testCtx, &studio, nil, aliases, db.Image, true)
 
 	assert := assert.New(t)
 
@@ -372,7 +372,7 @@ func testStudioGalleries(t *testing.T, tc testStudioCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.StudioGalleries(testCtx, &studio, nil, aliases, db.Gallery)
+	err := tagger.StudioGalleries(testCtx, &studio, nil, aliases, db.Gallery, true)
 
 	assert := assert.New(t)
 

--- a/internal/autotag/tag.go
+++ b/internal/autotag/tag.go
@@ -30,7 +30,7 @@ type GalleryQueryTagUpdater interface {
 	models.GalleryUpdater
 }
 
-func getTagTaggers(p *models.Tag, aliases []string, cache *match.Cache) []tagger {
+func getTagTaggers(p *models.Tag, aliases []string, cache *match.Cache, matchAliases bool) []tagger {
 	ret := []tagger{{
 		ID:    p.ID,
 		Type:  "tag",
@@ -38,21 +38,23 @@ func getTagTaggers(p *models.Tag, aliases []string, cache *match.Cache) []tagger
 		cache: cache,
 	}}
 
-	for _, a := range aliases {
-		ret = append(ret, tagger{
-			ID:    p.ID,
-			Type:  "tag",
-			Name:  a,
-			cache: cache,
-		})
+	if matchAliases {
+		for _, a := range aliases {
+			ret = append(ret, tagger{
+				ID:    p.ID,
+				Type:  "tag",
+				Name:  a,
+				cache: cache,
+			})
+		}
 	}
 
 	return ret
 }
 
 // TagScenes searches for scenes whose path matches the provided tag name and tags the scene with the tag.
-func (tagger *Tagger) TagScenes(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw SceneQueryTagUpdater) error {
-	t := getTagTaggers(p, aliases, tagger.Cache)
+func (tagger *Tagger) TagScenes(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw SceneQueryTagUpdater, matchAliases bool) error {
+	t := getTagTaggers(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagScenes(ctx, paths, rw, func(o *models.Scene) (bool, error) {
@@ -80,8 +82,8 @@ func (tagger *Tagger) TagScenes(ctx context.Context, p *models.Tag, paths []stri
 }
 
 // TagImages searches for images whose path matches the provided tag name and tags the image with the tag.
-func (tagger *Tagger) TagImages(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw ImageQueryTagUpdater) error {
-	t := getTagTaggers(p, aliases, tagger.Cache)
+func (tagger *Tagger) TagImages(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw ImageQueryTagUpdater, matchAliases bool) error {
+	t := getTagTaggers(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagImages(ctx, paths, rw, func(o *models.Image) (bool, error) {
@@ -109,8 +111,8 @@ func (tagger *Tagger) TagImages(ctx context.Context, p *models.Tag, paths []stri
 }
 
 // TagGalleries searches for galleries whose path matches the provided tag name and tags the gallery with the tag.
-func (tagger *Tagger) TagGalleries(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw GalleryQueryTagUpdater) error {
-	t := getTagTaggers(p, aliases, tagger.Cache)
+func (tagger *Tagger) TagGalleries(ctx context.Context, p *models.Tag, paths []string, aliases []string, rw GalleryQueryTagUpdater, matchAliases bool) error {
+	t := getTagTaggers(p, aliases, tagger.Cache, matchAliases)
 
 	for _, tt := range t {
 		if err := tt.tagGalleries(ctx, paths, rw, func(o *models.Gallery) (bool, error) {

--- a/internal/autotag/tag_test.go
+++ b/internal/autotag/tag_test.go
@@ -169,7 +169,7 @@ func testTagScenes(t *testing.T, tc testTagCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.TagScenes(testCtx, &tag, nil, aliases, db.Scene)
+	err := tagger.TagScenes(testCtx, &tag, nil, aliases, db.Scene, true)
 
 	assert := assert.New(t)
 
@@ -276,7 +276,7 @@ func testTagImages(t *testing.T, tc testTagCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.TagImages(testCtx, &tag, nil, aliases, db.Image)
+	err := tagger.TagImages(testCtx, &tag, nil, aliases, db.Image, true)
 
 	assert := assert.New(t)
 
@@ -384,7 +384,7 @@ func testTagGalleries(t *testing.T, tc testTagCase) {
 		TxnManager: db,
 	}
 
-	err := tagger.TagGalleries(testCtx, &tag, nil, aliases, db.Gallery)
+	err := tagger.TagGalleries(testCtx, &tag, nil, aliases, db.Gallery, true)
 
 	assert := assert.New(t)
 

--- a/internal/autotag/tagger.go
+++ b/internal/autotag/tagger.go
@@ -51,8 +51,8 @@ func (t *tagger) addLog(otherType, otherName string) {
 	logger.Infof("Added %s '%s' to %s '%s'", otherType, otherName, t.Type, t.Name)
 }
 
-func (t *tagger) tagPerformers(ctx context.Context, performerReader models.PerformerAutoTagQueryer, addFunc addLinkFunc) error {
-	others, err := match.PathToPerformers(ctx, t.Path, performerReader, t.cache, t.trimExt)
+func (t *tagger) tagPerformers(ctx context.Context, performerReader models.PerformerAutoTagQueryer, addFunc addLinkFunc, matchAliases bool) error {
+	others, err := match.PathToPerformers(ctx, t.Path, performerReader, t.cache, t.trimExt, matchAliases)
 	if err != nil {
 		return err
 	}
@@ -72,8 +72,8 @@ func (t *tagger) tagPerformers(ctx context.Context, performerReader models.Perfo
 	return nil
 }
 
-func (t *tagger) tagStudios(ctx context.Context, studioReader models.StudioAutoTagQueryer, addFunc addLinkFunc) error {
-	studio, err := match.PathToStudio(ctx, t.Path, studioReader, t.cache, t.trimExt)
+func (t *tagger) tagStudios(ctx context.Context, studioReader models.StudioAutoTagQueryer, addFunc addLinkFunc, matchAliases bool) error {
+	studio, err := match.PathToStudio(ctx, t.Path, studioReader, t.cache, t.trimExt, matchAliases)
 	if err != nil {
 		return err
 	}
@@ -93,8 +93,8 @@ func (t *tagger) tagStudios(ctx context.Context, studioReader models.StudioAutoT
 	return nil
 }
 
-func (t *tagger) tagTags(ctx context.Context, tagReader models.TagAutoTagQueryer, addFunc addLinkFunc) error {
-	others, err := match.PathToTags(ctx, t.Path, tagReader, t.cache, t.trimExt)
+func (t *tagger) tagTags(ctx context.Context, tagReader models.TagAutoTagQueryer, addFunc addLinkFunc, matchAliases bool) error {
+	others, err := match.PathToTags(ctx, t.Path, tagReader, t.cache, t.trimExt, matchAliases)
 	if err != nil {
 		return err
 	}

--- a/internal/manager/config/tasks.go
+++ b/internal/manager/config/tasks.go
@@ -28,4 +28,10 @@ type AutoTagMetadataOptions struct {
 	Studios []string `json:"studios"`
 	// IDs of tags to tag files with, or "*" for all
 	Tags []string `json:"tags"`
+	// If true, will also match performer aliases
+	PerformerAliases bool `json:"performerAliases"`
+	// If true, will also match studio aliases
+	StudioAliases bool `json:"studioAliases"`
+	// If true, will also match tag aliases
+	TagAliases bool `json:"tagAliases"`
 }

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -299,9 +299,28 @@ type AutoTagMetadataInput struct {
 	Studios []string `json:"studios"`
 	// IDs of tags to tag files with, or "*" for all
 	Tags []string `json:"tags"`
+	// If true, will also match performer aliases
+	PerformerAliases *bool `json:"performerAliases"`
+	// If true, will also match studio aliases
+	StudioAliases *bool `json:"studioAliases"`
+	// If true, will also match tag aliases
+	TagAliases *bool `json:"tagAliases"`
 }
 
 func (s *Manager) AutoTag(ctx context.Context, input AutoTagMetadataInput) int {
+	defaults := s.Config.GetDefaultAutoTagSettings()
+	if defaults != nil {
+		if input.PerformerAliases == nil {
+			input.PerformerAliases = &defaults.PerformerAliases
+		}
+		if input.StudioAliases == nil {
+			input.StudioAliases = &defaults.StudioAliases
+		}
+		if input.TagAliases == nil {
+			input.TagAliases = &defaults.TagAliases
+		}
+	}
+
 	j := autoTagJob{
 		repository: s.Repository,
 		input:      input,

--- a/internal/manager/task_autotag.go
+++ b/internal/manager/task_autotag.go
@@ -180,13 +180,13 @@ func (j *autoTagJob) autoTagPerformers(ctx context.Context, progress *job.Progre
 				}
 
 				err := func() error {
-					if err := tagger.PerformerScenes(ctx, performer, paths, r.Scene); err != nil {
+					if err := tagger.PerformerScenes(ctx, performer, paths, r.Scene, j.input.PerformerAliases != nil && *j.input.PerformerAliases); err != nil {
 						return fmt.Errorf("processing scenes: %w", err)
 					}
-					if err := tagger.PerformerImages(ctx, performer, paths, r.Image); err != nil {
+					if err := tagger.PerformerImages(ctx, performer, paths, r.Image, j.input.PerformerAliases != nil && *j.input.PerformerAliases); err != nil {
 						return fmt.Errorf("processing images: %w", err)
 					}
-					if err := tagger.PerformerGalleries(ctx, performer, paths, r.Gallery); err != nil {
+					if err := tagger.PerformerGalleries(ctx, performer, paths, r.Gallery, j.input.PerformerAliases != nil && *j.input.PerformerAliases); err != nil {
 						return fmt.Errorf("processing galleries: %w", err)
 					}
 
@@ -278,13 +278,13 @@ func (j *autoTagJob) autoTagStudios(ctx context.Context, progress *job.Progress,
 						return fmt.Errorf("getting studio aliases: %w", err)
 					}
 
-					if err := tagger.StudioScenes(ctx, studio, paths, aliases, r.Scene); err != nil {
+					if err := tagger.StudioScenes(ctx, studio, paths, aliases, r.Scene, j.input.StudioAliases != nil && *j.input.StudioAliases); err != nil {
 						return fmt.Errorf("processing scenes: %w", err)
 					}
-					if err := tagger.StudioImages(ctx, studio, paths, aliases, r.Image); err != nil {
+					if err := tagger.StudioImages(ctx, studio, paths, aliases, r.Image, j.input.StudioAliases != nil && *j.input.StudioAliases); err != nil {
 						return fmt.Errorf("processing images: %w", err)
 					}
-					if err := tagger.StudioGalleries(ctx, studio, paths, aliases, r.Gallery); err != nil {
+					if err := tagger.StudioGalleries(ctx, studio, paths, aliases, r.Gallery, j.input.StudioAliases != nil && *j.input.StudioAliases); err != nil {
 						return fmt.Errorf("processing galleries: %w", err)
 					}
 
@@ -375,13 +375,13 @@ func (j *autoTagJob) autoTagTags(ctx context.Context, progress *job.Progress, pa
 						return fmt.Errorf("getting tag aliases: %w", err)
 					}
 
-					if err := tagger.TagScenes(ctx, tag, paths, aliases, r.Scene); err != nil {
+					if err := tagger.TagScenes(ctx, tag, paths, aliases, r.Scene, j.input.TagAliases != nil && *j.input.TagAliases); err != nil {
 						return fmt.Errorf("processing scenes: %w", err)
 					}
-					if err := tagger.TagImages(ctx, tag, paths, aliases, r.Image); err != nil {
+					if err := tagger.TagImages(ctx, tag, paths, aliases, r.Image, j.input.TagAliases != nil && *j.input.TagAliases); err != nil {
 						return fmt.Errorf("processing images: %w", err)
 					}
-					if err := tagger.TagGalleries(ctx, tag, paths, aliases, r.Gallery); err != nil {
+					if err := tagger.TagGalleries(ctx, tag, paths, aliases, r.Gallery, j.input.TagAliases != nil && *j.input.TagAliases); err != nil {
 						return fmt.Errorf("processing galleries: %w", err)
 					}
 
@@ -412,10 +412,13 @@ func (j *autoTagJob) autoTagTags(ctx context.Context, progress *job.Progress, pa
 }
 
 type autoTagFilesTask struct {
-	paths      []string
-	performers bool
-	studios    bool
-	tags       bool
+	paths            []string
+	performers       bool
+	studios          bool
+	tags             bool
+	performerAliases bool
+	studioAliases    bool
+	tagAliases       bool
 
 	progress   *job.Progress
 	repository models.Repository
@@ -575,12 +578,15 @@ func (t *autoTagFilesTask) processScenes(ctx context.Context) {
 			}
 
 			tt := autoTagSceneTask{
-				repository: r,
-				scene:      ss,
-				performers: t.performers,
-				studios:    t.studios,
-				tags:       t.tags,
-				cache:      t.cache,
+				repository:       r,
+				scene:            ss,
+				performers:       t.performers,
+				studios:          t.studios,
+				tags:             t.tags,
+				performerAliases: t.performerAliases,
+				studioAliases:    t.studioAliases,
+				tagAliases:       t.tagAliases,
+				cache:            t.cache,
 			}
 
 			var wg sync.WaitGroup
@@ -638,12 +644,15 @@ func (t *autoTagFilesTask) processImages(ctx context.Context) {
 			}
 
 			tt := autoTagImageTask{
-				repository: t.repository,
-				image:      ss,
-				performers: t.performers,
-				studios:    t.studios,
-				tags:       t.tags,
-				cache:      t.cache,
+				repository:       t.repository,
+				image:            ss,
+				performers:       t.performers,
+				studios:          t.studios,
+				tags:             t.tags,
+				performerAliases: t.performerAliases,
+				studioAliases:    t.studioAliases,
+				tagAliases:       t.tagAliases,
+				cache:            t.cache,
 			}
 
 			var wg sync.WaitGroup
@@ -701,12 +710,15 @@ func (t *autoTagFilesTask) processGalleries(ctx context.Context) {
 			}
 
 			tt := autoTagGalleryTask{
-				repository: t.repository,
-				gallery:    ss,
-				performers: t.performers,
-				studios:    t.studios,
-				tags:       t.tags,
-				cache:      t.cache,
+				repository:       t.repository,
+				gallery:          ss,
+				performers:       t.performers,
+				studios:          t.studios,
+				tags:             t.tags,
+				performerAliases: t.performerAliases,
+				studioAliases:    t.studioAliases,
+				tagAliases:       t.tagAliases,
+				cache:            t.cache,
 			}
 
 			var wg sync.WaitGroup
@@ -756,9 +768,12 @@ type autoTagSceneTask struct {
 	repository models.Repository
 	scene      *models.Scene
 
-	performers bool
-	studios    bool
-	tags       bool
+	performers       bool
+	studios          bool
+	tags             bool
+	performerAliases bool
+	studioAliases    bool
+	tagAliases       bool
 
 	cache *match.Cache
 }
@@ -773,17 +788,17 @@ func (t *autoTagSceneTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 		}
 
 		if t.performers {
-			if err := autotag.ScenePerformers(ctx, t.scene, r.Scene, r.Performer, t.cache); err != nil {
+			if err := autotag.ScenePerformers(ctx, t.scene, r.Scene, r.Performer, t.cache, t.performers); err != nil {
 				return fmt.Errorf("tagging scene performers for %s: %v", t.scene.DisplayName(), err)
 			}
 		}
 		if t.studios {
-			if err := autotag.SceneStudios(ctx, t.scene, r.Scene, r.Studio, t.cache); err != nil {
+			if err := autotag.SceneStudios(ctx, t.scene, r.Scene, r.Studio, t.cache, t.studios); err != nil {
 				return fmt.Errorf("tagging scene studio for %s: %v", t.scene.DisplayName(), err)
 			}
 		}
 		if t.tags {
-			if err := autotag.SceneTags(ctx, t.scene, r.Scene, r.Tag, t.cache); err != nil {
+			if err := autotag.SceneTags(ctx, t.scene, r.Scene, r.Tag, t.cache, t.tags); err != nil {
 				return fmt.Errorf("tagging scene tags for %s: %v", t.scene.DisplayName(), err)
 			}
 		}
@@ -800,9 +815,12 @@ type autoTagImageTask struct {
 	repository models.Repository
 	image      *models.Image
 
-	performers bool
-	studios    bool
-	tags       bool
+	performers       bool
+	studios          bool
+	tags             bool
+	performerAliases bool
+	studioAliases    bool
+	tagAliases       bool
 
 	cache *match.Cache
 }
@@ -812,17 +830,17 @@ func (t *autoTagImageTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	r := t.repository
 	if err := r.WithTxn(ctx, func(ctx context.Context) error {
 		if t.performers {
-			if err := autotag.ImagePerformers(ctx, t.image, r.Image, r.Performer, t.cache); err != nil {
+			if err := autotag.ImagePerformers(ctx, t.image, r.Image, r.Performer, t.cache, t.performers); err != nil {
 				return fmt.Errorf("tagging image performers for %s: %v", t.image.DisplayName(), err)
 			}
 		}
 		if t.studios {
-			if err := autotag.ImageStudios(ctx, t.image, r.Image, r.Studio, t.cache); err != nil {
+			if err := autotag.ImageStudios(ctx, t.image, r.Image, r.Studio, t.cache, t.studios); err != nil {
 				return fmt.Errorf("tagging image studio for %s: %v", t.image.DisplayName(), err)
 			}
 		}
 		if t.tags {
-			if err := autotag.ImageTags(ctx, t.image, r.Image, r.Tag, t.cache); err != nil {
+			if err := autotag.ImageTags(ctx, t.image, r.Image, r.Tag, t.cache, t.tags); err != nil {
 				return fmt.Errorf("tagging image tags for %s: %v", t.image.DisplayName(), err)
 			}
 		}
@@ -839,9 +857,12 @@ type autoTagGalleryTask struct {
 	repository models.Repository
 	gallery    *models.Gallery
 
-	performers bool
-	studios    bool
-	tags       bool
+	performers       bool
+	studios          bool
+	tags             bool
+	performerAliases bool
+	studioAliases    bool
+	tagAliases       bool
 
 	cache *match.Cache
 }
@@ -851,17 +872,17 @@ func (t *autoTagGalleryTask) Start(ctx context.Context, wg *sync.WaitGroup) {
 	r := t.repository
 	if err := r.WithTxn(ctx, func(ctx context.Context) error {
 		if t.performers {
-			if err := autotag.GalleryPerformers(ctx, t.gallery, r.Gallery, r.Performer, t.cache); err != nil {
+			if err := autotag.GalleryPerformers(ctx, t.gallery, r.Gallery, r.Performer, t.cache, t.performers); err != nil {
 				return fmt.Errorf("tagging gallery performers for %s: %v", t.gallery.DisplayName(), err)
 			}
 		}
 		if t.studios {
-			if err := autotag.GalleryStudios(ctx, t.gallery, r.Gallery, r.Studio, t.cache); err != nil {
+			if err := autotag.GalleryStudios(ctx, t.gallery, r.Gallery, r.Studio, t.cache, t.studios); err != nil {
 				return fmt.Errorf("tagging gallery studio for %s: %v", t.gallery.DisplayName(), err)
 			}
 		}
 		if t.tags {
-			if err := autotag.GalleryTags(ctx, t.gallery, r.Gallery, r.Tag, t.cache); err != nil {
+			if err := autotag.GalleryTags(ctx, t.gallery, r.Gallery, r.Tag, t.cache, t.tags); err != nil {
 				return fmt.Errorf("tagging gallery tags for %s: %v", t.gallery.DisplayName(), err)
 			}
 		}

--- a/pkg/match/path.go
+++ b/pkg/match/path.go
@@ -127,8 +127,8 @@ func regexpMatchesPath(r *regexp.Regexp, path string) int {
 	return found[len(found)-1][0]
 }
 
-func getPerformers(ctx context.Context, words []string, performerReader models.PerformerAutoTagQueryer, cache *Cache) ([]*models.Performer, error) {
-	performers, err := performerReader.QueryForAutoTag(ctx, words)
+func getPerformers(ctx context.Context, words []string, performerReader models.PerformerAutoTagQueryer, cache *Cache, matchAliases bool) ([]*models.Performer, error) {
+	performers, err := performerReader.QueryForAutoTag(ctx, words, matchAliases)
 	if err != nil {
 		return nil, err
 	}
@@ -141,10 +141,10 @@ func getPerformers(ctx context.Context, words []string, performerReader models.P
 	return append(performers, swPerformers...), nil
 }
 
-func PathToPerformers(ctx context.Context, path string, reader models.PerformerAutoTagQueryer, cache *Cache, trimExt bool) ([]*models.Performer, error) {
+func PathToPerformers(ctx context.Context, path string, reader models.PerformerAutoTagQueryer, cache *Cache, trimExt bool, matchAliases bool) ([]*models.Performer, error) {
 	words := getPathWords(path, trimExt)
 
-	performers, err := getPerformers(ctx, words, reader, cache)
+	performers, err := getPerformers(ctx, words, reader, cache, matchAliases)
 	if err != nil {
 		return nil, err
 	}
@@ -156,20 +156,18 @@ func PathToPerformers(ctx context.Context, path string, reader models.PerformerA
 			matches = true
 		}
 
-		// TODO - disabled alias matching until we can get finer
-		// control over the matching
-		// if !matches {
-		// 	if err := p.LoadAliases(ctx, reader); err != nil {
-		// 		return nil, err
-		// 	}
+		if !matches && matchAliases {
+			if err := p.LoadAliases(ctx, reader); err != nil {
+				return nil, err
+			}
 
-		// 	for _, alias := range p.Aliases.List() {
-		// 		if nameMatchesPath(alias, path) != -1 {
-		// 			matches = true
-		// 			break
-		// 		}
-		// 	}
-		// }
+			for _, alias := range p.Aliases.List() {
+				if nameMatchesPath(alias, path) != -1 {
+					matches = true
+					break
+				}
+			}
+		}
 
 		if matches {
 			ret = append(ret, p)
@@ -179,8 +177,8 @@ func PathToPerformers(ctx context.Context, path string, reader models.PerformerA
 	return ret, nil
 }
 
-func getStudios(ctx context.Context, words []string, reader models.StudioAutoTagQueryer, cache *Cache) ([]*models.Studio, error) {
-	studios, err := reader.QueryForAutoTag(ctx, words)
+func getStudios(ctx context.Context, words []string, reader models.StudioAutoTagQueryer, cache *Cache, matchAliases bool) ([]*models.Studio, error) {
+	studios, err := reader.QueryForAutoTag(ctx, words, matchAliases)
 	if err != nil {
 		return nil, err
 	}
@@ -196,9 +194,9 @@ func getStudios(ctx context.Context, words []string, reader models.StudioAutoTag
 // PathToStudio returns the Studio that matches the given path.
 // Where multiple matching studios are found, the one that matches the latest
 // position in the path is returned.
-func PathToStudio(ctx context.Context, path string, reader models.StudioAutoTagQueryer, cache *Cache, trimExt bool) (*models.Studio, error) {
+func PathToStudio(ctx context.Context, path string, reader models.StudioAutoTagQueryer, cache *Cache, trimExt bool, matchAliases bool) (*models.Studio, error) {
 	words := getPathWords(path, trimExt)
-	candidates, err := getStudios(ctx, words, reader, cache)
+	candidates, err := getStudios(ctx, words, reader, cache, matchAliases)
 
 	if err != nil {
 		return nil, err
@@ -213,16 +211,18 @@ func PathToStudio(ctx context.Context, path string, reader models.StudioAutoTagQ
 			index = matchIndex
 		}
 
-		aliases, err := reader.GetAliases(ctx, c.ID)
-		if err != nil {
-			return nil, err
-		}
+		if matchAliases {
+			aliases, err := reader.GetAliases(ctx, c.ID)
+			if err != nil {
+				return nil, err
+			}
 
-		for _, alias := range aliases {
-			matchIndex = nameMatchesPath(alias, path)
-			if matchIndex != -1 && matchIndex > index {
-				ret = c
-				index = matchIndex
+			for _, alias := range aliases {
+				matchIndex = nameMatchesPath(alias, path)
+				if matchIndex != -1 && matchIndex > index {
+					ret = c
+					index = matchIndex
+				}
 			}
 		}
 	}
@@ -230,8 +230,8 @@ func PathToStudio(ctx context.Context, path string, reader models.StudioAutoTagQ
 	return ret, nil
 }
 
-func getTags(ctx context.Context, words []string, reader models.TagAutoTagQueryer, cache *Cache) ([]*models.Tag, error) {
-	tags, err := reader.QueryForAutoTag(ctx, words)
+func getTags(ctx context.Context, words []string, reader models.TagAutoTagQueryer, cache *Cache, matchAliases bool) ([]*models.Tag, error) {
+	tags, err := reader.QueryForAutoTag(ctx, words, matchAliases)
 	if err != nil {
 		return nil, err
 	}
@@ -244,9 +244,9 @@ func getTags(ctx context.Context, words []string, reader models.TagAutoTagQuerye
 	return append(tags, swTags...), nil
 }
 
-func PathToTags(ctx context.Context, path string, reader models.TagAutoTagQueryer, cache *Cache, trimExt bool) ([]*models.Tag, error) {
+func PathToTags(ctx context.Context, path string, reader models.TagAutoTagQueryer, cache *Cache, trimExt bool, matchAliases bool) ([]*models.Tag, error) {
 	words := getPathWords(path, trimExt)
-	tags, err := getTags(ctx, words, reader, cache)
+	tags, err := getTags(ctx, words, reader, cache, matchAliases)
 
 	if err != nil {
 		return nil, err
@@ -259,7 +259,7 @@ func PathToTags(ctx context.Context, path string, reader models.TagAutoTagQuerye
 			matches = true
 		}
 
-		if !matches {
+		if !matches && matchAliases {
 			aliases, err := reader.GetAliases(ctx, t.ID)
 			if err != nil {
 				return nil, err

--- a/pkg/models/mocks/PerformerReaderWriter.go
+++ b/pkg/models/mocks/PerformerReaderWriter.go
@@ -539,8 +539,8 @@ func (_m *PerformerReaderWriter) QueryCount(ctx context.Context, performerFilter
 }
 
 // QueryForAutoTag provides a mock function with given fields: ctx, words
-func (_m *PerformerReaderWriter) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Performer, error) {
-	ret := _m.Called(ctx, words)
+func (_m *PerformerReaderWriter) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Performer, error) {
+	ret := _m.Called(ctx, words, matchAliases)
 
 	var r0 []*models.Performer
 	if rf, ok := ret.Get(0).(func(context.Context, []string) []*models.Performer); ok {

--- a/pkg/models/mocks/StudioReaderWriter.go
+++ b/pkg/models/mocks/StudioReaderWriter.go
@@ -502,8 +502,8 @@ func (_m *StudioReaderWriter) QueryCount(ctx context.Context, studioFilter *mode
 }
 
 // QueryForAutoTag provides a mock function with given fields: ctx, words
-func (_m *StudioReaderWriter) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Studio, error) {
-	ret := _m.Called(ctx, words)
+func (_m *StudioReaderWriter) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Studio, error) {
+	ret := _m.Called(ctx, words, matchAliases)
 
 	var r0 []*models.Studio
 	if rf, ok := ret.Get(0).(func(context.Context, []string) []*models.Studio); ok {

--- a/pkg/models/mocks/TagReaderWriter.go
+++ b/pkg/models/mocks/TagReaderWriter.go
@@ -746,8 +746,8 @@ func (_m *TagReaderWriter) Query(ctx context.Context, tagFilter *models.TagFilte
 }
 
 // QueryForAutoTag provides a mock function with given fields: ctx, words
-func (_m *TagReaderWriter) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Tag, error) {
-	ret := _m.Called(ctx, words)
+func (_m *TagReaderWriter) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Tag, error) {
+	ret := _m.Called(ctx, words, matchAliases)
 
 	var r0 []*models.Tag
 	if rf, ok := ret.Get(0).(func(context.Context, []string) []*models.Tag); ok {

--- a/pkg/models/repository_performer.go
+++ b/pkg/models/repository_performer.go
@@ -32,7 +32,7 @@ type PerformerAutoTagQueryer interface {
 
 	// TODO - this interface is temporary until the filter schema can fully
 	// support the query needed
-	QueryForAutoTag(ctx context.Context, words []string) ([]*Performer, error)
+	QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*Performer, error)
 }
 
 // PerformerCounter provides methods to count performers.

--- a/pkg/models/repository_studio.go
+++ b/pkg/models/repository_studio.go
@@ -31,7 +31,7 @@ type StudioAutoTagQueryer interface {
 
 	// TODO - this interface is temporary until the filter schema can fully
 	// support the query needed
-	QueryForAutoTag(ctx context.Context, words []string) ([]*Studio, error)
+	QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*Studio, error)
 }
 
 // StudioCounter provides methods to count studios.

--- a/pkg/models/repository_tag.go
+++ b/pkg/models/repository_tag.go
@@ -40,7 +40,7 @@ type TagAutoTagQueryer interface {
 
 	// TODO - this interface is temporary until the filter schema can fully
 	// support the query needed
-	QueryForAutoTag(ctx context.Context, words []string) ([]*Tag, error)
+	QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*Tag, error)
 }
 
 // TagCounter provides methods to count tags.

--- a/pkg/scraper/autotag.go
+++ b/pkg/scraper/autotag.go
@@ -27,7 +27,7 @@ type autotagScraper struct {
 }
 
 func autotagMatchPerformers(ctx context.Context, path string, performerReader models.PerformerAutoTagQueryer, trimExt bool) ([]*models.ScrapedPerformer, error) {
-	p, err := match.PathToPerformers(ctx, path, performerReader, nil, trimExt)
+	p, err := match.PathToPerformers(ctx, path, performerReader, nil, trimExt, false)
 	if err != nil {
 		return nil, fmt.Errorf("error matching performers: %w", err)
 	}
@@ -52,7 +52,7 @@ func autotagMatchPerformers(ctx context.Context, path string, performerReader mo
 }
 
 func autotagMatchStudio(ctx context.Context, path string, studioReader models.StudioAutoTagQueryer, trimExt bool) (*models.ScrapedStudio, error) {
-	studio, err := match.PathToStudio(ctx, path, studioReader, nil, trimExt)
+	studio, err := match.PathToStudio(ctx, path, studioReader, nil, trimExt, false)
 	if err != nil {
 		return nil, fmt.Errorf("error matching studios: %w", err)
 	}
@@ -69,7 +69,7 @@ func autotagMatchStudio(ctx context.Context, path string, studioReader models.St
 }
 
 func autotagMatchTags(ctx context.Context, path string, tagReader models.TagAutoTagQueryer, trimExt bool) ([]*models.ScrapedTag, error) {
-	t, err := match.PathToTags(ctx, path, tagReader, nil, trimExt)
+	t, err := match.PathToTags(ctx, path, tagReader, nil, trimExt, false)
 	if err != nil {
 		return nil, fmt.Errorf("error matching tags: %w", err)
 	}

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -837,7 +837,7 @@ func (qb *ImageStore) makeQuery(ctx context.Context, imageFilter *models.ImageFi
 		)
 
 		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
-		searchColumns := []string{"images.title", filepathColumn, "files_fingerprints.fingerprint"}
+		searchColumns := []string{"images.title", "images.details", filepathColumn, "files_fingerprints.fingerprint"}
 		query.parseQueryString(searchColumns, *q)
 	}
 

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -1596,6 +1596,20 @@ func TestImageQueryQ(t *testing.T) {
 	})
 }
 
+func TestImageQueryQ_Details(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		const imageIdx = 3
+
+		q := getImageStringValue(imageIdx, "Details")
+
+		sqb := db.Image
+
+		imageQueryQ(ctx, t, sqb, q, imageIdx)
+
+		return nil
+	})
+}
+
 func queryImagesWithCount(ctx context.Context, sqb models.ImageReader, imageFilter *models.ImageFilterType, findFilter *models.FindFilterType) ([]*models.Image, int, error) {
 	result, err := sqb.Query(ctx, models.ImageQueryOptions{
 		QueryOptions: models.QueryOptions{

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -580,23 +580,26 @@ func (qb *PerformerStore) All(ctx context.Context) ([]*models.Performer, error) 
 	return qb.getMany(ctx, qb.selectDataset().Order(table.Col("name").Asc()))
 }
 
-func (qb *PerformerStore) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Performer, error) {
+func (qb *PerformerStore) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Performer, error) {
 	// TODO - Query needs to be changed to support queries of this type, and
 	// this method should be removed
 	table := qb.table()
 	sq := dialect.From(table).Select(table.Col(idColumn))
-	// TODO - disabled alias matching until we get finer control over it
-	// .LeftJoin(
-	// 	performersAliasesJoinTable,
-	// 	goqu.On(performersAliasesJoinTable.Col(performerIDColumn).Eq(table.Col(idColumn))),
-	// )
+
+	if matchAliases {
+		sq = sq.LeftJoin(
+			performersAliasesJoinTable,
+			goqu.On(performersAliasesJoinTable.Col(performerIDColumn).Eq(table.Col(idColumn))),
+		)
+	}
 
 	var whereClauses []exp.Expression
 
 	for _, w := range words {
 		whereClauses = append(whereClauses, table.Col("name").Like(w+"%"))
-		// TODO - see above
-		// whereClauses = append(whereClauses, performersAliasesJoinTable.Col("alias").Like(w+"%"))
+		if matchAliases {
+			whereClauses = append(whereClauses, performersAliasesJoinTable.Col("alias").Like(w+"%"))
+		}
 	}
 
 	sq = sq.Where(

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -1683,7 +1683,7 @@ func TestPerformerQueryForAutoTag(t *testing.T) {
 
 		name := performerNames[performerIdx1WithScene] // find a performer by name
 
-		performers, err := tqb.QueryForAutoTag(ctx, []string{name})
+		performers, err := tqb.QueryForAutoTag(ctx, []string{name}, true)
 
 		if err != nil {
 			t.Errorf("Error finding performers: %s", err.Error())

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1294,6 +1294,7 @@ func makeImageFile(i int) *models.ImageFile {
 
 func makeImage(i int) *models.Image {
 	title := getImageStringValue(i, titleField)
+	details := getImageStringValue(i, "Details")
 	var studioID *int
 	if _, ok := imageStudios[i]; ok {
 		v := studioIDs[imageStudios[i]]
@@ -1306,6 +1307,7 @@ func makeImage(i int) *models.Image {
 
 	return &models.Image{
 		Title:  title,
+		Details: details,
 		Rating: getIntPtr(getRating(i)),
 		Date:   getObjectDate(i),
 		URLs: models.NewRelatedStrings([]string{

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -526,20 +526,26 @@ func (qb *StudioStore) All(ctx context.Context) ([]*models.Studio, error) {
 	return qb.getMany(ctx, qb.selectDataset().Order(table.Col(studioNameColumn).Asc()))
 }
 
-func (qb *StudioStore) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Studio, error) {
+func (qb *StudioStore) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Studio, error) {
 	// TODO - Query needs to be changed to support queries of this type, and
 	// this method should be removed
 	table := qb.table()
-	sq := dialect.From(table).Select(table.Col(idColumn)).LeftJoin(
-		studiosAliasesJoinTable,
-		goqu.On(studiosAliasesJoinTable.Col(studioIDColumn).Eq(table.Col(idColumn))),
-	)
+	sq := dialect.From(table).Select(table.Col(idColumn))
+
+	if matchAliases {
+		sq = sq.LeftJoin(
+			studiosAliasesJoinTable,
+			goqu.On(studiosAliasesJoinTable.Col(studioIDColumn).Eq(table.Col(idColumn))),
+		)
+	}
 
 	var whereClauses []exp.Expression
 
 	for _, w := range words {
 		whereClauses = append(whereClauses, table.Col(studioNameColumn).Like(w+"%"))
-		whereClauses = append(whereClauses, studiosAliasesJoinTable.Col("alias").Like(w+"%"))
+		if matchAliases {
+			whereClauses = append(whereClauses, studiosAliasesJoinTable.Col("alias").Like(w+"%"))
+		}
 	}
 
 	sq = sq.Where(

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -790,7 +790,7 @@ func TestStudioQueryForAutoTag(t *testing.T) {
 
 		name := studioNames[studioIdxWithGroup] // find a studio by name
 
-		studios, err := tqb.QueryForAutoTag(ctx, []string{name})
+		studios, err := tqb.QueryForAutoTag(ctx, []string{name}, true)
 
 		if err != nil {
 			t.Errorf("Error finding studios: %s", err.Error())
@@ -800,7 +800,7 @@ func TestStudioQueryForAutoTag(t *testing.T) {
 		assert.Equal(t, strings.ToLower(studioNames[studioIdxWithGroup]), strings.ToLower(studios[0].Name))
 
 		name = getStudioStringValue(studioIdxWithGroup, "Alias")
-		studios, err = tqb.QueryForAutoTag(ctx, []string{name})
+		studios, err = tqb.QueryForAutoTag(ctx, []string{name}, true)
 
 		if err != nil {
 			t.Errorf("Error finding studios: %s", err.Error())

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -685,7 +685,7 @@ func (qb *TagStore) All(ctx context.Context) ([]*models.Tag, error) {
 	))
 }
 
-func (qb *TagStore) QueryForAutoTag(ctx context.Context, words []string) ([]*models.Tag, error) {
+func (qb *TagStore) QueryForAutoTag(ctx context.Context, words []string, matchAliases bool) ([]*models.Tag, error) {
 	// TODO - Query needs to be changed to support queries of this type, and
 	// this method should be removed
 	query := selectAll(tagTable)

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -126,7 +126,7 @@ func TestTagQueryForAutoTag(t *testing.T) {
 
 		name := tagNames[tagIdx1WithScene] // find a tag by name
 
-		tags, err := tqb.QueryForAutoTag(ctx, []string{name})
+		tags, err := tqb.QueryForAutoTag(ctx, []string{name}, true)
 
 		if err != nil {
 			t.Errorf("Error finding tags: %s", err.Error())
@@ -139,7 +139,7 @@ func TestTagQueryForAutoTag(t *testing.T) {
 
 		// find by alias
 		name = getTagStringValue(tagIdx1WithScene, "Alias")
-		tags, err = tqb.QueryForAutoTag(ctx, []string{name})
+		tags, err = tqb.QueryForAutoTag(ctx, []string{name}, true)
 
 		if err != nil {
 			t.Errorf("Error finding tags: %s", err.Error())

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -191,6 +191,9 @@ fragment ConfigDefaultSettingsData on ConfigDefaultSettingsResult {
     performers
     studios
     tags
+    performerAliases
+    studioAliases
+    tagAliases
   }
 
   generate {

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -53,16 +53,34 @@ const AutoTagOptions: React.FC<IAutoTagOptions> = ({
         onChange={(v) => setOptions({ performers: set(v) })}
       />
       <BooleanSetting
+        id="autotag-performer-aliases"
+        checked={options.performerAliases ?? false}
+        headingID="config.tasks.autotag_performer_aliases"
+        onChange={(v) => setOptions({ performerAliases: v })}
+      />
+      <BooleanSetting
         id="autotag-studios"
         checked={!!studios?.length}
         headingID="studios"
         onChange={(v) => setOptions({ studios: set(v) })}
       />
       <BooleanSetting
+        id="autotag-studio-aliases"
+        checked={options.studioAliases ?? false}
+        headingID="config.tasks.autotag_studio_aliases"
+        onChange={(v) => setOptions({ studioAliases: v })}
+      />
+      <BooleanSetting
         id="autotag-tags"
         checked={!!tags?.length}
         headingID="tags"
         onChange={(v) => setOptions({ tags: set(v) })}
+      />
+      <BooleanSetting
+        id="autotag-tag-aliases"
+        checked={options.tagAliases ?? false}
+        headingID="config.tasks.autotag_tag_aliases"
+        onChange={(v) => setOptions({ tagAliases: v })}
       />
     </>
   );

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -511,6 +511,9 @@
         "auto_tagging_paths": "Auto tagging the following paths"
       },
       "auto_tag_based_on_filenames": "Auto tag content based on file paths.",
+      "autotag_performer_aliases": "Include performer aliases",
+      "autotag_studio_aliases": "Include studio aliases",
+      "autotag_tag_aliases": "Include tag aliases",
       "auto_tagging": "Auto tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",


### PR DESCRIPTION
This PR ensures that it's possible to search for text contained in the details fields of images in various image collection views.