### PR TITLE
Fix lightbox not reading scale-up form config

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -206,8 +206,25 @@ export const LightboxComponent: React.FC<IProps> = ({
     setLightboxSettings({ slideshowDelay: v });
   }
 
+  const scaleUp =
+    lightboxSettings?.scaleUp ??
+    config?.interface.imageLightbox.scaleUp ??
+    false;
+
+  const resetZoomOnNav =
+    lightboxSettings?.resetZoomOnNav ??
+    config?.interface.imageLightbox.resetZoomOnNav ??
+    false;
+
+  const scrollMode =
+    lightboxSettings?.scrollMode ??
+    config?.interface.imageLightbox.scrollMode ??
+    GQL.ImageLightboxScrollMode.Zoom;
+
   const displayMode =
-    lightboxSettings?.displayMode ?? GQL.ImageLightboxDisplayMode.FitXy;
+    lightboxSettings?.displayMode ??
+    config?.interface.imageLightbox.displayMode ??
+    GQL.ImageLightboxDisplayMode.FitXy;
   const oldDisplayMode = useRef(displayMode);
 
   function setDisplayMode(v: GQL.ImageLightboxDisplayMode) {
@@ -250,13 +267,13 @@ export const LightboxComponent: React.FC<IProps> = ({
     // reset zoom status
     // setResetZoom((r) => !r);
     // setZoomed(false);
-    if (lightboxSettings?.resetZoomOnNav) {
+    if (resetZoomOnNav) {
       setZoom(1);
     }
     setResetPosition((r) => !r);
 
     oldIndex.current = index;
-  }, [index, images.length, lightboxSettings?.resetZoomOnNav]);
+  }, [index, images.length, resetZoomOnNav]);
 
   const getNavOffset = useCallback(() => {
     if (images.length < 2) return;
@@ -288,13 +305,13 @@ export const LightboxComponent: React.FC<IProps> = ({
       // reset zoom status
       // setResetZoom((r) => !r);
       // setZoomed(false);
-      if (lightboxSettings?.resetZoomOnNav) {
+      if (resetZoomOnNav) {
         setZoom(1);
       }
       setResetPosition((r) => !r);
     }
     oldDisplayMode.current = displayMode;
-  }, [displayMode, lightboxSettings?.resetZoomOnNav]);
+  }, [displayMode, resetZoomOnNav]);
 
   const selectIndex = (e: React.MouseEvent, i: number) => {
     setIndex(i);
@@ -635,7 +652,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                 label={intl.formatMessage({
                   id: "dialogs.lightbox.scale_up.label",
                 })}
-                checked={lightboxSettings?.scaleUp ?? false}
+                checked={scaleUp}
                 disabled={displayMode === GQL.ImageLightboxDisplayMode.Original}
                 onChange={(v) => setScaleUp(v.currentTarget.checked)}
               />
@@ -655,7 +672,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                 label={intl.formatMessage({
                   id: "dialogs.lightbox.reset_zoom_on_nav",
                 })}
-                checked={lightboxSettings?.resetZoomOnNav ?? false}
+                checked={resetZoomOnNav}
                 onChange={(v) => setResetZoomOnNav(v.currentTarget.checked)}
               />
             </Col>
@@ -674,10 +691,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                 onChange={(e) =>
                   setScrollMode(e.target.value as GQL.ImageLightboxScrollMode)
                 }
-                value={
-                  lightboxSettings?.scrollMode ??
-                  GQL.ImageLightboxScrollMode.Zoom
-                }
+                value={scrollMode}
                 className="btn-secondary mx-1 mb-1"
               >
                 <option
@@ -885,11 +899,8 @@ export const LightboxComponent: React.FC<IProps> = ({
                     width={image.visual_files?.[0]?.width ?? 0}
                     height={image.visual_files?.[0]?.height ?? 0}
                     displayMode={displayMode}
-                    scaleUp={lightboxSettings?.scaleUp ?? false}
-                    scrollMode={
-                      lightboxSettings?.scrollMode ??
-                      GQL.ImageLightboxScrollMode.Zoom
-                    }
+                    scaleUp={scaleUp}
+                    scrollMode={scrollMode}
                     resetPosition={resetPosition}
                     zoom={i === currentIndex ? zoom : 1}
                     scrollAttemptsBeforeChange={scrollAttemptsBeforeChange}


### PR DESCRIPTION
close #6504
per @feederbox826

> Was only able to reproduce with the following steps
> IN settings -> interface -> image lightbox, set "scale up to fit" to true
> clear/ ensure localforage/ keyvaluepairs is clear (this will override the global settings)
> a. Clear cache/ localstorage works
> view settings box in individual lightbox
>This seemingly ONLY affects "scale to fit" I suspect because it's a binary value and it's evaluating undefined as falsey. > Regardless, localForage overrides stash config



figured out localForage was overriding the global config with undefined evaluating as falsey...
fixed for lightbox settings to now fall through localForage > config > default

Left contains current behavior, right contains this PR with desired behavior
<img width="2560" height="1440" alt="2026-03-23-230418_2560x1440_scrot" src="https://github.com/user-attachments/assets/b8b53a74-fb1f-4a5c-9318-815661ae6d2c" />

thats all for tonight