### PR TITLE
fix memory leak

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -81,6 +81,7 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	j.runJob(ctx, paths, nTasks, progress)
 
 	taskQueue.Close()
+	j.releaseScanResources()
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
@@ -129,6 +130,11 @@ func (j *ScanJob) runJob(ctx context.Context, paths []string, nTasks int, progre
 }
 
 const scanQueueSize = 200000
+
+func (j *ScanJob) releaseScanResources() {
+	j.fileQueue = nil
+	j.scanner = nil
+}
 
 func (j *ScanJob) queueFiles(ctx context.Context, paths []string, progress *job.Progress) error {
 	fs := &file.OsFS{}
@@ -283,8 +289,10 @@ func (j *ScanJob) processQueue(ctx context.Context, parallelTasks int, progress 
 
 		for f := range j.fileQueue {
 			logger.Tracef("Processing queued file %s", f.Path)
-			if err := ctx.Err(); err != nil {
-				return
+			if ctx.Err() != nil {
+				// Keep receiving until queueFiles closes the channel; otherwise
+				// the walker can block on send (full buffer) and never finish.
+				continue
 			}
 
 			wg.Add()

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -81,7 +81,6 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	j.runJob(ctx, paths, nTasks, progress)
 
 	taskQueue.Close()
-	j.releaseScanResources()
 
 	if job.IsCancelled(ctx) {
 		logger.Info("Stopping due to user request")
@@ -130,11 +129,6 @@ func (j *ScanJob) runJob(ctx context.Context, paths []string, nTasks int, progre
 }
 
 const scanQueueSize = 200000
-
-func (j *ScanJob) releaseScanResources() {
-	j.fileQueue = nil
-	j.scanner = nil
-}
 
 func (j *ScanJob) queueFiles(ctx context.Context, paths []string, progress *job.Progress) error {
 	fs := &file.OsFS{}

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -66,6 +66,23 @@ type Job struct {
 	cancelFunc context.CancelFunc
 }
 
+// statusCopy returns a copy of the Job with only the fields needed for
+// status reporting. Internal fields (exec, cancelFunc, outerCtx) are
+// excluded so that subscription channels don't retain heavy resources.
+func (j *Job) statusCopy() Job {
+	return Job{
+		ID:          j.ID,
+		Status:      j.Status,
+		Details:     j.Details,
+		Description: j.Description,
+		Progress:    j.Progress,
+		StartTime:   j.StartTime,
+		EndTime:     j.EndTime,
+		AddTime:     j.AddTime,
+		Error:       j.Error,
+	}
+}
+
 // TimeElapsed returns the total time elapsed for the job.
 // If the EndTime is set, then it uses this to calculate the elapsed time, otherwise it uses time.Now.
 func (j *Job) TimeElapsed() time.Duration {

--- a/pkg/job/manager.go
+++ b/pkg/job/manager.go
@@ -232,7 +232,9 @@ func (m *Manager) removeJob(job *Job) {
 		return
 	}
 
-	// clear any subtasks
+	// release the executor and subtask details so they can be GC'd
+	// while the job remains in the graveyard for status reporting
+	job.exec = nil
 	job.Details = nil
 
 	m.queue = append(m.queue[:index], m.queue[index+1:]...)

--- a/pkg/job/manager.go
+++ b/pkg/job/manager.go
@@ -105,7 +105,7 @@ func (m *Manager) notifyNewJob(j *Job) {
 	for _, s := range m.subscriptions {
 		// don't block if channel is full
 		select {
-		case s.newJob <- *j:
+		case s.newJob <- j.statusCopy():
 		default:
 		}
 	}
@@ -248,7 +248,7 @@ func (m *Manager) removeJob(job *Job) {
 	for _, s := range m.subscriptions {
 		// don't block if channel is full
 		select {
-		case s.removedJob <- *job:
+		case s.removedJob <- job.statusCopy():
 		default:
 		}
 	}
@@ -312,8 +312,7 @@ func (m *Manager) GetJob(id int) *Job {
 	// get from the queue or graveyard
 	_, j := m.getJob(append(m.queue, m.graveyard...), id)
 	if j != nil {
-		// make a copy of the job and return the pointer
-		jCopy := *j
+		jCopy := j.statusCopy()
 		return &jCopy
 	}
 
@@ -328,8 +327,7 @@ func (m *Manager) GetQueue() []Job {
 	var ret []Job
 
 	for _, j := range m.queue {
-		jCopy := *j
-		ret = append(ret, jCopy)
+		ret = append(ret, j.statusCopy())
 	}
 
 	return ret
@@ -374,7 +372,7 @@ func (m *Manager) notifyJobUpdate(j *Job) {
 	for _, s := range m.subscriptions {
 		// don't block if channel is full
 		select {
-		case s.updatedJob <- *j:
+		case s.updatedJob <- j.statusCopy():
 		default:
 		}
 	}

--- a/pkg/job/task.go
+++ b/pkg/job/task.go
@@ -51,7 +51,7 @@ func (tq *TaskQueue) executer(ctx context.Context) {
 	defer tq.wg.Wait()
 	for task := range tq.tasks {
 		if IsCancelled(ctx) {
-			return
+			continue // allow channel to continue draining until Close()
 		}
 
 		tt := task


### PR DESCRIPTION
fixes #6794. The logic according to LLM was that return can break the queue and cause it to remain allocated, and fileQueue and scanner both kill the channel and any hanging handlers. There were other fixes recommended but after trial and error this is the minimum necessary to prevent memory leak. The memory will spike (by ~14M) on first scan, more than 0.30.1, and does spike again on subsequent scans but does eventually GC down to the first spike instead of running away.

IO spike corresponds to 'scan" button being hit. First climb is from ~34M

<img width="395" height="330" alt="image" src="https://github.com/user-attachments/assets/02a8bd19-d6a4-419f-9b71-962993b3b117" />
