### PR TITLE
Fix portrait videos generating oversized sprites with slow seek

### DIFF
--- a/internal/manager/generator_sprite.go
+++ b/internal/manager/generator_sprite.go
@@ -227,7 +227,7 @@ func (g *SpriteGenerator) generateSpriteImage() error {
 				return errors.New("invalid frame number conversion")
 			}
 
-			img, err := g.g.SpriteScreenshotSlow(context.TODO(), g.Info.VideoFile.Path, int(frame), g.Config.SpriteSize)
+			img, err := g.g.SpriteScreenshotSlow(context.TODO(), g.Info.VideoFile.Path, int(frame), g.Config.SpriteSize, isPortrait)
 			if err != nil {
 				return err
 			}

--- a/pkg/scene/generate/sprite.go
+++ b/pkg/scene/generate/sprite.go
@@ -38,14 +38,19 @@ func (g Generator) SpriteScreenshot(ctx context.Context, input string, seconds f
 	return g.generateImage(lockCtx, args)
 }
 
-func (g Generator) SpriteScreenshotSlow(ctx context.Context, input string, frame int, width int) (image.Image, error) {
+func (g Generator) SpriteScreenshotSlow(ctx context.Context, input string, frame int, size int, isPortrait bool) (image.Image, error) {
 	lockCtx := g.LockManager.ReadLock(ctx, input)
 	defer lockCtx.Cancel()
 
 	ssOptions := transcoder.ScreenshotOptions{
 		OutputPath: "-",
 		OutputType: transcoder.ScreenshotOutputTypeBMP,
-		Width:      width,
+	}
+
+	if isPortrait {
+		ssOptions.Height = size
+	} else {
+		ssOptions.Width = size
 	}
 
 	args := transcoder.ScreenshotFrame(input, frame, ssOptions)


### PR DESCRIPTION
## Summary

- `SpriteScreenshotSlow` always set `Width: size` regardless of video orientation, so portrait videos (9:16 etc.) generated sprite thumbnails at e.g. 1440×2556 instead of the expected ~640×1138
- `SpriteScreenshot` already handled this correctly via an `isPortrait` flag — `SpriteScreenshotSlow` just wasn't wired up the same way
- Added `isPortrait bool` parameter to `SpriteScreenshotSlow` and pass `Height: size` when portrait, matching the existing fast-seek path

## Test plan

- [ ] Generate sprites for a portrait (9:16) video using slow seek (short video / low frame count)
- [ ] Confirm sprite dimensions are portrait-sized (height = configured size, width proportional) rather than landscape-capped

Fixes #4830

🤖 Generated with [Claude Code](https://claude.com/claude-code)