### PR TITLE
[hwaccel] add envvar for /dev/dri device

### DIFF
--- a/pkg/ffmpeg/codec_hardware.go
+++ b/pkg/ffmpeg/codec_hardware.go
@@ -185,6 +185,12 @@ func (f *FFMpeg) hwCanFullHWTranscode(ctx context.Context, codec VideoCodec, vf 
 
 // Prepend input for hardware encoding only
 func (f *FFMpeg) hwDeviceInit(args Args, toCodec VideoCodec, fullhw bool) Args {
+	// check for custom /dev/dri device #6435
+	driDevice := os.Getenv("STASH_HW_DRI_DEVICE")
+	if driDevice == "" {
+		driDevice = "/dev/dri/renderD128"
+	}
+
 	switch toCodec {
 	case VideoCodecN264,
 		VideoCodecN264H:
@@ -201,7 +207,7 @@ func (f *FFMpeg) hwDeviceInit(args Args, toCodec VideoCodec, fullhw bool) Args {
 	case VideoCodecV264,
 		VideoCodecVVP9:
 		args = append(args, "-vaapi_device")
-		args = append(args, "/dev/dri/renderD128")
+		args = append(args, driDevice)
 		if fullhw {
 			args = append(args, "-hwaccel")
 			args = append(args, "vaapi")

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -194,6 +194,8 @@ The following environment variables are also supported:
 | Environment variable | Remarks |
 |----------------------|---------|
 | `STASH_SQLITE_CACHE_SIZE` | Sets the SQLite cache size. See https://www.sqlite.org/pragma.html#pragma_cache_size. Default is `-2000` which is 2MB. |
+| `STASH_HW_TEST_TIMEOUT` | Sets the Hardware Acceleration test timeout in seconds. Default is 10 seconds
+| `STASH_HW_DRI_DEVICE` | Overrides the default `/dev/dri` device used for VAAPI hardware acceleration. Default is `/dev/dri/renderD128`
 
 ### Custom favicon
 


### PR DESCRIPTION
closes #6435 

Tried adding it to config, ended up with weird errors about circular imports. Ended up with a super complicated roundabour way of passing it through...

Or yolo and add an advanced env var, since this is quite low level and you have to **really** know what you're doing to get down here anyways