### PR TITLE
Show stash-box name in studio/performer tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
@@ -20,10 +20,7 @@ export const StashBoxSelector: React.FC<IStashBoxSelectorProps> = ({
     let box = configuration?.general.stashBoxes.find(
       (sb) => sb.endpoint === endpoint
     );
-    if (!box) {
-      return endpoint;
-    }
-    return `${box.name}: ${endpoint}`;
+    return `stash-box: ${box?.name ?? endpoint}`;
   }
 
   return (

--- a/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
@@ -1,6 +1,7 @@
 import { Form } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import { StashBox } from "src/core/generated-graphql";
+import { useConfigurationContext } from "src/hooks/Config";
 
 interface IStashBoxSelectorProps {
   stashBoxes: StashBox[];
@@ -13,6 +14,16 @@ export const StashBoxSelector: React.FC<IStashBoxSelectorProps> = ({
   selectedEndpoint,
   onEndpointChange,
 }) => {
+  const { configuration } = useConfigurationContext();
+
+  function stashboxNameForEndpoint(endpoint: string) {
+    let box = configuration?.general.stashBoxes.find((sb) => sb.endpoint === endpoint);
+    if (!box) {
+      return endpoint;
+    }
+    return `${box.name}: ${endpoint}`;
+  }
+
   return (
     <Form.Control
       as="select"
@@ -28,7 +39,7 @@ export const StashBoxSelector: React.FC<IStashBoxSelectorProps> = ({
       )}
       {stashBoxes.map((i) => (
         <option value={i.endpoint} key={i.endpoint}>
-          {i.endpoint}
+          {stashboxNameForEndpoint(i.endpoint)}
         </option>
       ))}
     </Form.Control>

--- a/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
+++ b/ui/v2.5/src/components/Tagger/StashBoxSelector.tsx
@@ -17,7 +17,9 @@ export const StashBoxSelector: React.FC<IStashBoxSelectorProps> = ({
   const { configuration } = useConfigurationContext();
 
   function stashboxNameForEndpoint(endpoint: string) {
-    let box = configuration?.general.stashBoxes.find((sb) => sb.endpoint === endpoint);
+    let box = configuration?.general.stashBoxes.find(
+      (sb) => sb.endpoint === endpoint
+    );
     if (!box) {
       return endpoint;
     }


### PR DESCRIPTION
Currently, the stash box selector component just shows the endpoint URL.

This PR makes it so that it shows the configured name as well.

I was debating between showing `Name: URL`, `Name` and `stash-box: Name`.
The latter matches what the scene tagger shows.

What I have implemented for now is this:
<img width="419" height="284" alt="Screenshot 2026-03-27 140842" src="https://github.com/user-attachments/assets/adb306cf-0aba-4b38-8247-b9bbbdfb7c4a" />
