### PR TITLE
Show studio name if studio image not set on detail pages

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -62,6 +62,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
   const Toast = useToast();
   const intl = useIntl();
   const { configuration } = useConfigurationContext();
+  const { showStudioText } = configuration?.ui ?? {};
   const showLightbox = useGalleryLightbox(gallery.id, gallery.chapters);
 
   const [collapsed, setCollapsed] = useState(false);
@@ -411,7 +412,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
       <div className={`gallery-tabs ${collapsed ? "collapsed" : ""}`}>
         <div>
           <div className="gallery-header-container">
-            <StudioLogo studio={gallery.studio} />
+            <StudioLogo studio={gallery.studio} showText={showStudioText} />
             <h3
               className={cx("gallery-header", { "no-studio": !gallery.studio })}
             >

--- a/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/Gallery.tsx
@@ -1,11 +1,6 @@
 import { Button, Tab, Nav, Dropdown } from "react-bootstrap";
 import React, { useEffect, useMemo, useState } from "react";
-import {
-  useHistory,
-  Link,
-  RouteComponentProps,
-  Redirect,
-} from "react-router-dom";
+import { useHistory, RouteComponentProps, Redirect } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Helmet } from "react-helmet";
 import * as GQL from "src/core/generated-graphql";
@@ -50,6 +45,7 @@ import { useConfigurationContext } from "src/hooks/Config";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { goBackOrReplace } from "src/utils/history";
 import { FormattedDate } from "src/components/Shared/Date";
+import { StudioLogo } from "src/components/Shared/StudioLogo";
 
 interface IProps {
   gallery: GQL.GalleryDataFragment;
@@ -415,17 +411,7 @@ export const GalleryPage: React.FC<IProps> = ({ gallery, add }) => {
       <div className={`gallery-tabs ${collapsed ? "collapsed" : ""}`}>
         <div>
           <div className="gallery-header-container">
-            {gallery.studio && (
-              <h1 className="text-center gallery-studio-image">
-                <Link to={`/studios/${gallery.studio.id}`}>
-                  <img
-                    src={gallery.studio.image_path ?? ""}
-                    alt={`${gallery.studio.name} logo`}
-                    className="studio-logo"
-                  />
-                </Link>
-              </h1>
-            )}
+            <StudioLogo studio={gallery.studio} />
             <h3
               className={cx("gallery-header", { "no-studio": !gallery.studio })}
             >

--- a/ui/v2.5/src/components/Galleries/styles.scss
+++ b/ui/v2.5/src/components/Galleries/styles.scss
@@ -17,7 +17,7 @@
       order: 1;
     }
 
-    .gallery-studio-image {
+    .studio-logo {
       flex: 0 0 25%;
       order: 2;
     }

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -1,7 +1,7 @@
 import { Tab, Nav, Dropdown } from "react-bootstrap";
 import React, { useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory, Link, RouteComponentProps } from "react-router-dom";
+import { useHistory, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import {
   useFindImage,
@@ -37,6 +37,7 @@ import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { goBackOrReplace } from "src/utils/history";
 import { FormattedDate } from "src/components/Shared/Date";
 import { GenerateDialog } from "src/components/Dialogs/GenerateDialog";
+import { StudioLogo } from "src/components/Shared/StudioLogo";
 
 interface IProps {
   image: GQL.ImageDataFragment;
@@ -51,6 +52,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
   const Toast = useToast();
   const intl = useIntl();
   const { configuration } = useConfigurationContext();
+  const { showStudioText } = configuration?.ui ?? {};
 
   const [incrementO] = useImageIncrementO(image.id);
   const [decrementO] = useImageDecrementO(image.id);
@@ -326,17 +328,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
       <div className="image-tabs order-xl-first order-last">
         <div>
           <div className="image-header-container">
-            {image.studio && (
-              <h1 className="text-center image-studio-image">
-                <Link to={`/studios/${image.studio.id}`}>
-                  <img
-                    src={image.studio.image_path ?? ""}
-                    alt={`${image.studio.name} logo`}
-                    className="studio-logo"
-                  />
-                </Link>
-              </h1>
-            )}
+            <StudioLogo studio={image.studio} showText={showStudioText} />
             <h3 className={cx("image-header", { "no-studio": !image.studio })}>
               <TruncatedText lineCount={2} text={title} />
             </h3>

--- a/ui/v2.5/src/components/Images/styles.scss
+++ b/ui/v2.5/src/components/Images/styles.scss
@@ -9,7 +9,7 @@
       order: 1;
     }
 
-    .image-studio-image {
+    .studio-logo {
       flex: 0 0 25%;
       order: 2;
     }

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -7,7 +7,7 @@ import React, {
   useLayoutEffect,
 } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory, Link, RouteComponentProps } from "react-router-dom";
+import { useHistory, RouteComponentProps } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import * as GQL from "src/core/generated-graphql";
 import {
@@ -56,6 +56,7 @@ import { PatchComponent, PatchContainerComponent } from "src/patch";
 import { SceneMergeModal } from "../SceneMergeDialog";
 import { goBackOrReplace } from "src/utils/history";
 import { FormattedDate } from "src/components/Shared/Date";
+import { StudioLogo } from "src/components/Shared/StudioLogo";
 
 const SubmitStashBoxDraft = lazyComponent(
   () => import("src/components/Dialogs/SubmitDraft")
@@ -674,17 +675,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       >
         <div>
           <div className="scene-header-container">
-            {scene.studio && (
-              <h1 className="text-center scene-studio-image">
-                <Link to={`/studios/${scene.studio.id}`}>
-                  <img
-                    src={scene.studio.image_path ?? ""}
-                    alt={`${scene.studio.name} logo`}
-                    className="studio-logo"
-                  />
-                </Link>
-              </h1>
-            )}
+            <StudioLogo studio={scene.studio} />
             <h3 className={cx("scene-header", { "no-studio": !scene.studio })}>
               <TruncatedText lineCount={2} text={title} />
             </h3>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -191,6 +191,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
   const [updateScene] = useSceneUpdate();
   const [generateScreenshot] = useSceneGenerateScreenshot();
   const { configuration } = useConfigurationContext();
+  const { showStudioText } = configuration?.ui ?? {};
 
   const [showDraftModal, setShowDraftModal] = useState(false);
   const boxes = configuration?.general?.stashBoxes ?? [];
@@ -675,7 +676,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       >
         <div>
           <div className="scene-header-container">
-            <StudioLogo studio={scene.studio} />
+            <StudioLogo studio={scene.studio} showText={showStudioText} />
             <h3 className={cx("scene-header", { "no-studio": !scene.studio })}>
               <TruncatedText lineCount={2} text={title} />
             </h3>

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -74,7 +74,7 @@
       order: 1;
     }
 
-    .scene-studio-image {
+    .studio-logo {
       flex: 0 0 25%;
       order: 2;
     }

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -692,6 +692,13 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             checked={ui.compactExpandedDetails ?? undefined}
             onChange={(v) => saveUI({ compactExpandedDetails: v })}
           />
+          <BooleanSetting
+            id="show_studio_text"
+            headingID="config.ui.detail.show_studio_text.heading"
+            subHeadingID="config.ui.detail.show_studio_text.description"
+            checked={ui.showStudioText ?? false}
+            onChange={(v) => saveUI({ showStudioText: v })}
+          />
         </SettingSection>
 
         <SettingSection headingID="config.ui.editing.heading">

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -372,6 +372,7 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
           <BooleanSetting
             id="show-text-studios"
             headingID="config.ui.scene_list.options.show_studio_as_text"
+            subHeadingID="config.ui.scene_list.options.show_studio_as_text_desc"
             checked={iface.showStudioAsText ?? undefined}
             onChange={(v) => saveInterface({ showStudioAsText: v })}
           />

--- a/ui/v2.5/src/components/Shared/StudioLogo.tsx
+++ b/ui/v2.5/src/components/Shared/StudioLogo.tsx
@@ -5,11 +5,14 @@ import { faVideo } from "@fortawesome/free-solid-svg-icons";
 
 export const StudioLogo: React.FC<{
   studio: Pick<Studio, "id" | "image_path" | "name"> | undefined | null;
-}> = ({ studio }) => {
+  showText?: boolean;
+}> = ({ studio, showText = false }) => {
   if (!studio) return null;
 
   const hasLogo =
-    studio.image_path && !studio.image_path.endsWith("default=true");
+    !showText &&
+    studio.image_path &&
+    !studio.image_path.endsWith("default=true");
 
   return (
     <h1 className="text-center studio-logo">

--- a/ui/v2.5/src/components/Shared/StudioLogo.tsx
+++ b/ui/v2.5/src/components/Shared/StudioLogo.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { Studio } from "src/core/generated-graphql";
+import { Icon } from "./Icon";
+import { faVideo } from "@fortawesome/free-solid-svg-icons";
+
+export const StudioLogo: React.FC<{
+  studio: Pick<Studio, "id" | "image_path" | "name"> | undefined | null;
+}> = ({ studio }) => {
+  if (!studio) return null;
+
+  const hasLogo =
+    studio.image_path && !studio.image_path.endsWith("default=true");
+
+  return (
+    <h1 className="text-center studio-logo">
+      <Link to={`/studios/${studio.id}`}>
+        {hasLogo ? (
+          <img
+            src={studio.image_path ?? ""}
+            alt={`${studio.name} logo`}
+            className="studio-logo"
+          />
+        ) : (
+          <span className="studio-name">
+            <Icon icon={faVideo} />
+            {studio.name}
+          </span>
+        )}
+      </Link>
+    </h1>
+  );
+};

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -1252,3 +1252,15 @@ input[type="range"].double-range-slider-max {
 .text-input + .input-group-append .btn.minimal {
   background-color: $textfield-bg;
 }
+
+.studio-logo a:hover {
+  color: inherit;
+}
+
+.studio-logo .studio-name {
+  color: $text-color;
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+  text-align: center;
+}

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -49,6 +49,8 @@ export interface IUIConfig {
   showLinksOnPerformerCard?: boolean;
   showTagCardOnHover?: boolean;
 
+  showStudioText?: boolean;
+
   previewVolume?: number;
 
   abbreviateCounters?: boolean;

--- a/ui/v2.5/src/docs/en/Manual/Interface.md
+++ b/ui/v2.5/src/docs/en/Manual/Interface.md
@@ -19,9 +19,9 @@ The Scene Wall and Marker pages display scene preview videos (mp4) by default. T
 
 > **⚠️ Note:** scene/marker preview videos must be generated to see them in the applicable wall page if Video preview type is selected. Likewise, if Animated image is selected, then Image Previews must be generated.
 
-## Show Studios as text
+## Show studio overlay as text
 
-By default, a scene's studio will be shown as an image overlay. Checking this option changes this to display studios as a text name instead.
+By default, in the grid card view the studio will be shown as an image overlay of the studio logo. Checking this option changes this to display studios as a text name instead.
 
 ## Scene Player options
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -710,6 +710,10 @@
         "show_all_details": {
           "description": "When enabled, all content details will be shown by default and each detail item will fit under a single column.",
           "heading": "Show all details"
+        },
+        "show_studio_text": {
+          "description": "Always display studio name as text on details views instead of an icon.",
+          "heading": "Show studio as text"
         }
       },
       "editing": {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -819,7 +819,8 @@
       "scene_list": {
         "heading": "Grid View",
         "options": {
-          "show_studio_as_text": "Display studio overlay as text"
+          "show_studio_as_text": "Display studio overlay as text",
+          "show_studio_as_text_desc": "By default, the studio logo is shown on cards in the grid. Enable this option to always show the studio name as text instead."
         }
       },
       "scene_player": {


### PR DESCRIPTION
If no studio image is set, shows the studio icon with the studio name.

<img width="690" height="318" alt="image" src="https://github.com/user-attachments/assets/b241a537-4415-404d-9338-a5d173002883" />

<img width="1431" height="291" alt="image" src="https://github.com/user-attachments/assets/0373ac6a-771d-461d-8735-ca5f8c17f36e" />

Happy to refine this as needed based on feedback. This is a low-risk PR so we could squeeze it into 0.31.

Resolves #5073

Added new interface option to always show studio text instead of logo:

<img width="1207" height="781" alt="image" src="https://github.com/user-attachments/assets/1d8dbb07-8481-4bab-8531-e0ad0d8b76de" />

Also clarified existing show studio as text option:

<img width="1201" height="209" alt="image" src="https://github.com/user-attachments/assets/65f415c0-3abf-4e50-b644-388674396044" />
