### PR TITLE
Show warning when creating parent tag without remote_site_id

### DIFF
--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -278,6 +278,10 @@
   .form-check {
     font-size: 1rem;
   }
+
+  p.lead {
+    margin-top: 1rem;
+  }
 }
 
 .StudioTagger,

--- a/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagModal.tsx
@@ -5,14 +5,18 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import * as GQL from "src/core/generated-graphql";
 import { Icon } from "src/components/Shared/Icon";
 import { ModalComponent } from "src/components/Shared/Modal";
-import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCheck,
+  faExclamationTriangle,
+  faTimes,
+} from "@fortawesome/free-solid-svg-icons";
 import { Button, Form } from "react-bootstrap";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { excludeFields } from "src/utils/data";
 import { StashIDPill } from "src/components/Shared/StashID";
 
 interface ITagModalProps {
-  tag: GQL.ScrapedSceneTagDataFragment;
+  tag: GQL.ScrapedTag;
   modalVisible: boolean;
   closeModal: () => void;
   onSave: (input: GQL.TagCreateInput, parentInput?: GQL.TagCreateInput) => void;
@@ -178,6 +182,15 @@ const TagModal: React.FC<ITagModalProps> = ({
     // force create if there is no current parent tag and parent tag is not excluded
     const mustCreateParent = true;
 
+    // warn the user if the parent tag does not have a remote_site_id,
+    // which means it won't be automatically linked to the source tag
+    const missingStashIDWarning = !tag.parent.remote_site_id && (
+      <p className="lead">
+        <Icon icon={faExclamationTriangle} className="text-warning" />
+        <FormattedMessage id="tag_tagger.parent_tag_no_remote_site_id_warning" />
+      </p>
+    );
+
     return (
       <div>
         <div className="mb-4 mt-4">
@@ -192,6 +205,7 @@ const TagModal: React.FC<ITagModalProps> = ({
           />
         </div>
         {maybeRenderParentTagDetails()}
+        {missingStashIDWarning}
       </div>
     );
   }

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -103,7 +103,7 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
   const [modalTag, setModalTag] = useState<
     | {
         existingTag: GQL.TagListDataFragment;
-        scrapedTag: GQL.ScrapedSceneTagDataFragment;
+        scrapedTag: GQL.ScrapedTag;
       }
     | undefined
   >();

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1638,6 +1638,7 @@
     "network_error": "Network Error",
     "no_results_found": "No results found.",
     "number_of_tags_will_be_processed": "{tag_count} tags will be processed",
+    "parent_tag_no_remote_site_id_warning": "Parent tag does not have a remote site ID, and will not be linked to the stash-box instance.",
     "query_all_tags_in_the_database": "All tags in the database",
     "refresh_tagged_tags": "Refresh tagged tags",
     "refreshing_will_update_the_data": "Refreshing will update the data of any tagged tags from the stash-box instance.",


### PR DESCRIPTION
Adds a warning to the create tag modal when creating a parent tag that does not have a `remote_site_id` (which is all stash-box tags currently). Addresses concern raised on Discord where the created parent tag is not linked with the stash-box-side object (which it can't be). This message should improve clarity around the issue.

<img width="1202" height="410" alt="image" src="https://github.com/user-attachments/assets/ddfb5a08-9d20-4ac3-9a1a-564d8df64063" />
