### PR TITLE
Added check for webp images when getting the src img for SceneWall.

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -240,7 +240,9 @@ const SceneWall: React.FC<ISceneWallProps> = ({
       return {
         scene: s,
         src:
-          s.paths.preview && !erroredImgs.includes(s.paths.preview)
+          s.paths.webp && !erroredImgs.includes(s.paths.webp)
+            ? s.paths.webp
+            : s.paths.preview && !erroredImgs.includes(s.paths.preview)
             ? s.paths.preview!
             : s.paths.screenshot!,
         link: sceneQueue


### PR DESCRIPTION
Webp images are never used when browsing SceneWall, UI is always loading /previews aka mp4s. 
Seems to be the same all over the place, e.g hoovering a scene anywhere.

Added a check if webp images exists, in that case use it instead.
Guess you could also check "Preview type" in Interface settings but idk where that setting is located.. :)

I'm running this on my machine and it works fine anyway.