### PR TITLE
feat: add per-alias autotag toggle + general api/app support for per-alias autotag

### DIFF
--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -35,7 +35,9 @@ type Performer {
   career_end: String
   tattoos: String
   piercings: String
-  alias_list: [String!]!
+  alias_list: [String!] @deprecated(reason: "Use aliases")
+
+  aliases: [PerformerAlias!]!
   favorite: Boolean!
   tags: [Tag!]!
   ignore_auto_tag: Boolean!
@@ -85,7 +87,8 @@ input PerformerCreateInput {
   tattoos: String
   piercings: String
   "Duplicate aliases and those equal to name will be ignored (case-insensitive)"
-  alias_list: [String!]
+  alias_list: [String!] @deprecated(reason: "Use aliases")
+  aliases: [PerformerAliasInput!]
   twitter: String @deprecated(reason: "Use urls")
   instagram: String @deprecated(reason: "Use urls")
   favorite: Boolean
@@ -126,7 +129,8 @@ input PerformerUpdateInput {
   tattoos: String
   piercings: String
   "Duplicate aliases and those equal to name will be ignored (case-insensitive)"
-  alias_list: [String!]
+  alias_list: [String!] @deprecated(reason: "Use aliases")
+  aliases: [PerformerAliasInput!]
   twitter: String @deprecated(reason: "Use urls")
   instagram: String @deprecated(reason: "Use urls")
   favorite: Boolean
@@ -172,7 +176,8 @@ input BulkPerformerUpdateInput {
   tattoos: String
   piercings: String
   "Duplicate aliases and those equal to name will result in an error (case-insensitive)"
-  alias_list: BulkUpdateStrings
+  alias_list: BulkUpdateStrings @deprecated(reason: "Use aliases")
+  aliases: BulkUpdatePerformerAliases
   twitter: String @deprecated(reason: "Use urls")
   instagram: String @deprecated(reason: "Use urls")
   favorite: Boolean
@@ -202,4 +207,19 @@ input PerformerMergeInput {
   destination: ID!
   # values defined here will override values in the destination
   values: PerformerUpdateInput
+}
+
+type PerformerAlias {
+  alias: String!
+  ignore_auto_tag: Boolean!
+}
+
+input PerformerAliasInput {
+  alias: String!
+  ignore_auto_tag: Boolean!
+}
+
+input BulkUpdatePerformerAliases {
+  values: [PerformerAliasInput!]
+  mode: BulkUpdateIdMode!
 }

--- a/internal/api/resolver_model_performer.go
+++ b/internal/api/resolver_model_performer.go
@@ -21,7 +21,7 @@ func (r *performerResolver) AliasList(ctx context.Context, obj *models.Performer
 		}
 	}
 
-	return obj.Aliases.List(), nil
+	return obj.Aliases.ToAliases(), nil
 }
 
 func (r *performerResolver) URL(ctx context.Context, obj *models.Performer) (*string, error) {
@@ -309,4 +309,22 @@ func (r *performerResolver) CustomFields(ctx context.Context, obj *models.Perfor
 // deprecated
 func (r *performerResolver) Movies(ctx context.Context, obj *models.Performer) (ret []*models.Group, err error) {
 	return r.Groups(ctx, obj)
+}
+
+func (r *performerResolver) Aliases(ctx context.Context, obj *models.Performer) ([]*models.PerformerAlias, error) {
+	if !obj.Aliases.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			qb := r.repository.Performer
+			return obj.LoadAliases(ctx, qb)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	ret := make([]*models.PerformerAlias, len(obj.Aliases.List()))
+	for i, v := range obj.Aliases.List() {
+		vCopy := v
+		ret[i] = &vCopy
+	}
+	return ret, nil
 }

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -43,7 +43,20 @@ func (r *mutationResolver) PerformerCreate(ctx context.Context, input models.Per
 
 	newPerformer.Name = strings.TrimSpace(input.Name)
 	newPerformer.Disambiguation = translator.string(input.Disambiguation)
-	newPerformer.Aliases = models.NewRelatedStrings(stringslice.UniqueExcludeFold(stringslice.TrimSpace(input.AliasList), newPerformer.Name))
+	var aliases []models.PerformerAlias
+	if input.Aliases != nil {
+		for _, a := range input.Aliases {
+			aliases = append(aliases, models.PerformerAlias{
+				Alias:         strings.TrimSpace(a.Alias),
+				IgnoreAutoTag: a.IgnoreAutoTag,
+			})
+		}
+	} else if input.AliasList != nil {
+		for _, a := range stringslice.UniqueExcludeFold(stringslice.TrimSpace(input.AliasList), newPerformer.Name) {
+			aliases = append(aliases, models.PerformerAlias{Alias: a, IgnoreAutoTag: true})
+		}
+	}
+	newPerformer.Aliases = models.NewRelatedPerformerAliases(aliases)
 	newPerformer.Gender = input.Gender
 	newPerformer.Ethnicity = translator.string(input.Ethnicity)
 	newPerformer.Country = translator.string(input.Country)
@@ -337,9 +350,28 @@ func performerPartialFromInput(input models.PerformerUpdateInput, translator cha
 		updatedPerformer.Height = translator.optionalInt(input.HeightCm, "height_cm")
 	}
 
-	// prefer alias_list over aliases
-	if translator.hasField("alias_list") {
-		updatedPerformer.Aliases = translator.updateStrings(input.AliasList, "alias_list")
+	// prefer aliases over alias_list
+	if translator.hasField("aliases") {
+		var aliases []models.PerformerAlias
+		for _, a := range input.Aliases.Values {
+			aliases = append(aliases, models.PerformerAlias{
+				Alias:         strings.TrimSpace(a.Alias),
+				IgnoreAutoTag: a.IgnoreAutoTag,
+			})
+		}
+		updatedPerformer.Aliases = &models.UpdatePerformerAliases{
+			Values: aliases,
+			Mode:   input.Aliases.Mode,
+		}
+	} else if translator.hasField("alias_list") {
+		var aliases []models.PerformerAlias
+		for _, a := range input.AliasList {
+			aliases = append(aliases, models.PerformerAlias{Alias: a, IgnoreAutoTag: true})
+		}
+		updatedPerformer.Aliases = &models.UpdatePerformerAliases{
+			Values: aliases,
+			Mode:   models.RelationshipUpdateModeSet,
+		}
 	}
 
 	updatedPerformer.TagIDs, err = translator.updateIds(input.TagIds, "tag_ids")
@@ -350,6 +382,20 @@ func performerPartialFromInput(input models.PerformerUpdateInput, translator cha
 	updatedPerformer.CustomFields = handleUpdateCustomFields(input.CustomFields)
 
 	return &updatedPerformer, nil
+}
+
+type performerUpdateInputResolver struct{ *Resolver }
+
+func (r *performerUpdateInputResolver) Aliases(ctx context.Context, obj *models.PerformerUpdateInput, data []*models.PerformerAliasInput) error {
+	obj.Aliases = &models.UpdatePerformerAliasesInput{
+		Values: data,
+		Mode:   models.RelationshipUpdateModeSet, // Use Set mode for simple aliases property, though client can also use AliasList
+	}
+	return nil
+}
+
+func (r *Resolver) PerformerUpdateInput() PerformerUpdateInputResolver {
+	return &performerUpdateInputResolver{r}
 }
 
 func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.PerformerUpdateInput) (*models.Performer, error) {
@@ -398,13 +444,61 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 					return err
 				}
 
-				effectiveAliases := updatedPerformer.Aliases.Apply(p.Aliases.List())
+				var effectiveAliases []models.PerformerAlias
+				switch updatedPerformer.Aliases.Mode {
+				case models.RelationshipUpdateModeSet:
+					// We need to preserve the IgnoreAutoTag state when updating aliases via AliasList (which sets them to true by default)
+					// if they already existed.
+					if translator.hasField("alias_list") && !translator.hasField("aliases") {
+						existingAliases := p.Aliases.List()
+						existingAliasMap := make(map[string]bool)
+						for _, existing := range existingAliases {
+							existingAliasMap[existing.Alias] = existing.IgnoreAutoTag
+						}
+
+						for _, a := range updatedPerformer.Aliases.Values {
+							if ignore, ok := existingAliasMap[a.Alias]; ok {
+								a.IgnoreAutoTag = ignore
+							}
+							effectiveAliases = append(effectiveAliases, a)
+						}
+					} else {
+						effectiveAliases = updatedPerformer.Aliases.Values
+					}
+				case models.RelationshipUpdateModeAdd:
+					effectiveAliases = append(p.Aliases.List(), updatedPerformer.Aliases.Values...)
+				case models.RelationshipUpdateModeRemove:
+					for _, existing := range p.Aliases.List() {
+						found := false
+						for _, toRemove := range updatedPerformer.Aliases.Values {
+							if existing.Alias == toRemove.Alias {
+								found = true
+								break
+							}
+						}
+						if !found {
+							effectiveAliases = append(effectiveAliases, existing)
+						}
+					}
+				}
+
 				name := p.Name
 				if updatedPerformer.Name.Set {
 					name = updatedPerformer.Name.Value
 				}
 
-				sanitized := stringslice.UniqueExcludeFold(effectiveAliases, name)
+				var sanitized []models.PerformerAlias
+				seen := make(map[string]bool)
+				for _, a := range effectiveAliases {
+					trimmed := strings.TrimSpace(a.Alias)
+					lower := strings.ToLower(trimmed)
+					if trimmed != "" && lower != strings.ToLower(name) && !seen[lower] {
+						seen[lower] = true
+						a.Alias = trimmed
+						sanitized = append(sanitized, a)
+					}
+				}
+
 				updatedPerformer.Aliases.Values = sanitized
 				updatedPerformer.Aliases.Mode = models.RelationshipUpdateModeSet
 			}
@@ -518,9 +612,28 @@ func (r *mutationResolver) BulkPerformerUpdate(ctx context.Context, input BulkPe
 		updatedPerformer.Height = translator.optionalInt(input.HeightCm, "height_cm")
 	}
 
-	// prefer alias_list over aliases
-	if translator.hasField("alias_list") {
-		updatedPerformer.Aliases = translator.updateStringsBulk(input.AliasList, "alias_list")
+	// prefer aliases over alias_list
+	if translator.hasField("aliases") {
+		var aliases []models.PerformerAlias
+		for _, a := range input.Aliases.Values {
+			aliases = append(aliases, models.PerformerAlias{
+				Alias:         strings.TrimSpace(a.Alias),
+				IgnoreAutoTag: a.IgnoreAutoTag,
+			})
+		}
+		updatedPerformer.Aliases = &models.UpdatePerformerAliases{
+			Values: aliases,
+			Mode:   input.Aliases.Mode,
+		}
+	} else if translator.hasField("alias_list") {
+		var aliases []models.PerformerAlias
+		for _, a := range input.AliasList.Values {
+			aliases = append(aliases, models.PerformerAlias{Alias: a, IgnoreAutoTag: true})
+		}
+		updatedPerformer.Aliases = &models.UpdatePerformerAliases{
+			Values: aliases,
+			Mode:   input.AliasList.Mode,
+		}
 	}
 
 	updatedPerformer.TagIDs, err = translator.updateIdsBulk(input.TagIds, "tag_ids")

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -47,16 +47,16 @@ func (r *mutationResolver) PerformerCreate(ctx context.Context, input models.Per
 	if input.Aliases != nil {
 		for _, a := range input.Aliases {
 			aliases = append(aliases, models.PerformerAlias{
-				Alias:         strings.TrimSpace(a.Alias),
+				Alias:         a.Alias,
 				IgnoreAutoTag: a.IgnoreAutoTag,
 			})
 		}
 	} else if input.AliasList != nil {
-		for _, a := range stringslice.UniqueExcludeFold(stringslice.TrimSpace(input.AliasList), newPerformer.Name) {
+		for _, a := range input.AliasList {
 			aliases = append(aliases, models.PerformerAlias{Alias: a, IgnoreAutoTag: true})
 		}
 	}
-	newPerformer.Aliases = models.NewRelatedPerformerAliases(aliases)
+	newPerformer.Aliases = models.NewRelatedPerformerAliases(performer.NormalizeAliases(newPerformer.Name, aliases))
 	newPerformer.Gender = input.Gender
 	newPerformer.Ethnicity = translator.string(input.Ethnicity)
 	newPerformer.Country = translator.string(input.Country)
@@ -444,62 +444,17 @@ func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.Per
 					return err
 				}
 
-				var effectiveAliases []models.PerformerAlias
-				switch updatedPerformer.Aliases.Mode {
-				case models.RelationshipUpdateModeSet:
-					// We need to preserve the IgnoreAutoTag state when updating aliases via AliasList (which sets them to true by default)
-					// if they already existed.
-					if translator.hasField("alias_list") && !translator.hasField("aliases") {
-						existingAliases := p.Aliases.List()
-						existingAliasMap := make(map[string]bool)
-						for _, existing := range existingAliases {
-							existingAliasMap[existing.Alias] = existing.IgnoreAutoTag
-						}
-
-						for _, a := range updatedPerformer.Aliases.Values {
-							if ignore, ok := existingAliasMap[a.Alias]; ok {
-								a.IgnoreAutoTag = ignore
-							}
-							effectiveAliases = append(effectiveAliases, a)
-						}
-					} else {
-						effectiveAliases = updatedPerformer.Aliases.Values
-					}
-				case models.RelationshipUpdateModeAdd:
-					effectiveAliases = append(p.Aliases.List(), updatedPerformer.Aliases.Values...)
-				case models.RelationshipUpdateModeRemove:
-					for _, existing := range p.Aliases.List() {
-						found := false
-						for _, toRemove := range updatedPerformer.Aliases.Values {
-							if existing.Alias == toRemove.Alias {
-								found = true
-								break
-							}
-						}
-						if !found {
-							effectiveAliases = append(effectiveAliases, existing)
-						}
-					}
-				}
+				// Preserve IgnoreAutoTag state when updating aliases via AliasList (which sets them to true by default)
+				// if they already existed.
+				preserveIgnore := translator.hasField("alias_list") && !translator.hasField("aliases")
+				effectiveAliases := performer.GetEffectiveAliases(p.Aliases.List(), updatedPerformer.Aliases.Values, updatedPerformer.Aliases.Mode, preserveIgnore)
 
 				name := p.Name
 				if updatedPerformer.Name.Set {
 					name = updatedPerformer.Name.Value
 				}
 
-				var sanitized []models.PerformerAlias
-				seen := make(map[string]bool)
-				for _, a := range effectiveAliases {
-					trimmed := strings.TrimSpace(a.Alias)
-					lower := strings.ToLower(trimmed)
-					if trimmed != "" && lower != strings.ToLower(name) && !seen[lower] {
-						seen[lower] = true
-						a.Alias = trimmed
-						sanitized = append(sanitized, a)
-					}
-				}
-
-				updatedPerformer.Aliases.Values = sanitized
+				updatedPerformer.Aliases.Values = performer.NormalizeAliases(name, effectiveAliases)
 				updatedPerformer.Aliases.Mode = models.RelationshipUpdateModeSet
 			}
 		}

--- a/internal/autotag/gallery_test.go
+++ b/internal/autotag/gallery_test.go
@@ -36,7 +36,7 @@ func TestGalleryPerformers(t *testing.T) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	const reversedPerformerName = "name performer"
@@ -44,12 +44,47 @@ func TestGalleryPerformers(t *testing.T) {
 	reversedPerformer := models.Performer{
 		ID:      reversedPerformerID,
 		Name:    reversedPerformerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	testTables := generateTestTable(performerName, galleryExt)
 
 	assert := assert.New(t)
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.GalleryPartial) bool {
+				expected := models.GalleryPartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return galleryPartialsEqual(got, expected)
+			})
+			db.Gallery.On("UpdatePartial", testCtx, galleryID, matchPartial).Return(nil, nil).Once()
+		}
+
+		gallery := models.Gallery{
+			ID:           galleryID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
+		err := GalleryPerformers(testCtx, &gallery, db.Gallery, db.Performer, nil)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: performerName, IgnoreAutoTag: false}})
 
 	for _, test := range testTables {
 		db := mocks.NewDatabase()

--- a/internal/autotag/image_test.go
+++ b/internal/autotag/image_test.go
@@ -33,7 +33,7 @@ func TestImagePerformers(t *testing.T) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	const reversedPerformerName = "name performer"
@@ -41,12 +41,47 @@ func TestImagePerformers(t *testing.T) {
 	reversedPerformer := models.Performer{
 		ID:      reversedPerformerID,
 		Name:    reversedPerformerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	testTables := generateTestTable(performerName, imageExt)
 
 	assert := assert.New(t)
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.ImagePartial) bool {
+				expected := models.ImagePartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return imagePartialsEqual(got, expected)
+			})
+			db.Image.On("UpdatePartial", testCtx, imageID, matchPartial).Return(nil, nil).Once()
+		}
+
+		image := models.Image{
+			ID:           imageID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
+		err := ImagePerformers(testCtx, &image, db.Image, db.Performer, nil)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: performerName, IgnoreAutoTag: false}})
 
 	for _, test := range testTables {
 		db := mocks.NewDatabase()

--- a/internal/autotag/performer.go
+++ b/internal/autotag/performer.go
@@ -38,15 +38,16 @@ func getPerformerTaggers(p *models.Performer, cache *match.Cache) []tagger {
 		cache: cache,
 	}}
 
-	// TODO - disabled until we can have finer control over alias matching
-	// for _, a := range p.Aliases.List() {
-	// 	ret = append(ret, tagger{
-	// 		ID:    p.ID,
-	// 		Type:  "performer",
-	// 		Name:  a,
-	// 		cache: cache,
-	// 	})
-	// }
+	for _, a := range p.Aliases.List() {
+		if !a.IgnoreAutoTag {
+			ret = append(ret, tagger{
+				ID:    p.ID,
+				Type:  "performer",
+				Name:  a.Alias,
+				cache: cache,
+			})
+		}
+	}
 
 	return ret
 }

--- a/internal/autotag/performer_test.go
+++ b/internal/autotag/performer_test.go
@@ -62,7 +62,7 @@ func testPerformerScenes(t *testing.T, performerName, expectedRegex string) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	organized := false
@@ -157,7 +157,7 @@ func testPerformerImages(t *testing.T, performerName, expectedRegex string) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	organized := false
@@ -253,7 +253,7 @@ func testPerformerGalleries(t *testing.T, performerName, expectedRegex string) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	organized := false

--- a/internal/autotag/scene_test.go
+++ b/internal/autotag/scene_test.go
@@ -166,7 +166,7 @@ func TestScenePerformers(t *testing.T) {
 	performer := models.Performer{
 		ID:      performerID,
 		Name:    performerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	const reversedPerformerName = "name performer"
@@ -174,7 +174,7 @@ func TestScenePerformers(t *testing.T) {
 	reversedPerformer := models.Performer{
 		ID:      reversedPerformerID,
 		Name:    reversedPerformerName,
-		Aliases: models.NewRelatedStrings([]string{}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 	}
 
 	testTables := generateTestTable(performerName, sceneExt)
@@ -207,6 +207,41 @@ func TestScenePerformers(t *testing.T) {
 			db.Scene.On("UpdatePartial", testCtx, sceneID, matchPartial).Return(nil, nil).Once()
 		}
 
+		err := ScenePerformers(testCtx, &scene, db.Scene, db.Performer, nil)
+
+		assert.Nil(err)
+		db.AssertExpectations(t)
+	}
+
+	// test against aliases
+	performer.Name = "unmatched"
+	performer.Aliases = models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: performerName, IgnoreAutoTag: false}})
+
+	for _, test := range testTables {
+		db := mocks.NewDatabase()
+
+		db.Performer.On("Query", testCtx, mock.Anything, mock.Anything).Return(nil, 0, nil)
+		db.Performer.On("QueryForAutoTag", testCtx, mock.Anything).Return([]*models.Performer{&performer, &reversedPerformer}, nil).Once()
+
+		if test.Matches {
+			matchPartial := mock.MatchedBy(func(got models.ScenePartial) bool {
+				expected := models.ScenePartial{
+					PerformerIDs: &models.UpdateIDs{
+						IDs:  []int{performerID},
+						Mode: models.RelationshipUpdateModeAdd,
+					},
+				}
+
+				return scenePartialsEqual(got, expected)
+			})
+			db.Scene.On("UpdatePartial", testCtx, sceneID, matchPartial).Return(nil, nil).Once()
+		}
+
+		scene := models.Scene{
+			ID:           sceneID,
+			Path:         test.Path,
+			PerformerIDs: models.NewRelatedIDs([]int{}),
+		}
 		err := ScenePerformers(testCtx, &scene, db.Scene, db.Performer, nil)
 
 		assert.Nil(err)

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -178,16 +178,43 @@ func (t *stashBoxBatchPerformerTagTask) processMatchedPerformer(ctx context.Cont
 
 			partial := p.ToPartial(t.box.Endpoint, excluded, existingStashIDs)
 
+			// Preserving existing aliases' IgnoreAutoTag state
+			if partial.Aliases != nil {
+				if err := t.performer.LoadAliases(ctx, qb); err == nil {
+					existingAliases := t.performer.Aliases.List()
+					existingAliasMap := make(map[string]bool)
+					for _, existing := range existingAliases {
+						existingAliasMap[existing.Alias] = existing.IgnoreAutoTag
+					}
+
+					for i, a := range partial.Aliases.Values {
+						if ignore, ok := existingAliasMap[a.Alias]; ok {
+							partial.Aliases.Values[i].IgnoreAutoTag = ignore
+						}
+					}
+				}
+			}
+
 			// if we're setting the performer's aliases, and not the name, then filter out the name
 			// from the aliases to avoid duplicates
 			// add the name to the aliases if it's not already there
 			if partial.Aliases != nil && !partial.Name.Set {
-				partial.Aliases.Values = sliceutil.Filter(partial.Aliases.Values, func(s string) bool {
-					return s != t.performer.Name
+				partial.Aliases.Values = sliceutil.Filter(partial.Aliases.Values, func(a models.PerformerAlias) bool {
+					return a.Alias != t.performer.Name
 				})
 
 				if p.Name != nil && t.performer.Name != *p.Name {
-					partial.Aliases.Values = sliceutil.AppendUnique(partial.Aliases.Values, *p.Name)
+					// Check if already exists before appending
+					exists := false
+					for _, existing := range partial.Aliases.Values {
+						if existing.Alias == *p.Name {
+							exists = true
+							break
+						}
+					}
+					if !exists {
+						partial.Aliases.Values = append(partial.Aliases.Values, models.PerformerAlias{Alias: *p.Name, IgnoreAutoTag: true})
+					}
 				}
 			}
 

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stashapp/stash/pkg/match"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/performer"
-	"github.com/stashapp/stash/pkg/sliceutil"
 	"github.com/stashapp/stash/pkg/stashbox"
 	"github.com/stashapp/stash/pkg/studio"
 	"github.com/stashapp/stash/pkg/tag"
@@ -181,17 +180,7 @@ func (t *stashBoxBatchPerformerTagTask) processMatchedPerformer(ctx context.Cont
 			// Preserving existing aliases' IgnoreAutoTag state
 			if partial.Aliases != nil {
 				if err := t.performer.LoadAliases(ctx, qb); err == nil {
-					existingAliases := t.performer.Aliases.List()
-					existingAliasMap := make(map[string]bool)
-					for _, existing := range existingAliases {
-						existingAliasMap[existing.Alias] = existing.IgnoreAutoTag
-					}
-
-					for i, a := range partial.Aliases.Values {
-						if ignore, ok := existingAliasMap[a.Alias]; ok {
-							partial.Aliases.Values[i].IgnoreAutoTag = ignore
-						}
-					}
+					partial.Aliases.Values = performer.GetEffectiveAliases(t.performer.Aliases.List(), partial.Aliases.Values, partial.Aliases.Mode, true)
 				}
 			}
 
@@ -199,23 +188,11 @@ func (t *stashBoxBatchPerformerTagTask) processMatchedPerformer(ctx context.Cont
 			// from the aliases to avoid duplicates
 			// add the name to the aliases if it's not already there
 			if partial.Aliases != nil && !partial.Name.Set {
-				partial.Aliases.Values = sliceutil.Filter(partial.Aliases.Values, func(a models.PerformerAlias) bool {
-					return a.Alias != t.performer.Name
-				})
-
 				if p.Name != nil && t.performer.Name != *p.Name {
-					// Check if already exists before appending
-					exists := false
-					for _, existing := range partial.Aliases.Values {
-						if existing.Alias == *p.Name {
-							exists = true
-							break
-						}
-					}
-					if !exists {
-						partial.Aliases.Values = append(partial.Aliases.Values, models.PerformerAlias{Alias: *p.Name, IgnoreAutoTag: true})
-					}
+					partial.Aliases.Values = append(partial.Aliases.Values, models.PerformerAlias{Alias: *p.Name, IgnoreAutoTag: true})
 				}
+
+				partial.Aliases.Values = performer.NormalizeAliases(t.performer.Name, partial.Aliases.Values)
 			}
 
 			if err := performer.ValidateUpdate(ctx, t.performer.ID, partial, qb); err != nil {

--- a/pkg/match/path.go
+++ b/pkg/match/path.go
@@ -156,20 +156,18 @@ func PathToPerformers(ctx context.Context, path string, reader models.PerformerA
 			matches = true
 		}
 
-		// TODO - disabled alias matching until we can get finer
-		// control over the matching
-		// if !matches {
-		// 	if err := p.LoadAliases(ctx, reader); err != nil {
-		// 		return nil, err
-		// 	}
+		if !matches {
+			if err := p.LoadAliases(ctx, reader); err != nil {
+				return nil, err
+			}
 
-		// 	for _, alias := range p.Aliases.List() {
-		// 		if nameMatchesPath(alias, path) != -1 {
-		// 			matches = true
-		// 			break
-		// 		}
-		// 	}
-		// }
+			for _, alias := range p.Aliases.List() {
+				if !alias.IgnoreAutoTag && nameMatchesPath(alias.Alias, path) != -1 {
+					matches = true
+					break
+				}
+			}
+		}
 
 		if matches {
 			ret = append(ret, p)
@@ -213,16 +211,18 @@ func PathToStudio(ctx context.Context, path string, reader models.StudioAutoTagQ
 			index = matchIndex
 		}
 
-		aliases, err := reader.GetAliases(ctx, c.ID)
-		if err != nil {
-			return nil, err
-		}
+		{
+			aliases, err := reader.GetAliases(ctx, c.ID)
+			if err != nil {
+				return nil, err
+			}
 
-		for _, alias := range aliases {
-			matchIndex = nameMatchesPath(alias, path)
-			if matchIndex != -1 && matchIndex > index {
-				ret = c
-				index = matchIndex
+			for _, alias := range aliases {
+				matchIndex = nameMatchesPath(alias, path)
+				if matchIndex != -1 && matchIndex > index {
+					ret = c
+					index = matchIndex
+				}
 			}
 		}
 	}

--- a/pkg/models/mocks/PerformerReaderWriter.go
+++ b/pkg/models/mocks/PerformerReaderWriter.go
@@ -291,29 +291,6 @@ func (_m *PerformerReaderWriter) FindMany(ctx context.Context, ids []int) ([]*mo
 	return r0, r1
 }
 
-// GetAliases provides a mock function with given fields: ctx, relatedID
-func (_m *PerformerReaderWriter) GetAliases(ctx context.Context, relatedID int) ([]string, error) {
-	ret := _m.Called(ctx, relatedID)
-
-	var r0 []string
-	if rf, ok := ret.Get(0).(func(context.Context, int) []string); ok {
-		r0 = rf(ctx, relatedID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
-		r1 = rf(ctx, relatedID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetCustomFields provides a mock function with given fields: ctx, id
 func (_m *PerformerReaderWriter) GetCustomFields(ctx context.Context, id int) (map[string]interface{}, error) {
 	ret := _m.Called(ctx, id)
@@ -376,6 +353,29 @@ func (_m *PerformerReaderWriter) GetImage(ctx context.Context, performerID int) 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
 		r1 = rf(ctx, performerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPerformerAliases provides a mock function with given fields: ctx, relatedID
+func (_m *PerformerReaderWriter) GetPerformerAliases(ctx context.Context, relatedID int) ([]models.PerformerAlias, error) {
+	ret := _m.Called(ctx, relatedID)
+
+	var r0 []models.PerformerAlias
+	if rf, ok := ret.Get(0).(func(context.Context, int) []models.PerformerAlias); ok {
+		r0 = rf(ctx, relatedID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.PerformerAlias)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, relatedID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/models/model_performer.go
+++ b/pkg/models/model_performer.go
@@ -34,10 +34,10 @@ type Performer struct {
 	Weight        *int   `json:"weight"`
 	IgnoreAutoTag bool   `json:"ignore_auto_tag"`
 
-	Aliases  RelatedStrings  `json:"aliases"`
-	URLs     RelatedStrings  `json:"urls"`
-	TagIDs   RelatedIDs      `json:"tag_ids"`
-	StashIDs RelatedStashIDs `json:"stash_ids"`
+	Aliases  RelatedPerformerAliases `json:"aliases"`
+	URLs     RelatedStrings          `json:"urls"`
+	TagIDs   RelatedIDs              `json:"tag_ids"`
+	StashIDs RelatedStashIDs         `json:"stash_ids"`
 }
 
 type CreatePerformerInput struct {
@@ -91,7 +91,7 @@ type PerformerPartial struct {
 	Weight        OptionalInt
 	IgnoreAutoTag OptionalBool
 
-	Aliases  *UpdateStrings
+	Aliases  *UpdatePerformerAliases
 	TagIDs   *UpdateIDs
 	StashIDs *UpdateStashIDs
 
@@ -105,9 +105,9 @@ func NewPerformerPartial() PerformerPartial {
 	}
 }
 
-func (s *Performer) LoadAliases(ctx context.Context, l AliasLoader) error {
-	return s.Aliases.load(func() ([]string, error) {
-		return l.GetAliases(ctx, s.ID)
+func (s *Performer) LoadAliases(ctx context.Context, l PerformerAliasLoader) error {
+	return s.Aliases.load(func() ([]PerformerAlias, error) {
+		return l.GetPerformerAliases(ctx, s.ID)
 	})
 }
 

--- a/pkg/models/model_scraped_item.go
+++ b/pkg/models/model_scraped_item.go
@@ -204,10 +204,14 @@ func (p *ScrapedPerformer) ToPerformer(endpoint string, excluded map[string]bool
 
 	if p.Aliases != nil && !excluded["aliases"] {
 		aliases := stringslice.FromString(*p.Aliases, ",")
-		for i, alias := range aliases {
-			aliases[i] = strings.TrimSpace(alias)
+		var parsedAliases []PerformerAlias
+		for _, alias := range aliases {
+			parsedAliases = append(parsedAliases, PerformerAlias{
+				Alias:         strings.TrimSpace(alias),
+				IgnoreAutoTag: true,
+			})
 		}
-		ret.Aliases = NewRelatedStrings(aliases)
+		ret.Aliases = NewRelatedPerformerAliases(parsedAliases)
 	}
 	if p.Birthdate != nil && !excluded["birthdate"] {
 		date, err := ParseDate(*p.Birthdate)
@@ -352,8 +356,15 @@ func (p *ScrapedPerformer) ToPartial(endpoint string, excluded map[string]bool, 
 	ret := NewPerformerPartial()
 
 	if p.Aliases != nil && !excluded["aliases"] {
-		ret.Aliases = &UpdateStrings{
-			Values: stringslice.FromString(*p.Aliases, ","),
+		var aliases []PerformerAlias
+		for _, a := range stringslice.FromString(*p.Aliases, ",") {
+			aliases = append(aliases, PerformerAlias{
+				Alias:         strings.TrimSpace(a),
+				IgnoreAutoTag: true,
+			})
+		}
+		ret.Aliases = &UpdatePerformerAliases{
+			Values: aliases,
 			Mode:   RelationshipUpdateModeSet,
 		}
 	}

--- a/pkg/models/model_scraped_item_test.go
+++ b/pkg/models/model_scraped_item_test.go
@@ -214,7 +214,7 @@ func Test_scrapedToPerformerInput(t *testing.T) {
 				CareerEnd:      dateFromInt(2015),
 				Tattoos:        *nextVal(), // skip CareerLength counter slot
 				Piercings:      *nextVal(),
-				Aliases:        NewRelatedStrings([]string{*nextVal()}),
+				Aliases:        NewRelatedPerformerAliases([]PerformerAlias{{Alias: *nextVal(), IgnoreAutoTag: true}}),
 				URLs:           NewRelatedStrings([]string{*nextVal(), *nextVal(), *nextVal()}),
 				Details:        *nextVal(),
 				StashIDs: NewRelatedStashIDs([]StashID{

--- a/pkg/models/model_studio.go
+++ b/pkg/models/model_studio.go
@@ -104,7 +104,7 @@ func (s *Studio) LoadStashIDs(ctx context.Context, l StashIDLoader) error {
 	})
 }
 
-func (s *Studio) LoadRelationships(ctx context.Context, l PerformerReader) error {
+func (s *Studio) LoadRelationships(ctx context.Context, l StudioReader) error {
 	if err := s.LoadAliases(ctx, l); err != nil {
 		return err
 	}

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -247,9 +247,9 @@ type PerformerCreateInput struct {
 	Tattoos        *string                `json:"tattoos"`
 	Piercings      *string                `json:"piercings"`
 	Aliases        []*PerformerAliasInput `json:"aliases"`
-	AliasList      []string               `json:"alias_list"`
-	Twitter        *string                `json:"twitter"`   // deprecated
-	Instagram      *string                `json:"instagram"` // deprecated
+	AliasList      []string               `json:"alias_list"` // deprecated
+	Twitter        *string                `json:"twitter"`    // deprecated
+	Instagram      *string                `json:"instagram"`  // deprecated
 	Favorite       *bool                  `json:"favorite"`
 	TagIds         []string               `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL
@@ -288,9 +288,9 @@ type PerformerUpdateInput struct {
 	Tattoos        *string                      `json:"tattoos"`
 	Piercings      *string                      `json:"piercings"`
 	Aliases        *UpdatePerformerAliasesInput `json:"aliases"`
-	AliasList      []string                     `json:"alias_list"`
-	Twitter        *string                      `json:"twitter"`   // deprecated
-	Instagram      *string                      `json:"instagram"` // deprecated
+	AliasList      []string                     `json:"alias_list"` // deprecated
+	Twitter        *string                      `json:"twitter"`    // deprecated
+	Instagram      *string                      `json:"instagram"`  // deprecated
 	Favorite       *bool                        `json:"favorite"`
 	TagIds         []string                     `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -215,33 +215,43 @@ type PerformerFilterType struct {
 	CustomFields []CustomFieldCriterionInput `json:"custom_fields"`
 }
 
+type PerformerAliasInput struct {
+	Alias         string `json:"alias"`
+	IgnoreAutoTag bool   `json:"ignore_auto_tag"`
+}
+
+type UpdatePerformerAliasesInput struct {
+	Values []*PerformerAliasInput `json:"values"`
+	Mode   RelationshipUpdateMode `json:"mode"`
+}
+
 type PerformerCreateInput struct {
-	Name           string           `json:"name"`
-	Disambiguation *string          `json:"disambiguation"`
-	URL            *string          `json:"url"` // deprecated
-	Urls           []string         `json:"urls"`
-	Gender         *GenderEnum      `json:"gender"`
-	Birthdate      *string          `json:"birthdate"`
-	Ethnicity      *string          `json:"ethnicity"`
-	Country        *string          `json:"country"`
-	EyeColor       *string          `json:"eye_color"`
-	Height         *string          `json:"height"`
-	HeightCm       *int             `json:"height_cm"`
-	Measurements   *string          `json:"measurements"`
-	FakeTits       *string          `json:"fake_tits"`
-	PenisLength    *float64         `json:"penis_length"`
-	Circumcised    *CircumcisedEnum `json:"circumcised"`
-	CareerLength   *string          `json:"career_length"`
-	CareerStart    *string          `json:"career_start"`
-	CareerEnd      *string          `json:"career_end"`
-	Tattoos        *string          `json:"tattoos"`
-	Piercings      *string          `json:"piercings"`
-	Aliases        *string          `json:"aliases"`
-	AliasList      []string         `json:"alias_list"`
-	Twitter        *string          `json:"twitter"`   // deprecated
-	Instagram      *string          `json:"instagram"` // deprecated
-	Favorite       *bool            `json:"favorite"`
-	TagIds         []string         `json:"tag_ids"`
+	Name           string                 `json:"name"`
+	Disambiguation *string                `json:"disambiguation"`
+	URL            *string                `json:"url"` // deprecated
+	Urls           []string               `json:"urls"`
+	Gender         *GenderEnum            `json:"gender"`
+	Birthdate      *string                `json:"birthdate"`
+	Ethnicity      *string                `json:"ethnicity"`
+	Country        *string                `json:"country"`
+	EyeColor       *string                `json:"eye_color"`
+	Height         *string                `json:"height"`
+	HeightCm       *int                   `json:"height_cm"`
+	Measurements   *string                `json:"measurements"`
+	FakeTits       *string                `json:"fake_tits"`
+	PenisLength    *float64               `json:"penis_length"`
+	Circumcised    *CircumcisedEnum       `json:"circumcised"`
+	CareerLength   *string                `json:"career_length"`
+	CareerStart    *string                `json:"career_start"`
+	CareerEnd      *string                `json:"career_end"`
+	Tattoos        *string                `json:"tattoos"`
+	Piercings      *string                `json:"piercings"`
+	Aliases        []*PerformerAliasInput `json:"aliases"`
+	AliasList      []string               `json:"alias_list"`
+	Twitter        *string                `json:"twitter"`   // deprecated
+	Instagram      *string                `json:"instagram"` // deprecated
+	Favorite       *bool                  `json:"favorite"`
+	TagIds         []string               `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`
@@ -256,33 +266,33 @@ type PerformerCreateInput struct {
 }
 
 type PerformerUpdateInput struct {
-	ID             string           `json:"id"`
-	Name           *string          `json:"name"`
-	Disambiguation *string          `json:"disambiguation"`
-	URL            *string          `json:"url"` // deprecated
-	Urls           []string         `json:"urls"`
-	Gender         *GenderEnum      `json:"gender"`
-	Birthdate      *string          `json:"birthdate"`
-	Ethnicity      *string          `json:"ethnicity"`
-	Country        *string          `json:"country"`
-	EyeColor       *string          `json:"eye_color"`
-	Height         *string          `json:"height"`
-	HeightCm       *int             `json:"height_cm"`
-	Measurements   *string          `json:"measurements"`
-	FakeTits       *string          `json:"fake_tits"`
-	PenisLength    *float64         `json:"penis_length"`
-	Circumcised    *CircumcisedEnum `json:"circumcised"`
-	CareerLength   *string          `json:"career_length"`
-	CareerStart    *string          `json:"career_start"`
-	CareerEnd      *string          `json:"career_end"`
-	Tattoos        *string          `json:"tattoos"`
-	Piercings      *string          `json:"piercings"`
-	Aliases        *string          `json:"aliases"`
-	AliasList      []string         `json:"alias_list"`
-	Twitter        *string          `json:"twitter"`   // deprecated
-	Instagram      *string          `json:"instagram"` // deprecated
-	Favorite       *bool            `json:"favorite"`
-	TagIds         []string         `json:"tag_ids"`
+	ID             string                       `json:"id"`
+	Name           *string                      `json:"name"`
+	Disambiguation *string                      `json:"disambiguation"`
+	URL            *string                      `json:"url"` // deprecated
+	Urls           []string                     `json:"urls"`
+	Gender         *GenderEnum                  `json:"gender"`
+	Birthdate      *string                      `json:"birthdate"`
+	Ethnicity      *string                      `json:"ethnicity"`
+	Country        *string                      `json:"country"`
+	EyeColor       *string                      `json:"eye_color"`
+	Height         *string                      `json:"height"`
+	HeightCm       *int                         `json:"height_cm"`
+	Measurements   *string                      `json:"measurements"`
+	FakeTits       *string                      `json:"fake_tits"`
+	PenisLength    *float64                     `json:"penis_length"`
+	Circumcised    *CircumcisedEnum             `json:"circumcised"`
+	CareerLength   *string                      `json:"career_length"`
+	CareerStart    *string                      `json:"career_start"`
+	CareerEnd      *string                      `json:"career_end"`
+	Tattoos        *string                      `json:"tattoos"`
+	Piercings      *string                      `json:"piercings"`
+	Aliases        *UpdatePerformerAliasesInput `json:"aliases"`
+	AliasList      []string                     `json:"alias_list"`
+	Twitter        *string                      `json:"twitter"`   // deprecated
+	Instagram      *string                      `json:"instagram"` // deprecated
+	Favorite       *bool                        `json:"favorite"`
+	TagIds         []string                     `json:"tag_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`

--- a/pkg/models/relationships.go
+++ b/pkg/models/relationships.go
@@ -611,10 +611,8 @@ func (r RelatedPerformerAliases) List() []PerformerAlias {
 }
 
 func (r RelatedPerformerAliases) ToAliases() []string {
+	r.mustLoaded()
 	aliases := []string{}
-	if !r.Loaded() {
-		return aliases
-	}
 	for _, a := range r.list {
 		aliases = append(aliases, a.Alias)
 	}

--- a/pkg/models/relationships.go
+++ b/pkg/models/relationships.go
@@ -570,3 +570,85 @@ func (r *RelatedStrings) load(fn func() ([]string, error)) error {
 
 	return nil
 }
+
+type PerformerAlias struct {
+	Alias         string `json:"alias"`
+	IgnoreAutoTag bool   `json:"ignore_auto_tag"`
+}
+
+type PerformerAliasLoader interface {
+	GetPerformerAliases(ctx context.Context, relatedID int) ([]PerformerAlias, error)
+}
+
+// RelatedPerformerAliases represents a list of related PerformerAlias objects.
+type RelatedPerformerAliases struct {
+	list []PerformerAlias
+}
+
+// NewRelatedPerformerAliases returns a loaded RelatedPerformerAliases object with the provided values.
+func NewRelatedPerformerAliases(values []PerformerAlias) RelatedPerformerAliases {
+	return RelatedPerformerAliases{
+		list: values,
+	}
+}
+
+// Loaded returns true if the related aliases have been loaded.
+func (r RelatedPerformerAliases) Loaded() bool {
+	return r.list != nil
+}
+
+func (r RelatedPerformerAliases) mustLoaded() {
+	if !r.Loaded() {
+		panic("list has not been loaded")
+	}
+}
+
+// List returns the related values. Panics if the relationship has not been loaded.
+func (r RelatedPerformerAliases) List() []PerformerAlias {
+	r.mustLoaded()
+
+	return r.list
+}
+
+func (r RelatedPerformerAliases) ToAliases() []string {
+	aliases := []string{}
+	if !r.Loaded() {
+		return aliases
+	}
+	for _, a := range r.list {
+		aliases = append(aliases, a.Alias)
+	}
+	return aliases
+}
+
+// Add adds the provided values to the list. Panics if the relationship has not been loaded.
+func (r *RelatedPerformerAliases) Add(values ...PerformerAlias) {
+	r.mustLoaded()
+
+	r.list = append(r.list, values...)
+}
+
+func (r *RelatedPerformerAliases) load(fn func() ([]PerformerAlias, error)) error {
+	if r.Loaded() {
+		return nil
+	}
+
+	values, err := fn()
+	if err != nil {
+		return err
+	}
+
+	if values == nil {
+		values = []PerformerAlias{}
+	}
+
+	r.list = values
+
+	return nil
+}
+
+// UpdatePerformerAliases contains the required information to perform a bulk update on performer aliases.
+type UpdatePerformerAliases struct {
+	Values []PerformerAlias
+	Mode   RelationshipUpdateMode
+}

--- a/pkg/models/repository_performer.go
+++ b/pkg/models/repository_performer.go
@@ -28,7 +28,7 @@ type PerformerQueryer interface {
 
 type PerformerAutoTagQueryer interface {
 	PerformerQueryer
-	AliasLoader
+	PerformerAliasLoader
 
 	// TODO - this interface is temporary until the filter schema can fully
 	// support the query needed
@@ -75,7 +75,7 @@ type PerformerReader interface {
 	PerformerAutoTagQueryer
 	PerformerCounter
 
-	AliasLoader
+	PerformerAliasLoader
 	StashIDLoader
 	TagIDLoader
 	URLLoader

--- a/pkg/performer/alias.go
+++ b/pkg/performer/alias.go
@@ -1,0 +1,68 @@
+package performer
+
+import (
+	"strings"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// NormalizeAliases trims whitespace, deduplicates aliases (case-insensitively),
+// and ensures aliases are not empty and do not match the performer's name.
+func NormalizeAliases(performerName string, aliases []models.PerformerAlias) []models.PerformerAlias {
+	var sanitized []models.PerformerAlias
+	seen := make(map[string]bool)
+	nameLower := strings.ToLower(strings.TrimSpace(performerName))
+
+	for _, a := range aliases {
+		trimmed := strings.TrimSpace(a.Alias)
+		lower := strings.ToLower(trimmed)
+		if trimmed != "" && lower != nameLower && !seen[lower] {
+			seen[lower] = true
+			a.Alias = trimmed
+			sanitized = append(sanitized, a)
+		}
+	}
+
+	return sanitized
+}
+
+// GetEffectiveAliases calculates the final list of aliases based on the update mode
+// and optionally preserves the IgnoreAutoTag state for existing aliases.
+func GetEffectiveAliases(existing []models.PerformerAlias, update []models.PerformerAlias, mode models.RelationshipUpdateMode, preserveIgnore bool) []models.PerformerAlias {
+	var effective []models.PerformerAlias
+
+	switch mode {
+	case models.RelationshipUpdateModeSet:
+		if preserveIgnore {
+			existingMap := make(map[string]bool)
+			for _, e := range existing {
+				existingMap[e.Alias] = e.IgnoreAutoTag
+			}
+
+			for _, u := range update {
+				if ignore, ok := existingMap[u.Alias]; ok {
+					u.IgnoreAutoTag = ignore
+				}
+				effective = append(effective, u)
+			}
+		} else {
+			effective = update
+		}
+	case models.RelationshipUpdateModeAdd:
+		effective = append(effective, existing...)
+		effective = append(effective, update...)
+	case models.RelationshipUpdateModeRemove:
+		updateMap := make(map[string]bool)
+		for _, u := range update {
+			updateMap[u.Alias] = true
+		}
+
+		for _, e := range existing {
+			if !updateMap[e.Alias] {
+				effective = append(effective, e)
+			}
+		}
+	}
+
+	return effective
+}

--- a/pkg/performer/alias.go
+++ b/pkg/performer/alias.go
@@ -9,7 +9,7 @@ import (
 // NormalizeAliases trims whitespace, deduplicates aliases (case-insensitively),
 // and ensures aliases are not empty and do not match the performer's name.
 func NormalizeAliases(performerName string, aliases []models.PerformerAlias) []models.PerformerAlias {
-	var sanitized []models.PerformerAlias
+	sanitized := []models.PerformerAlias{}
 	seen := make(map[string]bool)
 	nameLower := strings.ToLower(strings.TrimSpace(performerName))
 

--- a/pkg/performer/alias_test.go
+++ b/pkg/performer/alias_test.go
@@ -1,0 +1,67 @@
+package performer
+
+import (
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeAliases(t *testing.T) {
+	name := "Performer Name"
+	aliases := []models.PerformerAlias{
+		{Alias: " Alias 1 "},
+		{Alias: "alias 1"},        // Duplicate (case-insensitive)
+		{Alias: "Performer Name"}, // Same as name
+		{Alias: "performer name"}, // Same as name (case-insensitive)
+		{Alias: ""},               // Empty
+		{Alias: "Alias 2"},
+	}
+
+	normalized := NormalizeAliases(name, aliases)
+
+	assert.Len(t, normalized, 2)
+	assert.Equal(t, "Alias 1", normalized[0].Alias)
+	assert.Equal(t, "Alias 2", normalized[1].Alias)
+}
+
+func TestGetEffectiveAliases(t *testing.T) {
+	existing := []models.PerformerAlias{
+		{Alias: "A", IgnoreAutoTag: false},
+		{Alias: "B", IgnoreAutoTag: true},
+	}
+	update := []models.PerformerAlias{
+		{Alias: "B", IgnoreAutoTag: false}, // Note: IgnoreAutoTag is false here
+		{Alias: "C", IgnoreAutoTag: true},
+	}
+
+	t.Run("Mode SET with preservation", func(t *testing.T) {
+		effective := GetEffectiveAliases(existing, update, models.RelationshipUpdateModeSet, true)
+		assert.Len(t, effective, 2)
+		assert.Equal(t, "B", effective[0].Alias)
+		assert.True(t, effective[0].IgnoreAutoTag, "Should have preserved IgnoreAutoTag: true from existing")
+		assert.Equal(t, "C", effective[1].Alias)
+	})
+
+	t.Run("Mode SET without preservation", func(t *testing.T) {
+		effective := GetEffectiveAliases(existing, update, models.RelationshipUpdateModeSet, false)
+		assert.Len(t, effective, 2)
+		assert.Equal(t, "B", effective[0].Alias)
+		assert.False(t, effective[0].IgnoreAutoTag, "Should NOT have preserved IgnoreAutoTag")
+	})
+
+	t.Run("Mode ADD", func(t *testing.T) {
+		effective := GetEffectiveAliases(existing, update, models.RelationshipUpdateModeAdd, false)
+		assert.Len(t, effective, 4)
+		assert.Equal(t, "A", effective[0].Alias)
+		assert.Equal(t, "B", effective[1].Alias)
+		assert.Equal(t, "B", effective[2].Alias)
+		assert.Equal(t, "C", effective[3].Alias)
+	})
+
+	t.Run("Mode REMOVE", func(t *testing.T) {
+		effective := GetEffectiveAliases(existing, update, models.RelationshipUpdateModeRemove, false)
+		assert.Len(t, effective, 1)
+		assert.Equal(t, "A", effective[0].Alias)
+	})
+}

--- a/pkg/performer/export.go
+++ b/pkg/performer/export.go
@@ -14,7 +14,7 @@ import (
 
 type ImageAliasStashIDGetter interface {
 	GetImage(ctx context.Context, performerID int) ([]byte, error)
-	models.AliasLoader
+	models.PerformerAliasLoader
 	models.StashIDLoader
 	models.URLLoader
 	models.CustomFieldsReader
@@ -81,7 +81,7 @@ func ToJSON(ctx context.Context, reader ImageAliasStashIDGetter, performer *mode
 		return nil, fmt.Errorf("loading performer aliases: %w", err)
 	}
 
-	newPerformerJSON.Aliases = performer.Aliases.List()
+	newPerformerJSON.Aliases = performer.Aliases.ToAliases()
 
 	if err := performer.LoadURLs(ctx, reader); err != nil {
 		return nil, fmt.Errorf("loading performer urls: %w", err)

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -86,7 +86,7 @@ func createFullPerformer(id int, name string) *models.Performer {
 		Name:           name,
 		Disambiguation: disambiguation,
 		URLs:           models.NewRelatedStrings([]string{url, twitter, instagram}),
-		Aliases:        models.NewRelatedStrings(aliases),
+		Aliases:        models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: aliases[0], IgnoreAutoTag: false}, {Alias: aliases[1], IgnoreAutoTag: false}}),
 		Birthdate:      &birthDate,
 		CareerStart:    &careerStart,
 		CareerEnd:      &careerEnd,
@@ -120,7 +120,7 @@ func createEmptyPerformer(id int) models.Performer {
 		ID:        id,
 		CreatedAt: createTime,
 		UpdatedAt: updateTime,
-		Aliases:   models.NewRelatedStrings([]string{}),
+		Aliases:   models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 		URLs:      models.NewRelatedStrings([]string{}),
 		TagIDs:    models.NewRelatedIDs([]int{}),
 		StashIDs:  models.NewRelatedStashIDs([]models.StashID{}),
@@ -253,7 +253,8 @@ func TestToJSON(t *testing.T) {
 
 	for i, s := range scenarios {
 		tag := s.input
-		json, err := ToJSON(testCtx, db.Performer, &tag)
+		var testDb ImageAliasStashIDGetter = db.Performer
+		json, err := ToJSON(testCtx, testDb, &tag)
 
 		switch {
 		case !s.err && err != nil:

--- a/pkg/performer/export_test.go
+++ b/pkg/performer/export_test.go
@@ -86,7 +86,7 @@ func createFullPerformer(id int, name string) *models.Performer {
 		Name:           name,
 		Disambiguation: disambiguation,
 		URLs:           models.NewRelatedStrings([]string{url, twitter, instagram}),
-		Aliases:        models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: aliases[0], IgnoreAutoTag: false}, {Alias: aliases[1], IgnoreAutoTag: false}}),
+		Aliases:        models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: aliases[0], IgnoreAutoTag: true}, {Alias: aliases[1], IgnoreAutoTag: true}}),
 		Birthdate:      &birthDate,
 		CareerStart:    &careerStart,
 		CareerEnd:      &careerEnd,

--- a/pkg/performer/import.go
+++ b/pkg/performer/import.go
@@ -309,7 +309,7 @@ func performerJSONToPerformer(performerJSON jsonschema.Performer) (models.Perfor
 func toPerformerAliases(aliases []string) []models.PerformerAlias {
 	var res []models.PerformerAlias
 	for _, a := range aliases {
-		res = append(res, models.PerformerAlias{Alias: a, IgnoreAutoTag: false})
+		res = append(res, models.PerformerAlias{Alias: a, IgnoreAutoTag: true})
 	}
 	return res
 }

--- a/pkg/performer/import.go
+++ b/pkg/performer/import.go
@@ -210,7 +210,7 @@ func performerJSONToPerformer(performerJSON jsonschema.Performer) (models.Perfor
 		FakeTits:       performerJSON.FakeTits,
 		Tattoos:        performerJSON.Tattoos,
 		Piercings:      performerJSON.Piercings,
-		Aliases:        models.NewRelatedStrings(performerJSON.Aliases),
+		Aliases:        models.NewRelatedPerformerAliases(toPerformerAliases(performerJSON.Aliases)),
 		Details:        performerJSON.Details,
 		HairColor:      performerJSON.HairColor,
 		Favorite:       performerJSON.Favorite,
@@ -304,4 +304,12 @@ func performerJSONToPerformer(performerJSON jsonschema.Performer) (models.Perfor
 	}
 
 	return newPerformer, nil
+}
+
+func toPerformerAliases(aliases []string) []models.PerformerAlias {
+	var res []models.PerformerAlias
+	for _, a := range aliases {
+		res = append(res, models.PerformerAlias{Alias: a, IgnoreAutoTag: false})
+	}
+	return res
 }

--- a/pkg/performer/validate.go
+++ b/pkg/performer/validate.go
@@ -55,7 +55,7 @@ func ValidateCreate(ctx context.Context, performer models.Performer, qb models.P
 		return err
 	}
 
-	if err := ValidateAliases(performer.Name, performer.Aliases.ToAliases()); err != nil {
+	if err := ValidateAliases(performer.Name, performer.Aliases.List()); err != nil {
 		return err
 	}
 
@@ -83,18 +83,8 @@ func ValidateUpdate(ctx context.Context, id int, partial models.PerformerPartial
 	if err := existing.LoadAliases(ctx, qb); err != nil {
 		return err
 	}
-	var partialAliases *models.UpdateStrings
-	if partial.Aliases != nil {
-		var stringValues []string
-		for _, v := range partial.Aliases.Values {
-			stringValues = append(stringValues, v.Alias)
-		}
-		partialAliases = &models.UpdateStrings{
-			Values: stringValues,
-			Mode:   partial.Aliases.Mode,
-		}
-	}
-	if err := ValidateUpdateAliases(*existing, partial.Name, partialAliases); err != nil {
+
+	if err := ValidateUpdateAliases(*existing, partial.Name, partial.Aliases); err != nil {
 		return err
 	}
 
@@ -205,15 +195,15 @@ func ValidateUpdateName(ctx context.Context, existing models.Performer, name mod
 	return validateName(ctx, newName, newDisambig, &existing.ID, qb)
 }
 
-func ValidateAliases(name string, aliases []string) error {
+func ValidateAliases(name string, aliases []models.PerformerAlias) error {
 	m := make(map[string]bool)
 	nameL := strings.ToLower(name)
 	m[nameL] = true
 
-	for _, alias := range aliases {
-		aliasL := strings.ToLower(alias)
+	for _, a := range aliases {
+		aliasL := strings.ToLower(a.Alias)
 		if m[aliasL] {
-			return &DuplicateAliasError{alias}
+			return &DuplicateAliasError{a.Alias}
 		}
 		m[aliasL] = true
 	}
@@ -221,7 +211,7 @@ func ValidateAliases(name string, aliases []string) error {
 	return nil
 }
 
-func ValidateUpdateAliases(existing models.Performer, name models.OptionalString, aliases *models.UpdateStrings) error {
+func ValidateUpdateAliases(existing models.Performer, name models.OptionalString, aliases *models.UpdatePerformerAliases) error {
 	// if neither name nor aliases is set, don't check anything
 	if !name.Set && aliases == nil {
 		return nil
@@ -234,10 +224,10 @@ func ValidateUpdateAliases(existing models.Performer, name models.OptionalString
 
 	// If aliases is nil, we're only changing the name - check existing aliases against new name
 	if aliases == nil {
-		return ValidateAliases(newName, existing.Aliases.ToAliases())
+		return ValidateAliases(newName, existing.Aliases.List())
 	}
 
-	newAliases := aliases.Apply(existing.Aliases.ToAliases())
+	newAliases := GetEffectiveAliases(existing.Aliases.List(), aliases.Values, aliases.Mode, false)
 
 	return ValidateAliases(newName, newAliases)
 }

--- a/pkg/performer/validate.go
+++ b/pkg/performer/validate.go
@@ -55,7 +55,7 @@ func ValidateCreate(ctx context.Context, performer models.Performer, qb models.P
 		return err
 	}
 
-	if err := ValidateAliases(performer.Name, performer.Aliases); err != nil {
+	if err := ValidateAliases(performer.Name, performer.Aliases.ToAliases()); err != nil {
 		return err
 	}
 
@@ -83,7 +83,18 @@ func ValidateUpdate(ctx context.Context, id int, partial models.PerformerPartial
 	if err := existing.LoadAliases(ctx, qb); err != nil {
 		return err
 	}
-	if err := ValidateUpdateAliases(*existing, partial.Name, partial.Aliases); err != nil {
+	var partialAliases *models.UpdateStrings
+	if partial.Aliases != nil {
+		var stringValues []string
+		for _, v := range partial.Aliases.Values {
+			stringValues = append(stringValues, v.Alias)
+		}
+		partialAliases = &models.UpdateStrings{
+			Values: stringValues,
+			Mode:   partial.Aliases.Mode,
+		}
+	}
+	if err := ValidateUpdateAliases(*existing, partial.Name, partialAliases); err != nil {
 		return err
 	}
 
@@ -194,16 +205,12 @@ func ValidateUpdateName(ctx context.Context, existing models.Performer, name mod
 	return validateName(ctx, newName, newDisambig, &existing.ID, qb)
 }
 
-func ValidateAliases(name string, aliases models.RelatedStrings) error {
-	if !aliases.Loaded() {
-		return nil
-	}
-
+func ValidateAliases(name string, aliases []string) error {
 	m := make(map[string]bool)
 	nameL := strings.ToLower(name)
 	m[nameL] = true
 
-	for _, alias := range aliases.List() {
+	for _, alias := range aliases {
 		aliasL := strings.ToLower(alias)
 		if m[aliasL] {
 			return &DuplicateAliasError{alias}
@@ -227,12 +234,12 @@ func ValidateUpdateAliases(existing models.Performer, name models.OptionalString
 
 	// If aliases is nil, we're only changing the name - check existing aliases against new name
 	if aliases == nil {
-		return ValidateAliases(newName, existing.Aliases)
+		return ValidateAliases(newName, existing.Aliases.ToAliases())
 	}
 
-	newAliases := aliases.Apply(existing.Aliases.List())
+	newAliases := aliases.Apply(existing.Aliases.ToAliases())
 
-	return ValidateAliases(newName, models.NewRelatedStrings(newAliases))
+	return ValidateAliases(newName, newAliases)
 }
 
 // ValidateDeathDate returns an error if the birthdate is after the death date.

--- a/pkg/performer/validate_test.go
+++ b/pkg/performer/validate_test.go
@@ -180,7 +180,7 @@ func TestValidateAliases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.tName, func(t *testing.T) {
-			got := ValidateAliases(tt.name, models.NewRelatedStrings(tt.aliases))
+			got := ValidateAliases(tt.name, tt.aliases)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -197,7 +197,7 @@ func TestValidateUpdateAliases(t *testing.T) {
 
 	existing := models.Performer{
 		Name:    name1,
-		Aliases: models.NewRelatedStrings([]string{name2}),
+		Aliases: models.NewRelatedPerformerAliases([]models.PerformerAlias{{Alias: name2}}),
 	}
 
 	osUnset := models.OptionalString{}

--- a/pkg/performer/validate_test.go
+++ b/pkg/performer/validate_test.go
@@ -307,3 +307,32 @@ func TestValidateUpdateDeathDate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCreate(t *testing.T) {
+	db := mocks.NewDatabase()
+	db.Performer.On("QueryCount", mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+
+	tests := []struct {
+		name    string
+		pName   string
+		aliases []models.PerformerAlias
+	}{
+		{"no aliases", "Performer 1", nil},
+		{"empty aliases", "Performer 2", []models.PerformerAlias{}},
+		{"alias matches name", "Performer 3", []models.PerformerAlias{{Alias: "Performer 3", IgnoreAutoTag: true}}},
+		{"duplicate aliases", "Performer 4", []models.PerformerAlias{{Alias: "Alias 1", IgnoreAutoTag: true}, {Alias: "Alias 1", IgnoreAutoTag: false}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := models.Performer{
+				Name: tt.pName,
+			}
+			p.Aliases = models.NewRelatedPerformerAliases(NormalizeAliases(p.Name, tt.aliases))
+
+			// This should NOT panic
+			err := ValidateCreate(testCtx, p, db.Performer)
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/pkg/performer/validate_test.go
+++ b/pkg/performer/validate_test.go
@@ -167,15 +167,15 @@ func TestValidateAliases(t *testing.T) {
 	tests := []struct {
 		tName   string
 		name    string
-		aliases []string
+		aliases []models.PerformerAlias
 		want    error
 	}{
 		{"no aliases", name1, nil, nil},
-		{"valid aliases", name2, []string{name3, name4}, nil},
-		{"duplicate alias", name1, []string{name2, name3, name2}, &DuplicateAliasError{name2}},
-		{"duplicate name", name4, []string{name4, name3}, &DuplicateAliasError{name4}},
-		{"duplicate alias caps", name2, []string{name1, name1U}, &DuplicateAliasError{name1U}},
-		{"duplicate name caps", name1U, []string{name1}, &DuplicateAliasError{name1}},
+		{"valid aliases", name2, []models.PerformerAlias{{Alias: name3}, {Alias: name4}}, nil},
+		{"duplicate alias", name1, []models.PerformerAlias{{Alias: name2}, {Alias: name3}, {Alias: name2}}, &DuplicateAliasError{name2}},
+		{"duplicate name", name4, []models.PerformerAlias{{Alias: name4}, {Alias: name3}}, &DuplicateAliasError{name4}},
+		{"duplicate alias caps", name2, []models.PerformerAlias{{Alias: name1}, {Alias: name1U}}, &DuplicateAliasError{name1U}},
+		{"duplicate name caps", name1U, []models.PerformerAlias{{Alias: name1}}, &DuplicateAliasError{name1}},
 	}
 
 	for _, tt := range tests {
@@ -209,24 +209,24 @@ func TestValidateUpdateAliases(t *testing.T) {
 	tests := []struct {
 		tName   string
 		name    models.OptionalString
-		aliases []string
+		aliases []models.PerformerAlias
 		want    error
 	}{
 		{"both unset", osUnset, nil, nil},
 		{"name conflicts with alias", os2, nil, &DuplicateAliasError{name2}},
 		{"valid name set", os3, nil, nil},
-		{"valid aliases empty", os1, []string{}, nil},
-		{"alias matches name", osUnset, []string{name1U}, &DuplicateAliasError{name1U}},
-		{"valid aliases set", osUnset, []string{name3, name2}, nil},
-		{"alias matches new name", os4, []string{name4}, &DuplicateAliasError{name4}},
-		{"valid both set", os2, []string{name1}, nil},
+		{"valid aliases empty", os1, []models.PerformerAlias{}, nil},
+		{"alias matches name", osUnset, []models.PerformerAlias{{Alias: name1U}}, &DuplicateAliasError{name1U}},
+		{"valid aliases set", osUnset, []models.PerformerAlias{{Alias: name3}, {Alias: name2}}, nil},
+		{"alias matches new name", os4, []models.PerformerAlias{{Alias: name4}}, &DuplicateAliasError{name4}},
+		{"valid both set", os2, []models.PerformerAlias{{Alias: name1}}, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.tName, func(t *testing.T) {
-			var aliases *models.UpdateStrings
+			var aliases *models.UpdatePerformerAliases
 			if tt.aliases != nil {
-				aliases = &models.UpdateStrings{
+				aliases = &models.UpdatePerformerAliases{
 					Values: tt.aliases,
 					Mode:   models.RelationshipUpdateModeSet,
 				}

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 85
+var appSchemaVersion uint = 86
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/86_performer_aliases_ignore_auto_tag.up.sql
+++ b/pkg/sqlite/migrations/86_performer_aliases_ignore_auto_tag.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `performer_aliases` ADD COLUMN `ignore_auto_tag` BOOLEAN DEFAULT 1 NOT NULL;

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -589,18 +589,17 @@ func (qb *PerformerStore) QueryForAutoTag(ctx context.Context, words []string) (
 	// this method should be removed
 	table := qb.table()
 	sq := dialect.From(table).Select(table.Col(idColumn))
-	// TODO - disabled alias matching until we get finer control over it
-	// .LeftJoin(
-	// 	performersAliasesJoinTable,
-	// 	goqu.On(performersAliasesJoinTable.Col(performerIDColumn).Eq(table.Col(idColumn))),
-	// )
+
+	sq = sq.LeftJoin(
+		performersAliasesJoinTable,
+		goqu.On(performersAliasesJoinTable.Col(performerIDColumn).Eq(table.Col(idColumn))),
+	)
 
 	var whereClauses []exp.Expression
 
 	for _, w := range words {
 		whereClauses = append(whereClauses, table.Col("name").Like(w+"%"))
-		// TODO - see above
-		// whereClauses = append(whereClauses, performersAliasesJoinTable.Col("alias").Like(w+"%"))
+		whereClauses = append(whereClauses, performersAliasesJoinTable.Col("alias").Like(w+"%"))
 	}
 
 	sq = sq.Where(
@@ -900,7 +899,7 @@ func (qb *PerformerStore) destroyImage(ctx context.Context, performerID int) err
 	return qb.blobJoinQueryBuilder.DestroyImage(ctx, performerID, performerImageBlobColumn)
 }
 
-func (qb *PerformerStore) GetAliases(ctx context.Context, performerID int) ([]string, error) {
+func (qb *PerformerStore) GetPerformerAliases(ctx context.Context, performerID int) ([]models.PerformerAlias, error) {
 	return performersAliasesTableMgr.get(ctx, performerID)
 }
 

--- a/pkg/sqlite/performer_test.go
+++ b/pkg/sqlite/performer_test.go
@@ -120,7 +120,7 @@ func Test_PerformerStore_Create(t *testing.T) {
 					Weight:         &weight,
 					IgnoreAutoTag:  ignoreAutoTag,
 					TagIDs:         models.NewRelatedIDs([]int{tagIDs[tagIdx1WithPerformer], tagIDs[tagIdx1WithDupName]}),
-					Aliases:        models.NewRelatedStrings(aliases),
+					Aliases:        models.NewRelatedPerformerAliases(toTestPerformerAliases(aliases)),
 					StashIDs: models.NewRelatedStashIDs([]models.StashID{
 						{
 							StashID:   stashID1,
@@ -283,7 +283,7 @@ func Test_PerformerStore_Update(t *testing.T) {
 					HairColor:      hairColor,
 					Weight:         &weight,
 					IgnoreAutoTag:  ignoreAutoTag,
-					Aliases:        models.NewRelatedStrings(aliases),
+					Aliases:        models.NewRelatedPerformerAliases(toTestPerformerAliases(aliases)),
 					TagIDs:         models.NewRelatedIDs([]int{tagIDs[tagIdx1WithDupName], tagIDs[tagIdx1WithPerformer]}),
 					StashIDs: models.NewRelatedStashIDs([]models.StashID{
 						{
@@ -308,7 +308,7 @@ func Test_PerformerStore_Update(t *testing.T) {
 			models.UpdatePerformerInput{
 				Performer: &models.Performer{
 					ID:       performerIDs[performerIdxWithGallery],
-					Aliases:  models.NewRelatedStrings([]string{}),
+					Aliases:  models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 					URLs:     models.NewRelatedStrings([]string{}),
 					TagIDs:   models.NewRelatedIDs([]int{}),
 					StashIDs: models.NewRelatedStashIDs([]models.StashID{}),
@@ -428,7 +428,7 @@ func clearPerformerPartial() models.PerformerPartial {
 		CareerEnd:      nullDate,
 		Tattoos:        nullString,
 		Piercings:      nullString,
-		Aliases:        &models.UpdateStrings{Mode: models.RelationshipUpdateModeSet},
+		Aliases:        &models.UpdatePerformerAliases{Mode: models.RelationshipUpdateModeSet},
 		Rating:         nullInt,
 		Details:        nullString,
 		DeathDate:      nullDate,
@@ -509,8 +509,8 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 				CareerEnd:    models.NewOptionalDate(careerEnd),
 				Tattoos:      models.NewOptionalString(tattoos),
 				Piercings:    models.NewOptionalString(piercings),
-				Aliases: &models.UpdateStrings{
-					Values: aliases,
+				Aliases: &models.UpdatePerformerAliases{
+					Values: toTestPerformerAliases(aliases),
 					Mode:   models.RelationshipUpdateModeSet,
 				},
 				Favorite:      models.NewOptionalBool(favorite),
@@ -561,7 +561,7 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 				CareerEnd:      &careerEnd,
 				Tattoos:        tattoos,
 				Piercings:      piercings,
-				Aliases:        models.NewRelatedStrings(aliases),
+				Aliases:        models.NewRelatedPerformerAliases(toTestPerformerAliases(aliases)),
 				Favorite:       favorite,
 				Rating:         &rating,
 				Details:        details,
@@ -596,7 +596,7 @@ func Test_PerformerStore_UpdatePartial(t *testing.T) {
 				Name:          getPerformerStringValue(performerIdxWithTwoTags, "Name"),
 				Favorite:      getPerformerBoolValue(performerIdxWithTwoTags),
 				URLs:          models.NewRelatedStrings([]string{}),
-				Aliases:       models.NewRelatedStrings([]string{}),
+				Aliases:       models.NewRelatedPerformerAliases([]models.PerformerAlias{}),
 				TagIDs:        models.NewRelatedIDs([]int{}),
 				StashIDs:      models.NewRelatedStashIDs([]models.StashID{}),
 				IgnoreAutoTag: getIgnoreAutoTag(performerIdxWithTwoTags),
@@ -2482,7 +2482,7 @@ func TestPerformerQueryIsMissingAlias(t *testing.T) {
 		assert.True(t, len(performers) > 0)
 
 		for _, performer := range performers {
-			a, err := db.Performer.GetAliases(ctx, performer.ID)
+			a, err := db.Performer.GetPerformerAliases(ctx, performer.ID)
 			if err != nil {
 				t.Errorf("error getting performer aliases: %s", err.Error())
 			}

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1696,7 +1696,7 @@ func createPerformers(ctx context.Context, n int, o int) error {
 		performer := models.Performer{
 			Name:           getPerformerStringValue(index, name),
 			Disambiguation: getPerformerStringValue(index, "disambiguation"),
-			Aliases:        models.NewRelatedStrings(performerAliases(index)),
+			Aliases:        models.NewRelatedPerformerAliases(toTestPerformerAliases(performerAliases(index))),
 			URLs: models.NewRelatedStrings([]string{
 				getPerformerEmptyString(i, urlField),
 			}),
@@ -2172,4 +2172,12 @@ func linkGroupsParent(ctx context.Context, qb models.GroupReaderWriter) error {
 
 func addTagImage(ctx context.Context, qb models.TagWriter, tagIndex int) error {
 	return qb.UpdateImage(ctx, tagIDs[tagIndex], []byte("image"))
+}
+
+func toTestPerformerAliases(aliases []string) []models.PerformerAlias {
+	var ret []models.PerformerAlias
+	for _, a := range aliases {
+		ret = append(ret, models.PerformerAlias{Alias: a})
+	}
+	return ret
 }

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -530,7 +530,9 @@ func (qb *StudioStore) QueryForAutoTag(ctx context.Context, words []string) ([]*
 	// TODO - Query needs to be changed to support queries of this type, and
 	// this method should be removed
 	table := qb.table()
-	sq := dialect.From(table).Select(table.Col(idColumn)).LeftJoin(
+	sq := dialect.From(table).Select(table.Col(idColumn))
+
+	sq = sq.LeftJoin(
 		studiosAliasesJoinTable,
 		goqu.On(studiosAliasesJoinTable.Col(studioIDColumn).Eq(table.Col(idColumn))),
 	)

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -1,7 +1,13 @@
 package sqlite
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
+
 	"github.com/doug-martin/goqu/v9"
+	"github.com/jmoiron/sqlx"
+	"github.com/stashapp/stash/pkg/models"
 
 	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 )
@@ -279,12 +285,11 @@ var (
 		idColumn: goqu.T(performerTable).Col(idColumn),
 	}
 
-	performersAliasesTableMgr = &stringTable{
+	performersAliasesTableMgr = &performerAliasTable{
 		table: table{
 			table:    performersAliasesJoinTable,
 			idColumn: performersAliasesJoinTable.Col(performerIDColumn),
 		},
-		stringColumn: performersAliasesJoinTable.Col(performerAliasColumn),
 	}
 
 	performersURLsTableMgr = &orderedValueTable[string]{
@@ -433,3 +438,118 @@ var (
 		idColumn: goqu.T(savedFilterTable).Col(idColumn),
 	}
 )
+
+type performerAliasTable struct {
+	table
+}
+
+type performerAliasRow struct {
+	Alias         string `db:"alias"`
+	IgnoreAutoTag bool   `db:"ignore_auto_tag"`
+}
+
+func (t *performerAliasTable) get(ctx context.Context, id int) ([]models.PerformerAlias, error) {
+	q := dialect.Select("alias", "ignore_auto_tag").From(t.table.table).Where(t.idColumn.Eq(id))
+
+	const single = false
+	var ret []models.PerformerAlias
+	if err := queryFunc(ctx, q, single, func(rows *sqlx.Rows) error {
+		var v performerAliasRow
+		if err := rows.StructScan(&v); err != nil {
+			return err
+		}
+
+		ret = append(ret, models.PerformerAlias{
+			Alias:         v.Alias,
+			IgnoreAutoTag: v.IgnoreAutoTag,
+		})
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("getting performer aliases from %s: %w", t.table.table.GetTable(), err)
+	}
+
+	return ret, nil
+}
+
+func (t *performerAliasTable) insertJoin(ctx context.Context, id int, v models.PerformerAlias) (sql.Result, error) {
+	q := dialect.Insert(t.table.table).Cols(t.idColumn.GetCol(), "alias", "ignore_auto_tag").Vals(
+		goqu.Vals{id, v.Alias, v.IgnoreAutoTag},
+	)
+	ret, err := exec(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("inserting into %s: %w", t.table.table.GetTable(), err)
+	}
+
+	return ret, nil
+}
+
+func (t *performerAliasTable) insertJoins(ctx context.Context, id int, v []models.PerformerAlias) error {
+	for _, fk := range v {
+		if _, err := t.insertJoin(ctx, id, fk); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *performerAliasTable) replaceJoins(ctx context.Context, id int, v []models.PerformerAlias) error {
+	if err := t.destroy(ctx, []int{id}); err != nil {
+		return err
+	}
+
+	return t.insertJoins(ctx, id, v)
+}
+
+func (t *performerAliasTable) addJoins(ctx context.Context, id int, v []models.PerformerAlias) error {
+	// get existing foreign keys
+	existing, err := t.get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// only add values that are not already present
+	var filtered []models.PerformerAlias
+	for _, vv := range v {
+		found := false
+		for _, e := range existing {
+			if e.Alias == vv.Alias {
+				found = true
+				break
+			}
+		}
+		if !found {
+			filtered = append(filtered, vv)
+		}
+	}
+	return t.insertJoins(ctx, id, filtered)
+}
+
+func (t *performerAliasTable) destroyJoins(ctx context.Context, id int, v []models.PerformerAlias) error {
+	for _, vv := range v {
+		q := dialect.Delete(t.table.table).Where(
+			t.idColumn.Eq(id),
+			t.table.table.Col("alias").Eq(vv.Alias),
+		)
+
+		if _, err := exec(ctx, q); err != nil {
+			return fmt.Errorf("destroying %s: %w", t.table.table.GetTable(), err)
+		}
+	}
+
+	return nil
+}
+
+func (t *performerAliasTable) modifyJoins(ctx context.Context, id int, v []models.PerformerAlias, mode models.RelationshipUpdateMode) error {
+	switch mode {
+	case models.RelationshipUpdateModeSet:
+		return t.replaceJoins(ctx, id, v)
+	case models.RelationshipUpdateModeAdd:
+		return t.addJoins(ctx, id, v)
+	case models.RelationshipUpdateModeRemove:
+		return t.destroyJoins(ctx, id, v)
+	}
+
+	return nil
+}

--- a/pkg/stashbox/performer.go
+++ b/pkg/stashbox/performer.go
@@ -377,8 +377,8 @@ func (c Client) SubmitPerformerDraft(ctx context.Context, performer *models.Perf
 	if performer.Tattoos != "" {
 		draft.Tattoos = &performer.Tattoos
 	}
-	if len(performer.Aliases.List()) > 0 {
-		aliases := strings.Join(performer.Aliases.List(), ",")
+	if len(performer.Aliases.ToAliases()) > 0 {
+		aliases := strings.Join(performer.Aliases.ToAliases(), ",")
 		draft.Aliases = &aliases
 	}
 	if performer.CareerStart != nil {

--- a/ui/v2.5/graphql/data/performer-slim.graphql
+++ b/ui/v2.5/graphql/data/performer-slim.graphql
@@ -20,7 +20,6 @@ fragment SlimPerformerData on Performer {
   career_end
   tattoos
   piercings
-  alias_list
   aliases {
     ...PerformerAliasData
   }
@@ -42,7 +41,6 @@ fragment SelectPerformerData on Performer {
   id
   name
   disambiguation
-  alias_list
   aliases {
     ...PerformerAliasData
   }

--- a/ui/v2.5/graphql/data/performer-slim.graphql
+++ b/ui/v2.5/graphql/data/performer-slim.graphql
@@ -21,6 +21,9 @@ fragment SlimPerformerData on Performer {
   tattoos
   piercings
   alias_list
+  aliases {
+    ...PerformerAliasData
+  }
   tags {
     id
     name
@@ -40,6 +43,9 @@ fragment SelectPerformerData on Performer {
   name
   disambiguation
   alias_list
+  aliases {
+    ...PerformerAliasData
+  }
   image_path
   birthdate
   death_date

--- a/ui/v2.5/graphql/data/performer.graphql
+++ b/ui/v2.5/graphql/data/performer.graphql
@@ -22,7 +22,6 @@ fragment PerformerData on Performer {
   career_end
   tattoos
   piercings
-  alias_list
   aliases {
     ...PerformerAliasData
   }

--- a/ui/v2.5/graphql/data/performer.graphql
+++ b/ui/v2.5/graphql/data/performer.graphql
@@ -1,3 +1,8 @@
+fragment PerformerAliasData on PerformerAlias {
+  alias
+  ignore_auto_tag
+}
+
 fragment PerformerData on Performer {
   id
   name
@@ -18,6 +23,9 @@ fragment PerformerData on Performer {
   tattoos
   piercings
   alias_list
+  aliases {
+    ...PerformerAliasData
+  }
   favorite
   ignore_auto_tag
   image_path

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -326,6 +326,7 @@ export const GalleryEditPanel: React.FC<IProps> = ({
               id: p.stored_id!,
               name: p.name ?? "",
               alias_list: [],
+              aliases: [],
             };
           })
         );

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -325,7 +325,6 @@ export const GalleryEditPanel: React.FC<IProps> = ({
             return {
               id: p.stored_id!,
               name: p.name ?? "",
-              alias_list: [],
               aliases: [],
             };
           })

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -270,6 +270,7 @@ export const ImageEditPanel: React.FC<IProps> = ({
               id: p.stored_id!,
               name: p.name ?? "",
               alias_list: [],
+              aliases: [],
             };
           })
         );

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -269,7 +269,6 @@ export const ImageEditPanel: React.FC<IProps> = ({
             return {
               id: p.stored_id!,
               name: p.name ?? "",
-              alias_list: [],
               aliases: [],
             };
           })

--- a/ui/v2.5/src/components/List/Filters/PerformersFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/PerformersFilter.tsx
@@ -65,7 +65,7 @@ function sortResults(
     query,
     performers ?? [],
     (p) => p.name,
-    (p) => p.alias_list
+    (p) => p.alias_list ?? undefined
   ).map((p) => {
     return {
       id: p.id,

--- a/ui/v2.5/src/components/List/Filters/PerformersFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/PerformersFilter.tsx
@@ -59,13 +59,13 @@ function queryVariables(
 
 function sortResults(
   query: string,
-  performers?: Pick<PerformerDataFragment, "name" | "alias_list" | "id">[]
+  performers?: Pick<PerformerDataFragment, "name" | "aliases" | "id">[]
 ) {
   return sortByRelevance(
     query,
     performers ?? [],
     (p) => p.name,
-    (p) => p.alias_list ?? undefined
+    (p) => p.aliases.map((a) => a.alias)
   ).map((p) => {
     return {
       id: p.id,

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -452,7 +452,9 @@ const PerformerPage: React.FC<IProps> = PatchComponent(
                     <ExternalLinkButtons urls={performer.urls ?? undefined} />
                   </span>
                 </DetailTitle>
-                <AliasList aliases={performer.alias_list ?? undefined} />
+                <AliasList
+                  aliases={performer.aliases?.map((a) => a.alias) ?? undefined}
+                />
                 <div className="quality-group">
                   <RatingSystem
                     value={performer.rating100}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -452,7 +452,7 @@ const PerformerPage: React.FC<IProps> = PatchComponent(
                     <ExternalLinkButtons urls={performer.urls ?? undefined} />
                   </span>
                 </DetailTitle>
-                <AliasList aliases={performer.alias_list} />
+                <AliasList aliases={performer.alias_list ?? undefined} />
                 <div className="quality-group">
                   <RatingSystem
                     value={performer.rating100}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -452,9 +452,7 @@ const PerformerPage: React.FC<IProps> = PatchComponent(
                     <ExternalLinkButtons urls={performer.urls ?? undefined} />
                   </span>
                 </DetailTitle>
-                <AliasList
-                  aliases={performer.aliases?.map((a) => a.alias) ?? undefined}
-                />
+                <AliasList aliases={performer.aliases.map((a) => a.alias)} />
                 <div className="quality-group">
                   <RatingSystem
                     value={performer.rating100}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -173,11 +173,9 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   const [customFieldsError, setCustomFieldsError] = useState<string>();
 
   function submit(values: InputValues, andNew?: boolean) {
-    const { aliases, ...rest } = values;
-
     const input = {
-      ...schema.cast(rest),
-      aliases: normalizeAliases(aliases),
+      ...schema.cast(values),
+      aliases: normalizeAliases(values.aliases),
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
     };
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -52,6 +52,7 @@ import {
   formatCustomFieldInput,
 } from "src/components/Shared/CustomFields";
 import { cloneDeep } from "@apollo/client/utilities";
+import { normalizeAliases, mergeScrapedAliases } from "src/core/performers";
 
 const isScraper = (
   scraper: GQL.Scraper | GQL.StashBox
@@ -171,44 +172,23 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   const [customFieldsError, setCustomFieldsError] = useState<string>();
 
-  function submit(values: InputValues) {
+  function submit(values: InputValues, andNew?: boolean) {
     const { aliases, ...rest } = values;
-
-    // deduplicate aliases
-    const aliasesMap = new Map<string, boolean>();
-    (aliases || []).forEach((a) => {
-      const existing = aliasesMap.get(a.alias);
-      if (existing !== undefined) {
-        // If duplicates exist, and their ignore_auto_tag differs, we default to true (ignore auto tag)
-        if (existing !== a.ignore_auto_tag) {
-          aliasesMap.set(a.alias, true);
-        }
-      } else {
-        aliasesMap.set(a.alias, a.ignore_auto_tag);
-      }
-    });
-
-    const finalAliases = Array.from(aliasesMap.entries()).map(
-      ([alias, ignore_auto_tag]) => ({
-        alias,
-        ignore_auto_tag,
-      })
-    );
 
     const input = {
       ...schema.cast(rest),
-      aliases: finalAliases,
+      aliases: normalizeAliases(aliases),
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
     };
 
-    onSave(input);
+    onSave(input, andNew);
   }
 
   const formik = useFormik<InputValues>({
     initialValues,
     enableReinitialize: true,
     validate: yupFormikValidate(schema),
-    onSubmit: submit,
+    onSubmit: (values) => submit(values),
   });
 
   const { tags, updateTagsStateFromScraper, tagsControl } = useTagsEdit(
@@ -258,20 +238,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       formik.setFieldValue("disambiguation", state.disambiguation);
     }
     if (state.aliases) {
-      const existingMap = new Map<string, boolean>();
-      formik.values.aliases?.forEach((a) => {
-        existingMap.set(a.alias, a.ignore_auto_tag);
-      });
-
-      const aliasModels = state.aliases.split(",").map((a) => {
-        const trimmed = a.trim();
-        const existing = existingMap.get(trimmed);
-        return {
-          alias: trimmed,
-          ignore_auto_tag: existing !== undefined ? existing : true,
-        };
-      });
-      formik.setFieldValue("aliases", aliasModels);
+      formik.setFieldValue(
+        "aliases",
+        mergeScrapedAliases(state.aliases, formik.values.aliases)
+      );
     }
     if (state.birthdate) {
       formik.setFieldValue("birthdate", state.birthdate);
@@ -400,39 +370,8 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     setIsLoading(false);
   }
 
-  async function onSaveAndNewClick() {
-    const { values } = formik;
-
-    const { aliases, ...rest } = values;
-
-    // deduplicate aliases
-    const aliasesMap = new Map<string, boolean>();
-    (aliases || []).forEach((a) => {
-      const existing = aliasesMap.get(a.alias);
-      if (existing !== undefined) {
-        // If duplicates exist, and their ignore_auto_tag differs, we default to true (ignore auto tag)
-        if (existing !== a.ignore_auto_tag) {
-          aliasesMap.set(a.alias, true);
-        }
-      } else {
-        aliasesMap.set(a.alias, a.ignore_auto_tag);
-      }
-    });
-
-    const finalAliases = Array.from(aliasesMap.entries()).map(
-      ([alias, ignore_auto_tag]) => ({
-        alias,
-        ignore_auto_tag,
-      })
-    );
-
-    const input = {
-      ...schema.cast(rest),
-      aliases: finalAliases,
-      custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
-    };
-
-    onSave(input, true);
+  function onSaveAndNewClick() {
+    submit(formik.values, true);
   }
 
   // set up hotkeys

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -199,7 +199,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       ...schema.cast(rest),
       aliases: finalAliases,
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
-    } as GQL.PerformerCreateInput;
+    };
 
     onSave(input);
   }
@@ -430,7 +430,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       ...schema.cast(rest),
       aliases: finalAliases,
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
-    } as GQL.PerformerCreateInput;
+    };
 
     onSave(input, true);
   }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -44,7 +44,6 @@ import {
   yupInputNumber,
   yupInputEnum,
   yupDateString,
-  yupRequiredStringArray,
   yupUniqueStringList,
 } from "src/utils/yup";
 import { useTagsEdit } from "src/hooks/tagsEdit";
@@ -103,7 +102,16 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   const schema = yup.object({
     name: yup.string().required(),
     disambiguation: yup.string().ensure(),
-    alias_list: yupRequiredStringArray(intl).defined(),
+    aliases: yup
+      .array(
+        yup
+          .object({
+            alias: yup.string().required(),
+            ignore_auto_tag: yup.boolean().required(),
+          })
+          .required()
+      )
+      .defined(),
     gender: yupInputEnum(GQL.GenderEnum).nullable().defined(),
     birthdate: yupDateString(intl),
     death_date: yupDateString(intl),
@@ -133,7 +141,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   const initialValues = {
     name: performer.name ?? "",
     disambiguation: performer.disambiguation ?? "",
-    alias_list: performer.alias_list ?? [],
+    aliases: performer.aliases ?? [],
     gender: performer.gender ?? null,
     birthdate: performer.birthdate ?? "",
     death_date: performer.death_date ?? "",
@@ -164,10 +172,35 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   const [customFieldsError, setCustomFieldsError] = useState<string>();
 
   function submit(values: InputValues) {
+    const { aliases, ...rest } = values;
+
+    // deduplicate aliases
+    const aliasesMap = new Map<string, boolean>();
+    (aliases || []).forEach((a) => {
+      const existing = aliasesMap.get(a.alias);
+      if (existing !== undefined) {
+        // If duplicates exist, and their ignore_auto_tag differs, we default to true (ignore auto tag)
+        if (existing !== a.ignore_auto_tag) {
+          aliasesMap.set(a.alias, true);
+        }
+      } else {
+        aliasesMap.set(a.alias, a.ignore_auto_tag);
+      }
+    });
+
+    const finalAliases = Array.from(aliasesMap.entries()).map(
+      ([alias, ignore_auto_tag]) => ({
+        alias,
+        ignore_auto_tag,
+      })
+    );
+
     const input = {
-      ...schema.cast(values),
+      ...schema.cast(rest),
+      aliases: finalAliases,
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
-    };
+    } as GQL.PerformerCreateInput;
+
     onSave(input);
   }
 
@@ -225,10 +258,20 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
       formik.setFieldValue("disambiguation", state.disambiguation);
     }
     if (state.aliases) {
-      formik.setFieldValue(
-        "alias_list",
-        state.aliases.split(",").map((a) => a.trim())
-      );
+      const existingMap = new Map<string, boolean>();
+      formik.values.aliases?.forEach((a) => {
+        existingMap.set(a.alias, a.ignore_auto_tag);
+      });
+
+      const aliasModels = state.aliases.split(",").map((a) => {
+        const trimmed = a.trim();
+        const existing = existingMap.get(trimmed);
+        return {
+          alias: trimmed,
+          ignore_auto_tag: existing !== undefined ? existing : true,
+        };
+      });
+      formik.setFieldValue("aliases", aliasModels);
     }
     if (state.birthdate) {
       formik.setFieldValue("birthdate", state.birthdate);
@@ -346,7 +389,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     ImageUtils.onImageChange(event, onImageLoad);
   }
 
-  async function onSave(input: InputValues, andNew?: boolean) {
+  async function onSave(input: GQL.PerformerCreateInput, andNew?: boolean) {
     setIsLoading(true);
     try {
       await onSubmit(input, andNew);
@@ -359,10 +402,36 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
   async function onSaveAndNewClick() {
     const { values } = formik;
+
+    const { aliases, ...rest } = values;
+
+    // deduplicate aliases
+    const aliasesMap = new Map<string, boolean>();
+    (aliases || []).forEach((a) => {
+      const existing = aliasesMap.get(a.alias);
+      if (existing !== undefined) {
+        // If duplicates exist, and their ignore_auto_tag differs, we default to true (ignore auto tag)
+        if (existing !== a.ignore_auto_tag) {
+          aliasesMap.set(a.alias, true);
+        }
+      } else {
+        aliasesMap.set(a.alias, a.ignore_auto_tag);
+      }
+    });
+
+    const finalAliases = Array.from(aliasesMap.entries()).map(
+      ([alias, ignore_auto_tag]) => ({
+        alias,
+        ignore_auto_tag,
+      })
+    );
+
     const input = {
-      ...schema.cast(values),
+      ...schema.cast(rest),
+      aliases: finalAliases,
       custom_fields: formatCustomFieldInput(isNew, values.custom_fields),
-    };
+    } as GQL.PerformerCreateInput;
+
     onSave(input, true);
   }
 
@@ -669,9 +738,9 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     renderInputField,
     renderSelectField,
     renderDateField,
-    renderStringListField,
     renderStashIDsField,
     renderURLListField,
+    renderPerformerAliasListField,
   } = formikUtils(intl, formik);
 
   function renderCountryField() {
@@ -721,7 +790,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         {renderInputField("name")}
         {renderInputField("disambiguation")}
 
-        {renderStringListField("alias_list", "aliases", { orderable: false })}
+        {renderPerformerAliasListField("aliases", "aliases")}
 
         {renderSelectField("gender", stringGenderMap)}
 

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -217,7 +217,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
   );
   const [aliases, setAliases] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(
-      props.performer.alias_list?.join(", "),
+      props.performer.aliases?.map((a) => a.alias).join(", "),
       props.scraped.aliases
     )
   );

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerScrapeDialog.tsx
@@ -217,7 +217,7 @@ export const PerformerScrapeDialog: React.FC<IPerformerScrapeDialogProps> = (
   );
   const [aliases, setAliases] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(
-      props.performer.aliases?.map((a) => a.alias).join(", "),
+      (props.performer.aliases ?? []).map((a) => a.alias).join(", "),
       props.scraped.aliases
     )
   );

--- a/ui/v2.5/src/components/Performers/PerformerListTable.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerListTable.tsx
@@ -89,9 +89,7 @@ export const PerformerListTable: React.FC<IPerformerListTableProps> = (
   );
 
   const AliasesCell = (performer: GQL.PerformerDataFragment) => {
-    let aliases = performer.aliases
-      ? performer.aliases.map((a) => a.alias).join(", ")
-      : "";
+    const aliases = performer.aliases.map((a) => a.alias).join(", ");
     return (
       <span className="ellips-data" title={aliases}>
         {aliases}

--- a/ui/v2.5/src/components/Performers/PerformerListTable.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerListTable.tsx
@@ -89,7 +89,9 @@ export const PerformerListTable: React.FC<IPerformerListTableProps> = (
   );
 
   const AliasesCell = (performer: GQL.PerformerDataFragment) => {
-    let aliases = performer.alias_list ? performer.alias_list.join(", ") : "";
+    let aliases = performer.aliases
+      ? performer.aliases.map((a) => a.alias).join(", ")
+      : "";
     return (
       <span className="ellips-data" title={aliases}>
         {aliases}

--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -188,14 +188,14 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     // default alias list should be the existing aliases, plus the names of all sources,
     // plus all source aliases, deduplicated
     const allAliases = uniq(
-      dest.alias_list.concat(
+      (dest.alias_list ?? []).concat(
         sources.map((s) => s.name),
-        sources.flatMap((s) => s.alias_list)
+        sources.flatMap((s) => s.alias_list ?? [])
       )
     );
 
     setAliases(
-      new ScrapeResult(dest.alias_list, allAliases, !!allAliases.length)
+      new ScrapeResult(dest.alias_list ?? [], allAliases, !!allAliases.length)
     );
     setBirthdate(
       new ScrapeResult(

--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -69,7 +69,7 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     new ScrapeResult<string>(dest.disambiguation)
   );
   const [aliases, setAliases] = useState<ScrapeResult<string[]>>(
-    new ScrapeResult<string[]>(dest.alias_list)
+    new ScrapeResult<string[]>(dest.aliases.map((a) => a.alias))
   );
   const [birthdate, setBirthdate] = useState<ScrapeResult<string>>(
     new ScrapeResult<string>(dest.birthdate)
@@ -188,14 +188,18 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     // default alias list should be the existing aliases, plus the names of all sources,
     // plus all source aliases, deduplicated
     const allAliases = uniq(
-      (dest.alias_list ?? []).concat(
+      (dest.aliases.map((a) => a.alias) ?? []).concat(
         sources.map((s) => s.name),
-        sources.flatMap((s) => s.alias_list ?? [])
+        sources.flatMap((s) => s.aliases.map((a) => a.alias) ?? [])
       )
     );
 
     setAliases(
-      new ScrapeResult(dest.alias_list ?? [], allAliases, !!allAliases.length)
+      new ScrapeResult(
+        dest.aliases.map((a) => a.alias) ?? [],
+        allAliases,
+        !!allAliases.length
+      )
     );
     setBirthdate(
       new ScrapeResult(
@@ -648,10 +652,10 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
         id: dest.id,
         name: name.getNewValue(),
         disambiguation: disambiguation.getNewValue(),
-        alias_list: aliases
+        aliases: aliases
           .getNewValue()
-          ?.map((s) => s.trim())
-          .filter((s) => s.length > 0),
+          ?.map((s) => ({ alias: s.trim(), ignore_auto_tag: true }))
+          .filter((a) => a.alias.length > 0),
         birthdate: birthdate.getNewValue(),
         death_date: deathDate.getNewValue(),
         ethnicity: ethnicity.getNewValue(),

--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -188,15 +188,17 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     // default alias list should be the existing aliases, plus the names of all sources,
     // plus all source aliases, deduplicated
     const allAliases = uniq(
-      (dest.aliases.map((a) => a.alias) ?? []).concat(
-        sources.map((s) => s.name),
-        sources.flatMap((s) => s.aliases.map((a) => a.alias) ?? [])
-      )
+      dest.aliases
+        .map((a) => a.alias)
+        .concat(
+          sources.map((s) => s.name),
+          sources.flatMap((s) => s.aliases.map((a) => a.alias))
+        )
     );
 
     setAliases(
       new ScrapeResult(
-        dest.aliases.map((a) => a.alias) ?? [],
+        dest.aliases.map((a) => a.alias),
         allAliases,
         !!allAliases.length
       )
@@ -647,15 +649,17 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     // only set the cover image if it's different from the existing cover image
     const coverImage = image.useNewValue ? image.getNewValue() : undefined;
 
+    const updatedAliases = aliases.getNewValue();
+    const finalAliases = updatedAliases
+      ?.map((s) => ({ alias: s.trim(), ignore_auto_tag: true }))
+      .filter((a) => a.alias.length > 0);
+
     return {
       values: {
         id: dest.id,
         name: name.getNewValue(),
         disambiguation: disambiguation.getNewValue(),
-        aliases: aliases
-          .getNewValue()
-          ?.map((s) => ({ alias: s.trim(), ignore_auto_tag: true }))
-          .filter((a) => a.alias.length > 0),
+        aliases: finalAliases,
         birthdate: birthdate.getNewValue(),
         death_date: deathDate.getNewValue(),
         ethnicity: ethnicity.getNewValue(),

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -47,6 +47,7 @@ export type Performer = Pick<
   | "id"
   | "name"
   | "alias_list"
+  | "aliases"
   | "disambiguation"
   | "image_path"
   | "birthdate"
@@ -66,7 +67,7 @@ function sortPerformersByRelevance(
     input,
     performers,
     (p) => p.name,
-    (p) => p.alias_list
+    (p) => p.alias_list ?? undefined
   );
 }
 
@@ -289,6 +290,7 @@ const _PerformerSelect: React.FC<
       id,
       name,
       alias_list: [],
+      aliases: [],
     };
   };
 

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -46,7 +46,6 @@ export type Performer = Pick<
   GQL.Performer,
   | "id"
   | "name"
-  | "alias_list"
   | "aliases"
   | "disambiguation"
   | "image_path"
@@ -67,7 +66,7 @@ function sortPerformersByRelevance(
     input,
     performers,
     (p) => p.name,
-    (p) => p.alias_list ?? undefined
+    (p) => p.aliases.map((a) => a.alias)
   );
 }
 
@@ -146,9 +145,9 @@ const _PerformerSelect: React.FC<
     const { inputValue } = optionProps.selectProps;
     let alias: string | undefined = "";
     if (!name.toLowerCase().includes(inputValue.toLowerCase())) {
-      alias = object.alias_list?.find((a) =>
-        a.toLowerCase().includes(inputValue.toLowerCase())
-      );
+      alias = object.aliases.find((a) =>
+        a.alias.toLowerCase().includes(inputValue.toLowerCase())
+      )?.alias;
     }
 
     const sceneAge = TextUtils.age(object.birthdate, props.ageFromDate);
@@ -289,7 +288,6 @@ const _PerformerSelect: React.FC<
     return {
       id,
       name,
-      alias_list: [],
       aliases: [],
     };
   };
@@ -303,8 +301,8 @@ const _PerformerSelect: React.FC<
       options.some((o) => {
         return (
           o.name.toLowerCase() === inputValue.toLowerCase() ||
-          o.alias_list?.some(
-            (a) => a.toLowerCase() === inputValue.toLowerCase()
+          o.aliases?.some(
+            (a) => a.alias.toLowerCase() === inputValue.toLowerCase()
           )
         );
       })

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -301,7 +301,7 @@ const _PerformerSelect: React.FC<
       options.some((o) => {
         return (
           o.name.toLowerCase() === inputValue.toLowerCase() ||
-          o.aliases?.some(
+          o.aliases.some(
             (a) => a.alias.toLowerCase() === inputValue.toLowerCase()
           )
         );

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -507,7 +507,6 @@ export const SceneEditPanel: React.FC<IProps> = ({
             return {
               id: p.stored_id!,
               name: p.name ?? "",
-              alias_list: [],
               aliases: [],
             };
           })

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -508,6 +508,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
               id: p.stored_id!,
               name: p.name ?? "",
               alias_list: [],
+              aliases: [],
             };
           })
         );

--- a/ui/v2.5/src/components/Shared/PerformerAliasListInput.tsx
+++ b/ui/v2.5/src/components/Shared/PerformerAliasListInput.tsx
@@ -1,0 +1,100 @@
+import { faMinus } from "@fortawesome/free-solid-svg-icons";
+import React from "react";
+import { Button, Form, InputGroup } from "react-bootstrap";
+import { Icon } from "./Icon";
+import * as GQL from "src/core/generated-graphql";
+import { FormattedMessage } from "react-intl";
+
+export interface IPerformerAliasListInputProps {
+  value: GQL.PerformerAliasInput[];
+  setValue: (value: GQL.PerformerAliasInput[]) => void;
+  placeholder?: string;
+  className?: string;
+  errors?: string;
+  errorIdx?: number[];
+  readOnly?: boolean;
+}
+
+export const PerformerAliasListInput: React.FC<
+  IPerformerAliasListInputProps
+> = (props) => {
+  const values = props.value.concat({ alias: "", ignore_auto_tag: true });
+
+  function valueChanged(
+    idx: number,
+    field: "alias" | "ignore_auto_tag",
+    value: string | boolean
+  ) {
+    const newValues = props.value.slice();
+    if (!newValues[idx]) {
+      newValues[idx] = { alias: "", ignore_auto_tag: true };
+    }
+    newValues[idx] = { ...newValues[idx], [field]: value };
+
+    // if we cleared the last string, delete it from the array entirely
+    if (!newValues[idx].alias && idx === newValues.length - 1) {
+      newValues.splice(newValues.length - 1);
+    }
+
+    props.setValue(newValues);
+  }
+
+  function removeValue(idx: number) {
+    const newValues = props.value.filter((_v, i) => i !== idx);
+
+    props.setValue(newValues);
+  }
+
+  return (
+    <>
+      <div className={`string-list-input ${props.errors ? "is-invalid" : ""}`}>
+        <Form.Group>
+          {values.map((v, i) => (
+            <InputGroup className={props.className} key={i}>
+              <Form.Control
+                className={`text-input ${
+                  props.errorIdx?.includes(i) ? "is-invalid" : ""
+                }`}
+                value={v.alias}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  valueChanged(i, "alias", e.currentTarget.value)
+                }
+                placeholder={props.placeholder}
+                readOnly={props.readOnly}
+              />
+              <div className="d-flex align-items-center ml-3 mr-3">
+                <Form.Check
+                  id={`ignore_auto_tag_${i}`}
+                  className="mb-0"
+                  custom
+                  type="switch"
+                  label={
+                    <FormattedMessage id="auto_tag" defaultMessage="Auto tag" />
+                  }
+                  checked={!v.ignore_auto_tag}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    valueChanged(i, "ignore_auto_tag", !e.currentTarget.checked)
+                  }
+                  disabled={props.readOnly || i === values.length - 1}
+                />
+              </div>
+              <InputGroup.Append>
+                {!props.readOnly && (
+                  <Button
+                    variant="danger"
+                    onClick={() => removeValue(i)}
+                    disabled={i === values.length - 1}
+                    size="sm"
+                  >
+                    <Icon icon={faMinus} />
+                  </Button>
+                )}
+              </InputGroup.Append>
+            </InputGroup>
+          ))}
+        </Form.Group>
+      </div>
+      <div className="invalid-feedback mt-n2">{props.errors}</div>
+    </>
+  );
+};

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -252,12 +252,14 @@ export const ScrapedPerformersRow: React.FC<
     const value = resultValue ?? [];
 
     const selectValue = value.map((p) => {
-      const alias_list: string[] = [];
+      const aliases =
+        p.aliases
+          ?.split(",")
+          .map((a) => ({ alias: a.trim(), ignore_auto_tag: true })) ?? [];
       return {
         id: p.stored_id ?? "",
         name: p.name ?? "",
-        alias_list,
-        aliases: [],
+        aliases,
       };
     });
 
@@ -271,8 +273,8 @@ export const ScrapedPerformersRow: React.FC<
             // map the id back to stored_id
             onChangeFn(
               items.map((p) => {
-                const { aliases, ...rest } = p;
-                return { ...rest, stored_id: p.id };
+                const aliases = p.aliases.map((a) => a.alias).join(", ");
+                return { ...p, aliases, stored_id: p.id };
               })
             );
           }
@@ -329,11 +331,10 @@ export const ScrapedGroupsRow: React.FC<
     const value = resultValue ?? [];
 
     const selectValue = value.map((p) => {
-      const aliases: string = "";
       return {
         id: p.stored_id ?? "",
         name: p.name ?? "",
-        aliases,
+        aliases: p.aliases ?? "",
       };
     });
 
@@ -347,8 +348,7 @@ export const ScrapedGroupsRow: React.FC<
             // map the id back to stored_id
             onChangeFn(
               items.map((p) => {
-                const { aliases, ...rest } = p;
-                return { ...rest, stored_id: p.id };
+                return { ...p, stored_id: p.id };
               })
             );
           }

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -16,6 +16,8 @@ import { Icon } from "../Icon";
 import { faLink, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { useIntl } from "react-intl";
 
+import { mergeScrapedAliases } from "src/core/performers";
+
 interface INewScrapedObjects<T> {
   newValues: T[];
   onCreateNew: (value: T) => void;
@@ -252,14 +254,10 @@ export const ScrapedPerformersRow: React.FC<
     const value = resultValue ?? [];
 
     const selectValue = value.map((p) => {
-      const aliases =
-        p.aliases
-          ?.split(",")
-          .map((a) => ({ alias: a.trim(), ignore_auto_tag: true })) ?? [];
       return {
         id: p.stored_id ?? "",
         name: p.name ?? "",
-        aliases,
+        aliases: mergeScrapedAliases(p.aliases),
       };
     });
 

--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -257,6 +257,7 @@ export const ScrapedPerformersRow: React.FC<
         id: p.stored_id ?? "",
         name: p.name ?? "",
         alias_list,
+        aliases: [],
       };
     });
 
@@ -268,7 +269,12 @@ export const ScrapedPerformersRow: React.FC<
         onSelect={(items) => {
           if (onChangeFn) {
             // map the id back to stored_id
-            onChangeFn(items.map((p) => ({ ...p, stored_id: p.id })));
+            onChangeFn(
+              items.map((p) => {
+                const { aliases, ...rest } = p;
+                return { ...rest, stored_id: p.id };
+              })
+            );
           }
         }}
         values={selectValue}
@@ -339,7 +345,12 @@ export const ScrapedGroupsRow: React.FC<
         onSelect={(items) => {
           if (onChangeFn) {
             // map the id back to stored_id
-            onChangeFn(items.map((p) => ({ ...p, stored_id: p.id })));
+            onChangeFn(
+              items.map((p) => {
+                const { aliases, ...rest } = p;
+                return { ...rest, stored_id: p.id };
+              })
+            );
           }
         }}
         values={selectValue}

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { ExternalLink } from "../Shared/ExternalLink";
 import { StashIDPill } from "../Shared/StashID";
+import { mergeScrapedAliases } from "src/core/performers";
 
 interface IPerformerModalProps {
   performer: GQL.ScrapedScenePerformerDataFragment;
@@ -228,11 +229,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
     } = {
       name: performer.name ?? "",
       disambiguation: performer.disambiguation ?? "",
-      aliases:
-        performer.aliases
-          ?.split(",")
-          .map((a) => ({ alias: a.trim(), ignore_auto_tag: true })) ??
-        undefined,
+      aliases: mergeScrapedAliases(performer.aliases) ?? undefined,
       gender: stringToGender(performer.gender ?? undefined, true),
       birthdate: performer.birthdate,
       ethnicity: performer.ethnicity,

--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -228,8 +228,11 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
     } = {
       name: performer.name ?? "",
       disambiguation: performer.disambiguation ?? "",
-      alias_list:
-        performer.aliases?.split(",").map((a) => a.trim()) ?? undefined,
+      aliases:
+        performer.aliases
+          ?.split(",")
+          .map((a) => ({ alias: a.trim(), ignore_auto_tag: true })) ??
+        undefined,
       gender: stringToGender(performer.gender ?? undefined, true),
       birthdate: performer.birthdate,
       ethnicity: performer.ethnicity,
@@ -282,8 +285,8 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
         performerData[k] = undefined;
       }
       // #5565 - special case aliases as the names differ
-      if (k == "alias_list" && excluded.aliases) {
-        performerData.alias_list = undefined;
+      if (k == "aliases" && excluded.aliases) {
+        performerData.aliases = undefined;
       }
     });
 

--- a/ui/v2.5/src/components/Tagger/performers/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/StashSearchResult.tsx
@@ -18,21 +18,6 @@ interface IStashSearchResultProps {
   excludedPerformerFields: string[];
 }
 
-// #4596 - remove any duplicate aliases or aliases that are the same as the performer's name
-function cleanAliases(currentName: string, aliases: string[]) {
-  const ret: string[] = [];
-  aliases.forEach((alias) => {
-    if (
-      alias.toLowerCase() !== currentName.toLowerCase() &&
-      !ret.find((r) => r.toLowerCase() === alias.toLowerCase())
-    ) {
-      ret.push(alias);
-    }
-  });
-
-  return ret;
-}
-
 const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   performer,
   stashboxPerformers,
@@ -56,10 +41,6 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
 
     if (input.stash_ids?.length) {
       input.stash_ids = mergeStashIDs(performer.stash_ids, input.stash_ids);
-    }
-
-    if (input.alias_list) {
-      input.alias_list = cleanAliases(performer.name, input.alias_list);
     }
 
     const updateData: GQL.PerformerUpdateInput = {

--- a/ui/v2.5/src/core/performers.ts
+++ b/ui/v2.5/src/core/performers.ts
@@ -83,16 +83,56 @@ export function sortPerformers<T extends IPerformerFragment>(performers: T[]) {
   return ret;
 }
 
+export function normalizeAliases(
+  aliases: GQL.PerformerAliasInput[]
+): GQL.PerformerAliasInput[] {
+  const aliasesMap = new Map<string, boolean>();
+  aliases.forEach((a) => {
+    const existing = aliasesMap.get(a.alias);
+    // If duplicates exist, and their ignore_auto_tag differs, we default to true (ignore auto tag)
+    const safeIgnore =
+      existing === undefined
+        ? a.ignore_auto_tag
+        : existing || a.ignore_auto_tag;
+    aliasesMap.set(a.alias, safeIgnore);
+  });
+
+  return [...aliasesMap].map(([alias, ignore_auto_tag]) => ({
+    alias,
+    ignore_auto_tag,
+  }));
+}
+
+export function mergeScrapedAliases(
+  scrapedAliases: string | null | undefined,
+  existingAliases: GQL.PerformerAliasInput[] = []
+): GQL.PerformerAliasInput[] {
+  if (!scrapedAliases) {
+    return existingAliases;
+  }
+
+  const existingMap = new Map<string, boolean>();
+  existingAliases.forEach((a) => {
+    existingMap.set(a.alias, a.ignore_auto_tag);
+  });
+
+  return scrapedAliases
+    .split(",")
+    .map((a) => {
+      const trimmed = a.trim();
+      const existing = existingMap.get(trimmed);
+      return {
+        alias: trimmed,
+        ignore_auto_tag: existing !== undefined ? existing : true,
+      };
+    })
+    .filter((a) => a.alias.length > 0);
+}
+
 export const scrapedPerformerToCreateInput = (
   toCreate: GQL.ScrapedPerformer,
   endpoint?: string
 ) => {
-  const aliases =
-    toCreate.aliases
-      ?.split(",")
-      .map((a) => a.trim())
-      .filter((a) => a) || [];
-
   const input: GQL.PerformerCreateInput = {
     name: toCreate.name ?? "",
     gender: stringToGender(toCreate.gender),
@@ -108,7 +148,7 @@ export const scrapedPerformerToCreateInput = (
     career_end: toCreate.career_end,
     tattoos: toCreate.tattoos,
     piercings: toCreate.piercings,
-    aliases: aliases.map((a) => ({ alias: a, ignore_auto_tag: true })),
+    aliases: mergeScrapedAliases(toCreate.aliases),
     urls: toCreate.urls,
     tag_ids: filterData((toCreate.tags ?? []).map((t) => t.stored_id)),
     image:

--- a/ui/v2.5/src/core/performers.ts
+++ b/ui/v2.5/src/core/performers.ts
@@ -108,7 +108,7 @@ export const scrapedPerformerToCreateInput = (
     career_end: toCreate.career_end,
     tattoos: toCreate.tattoos,
     piercings: toCreate.piercings,
-    alias_list: aliases,
+    aliases: aliases.map((a) => ({ alias: a, ignore_auto_tag: true })),
     urls: toCreate.urls,
     tag_ids: filterData((toCreate.tags ?? []).map((t) => t.stored_id)),
     image:

--- a/ui/v2.5/src/utils/form.tsx
+++ b/ui/v2.5/src/utils/form.tsx
@@ -16,6 +16,7 @@ import { DurationInput } from "src/components/Shared/DurationInput";
 import { Icon } from "src/components/Shared/Icon";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import { LinkType, StashIDPill } from "src/components/Shared/StashID";
+import { PerformerAliasListInput } from "src/components/Shared/PerformerAliasListInput";
 import { StringListInput } from "src/components/Shared/StringListInput";
 import { URLListInput } from "src/components/Shared/URLField";
 import * as GQL from "src/core/generated-graphql";
@@ -364,6 +365,29 @@ export function formikUtils<V extends FormikValues>(
     return renderField(field, title, control, props);
   }
 
+  function renderPerformerAliasListField(
+    field: Field,
+    messageID: string = field,
+    props?: IProps
+  ) {
+    const value = formik.values[field] as GQL.PerformerAliasInput[];
+    const error = formik.errors[field] as ErrorMessage[] | ErrorMessage;
+
+    const [errorMsg, errorIdx] = flattenError(error);
+
+    const title = intl.formatMessage({ id: messageID });
+    const control = (
+      <PerformerAliasListInput
+        value={value}
+        setValue={(v) => formik.setFieldValue(field, v)}
+        errors={errorMsg}
+        errorIdx={errorIdx}
+      />
+    );
+
+    return renderField(field, title, control, props);
+  }
+
   function renderStashIDsField(
     field: Field,
     linkType: LinkType,
@@ -421,6 +445,7 @@ export function formikUtils<V extends FormikValues>(
     renderRatingField,
     renderStringListField,
     renderURLListField,
+    renderPerformerAliasListField,
     renderStashIDsField,
   };
 }

--- a/ui/v2.5/src/utils/form.tsx
+++ b/ui/v2.5/src/utils/form.tsx
@@ -1,5 +1,5 @@
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import { FormikValues, useFormik } from "formik";
+import { FormikProps, FormikValues } from "formik";
 import React, { InputHTMLAttributes, useEffect, useRef } from "react";
 import {
   Button,
@@ -82,7 +82,7 @@ export const NumberField: React.FC<
   return <Form.Control {...props} type="number" ref={inputRef} />;
 };
 
-type Formik<V extends FormikValues> = ReturnType<typeof useFormik<V>>;
+type Formik<V extends FormikValues> = FormikProps<V>;
 
 interface IProps {
   labelProps?: FormLabelProps;
@@ -107,14 +107,34 @@ export function formikUtils<V extends FormikValues>(
   type Field = keyof V & string;
   type ErrorMessage = string | undefined;
 
-  function renderFormControl(field: Field, type: string, placeholder: string) {
-    const formikProps = formik.getFieldProps({ name: field, type: type });
-    const error = formik.errors[field] as ErrorMessage;
-
-    let { value } = formikProps;
-    if (value === null) {
-      value = "";
+  const getFlattenedError = (
+    field: Field
+  ): [string | undefined, number[] | undefined] => {
+    const error = formik.errors[field] as ErrorMessage | ErrorMessage[];
+    if (Array.isArray(error)) {
+      const errors: string[] = [];
+      const errorIdx: number[] = [];
+      for (let i = 0; i < error.length; i++) {
+        const err = error[i];
+        if (err) {
+          if (!errors.includes(err)) {
+            errors.push(err);
+          }
+          errorIdx.push(i);
+        }
+      }
+      return [errors.join("\n"), errorIdx];
+    } else {
+      return [error, undefined];
     }
+  };
+
+  function renderFormControl(field: Field, type: string, placeholder: string) {
+    const { value: rawValue, ...formikProps } = formik.getFieldProps<
+      string | null
+    >(field);
+    const { error } = formik.getFieldMeta(field);
+    const value = rawValue ?? "";
 
     let control: React.ReactNode;
     if (type === "checkbox") {
@@ -201,12 +221,10 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const formikProps = formik.getFieldProps(field);
-
-    let { value } = formikProps;
-    if (value === null) {
-      value = "";
-    }
+    const { value: rawValue, ...formikProps } = formik.getFieldProps<
+      string | null
+    >(field);
+    const value = rawValue ?? "";
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -233,8 +251,8 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const value = formik.values[field] as string;
-    const error = formik.errors[field] as ErrorMessage;
+    const { value } = formik.getFieldProps<string>(field);
+    const { error } = formik.getFieldMeta(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -253,8 +271,8 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const value = formik.values[field] as number | null;
-    const error = formik.errors[field] as ErrorMessage;
+    const { value } = formik.getFieldProps<number | null>(field);
+    const { error } = formik.getFieldMeta(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -273,7 +291,7 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const value = formik.values[field] as number | null;
+    const { value } = formik.getFieldProps<number | null>(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -286,29 +304,6 @@ export function formikUtils<V extends FormikValues>(
     return renderField(field, title, control, props);
   }
 
-  // flattens a potential list of errors into a [errorMsg, errorIdx] tuple
-  // error messages are joined with newlines, and duplicate messages are skipped
-  function flattenError(
-    error: ErrorMessage[] | ErrorMessage
-  ): [string | undefined, number[] | undefined] {
-    if (Array.isArray(error)) {
-      let errors: string[] = [];
-      const errorIdx = [];
-      for (let i = 0; i < error.length; i++) {
-        const err = error[i];
-        if (err) {
-          if (!errors.includes(err)) {
-            errors.push(err);
-          }
-          errorIdx.push(i);
-        }
-      }
-      return [errors.join("\n"), errorIdx];
-    } else {
-      return [error, undefined];
-    }
-  }
-
   interface IStringListProps extends IProps {
     // defaults to true if not provided
     orderable?: boolean;
@@ -319,10 +314,8 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IStringListProps
   ) {
-    const value = formik.values[field] as string[];
-    const error = formik.errors[field] as ErrorMessage[] | ErrorMessage;
-
-    const [errorMsg, errorIdx] = flattenError(error);
+    const { value } = formik.getFieldProps<string[]>(field);
+    const [errorMsg, errorIdx] = getFlattenedError(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -345,10 +338,8 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const value = formik.values[field] as string[];
-    const error = formik.errors[field] as ErrorMessage[] | ErrorMessage;
-
-    const [errorMsg, errorIdx] = flattenError(error);
+    const { value } = formik.getFieldProps<string[]>(field);
+    const [errorMsg, errorIdx] = getFlattenedError(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -370,10 +361,8 @@ export function formikUtils<V extends FormikValues>(
     messageID: string = field,
     props?: IProps
   ) {
-    const value = formik.values[field] as GQL.PerformerAliasInput[];
-    const error = formik.errors[field] as ErrorMessage[] | ErrorMessage;
-
-    const [errorMsg, errorIdx] = flattenError(error);
+    const { value } = formik.getFieldProps<GQL.PerformerAliasInput[]>(field);
+    const [errorMsg, errorIdx] = getFlattenedError(field);
 
     const title = intl.formatMessage({ id: messageID });
     const control = (
@@ -395,7 +384,7 @@ export function formikUtils<V extends FormikValues>(
     props?: IProps,
     addButton?: React.ReactNode
   ) {
-    const values = formik.values[field] as GQL.StashIdInput[];
+    const { value: values } = formik.getFieldProps<GQL.StashIdInput[]>(field);
 
     const title = intl.formatMessage({ id: messageID });
 

--- a/ui/v2.5/src/utils/form.tsx
+++ b/ui/v2.5/src/utils/form.tsx
@@ -138,11 +138,13 @@ export function formikUtils<V extends FormikValues>(
 
     let control: React.ReactNode;
     if (type === "checkbox") {
+      const checked = !!rawValue;
       control = (
         <Form.Check
           placeholder={placeholder}
           {...formikProps}
           value={value}
+          checked={checked}
           isInvalid={!!error}
         />
       );


### PR DESCRIPTION
Add DB support and graphQL API support to track alias matching for a performer being on or off on a per-alias basis. By default, new aliases (especially from scrapers) are set to be ignored for auto-tagging. The UI toggle has been updated to reflect an 'Auto tag' boolean toggle that allows users to opt-in specific aliases.

Attached is a screenshot of the new alias list UI with autotag toggles:

<img width="1280" height="1717" alt="New performer edit page with alias toggles" src="https://github.com/user-attachments/assets/9883df0e-5c69-4fa9-a3f1-0d4ba2e258d2" />
