### PR TITLE
FR: Auto Tag Confirmation Modal

### DIFF
--- a/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/DirectorySelectionDialog.tsx
@@ -20,7 +20,13 @@ interface IDirectorySelectionDialogProps {
 
 export const DirectorySelectionDialog: React.FC<
   IDirectorySelectionDialogProps
-> = ({ animation, allowEmpty = false, initialPaths = [], onClose }) => {
+> = ({
+  animation,
+  allowEmpty = false,
+  initialPaths = [],
+  onClose,
+  children,
+}) => {
   const intl = useIntl();
   const { configuration } = useConfigurationContext();
 
@@ -91,6 +97,8 @@ export const DirectorySelectionDialog: React.FC<
             </Button>
           }
         />
+
+        {children}
       </div>
     </ModalComponent>
   );

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -19,7 +19,10 @@ import { BooleanSetting, Setting, SettingGroup } from "../Inputs";
 import { ManualLink } from "src/components/Help/context";
 import { Icon } from "src/components/Shared/Icon";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { AutoTagConfirmDialog } from "src/components/Shared/AutoTagConfirmDialog";
+import {
+  AutoTagConfirmDialog,
+  AutoTagWarning,
+} from "src/components/Shared/AutoTagConfirmDialog";
 import { useSettings } from "../context";
 
 interface IAutoTagOptions {
@@ -244,7 +247,11 @@ export const LibraryTasks: React.FC = () => {
       return;
     }
 
-    return <DirectorySelectionDialog onClose={onAutoTagDialogClosed} />;
+    return (
+      <DirectorySelectionDialog onClose={onAutoTagDialogClosed}>
+        <AutoTagWarning />
+      </DirectorySelectionDialog>
+    );
   }
 
   function onAutoTagDialogClosed(paths?: string[]) {

--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -19,6 +19,7 @@ import { BooleanSetting, Setting, SettingGroup } from "../Inputs";
 import { ManualLink } from "src/components/Help/context";
 import { Icon } from "src/components/Shared/Icon";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { AutoTagConfirmDialog } from "src/components/Shared/AutoTagConfirmDialog";
 import { useSettings } from "../context";
 
 interface IAutoTagOptions {
@@ -78,6 +79,7 @@ export const LibraryTasks: React.FC = () => {
   const [dialogOpen, setDialogOpenState] = useState({
     scan: false,
     autoTag: false,
+    autoTagAlert: false,
     identify: false,
     generate: false,
   });
@@ -224,6 +226,19 @@ export const LibraryTasks: React.FC = () => {
     }
   }
 
+  function renderAutoTagAlert() {
+    return (
+      <AutoTagConfirmDialog
+        show={dialogOpen.autoTagAlert}
+        onConfirm={() => {
+          setDialogOpen({ autoTagAlert: false });
+          runAutoTag();
+        }}
+        onCancel={() => setDialogOpen({ autoTagAlert: false })}
+      />
+    );
+  }
+
   function renderAutoTagDialog() {
     if (!dialogOpen.autoTag) {
       return;
@@ -341,6 +356,7 @@ export const LibraryTasks: React.FC = () => {
   return (
     <Form.Group>
       {renderScanDialog()}
+      {renderAutoTagAlert()}
       {renderAutoTagDialog()}
       {maybeRenderIdentifyDialog()}
       {renderGenerateDialog()}
@@ -426,9 +442,9 @@ export const LibraryTasks: React.FC = () => {
                 variant="secondary"
                 type="submit"
                 className="mr-2"
-                onClick={() => runAutoTag()}
+                onClick={() => setDialogOpen({ autoTagAlert: true })}
               >
-                <FormattedMessage id="actions.auto_tag" />
+                <FormattedMessage id="actions.auto_tag" />…
               </Button>
               <Button
                 variant="secondary"

--- a/ui/v2.5/src/components/Shared/AutoTagConfirmDialog.tsx
+++ b/ui/v2.5/src/components/Shared/AutoTagConfirmDialog.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useIntl } from "react-intl";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { ModalComponent } from "./Modal";
+
+interface IAutoTagConfirmDialog {
+  show: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const AutoTagConfirmDialog: React.FC<IAutoTagConfirmDialog> = ({
+  show,
+  onConfirm,
+  onCancel,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <ModalComponent
+      show={show}
+      icon={faExclamationTriangle}
+      header={intl.formatMessage({ id: "actions.auto_tag" })}
+      accept={{
+        text: intl.formatMessage({ id: "actions.confirm" }),
+        variant: "danger",
+        onClick: onConfirm,
+      }}
+      cancel={{
+        onClick: onCancel,
+      }}
+    >
+      <p>
+        {intl.formatMessage({
+          id: "config.tasks.auto_tag_based_on_filenames",
+        })}
+      </p>
+      <p>{intl.formatMessage({ id: "config.tasks.auto_tag_confirm" })}</p>
+    </ModalComponent>
+  );
+};

--- a/ui/v2.5/src/components/Shared/AutoTagConfirmDialog.tsx
+++ b/ui/v2.5/src/components/Shared/AutoTagConfirmDialog.tsx
@@ -1,13 +1,29 @@
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { ModalComponent } from "./Modal";
+import { Icon } from "./Icon";
 
 interface IAutoTagConfirmDialog {
   show: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
+
+export const AutoTagWarning = () => (
+  <>
+    <p>
+      <FormattedMessage id="config.tasks.auto_tag_based_on_filenames" />
+    </p>
+    <p>
+      <FormattedMessage id="config.tasks.auto_tag_confirm" />
+    </p>
+    <p className="lead">
+      <Icon icon={faExclamationTriangle} className="text-warning" />
+      <FormattedMessage id="config.tasks.auto_tag_warning" />
+    </p>
+  </>
+);
 
 export const AutoTagConfirmDialog: React.FC<IAutoTagConfirmDialog> = ({
   show,
@@ -30,12 +46,7 @@ export const AutoTagConfirmDialog: React.FC<IAutoTagConfirmDialog> = ({
         onClick: onCancel,
       }}
     >
-      <p>
-        {intl.formatMessage({
-          id: "config.tasks.auto_tag_based_on_filenames",
-        })}
-      </p>
-      <p>{intl.formatMessage({ id: "config.tasks.auto_tag_confirm" })}</p>
+      <AutoTagWarning />
     </ModalComponent>
   );
 };

--- a/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsEditNavbar.tsx
@@ -2,6 +2,7 @@ import { Button, Dropdown, Modal, SplitButton } from "react-bootstrap";
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ImageInput } from "./ImageInput";
+import { AutoTagConfirmDialog } from "./AutoTagConfirmDialog";
 import cx from "classnames";
 
 interface IProps {
@@ -30,6 +31,7 @@ interface IProps {
 export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
   const intl = useIntl();
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+  const [isAutoTagAlertOpen, setIsAutoTagAlertOpen] = useState<boolean>(false);
 
   function renderEditButton() {
     if (props.isNew) return;
@@ -114,14 +116,20 @@ export const DetailsEditNavbar: React.FC<IProps> = (props: IProps) => {
           <Button
             variant="secondary"
             disabled={props.autoTagDisabled}
-            onClick={() => {
+            onClick={() => setIsAutoTagAlertOpen(true)}
+          >
+            <FormattedMessage id="actions.auto_tag" />…
+          </Button>
+          <AutoTagConfirmDialog
+            show={isAutoTagAlertOpen}
+            onConfirm={() => {
+              setIsAutoTagAlertOpen(false);
               if (props.onAutoTag) {
                 props.onAutoTag();
               }
             }}
-          >
-            <FormattedMessage id="actions.auto_tag" />
-          </Button>
+            onCancel={() => setIsAutoTagAlertOpen(false)}
+          />
         </div>
       );
     }

--- a/ui/v2.5/src/components/Shared/styles.scss
+++ b/ui/v2.5/src/components/Shared/styles.scss
@@ -127,10 +127,14 @@
 .folder-list {
   list-style-type: none;
   margin: 0;
-  max-height: 30vw;
+  max-height: 300px;
   overflow-x: auto;
   padding-bottom: 0.5rem;
   padding-top: 1rem;
+
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+  }
 
   &-item {
     white-space: nowrap;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -512,7 +512,8 @@
         "auto_tagging_paths": "Auto tagging the following paths"
       },
       "auto_tag_based_on_filenames": "Auto tag content based on file paths.",
-      "auto_tag_confirm": "This will attempt to match your content against existing metadata. This process cannot be undone and may produce incorrect matches. Are you sure you want to continue?",
+      "auto_tag_confirm": "This will attempt to match your content against existing metadata.",
+      "auto_tag_warning": "This process cannot be undone and may produce incorrect matches.",
       "auto_tagging": "Auto tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -512,6 +512,7 @@
         "auto_tagging_paths": "Auto tagging the following paths"
       },
       "auto_tag_based_on_filenames": "Auto tag content based on file paths.",
+      "auto_tag_confirm": "This will attempt to match your content against existing metadata. This process cannot be undone and may produce incorrect matches. Are you sure you want to continue?",
       "auto_tagging": "Auto tagging",
       "backing_up_database": "Backing up database",
       "backup_and_download": "Performs a backup of the database and downloads the resulting file.",


### PR DESCRIPTION
Currently, if you click on auto tag in the settings or on the various objects it just runs without warning. I don't personally like this as it's a destructive action and could screw up some peoples databases. This PR just simply adds a confirmation modal when you click it. This applies to the settings -> tasks page and the various individual modals where auto tag is accessible.

UI:
<img width="508" height="262" alt="Screenshot 2026-03-22 at 15 11 12" src="https://github.com/user-attachments/assets/d15b9c47-97d9-448c-8d87-402749a31b68" />


Somewhat supersedes: https://github.com/stashapp/stash/pull/4016
The linked PR has some other features involved that this PR doesn't cover but this is the most pressing concern in my opinion.

Partially addresses https://github.com/stashapp/stash/issues/3909