### PR TITLE
[ui] Fix Tag Modal cutting off

### DIFF
--- a/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
@@ -103,7 +103,7 @@ const TagModal: React.FC<ITagModalProps> = ({
             <FormattedMessage id={id} />:
           </strong>
         </div>
-        <TruncatedText className="col-7" text={text} />
+        <TruncatedText className="col-7" text={text} lineCount={3} />
       </div>
     );
   }
@@ -147,7 +147,7 @@ const TagModal: React.FC<ITagModalProps> = ({
             <FormattedMessage id={id} />:
           </strong>
         </div>
-        <TruncatedText className="col-7" text={text} />
+        <TruncatedText className="col-7" text={text} lineCount={3} />
       </div>
     );
   }


### PR DESCRIPTION
closes #6723

The actual issue is from the margins setting of `.no-gutters` interacting with the webkit display of `TruncatedText`. TruncatedText seems to have priority and cuts off the line, then the margin kicks in and wraps the overflow characters to the next line. This is only used in one other place, the description of studios when scraped, which doesn't exist on stash-box, so this hasn't come up

Instead, opted for parity with TagCardDetails to set lineCount to 3 https://github.com/stashapp/stash/blob/c832e1a8a29250cd2720bac3b3b042b0b62aee49/ui/v2.5/src/components/Tags/TagCard.tsx#L130-L140

UI validation on my machine
<img width="731" height="432" alt="image" src="https://github.com/user-attachments/assets/94bb8a5d-fee8-4148-9aab-309739cfe33e" />
