### PR TITLE
Feature: Add StashID guid consideration into performer search box

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -23,6 +23,7 @@ import {
   IFilterProps,
   IFilterValueProps,
   Option as SelectOption,
+  toOption,
 } from "../Shared/FilterSelect";
 import { useCompare } from "src/hooks/state";
 import { Link } from "react-router-dom";
@@ -32,7 +33,8 @@ import { TruncatedText } from "../Shared/TruncatedText";
 import TextUtils from "src/utils/text";
 import { PerformerPopover } from "./PerformerPopover";
 import { Placement } from "react-bootstrap/esm/Overlay";
-import { ModifierCriterion } from "src/models/list-filter/criteria/criterion";
+import { isUUID } from "src/utils/stashIds";
+import { filterByStashID } from "src/models/list-filter/utils";
 
 export type SelectObject = {
   id: string;
@@ -91,52 +93,33 @@ const _PerformerSelect: React.FC<
     !configuration?.interface.disableDropdownCreate.performer;
 
   async function loadPerformers(input: string): Promise<Option[]> {
-    // If the input looks like a GUID, search for stash_id first and return match immediately
-    if (
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        input.trim()
-      )
-    ) {
-      const stashFilter = new ListFilterModel(GQL.FilterMode.Performers);
-      stashFilter.searchTerm = "";
-      stashFilter.currentPage = 1;
-      stashFilter.itemsPerPage = maxOptionsShown;
-      stashFilter.sortBy = "name";
-      stashFilter.sortDirection = GQL.SortDirectionEnum.Asc;
-
-      const stashCriterion = stashFilter.makeCriterion(
-        "stash_id_endpoint"
-      ) as ModifierCriterion<{ endpoint: string; stashID: string }>;
-      stashCriterion.modifier = GQL.CriterionModifier.Equals;
-      stashCriterion.value = { endpoint: "", stashID: input.trim() };
-      stashFilter.criteria = [stashCriterion];
-
-      const stashQuery = await queryFindPerformersForSelect(stashFilter);
-      const stashMatches = stashQuery.data.findPerformers.performers.slice();
-      if (stashMatches.length > 0) {
-        // Matches found, return them immediately.
-        return stashMatches.map((performer) => ({
-          value: performer.id,
-          object: performer,
-        }));
-      }
-      // If no stash_id matches found, continue with standard name/alias search.
-    }
-
     const filter = new ListFilterModel(GQL.FilterMode.Performers);
-    filter.searchTerm = input;
     filter.currentPage = 1;
     filter.itemsPerPage = maxOptionsShown;
     filter.sortBy = "name";
     filter.sortDirection = GQL.SortDirectionEnum.Asc;
+
+    // If the input looks like a GUID, search for stash_id first and return match immediately
+    if (isUUID(input)) {
+      filterByStashID(filter, input);
+
+      const query = await queryFindPerformersForSelect(filter);
+      const matches = query.data.findPerformers.performers.slice();
+      if (matches.length > 0) {
+        // Matches found, return them immediately.
+        return matches.map(toOption);
+      }
+      // If no stash_id matches found, continue with standard name/alias search.
+      filter.criteria = []; // Clear stash_id criterion to search by name/alias below.
+    }
+
+    filter.searchTerm = input;
+
     const query = await queryFindPerformersForSelect(filter);
     return performerSelectSort(
       input,
       query.data.findPerformers.performers.slice()
-    ).map((performer) => ({
-      value: performer.id,
-      object: performer,
-    }));
+    ).map(toOption);
   }
 
   const PerformerOption: React.FC<OptionProps<Option, boolean>> = (

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -32,6 +32,7 @@ import { TruncatedText } from "../Shared/TruncatedText";
 import TextUtils from "src/utils/text";
 import { PerformerPopover } from "./PerformerPopover";
 import { Placement } from "react-bootstrap/esm/Overlay";
+import { ModifierCriterion } from "src/models/list-filter/criteria/criterion";
 
 export type SelectObject = {
   id: string;
@@ -103,13 +104,10 @@ const _PerformerSelect: React.FC<
 
       const stashCriterion = stashFilter.makeCriterion(
         "stash_id_endpoint"
-      ) as unknown as {
-        modifier: GQL.CriterionModifier;
-        value: { endpoint: string; stashID: string };
-      };
+      ) as ModifierCriterion<{ endpoint: string; stashID: string }>;
       stashCriterion.modifier = GQL.CriterionModifier.Equals;
       stashCriterion.value = { endpoint: "", stashID: input.trim() };
-      stashFilter.criteria = [stashCriterion as unknown as any];
+      stashFilter.criteria = [stashCriterion];
 
       const stashQuery = await queryFindPerformersForSelect(stashFilter);
       const stashMatches = stashQuery.data.findPerformers.performers.slice();

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -90,10 +90,10 @@ const _PerformerSelect: React.FC<
     !configuration?.interface.disableDropdownCreate.performer;
 
   async function loadPerformers(input: string): Promise<Option[]> {
-    const trimmed = input.trim();
+    
 
     // If the input looks like a GUID, search for stash_id first and return match immediately
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)) {
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(input.trim())) {
       const stashFilter = new ListFilterModel(GQL.FilterMode.Performers);
       stashFilter.searchTerm = "";
       stashFilter.currentPage = 1;
@@ -108,7 +108,7 @@ const _PerformerSelect: React.FC<
         value: { endpoint: string; stashID: string };
       };
       stashCriterion.modifier = GQL.CriterionModifier.Equals;
-      stashCriterion.value = { endpoint: "", stashID: trimmed };
+      stashCriterion.value = { endpoint: "", stashID: input.trim() };
       stashFilter.criteria = [stashCriterion as unknown as any];
 
       const stashQuery = await queryFindPerformersForSelect(stashFilter);

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -90,6 +90,39 @@ const _PerformerSelect: React.FC<
     !configuration?.interface.disableDropdownCreate.performer;
 
   async function loadPerformers(input: string): Promise<Option[]> {
+    const trimmed = input.trim();
+
+    // If the input looks like a GUID, search for stash_id first and return match immediately
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)) {
+      const stashFilter = new ListFilterModel(GQL.FilterMode.Performers);
+      stashFilter.searchTerm = "";
+      stashFilter.currentPage = 1;
+      stashFilter.itemsPerPage = maxOptionsShown;
+      stashFilter.sortBy = "name";
+      stashFilter.sortDirection = GQL.SortDirectionEnum.Asc;
+
+      const stashCriterion = stashFilter.makeCriterion(
+        "stash_id_endpoint"
+      ) as unknown as {
+        modifier: GQL.CriterionModifier;
+        value: { endpoint: string; stashID: string };
+      };
+      stashCriterion.modifier = GQL.CriterionModifier.Equals;
+      stashCriterion.value = { endpoint: "", stashID: trimmed };
+      stashFilter.criteria = [stashCriterion as unknown as any];
+
+      const stashQuery = await queryFindPerformersForSelect(stashFilter);
+      const stashMatches = stashQuery.data.findPerformers.performers.slice();
+      if (stashMatches.length > 0) {
+        // Matches found, return them immediately.
+        return stashMatches.map((performer) => ({
+          value: performer.id,
+          object: performer,
+        }));
+      }
+      // If no stash_id matches found, continue with standard name/alias search.
+    }
+    
     const filter = new ListFilterModel(GQL.FilterMode.Performers);
     filter.searchTerm = input;
     filter.currentPage = 1;

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -91,10 +91,12 @@ const _PerformerSelect: React.FC<
     !configuration?.interface.disableDropdownCreate.performer;
 
   async function loadPerformers(input: string): Promise<Option[]> {
-    
-
     // If the input looks like a GUID, search for stash_id first and return match immediately
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(input.trim())) {
+    if (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        input.trim()
+      )
+    ) {
       const stashFilter = new ListFilterModel(GQL.FilterMode.Performers);
       stashFilter.searchTerm = "";
       stashFilter.currentPage = 1;
@@ -120,7 +122,7 @@ const _PerformerSelect: React.FC<
       }
       // If no stash_id matches found, continue with standard name/alias search.
     }
-    
+
     const filter = new ListFilterModel(GQL.FilterMode.Performers);
     filter.searchTerm = input;
     filter.currentPage = 1;

--- a/ui/v2.5/src/components/Scenes/SceneSelect.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneSelect.tsx
@@ -22,6 +22,7 @@ import {
   IFilterProps,
   IFilterValueProps,
   Option as SelectOption,
+  toOption,
 } from "../Shared/FilterSelect";
 import { useCompare } from "src/hooks/state";
 import { Placement } from "react-bootstrap/esm/Overlay";
@@ -33,6 +34,8 @@ import {
   CriterionValue,
 } from "src/models/list-filter/criteria/criterion";
 import { TruncatedText } from "../Shared/TruncatedText";
+import { isUUID } from "src/utils/stashIds";
+import { filterByStashID } from "src/models/list-filter/utils";
 
 export type Scene = Pick<GQL.Scene, "id" | "title" | "date" | "code"> & {
   studio?: Pick<GQL.Studio, "name"> | null;
@@ -73,29 +76,44 @@ const _SceneSelect: React.FC<
 
   const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
 
+  function filterExcluded(scene: Scene) {
+    // HACK - we should probably exclude these in the backend query, but
+    // this will do in the short-term
+    return !exclude.includes(scene.id.toString());
+  }
+
   async function loadScenes(input: string): Promise<Option[]> {
     const filter = new ListFilterModel(GQL.FilterMode.Scenes);
-    filter.searchTerm = input;
     filter.currentPage = 1;
     filter.itemsPerPage = maxOptionsShown;
     filter.sortBy = "title";
     filter.sortDirection = GQL.SortDirectionEnum.Asc;
 
-    if (props.extraCriteria) {
-      filter.criteria = [...props.extraCriteria];
+    filter.criteria = [...(props.extraCriteria ?? [])];
+
+    if (isUUID(input)) {
+      const oldCriteria = filter.criteria;
+
+      filterByStashID(filter, input);
+
+      const query = await queryFindScenesForSelect(filter);
+      const matches = query.data.findScenes.scenes.filter(filterExcluded);
+
+      if (matches.length > 0) {
+        // Matches found, return them immediately.
+        return matches.map(toOption);
+      }
+
+      // If no stash_id matches found, continue with standard name/alias search.
+      filter.criteria = oldCriteria; // Clear stash_id criterion to search by name/alias below.
     }
 
-    const query = await queryFindScenesForSelect(filter);
-    let ret = query.data.findScenes.scenes.filter((scene) => {
-      // HACK - we should probably exclude these in the backend query, but
-      // this will do in the short-term
-      return !exclude.includes(scene.id.toString());
-    });
+    filter.searchTerm = input;
 
-    return sceneSelectSort(input, ret).map((scene) => ({
-      value: scene.id,
-      object: scene,
-    }));
+    const query = await queryFindScenesForSelect(filter);
+    const ret = query.data.findScenes.scenes.filter(filterExcluded);
+
+    return sceneSelectSort(input, ret).map(toOption);
   }
 
   const SceneOption: React.FC<OptionProps<Option, boolean>> = (optionProps) => {

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -256,3 +256,10 @@ export interface IFilterIDProps<T> {
   ids?: string[];
   onSelect?: (item: T[]) => void;
 }
+
+export function toOption<T extends IHasID>(item: T): Option<T> {
+  return {
+    value: item.id,
+    object: item,
+  };
+}

--- a/ui/v2.5/src/components/Studios/StudioSelect.tsx
+++ b/ui/v2.5/src/components/Studios/StudioSelect.tsx
@@ -23,11 +23,14 @@ import {
   IFilterProps,
   IFilterValueProps,
   Option as SelectOption,
+  toOption,
 } from "../Shared/FilterSelect";
 import { useCompare } from "src/hooks/state";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
 import { PatchComponent, PatchFunction } from "src/patch";
+import { isUUID } from "src/utils/stashIds";
+import { filterByStashID } from "src/models/list-filter/utils";
 
 export type SelectObject = {
   id: string;
@@ -74,24 +77,40 @@ const _StudioSelect: React.FC<
 
   const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
 
+  function filterExcluded(studio: Studio) {
+    // HACK - we should probably exclude these in the backend query, but
+    // this will do in the short-term
+    return !exclude.includes(studio.id.toString());
+  }
+
   async function loadStudios(input: string): Promise<Option[]> {
     const filter = new ListFilterModel(GQL.FilterMode.Studios);
-    filter.searchTerm = input;
     filter.currentPage = 1;
     filter.itemsPerPage = maxOptionsShown;
     filter.sortBy = "name";
     filter.sortDirection = GQL.SortDirectionEnum.Asc;
-    const query = await queryFindStudiosForSelect(filter);
-    let ret = query.data.findStudios.studios.filter((studio) => {
-      // HACK - we should probably exclude these in the backend query, but
-      // this will do in the short-term
-      return !exclude.includes(studio.id.toString());
-    });
 
-    return studioSelectSort(input, ret).map((studio) => ({
-      value: studio.id,
-      object: studio,
-    }));
+    if (isUUID(input)) {
+      filterByStashID(filter, input);
+
+      const query = await queryFindStudiosForSelect(filter);
+      const matches = query.data.findStudios.studios.filter(filterExcluded);
+
+      if (matches.length > 0) {
+        // Matches found, return them immediately.
+        return matches.map(toOption);
+      }
+
+      // If no stash_id matches found, continue with standard name/alias search.
+      filter.criteria = []; // Clear stash_id criterion to search by name/alias below.
+    }
+
+    filter.searchTerm = input;
+
+    const query = await queryFindStudiosForSelect(filter);
+    const ret = query.data.findStudios.studios.filter(filterExcluded);
+
+    return studioSelectSort(input, ret).map(toOption);
   }
 
   const StudioOption: React.FC<OptionProps<Option, boolean>> = (

--- a/ui/v2.5/src/components/Tags/TagSelect.tsx
+++ b/ui/v2.5/src/components/Tags/TagSelect.tsx
@@ -23,12 +23,15 @@ import {
   IFilterProps,
   IFilterValueProps,
   Option as SelectOption,
+  toOption,
 } from "../Shared/FilterSelect";
 import { useCompare } from "src/hooks/state";
 import { TagPopover } from "./TagPopover";
 import { Placement } from "react-bootstrap/esm/Overlay";
 import { sortByRelevance } from "src/utils/query";
 import { PatchComponent, PatchFunction } from "src/patch";
+import { isUUID } from "src/utils/stashIds";
+import { filterByStashID } from "src/models/list-filter/utils";
 
 export type SelectObject = {
   id: string;
@@ -75,24 +78,40 @@ const _TagSelect: React.FC<TagSelectProps> = (props) => {
 
   const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
 
+  function filterExcluded(tag: Tag) {
+    // HACK - we should probably exclude these in the backend query, but
+    // this will do in the short-term
+    return !exclude.includes(tag.id.toString());
+  }
+
   async function loadTags(input: string): Promise<Option[]> {
     const filter = new ListFilterModel(GQL.FilterMode.Tags);
-    filter.searchTerm = input;
     filter.currentPage = 1;
     filter.itemsPerPage = maxOptionsShown;
     filter.sortBy = "name";
     filter.sortDirection = GQL.SortDirectionEnum.Asc;
-    const query = await queryFindTagsForSelect(filter);
-    let ret = query.data.findTags.tags.filter((tag) => {
-      // HACK - we should probably exclude these in the backend query, but
-      // this will do in the short-term
-      return !exclude.includes(tag.id.toString());
-    });
 
-    return tagSelectSort(input, ret).map((tag) => ({
-      value: tag.id,
-      object: tag,
-    }));
+    if (isUUID(input)) {
+      filterByStashID(filter, input);
+
+      const query = await queryFindTagsForSelect(filter);
+      const matches = query.data.findTags.tags.filter(filterExcluded);
+
+      if (matches.length > 0) {
+        // Matches found, return them immediately.
+        return matches.map(toOption);
+      }
+
+      // If no stash_id matches found, continue with standard name/alias search.
+      filter.criteria = []; // Clear stash_id criterion to search by name/alias below.
+    }
+
+    filter.searchTerm = input;
+
+    const query = await queryFindTagsForSelect(filter);
+    const ret = query.data.findTags.tags.filter(filterExcluded);
+
+    return tagSelectSort(input, ret).map(toOption);
   }
 
   const TagOption: React.FC<OptionProps<Option, boolean>> = (optionProps) => {

--- a/ui/v2.5/src/models/list-filter/utils.ts
+++ b/ui/v2.5/src/models/list-filter/utils.ts
@@ -1,0 +1,12 @@
+import { CriterionModifier } from "src/core/generated-graphql";
+import { ModifierCriterion } from "./criteria/criterion";
+import { ListFilterModel } from "./filter";
+
+export function filterByStashID(filter: ListFilterModel, stashID: string) {
+  const stashCriterion = filter.makeCriterion(
+    "stash_id_endpoint"
+  ) as ModifierCriterion<{ endpoint: string; stashID: string }>;
+  stashCriterion.modifier = CriterionModifier.Equals;
+  stashCriterion.value = { endpoint: "", stashID: stashID.trim() };
+  filter.criteria = [stashCriterion];
+}

--- a/ui/v2.5/src/utils/stashIds.ts
+++ b/ui/v2.5/src/utils/stashIds.ts
@@ -13,6 +13,10 @@ export const getStashIDs = (
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+export function isUUID(input: string): boolean {
+  return UUID_PATTERN.test(input.trim());
+}
+
 /**
  * Separates a list of inputs into names and StashIDs based on UUID pattern matching
  * @param inputs - Array of strings that could be either names or StashIDs
@@ -25,7 +29,7 @@ export const separateNamesAndStashIds = (
   const stashIds: string[] = [];
 
   inputs.forEach((input) => {
-    if (UUID_PATTERN.test(input)) {
+    if (isUUID(input)) {
       stashIds.push(input);
     } else {
       names.push(input);


### PR DESCRIPTION
Resolves #5676 

## Summary
Extend the scene (and shared) performer picker so it can search performers not only by name/alias but also by `stash_id` GUID.
## Details
- In `PerformerSelect.tsx`, the `loadPerformers` function now:
  - Detects GUID-like input using a simple 8‑4‑4‑4‑12 hex pattern.
  - When the input matches, performs a `findPerformers` query with a `stash_id_endpoint` criterion (endpoint blank, `stash_id` = input).
  - If any performers are found, returns those immediately.
  - If none are found, falls back to the existing name/alias search behavior.
- Normal name/alias search behavior is unchanged for non‑GUID input.
## Rationale
For users with large performer libraries and many name collisions, face matchers and external tools often provide a performer GUID. This change allows pasting that GUID directly into the performer picker on the scene page and selecting the correct performer without having to search the Performers list first.
## Testing
- `make validate-ui` (lint, typecheck, prettier) passes.
- Verified in the UI:
  - Typing a normal name still performs the existing name/alias search.
  - Pasting an existing performer `stash_id` GUID selects that performer via the picker.
  
Example: 
<img width="408" height="200" alt="image" src="https://github.com/user-attachments/assets/f0cf0b7c-1bef-4a61-a10c-c603009139d5" />

