### PR TITLE
Exclude source objects from destination select and vice versa in merge dialogs

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -754,6 +754,15 @@ export const PerformerMergeModal: React.FC<IPerformerMergeModalProps> = ({
     id: "actions.merge",
   });
 
+  const srcIDs = useMemo(
+    () => sourcePerformers.map((s) => s.id),
+    [sourcePerformers]
+  );
+  const destID = useMemo(
+    () => (destPerformer[0] ? [destPerformer[0].id] : []),
+    [destPerformer]
+  );
+
   useEffect(() => {
     if (performers.length > 0) {
       // set the first performer as the destination, others as source
@@ -862,6 +871,7 @@ export const PerformerMergeModal: React.FC<IPerformerMergeModalProps> = ({
                 onSelect={(items) => setSourcePerformers(items)}
                 values={sourcePerformers}
                 menuPortalTarget={document.body}
+                excludeIds={destID}
               />
             </Col>
           </Form.Group>
@@ -895,6 +905,7 @@ export const PerformerMergeModal: React.FC<IPerformerMergeModalProps> = ({
                 onSelect={(items) => setDestPerformer(items)}
                 values={destPerformer}
                 menuPortalTarget={document.body}
+                excludeIds={srcIDs}
               />
             </Col>
           </Form.Group>

--- a/ui/v2.5/src/components/Performers/PerformerSelect.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   OptionProps,
   components as reactSelectComponents,
@@ -81,6 +81,7 @@ const _PerformerSelect: React.FC<
       ageFromDate?: string | null;
       hoverPlacementLabel?: Placement;
       hoverPlacementOptions?: Placement;
+      excludeIds?: string[];
     }
 > = (props) => {
   const [createPerformer] = usePerformerCreate();
@@ -91,6 +92,14 @@ const _PerformerSelect: React.FC<
     configuration?.ui.maxOptionsShown ?? defaultMaxOptionsShown;
   const defaultCreatable =
     !configuration?.interface.disableDropdownCreate.performer;
+
+  const exclude = useMemo(() => props.excludeIds ?? [], [props.excludeIds]);
+
+  function filterExcluded(performer: Performer) {
+    // HACK - we should probably exclude these in the backend query, but
+    // this will do in the short-term
+    return !exclude.includes(performer.id.toString());
+  }
 
   async function loadPerformers(input: string): Promise<Option[]> {
     const filter = new ListFilterModel(GQL.FilterMode.Performers);
@@ -104,7 +113,8 @@ const _PerformerSelect: React.FC<
       filterByStashID(filter, input);
 
       const query = await queryFindPerformersForSelect(filter);
-      const matches = query.data.findPerformers.performers.slice();
+      const matches =
+        query.data.findPerformers.performers.filter(filterExcluded);
       if (matches.length > 0) {
         // Matches found, return them immediately.
         return matches.map(toOption);
@@ -118,7 +128,7 @@ const _PerformerSelect: React.FC<
     const query = await queryFindPerformersForSelect(filter);
     return performerSelectSort(
       input,
-      query.data.findPerformers.performers.slice()
+      query.data.findPerformers.performers.filter(filterExcluded)
     ).map(toOption);
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -719,6 +719,12 @@ export const SceneMergeModal: React.FC<ISceneMergeModalProps> = ({
     id: "actions.merge",
   });
 
+  const srcIDs = useMemo(() => sourceScenes.map((s) => s.id), [sourceScenes]);
+  const destID = useMemo(
+    () => (destScene[0] ? [destScene[0].id] : []),
+    [destScene]
+  );
+
   useEffect(() => {
     if (scenes.length > 0) {
       // set the first scene as the destination, others as source
@@ -826,6 +832,7 @@ export const SceneMergeModal: React.FC<ISceneMergeModalProps> = ({
                 onSelect={(items) => setSourceScenes(items)}
                 values={sourceScenes}
                 menuPortalTarget={document.body}
+                excludeIds={destID}
               />
             </Col>
           </Form.Group>
@@ -859,6 +866,7 @@ export const SceneMergeModal: React.FC<ISceneMergeModalProps> = ({
                 onSelect={(items) => setDestScene(items)}
                 values={destScene}
                 menuPortalTarget={document.body}
+                excludeIds={srcIDs}
               />
             </Col>
           </Form.Group>

--- a/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
@@ -433,6 +433,9 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
     id: "actions.merge",
   });
 
+  const srcIDs = useMemo(() => src.map((s) => s.id), [src]);
+  const destID = useMemo(() => (dest ? [dest.id] : []), [dest]);
+
   useEffect(() => {
     if (tags.length > 0) {
       setDest(tags[0]);
@@ -544,6 +547,7 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
                 creatable={false}
                 onSelect={(items) => setSrc(items)}
                 values={src}
+                excludeIds={destID}
                 menuPortalTarget={document.body}
               />
             </Col>
@@ -579,6 +583,7 @@ export const TagMergeModal: React.FC<ITagMergeModalProps> = ({
                 creatable={false}
                 onSelect={(items) => setDest(items[0])}
                 values={dest ? [dest] : undefined}
+                excludeIds={srcIDs}
                 menuPortalTarget={document.body}
               />
             </Col>


### PR DESCRIPTION
Resolves issue raised in Discord.