### PR TITLE
Fix: Remove padFuzzyDate From Performer

### DIFF
--- a/pkg/stashbox/performer.go
+++ b/pkg/stashbox/performer.go
@@ -242,11 +242,11 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 	}
 
 	if p.BirthDate != nil {
-		sp.Birthdate = padFuzzyDate(p.BirthDate)
+		sp.Birthdate = p.BirthDate
 	}
 
 	if p.DeathDate != nil {
-		sp.DeathDate = padFuzzyDate(p.DeathDate)
+		sp.DeathDate = p.DeathDate
 	}
 
 	if p.Gender != nil {
@@ -290,22 +290,6 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 	return sp
 }
 
-func padFuzzyDate(date *string) *string {
-	if date == nil {
-		return nil
-	}
-
-	var paddedDate string
-	switch len(*date) {
-	case 10:
-		paddedDate = *date
-	case 7:
-		paddedDate = fmt.Sprintf("%s-01", *date)
-	case 4:
-		paddedDate = fmt.Sprintf("%s-01-01", *date)
-	}
-	return &paddedDate
-}
 
 // FindPerformerByID queries stash-box for a performer by ID.
 func (c Client) FindPerformerByID(ctx context.Context, id string) (*models.ScrapedPerformer, error) {

--- a/pkg/stashbox/performer.go
+++ b/pkg/stashbox/performer.go
@@ -290,7 +290,6 @@ func performerFragmentToScrapedPerformer(p graphql.PerformerFragment) *models.Sc
 	return sp
 }
 
-
 // FindPerformerByID queries stash-box for a performer by ID.
 func (c Client) FindPerformerByID(ctx context.Context, id string) (*models.ScrapedPerformer, error) {
 	performer, err := c.client.FindPerformerByID(ctx, id)


### PR DESCRIPTION
Removes `padFuzzyDate` which was converting partial dates into full dates. `ParseDate()` Already supports partial dates anyway and this function was causing it to lose precision.

Fixes: https://github.com/stashapp/stash/issues/6752

UI: 
<img width="478" height="324" alt="Screenshot 2026-03-26 at 16 18 55" src="https://github.com/user-attachments/assets/f870d932-0b85-4292-8c63-f886802c3888" />
