### PR TITLE
Try to create backup directory during migrate

### DIFF
--- a/internal/api/resolver_mutation_migrate.go
+++ b/internal/api/resolver_mutation_migrate.go
@@ -47,6 +47,10 @@ func (r *mutationResolver) Migrate(ctx context.Context, input manager.MigrateInp
 		Database:   mgr.Database,
 	}
 
+	if err := t.PreExecute(); err != nil {
+		return "", err
+	}
+
 	jobID := mgr.JobManager.Add(ctx, "Migrating database...", t)
 
 	return strconv.Itoa(jobID), nil

--- a/internal/manager/task/migrate.go
+++ b/internal/manager/task/migrate.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/stashapp/stash/internal/manager/config"
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/job"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/sqlite"
@@ -27,6 +29,21 @@ type databaseSchemaInfo struct {
 	CurrentSchemaVersion  uint
 	RequiredSchemaVersion uint
 	StepsRequired         uint
+}
+
+// PreExecute validates the environment before executing the migration.
+// It returns an error if the migration cannot be performed.
+func (s *MigrateJob) PreExecute() error {
+	// ensure backup directory exists and is writable
+	backupDir := s.Config.GetBackupDirectoryPathOrDefault()
+	if backupDir != "" {
+		if err := fsutil.EnsureDir(backupDir); err != nil {
+			logger.Errorf("error ensuring backup directory exists: %s", err)
+			logger.Warnf("Backup directory (%s) must be modified to a valid directory or removed from the config file", config.BackupDirectoryPath)
+			return fmt.Errorf("error creating backup directory: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *MigrateJob) Execute(ctx context.Context, progress *job.Progress) error {


### PR DESCRIPTION
Creates the configured backup directory before migrating. Logs a warning with steps to address on failure. 

Resolves #6787 