### PR TITLE
Keep tag/entity select input focused after creating a new item

### DIFF
--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -58,7 +58,6 @@ const SelectComponent = <T, IsMulti extends boolean>(
 ) => {
   const {
     selectedOptions,
-    isLoading,
     isDisabled = false,
     creatable = false,
     components,

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -103,7 +103,7 @@ const SelectComponent = <T, IsMulti extends boolean>(
   return creatable ? (
     <AsyncCreatableSelect
       {...componentProps}
-      isDisabled={isLoading || isDisabled}
+      isDisabled={isDisabled}
     />
   ) : (
     <AsyncSelect {...componentProps} />

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -100,10 +100,7 @@ const SelectComponent = <T, IsMulti extends boolean>(
   };
 
   return creatable ? (
-    <AsyncCreatableSelect
-      {...componentProps}
-      isDisabled={isDisabled}
-    />
+    <AsyncCreatableSelect {...componentProps} isDisabled={isDisabled} />
   ) : (
     <AsyncSelect {...componentProps} />
   );


### PR DESCRIPTION
## Summary

- When creating a new tag (or any entity) via the dropdown, the select input loses focus after creation, forcing the user to click back into the field to keep typing
- Root cause: `FilterSelectComponent` calls `setLoading(true)` during the async creation, which propagated into `isDisabled={isLoading || isDisabled}` on `AsyncCreatableSelect` — disabling the input triggers a blur event
- Fix: remove `isLoading` from the `isDisabled` condition so the input stays interactive during creation; the loading spinner still displays via the `isLoading` prop

## Test plan

- [ ] On a scene edit panel, type a new tag name in the Tags field and press Enter to create it
- [ ] Confirm focus stays in the Tags input after creation so you can immediately start typing the next tag

Fixes #3998

🤖 Generated with [Claude Code](https://claude.com/claude-code)