### PR TITLE
fix screenshot generation for .webm with sparse keyframe

### DIFF
--- a/pkg/ffmpeg/transcoder/screenshot.go
+++ b/pkg/ffmpeg/transcoder/screenshot.go
@@ -60,9 +60,9 @@ func ScreenshotTime(input string, t float64, options ScreenshotOptions) ffmpeg.A
 	var args ffmpeg.Args
 	args = args.LogLevel(options.Verbosity)
 	args = args.Overwrite()
-	args = args.Seek(t)
 
 	args = args.Input(input)
+	args = args.Seek(t)
 	args = args.VideoFrames(1)
 
 	if options.Quality > 0 {


### PR DESCRIPTION
title

close #6499

ref
<img width="1331" height="931" alt="2026-03-24-131949_2560x1440_scrot" src="https://github.com/user-attachments/assets/573f5a8b-3cff-43cc-9558-5c73dc900284" />
