### PR TITLE
Changelog v0.31

### DIFF
--- a/ui/v2.5/src/components/Changelog/Changelog.tsx
+++ b/ui/v2.5/src/components/Changelog/Changelog.tsx
@@ -35,6 +35,7 @@ import V0270 from "src/docs/en/Changelog/v0270.md";
 import V0280 from "src/docs/en/Changelog/v0280.md";
 import V0290 from "src/docs/en/Changelog/v0290.md";
 import V0300 from "src/docs/en/Changelog/v0300.md";
+import V0310 from "src/docs/en/Changelog/v0310.md";
 
 import V0290ReleaseNotes from "src/docs/en/ReleaseNotes/v0290.md";
 
@@ -75,9 +76,9 @@ const Changelog: React.FC = () => {
   // after new release:
   // add entry to releases, using the current* fields
   // then update the current fields.
-  const currentVersion = stashVersion || "v0.30.0";
+  const currentVersion = stashVersion || "v0.31.0";
   const currentDate = buildDate;
-  const currentPage = V0300;
+  const currentPage = V0310;
 
   const releases: IStashRelease[] = [
     {
@@ -85,6 +86,12 @@ const Changelog: React.FC = () => {
       date: currentDate,
       page: currentPage,
       defaultOpen: true,
+    },
+    {
+      version: "v0.30.1",
+      date: "2025-12-18",
+      page: V0300,
+      releaseNotes: V0290ReleaseNotes,
     },
     {
       version: "v0.29.3",

--- a/ui/v2.5/src/components/Changelog/styles.scss
+++ b/ui/v2.5/src/components/Changelog/styles.scss
@@ -20,11 +20,6 @@
     padding: 0;
   }
 
-  ul {
-    list-style-type: none;
-    padding-left: 0.5rem;
-  }
-
   &-version {
     &-body {
       padding: 1rem 2rem;

--- a/ui/v2.5/src/docs/en/Changelog/v0310.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0310.md
@@ -1,0 +1,78 @@
+### ✨ New Features
+
+* Added Troubleshooting Mode to help identify and resolve common issues. ([#6343](https://github.com/stashapp/stash/pull/6343))
+* Added support for image phash generation and filtering. ([#6497](https://github.com/stashapp/stash/pull/6497))
+* Added minimum/maximum number of sprites and sprite size options to support customised scene sprite generation. ([#6588](https://github.com/stashapp/stash/pull/6588))
+* Added support for merging performers. ([#5910](https://github.com/stashapp/stash/pull/5910))
+* Added `Reveal in file manager` button to file info panel when running locally. ([#6587](https://github.com/stashapp/stash/pull/6587))
+* Added `.stashignore` support for gitignore-style scan exclusions. ([#6485](https://github.com/stashapp/stash/pull/6485))
+* Added Selective generate option. ([#6621](https://github.com/stashapp/stash/pull/6621))
+* Added `From Clipboard` option to Set Image dropdown button (on secure connections). ([#6637](https://github.com/stashapp/stash/pull/6637))
+* Added Tags tagger view. ([#6559](https://github.com/stashapp/stash/pull/6559), [#6620](https://github.com/stashapp/stash/pull/6620))
+* Added loop option for markers. ([#6510](https://github.com/stashapp/stash/pull/6510))
+* Added support for custom favicon and title. ([#6366](https://github.com/stashapp/stash/pull/6366))
+
+### 🎨 Improvements
+
+* Sidebars are now used for lists of galleries ([#6157](https://github.com/stashapp/stash/pull/6157)), images ([#6607](https://github.com/stashapp/stash/pull/6607)), groups ([#6573](https://github.com/stashapp/stash/pull/6573)), performers ([#6547](https://github.com/stashapp/stash/pull/6547)), studios ([#6549](https://github.com/stashapp/stash/pull/6549)), tags ([#6610](https://github.com/stashapp/stash/pull/6610)), and scene markers ([#6603](https://github.com/stashapp/stash/pull/6603)).
+* Added folder sidebar criterion option for scenes, images and galleries. ([#6636](https://github.com/stashapp/stash/pull/6636))
+* Custom field support has been added to scenes ([#6584](https://github.com/stashapp/stash/pull/6584)), galleries ([#6592](https://github.com/stashapp/stash/pull/6592)), images ([#6598](https://github.com/stashapp/stash/pull/6598)), groups ([#6596](https://github.com/stashapp/stash/pull/6596)) studios ([#6156](https://github.com/stashapp/stash/pull/6156)) and tags ([#6546](https://github.com/stashapp/stash/pull/6546)). 
+* Bulk edit dialogs have been refactored to include more fields. ([#6647](https://github.com/stashapp/stash/pull/6647))
+* Extended duplicate criterion to filter by duplicated titles and stash IDs. ([#6344](https://github.com/stashapp/stash/pull/6344))
+* Extended missing criterion to add full coverage of fields. ([#6565](https://github.com/stashapp/stash/pull/6565))
+* Identify settings now allows for selecting included genders. ([#6557](https://github.com/stashapp/stash/pull/6557))
+* Backup now provides an option to include blobs in a backup zip. ([#6586](https://github.com/stashapp/stash/pull/6586))
+* Added checkbox selection on wall and tagger views. ([#6476](https://github.com/stashapp/stash/pull/6476))
+* Performer career length field has been replaced with career start and end fields. ([#6449](https://github.com/stashapp/stash/pull/6449))
+* Added organised flag to studios. ([#6303](https://github.com/stashapp/stash/pull/6303))
+* Merging tags now shows a dialog to edit the merged tag's details. ([#6552](https://github.com/stashapp/stash/pull/6552))
+* New object pages now support for saving and creating another object. ([#6438](https://github.com/stashapp/stash/pull/6438))
+* Default performer images have been updated to be consistent with other card images. ([#6566](https://github.com/stashapp/stash/pull/6566))
+* Unsupported filter criteria are now indicated in the UI. ([#6604](https://github.com/stashapp/stash/pull/6604))
+* Marker screenshots can now be generated independently of marker previews. ([#6433](https://github.com/stashapp/stash/pull/6433))
+* Added invert selection option to list menus. ([#6491](https://github.com/stashapp/stash/pull/6491))
+* Added Generate task option for galleries. ([#6442](https://github.com/stashapp/stash/pull/6442))
+* Scene resolution and duration is now shown in the tagger view. ([#6663](https://github.com/stashapp/stash/pull/6663))
+* Added button to delete scene cover. ([#6444](https://github.com/stashapp/stash/pull/6444))
+* Duplicate aliases are now silently removed. ([#6514](https://github.com/stashapp/stash/pull/6514))
+* Image query now includes image details field. ([#6673](https://github.com/stashapp/stash/pull/6673))
+* Added non-binary gender icon. ([#6489](https://github.com/stashapp/stash/pull/6489))
+* Transgender icons are now coloured by their presented gender. ([#6489](https://github.com/stashapp/stash/pull/6489))
+* It is now possible to add a library path to a non-existing directory (useful for disconnected network paths). ([#6644](https://github.com/stashapp/stash/pull/6644))
+* Added activity tracking for DLNA resume/view counts. ([#6407](https://github.com/stashapp/stash/pull/6407), [#6483](https://github.com/stashapp/stash/pull/6483))
+* SFW Mode now shows performer ages. ([#6450](https://github.com/stashapp/stash/pull/6450))
+* Added support for sorting scenes and images by resolution. ([#6441](https://github.com/stashapp/stash/pull/6441))
+* Added support for sorting performers and studios by latest scene. ([#6501](https://github.com/stashapp/stash/pull/6501))
+* Added support for filtering by stash ID count. ([#6437](https://github.com/stashapp/stash/pull/6437))
+* Added support for filtering group by scene count. ([#6593](https://github.com/stashapp/stash/pull/6593))
+* Installed plugins/scrapers no longer show in the available list. ([#6443](https://github.com/stashapp/stash/pull/6443))
+* Name is now populated when searching by stash-box. ([#6447](https://github.com/stashapp/stash/pull/6447))
+* Improved performance of group queries on large systems. ([#6478](https://github.com/stashapp/stash/pull/6478))
+* Systray notification now shows the port stash is running on. ([#6448](https://github.com/stashapp/stash/pull/6448))
+
+### 🐛 Bug fixes
+
+* Fixed certain unicode characters in library path causing panic in scan task. ([#6431](https://github.com/stashapp/stash/pull/6431), [#6589](https://github.com/stashapp/stash/pull/6589), [#6635](https://github.com/stashapp/stash/pull/6635))
+* Fixed bad network path error preventing rename detection during scanning. ([#6680](https://github.com/stashapp/stash/pull/6680))
+* Fixed duplicate files in zips being incorrectly reported as renames. ([#6493](https://github.com/stashapp/stash/pull/6493))
+* Fixed merging scene causing cover to be lost. ([#6542](https://github.com/stashapp/stash/pull/6542))
+* Improved scanning algorithm to prevent creation of orphaned folders and handle missing parent folders. ([#6608](https://github.com/stashapp/stash/pull/6608))
+* Scanning no longer scans zip contents when the zip file is unchanged. ([#6633](https://github.com/stashapp/stash/pull/6633))
+* Captions are now correctly detected in a single scan. ([#6634](https://github.com/stashapp/stash/pull/6634))
+* Fixed mis-clicks on cards navigating to new page when selecting items. ([#6599](https://github.com/stashapp/stash/pull/6599), [#6649](https://github.com/stashapp/stash/pull/6649))
+* Fixed custom field filtering not working correctly when query value was provided. ([#6614](https://github.com/stashapp/stash/pull/6614))
+* Fixed stale thumbnails after file content is changed. ([#6622](https://github.com/stashapp/stash/pull/6622))
+* Clicking on the scrubber in the scene player no longer pauses the video. ([#6336](https://github.com/stashapp/stash/pull/6336))
+* Fixed string-based hash filtering not functioning correctly. ([#6654](https://github.com/stashapp/stash/pull/6654))
+* Fixed hardware decoding detection for 10-bit videos on rkmpp. ([#6420](https://github.com/stashapp/stash/pull/6420))
+
+### Api Changes
+
+* Many new components are now patchable. ([#6468](https://github.com/stashapp/stash/pull/6468), [#6463](https://github.com/stashapp/stash/pull/6463), [#6482](https://github.com/stashapp/stash/pull/6482), [#6492](https://github.com/stashapp/stash/pull/6492), [#6470](https://github.com/stashapp/stash/pull/6470))
+* Added access to `ReactFontAwesome` in the plugin API. ([#6487](https://github.com/stashapp/stash/pull/6487))
+* Added `destroyFiles` mutation to delete file entries from the database. ([#6437](https://github.com/stashapp/stash/pull/6437))
+* Added `destroy_file_entry` flag to destroy inputs to destroy file entries when destroying scenes, images, and galleries. ([#6437](https://github.com/stashapp/stash/pull/6437))
+* Added `basename` and `parent_folders` fields to the `folder` type. ([#6494](https://github.com/stashapp/stash/pull/6494))
+* Added `basename` filter field to `FolderFilterType`. ([#6494](https://github.com/stashapp/stash/pull/6494))
+* Added `parent_folder` filter field to `GalleryFilterType`. ([#6636](https://github.com/stashapp/stash/pull/6636))
+* Performer `career_length` field is deprecated in favour of `career_start` and `career_end`.

--- a/ui/v2.5/src/docs/en/Changelog/v0310.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0310.md
@@ -43,6 +43,7 @@
 * SFW Mode now shows performer ages. ([#6450](https://github.com/stashapp/stash/pull/6450))
 * Added support for sorting scenes and images by resolution. ([#6441](https://github.com/stashapp/stash/pull/6441))
 * Added support for sorting performers and studios by latest scene. ([#6501](https://github.com/stashapp/stash/pull/6501))
+* Added support for sorting performers, studios and tags by total scene file size. ([#6642](https://github.com/stashapp/stash/pull/6642))
 * Added support for filtering by stash ID count. ([#6437](https://github.com/stashapp/stash/pull/6437))
 * Added support for filtering group by scene count. ([#6593](https://github.com/stashapp/stash/pull/6593))
 * Installed plugins/scrapers no longer show in the available list. ([#6443](https://github.com/stashapp/stash/pull/6443))

--- a/ui/v2.5/src/docs/en/Changelog/v0310.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0310.md
@@ -1,6 +1,5 @@
 ### ✨ New Features
 
-* Added Troubleshooting Mode to help identify and resolve common issues. ([#6343](https://github.com/stashapp/stash/pull/6343))
 * Added support for image phash generation and filtering. ([#6497](https://github.com/stashapp/stash/pull/6497))
 * Added minimum/maximum number of sprites and sprite size options to support customised scene sprite generation. ([#6588](https://github.com/stashapp/stash/pull/6588))
 * Added support for merging performers. ([#5910](https://github.com/stashapp/stash/pull/5910))
@@ -11,6 +10,7 @@
 * Added Tags tagger view. ([#6559](https://github.com/stashapp/stash/pull/6559), [#6620](https://github.com/stashapp/stash/pull/6620))
 * Added loop option for markers. ([#6510](https://github.com/stashapp/stash/pull/6510))
 * Added support for custom favicon and title. ([#6366](https://github.com/stashapp/stash/pull/6366))
+* Added Troubleshooting Mode to help identify and resolve common issues. ([#6343](https://github.com/stashapp/stash/pull/6343))
 
 ### 🎨 Improvements
 


### PR DESCRIPTION
Adds changelog for 0.31. Also adjusts the styling of the changelog to improve readability of the lists:

<img width="1165" height="439" alt="image" src="https://github.com/user-attachments/assets/30a3e202-3e69-448c-81cd-f1d0b1d8359e" />
