### PR TITLE
Add mutex to repositoryCache for thread safety

### DIFF
--- a/pkg/pkg/cache.go
+++ b/pkg/pkg/cache.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"sync"
 	"time"
 )
 
@@ -10,14 +11,9 @@ type cacheEntry struct {
 }
 
 type repositoryCache struct {
+	mu sync.RWMutex
 	// cache maps the URL to the last modified time and the data
 	cache map[string]cacheEntry
-}
-
-func (c *repositoryCache) ensureCache() {
-	if c.cache == nil {
-		c.cache = make(map[string]cacheEntry)
-	}
 }
 
 func (c *repositoryCache) lastModified(url string) *time.Time {
@@ -25,7 +21,13 @@ func (c *repositoryCache) lastModified(url string) *time.Time {
 		return nil
 	}
 
-	c.ensureCache()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.cache == nil {
+		return nil
+	}
+
 	e, found := c.cache[url]
 
 	if !found {
@@ -36,7 +38,13 @@ func (c *repositoryCache) lastModified(url string) *time.Time {
 }
 
 func (c *repositoryCache) getPackageList(url string) []RemotePackage {
-	c.ensureCache()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.cache == nil {
+		return nil
+	}
+
 	e, found := c.cache[url]
 
 	if !found {
@@ -51,7 +59,13 @@ func (c *repositoryCache) cacheList(url string, lastModified time.Time, data []R
 		return
 	}
 
-	c.ensureCache()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cache == nil {
+		c.cache = make(map[string]cacheEntry)
+	}
+
 	c.cache[url] = cacheEntry{
 		lastModified: lastModified,
 		data:         data,

--- a/pkg/pkg/manager.go
+++ b/pkg/pkg/manager.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"sync"
 
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
@@ -31,13 +32,14 @@ type Manager struct {
 
 	Client *http.Client
 
-	cache *repositoryCache
+	cacheOnce sync.Once
+	cache     *repositoryCache
 }
 
 func (m *Manager) getCache() *repositoryCache {
-	if m.cache == nil {
+	m.cacheOnce.Do(func() {
 		m.cache = &repositoryCache{}
-	}
+	})
 
 	return m.cache
 }


### PR DESCRIPTION
added `sync.RWMutex` to `repositoryCache`... removed `ensureCache()` and handle nil-map init under the lock instead

should close #6730, see if @dustinruusu can confirm this fix