### PR TITLE
feat: Implement Image Duplicate Checker

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -53,6 +53,9 @@ type Query {
     duration_diff: Float
   ): [[Scene!]!]!
 
+  "Find duplicate images"
+  findDuplicateImages(distance: Int! = 0): [[Image!]!]!
+
   "Return valid stream paths"
   sceneStreams(id: ID): [SceneStreamEndpoint!]!
 

--- a/internal/api/resolver_query_find_image.go
+++ b/internal/api/resolver_query_find_image.go
@@ -135,6 +135,13 @@ func (r *queryResolver) AllImages(ctx context.Context) (ret []*models.Image, err
 	return ret, nil
 }
 
-func (r *queryResolver) FindDuplicateImages(ctx context.Context, distance int) ([][]*models.Image, error) {
-	return r.repository.Image.FindDuplicates(ctx, distance)
+func (r *queryResolver) FindDuplicateImages(ctx context.Context, distance int) (ret [][]*models.Image, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Image.FindDuplicates(ctx, distance)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
 }

--- a/internal/api/resolver_query_find_image.go
+++ b/internal/api/resolver_query_find_image.go
@@ -134,3 +134,7 @@ func (r *queryResolver) AllImages(ctx context.Context) (ret []*models.Image, err
 
 	return ret, nil
 }
+
+func (r *queryResolver) FindDuplicateImages(ctx context.Context, distance int) ([][]*models.Image, error) {
+	return r.repository.Image.FindDuplicates(ctx, distance)
+}

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -370,6 +370,29 @@ func (_m *ImageReaderWriter) FindByZipFileID(ctx context.Context, zipFileID mode
 	return r0, r1
 }
 
+// FindDuplicates provides a mock function with given fields: ctx, distance
+func (_m *ImageReaderWriter) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {
+	ret := _m.Called(ctx, distance)
+
+	var r0 [][]*models.Image
+	if rf, ok := ret.Get(0).(func(context.Context, int) [][]*models.Image); ok {
+		r0 = rf(ctx, distance)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([][]*models.Image)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, distance)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FindMany provides a mock function with given fields: ctx, ids
 func (_m *ImageReaderWriter) FindMany(ctx context.Context, ids []int) ([]*models.Image, error) {
 	ret := _m.Called(ctx, ids)

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -19,6 +19,7 @@ type ImageFinder interface {
 	FindByZipFileID(ctx context.Context, zipFileID FileID) ([]*Image, error)
 	FindByGalleryID(ctx context.Context, galleryID int) ([]*Image, error)
 	FindByGalleryIDIndex(ctx context.Context, galleryID int, index uint) (*Image, error)
+	FindDuplicates(ctx context.Context, distance int) ([][]*Image, error)
 }
 
 // ImageQueryer provides methods to query images.

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -412,6 +411,11 @@ func (qb *ImageStore) Find(ctx context.Context, id int) (*models.Image, error) {
 func (qb *ImageStore) FindMany(ctx context.Context, ids []int) ([]*models.Image, error) {
 	images := make([]*models.Image, len(ids))
 
+	idToIndex := make(map[int]int, len(ids))
+	for i, id := range ids {
+		idToIndex[id] = i
+	}
+
 	if err := batchExec(ids, defaultBatchSize, func(batch []int) error {
 		q := qb.selectDataset().Prepared(true).Where(qb.table().Col(idColumn).In(batch))
 		unsorted, err := qb.getMany(ctx, q)
@@ -420,8 +424,9 @@ func (qb *ImageStore) FindMany(ctx context.Context, ids []int) ([]*models.Image,
 		}
 
 		for _, s := range unsorted {
-			i := slices.Index(ids, s.ID)
-			images[i] = s
+			if i, ok := idToIndex[s.ID]; ok {
+				images[i] = s
+			}
 		}
 
 		return nil
@@ -1099,14 +1104,20 @@ func (qb *ImageStore) GetURLs(ctx context.Context, imageID int) ([]string, error
 
 var findExactImageDuplicateQuery = `
 SELECT GROUP_CONCAT(DISTINCT image_id) as ids
-FROM images_files
-JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
-WHERE files_fingerprints.type = 'phash' 
-  AND files_fingerprints.fingerprint != zeroblob(8)
-  AND files_fingerprints.fingerprint != ''
-GROUP BY fingerprint
+FROM (
+	SELECT images_files.image_id
+		 , files.size as file_size
+		 , files_fingerprints.fingerprint as phash
+	FROM images_files
+	JOIN files ON images_files.file_id = files.id
+	JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
+	WHERE files_fingerprints.type = 'phash' 
+	  AND files_fingerprints.fingerprint != zeroblob(8)
+	  AND files_fingerprints.fingerprint != ''
+)
+GROUP BY phash
 HAVING COUNT(DISTINCT image_id) > 1
-LIMIT 1000;
+ORDER BY SUM(file_size) DESC;
 `
 
 func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -838,7 +838,7 @@ func (qb *ImageStore) makeQuery(ctx context.Context, imageFilter *models.ImageFi
 		)
 
 		filepathColumn := "folders.path || '" + string(filepath.Separator) + "' || files.basename"
-		searchColumns := []string{"images.title", "images.details", filepathColumn, "files_fingerprints.fingerprint"}
+		searchColumns := []string{"images.title", filepathColumn, "files_fingerprints.fingerprint"}
 		query.parseQueryString(searchColumns, *q)
 	}
 
@@ -1104,28 +1104,29 @@ func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
         WHERE files_fingerprints.type = 'phash'`
 
 	var hashes []*utils.Phash
-	err := imageRepository.queryStruct(ctx, query, nil, &hashes)
-	if err != nil {
-		return nil, err
-	}
+	if err := imageRepository.queryFunc(ctx, query, nil, false, func(rows *sqlx.Rows) error {
+		phash := utils.Phash{
+			Bucket:   -1,
+			Duration: -1,
+		}
+		if err := rows.StructScan(&phash); err != nil {
+			return err
+		}
 
-	for _, h := range hashes {
-		h.Bucket = -1
+		hashes = append(hashes, &phash)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	dupeIds := utils.FindDuplicates(hashes, distance, -1)
 
 	var result [][]*models.Image
 	for _, comp := range dupeIds {
-		var group []*models.Image
-		for _, id := range comp {
-			img, err := qb.Find(ctx, id)
-			if err == nil && img != nil {
-				group = append(group, img)
+		if images, err := qb.FindMany(ctx, comp); err == nil {
+			if len(images) > 1 {
+				result = append(result, images)
 			}
-		}
-		if len(group) > 1 {
-			result = append(result, group)
 		}
 	}
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1096,10 +1096,6 @@ func (qb *ImageStore) GetURLs(ctx context.Context, imageID int) ([]string, error
 }
 
 func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {
-	return qb.findPhashMatches(ctx, distance)
-}
-
-func (qb *ImageStore) findPhashMatches(ctx context.Context, distance int) ([][]*models.Image, error) {
 	query := `
         SELECT images.id, files_fingerprints.fingerprint as phash
         FROM images
@@ -1107,88 +1103,20 @@ func (qb *ImageStore) findPhashMatches(ctx context.Context, distance int) ([][]*
         JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
         WHERE files_fingerprints.type = 'phash'`
 
-	type ImagePhash struct {
-		ID    int    `db:"id"`
-		PHash string `db:"phash"`
-	}
-
-	var hashes []ImagePhash
+	var hashes []*utils.Phash
 	err := imageRepository.queryStruct(ctx, query, nil, &hashes)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse hashes
-	type ParsedPhash struct {
-		ID    int
-		PHash uint64
-	}
-	var parsedHashes []ParsedPhash
 	for _, h := range hashes {
-		val, parseErr := strconv.ParseUint(h.PHash, 16, 64)
-		if parseErr == nil {
-			parsedHashes = append(parsedHashes, ParsedPhash{ID: h.ID, PHash: val})
-		}
+		h.Bucket = -1
 	}
 
-	// Helper for Popcount
-	popcount := func(x uint64) int {
-		x -= (x >> 1) & 0x5555555555555555
-		x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333)
-		x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f
-		return int((x * 0x0101010101010101) >> 56)
-	}
+	dupeIds := utils.FindDuplicates(hashes, distance, -1)
 
-	// Adjacency list for connected components
-	adj := make(map[int][]int)
-	nodes := make(map[int]bool)
-
-	// O(N^2) comparison in memory
-	for i := 0; i < len(parsedHashes); i++ {
-		for j := i + 1; j < len(parsedHashes); j++ {
-			diff := popcount(parsedHashes[i].PHash ^ parsedHashes[j].PHash)
-			if diff <= distance {
-				id1 := parsedHashes[i].ID
-				id2 := parsedHashes[j].ID
-				adj[id1] = append(adj[id1], id2)
-				adj[id2] = append(adj[id2], id1)
-				nodes[id1] = true
-				nodes[id2] = true
-			}
-		}
-	}
-
-	// Find connected components
-	visited := make(map[int]bool)
-	var components [][]int
-
-	for node := range nodes {
-		if !visited[node] {
-			var component []int
-			queue := []int{node}
-			visited[node] = true
-
-			for len(queue) > 0 {
-				curr := queue[0]
-				queue = queue[1:]
-				component = append(component, curr)
-
-				for _, neighbor := range adj[curr] {
-					if !visited[neighbor] {
-						visited[neighbor] = true
-						queue = append(queue, neighbor)
-					}
-				}
-			}
-			if len(component) > 1 {
-				components = append(components, component)
-			}
-		}
-	}
-
-	// Fetch actual image objects
 	var result [][]*models.Image
-	for _, comp := range components {
+	for _, comp := range dupeIds {
 		var group []*models.Image
 		for _, id := range comp {
 			img, err := qb.Find(ctx, id)
@@ -1203,3 +1131,4 @@ func (qb *ImageStore) findPhashMatches(ctx context.Context, distance int) ([][]*
 
 	return result, nil
 }
+

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1099,17 +1099,11 @@ func (qb *ImageStore) GetURLs(ctx context.Context, imageID int) ([]string, error
 
 var findExactImageDuplicateQuery = `
 SELECT GROUP_CONCAT(DISTINCT image_id) as ids
-FROM (
-	SELECT images.id as image_id
-		 , files_fingerprints.fingerprint as phash
-	FROM images
-	JOIN images_files ON images.id = images_files.image_id
-	JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
-	WHERE files_fingerprints.type = 'phash'
-)
-GROUP BY phash
-HAVING COUNT(phash) > 1
-   AND COUNT(DISTINCT image_id) > 1;
+FROM images_files
+JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
+WHERE files_fingerprints.type = 'phash'
+GROUP BY fingerprint
+HAVING COUNT(DISTINCT image_id) > 1;
 `
 
 func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {
@@ -1160,13 +1154,26 @@ func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 		dupeIds = utils.FindDuplicates(hashes, distance, -1)
 	}
 
-	var result [][]*models.Image
+	var allIds []int
 	for _, comp := range dupeIds {
-		if images, err := qb.FindMany(ctx, comp); err == nil {
-			if len(images) > 1 {
-				result = append(result, images)
-			}
-		}
+		allIds = append(allIds, comp...)
+	}
+
+	if len(allIds) == 0 {
+		return nil, nil
+	}
+
+	allImages, err := qb.FindMany(ctx, allIds)
+	if err != nil {
+		return nil, err
+	}
+
+	var result [][]*models.Image
+	offset := 0
+	for _, comp := range dupeIds {
+		group := allImages[offset : offset+len(comp)]
+		result = append(result, group)
+		offset += len(comp)
 	}
 
 	return result, nil

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1105,28 +1105,12 @@ func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 
 	var hashes []*utils.Phash
 	if err := imageRepository.queryFunc(ctx, query, nil, false, func(rows *sqlx.Rows) error {
-		var sq struct {
-			ID    int     `db:"id"`
-			Phash *string `db:"phash"`
-		}
-		if err := rows.StructScan(&sq); err != nil {
-			return err
-		}
-
-		if sq.Phash == nil {
-			return nil
-		}
-
-		hashInt, err := utils.StringToPhash(*sq.Phash)
-		if err != nil {
-			return nil
-		}
-
 		phash := utils.Phash{
-			ID:       sq.ID,
-			Hash:     hashInt,
 			Bucket:   -1,
 			Duration: -1,
+		}
+		if err := rows.StructScan(&phash); err != nil {
+			return err
 		}
 
 		hashes = append(hashes, &phash)

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1105,12 +1105,28 @@ func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 
 	var hashes []*utils.Phash
 	if err := imageRepository.queryFunc(ctx, query, nil, false, func(rows *sqlx.Rows) error {
+		var sq struct {
+			ID    int     `db:"id"`
+			Phash *string `db:"phash"`
+		}
+		if err := rows.StructScan(&sq); err != nil {
+			return err
+		}
+
+		if sq.Phash == nil {
+			return nil
+		}
+
+		hashInt, err := utils.StringToPhash(*sq.Phash)
+		if err != nil {
+			return nil
+		}
+
 		phash := utils.Phash{
+			ID:       sq.ID,
+			Hash:     hashInt,
 			Bucket:   -1,
 			Duration: -1,
-		}
-		if err := rows.StructScan(&phash); err != nil {
-			return err
 		}
 
 		hashes = append(hashes, &phash)

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/models"
@@ -1095,31 +1097,68 @@ func (qb *ImageStore) GetURLs(ctx context.Context, imageID int) ([]string, error
 	return imagesURLsTableMgr.get(ctx, imageID)
 }
 
+var findExactImageDuplicateQuery = `
+SELECT GROUP_CONCAT(DISTINCT image_id) as ids
+FROM (
+	SELECT images.id as image_id
+		 , files_fingerprints.fingerprint as phash
+	FROM images
+	JOIN images_files ON images.id = images_files.image_id
+	JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
+	WHERE files_fingerprints.type = 'phash'
+)
+GROUP BY phash
+HAVING COUNT(phash) > 1
+   AND COUNT(DISTINCT image_id) > 1;
+`
+
 func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {
-	query := `
+	var dupeIds [][]int
+	if distance == 0 {
+		var ids []string
+		if err := dbWrapper.Select(ctx, &ids, findExactImageDuplicateQuery); err != nil {
+			return nil, err
+		}
+
+		for _, id := range ids {
+			strIds := strings.Split(id, ",")
+			var imageIds []int
+			for _, strId := range strIds {
+				if intId, err := strconv.Atoi(strId); err == nil {
+					imageIds = sliceutil.AppendUnique(imageIds, intId)
+				}
+			}
+			// filter out
+			if len(imageIds) > 1 {
+				dupeIds = append(dupeIds, imageIds)
+			}
+		}
+	} else {
+		query := `
         SELECT images.id, files_fingerprints.fingerprint as phash
         FROM images
         JOIN images_files ON images.id = images_files.image_id
         JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
         WHERE files_fingerprints.type = 'phash'`
 
-	var hashes []*utils.Phash
-	if err := imageRepository.queryFunc(ctx, query, nil, false, func(rows *sqlx.Rows) error {
-		phash := utils.Phash{
-			Bucket:   -1,
-			Duration: -1,
-		}
-		if err := rows.StructScan(&phash); err != nil {
-			return err
+		var hashes []*utils.Phash
+		if err := imageRepository.queryFunc(ctx, query, nil, false, func(rows *sqlx.Rows) error {
+			phash := utils.Phash{
+				Bucket:   -1,
+				Duration: -1,
+			}
+			if err := rows.StructScan(&phash); err != nil {
+				return err
+			}
+
+			hashes = append(hashes, &phash)
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 
-		hashes = append(hashes, &phash)
-		return nil
-	}); err != nil {
-		return nil, err
+		dupeIds = utils.FindDuplicates(hashes, distance, -1)
 	}
-
-	dupeIds := utils.FindDuplicates(hashes, distance, -1)
 
 	var result [][]*models.Image
 	for _, comp := range dupeIds {

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -1101,9 +1101,12 @@ var findExactImageDuplicateQuery = `
 SELECT GROUP_CONCAT(DISTINCT image_id) as ids
 FROM images_files
 JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
-WHERE files_fingerprints.type = 'phash'
+WHERE files_fingerprints.type = 'phash' 
+  AND files_fingerprints.fingerprint != zeroblob(8)
+  AND files_fingerprints.fingerprint != ''
 GROUP BY fingerprint
-HAVING COUNT(DISTINCT image_id) > 1;
+HAVING COUNT(DISTINCT image_id) > 1
+LIMIT 1000;
 `
 
 func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
-	"strconv"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/sliceutil"
+	"github.com/stashapp/stash/pkg/utils"
 	"gopkg.in/guregu/null.v4"
 	"gopkg.in/guregu/null.v4/zero"
 
@@ -1131,4 +1131,3 @@ func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*mo
 
 	return result, nil
 }
-

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strconv"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stashapp/stash/pkg/models"
@@ -1092,4 +1093,113 @@ func (qb *ImageStore) UpdateTags(ctx context.Context, imageID int, tagIDs []int)
 
 func (qb *ImageStore) GetURLs(ctx context.Context, imageID int) ([]string, error) {
 	return imagesURLsTableMgr.get(ctx, imageID)
+}
+
+func (qb *ImageStore) FindDuplicates(ctx context.Context, distance int) ([][]*models.Image, error) {
+	return qb.findPhashMatches(ctx, distance)
+}
+
+func (qb *ImageStore) findPhashMatches(ctx context.Context, distance int) ([][]*models.Image, error) {
+	query := `
+        SELECT images.id, files_fingerprints.fingerprint as phash
+        FROM images
+        JOIN images_files ON images.id = images_files.image_id
+        JOIN files_fingerprints ON images_files.file_id = files_fingerprints.file_id
+        WHERE files_fingerprints.type = 'phash'`
+
+	type ImagePhash struct {
+		ID    int    `db:"id"`
+		PHash string `db:"phash"`
+	}
+
+	var hashes []ImagePhash
+	err := imageRepository.queryStruct(ctx, query, nil, &hashes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse hashes
+	type ParsedPhash struct {
+		ID    int
+		PHash uint64
+	}
+	var parsedHashes []ParsedPhash
+	for _, h := range hashes {
+		val, parseErr := strconv.ParseUint(h.PHash, 16, 64)
+		if parseErr == nil {
+			parsedHashes = append(parsedHashes, ParsedPhash{ID: h.ID, PHash: val})
+		}
+	}
+
+	// Helper for Popcount
+	popcount := func(x uint64) int {
+		x -= (x >> 1) & 0x5555555555555555
+		x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333)
+		x = (x + (x >> 4)) & 0x0f0f0f0f0f0f0f0f
+		return int((x * 0x0101010101010101) >> 56)
+	}
+
+	// Adjacency list for connected components
+	adj := make(map[int][]int)
+	nodes := make(map[int]bool)
+
+	// O(N^2) comparison in memory
+	for i := 0; i < len(parsedHashes); i++ {
+		for j := i + 1; j < len(parsedHashes); j++ {
+			diff := popcount(parsedHashes[i].PHash ^ parsedHashes[j].PHash)
+			if diff <= distance {
+				id1 := parsedHashes[i].ID
+				id2 := parsedHashes[j].ID
+				adj[id1] = append(adj[id1], id2)
+				adj[id2] = append(adj[id2], id1)
+				nodes[id1] = true
+				nodes[id2] = true
+			}
+		}
+	}
+
+	// Find connected components
+	visited := make(map[int]bool)
+	var components [][]int
+
+	for node := range nodes {
+		if !visited[node] {
+			var component []int
+			queue := []int{node}
+			visited[node] = true
+
+			for len(queue) > 0 {
+				curr := queue[0]
+				queue = queue[1:]
+				component = append(component, curr)
+
+				for _, neighbor := range adj[curr] {
+					if !visited[neighbor] {
+						visited[neighbor] = true
+						queue = append(queue, neighbor)
+					}
+				}
+			}
+			if len(component) > 1 {
+				components = append(components, component)
+			}
+		}
+	}
+
+	// Fetch actual image objects
+	var result [][]*models.Image
+	for _, comp := range components {
+		var group []*models.Image
+		for _, id := range comp {
+			img, err := qb.Find(ctx, id)
+			if err == nil && img != nil {
+				group = append(group, img)
+			}
+		}
+		if len(group) > 1 {
+			result = append(result, group)
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/sqlite/image_filter.go
+++ b/pkg/sqlite/image_filter.go
@@ -185,6 +185,10 @@ func (qb *imageFilterHandler) missingCriterionHandler(isMissing *string) criteri
 			case "tags":
 				imageRepository.tags.join(f, "tags_join", "images.id")
 				f.addWhere("tags_join.image_id IS NULL")
+			case "phash":
+				f.addInnerJoin("images_files", "", "images_files.image_id = images.id")
+				f.addLeftJoin(fingerprintTable, "fingerprints_phash", "images_files.file_id = fingerprints_phash.file_id AND fingerprints_phash.type = 'phash'")
+				f.addWhere("fingerprints_phash.fingerprint IS NULL")
 			default:
 				if err := validateIsMissing(*isMissing, []string{
 					"title", "details", "photographer", "date", "code", "rating",

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -1596,20 +1596,6 @@ func TestImageQueryQ(t *testing.T) {
 	})
 }
 
-func TestImageQueryQ_Details(t *testing.T) {
-	withTxn(func(ctx context.Context) error {
-		const imageIdx = 3
-
-		q := getImageStringValue(imageIdx, detailsField)
-
-		sqb := db.Image
-
-		imageQueryQ(ctx, t, sqb, q, imageIdx)
-
-		return nil
-	})
-}
-
 func queryImagesWithCount(ctx context.Context, sqb models.ImageReader, imageFilter *models.ImageFilterType, findFilter *models.FindFilterType) ([]*models.Image, int, error) {
 	result, err := sqb.Query(ctx, models.ImageQueryOptions{
 		QueryOptions: models.QueryOptions{

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -533,9 +532,15 @@ func (qb *SceneStore) FindMany(ctx context.Context, ids []int) ([]*models.Scene,
 		return nil, err
 	}
 
+	idToIndex := make(map[int]int, len(ids))
+	for i, id := range ids {
+		idToIndex[id] = i
+	}
+
 	for _, s := range unsorted {
-		i := slices.Index(ids, s.ID)
-		scenes[i] = s
+		if i, ok := idToIndex[s.ID]; ok {
+			scenes[i] = s
+		}
 	}
 
 	for i := range scenes {

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1472,11 +1472,26 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, duration
 		dupeIds = utils.FindDuplicates(hashes, distance, durationDiff)
 	}
 
+	var allIds []int
+	for _, comp := range dupeIds {
+		allIds = append(allIds, comp...)
+	}
+
+	if len(allIds) == 0 {
+		return nil, nil
+	}
+
+	allScenes, err := qb.FindMany(ctx, allIds)
+	if err != nil {
+		return nil, err
+	}
+
 	var duplicates [][]*models.Scene
-	for _, sceneIds := range dupeIds {
-		if scenes, err := qb.FindMany(ctx, sceneIds); err == nil {
-			duplicates = append(duplicates, scenes)
-		}
+	offset := 0
+	for _, comp := range dupeIds {
+		group := allScenes[offset : offset+len(comp)]
+		duplicates = append(duplicates, group)
+		offset += len(comp)
 	}
 
 	sortByPath(duplicates)

--- a/pkg/utils/phash.go
+++ b/pkg/utils/phash.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Phash struct {
-	ID        int    `db:"id"`
-	Hash      int64  `db:"phash"`
+	ID        int     `db:"id"`
+	Hash      int64   `db:"phash"`
 	Duration  float64 `db:"duration"`
 	Neighbors []int
 	Bucket    int

--- a/pkg/utils/phash.go
+++ b/pkg/utils/phash.go
@@ -5,7 +5,6 @@ import (
 	"math/bits"
 	"strconv"
 
-	"github.com/corona10/goimagehash"
 	"github.com/stashapp/stash/pkg/sliceutil"
 )
 

--- a/pkg/utils/phash.go
+++ b/pkg/utils/phash.go
@@ -3,7 +3,9 @@ package utils
 import (
 	"math"
 	"math/bits"
+	"runtime"
 	"strconv"
+	"sync"
 
 	"github.com/stashapp/stash/pkg/sliceutil"
 )
@@ -23,31 +25,48 @@ func FindDuplicates(hashes []*Phash, distance int, durationDiff float64) [][]int
 		uintHashes[i] = uint64(h.Hash)
 	}
 
-	for i, subject := range hashes {
-		subjectHash := uintHashes[i]
-		for j := i + 1; j < len(hashes); j++ {
-			neighbor := hashes[j]
-			if subject.ID == neighbor.ID {
-				continue
-			}
+	numHashes := len(hashes)
+	numWorkers := runtime.GOMAXPROCS(0)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
 
-			// Check duration if applicable (for scenes)
-			if durationDiff >= 0 {
-				if subject.Duration > 0 && neighbor.Duration > 0 {
-					if math.Abs(subject.Duration-neighbor.Duration) > durationDiff {
+	// Distribute work among workers
+	for w := 0; w < numWorkers; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for i := workerID; i < numHashes; i += numWorkers {
+				subject := hashes[i]
+				subjectHash := uintHashes[i]
+
+				for j := 0; j < numHashes; j++ {
+					if i == j {
 						continue
+					}
+					neighbor := hashes[j]
+					if subject.ID == neighbor.ID {
+						continue
+					}
+
+					// Check duration if applicable (for scenes)
+					if durationDiff >= 0 {
+						if subject.Duration > 0 && neighbor.Duration > 0 {
+							if math.Abs(subject.Duration-neighbor.Duration) > durationDiff {
+								continue
+							}
+						}
+					}
+
+					neighborHash := uintHashes[j]
+					// Hamming distance using native bit counting
+					if bits.OnesCount64(subjectHash^neighborHash) <= distance {
+						subject.Neighbors = append(subject.Neighbors, j)
 					}
 				}
 			}
-
-			neighborHash := uintHashes[j]
-			// Hamming distance using native bit counting
-			if bits.OnesCount64(subjectHash^neighborHash) <= distance {
-				subject.Neighbors = append(subject.Neighbors, j)
-				neighbor.Neighbors = append(neighbor.Neighbors, i)
-			}
-		}
+		}(w)
 	}
+
+	wg.Wait()
 
 	var buckets [][]int
 	for _, subject := range hashes {

--- a/pkg/utils/phash.go
+++ b/pkg/utils/phash.go
@@ -9,27 +9,27 @@ import (
 )
 
 type Phash struct {
-	SceneID   int     `db:"id"`
-	Hash      int64   `db:"phash"`
+	ID        int    `db:"id"`
+	Hash      int64  `db:"phash"`
 	Duration  float64 `db:"duration"`
 	Neighbors []int
 	Bucket    int
 }
 
 func FindDuplicates(hashes []*Phash, distance int, durationDiff float64) [][]int {
-	for i, scene := range hashes {
-		sceneHash := goimagehash.NewImageHash(uint64(scene.Hash), goimagehash.PHash)
+	for i, subject := range hashes {
+		subjectHash := goimagehash.NewImageHash(uint64(subject.Hash), goimagehash.PHash)
 		for j, neighbor := range hashes {
-			if i != j && scene.SceneID != neighbor.SceneID {
+			if i != j && subject.ID != neighbor.ID {
 				neighbourDurationDistance := 0.
-				if scene.Duration > 0 && neighbor.Duration > 0 {
-					neighbourDurationDistance = math.Abs(scene.Duration - neighbor.Duration)
+				if subject.Duration > 0 && neighbor.Duration > 0 {
+					neighbourDurationDistance = math.Abs(subject.Duration - neighbor.Duration)
 				}
 				if (neighbourDurationDistance <= durationDiff) || (durationDiff < 0) {
 					neighborHash := goimagehash.NewImageHash(uint64(neighbor.Hash), goimagehash.PHash)
-					neighborDistance, _ := sceneHash.Distance(neighborHash)
+					neighborDistance, _ := subjectHash.Distance(neighborHash)
 					if neighborDistance <= distance {
-						scene.Neighbors = append(scene.Neighbors, j)
+						subject.Neighbors = append(subject.Neighbors, j)
 					}
 				}
 			}
@@ -37,15 +37,15 @@ func FindDuplicates(hashes []*Phash, distance int, durationDiff float64) [][]int
 	}
 
 	var buckets [][]int
-	for _, scene := range hashes {
-		if len(scene.Neighbors) > 0 && scene.Bucket == -1 {
+	for _, subject := range hashes {
+		if len(subject.Neighbors) > 0 && subject.Bucket == -1 {
 			bucket := len(buckets)
-			scenes := []int{scene.SceneID}
-			scene.Bucket = bucket
-			findNeighbors(bucket, scene.Neighbors, hashes, &scenes)
+			ids := []int{subject.ID}
+			subject.Bucket = bucket
+			findNeighbors(bucket, subject.Neighbors, hashes, &ids)
 
-			if len(scenes) > 1 {
-				buckets = append(buckets, scenes)
+			if len(ids) > 1 {
+				buckets = append(buckets, ids)
 			}
 		}
 	}
@@ -53,13 +53,13 @@ func FindDuplicates(hashes []*Phash, distance int, durationDiff float64) [][]int
 	return buckets
 }
 
-func findNeighbors(bucket int, neighbors []int, hashes []*Phash, scenes *[]int) {
+func findNeighbors(bucket int, neighbors []int, hashes []*Phash, ids *[]int) {
 	for _, id := range neighbors {
 		hash := hashes[id]
 		if hash.Bucket == -1 {
 			hash.Bucket = bucket
-			*scenes = sliceutil.AppendUnique(*scenes, hash.SceneID)
-			findNeighbors(bucket, hash.Neighbors, hashes, scenes)
+			*ids = sliceutil.AppendUnique(*ids, hash.ID)
+			findNeighbors(bucket, hash.Neighbors, hashes, ids)
 		}
 	}
 }

--- a/pkg/utils/phash.go
+++ b/pkg/utils/phash.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math"
+	"math/bits"
 	"strconv"
 
 	"github.com/corona10/goimagehash"
@@ -17,21 +18,34 @@ type Phash struct {
 }
 
 func FindDuplicates(hashes []*Phash, distance int, durationDiff float64) [][]int {
+	// Pre-calculate hash values to avoid allocations and method calls in the inner loop
+	uintHashes := make([]uint64, len(hashes))
+	for i, h := range hashes {
+		uintHashes[i] = uint64(h.Hash)
+	}
+
 	for i, subject := range hashes {
-		subjectHash := goimagehash.NewImageHash(uint64(subject.Hash), goimagehash.PHash)
-		for j, neighbor := range hashes {
-			if i != j && subject.ID != neighbor.ID {
-				neighbourDurationDistance := 0.
+		subjectHash := uintHashes[i]
+		for j := i + 1; j < len(hashes); j++ {
+			neighbor := hashes[j]
+			if subject.ID == neighbor.ID {
+				continue
+			}
+
+			// Check duration if applicable (for scenes)
+			if durationDiff >= 0 {
 				if subject.Duration > 0 && neighbor.Duration > 0 {
-					neighbourDurationDistance = math.Abs(subject.Duration - neighbor.Duration)
-				}
-				if (neighbourDurationDistance <= durationDiff) || (durationDiff < 0) {
-					neighborHash := goimagehash.NewImageHash(uint64(neighbor.Hash), goimagehash.PHash)
-					neighborDistance, _ := subjectHash.Distance(neighborHash)
-					if neighborDistance <= distance {
-						subject.Neighbors = append(subject.Neighbors, j)
+					if math.Abs(subject.Duration-neighbor.Duration) > durationDiff {
+						continue
 					}
 				}
+			}
+
+			neighborHash := uintHashes[j]
+			// Hamming distance using native bit counting
+			if bits.OnesCount64(subjectHash^neighborHash) <= distance {
+				subject.Neighbors = append(subject.Neighbors, j)
+				neighbor.Neighbors = append(neighbor.Neighbors, i)
 			}
 		}
 	}

--- a/ui/v2.5/graphql/queries/image.graphql
+++ b/ui/v2.5/graphql/queries/image.graphql
@@ -38,6 +38,6 @@ query FindImage($id: ID!, $checksum: String) {
 
 query FindDuplicateImages($distance: Int!) {
   findDuplicateImages(distance: $distance) {
-    ...ImageData
+    ...SlimImageData
   }
 }

--- a/ui/v2.5/graphql/queries/image.graphql
+++ b/ui/v2.5/graphql/queries/image.graphql
@@ -36,7 +36,7 @@ query FindImage($id: ID!, $checksum: String) {
   }
 }
 
-query FindDuplicateImages($distance: Int) {
+query FindDuplicateImages($distance: Int!) {
   findDuplicateImages(distance: $distance) {
     ...ImageData
   }

--- a/ui/v2.5/graphql/queries/image.graphql
+++ b/ui/v2.5/graphql/queries/image.graphql
@@ -35,3 +35,9 @@ query FindImage($id: ID!, $checksum: String) {
     ...ImageData
   }
 }
+
+query FindDuplicateImages($distance: Int) {
+  findDuplicateImages(distance: $distance) {
+    ...ImageData
+  }
+}

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -82,6 +82,9 @@ const SceneFilenameParser = lazyComponent(
 const SceneDuplicateChecker = lazyComponent(
   () => import("./components/SceneDuplicateChecker/SceneDuplicateChecker")
 );
+const ImageDuplicateChecker = lazyComponent(
+  () => import("./components/ImageDuplicateChecker/ImageDuplicateChecker")
+);
 
 const appleRendering = isPlatformUniquelyRenderedByApple();
 
@@ -268,6 +271,10 @@ export const App: React.FC = () => {
             <Route
               path="/sceneDuplicateChecker"
               component={SceneDuplicateChecker}
+            />
+            <Route
+              path="/imageDuplicateChecker"
+              component={ImageDuplicateChecker}
             />
             <Route path="/setup" component={Setup} />
             <Route path="/migrate" component={Migrate} />

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -39,8 +39,11 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const [isSearching, setIsSearching] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
-  const [checkedImages, setCheckedImages] = useState<Record<string, boolean>>({});
-  const [selectedImages, setSelectedImages] = useState<GQL.ImageDataFragment[]>();
+  const [checkedImages, setCheckedImages] = useState<Record<string, boolean>>(
+    {}
+  );
+  const [selectedImages, setSelectedImages] =
+    useState<GQL.ImageDataFragment[]>();
   const [deletingImages, setDeletingImages] = useState(false);
   const [editingImages, setEditingImages] = useState(false);
 
@@ -79,7 +82,9 @@ const ImageDuplicateChecker: React.FC = () => {
     return allGroups.slice(start, start + pageSize);
   }, [allGroups, currentPage, pageSize]);
 
-  const checkCount = Object.keys(checkedImages).filter((id) => checkedImages[id]).length;
+  const checkCount = Object.keys(checkedImages).filter(
+    (id) => checkedImages[id]
+  ).length;
 
   const handleCheck = (checked: boolean, imageID: string) => {
     setCheckedImages({ ...checkedImages, [imageID]: checked });
@@ -144,7 +149,9 @@ const ImageDuplicateChecker: React.FC = () => {
                     <td className="text-center align-middle">
                       <Form.Check
                         checked={checkedImages[img.id] || false}
-                        onChange={(e) => handleCheck(e.currentTarget.checked, img.id)}
+                        onChange={(e) =>
+                          handleCheck(e.currentTarget.checked, img.id)
+                        }
                       />
                     </td>
                     <td>
@@ -160,7 +167,10 @@ const ImageDuplicateChecker: React.FC = () => {
                     </td>
                     <td>
                       <div className="fw-bold">{img.title || "(No Title)"}</div>
-                      <div className="text-muted small text-truncate" style={{ maxWidth: "400px" }}>
+                      <div
+                        className="text-muted small text-truncate"
+                        style={{ maxWidth: "400px" }}
+                      >
                         {img.visual_files[0]?.path}
                       </div>
                       <div className="mt-1 small">ID: {img.id}</div>
@@ -169,7 +179,8 @@ const ImageDuplicateChecker: React.FC = () => {
                       <FileSize size={file?.size ?? 0} />
                     </td>
                     <td>
-                      {file?.__typename === "ImageFile" || file?.__typename === "VideoFile" ? (
+                      {file?.__typename === "ImageFile" ||
+                      file?.__typename === "VideoFile" ? (
                         <>
                           {file.width} x {file.height}
                         </>
@@ -252,7 +263,9 @@ const ImageDuplicateChecker: React.FC = () => {
 
         {hasSearched && !loading && !error && allGroups.length === 0 && (
           <div className="text-center py-5 border rounded bg-light">
-            <p className="mb-0">No duplicates found with the current distance.</p>
+            <p className="mb-0">
+              No duplicates found with the current distance.
+            </p>
           </div>
         )}
 
@@ -297,7 +310,7 @@ const ImageDuplicateChecker: React.FC = () => {
             <Pagination
               currentPage={currentPage}
               totalItems={allGroups.length}
-              pageSize={pageSize}
+              itemsPerPage={pageSize}
               onChangePage={(page) => {
                 query.set("page", page.toString());
                 history.push({ search: query.toString() });

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -250,9 +250,12 @@ const ImageDuplicateChecker: React.FC = () => {
   };
 
   function checkSameResolution(dataGroup: GQL.SlimImageDataFragment[]) {
-    const resolutions = dataGroup.map(
-      (s) => (s.visual_files[0]?.width ?? 0) * (s.visual_files[0]?.height ?? 0)
-    );
+    const resolutions = dataGroup.map((s) => {
+      return s.visual_files.reduce(
+        (prev, f) => Math.max(prev, (f.height ?? 0) * (f.width ?? 0)),
+        0
+      );
+    });
     return new Set(resolutions).size === 1;
   }
 

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -54,7 +54,7 @@ const ImageDuplicateChecker: React.FC = () => {
     {}
   );
   const [selectedImages, setSelectedImages] =
-    useState<GQL.ImageDataFragment[]>();
+    useState<GQL.SlimImageDataFragment[]>();
   const [deletingImages, setDeletingImages] = useState(false);
   const [editingImages, setEditingImages] = useState(false);
 
@@ -89,7 +89,7 @@ const ImageDuplicateChecker: React.FC = () => {
     fetchPolicy: "network-only",
   });
 
-  const getGroupTotalSize = (group: GQL.ImageDataFragment[]) => {
+  const getGroupTotalSize = (group: GQL.SlimImageDataFragment[]) => {
     return group.reduce((groupTotal, img) => {
       const imgTotal = img.visual_files.reduce(
         (fileTotal, file) => fileTotal + (file.size ?? 0),
@@ -188,8 +188,8 @@ const ImageDuplicateChecker: React.FC = () => {
     setCheckedImages(updatedImages);
   };
 
-  const findLargestImage = (group: GQL.ImageDataFragment[]) => {
-    const totalSize = (image: GQL.ImageDataFragment) => {
+  const findLargestImage = (group: GQL.SlimImageDataFragment[]) => {
+    const totalSize = (image: GQL.SlimImageDataFragment) => {
       return image.visual_files.reduce(
         (prev: number, f) => Math.max(prev, f.size ?? 0),
         0
@@ -202,8 +202,8 @@ const ImageDuplicateChecker: React.FC = () => {
     });
   };
 
-  const findLargestResolutionImage = (group: GQL.ImageDataFragment[]) => {
-    const imgResolution = (image: GQL.ImageDataFragment) => {
+  const findLargestResolutionImage = (group: GQL.SlimImageDataFragment[]) => {
+    const imgResolution = (image: GQL.SlimImageDataFragment) => {
       return image.visual_files.reduce(
         (prev: number, f) => Math.max(prev, (f.height ?? 0) * (f.width ?? 0)),
         0
@@ -218,7 +218,7 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const findFirstFileByAge = (
     oldest: boolean,
-    compareImages: GQL.ImageDataFragment[]
+    compareImages: GQL.SlimImageDataFragment[]
   ) => {
     let selectedFile: GQL.ImageFileDataFragment | GQL.VideoFileDataFragment;
     let oldestTimestamp: Date | undefined = undefined;
@@ -243,7 +243,7 @@ const ImageDuplicateChecker: React.FC = () => {
     );
   };
 
-  function checkSameResolution(dataGroup: GQL.ImageDataFragment[]) {
+  function checkSameResolution(dataGroup: GQL.SlimImageDataFragment[]) {
     const resolutions = dataGroup.map(
       (s) => (s.visual_files[0]?.width ?? 0) * (s.visual_files[0]?.height ?? 0)
     );
@@ -300,7 +300,7 @@ const ImageDuplicateChecker: React.FC = () => {
     setCheckedImages(checkedArray);
   };
 
-  const handleDeleteImage = (image: GQL.ImageDataFragment) => {
+  const handleDeleteImage = (image: GQL.SlimImageDataFragment) => {
     setSelectedImages([image]);
     setDeletingImages(true);
   };
@@ -372,7 +372,7 @@ const ImageDuplicateChecker: React.FC = () => {
     );
   }
 
-  function maybeRenderPopoverButtonGroup(image: GQL.ImageDataFragment) {
+  function maybeRenderPopoverButtonGroup(image: GQL.SlimImageDataFragment) {
     if (
       image.tags.length > 0 ||
       image.performers.length > 0 ||

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -7,6 +7,9 @@ import {
   Row,
   Col,
   Card,
+  ButtonGroup,
+  OverlayTrigger,
+  Tooltip,
 } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useFindDuplicateImagesQuery } from "src/core/generated-graphql";
@@ -17,6 +20,10 @@ import { ErrorMessage } from "../Shared/ErrorMessage";
 import { FileSize } from "../Shared/FileSize";
 import { Pagination } from "src/components/List/Pagination";
 import { useHistory } from "react-router-dom";
+import { DeleteImagesDialog } from "../Images/DeleteImagesDialog";
+import { EditImagesDialog } from "../Images/EditImagesDialog";
+import { Icon } from "../Shared/Icon";
+import { faPencilAlt, faTrash } from "@fortawesome/free-solid-svg-icons";
 
 const ImageDuplicateCheckerSection = PatchContainerComponent(
   "ImageDuplicateCheckerSection"
@@ -32,6 +39,10 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const [isSearching, setIsSearching] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
+  const [checkedImages, setCheckedImages] = useState<Record<string, boolean>>({});
+  const [selectedImages, setSelectedImages] = useState<GQL.ImageDataFragment[]>();
+  const [deletingImages, setDeletingImages] = useState(false);
+  const [editingImages, setEditingImages] = useState(false);
 
   const { data, loading, error, refetch } = useFindDuplicateImagesQuery({
     variables: { distance: hashDistance },
@@ -42,6 +53,7 @@ const ImageDuplicateChecker: React.FC = () => {
   const handleSearch = () => {
     setIsSearching(true);
     setHasSearched(true);
+    setCheckedImages({});
     refetch({ distance: hashDistance }).finally(() => setIsSearching(false));
   };
 
@@ -67,6 +79,40 @@ const ImageDuplicateChecker: React.FC = () => {
     return allGroups.slice(start, start + pageSize);
   }, [allGroups, currentPage, pageSize]);
 
+  const checkCount = Object.keys(checkedImages).filter((id) => checkedImages[id]).length;
+
+  const handleCheck = (checked: boolean, imageID: string) => {
+    setCheckedImages({ ...checkedImages, [imageID]: checked });
+  };
+
+  const handleDeleteChecked = () => {
+    setSelectedImages(allGroups.flat().filter((i) => checkedImages[i.id]));
+    setDeletingImages(true);
+  };
+
+  const onEdit = () => {
+    setSelectedImages(allGroups.flat().filter((i) => checkedImages[i.id]));
+    setEditingImages(true);
+    setCheckedImages({});
+  };
+
+  const onDeleteDialogClosed = (confirmed: boolean) => {
+    setDeletingImages(false);
+    setSelectedImages(undefined);
+    if (confirmed) {
+      setCheckedImages({});
+      refetch();
+    }
+  };
+
+  const onEditDialogClosed = (applied: boolean) => {
+    setEditingImages(false);
+    setSelectedImages(undefined);
+    if (applied) {
+      refetch();
+    }
+  };
+
   if (error) return <ErrorMessage error={error.message} />;
 
   const renderGroup = (group: GQL.ImageDataFragment[], index: number) => {
@@ -83,6 +129,7 @@ const ImageDuplicateChecker: React.FC = () => {
           <Table striped bordered hover responsive size="sm">
             <thead>
               <tr>
+                <th style={{ width: "40px" }}></th>
                 <th style={{ width: "150px" }}>Image</th>
                 <th>Details</th>
                 <th style={{ width: "120px" }}>Size</th>
@@ -94,6 +141,12 @@ const ImageDuplicateChecker: React.FC = () => {
                 const file = img.visual_files[0];
                 return (
                   <tr key={img.id}>
+                    <td className="text-center align-middle">
+                      <Form.Check
+                        checked={checkedImages[img.id] || false}
+                        onChange={(e) => handleCheck(e.currentTarget.checked, img.id)}
+                      />
+                    </td>
                     <td>
                       <img
                         src={img.paths.thumbnail || ""}
@@ -137,6 +190,18 @@ const ImageDuplicateChecker: React.FC = () => {
   return (
     <div className="container-fluid py-4">
       <ImageDuplicateCheckerSection>
+        {deletingImages && selectedImages && (
+          <DeleteImagesDialog
+            selected={selectedImages}
+            onClose={onDeleteDialogClosed}
+          />
+        )}
+        {editingImages && selectedImages && (
+          <EditImagesDialog
+            selected={selectedImages}
+            onClose={onEditDialogClosed}
+          />
+        )}
         <Row className="mb-4">
           <Col>
             <h3>
@@ -188,6 +253,40 @@ const ImageDuplicateChecker: React.FC = () => {
         {hasSearched && !loading && !error && allGroups.length === 0 && (
           <div className="text-center py-5 border rounded bg-light">
             <p className="mb-0">No duplicates found with the current distance.</p>
+          </div>
+        )}
+
+        {hasSearched && !loading && !error && allGroups.length > 0 && (
+          <div className="d-flex mb-3 align-items-center">
+            <h6 className="me-auto mb-0">
+              Found {allGroups.length} duplicate groups
+            </h6>
+            {checkCount > 0 && (
+              <ButtonGroup>
+                <OverlayTrigger
+                  overlay={
+                    <Tooltip id="edit">
+                      {intl.formatMessage({ id: "actions.edit" })}
+                    </Tooltip>
+                  }
+                >
+                  <Button variant="secondary" onClick={onEdit}>
+                    <Icon icon={faPencilAlt} />
+                  </Button>
+                </OverlayTrigger>
+                <OverlayTrigger
+                  overlay={
+                    <Tooltip id="delete">
+                      {intl.formatMessage({ id: "actions.delete" })}
+                    </Tooltip>
+                  }
+                >
+                  <Button variant="danger" onClick={handleDeleteChecked}>
+                    <Icon icon={faTrash} />
+                  </Button>
+                </OverlayTrigger>
+              </ButtonGroup>
+            )}
           </div>
         )}
 

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -86,7 +86,7 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const { data, loading, refetch } = useFindDuplicateImagesQuery({
     variables: { distance: hashDistance },
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
   });
 
   const getGroupTotalSize = (group: GQL.SlimImageDataFragment[]) => {
@@ -101,8 +101,14 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const allGroups = useMemo(() => {
     const groups = data?.findDuplicateImages ?? [];
+    
+    const groupSizes = new Map<GQL.SlimImageDataFragment[], number>();
+    groups.forEach((group) => {
+      groupSizes.set(group, getGroupTotalSize(group));
+    });
+
     return [...groups].sort((a, b) => {
-      return getGroupTotalSize(b) - getGroupTotalSize(a);
+      return (groupSizes.get(b) ?? 0) - (groupSizes.get(a) ?? 0);
     });
   }, [data?.findDuplicateImages]);
 

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -1,21 +1,40 @@
-import React, { useState } from "react";
-import { Button, Form, Spinner } from "react-bootstrap";
-import { FormattedMessage } from "react-intl";
+import React, { useMemo, useState } from "react";
+import {
+  Button,
+  Form,
+  Spinner,
+  Table,
+  Row,
+  Col,
+  Card,
+} from "react-bootstrap";
+import { FormattedMessage, useIntl } from "react-intl";
 import { useFindDuplicateImagesQuery } from "src/core/generated-graphql";
+import * as GQL from "src/core/generated-graphql";
 import { PatchContainerComponent } from "src/patch";
+import { LoadingIndicator } from "../Shared/LoadingIndicator";
+import { ErrorMessage } from "../Shared/ErrorMessage";
+import { FileSize } from "../Shared/FileSize";
+import { Pagination } from "src/components/List/Pagination";
+import { useHistory } from "react-router-dom";
 
 const ImageDuplicateCheckerSection = PatchContainerComponent(
   "ImageDuplicateCheckerSection"
 );
 
 const ImageDuplicateChecker: React.FC = () => {
-  const [distance, setDistance] = useState(0);
+  const intl = useIntl();
+  const history = useHistory();
+  const query = new URLSearchParams(history.location.search);
+  const currentPage = Number.parseInt(query.get("page") ?? "1", 10);
+  const pageSize = Number.parseInt(query.get("size") ?? "20", 10);
+  const hashDistance = Number.parseInt(query.get("distance") ?? "0", 10);
+
   const [isSearching, setIsSearching] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
 
-  // We lazily fetch the query only when "Search" is clicked
   const { data, loading, error, refetch } = useFindDuplicateImagesQuery({
-    variables: { distance },
+    variables: { distance: hashDistance },
     skip: !hasSearched,
     fetchPolicy: "network-only",
   });
@@ -23,90 +42,171 @@ const ImageDuplicateChecker: React.FC = () => {
   const handleSearch = () => {
     setIsSearching(true);
     setHasSearched(true);
-    refetch({ distance }).finally(() => setIsSearching(false));
+    refetch({ distance: hashDistance }).finally(() => setIsSearching(false));
   };
 
-  const results = data?.findDuplicateImages ?? [];
+  const getGroupTotalSize = (group: GQL.ImageDataFragment[]) => {
+    return group.reduce((groupTotal, img) => {
+      const imgTotal = img.visual_files.reduce(
+        (fileTotal, file) => fileTotal + (file.size ?? 0),
+        0
+      );
+      return groupTotal + imgTotal;
+    }, 0);
+  };
 
-  return (
-    <div className="row image-duplicate-checker">
-      <div className="col-md-12">
-        <ImageDuplicateCheckerSection>
-          <h3>
-            <FormattedMessage id="config.tools.image_duplicate_checker" />
-          </h3>
-          <Form className="d-flex align-items-end mb-4">
-            <Form.Group controlId="distanceInput" className="mb-0 me-3">
-              <Form.Label>PHash Distance</Form.Label>
-              <Form.Control
-                type="number"
-                value={distance}
-                min={0}
-                max={10}
-                onChange={(e) => setDistance(parseInt(e.target.value) || 0)}
-              />
-              <Form.Text className="text-muted">
-                Distance 0 means exact matches.
-              </Form.Text>
-            </Form.Group>
+  const allGroups = useMemo(() => {
+    const groups = data?.findDuplicateImages ?? [];
+    return [...groups].sort((a, b) => {
+      return getGroupTotalSize(b) - getGroupTotalSize(a);
+    });
+  }, [data?.findDuplicateImages]);
 
-            <Button
-              variant="primary"
-              onClick={handleSearch}
-              disabled={isSearching || loading}
-            >
-              {isSearching || loading ? (
-                <Spinner animation="border" size="sm" />
-              ) : (
-                "Search"
-              )}
-            </Button>
-          </Form>
+  const pagedGroups = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return allGroups.slice(start, start + pageSize);
+  }, [allGroups, currentPage, pageSize]);
 
-          {error && (
-            <div className="text-danger mb-4">Error: {error.message}</div>
-          )}
+  if (error) return <ErrorMessage error={error.message} />;
 
-          {hasSearched && !loading && !error && results.length === 0 && (
-            <p>No duplicates found.</p>
-          )}
-
-          {results.map((group, index) => {
-            if (!group || group.length < 2) return null;
-            return (
-              <div
-                key={index}
-                className="duplicate-group mb-4 pb-4 border-bottom"
-              >
-                <h5>Group {index + 1}</h5>
-                {/* ImageList requires an array of items with proper types. We map it nicely. */}
-                <div className="d-flex flex-wrap gap-3">
-                  {group.map((img) => (
-                    <div key={img.id} className="border p-2 rounded">
+  const renderGroup = (group: GQL.ImageDataFragment[], index: number) => {
+    const groupIndex = (currentPage - 1) * pageSize + index + 1;
+    return (
+      <Card key={groupIndex} className="mb-4">
+        <Card.Header className="d-flex justify-content-between align-items-center">
+          <h5>Group {groupIndex}</h5>
+          <span className="text-muted">
+            Total Size: <FileSize size={getGroupTotalSize(group)} />
+          </span>
+        </Card.Header>
+        <Card.Body>
+          <Table striped bordered hover responsive size="sm">
+            <thead>
+              <tr>
+                <th style={{ width: "150px" }}>Image</th>
+                <th>Details</th>
+                <th style={{ width: "120px" }}>Size</th>
+                <th style={{ width: "150px" }}>Dimensions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.map((img) => {
+                const file = img.visual_files[0];
+                return (
+                  <tr key={img.id}>
+                    <td>
                       <img
                         src={img.paths.thumbnail || ""}
                         alt={img.title || img.id}
                         style={{
-                          maxWidth: "200px",
-                          maxHeight: "200px",
+                          maxWidth: "120px",
+                          maxHeight: "120px",
                           objectFit: "contain",
                         }}
                       />
-                      <div
-                        className="mt-2 text-center text-truncate"
-                        style={{ maxWidth: "200px" }}
-                        title={img.title || img.id}
-                      >
-                        {img.title || img.id}
+                    </td>
+                    <td>
+                      <div className="fw-bold">{img.title || "(No Title)"}</div>
+                      <div className="text-muted small text-truncate" style={{ maxWidth: "400px" }}>
+                        {img.visual_files[0]?.path}
                       </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </ImageDuplicateCheckerSection>
-      </div>
+                      <div className="mt-1 small">ID: {img.id}</div>
+                    </td>
+                    <td>
+                      <FileSize size={file?.size ?? 0} />
+                    </td>
+                    <td>
+                      {file?.__typename === "ImageFile" || file?.__typename === "VideoFile" ? (
+                        <>
+                          {file.width} x {file.height}
+                        </>
+                      ) : (
+                        "N/A"
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </Card.Body>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <ImageDuplicateCheckerSection>
+        <Row className="mb-4">
+          <Col>
+            <h3>
+              <FormattedMessage id="config.tools.image_duplicate_checker" />
+            </h3>
+          </Col>
+        </Row>
+
+        <Form className="bg-light p-3 rounded mb-4 shadow-sm">
+          <Row className="align-items-end">
+            <Col md={3}>
+              <Form.Group controlId="distanceInput">
+                <Form.Label>PHash Distance</Form.Label>
+                <Form.Control
+                  type="number"
+                  value={hashDistance}
+                  min={0}
+                  max={10}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value) || 0;
+                    query.set("distance", val.toString());
+                    history.push({ search: query.toString() });
+                  }}
+                />
+                <Form.Text className="text-muted small">
+                  0 = exact matches.
+                </Form.Text>
+              </Form.Group>
+            </Col>
+            <Col md={2}>
+              <Button
+                variant="primary"
+                className="w-100"
+                onClick={handleSearch}
+                disabled={isSearching || loading}
+              >
+                {isSearching || loading ? (
+                  <Spinner animation="border" size="sm" />
+                ) : (
+                  "Search"
+                )}
+              </Button>
+            </Col>
+          </Row>
+        </Form>
+
+        {loading && <LoadingIndicator />}
+
+        {hasSearched && !loading && !error && allGroups.length === 0 && (
+          <div className="text-center py-5 border rounded bg-light">
+            <p className="mb-0">No duplicates found with the current distance.</p>
+          </div>
+        )}
+
+        {pagedGroups.map((group, index) => renderGroup(group, index))}
+
+        {allGroups.length > pageSize && (
+          <div className="d-flex justify-content-center mt-4">
+            <Pagination
+              currentPage={currentPage}
+              totalItems={allGroups.length}
+              pageSize={pageSize}
+              onChangePage={(page) => {
+                query.set("page", page.toString());
+                history.push({ search: query.toString() });
+              }}
+            />
+          </div>
+        )}
+      </ImageDuplicateCheckerSection>
     </div>
   );
 };

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -2,28 +2,40 @@ import React, { useMemo, useState } from "react";
 import {
   Button,
   Form,
-  Spinner,
   Table,
   Row,
   Col,
   Card,
+  Dropdown,
   ButtonGroup,
   OverlayTrigger,
   Tooltip,
 } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Link, useHistory } from "react-router-dom";
+import TextUtils from "src/utils/text";
+import { HoverPopover } from "../Shared/HoverPopover";
+import { TagLink, GalleryLink } from "../Shared/TagLink";
+import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
+import {
+  faFileAlt,
+  faImages,
+  faTag,
+  faBox,
+  faExclamationTriangle,
+  faPencilAlt,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import { useFindDuplicateImagesQuery } from "src/core/generated-graphql";
 import * as GQL from "src/core/generated-graphql";
 import { PatchContainerComponent } from "src/patch";
-import { LoadingIndicator } from "../Shared/LoadingIndicator";
-import { ErrorMessage } from "../Shared/ErrorMessage";
 import { FileSize } from "../Shared/FileSize";
 import { Pagination } from "src/components/List/Pagination";
-import { useHistory } from "react-router-dom";
 import { DeleteImagesDialog } from "../Images/DeleteImagesDialog";
 import { EditImagesDialog } from "../Images/EditImagesDialog";
 import { Icon } from "../Shared/Icon";
-import { faPencilAlt, faTrash } from "@fortawesome/free-solid-svg-icons";
+
+const CLASSNAME = "duplicate-checker";
 
 const ImageDuplicateCheckerSection = PatchContainerComponent(
   "ImageDuplicateCheckerSection"
@@ -37,8 +49,7 @@ const ImageDuplicateChecker: React.FC = () => {
   const pageSize = Number.parseInt(query.get("size") ?? "20", 10);
   const hashDistance = Number.parseInt(query.get("distance") ?? "0", 10);
 
-  const [isSearching, setIsSearching] = useState(false);
-  const [hasSearched, setHasSearched] = useState(false);
+  const [currentPageSize, setCurrentPageSize] = useState(pageSize);
   const [checkedImages, setCheckedImages] = useState<Record<string, boolean>>(
     {}
   );
@@ -47,18 +58,36 @@ const ImageDuplicateChecker: React.FC = () => {
   const [deletingImages, setDeletingImages] = useState(false);
   const [editingImages, setEditingImages] = useState(false);
 
-  const { data, loading, error, refetch } = useFindDuplicateImagesQuery({
-    variables: { distance: hashDistance },
-    skip: !hasSearched,
-    fetchPolicy: "network-only",
+  const { data: missingPhash } = GQL.useFindImagesQuery({
+    variables: {
+      filter: {
+        per_page: 0,
+      },
+      image_filter: {
+        is_missing: "phash",
+      },
+    },
   });
 
-  const handleSearch = () => {
-    setIsSearching(true);
-    setHasSearched(true);
-    setCheckedImages({});
-    refetch({ distance: hashDistance }).finally(() => setIsSearching(false));
-  };
+  function maybeRenderMissingPhashWarning() {
+    const missingPhashes = missingPhash?.findImages.count ?? 0;
+    if (missingPhashes > 0) {
+      return (
+        <p className="lead">
+          <Icon icon={faExclamationTriangle} className="text-warning" />
+          <FormattedMessage
+            id="dupe_check.missing_phash_warning"
+            values={{ count: missingPhashes }}
+          />
+        </p>
+      );
+    }
+  }
+
+  const { data, loading, refetch } = useFindDuplicateImagesQuery({
+    variables: { distance: hashDistance },
+    fetchPolicy: "network-only",
+  });
 
   const getGroupTotalSize = (group: GQL.ImageDataFragment[]) => {
     return group.reduce((groupTotal, img) => {
@@ -118,208 +147,551 @@ const ImageDuplicateChecker: React.FC = () => {
     }
   };
 
-  if (error) return <ErrorMessage error={error.message} />;
+  const pageOptions = useMemo(() => {
+    const pageSizes = [
+      10, 20, 30, 40, 50, 100, 150, 200, 250, 500, 750, 1000, 1250, 1500,
+    ];
 
-  const renderGroup = (group: GQL.ImageDataFragment[], index: number) => {
-    const groupIndex = (currentPage - 1) * pageSize + index + 1;
-    return (
-      <Card key={groupIndex} className="mb-4">
-        <Card.Header className="d-flex justify-content-between align-items-center">
-          <h5>Group {groupIndex}</h5>
-          <span className="text-muted">
-            Total Size: <FileSize size={getGroupTotalSize(group)} />
-          </span>
-        </Card.Header>
-        <Card.Body>
-          <Table striped bordered hover responsive size="sm">
-            <thead>
-              <tr>
-                <th style={{ width: "40px" }}></th>
-                <th style={{ width: "150px" }}>Image</th>
-                <th>Details</th>
-                <th style={{ width: "120px" }}>Size</th>
-                <th style={{ width: "150px" }}>Dimensions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {group.map((img) => {
-                const file = img.visual_files[0];
-                return (
-                  <tr key={img.id}>
-                    <td className="text-center align-middle">
-                      <Form.Check
-                        checked={checkedImages[img.id] || false}
-                        onChange={(e) =>
-                          handleCheck(e.currentTarget.checked, img.id)
-                        }
-                      />
-                    </td>
-                    <td>
-                      <img
-                        src={img.paths.thumbnail || ""}
-                        alt={img.title || img.id}
-                        style={{
-                          maxWidth: "120px",
-                          maxHeight: "120px",
-                          objectFit: "contain",
-                        }}
-                      />
-                    </td>
-                    <td>
-                      <div className="fw-bold">{img.title || "(No Title)"}</div>
-                      <div
-                        className="text-muted small text-truncate"
-                        style={{ maxWidth: "400px" }}
-                      >
-                        {img.visual_files[0]?.path}
-                      </div>
-                      <div className="mt-1 small">ID: {img.id}</div>
-                    </td>
-                    <td>
-                      <FileSize size={file?.size ?? 0} />
-                    </td>
-                    <td>
-                      {file?.__typename === "ImageFile" ||
-                      file?.__typename === "VideoFile" ? (
-                        <>
-                          {file.width} x {file.height}
-                        </>
-                      ) : (
-                        "N/A"
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </Table>
-        </Card.Body>
-      </Card>
+    const filteredSizes = pageSizes.filter((s, i) => {
+      return (
+        allGroups.length > s || i == 0 || allGroups.length > pageSizes[i - 1]
+      );
+    });
+
+    return filteredSizes.map((size) => {
+      return (
+        <option key={size} value={size}>
+          {size}
+        </option>
+      );
+    });
+  }, [allGroups.length]);
+
+  const setQuery = (q: Record<string, string | number | undefined>) => {
+    const newQuery = new URLSearchParams(query);
+    for (const key of Object.keys(q)) {
+      const value = q[key];
+      if (value !== undefined) {
+        newQuery.set(key, String(value));
+      } else {
+        newQuery.delete(key);
+      }
+    }
+    history.push({ search: newQuery.toString() });
+  };
+
+  const resetCheckboxSelection = () => {
+    const updatedImages: Record<string, boolean> = {};
+    Object.keys(checkedImages).forEach((imageKey) => {
+      updatedImages[imageKey] = false;
+    });
+    setCheckedImages(updatedImages);
+  };
+
+  const findLargestImage = (group: GQL.ImageDataFragment[]) => {
+    const totalSize = (image: GQL.ImageDataFragment) => {
+      return image.visual_files.reduce(
+        (prev: number, f) => Math.max(prev, f.size ?? 0),
+        0
+      );
+    };
+    return group.reduce((largest, image) => {
+      const largestSize = totalSize(largest);
+      const currentSize = totalSize(image);
+      return currentSize > largestSize ? image : largest;
+    });
+  };
+
+  const findLargestResolutionImage = (group: GQL.ImageDataFragment[]) => {
+    const imgResolution = (image: GQL.ImageDataFragment) => {
+      return image.visual_files.reduce(
+        (prev: number, f) => Math.max(prev, (f.height ?? 0) * (f.width ?? 0)),
+        0
+      );
+    };
+    return group.reduce((largest, image) => {
+      const largestSize = imgResolution(largest);
+      const currentSize = imgResolution(image);
+      return currentSize > largestSize ? image : largest;
+    });
+  };
+
+  const findFirstFileByAge = (
+    oldest: boolean,
+    compareImages: GQL.ImageDataFragment[]
+  ) => {
+    let selectedFile: GQL.ImageFileDataFragment | GQL.VideoFileDataFragment;
+    let oldestTimestamp: Date | undefined = undefined;
+
+    for (const file of compareImages.flatMap((s) => s.visual_files)) {
+      const timestamp: Date = new Date(file.mod_time);
+      if (oldest) {
+        if (oldestTimestamp === undefined || timestamp < oldestTimestamp) {
+          oldestTimestamp = timestamp;
+          selectedFile = file;
+        }
+      } else {
+        if (oldestTimestamp === undefined || timestamp > oldestTimestamp) {
+          oldestTimestamp = timestamp;
+          selectedFile = file;
+        }
+      }
+    }
+
+    return compareImages.find((s) =>
+      s.visual_files.some((f) => f.id === selectedFile?.id)
     );
   };
 
-  return (
-    <div className="container-fluid py-4">
-      <ImageDuplicateCheckerSection>
-        {deletingImages && selectedImages && (
-          <DeleteImagesDialog
-            selected={selectedImages}
-            onClose={onDeleteDialogClosed}
-          />
-        )}
-        {editingImages && selectedImages && (
-          <EditImagesDialog
-            selected={selectedImages}
-            onClose={onEditDialogClosed}
-          />
-        )}
-        <Row className="mb-4">
-          <Col>
-            <h3>
-              <FormattedMessage id="config.tools.image_duplicate_checker" />
-            </h3>
-          </Col>
-        </Row>
+  function checkSameResolution(dataGroup: GQL.ImageDataFragment[]) {
+    const resolutions = dataGroup.map(
+      (s) => (s.visual_files[0]?.width ?? 0) * (s.visual_files[0]?.height ?? 0)
+    );
+    return new Set(resolutions).size === 1;
+  }
 
-        <Form className="bg-light p-3 rounded mb-4 shadow-sm">
-          <Row className="align-items-end">
-            <Col md={3}>
-              <Form.Group controlId="distanceInput">
-                <Form.Label>PHash Distance</Form.Label>
-                <Form.Control
-                  type="number"
-                  value={hashDistance}
-                  min={0}
-                  max={10}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value) || 0;
-                    query.set("distance", val.toString());
-                    history.push({ search: query.toString() });
+  const onSelectLargestClick = () => {
+    setSelectedImages([]);
+    const checkedArray: Record<string, boolean> = {};
+
+    pagedGroups.forEach((group) => {
+      const largest = findLargestImage(group);
+      group.forEach((image) => {
+        if (image !== largest) {
+          checkedArray[image.id] = true;
+        }
+      });
+    });
+
+    setCheckedImages(checkedArray);
+  };
+
+  const onSelectLargestResolutionClick = () => {
+    setSelectedImages([]);
+    const checkedArray: Record<string, boolean> = {};
+
+    pagedGroups.forEach((group) => {
+      if (checkSameResolution(group)) return;
+
+      const highest = findLargestResolutionImage(group);
+      group.forEach((image) => {
+        if (image !== highest) {
+          checkedArray[image.id] = true;
+        }
+      });
+    });
+
+    setCheckedImages(checkedArray);
+  };
+
+  const onSelectByAge = (oldest: boolean) => {
+    setSelectedImages([]);
+    const checkedArray: Record<string, boolean> = {};
+
+    pagedGroups.forEach((group) => {
+      const oldestScene = findFirstFileByAge(oldest, group);
+      group.forEach((image) => {
+        if (image !== oldestScene) {
+          checkedArray[image.id] = true;
+        }
+      });
+    });
+
+    setCheckedImages(checkedArray);
+  };
+
+  const handleDeleteImage = (image: GQL.ImageDataFragment) => {
+    setSelectedImages([image]);
+    setDeletingImages(true);
+  };
+
+  function renderPagination() {
+    return (
+      <div className="d-flex mt-2 mb-2">
+        <h6 className="mr-auto align-self-center">
+          <FormattedMessage
+            id="dupe_check.found_sets"
+            values={{ setCount: allGroups.length }}
+          />
+        </h6>
+        {checkCount > 0 && (
+          <ButtonGroup>
+            <OverlayTrigger
+              overlay={
+                <Tooltip id="edit">
+                  {intl.formatMessage({ id: "actions.edit" })}
+                </Tooltip>
+              }
+            >
+              <Button variant="secondary" onClick={onEdit}>
+                <Icon icon={faPencilAlt} />
+              </Button>
+            </OverlayTrigger>
+            <OverlayTrigger
+              overlay={
+                <Tooltip id="delete">
+                  {intl.formatMessage({ id: "actions.delete" })}
+                </Tooltip>
+              }
+            >
+              <Button variant="danger" onClick={handleDeleteChecked}>
+                <Icon icon={faTrash} />
+              </Button>
+            </OverlayTrigger>
+          </ButtonGroup>
+        )}
+        <Pagination
+          itemsPerPage={pageSize}
+          currentPage={currentPage}
+          totalItems={allGroups.length}
+          metadataByline={[]}
+          onChangePage={(newPage) => {
+            setQuery({ page: newPage === 1 ? undefined : newPage });
+            resetCheckboxSelection();
+          }}
+        />
+        <Form.Control
+          as="select"
+          className="w-auto ml-2 btn-secondary"
+          defaultValue={pageSize}
+          value={currentPageSize}
+          onChange={(e) => {
+            setCurrentPageSize(parseInt(e.currentTarget.value, 10));
+            setQuery({
+              size:
+                e.currentTarget.value === "20"
+                  ? undefined
+                  : e.currentTarget.value,
+            });
+            resetCheckboxSelection();
+          }}
+        >
+          {pageOptions}
+        </Form.Control>
+      </div>
+    );
+  }
+
+  function maybeRenderPopoverButtonGroup(image: GQL.ImageDataFragment) {
+    if (
+      image.tags.length > 0 ||
+      image.performers.length > 0 ||
+      image.galleries.length > 0 ||
+      image.visual_files.length > 1 ||
+      image.organized
+    ) {
+      return (
+        <ButtonGroup className="flex-wrap">
+          {image.tags.length > 0 && (
+            <HoverPopover
+              placement="bottom"
+              content={image.tags.map((tag) => (
+                <TagLink key={tag.id} tag={tag} />
+              ))}
+            >
+              <Button className="minimal">
+                <Icon icon={faTag} />
+                <span>{image.tags.length}</span>
+              </Button>
+            </HoverPopover>
+          )}
+          {image.performers.length > 0 && (
+            <PerformerPopoverButton performers={image.performers} />
+          )}
+          {image.galleries.length > 0 && (
+            <HoverPopover
+              placement="bottom"
+              content={image.galleries.map((g) => (
+                <GalleryLink key={g.id} gallery={g} />
+              ))}
+            >
+              <Button className="minimal">
+                <Icon icon={faImages} />
+                <span>{image.galleries.length}</span>
+              </Button>
+            </HoverPopover>
+          )}
+          {image.visual_files.length > 1 && (
+            <HoverPopover
+              placement="bottom"
+              content={
+                <FormattedMessage
+                  id="files_amount"
+                  values={{
+                    value: intl.formatNumber(image.visual_files.length),
                   }}
                 />
-                <Form.Text className="text-muted small">
-                  0 = exact matches.
-                </Form.Text>
-              </Form.Group>
-            </Col>
-            <Col md={2}>
-              <Button
-                variant="primary"
-                className="w-100"
-                onClick={handleSearch}
-                disabled={isSearching || loading}
-              >
-                {isSearching || loading ? (
-                  <Spinner animation="border" size="sm" />
-                ) : (
-                  "Search"
-                )}
+              }
+            >
+              <Button className="minimal">
+                <Icon icon={faFileAlt} />
+                <span>{image.visual_files.length}</span>
               </Button>
-            </Col>
-          </Row>
-        </Form>
+            </HoverPopover>
+          )}
+          {image.organized && (
+            <div>
+              <Button className="minimal">
+                <Icon icon={faBox} />
+              </Button>
+            </div>
+          )}
+        </ButtonGroup>
+      );
+    }
+  }
 
-        {loading && <LoadingIndicator />}
-
-        {hasSearched && !loading && !error && allGroups.length === 0 && (
-          <div className="text-center py-5 border rounded bg-light">
-            <p className="mb-0">
-              No duplicates found with the current distance.
-            </p>
-          </div>
-        )}
-
-        {hasSearched && !loading && !error && allGroups.length > 0 && (
-          <div className="d-flex mb-3 align-items-center">
-            <h6 className="me-auto mb-0">
-              Found {allGroups.length} duplicate groups
-            </h6>
-            {checkCount > 0 && (
-              <ButtonGroup>
-                <OverlayTrigger
-                  overlay={
-                    <Tooltip id="edit">
-                      {intl.formatMessage({ id: "actions.edit" })}
-                    </Tooltip>
-                  }
-                >
-                  <Button variant="secondary" onClick={onEdit}>
-                    <Icon icon={faPencilAlt} />
-                  </Button>
-                </OverlayTrigger>
-                <OverlayTrigger
-                  overlay={
-                    <Tooltip id="delete">
-                      {intl.formatMessage({ id: "actions.delete" })}
-                    </Tooltip>
-                  }
-                >
-                  <Button variant="danger" onClick={handleDeleteChecked}>
-                    <Icon icon={faTrash} />
-                  </Button>
-                </OverlayTrigger>
-              </ButtonGroup>
-            )}
-          </div>
-        )}
-
-        {pagedGroups.map((group, index) => renderGroup(group, index))}
-
-        {allGroups.length > pageSize && (
-          <div className="d-flex justify-content-center mt-4">
-            <Pagination
-              currentPage={currentPage}
-              totalItems={allGroups.length}
-              itemsPerPage={pageSize}
-              onChangePage={(page) => {
-                query.set("page", page.toString());
-                history.push({ search: query.toString() });
-              }}
+  return (
+    <Card id="image-duplicate-checker" className="col col-xl-12 mx-auto">
+      <div className={CLASSNAME}>
+        <ImageDuplicateCheckerSection>
+          {deletingImages && selectedImages && (
+            <DeleteImagesDialog
+              selected={selectedImages}
+              onClose={onDeleteDialogClosed}
             />
-          </div>
-        )}
-      </ImageDuplicateCheckerSection>
-    </div>
+          )}
+          {editingImages && selectedImages && (
+            <EditImagesDialog
+              selected={selectedImages}
+              onClose={onEditDialogClosed}
+            />
+          )}
+
+          <h4>
+            <FormattedMessage id="config.tools.image_duplicate_checker" />
+          </h4>
+
+          <Form>
+            <Form.Group>
+              <Row noGutters>
+                <Form.Label>
+                  <FormattedMessage id="dupe_check.search_accuracy_label" />
+                </Form.Label>
+                <Col xs="auto">
+                  <Form.Control
+                    as="select"
+                    onChange={(e) =>
+                      setQuery({
+                        distance:
+                          e.currentTarget.value === "0"
+                            ? undefined
+                            : e.currentTarget.value,
+                        page: undefined,
+                      })
+                    }
+                    defaultValue={hashDistance}
+                    className="input-control ml-4"
+                  >
+                    <option value={0}>
+                      {intl.formatMessage({ id: "dupe_check.options.exact" })}
+                    </option>
+                    <option value={4}>
+                      {intl.formatMessage({ id: "dupe_check.options.high" })}
+                    </option>
+                    <option value={8}>
+                      {intl.formatMessage({ id: "dupe_check.options.medium" })}
+                    </option>
+                    <option value={10}>
+                      {intl.formatMessage({ id: "dupe_check.options.low" })}
+                    </option>
+                  </Form.Control>
+                </Col>
+              </Row>
+              <Form.Text>
+                <FormattedMessage id="dupe_check.description" />
+              </Form.Text>
+            </Form.Group>
+
+            <Form.Group>
+              <Row noGutters>
+                <Col xs="12">
+                  <Dropdown className="">
+                    <Dropdown.Toggle variant="secondary">
+                      <FormattedMessage id="dupe_check.select_options" />
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu className="bg-secondary text-white">
+                      <Dropdown.Item onClick={() => resetCheckboxSelection()}>
+                        {intl.formatMessage({ id: "dupe_check.select_none" })}
+                      </Dropdown.Item>
+
+                      <Dropdown.Item
+                        onClick={() => onSelectLargestResolutionClick()}
+                      >
+                        {intl.formatMessage({
+                          id: "dupe_check.select_all_but_largest_resolution",
+                        })}
+                      </Dropdown.Item>
+
+                      <Dropdown.Item onClick={() => onSelectLargestClick()}>
+                        {intl.formatMessage({
+                          id: "dupe_check.select_all_but_largest_file",
+                        })}
+                      </Dropdown.Item>
+
+                      <Dropdown.Item onClick={() => onSelectByAge(true)}>
+                        {intl.formatMessage({
+                          id: "dupe_check.select_oldest",
+                        })}
+                      </Dropdown.Item>
+
+                      <Dropdown.Item onClick={() => onSelectByAge(false)}>
+                        {intl.formatMessage({
+                          id: "dupe_check.select_youngest",
+                        })}
+                      </Dropdown.Item>
+                    </Dropdown.Menu>
+                  </Dropdown>
+                </Col>
+              </Row>
+            </Form.Group>
+          </Form>
+
+          {maybeRenderMissingPhashWarning()}
+          {renderPagination()}
+
+          <Table responsive striped className={`${CLASSNAME}-table`}>
+            <colgroup>
+              <col className={`${CLASSNAME}-checkbox`} />
+              <col className={`${CLASSNAME}-sprite`} />
+              <col className={`${CLASSNAME}-title`} />
+              <col className={`${CLASSNAME}-details`} />
+              <col className={`${CLASSNAME}-filesize`} />
+              <col className={`${CLASSNAME}-resolution`} />
+              <col className={`${CLASSNAME}-operations`} />
+            </colgroup>
+            <thead>
+              <tr>
+                <th> </th>
+                <th> </th>
+                <th>{intl.formatMessage({ id: "details" })}</th>
+                <th> </th>
+                <th>{intl.formatMessage({ id: "filesize" })}</th>
+                <th>{intl.formatMessage({ id: "resolution" })}</th>
+                <th>{intl.formatMessage({ id: "actions.delete" })}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pagedGroups.map((group, groupIndex) =>
+                group.map((image, i) => {
+                  const file = image.visual_files[0];
+
+                  return (
+                    <React.Fragment key={image.id}>
+                      {i === 0 && groupIndex !== 0 ? (
+                        <tr className="separator" />
+                      ) : undefined}
+                      <tr
+                        className={i === 0 ? "duplicate-group" : ""}
+                        key={image.id}
+                      >
+                        <td>
+                          <Form.Check
+                            checked={checkedImages[image.id] || false}
+                            onChange={(e) =>
+                              handleCheck(e.currentTarget.checked, image.id)
+                            }
+                          />
+                        </td>
+                        <td>
+                          <HoverPopover
+                            content={
+                              <img
+                                src={image.paths.thumbnail || ""}
+                                alt=""
+                                style={{
+                                  maxWidth: 600,
+                                  maxHeight: 600,
+                                  objectFit: "contain",
+                                }}
+                              />
+                            }
+                            placement="right"
+                          >
+                            <img
+                              src={image.paths.thumbnail || ""}
+                              alt=""
+                              style={{
+                                maxWidth: "120px",
+                                maxHeight: "120px",
+                                objectFit: "contain",
+                                border: checkedImages[image.id]
+                                  ? "2px solid red"
+                                  : "",
+                              }}
+                            />
+                          </HoverPopover>
+                        </td>
+                        <td className="text-left">
+                          <p>
+                            <Link
+                              to={`/images/${image.id}`}
+                              style={{
+                                fontWeight: checkedImages[image.id]
+                                  ? "bold"
+                                  : "inherit",
+                                textDecoration: checkedImages[image.id]
+                                  ? "line-through 3px"
+                                  : "inherit",
+                                textDecorationColor: checkedImages[image.id]
+                                  ? "red"
+                                  : "inherit",
+                              }}
+                            >
+                              {image.title ||
+                                TextUtils.fileNameFromPath(file?.path ?? "")}
+                            </Link>
+                          </p>
+                          <p className="scene-path">{file?.path ?? ""}</p>
+                        </td>
+                        <td className="scene-details">
+                          {maybeRenderPopoverButtonGroup(image)}
+                        </td>
+                        <td>
+                          <FileSize size={file?.size ?? 0} />
+                        </td>
+                        <td>
+                          {file?.__typename === "ImageFile" ||
+                          file?.__typename === "VideoFile" ? (
+                            <>
+                              {file.width ?? 0}x{file.height ?? 0}
+                            </>
+                          ) : (
+                            "N/A"
+                          )}
+                        </td>
+                        <td>
+                          <Button
+                            className="edit-button"
+                            variant="danger"
+                            onClick={() => handleDeleteImage(image)}
+                          >
+                            <FormattedMessage id="actions.delete" />
+                          </Button>
+                        </td>
+                      </tr>
+                    </React.Fragment>
+                  );
+                })
+              )}
+            </tbody>
+          </Table>
+
+          {allGroups.length === 0 && !loading && (
+            <h4 className="text-center mt-4">No duplicates found.</h4>
+          )}
+
+          {loading && (
+            <div className="text-center mt-4">
+              <Icon icon={faBox} spin className="fa-3x" />
+              <h4 className="mt-2">Loading...</h4>
+            </div>
+          )}
+
+          {renderPagination()}
+        </ImageDuplicateCheckerSection>
+      </div>
+    </Card>
   );
 };
 

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import { Button, Form, Spinner } from "react-bootstrap";
+import { FormattedMessage } from "react-intl";
+import { useFindDuplicateImagesQuery } from "src/core/generated-graphql";
+import { PatchContainerComponent } from "src/patch";
+
+const ImageDuplicateCheckerSection = PatchContainerComponent(
+  "ImageDuplicateCheckerSection"
+);
+
+const ImageDuplicateChecker: React.FC = () => {
+  const [distance, setDistance] = useState(0);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  // We lazily fetch the query only when "Search" is clicked
+  const { data, loading, error, refetch } = useFindDuplicateImagesQuery({
+    variables: { distance },
+    skip: !hasSearched,
+    fetchPolicy: "network-only",
+  });
+
+  const handleSearch = () => {
+    setIsSearching(true);
+    setHasSearched(true);
+    refetch({ distance }).finally(() => setIsSearching(false));
+  };
+
+  const results = data?.findDuplicateImages ?? [];
+
+  return (
+    <div className="row image-duplicate-checker">
+      <div className="col-md-12">
+        <ImageDuplicateCheckerSection>
+          <h3>
+            <FormattedMessage id="config.tools.image_duplicate_checker" />
+          </h3>
+          <Form className="d-flex align-items-end mb-4">
+            <Form.Group controlId="distanceInput" className="mb-0 me-3">
+              <Form.Label>PHash Distance</Form.Label>
+              <Form.Control
+                type="number"
+                value={distance}
+                min={0}
+                max={10}
+                onChange={(e) => setDistance(parseInt(e.target.value) || 0)}
+              />
+              <Form.Text className="text-muted">
+                Distance 0 means exact matches.
+              </Form.Text>
+            </Form.Group>
+
+            <Button
+              variant="primary"
+              onClick={handleSearch}
+              disabled={isSearching || loading}
+            >
+              {isSearching || loading ? (
+                <Spinner animation="border" size="sm" />
+              ) : (
+                "Search"
+              )}
+            </Button>
+          </Form>
+
+          {error && (
+            <div className="text-danger mb-4">Error: {error.message}</div>
+          )}
+
+          {hasSearched && !loading && !error && results.length === 0 && (
+            <p>No duplicates found.</p>
+          )}
+
+          {results.map((group, index) => {
+            if (!group || group.length < 2) return null;
+            return (
+              <div
+                key={index}
+                className="duplicate-group mb-4 pb-4 border-bottom"
+              >
+                <h5>Group {index + 1}</h5>
+                {/* ImageList requires an array of items with proper types. We map it nicely. */}
+                <div className="d-flex flex-wrap gap-3">
+                  {group.map((img) => (
+                    <div key={img.id} className="border p-2 rounded">
+                      <img
+                        src={img.paths.thumbnail || ""}
+                        alt={img.title || img.id}
+                        style={{
+                          maxWidth: "200px",
+                          maxHeight: "200px",
+                          objectFit: "contain",
+                        }}
+                      />
+                      <div
+                        className="mt-2 text-center text-truncate"
+                        style={{ maxWidth: "200px" }}
+                        title={img.title || img.id}
+                      >
+                        {img.title || img.id}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </ImageDuplicateCheckerSection>
+      </div>
+    </div>
+  );
+};
+
+export default ImageDuplicateChecker;

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -101,7 +101,7 @@ const ImageDuplicateChecker: React.FC = () => {
 
   const allGroups = useMemo(() => {
     const groups = data?.findDuplicateImages ?? [];
-    
+
     const groupSizes = new Map<GQL.SlimImageDataFragment[], number>();
     groups.forEach((group) => {
       groupSizes.set(group, getGroupTotalSize(group));

--- a/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/ImageDuplicateChecker/ImageDuplicateChecker.tsx
@@ -34,6 +34,8 @@ import { Pagination } from "src/components/List/Pagination";
 import { DeleteImagesDialog } from "../Images/DeleteImagesDialog";
 import { EditImagesDialog } from "../Images/EditImagesDialog";
 import { Icon } from "../Shared/Icon";
+import { LoadingIndicator } from "../Shared/LoadingIndicator";
+import { ErrorMessage } from "../Shared/ErrorMessage";
 
 const CLASSNAME = "duplicate-checker";
 
@@ -136,20 +138,20 @@ const ImageDuplicateChecker: React.FC = () => {
     setCheckedImages({});
   };
 
-  const onDeleteDialogClosed = (confirmed: boolean) => {
+  const onDeleteDialogClosed = async (confirmed: boolean) => {
     setDeletingImages(false);
     setSelectedImages(undefined);
     if (confirmed) {
       setCheckedImages({});
-      refetch();
+      await refetch();
     }
   };
 
-  const onEditDialogClosed = (applied: boolean) => {
+  const onEditDialogClosed = async (applied: boolean) => {
     setEditingImages(false);
     setSelectedImages(undefined);
     if (applied) {
-      refetch();
+      await refetch();
     }
   };
 
@@ -172,6 +174,9 @@ const ImageDuplicateChecker: React.FC = () => {
       );
     });
   }, [allGroups.length]);
+
+  if (loading) return <LoadingIndicator />;
+  if (!data) return <ErrorMessage error="Error searching for duplicates." />;
 
   const setQuery = (q: Record<string, string | number | undefined>) => {
     const newQuery = new URLSearchParams(query);

--- a/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
@@ -61,11 +61,12 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
     try {
       await deleteImage();
       Toast.success(toastMessage);
+      props.onClose(true);
     } catch (e) {
       Toast.error(e);
+      props.onClose(false);
     }
     setIsDeleting(false);
-    props.onClose(true);
   }
 
   function maybeRenderDeleteFileAlert() {

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -92,9 +92,15 @@ export const SceneDuplicateChecker: React.FC = () => {
 
   const scenes = useMemo(() => {
     const groups = data?.findDuplicateScenes ?? [];
+    
+    const groupSizes = new Map<GQL.SlimSceneDataFragment[], number>();
+    groups.forEach((group) => {
+      groupSizes.set(group, getGroupTotalSize(group));
+    });
+
     // Sort by total file size descending (largest groups first)
     return [...groups].sort((a, b) => {
-      return getGroupTotalSize(b) - getGroupTotalSize(a);
+      return (groupSizes.get(b) ?? 0) - (groupSizes.get(a) ?? 0);
     });
   }, [data?.findDuplicateScenes]);
 

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -92,7 +92,7 @@ export const SceneDuplicateChecker: React.FC = () => {
 
   const scenes = useMemo(() => {
     const groups = data?.findDuplicateScenes ?? [];
-    
+
     const groupSizes = new Map<GQL.SlimSceneDataFragment[], number>();
     groups.forEach((group) => {
       groupSizes.set(group, getGroupTotalSize(group));

--- a/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsToolsPanel.tsx
@@ -48,6 +48,20 @@ export const SettingsToolsPanel: React.FC = () => {
           />
         </SettingsToolsSection>
       </SettingSection>
+
+      <SettingSection headingID="config.tools.image_tools">
+        <SettingsToolsSection>
+          <Setting
+            heading={
+              <Link to="/imageDuplicateChecker">
+                <Button>
+                  <FormattedMessage id="config.tools.image_duplicate_checker" />
+                </Button>
+              </Link>
+            }
+          />
+        </SettingsToolsSection>
+      </SettingSection>
     </>
   );
 };

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1136,12 +1136,12 @@
       "medium": "Medium"
     },
     "search_accuracy_label": "Search Accuracy",
-    "select_all_but_largest_file": "Select every file in each duplicated group, except the largest file",
-    "select_all_but_largest_resolution": "Select every file in each duplicated group, except the file with highest resolution",
+    "select_all_but_largest_file": "Keep the largest file (select all but the largest)",
+    "select_all_but_largest_resolution": "Keep the highest resolution file (select all but the highest resolution)",
     "select_none": "Select None",
-    "select_oldest": "Select the oldest file in the duplicate group",
+    "select_oldest": "Keep the oldest file (select all but the oldest)",
     "select_options": "Select Options…",
-    "select_youngest": "Select the youngest file in the duplicate group",
+    "select_youngest": "Keep the youngest file (select all but the youngest)",
     "title": "Duplicate Scenes"
   },
   "duplicated": "Duplicated",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -625,9 +625,9 @@
       "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata"
     },
     "tools": {
-      "graphql_playground": "GraphQL Playground",
+      "graphql_playground": "GraphQL playground",
       "heading": "Tools",
-      "scene_duplicate_checker": "Scene Duplicate Checker",
+      "scene_duplicate_checker": "Scene duplicate checker",
       "scene_filename_parser": {
         "add_field": "Add Field",
         "capitalize_title": "Capitalize title",
@@ -639,13 +639,13 @@
         "ignored_words": "Ignored words",
         "matches_with": "Matches with {i}",
         "select_parser_recipe": "Select Parser Recipe",
-        "title": "Scene Filename Parser",
+        "title": "Scene filename parser",
         "whitespace_chars": "Whitespace characters",
         "whitespace_chars_desc": "These characters will be replaced with whitespace in the title"
       },
       "scene_tools": "Scene Tools",
       "image_tools": "Image Tools",
-      "image_duplicate_checker": "Image Duplicate Checker"
+      "image_duplicate_checker": "Image duplicate checker"
     },
     "ui": {
       "abbreviate_counters": {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -625,9 +625,9 @@
       "set_name_date_details_from_metadata_if_present": "Set name, date, details from embedded file metadata"
     },
     "tools": {
-      "graphql_playground": "GraphQL playground",
+      "graphql_playground": "GraphQL Playground",
       "heading": "Tools",
-      "scene_duplicate_checker": "Scene duplicate checker",
+      "scene_duplicate_checker": "Scene Duplicate Checker",
       "scene_filename_parser": {
         "add_field": "Add Field",
         "capitalize_title": "Capitalize title",
@@ -639,7 +639,7 @@
         "ignored_words": "Ignored words",
         "matches_with": "Matches with {i}",
         "select_parser_recipe": "Select Parser Recipe",
-        "title": "Scene filename parser",
+        "title": "Scene Filename Parser",
         "whitespace_chars": "Whitespace characters",
         "whitespace_chars_desc": "These characters will be replaced with whitespace in the title"
       },
@@ -1120,6 +1120,7 @@
   "distance": "Distance",
   "donate": "Donate",
   "dupe_check": {
+    "missing_phash_warning": "Missing phashes for {count} images. Please run the phash generation task.",
     "description": "Levels below 'Exact' can take longer to calculate. False positives might also be returned on lower accuracy levels.",
     "duration_diff": "Maximum Duration Difference",
     "duration_options": {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -643,7 +643,9 @@
         "whitespace_chars": "Whitespace characters",
         "whitespace_chars_desc": "These characters will be replaced with whitespace in the title"
       },
-      "scene_tools": "Scene Tools"
+      "scene_tools": "Scene Tools",
+      "image_tools": "Image Tools",
+      "image_duplicate_checker": "Image Duplicate Checker"
     },
     "ui": {
       "abbreviate_counters": {

--- a/ui/v2.5/src/locales/en-US.json
+++ b/ui/v2.5/src/locales/en-US.json
@@ -9,7 +9,9 @@
         "tools": {
             "scene_filename_parser": {
                 "ignore_organized": "Ignore organized scenes"
-            }
+            },
+            "image_tools": "Image Tools",
+            "image_duplicate_checker": "Image Duplicate Checker"
         },
         "ui": {
             "custom_locales": {

--- a/ui/v2.5/src/locales/en-US.json
+++ b/ui/v2.5/src/locales/en-US.json
@@ -9,9 +9,7 @@
         "tools": {
             "scene_filename_parser": {
                 "ignore_organized": "Ignore organized scenes"
-            },
-            "image_tools": "Image Tools",
-            "image_duplicate_checker": "Image Duplicate Checker"
+            }
         },
         "ui": {
             "custom_locales": {


### PR DESCRIPTION
This pull request introduces a new tool to identify duplicate images based on their perceptual hash (phash). The implementation is based directly on the one used for video pHashes and leverages a shared utility to ensure consistency and performance across the codebase.

It includes:
- Unified backend implementation for phash distance comparison and grouping.
- GraphQL schema updates and API resolvers.
- Enhanced frontend UI with pagination, group sorting, and detailed image previews.
- Unit tests for the image search and duplicate detection logic.

Example screenshot:
<img width="1920" height="1080" alt="download" src="https://github.com/user-attachments/assets/166aac4a-a6db-4f85-9d0e-10b0c2b6ab1f" />
