### PR TITLE
Further scan refactors and add scan file mutation

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -68,6 +68,8 @@ models:
     model: github.com/stashapp/stash/internal/manager/config.ConfigDisableDropdownCreate
   ScanMetadataOptions:
     model:  github.com/stashapp/stash/internal/manager/config.ScanMetadataOptions
+  ScanFileInput:
+    model:  github.com/stashapp/stash/internal/manager.ScanFileInput
   CleanGeneratedInput:
     model: github.com/stashapp/stash/internal/manager/task.CleanGeneratedOptions
   AutoTagMetadataOptions:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -477,6 +477,8 @@ type Mutation {
   metadataExport: ID!
   "Start a scan. Returns the job ID"
   metadataScan(input: ScanMetadataInput!): ID!
+  "Scans a single file, returning the file metadata."
+  scanFile(input: ScanFileInput!): BaseFile!
   "Start generating content. Returns the job ID"
   metadataGenerate(input: GenerateMetadataInput!): ID!
   "Start auto-tagging. Returns the job ID"

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -110,7 +110,7 @@ input ScanMetadataInput {
 # specifies when to generate metadata during a scan
 enum GenerateTiming {
   """
-  Generate artifacts before returning from the scan API call. 
+  Generate artifacts before returning from the scan API call.
   This will block the API call until generation is complete, and is not recommended for large artifacts.
   Recommended when you want the metadata/artifact to be available immediately after the scan completes (ie covers and phashes).
   """

--- a/graphql/schema/types/metadata.graphql
+++ b/graphql/schema/types/metadata.graphql
@@ -107,6 +107,45 @@ input ScanMetadataInput {
   filter: ScanMetaDataFilterInput
 }
 
+# specifies when to generate metadata during a scan
+enum GenerateTiming {
+  """
+  Generate artifacts before returning from the scan API call. 
+  This will block the API call until generation is complete, and is not recommended for large artifacts.
+  Recommended when you want the metadata/artifact to be available immediately after the scan completes (ie covers and phashes).
+  """
+  SYNC
+  """
+  Generate artifacts asynchronously and concurrently with the scan.
+  There is no guarantee that artifacts will be generated when the scan completes.
+  """
+  ASYNC
+}
+
+input ScanFileInput {
+  path: String!
+
+  "Forces a rescan on files even if modification time is unchanged"
+  rescan: Boolean
+
+  "Generate covers during scan"
+  generateCovers: GenerateTiming
+  "Generate video previews during scan"
+  generatePreviews: GenerateTiming
+  "Generate image previews during scan"
+  generateImagePreviews: GenerateTiming
+  "Generate video sprites during scan"
+  generateSprites: GenerateTiming
+  "Generate video phashes during scan"
+  generateVideoPhashes: GenerateTiming
+  "Generate image phashes during scan"
+  generateImagePhashes: GenerateTiming
+  "Generate image thumbnails during scan"
+  generateThumbnails: GenerateTiming
+  "Generate image clip previews during scan"
+  generateClipPreviews: GenerateTiming
+}
+
 type ScanMetadataOptions {
   "Forces a rescan on files even if modification time is unchanged"
   rescan: Boolean!

--- a/internal/api/resolver_mutation_metadata.go
+++ b/internal/api/resolver_mutation_metadata.go
@@ -24,6 +24,15 @@ func (r *mutationResolver) MetadataScan(ctx context.Context, input manager.ScanM
 	return strconv.Itoa(jobID), nil
 }
 
+func (r *mutationResolver) ScanFile(ctx context.Context, input manager.ScanFileInput) (BaseFile, error) {
+	f, err := manager.GetInstance().ScanFile(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertBaseFile(f), nil
+}
+
 func (r *mutationResolver) MetadataImport(ctx context.Context) (string, error) {
 	jobID, err := manager.GetInstance().Import(ctx)
 	if err != nil {

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -236,13 +236,13 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 
 		taskQueue := <-taskQueueChan
 
-	scanJob := ScanJob{
+		scanJob := ScanJob{
 			scanner:         scanner,
 			generateOptions: makeGenerateOptions(input),
 			paths:           input.Paths,
 			taskQueue:       taskQueue,
 			subscriptions:   s.scanSubs,
-	}
+		}
 
 		scanJob.Execute(ctx, progress)
 
@@ -254,6 +254,49 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 
 	return jobID, nil
 }
+
+type ScanFileInput struct {
+	Path string `json:"path"`
+	// Forces a rescan on files even if modification time is unchanged
+	Rescan *bool `json:"rescan,omitempty"`
+
+	ScanGenerateOptions
+}
+
+func (s *Manager) ScanFile(ctx context.Context, input ScanFileInput) (models.File, error) {
+	if err := s.validateFFmpeg(); err != nil {
+		return nil, err
+	}
+
+	taskQueueChan := make(chan *job.TaskQueue)
+
+	s.JobManager.Add(ctx, "Generating for scanned file...", job.MakeJobExec(func(ctx context.Context, progress *job.Progress) error {
+		nTasks := s.Config.GetParallelTasksWithAutoDetection()
+
+		const taskQueueSize = 200000
+		taskQueue := job.NewTaskQueue(ctx, progress, taskQueueSize, nTasks)
+		taskQueueChan <- taskQueue
+		close(taskQueueChan)
+		taskQueue.Wait()
+		return nil
+	}))
+
+	taskQueue := <-taskQueueChan
+
+	scanner := s.makeScanner(utils.IsTrue(input.Rescan), time.Time{})
+	scanner.FileHandlers = getScanHandlers(input.ScanGenerateOptions, taskQueue, nil)
+
+	scanJob := ScanJob{
+		scanner:         scanner,
+		generateOptions: input.ScanGenerateOptions,
+	}
+
+	f, err := scanJob.scanFile(ctx, input.Path)
+	taskQueue.Close()
+
+	s.scanSubs.notify()
+
+	return f, err
 }
 
 func (s *Manager) Import(ctx context.Context) (int, error) {

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -244,7 +244,8 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 			subscriptions:   s.scanSubs,
 		}
 
-		scanJob.Execute(ctx, progress)
+		// scan job does not return error
+		_ = scanJob.Execute(ctx, progress)
 
 		// close task queue
 		taskQueue.Close()

--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stashapp/stash/pkg/job"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
 )
 
 func useAsVideo(pathname string) bool {
@@ -117,14 +118,11 @@ type ScanMetaDataFilterInput struct {
 	MinModTime *time.Time `json:"minModTime"`
 }
 
-func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error) {
-	if err := s.validateFFmpeg(); err != nil {
-		return 0, err
-	}
-
+func (s *Manager) makeScanner(rescan bool, minModTime time.Time) *file.Scanner {
 	cfg := config.GetInstance()
+	repo := s.Repository
 
-	scanner := &file.Scanner{
+	return &file.Scanner{
 		Repository: file.NewRepository(s.Repository),
 		FileDecorators: []file.Decorator{
 			&file.FilteredDecorator{
@@ -143,19 +141,119 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		FingerprintCalculator: &fingerprintCalculator{s.Config},
 		FS:                    &file.OsFS{},
 		ZipFileExtensions:     cfg.GetGalleryExtensions(),
-		// ScanFilters is set in ScanJob.Execute
-		// HandlerRequiredFilters is set in ScanJob.Execute
-		RootPaths: cfg.GetStashPaths().Paths(),
-		Rescan:    input.Rescan,
+		// FileHandlers must be set during execute as it needs progress reference
+		ScanFilters:            []file.PathFilter{newScanFilter(cfg, repo, minModTime)},
+		HandlerRequiredFilters: []file.Filter{newHandlerRequiredFilter(cfg, repo)},
+		RootPaths:              cfg.GetStashPaths().Paths(),
+		Rescan:                 rescan,
 	}
+}
+
+type ScanGenerateOptions struct {
+	// Generate covers during scan
+	GenerateCovers *models.GenerateTiming `json:"generateCovers,omitempty"`
+	// Generate video previews during scan
+	GeneratePreviews *models.GenerateTiming `json:"generatePreviews,omitempty"`
+	// Generate image previews during scan
+	GenerateImagePreviews *models.GenerateTiming `json:"generateImagePreviews,omitempty"`
+	// Generate video sprites during scan
+	GenerateSprites *models.GenerateTiming `json:"generateSprites,omitempty"`
+	// Generate video phashes during scan
+	GenerateVideoPhashes *models.GenerateTiming `json:"generateVideoPhashes,omitempty"`
+	// Generate image phashes during scan
+	GenerateImagePhashes *models.GenerateTiming `json:"generateImagePhashes,omitempty"`
+	// Generate image thumbnails during scan
+	GenerateThumbnails *models.GenerateTiming `json:"generateThumbnails,omitempty"`
+	// Generate image clip previews during scan
+	GenerateClipPreviews *models.GenerateTiming `json:"generateClipPreviews,omitempty"`
+}
+
+func makeGenerateOptions(input ScanMetadataInput) ScanGenerateOptions {
+	cfg := config.GetInstance()
+	timing := models.GenerateTimingAsync
+	if cfg.GetSequentialScanning() {
+		timing = models.GenerateTimingSync
+	}
+
+	setTiming := func(include bool) *models.GenerateTiming {
+		if include {
+			return &timing
+		}
+		return nil
+	}
+
+	setTimingSync := func(include bool) *models.GenerateTiming {
+		if include {
+			v := models.GenerateTimingSync
+			return &v
+		}
+		return nil
+	}
+
+	return ScanGenerateOptions{
+		// covers should be generated synchronously to ensure they are available
+		// when the scene is created, as they are used as the default cover
+		GenerateCovers:        setTimingSync(input.ScanGenerateCovers),
+		GeneratePreviews:      setTiming(input.ScanGeneratePreviews),
+		GenerateImagePreviews: setTiming(input.ScanGenerateImagePreviews),
+		GenerateSprites:       setTiming(input.ScanGenerateSprites),
+		GenerateVideoPhashes:  setTiming(input.ScanGeneratePhashes),
+		GenerateThumbnails:    setTiming(input.ScanGenerateThumbnails),
+		GenerateClipPreviews:  setTiming(input.ScanGenerateClipPreviews),
+		GenerateImagePhashes:  setTiming(input.ScanGenerateImagePhashes),
+	}
+}
+
+func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error) {
+	if err := s.validateFFmpeg(); err != nil {
+		return 0, err
+	}
+
+	var minModTime time.Time
+	if input.Filter != nil && input.Filter.MinModTime != nil {
+		minModTime = *input.Filter.MinModTime
+	}
+
+	scanner := s.makeScanner(input.Rescan, minModTime)
+
+	// we want the generate task to run concurrently, but it shouldn't be created first
+	jobID := s.JobManager.Add(ctx, "Scanning...", job.MakeJobExec(func(ctx context.Context, progress *job.Progress) error {
+		taskQueueChan := make(chan *job.TaskQueue)
+
+		// add the generate task in here
+		s.JobManager.Start(ctx, "Generating for scanned files...", job.MakeJobExec(func(ctx context.Context, progress *job.Progress) error {
+			const taskQueueSize = 200000
+			nTasks := s.Config.GetParallelTasksWithAutoDetection()
+			taskQueue := job.NewTaskQueue(ctx, progress, taskQueueSize, nTasks)
+
+			taskQueueChan <- taskQueue
+			close(taskQueueChan)
+
+			taskQueue.Wait()
+			logger.Debug("Finished generating from scanned files")
+			return nil
+		}))
+
+		taskQueue := <-taskQueueChan
 
 	scanJob := ScanJob{
-		scanner:       scanner,
-		input:         input,
-		subscriptions: s.scanSubs,
+			scanner:         scanner,
+			generateOptions: makeGenerateOptions(input),
+			paths:           input.Paths,
+			taskQueue:       taskQueue,
+			subscriptions:   s.scanSubs,
 	}
 
-	return s.JobManager.Add(ctx, "Scanning...", &scanJob), nil
+		scanJob.Execute(ctx, progress)
+
+		// close task queue
+		taskQueue.Close()
+
+		return nil
+	}))
+
+	return jobID, nil
+}
 }
 
 func (s *Manager) Import(ctx context.Context) (int, error) {

--- a/internal/manager/task_generate_preview.go
+++ b/internal/manager/task_generate_preview.go
@@ -12,6 +12,7 @@ import (
 
 type GeneratePreviewTask struct {
 	Scene        models.Scene
+	VideoPreview bool
 	ImagePreview bool
 
 	Options generate.PreviewOptions
@@ -84,6 +85,10 @@ func (t *GeneratePreviewTask) required() bool {
 }
 
 func (t *GeneratePreviewTask) videoPreviewRequired() bool {
+	if !t.VideoPreview {
+		return false
+	}
+
 	if t.Scene.Path == "" {
 		return false
 	}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -166,6 +166,39 @@ func makeScannedFile(f models.FS, path string, info fs.FileInfo, zipFile *file.S
 	return &ff, nil
 }
 
+// used for individual scanning only
+func (j *ScanJob) scanFile(ctx context.Context, path string) (models.File, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file info for %q: %w", path, err)
+	}
+
+	if info.IsDir() {
+		return nil, fmt.Errorf("expected file but found directory: %s", path)
+	}
+
+	if !j.scanner.AcceptEntry(ctx, path, info) {
+		return nil, fmt.Errorf("file excluded from library")
+	}
+
+	if j.scanner.IsZipFile(info.Name()) {
+		return nil, fmt.Errorf("cannot scan zip file directly")
+	}
+
+	fs := &file.OsFS{}
+	ff, err := makeScannedFile(fs, path, info, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := j.scanner.ScanFile(ctx, *ff)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.File, nil
+}
+
 func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.ScannedFile, progress *job.Progress) fs.WalkDirFunc {
 	return func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -30,9 +31,11 @@ import (
 )
 
 type ScanJob struct {
-	scanner       *file.Scanner
-	input         ScanMetadataInput
-	subscriptions *subscriptionManager
+	scanner         *file.Scanner
+	paths           []string
+	generateOptions ScanGenerateOptions
+	taskQueue       *job.TaskQueue
+	subscriptions   *subscriptionManager
 
 	fileQueue chan file.ScannedFile
 	count     int
@@ -42,45 +45,28 @@ type ScanJob struct {
 
 func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	cfg := config.GetInstance()
-	input := j.input
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
 		return nil
 	}
 
-	sp := getScanPaths(input.Paths)
+	sp := getScanPaths(j.paths)
 	paths := make([]string, len(sp))
 	for i, p := range sp {
 		paths[i] = p.Path
 	}
 
-	mgr := GetInstance()
-	c := mgr.Config
-	repo := mgr.Repository
-
 	start := time.Now()
 
 	nTasks := cfg.GetParallelTasksWithAutoDetection()
 
-	const taskQueueSize = 200000
-	taskQueue := job.NewTaskQueue(ctx, progress, taskQueueSize, nTasks)
-
-	var minModTime time.Time
-	if j.input.Filter != nil && j.input.Filter.MinModTime != nil {
-		minModTime = *j.input.Filter.MinModTime
-	}
-
 	// HACK - these should really be set in the scanner initialization
-	j.scanner.FileHandlers = getScanHandlers(j.input, taskQueue, progress)
-	j.scanner.ScanFilters = []file.PathFilter{newScanFilter(c, repo, minModTime)}
-	j.scanner.HandlerRequiredFilters = []file.Filter{newHandlerRequiredFilter(cfg, repo)}
+	j.scanner.FileHandlers = getScanHandlers(j.generateOptions, j.taskQueue, progress)
 
 	logger.Infof("Starting scan of %d paths with %d parallel tasks", len(paths), nTasks)
 
 	j.runJob(ctx, paths, nTasks, progress)
-
-	taskQueue.Close()
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
@@ -153,6 +139,33 @@ func (j *ScanJob) queueFiles(ctx context.Context, paths []string, progress *job.
 	return err
 }
 
+func makeScannedFile(f models.FS, path string, info fs.FileInfo, zipFile *file.ScannedFile) (*file.ScannedFile, error) {
+	size, err := file.GetFileSize(f, path, info)
+	if err != nil {
+		return nil, err
+	}
+
+	ff := file.ScannedFile{
+		BaseFile: &models.BaseFile{
+			DirEntry: models.DirEntry{
+				ModTime: file.ModTime(info),
+			},
+			Path:     path,
+			Basename: filepath.Base(path),
+			Size:     size,
+		},
+		FS:   f,
+		Info: info,
+	}
+
+	if zipFile != nil {
+		ff.ZipFileID = &zipFile.ID
+		ff.ZipFile = zipFile
+	}
+
+	return &ff, nil
+}
+
 func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.ScannedFile, progress *job.Progress) fs.WalkDirFunc {
 	return func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -202,32 +215,14 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 			return nil
 		}
 
-		size, err := file.GetFileSize(f, path, info)
+		ff, err := makeScannedFile(f, path, info, zipFile)
 		if err != nil {
 			return err
 		}
 
-		ff := file.ScannedFile{
-			BaseFile: &models.BaseFile{
-				DirEntry: models.DirEntry{
-					ModTime: file.ModTime(info),
-				},
-				Path:     path,
-				Basename: filepath.Base(path),
-				Size:     size,
-			},
-			FS:   f,
-			Info: info,
-		}
-
-		if zipFile != nil {
-			ff.ZipFileID = &zipFile.ID
-			ff.ZipFile = zipFile
-		}
-
 		if info.IsDir() {
 			// handle folders immediately
-			if err := j.handleFolder(ctx, ff, progress); err != nil {
+			if err := j.handleFolder(ctx, *ff, progress); err != nil {
 				if !errors.Is(err, context.Canceled) {
 					logger.Errorf("error processing %q: %v", path, err)
 				}
@@ -243,7 +238,7 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 		if zipFile != nil {
 			progress.ExecuteTask("Scanning "+path, func() {
 				// don't increment progress in zip files
-				if err := j.handleFile(ctx, ff, nil); err != nil {
+				if err := j.handleFile(ctx, *ff, nil); err != nil {
 					if !errors.Is(err, context.Canceled) {
 						logger.Errorf("error processing %q: %v", path, err)
 					}
@@ -255,7 +250,7 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 		}
 
 		logger.Tracef("Queueing file %s for scanning", path)
-		j.fileQueue <- ff
+		j.fileQueue <- *ff
 
 		j.count++
 
@@ -632,9 +627,6 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo, 
 }
 
 type scanConfig struct {
-	isGenerateThumbnails   bool
-	isGenerateClipPreviews bool
-
 	createGalleriesFromFolders bool
 }
 
@@ -654,7 +646,7 @@ func galleryFileFilter(ctx context.Context, f models.File) bool {
 	return isZip(f.Base().Basename)
 }
 
-func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progress *job.Progress) []file.Handler {
+func getScanHandlers(options ScanGenerateOptions, taskQueue *job.TaskQueue, progress *job.Progress) []file.Handler {
 	mgr := GetInstance()
 	c := mgr.Config
 	r := mgr.Repository
@@ -668,15 +660,13 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 				GalleryFinder:      r.Gallery,
 				SceneFinderUpdater: r.Scene,
 				ScanGenerator: &imageGenerators{
-					input:              options,
-					taskQueue:          taskQueue,
-					progress:           progress,
-					paths:              mgr.Paths,
-					sequentialScanning: c.GetSequentialScanning(),
+					generators: generators{
+						taskQueue: taskQueue,
+					},
+					options: options,
+					paths:   mgr.Paths,
 				},
 				ScanConfig: &scanConfig{
-					isGenerateThumbnails:       options.ScanGenerateThumbnails,
-					isGenerateClipPreviews:     options.ScanGenerateClipPreviews,
 					createGalleriesFromFolders: c.GetCreateGalleriesFromFolders(),
 				},
 				PluginCache: pluginCache,
@@ -700,12 +690,12 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 				CaptionUpdater:       r.File,
 				PluginCache:          pluginCache,
 				ScanGenerator: &sceneGenerators{
-					input:               options,
-					taskQueue:           taskQueue,
-					progress:            progress,
+					generators: generators{
+						taskQueue: taskQueue,
+					},
+					options:             options,
 					paths:               mgr.Paths,
 					fileNamingAlgorithm: c.GetVideoFileNamingAlgorithm(),
-					sequentialScanning:  c.GetSequentialScanning(),
 				},
 				FileNamingAlgorithm: c.GetVideoFileNamingAlgorithm(),
 				Paths:               mgr.Paths,
@@ -714,20 +704,29 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 	}
 }
 
-type imageGenerators struct {
-	input     ScanMetadataInput
+type generators struct {
 	taskQueue *job.TaskQueue
-	progress  *job.Progress
+}
 
-	paths              *paths.Paths
-	sequentialScanning bool
+func (g *generators) generate(ctx context.Context, desc string, generateFunc func(ctx context.Context), timing models.GenerateTiming) {
+	if timing == models.GenerateTimingSync {
+		generateFunc(ctx)
+	} else {
+		g.taskQueue.Add(desc, generateFunc)
+	}
+}
+
+type imageGenerators struct {
+	generators
+	options ScanGenerateOptions
+
+	paths *paths.Paths
 }
 
 func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f models.File) error {
 	const overwrite = false
 
-	progress := g.progress
-	t := g.input
+	t := g.options
 	path := f.Base().Path
 
 	// this is a bit of a hack: the task requires files to be loaded, but
@@ -735,20 +734,18 @@ func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f model
 	ii := *i
 	ii.Files = models.NewRelatedFiles([]models.File{f})
 
-	if t.ScanGenerateThumbnails {
-		// this should be quick, so always generate sequentially
+	if t.GenerateThumbnails != nil {
 		taskThumbnail := GenerateImageThumbnailTask{
 			Image:     ii,
 			Overwrite: overwrite,
 		}
 
-		taskThumbnail.Start(ctx)
+		g.generate(ctx, fmt.Sprintf("Generating thumbnail for %s", path), taskThumbnail.Start, *t.GenerateThumbnails)
 	}
 
 	// avoid adding a task if the file isn't a video file
 	_, isVideo := f.(*models.VideoFile)
-	if isVideo && t.ScanGenerateClipPreviews {
-		progress.AddTotal(1)
+	if isVideo && t.GenerateClipPreviews != nil {
 		previewsFn := func(ctx context.Context) {
 			taskPreview := GenerateClipPreviewTask{
 				Image:     ii,
@@ -756,18 +753,12 @@ func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f model
 			}
 
 			taskPreview.Start(ctx)
-			progress.Increment()
 		}
 
-		if g.sequentialScanning {
-			previewsFn(ctx)
-		} else {
-			g.taskQueue.Add(fmt.Sprintf("Generating preview for %s", path), previewsFn)
-		}
+		g.generate(ctx, fmt.Sprintf("Generating preview for %s", path), previewsFn, *t.GenerateClipPreviews)
 	}
 
-	if t.ScanGenerateImagePhashes {
-		progress.AddTotal(1)
+	if t.GenerateImagePhashes != nil {
 		phashFn := func(ctx context.Context) {
 			mgr := GetInstance()
 			// Only generate phash for image files, not video files
@@ -779,40 +770,31 @@ func (g *imageGenerators) Generate(ctx context.Context, i *models.Image, f model
 				}
 				taskPhash.Start(ctx)
 			}
-			progress.Increment()
 		}
 
-		if g.sequentialScanning {
-			phashFn(ctx)
-		} else {
-			g.taskQueue.Add(fmt.Sprintf("Generating phash for %s", path), phashFn)
-		}
+		g.generate(ctx, fmt.Sprintf("Generating phash for %s", path), phashFn, *t.GenerateImagePhashes)
 	}
 
 	return nil
 }
 
 type sceneGenerators struct {
-	input     ScanMetadataInput
-	taskQueue *job.TaskQueue
-	progress  *job.Progress
+	generators
+	options ScanGenerateOptions
 
 	paths               *paths.Paths
 	fileNamingAlgorithm models.HashAlgorithm
-	sequentialScanning  bool
 }
 
 func (g *sceneGenerators) Generate(ctx context.Context, s *models.Scene, f *models.VideoFile) error {
 	const overwrite = false
 
-	progress := g.progress
-	t := g.input
+	t := g.options
 	path := f.Path
 
 	mgr := GetInstance()
 
-	if t.ScanGenerateSprites {
-		progress.AddTotal(1)
+	if t.GenerateSprites != nil {
 		spriteFn := func(ctx context.Context) {
 			taskSprite := GenerateSpriteTask{
 				Scene:               *s,
@@ -820,18 +802,12 @@ func (g *sceneGenerators) Generate(ctx context.Context, s *models.Scene, f *mode
 				fileNamingAlgorithm: g.fileNamingAlgorithm,
 			}
 			taskSprite.Start(ctx)
-			progress.Increment()
 		}
 
-		if g.sequentialScanning {
-			spriteFn(ctx)
-		} else {
-			g.taskQueue.Add(fmt.Sprintf("Generating sprites for %s", path), spriteFn)
-		}
+		g.generate(ctx, fmt.Sprintf("Generating sprites for %s", path), spriteFn, *t.GenerateSprites)
 	}
 
-	if t.ScanGeneratePhashes {
-		progress.AddTotal(1)
+	if t.GenerateVideoPhashes != nil {
 		phashFn := func(ctx context.Context) {
 			taskPhash := GeneratePhashTask{
 				repository:          mgr.Repository,
@@ -840,18 +816,12 @@ func (g *sceneGenerators) Generate(ctx context.Context, s *models.Scene, f *mode
 				fileNamingAlgorithm: g.fileNamingAlgorithm,
 			}
 			taskPhash.Start(ctx)
-			progress.Increment()
 		}
 
-		if g.sequentialScanning {
-			phashFn(ctx)
-		} else {
-			g.taskQueue.Add(fmt.Sprintf("Generating phash for %s", path), phashFn)
-		}
+		g.generate(ctx, fmt.Sprintf("Generating phash for %s", path), phashFn, *t.GenerateVideoPhashes)
 	}
 
-	if t.ScanGeneratePreviews {
-		progress.AddTotal(1)
+	if t.GeneratePreviews != nil || t.GenerateImagePreviews != nil {
 		previewsFn := func(ctx context.Context) {
 			options := getGeneratePreviewOptions(GeneratePreviewOptionsInput{})
 
@@ -866,34 +836,36 @@ func (g *sceneGenerators) Generate(ctx context.Context, s *models.Scene, f *mode
 
 			taskPreview := GeneratePreviewTask{
 				Scene:               *s,
-				ImagePreview:        t.ScanGenerateImagePreviews,
+				VideoPreview:        t.GeneratePreviews != nil,
+				ImagePreview:        t.GenerateImagePreviews != nil,
 				Options:             options,
 				Overwrite:           overwrite,
 				fileNamingAlgorithm: g.fileNamingAlgorithm,
 				generator:           generator,
 			}
 			taskPreview.Start(ctx)
-			progress.Increment()
 		}
 
-		if g.sequentialScanning {
-			previewsFn(ctx)
-		} else {
-			g.taskQueue.Add(fmt.Sprintf("Generating preview for %s", path), previewsFn)
+		// use value of generate previews if present, otherwise use images
+		timing := t.GeneratePreviews
+		if timing == nil {
+			timing = t.GenerateImagePreviews
 		}
+
+		g.generate(ctx, fmt.Sprintf("Generating preview for %s", path), previewsFn, *timing)
 	}
 
-	if t.ScanGenerateCovers {
-		progress.AddTotal(1)
-		g.taskQueue.Add(fmt.Sprintf("Generating cover for %s", path), func(ctx context.Context) {
+	if t.GenerateCovers != nil {
+		fn := func(ctx context.Context) {
 			taskCover := GenerateCoverTask{
 				repository: mgr.Repository,
 				Scene:      *s,
 				Overwrite:  overwrite,
 			}
 			taskCover.Start(ctx)
-			progress.Increment()
-		})
+		}
+
+		g.generate(ctx, fmt.Sprintf("Generating cover for %s", path), fn, *t.GenerateCovers)
 	}
 
 	return nil

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -177,7 +177,8 @@ func (j *ScanJob) scanFile(ctx context.Context, path string) (models.File, error
 		return nil, fmt.Errorf("expected file but found directory: %s", path)
 	}
 
-	if !j.scanner.AcceptEntry(ctx, path, info) {
+	const zipFilePath = ""
+	if !j.scanner.AcceptEntry(ctx, path, info, zipFilePath) {
 		return nil, fmt.Errorf("file excluded from library")
 	}
 

--- a/pkg/job/manager.go
+++ b/pkg/job/manager.go
@@ -95,7 +95,18 @@ func (m *Manager) Start(ctx context.Context, description string, e JobExec) int 
 
 	m.queue = append(m.queue, &j)
 
-	m.dispatch(ctx, &j)
+	m.notifyNewJob(&j)
+	done := m.dispatch(ctx, &j)
+
+	// handle removing the job from the queue when it is done
+	go func() {
+		<-done
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+
+		// remove the job from the queue
+		m.removeJob(&j)
+	}()
 
 	return j.ID
 }

--- a/pkg/job/progress.go
+++ b/pkg/job/progress.go
@@ -24,6 +24,10 @@ type task struct {
 }
 
 func (p *Progress) updated() {
+	if p == nil {
+		return
+	}
+
 	var details []string
 	for _, t := range p.currentTasks {
 		details = append(details, t.description)
@@ -34,6 +38,10 @@ func (p *Progress) updated() {
 
 // Indefinite sets the progress to an indefinite amount.
 func (p *Progress) Indefinite() {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -44,6 +52,10 @@ func (p *Progress) Indefinite() {
 
 // Definite notifies that the total is known.
 func (p *Progress) Definite() {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -54,6 +66,10 @@ func (p *Progress) Definite() {
 // SetTotal sets the total number of work units and sets definite to true.
 // This is used to calculate the progress percentage.
 func (p *Progress) SetTotal(total int) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -65,6 +81,10 @@ func (p *Progress) SetTotal(total int) {
 // AddTotal adds to the total number of work units. This is used to calculate the
 // progress percentage.
 func (p *Progress) AddTotal(total int) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -75,6 +95,10 @@ func (p *Progress) AddTotal(total int) {
 // SetProcessed sets the number of work units completed. This is used to
 // calculate the progress percentage.
 func (p *Progress) SetProcessed(processed int) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -83,6 +107,10 @@ func (p *Progress) SetProcessed(processed int) {
 }
 
 func (p *Progress) calculatePercent() {
+	if p == nil {
+		return
+	}
+
 	switch {
 	case !p.defined || p.total <= 0:
 		p.percent = ProgressIndefinite
@@ -102,6 +130,10 @@ func (p *Progress) calculatePercent() {
 // overwritten if Indefinite, SetTotal, Increment or SetProcessed is called.
 // Constrains the percent value between 0 and 1, inclusive.
 func (p *Progress) SetPercent(percent float64) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -118,6 +150,10 @@ func (p *Progress) SetPercent(percent float64) {
 // Increment increments the number of processed work units. This is used to calculate the percentage.
 // If total is set already, then the number of processed work units will not exceed the total.
 func (p *Progress) Increment() {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -130,6 +166,10 @@ func (p *Progress) Increment() {
 // AddProcessed increments the number of processed work units by the provided
 // amount. This is used to calculate the percentage.
 func (p *Progress) AddProcessed(v int) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -143,6 +183,10 @@ func (p *Progress) AddProcessed(v int) {
 }
 
 func (p *Progress) addTask(t *task) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -151,6 +195,10 @@ func (p *Progress) addTask(t *task) {
 }
 
 func (p *Progress) removeTask(t *task) {
+	if p == nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 

--- a/pkg/job/task.go
+++ b/pkg/job/task.go
@@ -32,6 +32,7 @@ func NewTaskQueue(ctx context.Context, p *Progress, queueSize int, processes int
 }
 
 func (tq *TaskQueue) Add(description string, fn func(ctx context.Context)) {
+	tq.p.AddTotal(1)
 	tq.tasks <- taskExec{
 		task: task{
 			description: description,
@@ -42,6 +43,10 @@ func (tq *TaskQueue) Add(description string, fn func(ctx context.Context)) {
 
 func (tq *TaskQueue) Close() {
 	close(tq.tasks)
+	tq.p.Definite()
+}
+
+func (tq *TaskQueue) Wait() {
 	// wait for all tasks to finish
 	<-tq.done
 }
@@ -59,6 +64,7 @@ func (tq *TaskQueue) executer(ctx context.Context) {
 		tq.wg.Add()
 		go func() {
 			defer tq.wg.Done()
+			defer tq.p.Increment()
 			tq.p.ExecuteTask(tt.description, func() {
 				tt.fn(ctx)
 			})

--- a/pkg/models/enums.go
+++ b/pkg/models/enums.go
@@ -1,0 +1,67 @@
+package models
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+type GenerateTiming string
+
+const (
+	// Generate metadata before returning from the scan API call.
+	// This will block the API call until generation is complete, and is not recommended for large artifacts.
+	// Recommended when you want the metadata/artifact to be available immediately after the scan completes (ie covers and phashes).
+	GenerateTimingSync GenerateTiming = "SYNC"
+	// Generate metadata asynchronously after the scan completes.
+	GenerateTimingAsync GenerateTiming = "ASYNC"
+)
+
+var AllGenerateTiming = []GenerateTiming{
+	GenerateTimingSync,
+	GenerateTimingAsync,
+}
+
+func (e GenerateTiming) IsValid() bool {
+	switch e {
+	case GenerateTimingSync, GenerateTimingAsync:
+		return true
+	}
+	return false
+}
+
+func (e GenerateTiming) String() string {
+	return string(e)
+}
+
+func (e *GenerateTiming) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = GenerateTiming(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid GenerateTiming", str)
+	}
+	return nil
+}
+
+func (e GenerateTiming) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *GenerateTiming) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e GenerateTiming) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
This ended up being a bit more wide ranging than originally intended.

- scanning now ~~creates~~ starts a second _concurrent_ task in the job manager for `Generating for scanned files...` 
  - progress is not shown for the generate task until scanning is completed
  - generation must be cancelled separately to scanning
- adds a `scanFile` graphql mutation
  - scans a file with a provided path and returns the scanned file information
  - accepts a number of `generateX` parameters in the form of a `GenerateTiming` enum value, which can be `SYNC` (run while scanning, wait for finish), or `ASYNC` (run asynchoronously). This allows for synchronised generation of phashes for example, so that it is returned when scan completes

In future, I anticipate adding an `Upload` parameter so that a file can be uploaded and scanned in the one operation.