### PR TITLE
Don't return heatmap path for non-interactive scenes

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayerScrubber.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayerScrubber.tsx
@@ -349,9 +349,10 @@ export const ScenePlayerScrubber: React.FC<IScenePlayerScrubberProps> = ({
         <div
           className="scrubber-heatmap"
           style={{
-            backgroundImage: scene.paths.interactive_heatmap
-              ? `url(${scene.paths.interactive_heatmap})`
-              : undefined,
+            backgroundImage:
+              scene.interactive_speed && scene.paths.interactive_heatmap
+                ? `url(${scene.paths.interactive_heatmap})`
+                : undefined,
           }}
         />
         <div ref={indicatorEl} id="scrubber-position-indicator" />


### PR DESCRIPTION
fixes #6477
Paths resolver was always returning the heatmap URL even after funscript being removed, now is only included when primary file is interactive
