### PR TITLE
Add keyboard shortcut "d d" to delete scene during playback

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -256,6 +256,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
     Mousetrap.bind("p p", () => onQueuePrevious());
     Mousetrap.bind("p r", () => onQueueRandom());
     Mousetrap.bind(",", () => setCollapsed(!collapsed));
+    Mousetrap.bind("d", () => setIsDeleteAlertOpen(true));
     Mousetrap.bind("c c", () => {
       onGenerateScreenshot(getPlayerPosition());
     });
@@ -271,6 +272,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       Mousetrap.unbind("i");
       Mousetrap.unbind("h");
       Mousetrap.unbind("o");
+      Mousetrap.unbind("d");
       Mousetrap.unbind("p n");
       Mousetrap.unbind("p p");
       Mousetrap.unbind("p r");

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -256,7 +256,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
     Mousetrap.bind("p p", () => onQueuePrevious());
     Mousetrap.bind("p r", () => onQueueRandom());
     Mousetrap.bind(",", () => setCollapsed(!collapsed));
-    Mousetrap.bind("d", () => setIsDeleteAlertOpen(true));
+    Mousetrap.bind("d d", () => setIsDeleteAlertOpen(true));
     Mousetrap.bind("c c", () => {
       onGenerateScreenshot(getPlayerPosition());
     });
@@ -272,7 +272,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       Mousetrap.unbind("i");
       Mousetrap.unbind("h");
       Mousetrap.unbind("o");
-      Mousetrap.unbind("d");
+      Mousetrap.unbind("d d");
       Mousetrap.unbind("p n");
       Mousetrap.unbind("p p");
       Mousetrap.unbind("p r");

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -64,7 +64,7 @@
 | `,` | Hide/Show sidebar |
 | `.` | Hide/Show scene scrubber |
 | `o` | Increment O-Counter |
-| `d d` | Delete Scene |
+| `d d` | Delete scene |
 | Ratings ||
 | `r {1-5}` | Set rating (stars) |
 | `r 0` | Unset rating (stars) |

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -64,6 +64,7 @@
 | `,` | Hide/Show sidebar |
 | `.` | Hide/Show scene scrubber |
 | `o` | Increment O-Counter |
+| `d d` | Delete Scene |
 | Ratings ||
 | `r {1-5}` | Set rating (stars) |
 | `r 0` | Unset rating (stars) |


### PR DESCRIPTION
Add keyboard shortcut "d" to bring up the delete scene window when viewing a scene. Allows to sort through and delete unwanted files quicker.