### PR TITLE
fix version string not being displayed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - name: Setup Go
       uses: actions/setup-go@v6
 
@@ -152,7 +155,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        fetch-depth: 1
+        fetch-depth: 0
         fetch-tags: true
 
     - name: Download generated artifacts


### PR DESCRIPTION
tl;dr regression from https://github.com/stashapp/stash/pull/6638

fetching shallow history of git was erroring out git tag --describe, it needs to be added both in generated for UI (vite) to properly display it and in compile for graphql to display it