### PR TITLE
[CI] add vips-heif

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then BIN=stash-linux-arm32v6; \
 FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 
-RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg tzdata vips vips-tools \
+RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg tzdata vips vips-tools vips-heif \
     && pip install --break-system-packages mechanicalsoup cloudscraper stashapp-tools
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 


### PR DESCRIPTION
libheif is also required, but already handled as a dependency. Not explicitly including in case alpine finds some way to bypass it

closes #6751 