### PR TITLE
Let the stash ID pill shrink in tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -51,6 +51,10 @@
     flex-direction: column;
     overflow-wrap: anywhere;
     width: 100%;
+
+    .optional-field-content{
+      min-width: 0;
+    }
   }
 
   .original-scene-details {

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -52,7 +52,7 @@
     overflow-wrap: anywhere;
     width: 100%;
 
-    .optional-field-content{
+    .optional-field-content {
       min-width: 0;
     }
   }


### PR DESCRIPTION
On very narrow viewports (e.g. mobile), the stash ID pill will overflow its container. With this PR, it will instead limit itself to the width of the container and display with an ellipsis if necessary.

Fixes #6786