### PR TITLE
Make tagger views consistent

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -208,7 +208,7 @@ const PerformerList: React.FC<{
 }> = PatchComponent(
   "PerformerList",
   ({ performers, filter, selectedIds, onSelectChange, extraCriteria }) => {
-    if (performers.length === 0) {
+    if (performers.length === 0 && filter.displayMode !== DisplayMode.Tagger) {
       return null;
     }
 

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -56,7 +56,7 @@ const StudioList: React.FC<{
 }> = PatchComponent(
   "StudioList",
   ({ studios, filter, selectedIds, onSelectChange, fromParent }) => {
-    if (studios.length === 0) {
+    if (studios.length === 0 && filter.displayMode !== DisplayMode.Tagger) {
       return null;
     }
 

--- a/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
@@ -1,0 +1,51 @@
+import { Form } from "react-bootstrap";
+import { FormattedMessage } from "react-intl";
+import { StashBox } from "src/core/generated-graphql";
+
+interface IStashBoxSelectorProps {
+  stashBoxes: StashBox[];
+  selectedEndpoint: string;
+  onEndpointChange: (endpoint: string) => void;
+}
+
+export const StashBoxSelector: React.FC<IStashBoxSelectorProps> = ({
+  stashBoxes,
+  selectedEndpoint,
+  onEndpointChange,
+}) => {
+  return (
+    <Form.Control
+      as="select"
+      value={selectedEndpoint}
+      className="input-control"
+      disabled={stashBoxes.length < 2}
+      onChange={(e) => onEndpointChange(e.target.value)}
+    >
+      {!stashBoxes.length && (
+        <option>
+          <FormattedMessage id="tagger.config.no_instances_found" />
+        </option>
+      )}
+      {stashBoxes.map((i) => (
+        <option value={i.endpoint} key={i.endpoint}>
+          {i.endpoint}
+        </option>
+      ))}
+    </Form.Control>
+  );
+};
+
+export const StashBoxSelectorField: React.FC<IStashBoxSelectorProps> = (
+  props
+) => {
+  return (
+    <Form.Group controlId="scraper">
+      <Form.Label>
+        <FormattedMessage id="component_tagger.config.source" />
+      </Form.Label>
+      <div>
+        <StashBoxSelector {...props} />
+      </div>
+    </Form.Group>
+  );
+};

--- a/ui/v2.5/src/components/Tagger/TaggerConfig.tsx
+++ b/ui/v2.5/src/components/Tagger/TaggerConfig.tsx
@@ -1,15 +1,12 @@
-import React, { Dispatch, useState } from "react";
+import React, { useState } from "react";
 import { Badge, Button, Card, Collapse, Form } from "react-bootstrap";
-import { FormattedMessage } from "react-intl";
-import { useConfigurationContext } from "src/hooks/Config";
-
-import { ITaggerConfig } from "./constants";
+import { FormattedMessage, useIntl } from "react-intl";
 import FieldSelector from "./FieldSelector";
+import { Icon } from "../Shared/Icon";
+import { faCog } from "@fortawesome/free-solid-svg-icons";
 
 interface ITaggerConfigProps {
   show: boolean;
-  config: ITaggerConfig;
-  setConfig: Dispatch<ITaggerConfig>;
   excludedFields: string[];
   onFieldsChange: (fields: string[]) => void;
   fields: string[];
@@ -19,26 +16,13 @@ interface ITaggerConfigProps {
 
 const TaggerConfig: React.FC<ITaggerConfigProps> = ({
   show,
-  config,
-  setConfig,
   excludedFields,
   onFieldsChange,
   fields,
   entityName,
   extraConfig,
 }) => {
-  const { configuration: stashConfig } = useConfigurationContext();
   const [showExclusionModal, setShowExclusionModal] = useState(false);
-
-  const handleInstanceSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedEndpoint = e.currentTarget.value;
-    setConfig({
-      ...config,
-      selectedEndpoint,
-    });
-  };
-
-  const stashBoxes = stashConfig?.general.stashBoxes ?? [];
 
   const handleFieldSelect = (selectedFields: string[]) => {
     onFieldsChange(selectedFields);
@@ -84,32 +68,6 @@ const TaggerConfig: React.FC<ITaggerConfigProps> = ({
                   <FormattedMessage id="tagger.config.edit_excluded_fields" />
                 </Button>
               </Form.Group>
-              <Form.Group
-                controlId="stash-box-endpoint"
-                className="align-items-center row no-gutters mt-4"
-              >
-                <Form.Label className="mr-4">
-                  <FormattedMessage id="tagger.config.active_stash-box_instance" />
-                </Form.Label>
-                <Form.Control
-                  as="select"
-                  value={config.selectedEndpoint}
-                  className="col-md-4 col-6 input-control"
-                  disabled={!stashBoxes.length}
-                  onChange={handleInstanceSelect}
-                >
-                  {!stashBoxes.length && (
-                    <option>
-                      <FormattedMessage id="tagger.config.no_instances_found" />
-                    </option>
-                  )}
-                  {stashConfig?.general.stashBoxes.map((i) => (
-                    <option value={i.endpoint} key={i.endpoint}>
-                      {i.endpoint}
-                    </option>
-                  ))}
-                </Form.Control>
-              </Form.Group>
             </div>
           </div>
         </Card>
@@ -125,3 +83,23 @@ const TaggerConfig: React.FC<ITaggerConfigProps> = ({
 };
 
 export default TaggerConfig;
+
+export const ConfigButton: React.FC<{
+  onClick: () => void;
+  showConfig: boolean;
+}> = ({ onClick, showConfig }) => {
+  const intl = useIntl();
+
+  const showHideConfigId = showConfig
+    ? "actions.hide_configuration"
+    : "actions.show_configuration";
+
+  return (
+    <Button
+      onClick={onClick}
+      title={intl.formatMessage({ id: showHideConfigId })}
+    >
+      <Icon className="fa-fw" icon={faCog} />
+    </Button>
+  );
+};

--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -15,11 +15,10 @@ import {
   evictQueries,
   performerMutationImpactedQueries,
 } from "src/core/StashService";
-import { Manual } from "src/components/Help/Manual";
 import { useConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
-import TaggerConfig from "../TaggerConfig";
+import TaggerConfig, { ConfigButton } from "../TaggerConfig";
 import { ITaggerConfig, PERFORMER_FIELDS } from "../constants";
 import PerformerModal from "../PerformerModal";
 import { useUpdatePerformer } from "../queries";
@@ -28,6 +27,7 @@ import { mergeStashIDs } from "src/utils/stashbox";
 import { separateNamesAndStashIds } from "src/utils/stashIds";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
 import { useTaggerConfig } from "../config";
+import { StashBoxSelectorField } from "../StashBoxSelector";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -620,11 +620,9 @@ interface ITaggerProps {
 
 export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
   const jobsSubscribe = useJobsSubscribe();
-  const intl = useIntl();
   const { configuration: stashConfig } = useConfigurationContext();
   const { config, setConfig } = useTaggerConfig();
   const [showConfig, setShowConfig] = useState(false);
-  const [showManual, setShowManual] = useState(false);
 
   const [batchJobID, setBatchJobID] = useState<string | undefined | null>();
   const [batchJob, setBatchJob] = useState<JobFragment | undefined>();
@@ -742,76 +740,80 @@ export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
     }
   }
 
-  const showHideConfigId = showConfig
-    ? "actions.hide_configuration"
-    : "actions.show_configuration";
+  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+    return (
+      <div className="my-4">
+        <h3 className="text-center mt-4">
+          <FormattedMessage id="performer_tagger.to_use_the_performer_tagger" />
+        </h3>
+        <h5 className="text-center">
+          <FormattedMessage
+            id="refer_to"
+            values={{
+              link: (
+                <HashLink
+                  to="/settings?tab=metadata-providers#stash-boxes"
+                  scroll={(el) =>
+                    el.scrollIntoView({ behavior: "smooth", block: "center" })
+                  }
+                >
+                  <FormattedMessage id="config.stashbox.title" />
+                </HashLink>
+              ),
+            }}
+          />
+        </h5>
+      </div>
+    );
+  }
 
   return (
     <>
-      <Manual
-        show={showManual}
-        onClose={() => setShowManual(false)}
-        defaultActiveTab="Tagger.md"
-      />
       {renderStatus()}
       <div className="tagger-container mx-md-auto">
-        {selectedEndpointIndex !== -1 && selectedEndpoint ? (
-          <>
-            <div className="row mb-2 no-gutters">
-              <Button onClick={() => setShowConfig(!showConfig)} variant="link">
-                {intl.formatMessage({ id: showHideConfigId })}
-              </Button>
-              <Button
-                className="ml-auto"
-                onClick={() => setShowManual(true)}
-                title={intl.formatMessage({ id: "help" })}
-                variant="link"
-              >
-                <FormattedMessage id="help" />
-              </Button>
-            </div>
-
-            <TaggerConfig
-              config={config}
-              setConfig={setConfig}
-              show={showConfig}
-              excludedFields={config.excludedPerformerFields ?? []}
-              onFieldsChange={(fields) =>
-                setConfig({ ...config, excludedPerformerFields: fields })
-              }
-              fields={PERFORMER_FIELDS}
-              entityName="performers"
-            />
-            <PerformerTaggerList
-              performers={performers}
-              selectedEndpoint={{
-                endpoint: selectedEndpoint.endpoint,
-                index: selectedEndpointIndex,
-              }}
-              isIdle={batchJobID === undefined}
-              config={config}
-              onBatchAdd={batchAdd}
-              onBatchUpdate={batchUpdate}
-            />
-          </>
-        ) : (
-          <div className="my-4">
-            <h3 className="text-center mt-4">
-              <FormattedMessage id="performer_tagger.to_use_the_performer_tagger" />
-            </h3>
-            <h5 className="text-center">
-              Please see{" "}
-              <HashLink
-                to="/settings?tab=metadata-providers#stash-boxes"
-                scroll={(el) =>
-                  el.scrollIntoView({ behavior: "smooth", block: "center" })
+        <div className="tagger-container-header">
+          <div className="d-flex justify-content-between align-items-center flex-wrap">
+            <div className="w-auto">
+              <StashBoxSelectorField
+                stashBoxes={stashConfig?.general.stashBoxes ?? []}
+                selectedEndpoint={selectedEndpoint.endpoint}
+                onEndpointChange={(endpoint) =>
+                  setConfig({ ...config, selectedEndpoint: endpoint })
                 }
-              >
-                Settings.
-              </HashLink>
-            </h5>
+              />
+            </div>
+            <div className="d-flex">
+              <div className="ml-2">
+                <ConfigButton
+                  showConfig={showConfig}
+                  onClick={() => setShowConfig(!showConfig)}
+                />
+              </div>
+            </div>
           </div>
-        )}
+
+          <TaggerConfig
+            show={showConfig}
+            excludedFields={config.excludedPerformerFields ?? []}
+            onFieldsChange={(fields) =>
+              setConfig({ ...config, excludedPerformerFields: fields })
+            }
+            fields={PERFORMER_FIELDS}
+            entityName="performers"
+          />
+        </div>
+
+        <PerformerTaggerList
+          performers={performers}
+          selectedEndpoint={{
+            endpoint: selectedEndpoint.endpoint,
+            index: selectedEndpointIndex,
+          }}
+          isIdle={batchJobID === undefined}
+          config={config}
+          onBatchAdd={batchAdd}
+          onBatchUpdate={batchUpdate}
+        />
       </div>
     </>
   );

--- a/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/SceneTagger.tsx
@@ -4,7 +4,6 @@ import { SceneQueue } from "src/models/sceneQueue";
 import { Button, Form } from "react-bootstrap";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { Icon } from "src/components/Shared/Icon";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { OperationButton } from "src/components/Shared/OperationButton";
 import { ISceneQueryResult, TaggerStateContext } from "../context";
@@ -13,8 +12,8 @@ import { TaggerScene } from "./TaggerScene";
 import { SceneTaggerModals } from "./sceneTaggerModals";
 import { SceneSearchResults } from "./StashSearchResult";
 import { useConfigurationContext } from "src/hooks/Config";
-import { faCog } from "@fortawesome/free-solid-svg-icons";
 import { useLightbox } from "src/hooks/Lightbox/hooks";
+import { ConfigButton } from "../TaggerConfig";
 
 const Scene: React.FC<{
   scene: GQL.SlimSceneDataFragment;
@@ -154,16 +153,6 @@ export const Tagger: React.FC<ITaggerProps> = ({
     );
   }
 
-  function renderConfigButton() {
-    return (
-      <div className="ml-2">
-        <Button onClick={() => setShowConfig(!showConfig)}>
-          <Icon className="fa-fw" icon={faCog} />
-        </Button>
-      </div>
-    );
-  }
-
   const [spriteImage, setSpriteImage] = useState<string | null>(null);
   const lightboxImage = useMemo(
     () => [{ paths: { thumbnail: spriteImage, image: spriteImage } }],
@@ -293,7 +282,12 @@ export const Tagger: React.FC<ITaggerProps> = ({
               {maybeRenderShowHideUnmatchedButton()}
               {maybeRenderSubmitFingerprintsButton()}
               {renderFragmentScrapeButton()}
-              {renderConfigButton()}
+              <div className="ml-2">
+                <ConfigButton
+                  showConfig={showConfig}
+                  onClick={() => setShowConfig(!showConfig)}
+                />
+              </div>
             </div>
           </div>
           <Config show={showConfig} />

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -15,11 +15,10 @@ import {
   useStudioCreate,
   evictQueries,
 } from "src/core/StashService";
-import { Manual } from "src/components/Help/Manual";
 import { useConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
-import TaggerConfig from "../TaggerConfig";
+import TaggerConfig, { ConfigButton } from "../TaggerConfig";
 import { ITaggerConfig, STUDIO_FIELDS } from "../constants";
 import StudioModal from "../scenes/StudioModal";
 import { useUpdateStudio } from "../queries";
@@ -33,6 +32,7 @@ import {
   BatchUpdateModal,
   BatchAddModal,
 } from "src/components/Shared/BatchModals";
+import { StashBoxSelectorField } from "../StashBoxSelector";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -471,11 +471,9 @@ interface ITaggerProps {
 
 export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
   const jobsSubscribe = useJobsSubscribe();
-  const intl = useIntl();
   const { configuration: stashConfig } = useConfigurationContext();
   const { config, setConfig } = useTaggerConfig();
   const [showConfig, setShowConfig] = useState(false);
-  const [showManual, setShowManual] = useState(false);
 
   const [batchJobID, setBatchJobID] = useState<string | undefined | null>();
   const [batchJob, setBatchJob] = useState<JobFragment | undefined>();
@@ -598,98 +596,102 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
     }
   }
 
-  const showHideConfigId = showConfig
-    ? "actions.hide_configuration"
-    : "actions.show_configuration";
+  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+    return (
+      <div className="my-4">
+        <h3 className="text-center mt-4">
+          <FormattedMessage id="studio_tagger.to_use_the_studio_tagger" />
+        </h3>
+        <h5 className="text-center">
+          <FormattedMessage
+            id="refer_to"
+            values={{
+              link: (
+                <HashLink
+                  to="/settings?tab=metadata-providers#stash-boxes"
+                  scroll={(el) =>
+                    el.scrollIntoView({ behavior: "smooth", block: "center" })
+                  }
+                >
+                  <FormattedMessage id="config.stashbox.title" />
+                </HashLink>
+              ),
+            }}
+          />
+        </h5>
+      </div>
+    );
+  }
 
   return (
     <>
-      <Manual
-        show={showManual}
-        onClose={() => setShowManual(false)}
-        defaultActiveTab="Tagger.md"
-      />
       {renderStatus()}
       <div className="tagger-container mx-md-auto">
-        {selectedEndpointIndex !== -1 && selectedEndpoint ? (
-          <>
-            <div className="row mb-2 no-gutters">
-              <Button onClick={() => setShowConfig(!showConfig)} variant="link">
-                {intl.formatMessage({ id: showHideConfigId })}
-              </Button>
-              <Button
-                className="ml-auto"
-                onClick={() => setShowManual(true)}
-                title={intl.formatMessage({ id: "help" })}
-                variant="link"
-              >
-                <FormattedMessage id="help" />
-              </Button>
-            </div>
-
-            <TaggerConfig
-              config={config}
-              setConfig={setConfig}
-              show={showConfig}
-              excludedFields={config.excludedStudioFields ?? []}
-              onFieldsChange={(fields) =>
-                setConfig({ ...config, excludedStudioFields: fields })
-              }
-              fields={STUDIO_FIELDS}
-              entityName="studios"
-              extraConfig={
-                <Form.Group
-                  controlId="create-parent"
-                  className="align-items-center"
-                >
-                  <Form.Check
-                    label={
-                      <FormattedMessage id="studio_tagger.config.create_parent_label" />
-                    }
-                    checked={config.createParentStudios}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setConfig({
-                        ...config,
-                        createParentStudios: e.currentTarget.checked,
-                      })
-                    }
-                  />
-                  <Form.Text>
-                    <FormattedMessage id="studio_tagger.config.create_parent_desc" />
-                  </Form.Text>
-                </Form.Group>
-              }
-            />
-            <StudioTaggerList
-              studios={studios}
-              selectedEndpoint={{
-                endpoint: selectedEndpoint.endpoint,
-                index: selectedEndpointIndex,
-              }}
-              isIdle={batchJobID === undefined}
-              config={config}
-              onBatchAdd={batchAdd}
-              onBatchUpdate={batchUpdate}
-            />
-          </>
-        ) : (
-          <div className="my-4">
-            <h3 className="text-center mt-4">
-              <FormattedMessage id="studio_tagger.to_use_the_studio_tagger" />
-            </h3>
-            <h5 className="text-center">
-              Please see{" "}
-              <HashLink
-                to="/settings?tab=metadata-providers#stash-boxes"
-                scroll={(el) =>
-                  el.scrollIntoView({ behavior: "smooth", block: "center" })
+        <div className="tagger-container-header">
+          <div className="d-flex justify-content-between align-items-center flex-wrap">
+            <div className="w-auto">
+              <StashBoxSelectorField
+                stashBoxes={stashConfig?.general.stashBoxes ?? []}
+                selectedEndpoint={selectedEndpoint.endpoint}
+                onEndpointChange={(endpoint) =>
+                  setConfig({ ...config, selectedEndpoint: endpoint })
                 }
-              >
-                Settings.
-              </HashLink>
-            </h5>
+              />
+            </div>
+            <div className="d-flex">
+              <div className="ml-2">
+                <ConfigButton
+                  showConfig={showConfig}
+                  onClick={() => setShowConfig(!showConfig)}
+                />
+              </div>
+            </div>
           </div>
-        )}
+
+          <TaggerConfig
+            show={showConfig}
+            excludedFields={config.excludedStudioFields ?? []}
+            onFieldsChange={(fields) =>
+              setConfig({ ...config, excludedStudioFields: fields })
+            }
+            fields={STUDIO_FIELDS}
+            entityName="studios"
+            extraConfig={
+              <Form.Group
+                controlId="create-parent"
+                className="align-items-center"
+              >
+                <Form.Check
+                  label={
+                    <FormattedMessage id="studio_tagger.config.create_parent_label" />
+                  }
+                  checked={config.createParentStudios}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setConfig({
+                      ...config,
+                      createParentStudios: e.currentTarget.checked,
+                    })
+                  }
+                />
+                <Form.Text>
+                  <FormattedMessage id="studio_tagger.config.create_parent_desc" />
+                </Form.Text>
+              </Form.Group>
+            }
+          />
+        </div>
+
+        <StudioTaggerList
+          studios={studios}
+          selectedEndpoint={{
+            endpoint: selectedEndpoint.endpoint,
+            index: selectedEndpointIndex,
+          }}
+          isIdle={batchJobID === undefined}
+          config={config}
+          onBatchAdd={batchAdd}
+          onBatchUpdate={batchUpdate}
+        />
       </div>
     </>
   );

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -12,11 +12,10 @@ import {
   mutateStashBoxBatchTagTag,
   getClient,
 } from "src/core/StashService";
-import { Manual } from "src/components/Help/Manual";
 import { useConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
-import TaggerConfig from "../TaggerConfig";
+import TaggerConfig, { ConfigButton } from "../TaggerConfig";
 import { ITaggerConfig, TAG_FIELDS } from "../constants";
 import { useUpdateTag } from "../queries";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
@@ -27,6 +26,7 @@ import {
   BatchUpdateModal,
   BatchAddModal,
 } from "src/components/Shared/BatchModals";
+import { StashBoxSelectorField } from "../StashBoxSelector";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -414,11 +414,9 @@ interface ITaggerProps {
 
 export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
   const jobsSubscribe = useJobsSubscribe();
-  const intl = useIntl();
   const { configuration: stashConfig } = useConfigurationContext();
   const { config, setConfig } = useTaggerConfig();
   const [showConfig, setShowConfig] = useState(false);
-  const [showManual, setShowManual] = useState(false);
 
   const [batchJobID, setBatchJobID] = useState<string | undefined | null>();
   const [batchJob, setBatchJob] = useState<JobFragment | undefined>();
@@ -533,98 +531,102 @@ export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
     }
   }
 
-  const showHideConfigId = showConfig
-    ? "actions.hide_configuration"
-    : "actions.show_configuration";
+  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+    return (
+      <div className="my-4">
+        <h3 className="text-center mt-4">
+          <FormattedMessage id="tag_tagger.to_use_the_tag_tagger" />
+        </h3>
+        <h5 className="text-center">
+          <FormattedMessage
+            id="refer_to"
+            values={{
+              link: (
+                <HashLink
+                  to="/settings?tab=metadata-providers#stash-boxes"
+                  scroll={(el) =>
+                    el.scrollIntoView({ behavior: "smooth", block: "center" })
+                  }
+                >
+                  <FormattedMessage id="config.stashbox.title" />
+                </HashLink>
+              ),
+            }}
+          />
+        </h5>
+      </div>
+    );
+  }
 
   return (
     <>
-      <Manual
-        show={showManual}
-        onClose={() => setShowManual(false)}
-        defaultActiveTab="Tagger.md"
-      />
       {renderStatus()}
       <div className="tagger-container mx-md-auto">
-        {selectedEndpointIndex !== -1 && selectedEndpoint ? (
-          <>
-            <div className="row mb-2 no-gutters">
-              <Button onClick={() => setShowConfig(!showConfig)} variant="link">
-                {intl.formatMessage({ id: showHideConfigId })}
-              </Button>
-              <Button
-                className="ml-auto"
-                onClick={() => setShowManual(true)}
-                title={intl.formatMessage({ id: "help" })}
-                variant="link"
-              >
-                <FormattedMessage id="help" />
-              </Button>
-            </div>
-
-            <TaggerConfig
-              config={config}
-              setConfig={setConfig}
-              show={showConfig}
-              excludedFields={config.excludedTagFields ?? []}
-              onFieldsChange={(fields) =>
-                setConfig({ ...config, excludedTagFields: fields })
-              }
-              fields={TAG_FIELDS}
-              entityName="tags"
-              extraConfig={
-                <Form.Group
-                  controlId="create-parent"
-                  className="align-items-center"
-                >
-                  <Form.Check
-                    label={
-                      <FormattedMessage id="tag_tagger.config.create_parent_label" />
-                    }
-                    checked={config.createParentTags}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setConfig({
-                        ...config,
-                        createParentTags: e.currentTarget.checked,
-                      })
-                    }
-                  />
-                  <Form.Text>
-                    <FormattedMessage id="tag_tagger.config.create_parent_desc" />
-                  </Form.Text>
-                </Form.Group>
-              }
-            />
-            <TagTaggerList
-              tags={tags}
-              selectedEndpoint={{
-                endpoint: selectedEndpoint.endpoint,
-                index: selectedEndpointIndex,
-              }}
-              isIdle={batchJobID === undefined}
-              config={config}
-              onBatchAdd={batchAdd}
-              onBatchUpdate={batchUpdate}
-            />
-          </>
-        ) : (
-          <div className="my-4">
-            <h3 className="text-center mt-4">
-              <FormattedMessage id="tag_tagger.to_use_the_tag_tagger" />
-            </h3>
-            <h5 className="text-center">
-              Please see{" "}
-              <HashLink
-                to="/settings?tab=metadata-providers#stash-boxes"
-                scroll={(el) =>
-                  el.scrollIntoView({ behavior: "smooth", block: "center" })
+        <div className="tagger-container-header">
+          <div className="d-flex justify-content-between align-items-center flex-wrap">
+            <div className="w-auto">
+              <StashBoxSelectorField
+                stashBoxes={stashConfig?.general.stashBoxes ?? []}
+                selectedEndpoint={selectedEndpoint.endpoint}
+                onEndpointChange={(endpoint) =>
+                  setConfig({ ...config, selectedEndpoint: endpoint })
                 }
-              >
-                Settings.
-              </HashLink>
-            </h5>
+              />
+            </div>
+            <div className="d-flex">
+              <div className="ml-2">
+                <ConfigButton
+                  showConfig={showConfig}
+                  onClick={() => setShowConfig(!showConfig)}
+                />
+              </div>
+            </div>
           </div>
-        )}
+
+          <TaggerConfig
+            show={showConfig}
+            excludedFields={config.excludedTagFields ?? []}
+            onFieldsChange={(fields) =>
+              setConfig({ ...config, excludedTagFields: fields })
+            }
+            fields={TAG_FIELDS}
+            entityName="tags"
+            extraConfig={
+              <Form.Group
+                controlId="create-parent"
+                className="align-items-center"
+              >
+                <Form.Check
+                  label={
+                    <FormattedMessage id="tag_tagger.config.create_parent_label" />
+                  }
+                  checked={config.createParentTags}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setConfig({
+                      ...config,
+                      createParentTags: e.currentTarget.checked,
+                    })
+                  }
+                />
+                <Form.Text>
+                  <FormattedMessage id="tag_tagger.config.create_parent_desc" />
+                </Form.Text>
+              </Form.Group>
+            }
+          />
+        </div>
+
+        <TagTaggerList
+          tags={tags}
+          selectedEndpoint={{
+            endpoint: selectedEndpoint.endpoint,
+            index: selectedEndpointIndex,
+          }}
+          isIdle={batchJobID === undefined}
+          config={config}
+          onBatchAdd={batchAdd}
+          onBatchUpdate={batchUpdate}
+        />
       </div>
     </>
   );

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1395,6 +1395,7 @@
   "rating": "Rating",
   "recently_added_objects": "Recently Added {objects}",
   "recently_released_objects": "Recently Released {objects}",
+  "refer_to": "Please see {link}.",
   "release_notes": "Release Notes",
   "resolution": "Resolution",
   "resume_time": "Resume Time",


### PR DESCRIPTION
Updated the performer/studio/tag tagger views to be consistent with the scene tagger view:
- source selector outside configuration at top left
- config toggle button with cog icon at top right
- removed manual link

Tag tagger for example:

<img width="1374" height="764" alt="image" src="https://github.com/user-attachments/assets/b453f165-eb29-4da1-b1cc-7191db5b084e" />

Also added internationalisation for "please see ..." string.