### PR TITLE
Match exact tag names for batch tagger and show exact matches first for query

### DIFF
--- a/internal/api/resolver_query_scraper.go
+++ b/internal/api/resolver_query_scraper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/stashapp/stash/pkg/match"
 	"github.com/stashapp/stash/pkg/models"
@@ -363,7 +364,8 @@ func (r *queryResolver) ScrapeSingleTag(ctx context.Context, source scraper.Sour
 		client := r.newStashBoxClient(*b)
 
 		var ret []*models.ScrapedTag
-		out, err := client.QueryTag(ctx, *input.Query)
+		query := *input.Query
+		out, err := client.QueryTag(ctx, query)
 
 		if err != nil {
 			return nil, err
@@ -383,6 +385,22 @@ func (r *queryResolver) ScrapeSingleTag(ctx context.Context, source scraper.Sour
 			}); err != nil {
 				return nil, err
 			}
+
+			// tag name query returns results that may not match the query exactly.
+			// if there is an exact match, it should be first
+			if query != "" {
+				for i, result := range ret {
+					if strings.EqualFold(result.Name, query) {
+						// prepend exact match to the front of the slice
+						if i != 0 {
+							ret = append([]*models.ScrapedTag{result}, append(ret[:i], ret[i+1:]...)...)
+						}
+
+						break
+					}
+				}
+			}
+
 			return ret, nil
 		}
 

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -637,15 +637,11 @@ func (t *stashBoxBatchTagTagTask) findStashBoxTag(ctx context.Context) (*models.
 
 	// QueryTag returns tags that partially match the name, so find the exact match if searching by name
 	if nameQuery != "" {
-		var exactMatch *models.ScrapedTag
-		for _, result := range results {
-			if strings.EqualFold(result.Name, nameQuery) {
-				exactMatch = result
+		for _, r := range results {
+			if strings.EqualFold(r.Name, nameQuery) {
+				result = r
 				break
 			}
-		}
-		if exactMatch != nil {
-			result = exactMatch
 		}
 	} else {
 		result = results[0]

--- a/internal/manager/task_stash_box_tag.go
+++ b/internal/manager/task_stash_box_tag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/match"
@@ -589,8 +590,11 @@ func (t *stashBoxBatchTagTagTask) findStashBoxTag(ctx context.Context) (*models.
 
 	client := stashbox.NewClient(*t.box, stashbox.ExcludeTagPatterns(instance.Config.GetScraperExcludeTagPatterns()))
 
+	nameQuery := ""
+
 	switch {
 	case t.name != nil:
+		nameQuery = *t.name
 		results, err = client.QueryTag(ctx, *t.name)
 	case t.stashID != nil:
 		results, err = client.QueryTag(ctx, *t.stashID)
@@ -616,6 +620,7 @@ func (t *stashBoxBatchTagTagTask) findStashBoxTag(ctx context.Context) (*models.
 		if remoteID != "" {
 			results, err = client.QueryTag(ctx, remoteID)
 		} else {
+			nameQuery = t.tag.Name
 			results, err = client.QueryTag(ctx, t.tag.Name)
 		}
 	}
@@ -628,7 +633,27 @@ func (t *stashBoxBatchTagTagTask) findStashBoxTag(ctx context.Context) (*models.
 		return nil, nil
 	}
 
-	result := results[0]
+	var result *models.ScrapedTag
+
+	// QueryTag returns tags that partially match the name, so find the exact match if searching by name
+	if nameQuery != "" {
+		var exactMatch *models.ScrapedTag
+		for _, result := range results {
+			if strings.EqualFold(result.Name, nameQuery) {
+				exactMatch = result
+				break
+			}
+		}
+		if exactMatch != nil {
+			result = exactMatch
+		}
+	} else {
+		result = results[0]
+	}
+
+	if result == nil {
+		return nil, nil
+	}
 
 	if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
 		return match.ScrapedTagHierarchy(ctx, r.Tag, result, t.box.Endpoint)


### PR DESCRIPTION
Resolves issue raised on Discord:
- batch adding/updating would query tag by name, but stash-box returns results for any tag that contains the input string and does not sort based on closest matching. This resulted in a tag with `Facial` as its name being matched to `Double Facial` as this was the first result from stash-box.

Resolved by ensuring that the batch tagging functionality matches input name exactly.

Also changed the `ScrapeSingleTag` behaviour to show exact matches first. This could potentially still have issues if the exact matching tag isn't in the first 25 results from stash-box, but that should probably be fixed upstream.