### PR TITLE
Make gallery/scene association during scan more consistent

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -660,8 +660,9 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 		&file.FilteredHandler{
 			Filter: file.FilterFunc(imageFileFilter),
 			Handler: &image.ScanHandler{
-				CreatorUpdater: r.Image,
-				GalleryFinder:  r.Gallery,
+				CreatorUpdater:     r.Image,
+				GalleryFinder:      r.Gallery,
+				SceneFinderUpdater: r.Scene,
 				ScanGenerator: &imageGenerators{
 					input:              options,
 					taskQueue:          taskQueue,
@@ -690,9 +691,10 @@ func getScanHandlers(options ScanMetadataInput, taskQueue *job.TaskQueue, progre
 		&file.FilteredHandler{
 			Filter: file.FilterFunc(videoFileFilter),
 			Handler: &scene.ScanHandler{
-				CreatorUpdater: r.Scene,
-				CaptionUpdater: r.File,
-				PluginCache:    pluginCache,
+				CreatorUpdater:       r.Scene,
+				GalleryFinderUpdater: r.Gallery,
+				CaptionUpdater:       r.File,
+				PluginCache:          pluginCache,
 				ScanGenerator: &sceneGenerators{
 					input:               options,
 					taskQueue:           taskQueue,

--- a/pkg/gallery/scan.go
+++ b/pkg/gallery/scan.go
@@ -24,7 +24,6 @@ type ScanCreatorUpdater interface {
 
 type ScanSceneFinderUpdater interface {
 	FindByPath(ctx context.Context, p string) ([]*models.Scene, error)
-	Update(ctx context.Context, updatedScene *models.Scene) error
 	AddGalleryIDs(ctx context.Context, sceneID int, galleryIDs []int) error
 }
 

--- a/pkg/image/scan.go
+++ b/pkg/image/scan.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
@@ -39,6 +40,11 @@ type GalleryFinderCreator interface {
 	UpdatePartial(ctx context.Context, id int, updatedGallery models.GalleryPartial) (*models.Gallery, error)
 }
 
+type ScanSceneFinderUpdater interface {
+	FindByPath(ctx context.Context, p string) ([]*models.Scene, error)
+	AddGalleryIDs(ctx context.Context, sceneID int, galleryIDs []int) error
+}
+
 type ScanConfig interface {
 	GetCreateGalleriesFromFolders() bool
 }
@@ -48,8 +54,9 @@ type ScanGenerator interface {
 }
 
 type ScanHandler struct {
-	CreatorUpdater ScanCreatorUpdater
-	GalleryFinder  GalleryFinderCreator
+	CreatorUpdater     ScanCreatorUpdater
+	GalleryFinder      GalleryFinderCreator
+	SceneFinderUpdater ScanSceneFinderUpdater
 
 	ScanGenerator ScanGenerator
 
@@ -322,9 +329,37 @@ func (h *ScanHandler) getOrCreateZipBasedGallery(ctx context.Context, zipFile mo
 		return nil, fmt.Errorf("creating zip-based gallery: %w", err)
 	}
 
+	// try to associate with scene
+	if err := h.associateScene(ctx, &newGallery, zipFile); err != nil {
+		return nil, fmt.Errorf("associating scene: %w", err)
+	}
+
 	h.PluginCache.RegisterPostHooks(ctx, newGallery.ID, hook.GalleryCreatePost, nil, nil)
 
 	return &newGallery, nil
+}
+
+func (h *ScanHandler) associateScene(ctx context.Context, existing *models.Gallery, zipFile models.File) error {
+	galleryIDs := []int{existing.ID}
+
+	path := zipFile.Base().Path
+	withoutExt := strings.TrimSuffix(path, filepath.Ext(path)) + ".*"
+
+	// find scenes with a file that matches
+	scenes, err := h.SceneFinderUpdater.FindByPath(ctx, withoutExt)
+	if err != nil {
+		return err
+	}
+
+	for _, scene := range scenes {
+		// found related Scene
+		logger.Infof("associate: Gallery %s is related to scene: %d", path, scene.ID)
+		if err := h.SceneFinderUpdater.AddGalleryIDs(ctx, scene.ID, galleryIDs); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (h *ScanHandler) getOrCreateGallery(ctx context.Context, f models.File) (*models.Gallery, error) {

--- a/pkg/models/mocks/GalleryReaderWriter.go
+++ b/pkg/models/mocks/GalleryReaderWriter.go
@@ -49,6 +49,20 @@ func (_m *GalleryReaderWriter) AddImages(ctx context.Context, galleryID int, ima
 	return r0
 }
 
+// AddSceneIDs provides a mock function with given fields: ctx, galleryID, sceneIDs
+func (_m *GalleryReaderWriter) AddSceneIDs(ctx context.Context, galleryID int, sceneIDs []int) error {
+	ret := _m.Called(ctx, galleryID, sceneIDs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, []int) error); ok {
+		r0 = rf(ctx, galleryID, sceneIDs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // All provides a mock function with given fields: ctx
 func (_m *GalleryReaderWriter) All(ctx context.Context) ([]*models.Gallery, error) {
 	ret := _m.Called(ctx)

--- a/pkg/models/repository_gallery.go
+++ b/pkg/models/repository_gallery.go
@@ -83,6 +83,7 @@ type GalleryWriter interface {
 
 	CustomFieldsWriter
 
+	AddSceneIDs(ctx context.Context, galleryID int, sceneIDs []int) error
 	AddFileID(ctx context.Context, id int, fileID FileID) error
 	AddImages(ctx context.Context, galleryID int, imageIDs ...int) error
 	RemoveImages(ctx context.Context, galleryID int, imageIDs ...int) error

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/stashapp/stash/pkg/file/video"
 	"github.com/stashapp/stash/pkg/logger"
@@ -32,12 +34,18 @@ type ScanCreatorUpdater interface {
 	AddFileID(ctx context.Context, id int, fileID models.FileID) error
 }
 
+type ScanGalleryFinderUpdater interface {
+	FindByPath(ctx context.Context, p string) ([]*models.Gallery, error)
+	AddSceneIDs(ctx context.Context, galleryID int, sceneIDs []int) error
+}
+
 type ScanGenerator interface {
 	Generate(ctx context.Context, s *models.Scene, f *models.VideoFile) error
 }
 
 type ScanHandler struct {
-	CreatorUpdater ScanCreatorUpdater
+	CreatorUpdater       ScanCreatorUpdater
+	GalleryFinderUpdater ScanGalleryFinderUpdater
 
 	ScanGenerator  ScanGenerator
 	CaptionUpdater video.CaptionUpdater
@@ -127,6 +135,10 @@ func (h *ScanHandler) Handle(ctx context.Context, f models.File, oldFile models.
 		}
 	}
 
+	if err := h.associateGallery(ctx, existing, f); err != nil {
+		return err
+	}
+
 	// do this after the commit so that cover generation doesn't hold up the transaction
 	txn.AddPostCommitHook(ctx, func(ctx context.Context) {
 		for _, s := range existing {
@@ -170,6 +182,32 @@ func (h *ScanHandler) associateExisting(ctx context.Context, existing []*models.
 			}
 
 			h.PluginCache.RegisterPostHooks(ctx, s.ID, hook.SceneUpdatePost, nil, nil)
+		}
+	}
+
+	return nil
+}
+
+func (h *ScanHandler) associateGallery(ctx context.Context, existing []*models.Scene, f models.File) error {
+	sceneIDs := make([]int, len(existing))
+	for i, s := range existing {
+		sceneIDs[i] = s.ID
+	}
+
+	path := f.Base().Path
+	zipPath := strings.TrimSuffix(path, filepath.Ext(path)) + ".zip"
+
+	// find galleries with a file that matches
+	galleries, err := h.GalleryFinderUpdater.FindByPath(ctx, zipPath)
+	if err != nil {
+		return err
+	}
+
+	for _, gallery := range galleries {
+		// found related Scene
+		logger.Infof("associate: Scene %s is related to gallery: %d", path, gallery.ID)
+		if err := h.GalleryFinderUpdater.AddSceneIDs(ctx, gallery.ID, sceneIDs); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -926,3 +926,7 @@ func (qb *GalleryStore) ResetCover(ctx context.Context, galleryID int) error {
 func (qb *GalleryStore) GetSceneIDs(ctx context.Context, id int) ([]int, error) {
 	return galleryRepository.scenes.getIDs(ctx, id)
 }
+
+func (qb *GalleryStore) AddSceneIDs(ctx context.Context, galleryID int, sceneIDs []int) error {
+	return scenesGalleriesTableMgr.addJoins(ctx, galleryID, sceneIDs)
+}

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -928,5 +928,5 @@ func (qb *GalleryStore) GetSceneIDs(ctx context.Context, id int) ([]int, error) 
 }
 
 func (qb *GalleryStore) AddSceneIDs(ctx context.Context, galleryID int, sceneIDs []int) error {
-	return scenesGalleriesTableMgr.addJoins(ctx, galleryID, sceneIDs)
+	return galleriesScenesTableMgr.insertJoins(ctx, galleryID, sceneIDs)
 }


### PR DESCRIPTION
Resolves #3344

Now performs the gallery/scene association check during image scan when creating a gallery from zip, and during scene scan.