### PR TITLE
Replace "Source" with "Combined" in merge dialogs

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -700,7 +700,7 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
     : intl.formatMessage({ id: "dialogs.merge.destination" });
   const sourceLabel = !hasValues
     ? ""
-    : intl.formatMessage({ id: "dialogs.merge.source" });
+    : intl.formatMessage({ id: "dialogs.merge.combined" });
 
   return (
     <ScrapeDialog

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -670,7 +670,7 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
     : intl.formatMessage({ id: "dialogs.merge.destination" });
   const sourceLabel = !hasValues
     ? ""
-    : intl.formatMessage({ id: "dialogs.merge.source" });
+    : intl.formatMessage({ id: "dialogs.merge.combined" });
 
   return (
     <ScrapeDialog

--- a/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
@@ -382,7 +382,7 @@ const TagMergeDetails: React.FC<ITagMergeDetailsProps> = ({
     : intl.formatMessage({ id: "dialogs.merge.destination" });
   const sourceLabel = !hasValues
     ? ""
-    : intl.formatMessage({ id: "dialogs.merge.source" });
+    : intl.formatMessage({ id: "dialogs.merge.combined" });
 
   return (
     <ScrapeDialog

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1023,6 +1023,7 @@
       }
     },
     "merge": {
+      "combined": "Combined",
       "destination": "Destination",
       "empty_results": "Destination field values will be unchanged.",
       "source": "Source"


### PR DESCRIPTION
Resolves: #6706

Replaces the `Source` column header text to `Combined` to more accurately convey the meaning of the second column:

<img width="1209" height="760" alt="image" src="https://github.com/user-attachments/assets/873fa4c8-9b4a-49d8-bf50-35d0433abae2" />
