### PR TITLE
Fix tagger modal issues

### DIFF
--- a/ui/v2.5/src/components/Tagger/PerformerModal.tsx
+++ b/ui/v2.5/src/components/Tagger/PerformerModal.tsx
@@ -92,7 +92,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 performer-create-modal-field" key={name}>
+        <div className="col-5 create-modal-field" key={name}>
           {!create && (
             <Button
               onClick={() => toggleField(name)}
@@ -107,11 +107,11 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
           </strong>
         </div>
         {truncate ? (
-          <div className="col-7 performer-create-modal-value">
+          <div className="col-7 create-modal-value">
             <TruncatedText text={text} />
           </div>
         ) : (
-          <span className="col-7 performer-create-modal-value">{text}</span>
+          <span className="col-7 create-modal-value">{text}</span>
         )}
       </div>
     );
@@ -126,7 +126,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 performer-create-modal-field" key={name}>
+        <div className="col-5 create-modal-field" key={name}>
           {!create && (
             <Button
               onClick={() => toggleField(name)}
@@ -140,7 +140,7 @@ const PerformerModal: React.FC<IPerformerModalProps> = ({
             <FormattedMessage id={name} />:
           </strong>
         </div>
-        <div className="col-7 performer-create-modal-value">
+        <div className="col-7 create-modal-value">
           <ul>
             {text.map((t, i) => (
               <li key={i}>

--- a/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
@@ -7,19 +7,16 @@ import * as GQL from "src/core/generated-graphql";
 import { useFindStudio } from "src/core/StashService";
 import { Icon } from "src/components/Shared/Icon";
 import { ModalComponent } from "src/components/Shared/Modal";
-import {
-  faCheck,
-  faExternalLinkAlt,
-  faTimes,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { Button, Form } from "react-bootstrap";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { excludeFields } from "src/utils/data";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
+import { StashIDPill } from "src/components/Shared/StashID";
 
 interface IStudioDetailsProps {
   studio: GQL.ScrapedSceneStudioDataFragment;
-  link?: string;
+  endpoint?: string;
   excluded: Record<string, boolean>;
   toggleField: (field: string) => void;
   isNew?: boolean;
@@ -27,7 +24,7 @@ interface IStudioDetailsProps {
 
 const StudioDetails: React.FC<IStudioDetailsProps> = ({
   studio,
-  link,
+  endpoint,
   excluded,
   toggleField,
   isNew = false,
@@ -123,15 +120,14 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
   }
 
   function maybeRenderStashBoxLink() {
-    if (!link) return;
+    const base = endpoint?.match(/https?:\/\/.*?\//)?.[0];
+    if (!base || !studio.remote_site_id) return;
 
     return (
-      <h6 className="mt-2">
-        <ExternalLink href={link}>
-          <FormattedMessage id="stashbox.source" />
-          <Icon icon={faExternalLinkAlt} className="ml-2" />
-        </ExternalLink>
-      </h6>
+      <StashIDPill
+        linkType="studios"
+        stashID={{ endpoint: endpoint, stash_id: studio.remote_site_id }}
+      />
     );
   }
 
@@ -303,12 +299,6 @@ const StudioModal: React.FC<IStudioModalProps> = ({
     handleStudioCreate(studioData, parentData);
   }
 
-  const base = endpoint?.match(/https?:\/\/.*?\//)?.[0];
-  const link = base ? `${base}studios/${studio.remote_site_id}` : undefined;
-  const parentLink = base
-    ? `${base}studios/${studio.parent?.remote_site_id}`
-    : undefined;
-
   function maybeRenderParentStudio() {
     // There is no parent studio or it already has a Stash ID
     if (!studio.parent || !sendParentStudio) {
@@ -342,7 +332,7 @@ const StudioModal: React.FC<IStudioModalProps> = ({
         studio={studio.parent}
         excluded={parentExcluded}
         toggleField={(field) => toggleParentField(field)}
-        link={parentLink}
+        endpoint={endpoint}
         isNew
       />
     );
@@ -365,7 +355,7 @@ const StudioModal: React.FC<IStudioModalProps> = ({
         studio={studio}
         excluded={excluded}
         toggleField={(field) => toggleField(field)}
-        link={link}
+        endpoint={endpoint}
       />
 
       {maybeRenderParentStudio()}

--- a/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
@@ -65,7 +65,7 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 studio-create-modal-field" key={id}>
+        <div className="col-5 create-modal-field" key={id}>
           {isSelectable && (
             <Button
               onClick={() => toggleField(id)}
@@ -93,7 +93,7 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 studio-create-modal-field" key={name}>
+        <div className="col-5 create-modal-field" key={name}>
           {!isNew && (
             <Button
               onClick={() => toggleField(name)}
@@ -107,7 +107,7 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
             <FormattedMessage id={name} />:
           </strong>
         </div>
-        <div className="col-7 studio-create-modal-value">
+        <div className="col-7 create-modal-value">
           <ul>
             {text.map((t, i) => (
               <li key={i}>

--- a/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StudioModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import cx from "classnames";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
@@ -56,9 +56,11 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
   function maybeRenderField(
     id: string,
     text: string | null | undefined,
-    isSelectable: boolean = true
+    isSelectable: boolean = true,
+    messageId?: string
   ) {
     if (!text) return;
+    if (!messageId) messageId = id;
 
     return (
       <div className="row no-gutters">
@@ -73,7 +75,7 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
             </Button>
           )}
           <strong>
-            <FormattedMessage id={id} />:
+            <FormattedMessage id={messageId} />:
           </strong>
         </div>
         <TruncatedText className="col-7" text={text} />
@@ -141,7 +143,12 @@ const StudioDetails: React.FC<IStudioDetailsProps> = ({
           {maybeRenderField("details", studio.details)}
           {maybeRenderField("aliases", studio.aliases)}
           {maybeRenderField("tags", studio.tags?.map((t) => t.name).join(", "))}
-          {maybeRenderField("parent_studio", studio.parent?.name, false)}
+          {maybeRenderField(
+            "parent_id",
+            studio.parent?.name,
+            true,
+            "parent_studio"
+          )}
           {maybeRenderStashBoxLink()}
         </div>
       </div>
@@ -202,6 +209,10 @@ const StudioModal: React.FC<IStudioModalProps> = ({
   const [createParentStudio, setCreateParentStudio] = useState<boolean>(
     !!studio.parent
   );
+
+  useEffect(() => {
+    setCreateParentStudio(!excluded.parent_id && !!studio.parent);
+  }, [excluded.parent_id, studio.parent]);
 
   let sendParentStudio = true;
   // The parent studio exists, need to check if it has a Stash ID.
@@ -301,22 +312,26 @@ const StudioModal: React.FC<IStudioModalProps> = ({
 
   function maybeRenderParentStudio() {
     // There is no parent studio or it already has a Stash ID
-    if (!studio.parent || !sendParentStudio) {
+    if (!studio.parent || !sendParentStudio || excluded.parent_id) {
       return;
     }
 
+    // force create if there is no current parent studio and parent studio is not excluded
+    const mustCreateParent = !studio.parent.stored_id;
+
     return (
       <div>
-        <div className="mb-4 mt-4">
+        <Form.Group className="mb-4 mt-4">
           <Form.Check
             id="create-parent"
             checked={createParentStudio}
             label={intl.formatMessage({
               id: parentStudioCreateText(),
             })}
+            disabled={mustCreateParent}
             onChange={() => setCreateParentStudio(!createParentStudio)}
           />
-        </div>
+        </Form.Group>
         {maybeRenderParentStudioDetails()}
       </div>
     );

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -385,20 +385,6 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
 
       return (
         <div key={studio.id} className={`${CLASSNAME}-studio`}>
-          {modalStudio && (
-            <StudioModal
-              closeModal={() => setModalStudio(undefined)}
-              modalVisible={modalStudio.stored_id === studio.id}
-              studio={modalStudio}
-              handleStudioCreate={handleStudioUpdate}
-              excludedStudioFields={config.excludedStudioFields}
-              icon={faTags}
-              header={intl.formatMessage({
-                id: "studio_tagger.update_studio",
-              })}
-              endpoint={selectedEndpoint.endpoint}
-            />
-          )}
           <div className={`${CLASSNAME}-details`}>
             <div></div>
             <div>
@@ -450,6 +436,20 @@ const StudioTaggerList: React.FC<IStudioTaggerListProps> = ({
           setBatchAddParents={setBatchAddParents}
           localePrefix="studio_tagger"
           entityName="studio"
+        />
+      )}
+      {modalStudio && (
+        <StudioModal
+          closeModal={() => setModalStudio(undefined)}
+          modalVisible={!!modalStudio.stored_id}
+          studio={modalStudio}
+          handleStudioCreate={handleStudioUpdate}
+          excludedStudioFields={config.excludedStudioFields}
+          icon={faTags}
+          header={intl.formatMessage({
+            id: "studio_tagger.update_studio",
+          })}
+          endpoint={selectedEndpoint.endpoint}
         />
       )}
       <div className="ml-auto mb-3">

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -658,7 +658,7 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
             entityName="studios"
             extraConfig={
               <Form.Group
-                controlId="create-parent"
+                controlId="config-create-parent"
                 className="align-items-center"
               >
                 <Form.Check

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -295,7 +295,8 @@
     }
   }
 
-  &-studio {
+  &-studio,
+  &-tag {
     background-color: #495b68;
     border-radius: 3px;
     display: flex;
@@ -303,7 +304,8 @@
     max-width: 100%;
     padding: 1rem;
 
-    .studio-card {
+    .studio-card,
+    .tag-card {
       box-shadow: none;
       flex-shrink: 0;
       margin: 0;

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -274,6 +274,10 @@
   .LoadingIndicator {
     height: 100%;
   }
+
+  .form-check {
+    font-size: 1rem;
+  }
 }
 
 .StudioTagger,

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -131,6 +131,24 @@
   font-weight: 500;
 }
 
+.create-modal-field {
+  margin-bottom: 5px;
+
+  .btn {
+    margin-right: 5px;
+  }
+
+  .fa-icon {
+    width: 12px;
+  }
+}
+
+.create-modal-value ul {
+  font-size: 0.8em;
+  list-style-type: none;
+  padding-inline-start: 0;
+}
+
 .performer-create-modal {
   font-size: 1.2rem;
   max-width: 800px;
@@ -158,24 +176,6 @@
 
   .LoadingIndicator {
     height: 100%;
-  }
-
-  &-field {
-    margin-bottom: 5px;
-
-    .btn {
-      margin-right: 5px;
-    }
-
-    .fa-icon {
-      width: 12px;
-    }
-  }
-
-  &-value ul {
-    font-size: 0.8em;
-    list-style-type: none;
-    padding-inline-start: 0;
   }
 }
 
@@ -246,7 +246,8 @@
   }
 }
 
-.studio-create-modal {
+.studio-create-modal,
+.tag-create-modal {
   font-size: 1.2rem;
   max-width: 800px;
 
@@ -272,18 +273,6 @@
 
   .LoadingIndicator {
     height: 100%;
-  }
-
-  &-field {
-    margin-bottom: 5px;
-
-    .btn {
-      margin-right: 5px;
-    }
-
-    .fa-icon {
-      width: 12px;
-    }
   }
 }
 

--- a/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
@@ -89,7 +89,7 @@ const TagModal: React.FC<ITagModalProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 studio-create-modal-field" key={id}>
+        <div className="col-5 create-modal-field" key={id}>
           {isSelectable && (
             <Button
               onClick={() => toggleField(id)}
@@ -133,7 +133,7 @@ const TagModal: React.FC<ITagModalProps> = ({
 
     return (
       <div className="row no-gutters">
-        <div className="col-5 studio-create-modal-field" key={id}>
+        <div className="col-5 create-modal-field" key={id}>
           {isSelectable && (
             <Button
               onClick={() => toggleParentField(id)}
@@ -249,7 +249,7 @@ const TagModal: React.FC<ITagModalProps> = ({
       }}
       cancel={{ onClick: () => closeModal(), variant: "secondary" }}
       onHide={() => closeModal()}
-      dialogClassName="studio-create-modal"
+      dialogClassName="tag-create-modal"
       icon={icon}
       header={header}
     >

--- a/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
@@ -47,6 +47,10 @@ const TagModal: React.FC<ITagModalProps> = ({
     !!tag.parent && !tag.parent.stored_id
   );
 
+  useEffect(() => {
+    setCreateParentTag(!excluded.parent_ids && !!tag.parent);
+  }, [excluded.parent_ids, tag.parent]);
+
   // Check if a tag with the parent name already exists locally.
   // Categories don't have stash IDs, so stored_id may be null even when the
   // parent tag has already been created (e.g. by tagging a sibling tag first).
@@ -70,6 +74,7 @@ const TagModal: React.FC<ITagModalProps> = ({
   const [parentExcluded, setParentExcluded] = useState<Record<string, boolean>>(
     excludedTagFields.reduce((dict, field) => ({ ...dict, [field]: true }), {})
   );
+
   const toggleParentField = (name: string) =>
     setParentExcluded({
       ...parentExcluded,
@@ -79,9 +84,11 @@ const TagModal: React.FC<ITagModalProps> = ({
   function maybeRenderField(
     id: string,
     text: string | null | undefined,
-    isSelectable: boolean = true
+    isSelectable: boolean = true,
+    messageId?: string
   ) {
     if (!text) return;
+    if (!messageId) messageId = id;
 
     return (
       <div className="row no-gutters">
@@ -96,7 +103,7 @@ const TagModal: React.FC<ITagModalProps> = ({
             </Button>
           )}
           <strong>
-            <FormattedMessage id={id} />:
+            <FormattedMessage id={messageId} />:
           </strong>
         </div>
         <TruncatedText className="col-7" text={text} lineCount={3} />
@@ -159,9 +166,17 @@ const TagModal: React.FC<ITagModalProps> = ({
 
   function maybeRenderParentTag() {
     // No parent tag, or parent already exists locally
-    if (!tag.parent || tag.parent.stored_id || !sendParentTag) {
+    if (
+      !tag.parent ||
+      tag.parent.stored_id ||
+      !sendParentTag ||
+      excluded.parent_ids
+    ) {
       return;
     }
+
+    // force create if there is no current parent tag and parent tag is not excluded
+    const mustCreateParent = true;
 
     return (
       <div>
@@ -172,6 +187,7 @@ const TagModal: React.FC<ITagModalProps> = ({
             label={intl.formatMessage({
               id: "actions.create_parent_tag",
             })}
+            disabled={mustCreateParent}
             onChange={() => setCreateParentTag(!createParentTag)}
           />
         </div>
@@ -251,7 +267,12 @@ const TagModal: React.FC<ITagModalProps> = ({
             {maybeRenderField("name", tag.name)}
             {maybeRenderField("description", tag.description)}
             {maybeRenderField("aliases", tag.alias_list?.join(", "))}
-            {maybeRenderField("parent_tags", tag.parent?.name, false)}
+            {maybeRenderField(
+              "parent_ids",
+              tag.parent?.name,
+              true,
+              "parent_tags"
+            )}
             {maybeRenderStashBoxLink()}
           </div>
         </div>

--- a/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
@@ -5,15 +5,11 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import * as GQL from "src/core/generated-graphql";
 import { Icon } from "src/components/Shared/Icon";
 import { ModalComponent } from "src/components/Shared/Modal";
-import {
-  faCheck,
-  faExternalLinkAlt,
-  faTimes,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { Button, Form } from "react-bootstrap";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { excludeFields } from "src/utils/data";
-import { ExternalLink } from "src/components/Shared/ExternalLink";
+import { StashIDPill } from "src/components/Shared/StashID";
 
 interface ITagModalProps {
   tag: GQL.ScrapedSceneTagDataFragment;
@@ -110,17 +106,13 @@ const TagModal: React.FC<ITagModalProps> = ({
 
   function maybeRenderStashBoxLink() {
     const base = endpoint?.match(/https?:\/\/.*?\//)?.[0];
-    const link = base ? `${base}tags/${tag.remote_site_id}` : undefined;
-
-    if (!link) return;
+    if (!base || !tag.remote_site_id) return;
 
     return (
-      <h6 className="mt-2">
-        <ExternalLink href={link}>
-          <FormattedMessage id="stashbox.source" />
-          <Icon icon={faExternalLinkAlt} className="ml-2" />
-        </ExternalLink>
-      </h6>
+      <StashIDPill
+        linkType="tags"
+        stashID={{ endpoint: endpoint, stash_id: tag.remote_site_id }}
+      />
     );
   }
 

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -593,7 +593,7 @@ export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
             entityName="tags"
             extraConfig={
               <Form.Group
-                controlId="create-parent"
+                controlId="config-create-parent"
                 className="align-items-center"
               >
                 <Form.Check

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -11,6 +11,7 @@ import {
   useJobsSubscribe,
   mutateStashBoxBatchTagTag,
   getClient,
+  useTagCreate,
 } from "src/core/StashService";
 import { useConfigurationContext } from "src/hooks/Config";
 
@@ -27,6 +28,10 @@ import {
   BatchAddModal,
 } from "src/components/Shared/BatchModals";
 import { StashBoxSelectorField } from "../StashBoxSelector";
+import { apolloError } from "src/utils";
+import TagModal from "./TagModal";
+import { faTags } from "@fortawesome/free-solid-svg-icons";
+import { uniq } from "lodash-es";
 
 type JobFragment = Pick<
   GQL.Job,
@@ -59,6 +64,7 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
   const intl = useIntl();
 
   const [loading, setLoading] = useState(false);
+
   const [searchResults, setSearchResults] = useState<
     Record<string, GQL.ScrapedSceneTagDataFragment[]>
   >({});
@@ -94,6 +100,13 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
     },
   });
 
+  const [modalTag, setModalTag] = useState<
+    | {
+        existingTag: GQL.TagListDataFragment;
+        scrapedTag: GQL.ScrapedSceneTagDataFragment;
+      }
+    | undefined
+  >();
   const [error, setError] = useState<
     Record<string, { message?: string; details?: string } | undefined>
   >({});
@@ -128,64 +141,30 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
     setLoading(true);
   };
 
+  const [createTag] = useTagCreate();
   const updateTag = useUpdateTag();
 
-  const doBoxUpdate = (tagID: string, stashID: string, endpoint: string) => {
+  const doBoxUpdate = (
+    tag: GQL.TagListDataFragment,
+    stashID: string,
+    endpoint: string
+  ) => {
     setLoadingUpdate(stashID);
     setError({
       ...error,
-      [tagID]: undefined,
+      [tag.id]: undefined,
     });
     stashBoxTagQuery(stashID, endpoint)
       .then(async (queryData) => {
         const data = queryData.data?.scrapeSingleTag ?? [];
         if (data.length > 0) {
-          const stashboxTag = data[0];
-          const updateData: GQL.TagUpdateInput = {
-            id: tagID,
-          };
-
-          if (
-            !(config.excludedTagFields ?? []).includes("name") &&
-            stashboxTag.name
-          ) {
-            updateData.name = stashboxTag.name;
-          }
-
-          if (
-            stashboxTag.description &&
-            !(config.excludedTagFields ?? []).includes("description")
-          ) {
-            updateData.description = stashboxTag.description;
-          }
-
-          if (
-            stashboxTag.alias_list &&
-            stashboxTag.alias_list.length > 0 &&
-            !(config.excludedTagFields ?? []).includes("aliases")
-          ) {
-            updateData.aliases = stashboxTag.alias_list;
-          }
-
-          if (stashboxTag.remote_site_id) {
-            updateData.stash_ids = await mergeTagStashIDs(tagID, [
-              {
-                endpoint,
-                stash_id: stashboxTag.remote_site_id,
-              },
-            ]);
-          }
-
-          const res = await updateTag(updateData);
-          if (!res?.data?.tagUpdate) {
-            setError({
-              ...error,
-              [tagID]: {
-                message: `Failed to update tag`,
-                details: res?.errors?.[0]?.message ?? "",
-              },
-            });
-          }
+          setModalTag({
+            scrapedTag: {
+              ...data[0],
+              stored_id: tag.id,
+            },
+            existingTag: tag,
+          });
         }
       })
       .finally(() => setLoadingUpdate(undefined));
@@ -203,6 +182,75 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
       batchAddParents
     );
     setShowBatchUpdate(false);
+  };
+
+  function handleSaveError(tagID: string, name: string, message: string) {
+    setError({
+      ...error,
+      [tagID]: {
+        message: intl.formatMessage(
+          { id: "tag_tagger.failed_to_save_tag" },
+          { tag: name }
+        ),
+        details:
+          message === "UNIQUE constraint failed: tags.name"
+            ? intl.formatMessage({
+                id: "tag_tagger.name_already_exists",
+              })
+            : message,
+      },
+    });
+  }
+
+  const handleTagUpdate = async (
+    input: GQL.TagCreateInput,
+    parentInput?: GQL.TagCreateInput
+  ) => {
+    const { existingTag, scrapedTag: tag } = modalTag!;
+    const tagID = existingTag.id;
+    setModalTag(undefined);
+
+    if (tagID) {
+      if (parentInput) {
+        try {
+          // cannot update parent tags, since there may be many
+          if (!!input.parent_ids?.length) {
+            // ignore
+          } else {
+            const parentRes = await createTag({
+              variables: { input: parentInput },
+            });
+            const parentID = parentRes.data?.tagCreate?.id;
+            if (parentID) {
+              // merge parent ids below
+              input.parent_ids = [parentID];
+            }
+          }
+        } catch (e) {
+          handleSaveError(tagID, parentInput.name, apolloError(e));
+        }
+      }
+
+      // always merge parent ids if included
+      if (input.parent_ids) {
+        input.parent_ids = uniq(
+          existingTag.parents.map((p) => p.id).concat(input.parent_ids)
+        );
+      }
+
+      const updateData: GQL.TagUpdateInput = {
+        ...input,
+        id: tagID,
+      };
+      updateData.stash_ids = await mergeTagStashIDs(
+        tagID,
+        input.stash_ids ?? []
+      );
+
+      const res = await updateTag(updateData);
+      if (!res?.data?.tagUpdate)
+        handleSaveError(tagID, tag.name ?? "", res?.errors?.[0]?.message ?? "");
+    }
   };
 
   const handleTaggedTag = (
@@ -292,7 +340,7 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
               <InputGroup.Append>
                 <Button
                   onClick={() =>
-                    doBoxUpdate(tag.id, stashID.stash_id, stashID.endpoint)
+                    doBoxUpdate(tag, stashID.stash_id, stashID.endpoint)
                   }
                   disabled={!!loadingUpdate}
                 >
@@ -344,11 +392,11 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
       }
 
       return (
-        <div key={tag.id} className={`${CLASSNAME}-studio`}>
+        <div key={tag.id} className={`${CLASSNAME}-tag`}>
           <div className={`${CLASSNAME}-details`}>
             <div></div>
             <div>
-              <Card className="studio-card">
+              <Card className="tag-card">
                 <img loading="lazy" src={tag.image_path ?? ""} alt="" />
               </Card>
             </div>
@@ -393,6 +441,19 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
           setBatchAddParents={setBatchAddParents}
           localePrefix="tag_tagger"
           entityName="tag"
+        />
+      )}
+
+      {modalTag && (
+        <TagModal
+          closeModal={() => setModalTag(undefined)}
+          modalVisible={modalTag !== undefined}
+          tag={modalTag.scrapedTag}
+          onSave={handleTagUpdate}
+          icon={faTags}
+          header="Update Tag"
+          excludedTagFields={config.excludedTagFields}
+          endpoint={selectedEndpoint.endpoint}
         />
       )}
       <div className="ml-auto mb-3">


### PR DESCRIPTION
- made URL list styling consistent across tagger modal dialogs. Resolves #6724 
- changed stash-box links to stashid pills in the studio and tag modals to be consistent with the performer modal
- added support for excluding parent studio/tag in tagger modals. This also meant forcing the create parent checkbox to true if parent is not excluded and does not exist
<img width="1205" height="962" alt="image" src="https://github.com/user-attachments/assets/65419569-2087-4f87-b280-d6cd4a3e73fc" />
<img width="1206" height="613" alt="image" src="https://github.com/user-attachments/assets/0adbeb9e-9b5e-411c-aecf-93e71316c2c7" />

- fixed refresh button in the tags tagger not allowing changing of fields before saving