### PR TITLE
feat: include api key in funscript url

### DIFF
--- a/internal/api/resolver_model_scene.go
+++ b/internal/api/resolver_model_scene.go
@@ -114,7 +114,7 @@ func (r *sceneResolver) Paths(ctx context.Context, obj *models.Scene) (*ScenePat
 	objHash := obj.GetHash(config.GetVideoFileNamingAlgorithm())
 	vttPath := builder.GetSpriteVTTURL(objHash)
 	spritePath := builder.GetSpriteURL(objHash)
-	funscriptPath := builder.GetFunscriptURL()
+	funscriptPath := builder.GetFunscriptURL(config.GetAPIKey()).String()
 	captionBasePath := builder.GetCaptionURL()
 	interactiveHeatmap := builder.GetInteractiveHeatmapURL()
 

--- a/internal/api/urlbuilders/scene.go
+++ b/internal/api/urlbuilders/scene.go
@@ -57,8 +57,20 @@ func (b SceneURLBuilder) GetScreenshotURL() string {
 	return b.BaseURL + "/scene/" + b.SceneID + "/screenshot?t=" + b.UpdatedAt
 }
 
-func (b SceneURLBuilder) GetFunscriptURL() string {
-	return b.BaseURL + "/scene/" + b.SceneID + "/funscript"
+func (b SceneURLBuilder) GetFunscriptURL(apiKey string) *url.URL {
+	u, err := url.Parse(fmt.Sprintf("%s/scene/%s/funscript", b.BaseURL, b.SceneID))
+	if err != nil {
+		// shouldn't happen
+		panic(err)
+	}
+
+	if apiKey != "" {
+		v := u.Query()
+		v.Set("apikey", apiKey)
+		u.RawQuery = v.Encode()
+	}
+
+	return u
 }
 
 func (b SceneURLBuilder) GetCaptionURL() string {


### PR DESCRIPTION
This make the URLs in the frontend consistent. Currently the Stream URL contains a API Key while the Funscript URL doesn't.

This is how it currently looks without this change:
<img width="439" height="67" alt="image" src="https://github.com/user-attachments/assets/4354d594-3c1a-4766-a5e5-5c0417fe1fd7" />


I cannot test this PR locally due to cross origin errors in dev mode. However it should work since the code is just copy-paste from the GetStreamURL() function a few lines above.