### PR TITLE
[CI] ensure artifacts have +x bit set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,11 +209,13 @@ jobs:
         path: artifacts
 
     # Reassemble platform binaries from matrix job artifacts into a single dist/ directory
+    # make sure that artifacts have executable bit set
     # upload-artifact@v4 strips the common path prefix (dist/), so files are at the artifact root
     - name: Collect binaries
       run: |
         mkdir -p dist
         cp artifacts/build-*/* dist/
+        chmod +x dist/*
 
     - name: Zip UI
       run: |


### PR DESCRIPTION
https://github.com/actions/download-artifact?tab=readme-ov-file#maintaining-file-permissions

permissions wiped out from artifacts builds, if not it can be overridden in docker images