### PR TITLE
Related to #1066 [Feature] add settings option to customize metadata items in scene card grid mode

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -30,6 +30,11 @@ import { StudioOverlay } from "../Shared/GridCard/StudioOverlay";
 import { GroupTag } from "../Groups/GroupTag";
 import { FileSize } from "../Shared/FileSize";
 import { OCounterButton } from "../Shared/CountButton";
+import {
+  IUIConfig,
+  ISceneCardOverlayOptions,
+  defaultSceneCardOptions,
+} from "src/core/config";
 
 interface IScenePreviewProps {
   isPortrait: boolean;
@@ -131,6 +136,13 @@ const Description: React.FC<{
 const SceneCardPopovers = PatchComponent(
   "SceneCard.Popovers",
   (props: ISceneCardProps) => {
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui as IUIConfig | undefined;
+    const popoverOpts = {
+      ...defaultSceneCardOptions.popovers,
+      ...(uiConfig?.sceneCard?.popovers ?? {}),
+    };
+
     const file = useMemo(
       () => (props.scene.files.length > 0 ? props.scene.files[0] : undefined),
       [props.scene]
@@ -148,6 +160,7 @@ const SceneCardPopovers = PatchComponent(
     }, [props.fromGroupId, props.scene.groups]);
 
     function maybeRenderTagPopoverButton() {
+      if (!popoverOpts.showTags) return;
       if (props.scene.tags.length <= 0) return;
 
       const popoverContent = props.scene.tags.map((tag) => (
@@ -169,6 +182,7 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderPerformerPopoverButton() {
+      if (!popoverOpts.showPerformers) return;
       if (props.scene.performers.length <= 0) return;
 
       return (
@@ -180,6 +194,7 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderGroupPopoverButton() {
+      if (!popoverOpts.showGroups) return;
       if (props.scene.groups.length <= 0) return;
 
       const popoverContent = props.scene.groups.map((sceneGroup) => (
@@ -201,6 +216,7 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderSceneMarkerPopoverButton() {
+      if (!popoverOpts.showMarkers) return;
       if (props.scene.scene_markers.length <= 0) return;
 
       const popoverContent = props.scene.scene_markers.map((marker) => {
@@ -223,12 +239,14 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderOCounter() {
+      if (!popoverOpts.showOCounter) return;
       if (props.scene.o_counter) {
         return <OCounterButton value={props.scene.o_counter} />;
       }
     }
 
     function maybeRenderGallery() {
+      if (!popoverOpts.showGalleries) return;
       if (props.scene.galleries.length <= 0) return;
 
       const popoverContent = props.scene.galleries.map((gallery) => (
@@ -250,6 +268,7 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderOrganized() {
+      if (!popoverOpts.showOrganized) return;
       if (props.scene.organized) {
         return (
           <OverlayTrigger
@@ -267,6 +286,7 @@ const SceneCardPopovers = PatchComponent(
     }
 
     function maybeRenderDupeCopies() {
+      if (!popoverOpts.showDuplicateCopies) return;
       const phash = file
         ? file.fingerprints.find((fp) => fp.type === "phash")
         : undefined;
@@ -320,51 +340,94 @@ const SceneCardPopovers = PatchComponent(
   }
 );
 
+
 const SceneCardDetails = PatchComponent(
   "SceneCard.Details",
   (props: ISceneCardProps) => {
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui as IUIConfig | undefined;
+    const detailOpts = {
+      ...defaultSceneCardOptions.details,
+      ...(uiConfig?.sceneCard?.details ?? {}),
+    };
+
     return (
       <div className="scene-card__details">
-        <span className="scene-card__date">{props.scene.date}</span>
-        <span className="file-path extra-scene-info">
-          {objectPath(props.scene)}
-        </span>
-        <TruncatedText
-          className="scene-card__description"
-          text={props.scene.details}
-          lineCount={3}
-        />
+        {detailOpts.showDate && (
+          <span className="scene-card__date">{props.scene.date}</span>
+        )}
+        {detailOpts.showFilePath && (
+          <span className="file-path extra-scene-info">
+            {objectPath(props.scene)}
+          </span>
+        )}
+        {detailOpts.showDescription && (
+          <TruncatedText
+            className="scene-card__description"
+            text={props.scene.details}
+            lineCount={3}
+          />
+        )}
       </div>
     );
   }
 );
 
+
 const SceneCardOverlays = PatchComponent(
   "SceneCard.Overlays",
   (props: ISceneCardProps) => {
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui as IUIConfig | undefined;
+    const overlayOpts = resolveOverlayOpts(uiConfig);
+
     const ret = useMemo(() => {
+      if (!overlayOpts.showStudio) return null;
       return (
         <StudioOverlay studio={props.scene.studio} disabled={props.selecting} />
       );
-    }, [props.scene.studio, props.selecting]);
+    }, [props.scene.studio, props.selecting, overlayOpts.showStudio]);
 
     return ret;
   }
 );
 
-interface ISceneSpecsOverlay {
-  scene: GQL.SlimSceneDataFragment;
+/** Helper: merge user settings over the all-true defaults for the overlay section. */
+function resolveOverlayOpts(
+  uiConfig: IUIConfig | undefined
+): Required<ISceneCardOverlayOptions> {
+  return {
+    ...defaultSceneCardOptions.overlay,
+    ...(uiConfig?.sceneCard?.overlay ?? {}),
+  } as Required<ISceneCardOverlayOptions>;
 }
 
-export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = ({ scene }) => {
+interface ISceneSpecsOverlayProps {
+  scene: GQL.SlimSceneDataFragment;
+  showResolution?: boolean;
+  showDuration?: boolean;
+  showFileSize?: boolean;
+}
+
+export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlayProps> = ({
+  scene,
+  showResolution = true,
+  showDuration = true,
+  showFileSize = true,
+}) => {
   if (!scene.files.length) return null;
-  let file = scene.files[0];
+  const file = scene.files[0];
+
+  if (!showResolution && !showDuration && !showFileSize) return null;
+
   return (
     <div className="scene-specs-overlay">
-      <span className="overlay-filesize extra-scene-info">
-        <FileSize size={file.size} />
-      </span>
-      {file.width && file.height ? (
+      {showFileSize && (
+        <span className="overlay-filesize extra-scene-info">
+          <FileSize size={file.size} />
+        </span>
+      )}
+      {showResolution && file.width && file.height ? (
         <span className="overlay-resolution">
           {" "}
           {TextUtils.resolution(file.width, file.height)}
@@ -372,7 +435,7 @@ export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = ({ scene }) => {
       ) : (
         ""
       )}
-      {(file.duration ?? 0) >= 1 ? (
+      {showDuration && (file.duration ?? 0) >= 1 ? (
         <span className="overlay-duration">
           {TextUtils.secondsToTimestamp(file.duration)}
         </span>
@@ -389,6 +452,8 @@ const SceneCardImage = PatchComponent(
     const history = useHistory();
     const { configuration } = useConfigurationContext();
     const cont = configuration?.interface.continuePlaylistDefault ?? false;
+    const uiConfig = configuration?.ui as IUIConfig | undefined;
+    const overlayOpts = resolveOverlayOpts(uiConfig);
 
     const file = useMemo(
       () => (props.scene.files.length > 0 ? props.scene.files[0] : undefined),
@@ -396,6 +461,7 @@ const SceneCardImage = PatchComponent(
     );
 
     function maybeRenderInteractiveSpeedOverlay() {
+      if (!overlayOpts.showInteractiveSpeed) return null;
       return (
         <div className="scene-interactive-speed-overlay">
           {props.scene.interactive_speed ?? ""}
@@ -433,8 +499,15 @@ const SceneCardImage = PatchComponent(
           onScrubberClick={onScrubberClick}
           disabled={props.selecting}
         />
-        <RatingBanner rating={props.scene.rating100} />
-        <SceneSpecsOverlay scene={props.scene} />
+        {overlayOpts.showRatingBanner && (
+          <RatingBanner rating={props.scene.rating100} />
+        )}
+        <SceneSpecsOverlay
+          scene={props.scene}
+          showResolution={overlayOpts.showResolution}
+          showDuration={overlayOpts.showDuration}
+          showFileSize={overlayOpts.showFileSize}
+        />
         {maybeRenderInteractiveSpeedOverlay()}
       </>
     );

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -42,7 +42,7 @@ import {
   defaultImageWallDirection,
   defaultImageWallMargin,
 } from "src/utils/imageWall";
-import { defaultMaxOptionsShown } from "src/core/config";
+import { defaultMaxOptionsShown, defaultSceneCardOptions } from "src/core/config";
 import { PatchComponent } from "src/patch";
 
 const allMenuItems = [
@@ -355,6 +355,343 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             checked={iface.showStudioAsText ?? undefined}
             onChange={(v) => saveInterface({ showStudioAsText: v })}
           />
+        </SettingSection>
+
+        {/* ═══════════════════════════════════════════════════════════
+            SCENE CARD DISPLAY — customise what shows on each card
+            ═══════════════════════════════════════════════════════════ */}
+        <SettingSection headingID="config.ui.scene_card.heading">
+
+          {/* ── Reset to Defaults button ── */}
+          <div className="setting">
+            <div>
+              <h3>
+                {intl.formatMessage({
+                  id: "config.ui.scene_card.reset.heading",
+                })}
+              </h3>
+              <div className="sub-heading">
+                {intl.formatMessage({
+                  id: "config.ui.scene_card.reset.description",
+                })}
+              </div>
+            </div>
+            <div>
+              <Button
+                id="scene-card-reset-defaults"
+                variant="secondary"
+                onClick={() => saveUI({ sceneCard: defaultSceneCardOptions })}
+              >
+                {intl.formatMessage({
+                  id: "config.ui.scene_card.reset.button",
+                })}
+              </Button>
+            </div>
+          </div>
+
+          {/* ── GROUP 1: Thumbnail Overlay ── */}
+          <div className="setting-group">
+            <div className="setting">
+              <div>
+                <h3>
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.overlay.heading",
+                  })}
+                </h3>
+                <div className="sub-heading">
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.overlay.description",
+                  })}
+                </div>
+              </div>
+              <div />
+            </div>
+
+            <BooleanSetting
+              id="scene-card-show-rating"
+              headingID="config.ui.scene_card.overlay.show_rating.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_rating.description"
+              checked={ui.sceneCard?.overlay?.showRatingBanner ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: { ...ui.sceneCard?.overlay, showRatingBanner: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-resolution"
+              headingID="config.ui.scene_card.overlay.show_resolution.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_resolution.description"
+              checked={ui.sceneCard?.overlay?.showResolution ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: { ...ui.sceneCard?.overlay, showResolution: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-duration"
+              headingID="config.ui.scene_card.overlay.show_duration.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_duration.description"
+              checked={ui.sceneCard?.overlay?.showDuration ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: { ...ui.sceneCard?.overlay, showDuration: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-filesize"
+              headingID="config.ui.scene_card.overlay.show_filesize.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_filesize.description"
+              checked={ui.sceneCard?.overlay?.showFileSize ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: { ...ui.sceneCard?.overlay, showFileSize: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-studio"
+              headingID="config.ui.scene_card.overlay.show_studio.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_studio.description"
+              checked={ui.sceneCard?.overlay?.showStudio ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: { ...ui.sceneCard?.overlay, showStudio: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-interactive-speed"
+              headingID="config.ui.scene_card.overlay.show_interactive_speed.heading"
+              subHeadingID="config.ui.scene_card.overlay.show_interactive_speed.description"
+              checked={ui.sceneCard?.overlay?.showInteractiveSpeed ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    overlay: {
+                      ...ui.sceneCard?.overlay,
+                      showInteractiveSpeed: v,
+                    },
+                  },
+                })
+              }
+            />
+          </div>
+
+          {/* ── GROUP 2: Card Details ── */}
+          <div className="setting-group">
+            <div className="setting">
+              <div>
+                <h3>
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.details.heading",
+                  })}
+                </h3>
+                <div className="sub-heading">
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.details.description",
+                  })}
+                </div>
+              </div>
+              <div />
+            </div>
+
+            <BooleanSetting
+              id="scene-card-show-date"
+              headingID="config.ui.scene_card.details.show_date.heading"
+              subHeadingID="config.ui.scene_card.details.show_date.description"
+              checked={ui.sceneCard?.details?.showDate ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    details: { ...ui.sceneCard?.details, showDate: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-description"
+              headingID="config.ui.scene_card.details.show_description.heading"
+              subHeadingID="config.ui.scene_card.details.show_description.description"
+              checked={ui.sceneCard?.details?.showDescription ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    details: { ...ui.sceneCard?.details, showDescription: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-filepath"
+              headingID="config.ui.scene_card.details.show_file_path.heading"
+              subHeadingID="config.ui.scene_card.details.show_file_path.description"
+              checked={ui.sceneCard?.details?.showFilePath ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    details: { ...ui.sceneCard?.details, showFilePath: v },
+                  },
+                })
+              }
+            />
+          </div>
+
+          {/* ── GROUP 3: Card Icon Buttons (Popovers) ── */}
+          <div className="setting-group">
+            <div className="setting">
+              <div>
+                <h3>
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.popovers.heading",
+                  })}
+                </h3>
+                <div className="sub-heading">
+                  {intl.formatMessage({
+                    id: "config.ui.scene_card.popovers.description",
+                  })}
+                </div>
+              </div>
+              <div />
+            </div>
+
+            <BooleanSetting
+              id="scene-card-show-tags"
+              headingID="config.ui.scene_card.popovers.show_tags.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_tags.description"
+              checked={ui.sceneCard?.popovers?.showTags ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showTags: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-performers"
+              headingID="config.ui.scene_card.popovers.show_performers.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_performers.description"
+              checked={ui.sceneCard?.popovers?.showPerformers ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showPerformers: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-groups"
+              headingID="config.ui.scene_card.popovers.show_groups.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_groups.description"
+              checked={ui.sceneCard?.popovers?.showGroups ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showGroups: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-markers"
+              headingID="config.ui.scene_card.popovers.show_markers.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_markers.description"
+              checked={ui.sceneCard?.popovers?.showMarkers ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showMarkers: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-o-counter"
+              headingID="config.ui.scene_card.popovers.show_o_counter.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_o_counter.description"
+              checked={ui.sceneCard?.popovers?.showOCounter ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showOCounter: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-galleries"
+              headingID="config.ui.scene_card.popovers.show_galleries.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_galleries.description"
+              checked={ui.sceneCard?.popovers?.showGalleries ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showGalleries: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-organized"
+              headingID="config.ui.scene_card.popovers.show_organized.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_organized.description"
+              checked={ui.sceneCard?.popovers?.showOrganized ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: { ...ui.sceneCard?.popovers, showOrganized: v },
+                  },
+                })
+              }
+            />
+            <BooleanSetting
+              id="scene-card-show-duplicate-copies"
+              headingID="config.ui.scene_card.popovers.show_duplicate_copies.heading"
+              subHeadingID="config.ui.scene_card.popovers.show_duplicate_copies.description"
+              checked={ui.sceneCard?.popovers?.showDuplicateCopies ?? true}
+              onChange={(v) =>
+                saveUI({
+                  sceneCard: {
+                    ...ui.sceneCard,
+                    popovers: {
+                      ...ui.sceneCard?.popovers,
+                      showDuplicateCopies: v,
+                    },
+                  },
+                })
+              }
+            />
+          </div>
         </SettingSection>
 
         <SettingSection headingID="config.ui.scene_player.heading">

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -39,6 +39,67 @@ export type FrontPageContent = ISavedFilterRow | ICustomFilter;
 
 export const defaultMaxOptionsShown = 200;
 
+// ── Scene Card Display Options ──────────────────────────────────────────────
+
+export interface ISceneCardOverlayOptions {
+  showRatingBanner?: boolean;     // default: true
+  showResolution?: boolean;       // default: true
+  showDuration?: boolean;         // default: true
+  showFileSize?: boolean;         // default: true
+  showStudio?: boolean;           // default: true
+  showInteractiveSpeed?: boolean; // default: true
+}
+
+export interface ISceneCardDetailsOptions {
+  showDate?: boolean;             // default: true
+  showDescription?: boolean;      // default: true
+  showFilePath?: boolean;         // default: true
+}
+
+export interface ISceneCardPopoverOptions {
+  showTags?: boolean;             // default: true
+  showPerformers?: boolean;       // default: true
+  showGroups?: boolean;           // default: true
+  showMarkers?: boolean;          // default: true
+  showOCounter?: boolean;         // default: true
+  showGalleries?: boolean;        // default: true
+  showOrganized?: boolean;        // default: true
+  showDuplicateCopies?: boolean;  // default: true
+}
+
+export interface ISceneCardOptions {
+  overlay?: ISceneCardOverlayOptions;
+  details?: ISceneCardDetailsOptions;
+  popovers?: ISceneCardPopoverOptions;
+}
+
+/** All fields default to `true`, so existing users see no visual change. */
+export const defaultSceneCardOptions: Required<ISceneCardOptions> = {
+  overlay: {
+    showRatingBanner: true,
+    showResolution: true,
+    showDuration: true,
+    showFileSize: true,
+    showStudio: true,
+    showInteractiveSpeed: true,
+  },
+  details: {
+    showDate: true,
+    showDescription: true,
+    showFilePath: true,
+  },
+  popovers: {
+    showTags: true,
+    showPerformers: true,
+    showGroups: true,
+    showMarkers: true,
+    showOCounter: true,
+    showGalleries: true,
+    showOrganized: true,
+    showDuplicateCopies: true,
+  },
+};
+
 export interface IUIConfig {
   // unknown to prevent direct access - use getFrontPageContent
   frontPageContent?: unknown;
@@ -105,6 +166,9 @@ export interface IUIConfig {
   taggerConfig?: ITaggerConfig;
 
   title?: string;
+
+  // Scene card display customization (see ISceneCardOptions)
+  sceneCard?: ISceneCardOptions;
 }
 
 export function getFrontPageContent(

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -815,6 +815,94 @@
           "show_studio_as_text": "Display studio overlay as text"
         }
       },
+      "scene_card": {
+        "heading": "Scene Card Display",
+        "reset": {
+          "heading": "Reset to Defaults",
+          "description": "Restore all scene card settings back to their original values. Everything will be visible again.",
+          "button": "Reset to Defaults"
+        },
+        "overlay": {
+          "heading": "Thumbnail Overlay",
+          "description": "These are the items shown on top of the video preview thumbnail.",
+          "show_rating": {
+            "heading": "Show Star Rating",
+            "description": "Shows a coloured bar at the bottom of the thumbnail with the scene's star rating. Example: ★★★★☆"
+          },
+          "show_resolution": {
+            "heading": "Show Video Quality",
+            "description": "Shows the video resolution on the thumbnail — like '4K', '1080p', or '720p'."
+          },
+          "show_duration": {
+            "heading": "Show Video Length",
+            "description": "Shows how long the video is, for example '1:23:45', on the thumbnail."
+          },
+          "show_filesize": {
+            "heading": "Show File Size",
+            "description": "Shows how much storage space the video file uses, for example '4.2 GB', on the thumbnail."
+          },
+          "show_studio": {
+            "heading": "Show Studio Logo",
+            "description": "Shows the studio logo or name on the thumbnail so you know which studio made it."
+          },
+          "show_interactive_speed": {
+            "heading": "Show Interactive Speed",
+            "description": "For interactive (haptic) scenes, shows the speed rating on the thumbnail."
+          }
+        },
+        "details": {
+          "heading": "Card Text Details",
+          "description": "These are the pieces of information shown in the text area below the thumbnail.",
+          "show_date": {
+            "heading": "Show Scene Date",
+            "description": "Shows the date the scene was released, for example '2024-01-15', below the thumbnail."
+          },
+          "show_description": {
+            "heading": "Show Description",
+            "description": "Shows a short preview of the scene's description text below the thumbnail."
+          },
+          "show_file_path": {
+            "heading": "Show File Location",
+            "description": "Shows the folder path of the video file on your computer. Useful for quickly finding it on disk."
+          }
+        },
+        "popovers": {
+          "heading": "Card Icon Buttons",
+          "description": "These are the small icon buttons at the bottom of each card. Hover over them to see more details.",
+          "show_tags": {
+            "heading": "Show Tags Button",
+            "description": "Shows a tag icon with the number of tags on the scene. Hover over it to see all tag names."
+          },
+          "show_performers": {
+            "heading": "Show Performers Button",
+            "description": "Shows a people icon. Hover over it to see the list of performers in the scene."
+          },
+          "show_groups": {
+            "heading": "Show Groups Button",
+            "description": "Shows a film reel icon. Hover over it to see which groups or movie collections this scene belongs to."
+          },
+          "show_markers": {
+            "heading": "Show Scene Markers Button",
+            "description": "Shows a pin icon with the number of bookmarked moments in the scene. Click to jump to them."
+          },
+          "show_o_counter": {
+            "heading": "Show O-Counter Button",
+            "description": "Shows your personal play counter for this scene."
+          },
+          "show_galleries": {
+            "heading": "Show Galleries Button",
+            "description": "Shows an images icon. Hover over it to see linked photo galleries for this scene."
+          },
+          "show_organized": {
+            "heading": "Show Organised Badge",
+            "description": "Shows a box icon when you have marked a scene as 'Organised' — meaning you have reviewed and sorted it."
+          },
+          "show_duplicate_copies": {
+            "heading": "Show Duplicate Copies Button",
+            "description": "Shows an icon if Stash has found a possible duplicate of this video file on your system."
+          }
+        }
+      },
       "scene_player": {
         "heading": "Scene Player",
         "options": {


### PR DESCRIPTION
Related to #1066 [[Feature] add settings option to customize metadata items in scene card grid mode](https://github.com/stashapp/stash/issues/1066)

## Summary

Implements [#1066](https://github.com/stashapp/stash/issues/1066) — adds per-user controls to show or hide individual metadata elements on scene cards in grid view.

A new **"Scene Card Display"** section is added to **Settings → Interface**, directly below "Grid View". All toggles default to `true`, so existing users see no visual change unless they opt-out of specific elements.

---
## Settings Location

Settings → Interface → Scene Card Display


---
## Screenshots

<img width="1151" height="965" alt="image" src="https://github.com/user-attachments/assets/623450bf-9ac1-4349-8ad4-3351a2fcd743" />
<img width="1157" height="953" alt="image" src="https://github.com/user-attachments/assets/78a67473-b6e8-48ff-8d1f-f49a90aeb452" />


---


## Changes

### [ui/v2.5/src/core/config.ts](cci:7://file://stash/ui/v2.5/src/core/config.ts:0:0-0:0)
- Added [ISceneCardOverlayOptions](cci:2://file://stash/ui/v2.5/src/core/config.ts:43:0-50:1), [ISceneCardDetailsOptions](cci:2://file://stash/ui/v2.5/src/core/config.ts:52:0-56:1), [ISceneCardPopoverOptions](cci:2://file://stash/ui/v2.5/src/core/config.ts:58:0-67:1), [ISceneCardOptions](cci:2://file://stash/ui/v2.5/src/core/config.ts:69:0-73:1) interfaces
- Added `defaultSceneCardOptions` constant (all fields `true`)
- Extended [IUIConfig](cci:2://file://stash/ui/v2.5/src/core/config.ts:102:0-171:1) with `sceneCard?: ISceneCardOptions`

### [ui/v2.5/src/components/Scenes/SceneCard.tsx](cci:7://file://stash/ui/v2.5/src/components/Scenes/SceneCard.tsx:0:0-0:0)
- `SceneCardImage` — conditionally renders rating banner, specs overlay fields (resolution / duration / file size), and interactive speed overlay
- [SceneCardDetails](cci:2://file://stash/ui/v2.5/src/core/config.ts:52:0-56:1) — conditionally renders date, description, and file path
- `SceneCardOverlays` — conditionally renders studio logo overlay
- `SceneCardPopovers` — conditionally renders each icon button (tags, performers, groups, markers, o-counter, galleries, organised badge, duplicate copies)
- [SceneSpecsOverlay](cci:1://file://stash/ui/v2.5/src/components/Scenes/SceneCard.tsx:411:0-446:2) — extended with `showResolution`, `showDuration`, `showFileSize` props

### [ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx](cci:7://file://stash/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx:0:0-0:0)
- New `SettingSection` with 17 [BooleanSetting](cci:2://file://stash/ui/v2.5/src/components/Settings/Inputs.tsx:148:0-152:1) toggles organised in 3 groups:
  - **Thumbnail Overlay** (6 toggles: rating, resolution, duration, file size, studio logo, interactive speed)
  - **Card Text Details** (3 toggles: date, description, file location)
  - **Card Icon Buttons** (8 toggles: tags, performers, groups, markers, o-counter, galleries, organised, duplicate copies)
- **Reset to Defaults** button at the top of the section

### [ui/v2.5/src/locales/en-GB.json](cci:7://file://stash/ui/v2.5/src/locales/en-GB.json:0:0-0:0)
- Added `config.ui.scene_card.*` locale block with heading and plain-language `description` (tooltip) for every toggle

---


## Behaviour

- **No backend changes** — settings are stored as free-form JSON in [IUIConfig](cci:2://file://stash/ui/v2.5/src/core/config.ts:102:0-171:1) via the existing `configureUI` GraphQL mutation (same pattern as `imageWallOptions`, `ratingSystemOptions`, etc.)
- **Zero visual regression** — all options default to `true`, preserving the current appearance for users who do not change any settings
- **Persistent** — preferences survive page reload via [saveUI](cci:1://file://stash/ui/v2.5/src/components/Settings/context.tsx:452:2-468:3)
- **Tooltips** — every toggle has a `subHeadingID` pointing to a plain-language description, visible on hover, understandable without technical knowledge

---



## Contributor Checklist

- [x] Code follows existing patterns (uses [BooleanSetting](cci:2://file://stash/ui/v2.5/src/components/Settings/Inputs.tsx:148:0-152:1), `SettingSection`, [saveUI](cci:1://file://stash/ui/v2.5/src/components/Settings/context.tsx:452:2-468:3) — same as adjacent settings)
- [x] No new external dependencies introduced
- [x] Locale strings added to [en-GB.json](cci:7://file://stash/ui/login/locales/en-GB.json:0:0-0:0) (the master locale)
- [x] Default values preserve existing visual behaviour for all current users
- [x] TypeScript compiles with zero new errors (`npx tsc --noEmit`)
- [x] Tested manually: toggling each option hides/shows the corresponding card element; Reset to Defaults restores all
- [x] Previously submitted issues and PRs reviewed — this directly addresses issue #1066 with no existing duplicate PR
- [x] I acknowledge the AGPL licence agreement per CONTRIBUTING.md

---

### `feel free to share your feedback and connect with me`
