### PR TITLE
fix: correct typos in GraphQL schema

### DIFF
--- a/graphql/schema/types/file.graphql
+++ b/graphql/schema/types/file.graphql
@@ -156,7 +156,7 @@ input MoveFilesInput {
 
 input SetFingerprintsInput {
   type: String!
-  "an null value will remove the fingerprint"
+  "a null value will remove the fingerprint"
   value: String
 }
 

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -152,7 +152,7 @@ input PerformerFilterType {
   fake_tits: StringCriterionInput
   "Filter by penis length value"
   penis_length: FloatCriterionInput
-  "Filter by ciricumcision"
+  "Filter by circumcision"
   circumcised: CircumcisionCriterionInput
   "Deprecated: use career_start and career_end. This filter is non-functional."
   career_length: StringCriterionInput
@@ -249,9 +249,9 @@ input SceneMarkerFilterType {
   updated_at: TimestampCriterionInput
   "Filter by scene date"
   scene_date: DateCriterionInput
-  "Filter by cscene reation time"
+  "Filter by scene creation time"
   scene_created_at: TimestampCriterionInput
-  "Filter by lscene ast update time"
+  "Filter by scene last update time"
   scene_updated_at: TimestampCriterionInput
   "Filter by related scenes that meet this criteria"
   scene_filter: SceneFilterType
@@ -665,7 +665,7 @@ input TagFilterType {
   "Filter by number of parent tags the tag has"
   parent_count: IntCriterionInput
 
-  "Filter by number f child tags the tag has"
+  "Filter by number of child tags the tag has"
   child_count: IntCriterionInput
 
   "Filter by autotag ignore value"

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -933,7 +933,7 @@ input GenderCriterionInput {
 }
 
 input CircumcisionCriterionInput {
-  value: [CircumisedEnum!]
+  value: [CircumcisedEnum!]
   modifier: CriterionModifier!
 }
 

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -7,7 +7,7 @@ enum GenderEnum {
   NON_BINARY
 }
 
-enum CircumisedEnum {
+enum CircumcisedEnum {
   CUT
   UNCUT
 }
@@ -29,7 +29,7 @@ type Performer {
   measurements: String
   fake_tits: String
   penis_length: Float
-  circumcised: CircumisedEnum
+  circumcised: CircumcisedEnum
   career_length: String @deprecated(reason: "Use career_start and career_end")
   career_start: Int
   career_end: Int
@@ -78,7 +78,7 @@ input PerformerCreateInput {
   measurements: String
   fake_tits: String
   penis_length: Float
-  circumcised: CircumisedEnum
+  circumcised: CircumcisedEnum
   career_length: String @deprecated(reason: "Use career_start and career_end")
   career_start: Int
   career_end: Int
@@ -119,7 +119,7 @@ input PerformerUpdateInput {
   measurements: String
   fake_tits: String
   penis_length: Float
-  circumcised: CircumisedEnum
+  circumcised: CircumcisedEnum
   career_length: String @deprecated(reason: "Use career_start and career_end")
   career_start: Int
   career_end: Int
@@ -165,7 +165,7 @@ input BulkPerformerUpdateInput {
   measurements: String
   fake_tits: String
   penis_length: Float
-  circumcised: CircumisedEnum
+  circumcised: CircumcisedEnum
   career_length: String @deprecated(reason: "Use career_start and career_end")
   career_start: Int
   career_end: Int

--- a/pkg/models/model_performer.go
+++ b/pkg/models/model_performer.go
@@ -6,26 +6,26 @@ import (
 )
 
 type Performer struct {
-	ID             int             `json:"id"`
-	Name           string          `json:"name"`
-	Disambiguation string          `json:"disambiguation"`
-	Gender         *GenderEnum     `json:"gender"`
-	Birthdate      *Date           `json:"birthdate"`
-	Ethnicity      string          `json:"ethnicity"`
-	Country        string          `json:"country"`
-	EyeColor       string          `json:"eye_color"`
-	Height         *int            `json:"height"`
-	Measurements   string          `json:"measurements"`
-	FakeTits       string          `json:"fake_tits"`
-	PenisLength    *float64        `json:"penis_length"`
+	ID             int              `json:"id"`
+	Name           string           `json:"name"`
+	Disambiguation string           `json:"disambiguation"`
+	Gender         *GenderEnum      `json:"gender"`
+	Birthdate      *Date            `json:"birthdate"`
+	Ethnicity      string           `json:"ethnicity"`
+	Country        string           `json:"country"`
+	EyeColor       string           `json:"eye_color"`
+	Height         *int             `json:"height"`
+	Measurements   string           `json:"measurements"`
+	FakeTits       string           `json:"fake_tits"`
+	PenisLength    *float64         `json:"penis_length"`
 	Circumcised    *CircumcisedEnum `json:"circumcised"`
-	CareerStart    *int            `json:"career_start"`
-	CareerEnd      *int            `json:"career_end"`
-	Tattoos        string          `json:"tattoos"`
-	Piercings      string          `json:"piercings"`
-	Favorite       bool            `json:"favorite"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	CareerStart    *int             `json:"career_start"`
+	CareerEnd      *int             `json:"career_end"`
+	Tattoos        string           `json:"tattoos"`
+	Piercings      string           `json:"piercings"`
+	Favorite       bool             `json:"favorite"`
+	CreatedAt      time.Time        `json:"created_at"`
+	UpdatedAt      time.Time        `json:"updated_at"`
 	// Rating expressed in 1-100 scale
 	Rating        *int   `json:"rating"`
 	Details       string `json:"details"`

--- a/pkg/models/model_performer.go
+++ b/pkg/models/model_performer.go
@@ -18,7 +18,7 @@ type Performer struct {
 	Measurements   string          `json:"measurements"`
 	FakeTits       string          `json:"fake_tits"`
 	PenisLength    *float64        `json:"penis_length"`
-	Circumcised    *CircumisedEnum `json:"circumcised"`
+	Circumcised    *CircumcisedEnum `json:"circumcised"`
 	CareerStart    *int            `json:"career_start"`
 	CareerEnd      *int            `json:"career_end"`
 	Tattoos        string          `json:"tattoos"`

--- a/pkg/models/model_scraped_item.go
+++ b/pkg/models/model_scraped_item.go
@@ -288,7 +288,7 @@ func (p *ScrapedPerformer) ToPerformer(endpoint string, excluded map[string]bool
 		}
 	}
 	if p.Circumcised != nil && !excluded["circumcised"] {
-		v := CircumisedEnum(*p.Circumcised)
+		v := CircumcisedEnum(*p.Circumcised)
 		if v.IsValid() {
 			ret.Circumcised = &v
 		}

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -61,49 +61,49 @@ type GenderCriterionInput struct {
 	Modifier  CriterionModifier `json:"modifier"`
 }
 
-type CircumisedEnum string
+type CircumcisedEnum string
 
 const (
-	CircumisedEnumCut   CircumisedEnum = "CUT"
-	CircumisedEnumUncut CircumisedEnum = "UNCUT"
+	CircumcisedEnumCut   CircumcisedEnum = "CUT"
+	CircumcisedEnumUncut CircumcisedEnum = "UNCUT"
 )
 
-var AllCircumcisionEnum = []CircumisedEnum{
-	CircumisedEnumCut,
-	CircumisedEnumUncut,
+var AllCircumcisionEnum = []CircumcisedEnum{
+	CircumcisedEnumCut,
+	CircumcisedEnumUncut,
 }
 
-func (e CircumisedEnum) IsValid() bool {
+func (e CircumcisedEnum) IsValid() bool {
 	switch e {
-	case CircumisedEnumCut, CircumisedEnumUncut:
+	case CircumcisedEnumCut, CircumcisedEnumUncut:
 		return true
 	}
 	return false
 }
 
-func (e CircumisedEnum) String() string {
+func (e CircumcisedEnum) String() string {
 	return string(e)
 }
 
-func (e *CircumisedEnum) UnmarshalGQL(v interface{}) error {
+func (e *CircumcisedEnum) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("enums must be strings")
 	}
 
-	*e = CircumisedEnum(str)
+	*e = CircumcisedEnum(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid CircumisedEnum", str)
+		return fmt.Errorf("%s is not a valid CircumcisedEnum", str)
 	}
 	return nil
 }
 
-func (e CircumisedEnum) MarshalGQL(w io.Writer) {
+func (e CircumcisedEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 type CircumcisionCriterionInput struct {
-	Value    []CircumisedEnum  `json:"value"`
+	Value    []CircumcisedEnum  `json:"value"`
 	Modifier CriterionModifier `json:"modifier"`
 }
 
@@ -230,7 +230,7 @@ type PerformerCreateInput struct {
 	Measurements   *string         `json:"measurements"`
 	FakeTits       *string         `json:"fake_tits"`
 	PenisLength    *float64        `json:"penis_length"`
-	Circumcised    *CircumisedEnum `json:"circumcised"`
+	Circumcised    *CircumcisedEnum `json:"circumcised"`
 	CareerLength   *string         `json:"career_length"`
 	CareerStart    *int            `json:"career_start"`
 	CareerEnd      *int            `json:"career_end"`
@@ -271,7 +271,7 @@ type PerformerUpdateInput struct {
 	Measurements   *string         `json:"measurements"`
 	FakeTits       *string         `json:"fake_tits"`
 	PenisLength    *float64        `json:"penis_length"`
-	Circumcised    *CircumisedEnum `json:"circumcised"`
+	Circumcised    *CircumcisedEnum `json:"circumcised"`
 	CareerLength   *string         `json:"career_length"`
 	CareerStart    *int            `json:"career_start"`
 	CareerEnd      *int            `json:"career_end"`

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -103,7 +103,7 @@ func (e CircumcisedEnum) MarshalGQL(w io.Writer) {
 }
 
 type CircumcisionCriterionInput struct {
-	Value    []CircumcisedEnum  `json:"value"`
+	Value    []CircumcisedEnum `json:"value"`
 	Modifier CriterionModifier `json:"modifier"`
 }
 
@@ -216,32 +216,32 @@ type PerformerFilterType struct {
 }
 
 type PerformerCreateInput struct {
-	Name           string          `json:"name"`
-	Disambiguation *string         `json:"disambiguation"`
-	URL            *string         `json:"url"` // deprecated
-	Urls           []string        `json:"urls"`
-	Gender         *GenderEnum     `json:"gender"`
-	Birthdate      *string         `json:"birthdate"`
-	Ethnicity      *string         `json:"ethnicity"`
-	Country        *string         `json:"country"`
-	EyeColor       *string         `json:"eye_color"`
-	Height         *string         `json:"height"`
-	HeightCm       *int            `json:"height_cm"`
-	Measurements   *string         `json:"measurements"`
-	FakeTits       *string         `json:"fake_tits"`
-	PenisLength    *float64        `json:"penis_length"`
+	Name           string           `json:"name"`
+	Disambiguation *string          `json:"disambiguation"`
+	URL            *string          `json:"url"` // deprecated
+	Urls           []string         `json:"urls"`
+	Gender         *GenderEnum      `json:"gender"`
+	Birthdate      *string          `json:"birthdate"`
+	Ethnicity      *string          `json:"ethnicity"`
+	Country        *string          `json:"country"`
+	EyeColor       *string          `json:"eye_color"`
+	Height         *string          `json:"height"`
+	HeightCm       *int             `json:"height_cm"`
+	Measurements   *string          `json:"measurements"`
+	FakeTits       *string          `json:"fake_tits"`
+	PenisLength    *float64         `json:"penis_length"`
 	Circumcised    *CircumcisedEnum `json:"circumcised"`
-	CareerLength   *string         `json:"career_length"`
-	CareerStart    *int            `json:"career_start"`
-	CareerEnd      *int            `json:"career_end"`
-	Tattoos        *string         `json:"tattoos"`
-	Piercings      *string         `json:"piercings"`
-	Aliases        *string         `json:"aliases"`
-	AliasList      []string        `json:"alias_list"`
-	Twitter        *string         `json:"twitter"`   // deprecated
-	Instagram      *string         `json:"instagram"` // deprecated
-	Favorite       *bool           `json:"favorite"`
-	TagIds         []string        `json:"tag_ids"`
+	CareerLength   *string          `json:"career_length"`
+	CareerStart    *int             `json:"career_start"`
+	CareerEnd      *int             `json:"career_end"`
+	Tattoos        *string          `json:"tattoos"`
+	Piercings      *string          `json:"piercings"`
+	Aliases        *string          `json:"aliases"`
+	AliasList      []string         `json:"alias_list"`
+	Twitter        *string          `json:"twitter"`   // deprecated
+	Instagram      *string          `json:"instagram"` // deprecated
+	Favorite       *bool            `json:"favorite"`
+	TagIds         []string         `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`
@@ -256,33 +256,33 @@ type PerformerCreateInput struct {
 }
 
 type PerformerUpdateInput struct {
-	ID             string          `json:"id"`
-	Name           *string         `json:"name"`
-	Disambiguation *string         `json:"disambiguation"`
-	URL            *string         `json:"url"` // deprecated
-	Urls           []string        `json:"urls"`
-	Gender         *GenderEnum     `json:"gender"`
-	Birthdate      *string         `json:"birthdate"`
-	Ethnicity      *string         `json:"ethnicity"`
-	Country        *string         `json:"country"`
-	EyeColor       *string         `json:"eye_color"`
-	Height         *string         `json:"height"`
-	HeightCm       *int            `json:"height_cm"`
-	Measurements   *string         `json:"measurements"`
-	FakeTits       *string         `json:"fake_tits"`
-	PenisLength    *float64        `json:"penis_length"`
+	ID             string           `json:"id"`
+	Name           *string          `json:"name"`
+	Disambiguation *string          `json:"disambiguation"`
+	URL            *string          `json:"url"` // deprecated
+	Urls           []string         `json:"urls"`
+	Gender         *GenderEnum      `json:"gender"`
+	Birthdate      *string          `json:"birthdate"`
+	Ethnicity      *string          `json:"ethnicity"`
+	Country        *string          `json:"country"`
+	EyeColor       *string          `json:"eye_color"`
+	Height         *string          `json:"height"`
+	HeightCm       *int             `json:"height_cm"`
+	Measurements   *string          `json:"measurements"`
+	FakeTits       *string          `json:"fake_tits"`
+	PenisLength    *float64         `json:"penis_length"`
 	Circumcised    *CircumcisedEnum `json:"circumcised"`
-	CareerLength   *string         `json:"career_length"`
-	CareerStart    *int            `json:"career_start"`
-	CareerEnd      *int            `json:"career_end"`
-	Tattoos        *string         `json:"tattoos"`
-	Piercings      *string         `json:"piercings"`
-	Aliases        *string         `json:"aliases"`
-	AliasList      []string        `json:"alias_list"`
-	Twitter        *string         `json:"twitter"`   // deprecated
-	Instagram      *string         `json:"instagram"` // deprecated
-	Favorite       *bool           `json:"favorite"`
-	TagIds         []string        `json:"tag_ids"`
+	CareerLength   *string          `json:"career_length"`
+	CareerStart    *int             `json:"career_start"`
+	CareerEnd      *int             `json:"career_end"`
+	Tattoos        *string          `json:"tattoos"`
+	Piercings      *string          `json:"piercings"`
+	Aliases        *string          `json:"aliases"`
+	AliasList      []string         `json:"alias_list"`
+	Twitter        *string          `json:"twitter"`   // deprecated
+	Instagram      *string          `json:"instagram"` // deprecated
+	Favorite       *bool            `json:"favorite"`
+	TagIds         []string         `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -51,7 +51,7 @@ var (
 	careerStart     = 2005
 	careerEnd       = 2015
 	penisLength     = 1.23
-	circumcisedEnum = models.CircumisedEnumCut
+	circumcisedEnum = models.CircumcisedEnumCut
 	circumcised     = circumcisedEnum.String()
 
 	emptyCustomFields = make(map[string]interface{})

--- a/pkg/performer/import.go
+++ b/pkg/performer/import.go
@@ -247,7 +247,7 @@ func performerJSONToPerformer(performerJSON jsonschema.Performer) (models.Perfor
 	}
 
 	if performerJSON.Circumcised != "" {
-		v := models.CircumisedEnum(performerJSON.Circumcised)
+		v := models.CircumcisedEnum(performerJSON.Circumcised)
 		newPerformer.Circumcised = &v
 	}
 

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -134,7 +134,7 @@ func (r *performerRow) resolve() *models.Performer {
 	}
 
 	if r.Circumcised.ValueOrZero() != "" {
-		v := models.CircumisedEnum(r.Circumcised.String)
+		v := models.CircumcisedEnum(r.Circumcised.String)
 		ret.Circumcised = &v
 	}
 

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -65,7 +65,7 @@ func Test_PerformerStore_Create(t *testing.T) {
 		measurements   = "measurements"
 		fakeTits       = "fakeTits"
 		penisLength    = 1.23
-		circumcised    = models.CircumisedEnumCut
+		circumcised    = models.CircumcisedEnumCut
 		careerStart    = 2005
 		careerEnd      = 2015
 		tattoos        = "tattoos"
@@ -228,7 +228,7 @@ func Test_PerformerStore_Update(t *testing.T) {
 		measurements   = "measurements"
 		fakeTits       = "fakeTits"
 		penisLength    = 1.23
-		circumcised    = models.CircumisedEnumCut
+		circumcised    = models.CircumcisedEnumCut
 		careerStart    = 2005
 		careerEnd      = 2015
 		tattoos        = "tattoos"
@@ -457,7 +457,7 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 		measurements   = "measurements"
 		fakeTits       = "fakeTits"
 		penisLength    = 1.23
-		circumcised    = models.CircumisedEnumCut
+		circumcised    = models.CircumcisedEnumCut
 		careerStart    = 2005
 		careerEnd      = 2015
 		tattoos        = "tattoos"
@@ -1200,7 +1200,7 @@ func TestPerformerQuery(t *testing.T) {
 			nil,
 			&models.PerformerFilterType{
 				Circumcised: &models.CircumcisionCriterionInput{
-					Value:    []models.CircumisedEnum{models.CircumisedEnumCut},
+					Value:    []models.CircumcisedEnum{models.CircumcisedEnumCut},
 					Modifier: models.CriterionModifierIncludes,
 				},
 			},
@@ -1213,7 +1213,7 @@ func TestPerformerQuery(t *testing.T) {
 			nil,
 			&models.PerformerFilterType{
 				Circumcised: &models.CircumcisionCriterionInput{
-					Value:    []models.CircumisedEnum{models.CircumisedEnumCut},
+					Value:    []models.CircumcisedEnum{models.CircumcisedEnumCut},
 					Modifier: models.CriterionModifierExcludes,
 				},
 			},

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1626,15 +1626,15 @@ func getPerformerPenisLength(index int) *float64 {
 	return &ret
 }
 
-func getPerformerCircumcised(index int) *models.CircumisedEnum {
-	var ret models.CircumisedEnum
+func getPerformerCircumcised(index int) *models.CircumcisedEnum {
+	var ret models.CircumcisedEnum
 	switch {
 	case index%3 == 0:
 		return nil
 	case index%3 == 1:
-		ret = models.CircumisedEnumCut
+		ret = models.CircumcisedEnumCut
 	default:
-		ret = models.CircumisedEnumUncut
+		ret = models.CircumcisedEnumUncut
 	}
 
 	return &ret

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -116,7 +116,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     measurements: yup.string().ensure(),
     fake_tits: yup.string().ensure(),
     penis_length: yupInputNumber().positive().nullable().defined(),
-    circumcised: yupInputEnum(GQL.CircumisedEnum).nullable().defined(),
+    circumcised: yupInputEnum(GQL.CircumcisedEnum).nullable().defined(),
     tattoos: yup.string().ensure(),
     piercings: yup.string().ensure(),
     career_start: yupInputNumber().positive().nullable().defined(),

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -191,7 +191,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
       return;
     }
 
-    let retEnum: GQL.CircumisedEnum | undefined;
+    let retEnum: GQL.CircumcisedEnum | undefined;
 
     // try to translate from enum values first
     const upperCircumcised = scrapedCircumcised.toUpperCase();

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -145,7 +145,7 @@ export function formatYearRange(
   return `${start ?? ""} - ${end ?? ""}`;
 }
 
-export const FormatCircumcised = (circumcised?: GQL.CircumisedEnum | null) => {
+export const FormatCircumcised = (circumcised?: GQL.CircumcisedEnum | null) => {
   const intl = useIntl();
   if (!circumcised) {
     return "";

--- a/ui/v2.5/src/models/list-filter/criteria/circumcised.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/circumcised.ts
@@ -1,6 +1,6 @@
 import {
   CircumcisionCriterionInput,
-  CircumisedEnum,
+  CircumcisedEnum,
   CriterionModifier,
 } from "src/core/generated-graphql";
 import { circumcisedStrings, stringToCircumcised } from "src/utils/circumcised";
@@ -28,7 +28,7 @@ export class CircumcisedCriterion extends MultiStringCriterion {
   public toCriterionInput(): CircumcisionCriterionInput {
     const value = this.value.map((v) =>
       stringToCircumcised(v)
-    ) as CircumisedEnum[];
+    ) as CircumcisedEnum[];
 
     return {
       value,

--- a/ui/v2.5/src/pluginApi.d.ts
+++ b/ui/v2.5/src/pluginApi.d.ts
@@ -15,7 +15,7 @@ declare namespace PluginApi {
     const BulkPerformerUpdateDocument: { [key: string]: any };
     const BulkSceneUpdateDocument: { [key: string]: any };
     const BulkUpdateIdMode: { [key: string]: any };
-    const CircumisedEnum: { [key: string]: any };
+    const CircumcisedEnum: { [key: string]: any };
     const ConfigDataFragmentDoc: { [key: string]: any };
     const ConfigDefaultSettingsDataFragmentDoc: { [key: string]: any };
     const ConfigDlnaDataFragmentDoc: { [key: string]: any };

--- a/ui/v2.5/src/utils/circumcised.ts
+++ b/ui/v2.5/src/utils/circumcised.ts
@@ -1,12 +1,12 @@
 import * as GQL from "../core/generated-graphql";
 
-export const stringCircumMap = new Map<string, GQL.CircumisedEnum>([
-  ["Uncut", GQL.CircumisedEnum.Uncut],
-  ["Cut", GQL.CircumisedEnum.Cut],
+export const stringCircumMap = new Map<string, GQL.CircumcisedEnum>([
+  ["Uncut", GQL.CircumcisedEnum.Uncut],
+  ["Cut", GQL.CircumcisedEnum.Cut],
 ]);
 
 export const circumcisedToString = (
-  value?: GQL.CircumisedEnum | String | null
+  value?: GQL.CircumcisedEnum | String | null
 ) => {
   if (!value) {
     return undefined;
@@ -24,12 +24,12 @@ export const circumcisedToString = (
 export const stringToCircumcised = (
   value?: string | null,
   caseInsensitive?: boolean
-): GQL.CircumisedEnum | undefined => {
+): GQL.CircumcisedEnum | undefined => {
   if (!value) {
     return undefined;
   }
 
-  const existing = Object.entries(GQL.CircumisedEnum).find(
+  const existing = Object.entries(GQL.CircumcisedEnum).find(
     (e) => e[1] === value
   );
   if (existing) return existing[1];


### PR DESCRIPTION
## Summary

- Fix comment typos in `filters.graphql` (`cscene reation time`, `lscene ast update time`, `ciricumcision`, `number f child tags`) and `file.graphql` (`an null value`)
- Rename `CircumisedEnum` → `CircumcisedEnum` across the full stack (GraphQL schema, Go models/API, generated files, TypeScript frontend)

## Test plan

- [ ] Go build passes (`make build`)
- [ ] Frontend build passes (`yarn build`)
- [ ] Existing performer filter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)