### PR TITLE
Fix clicking on scene/marker wall item pushing to history twice

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
@@ -73,7 +73,7 @@ export const MarkerWallItem: React.FC<
     divStyle.top = props.top;
   }
 
-  var handleClick = function handleClick(event: React.MouseEvent) {
+  const handleClick = function (event: React.MouseEvent) {
     if (props.selecting && props.onSelectedChanged) {
       props.onSelectedChanged(!props.selected, event.shiftKey);
       event.preventDefault();
@@ -131,7 +131,8 @@ export const MarkerWallItem: React.FC<
         alt={props.photo.alt}
         onMouseEnter={() => setActive(true)}
         onMouseLeave={() => setActive(false)}
-        onClick={handleClick}
+        // having a click handler here results in multiple calls to handleClick
+        // due to having the same click handler on the parent div
         onError={() => {
           props.photo.onError?.(props.photo);
         }}

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -70,7 +70,7 @@ export const SceneWallItem: React.FC<
     divStyle.top = props.top;
   }
 
-  var handleClick = function handleClick(event: React.MouseEvent) {
+  const handleClick = function (event: React.MouseEvent) {
     if (props.selecting && props.onSelectedChanged) {
       props.onSelectedChanged(!props.selected, event.shiftKey);
       event.preventDefault();
@@ -96,7 +96,8 @@ export const SceneWallItem: React.FC<
     alt: props.photo.alt,
     onMouseEnter: () => setActive(true),
     onMouseLeave: () => setActive(false),
-    onClick: handleClick,
+    // having a click handler here results in multiple calls to handleClick
+    // due to having the same click handler on the parent div
     onError: () => {
       props.photo.onError?.(props.photo);
     },


### PR DESCRIPTION
Fixed an annoying issue where clicking on the scene/marker wall item would result in having to press back twice to get back to the query page.