### PR TITLE
Fix WebSocket UTF-8 error for non-UTF-8 file paths in subscriptions

### DIFF
--- a/internal/api/resolver_query_job.go
+++ b/internal/api/resolver_query_job.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"strconv"
-	"strings"
 
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/pkg/job"
@@ -36,19 +35,19 @@ func (r *queryResolver) FindJob(ctx context.Context, input FindJobInput) (*Job, 
 func jobToJobModel(j job.Job) *Job {
 	subTasks := make([]string, len(j.Details))
 	for i, t := range j.Details {
-		subTasks[i] = strings.ToValidUTF8(t, "\uFFFD")
+		subTasks[i] = sanitiseWebsocketString(t)
 	}
 
 	var jobError *string
 	if j.Error != nil {
-		s := strings.ToValidUTF8(*j.Error, "\uFFFD")
+		s := sanitiseWebsocketString(*j.Error)
 		jobError = &s
 	}
 
 	ret := &Job{
 		ID:          strconv.Itoa(j.ID),
 		Status:      JobStatus(j.Status),
-		Description: strings.ToValidUTF8(j.Description, "\uFFFD"),
+		Description: sanitiseWebsocketString(j.Description),
 		SubTasks:    subTasks,
 		StartTime:   j.StartTime,
 		EndTime:     j.EndTime,

--- a/internal/api/resolver_query_job.go
+++ b/internal/api/resolver_query_job.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/pkg/job"
@@ -33,15 +34,26 @@ func (r *queryResolver) FindJob(ctx context.Context, input FindJobInput) (*Job, 
 }
 
 func jobToJobModel(j job.Job) *Job {
+	subTasks := make([]string, len(j.Details))
+	for i, t := range j.Details {
+		subTasks[i] = strings.ToValidUTF8(t, "\uFFFD")
+	}
+
+	var jobError *string
+	if j.Error != nil {
+		s := strings.ToValidUTF8(*j.Error, "\uFFFD")
+		jobError = &s
+	}
+
 	ret := &Job{
 		ID:          strconv.Itoa(j.ID),
 		Status:      JobStatus(j.Status),
-		Description: j.Description,
-		SubTasks:    j.Details,
+		Description: strings.ToValidUTF8(j.Description, "\uFFFD"),
+		SubTasks:    subTasks,
 		StartTime:   j.StartTime,
 		EndTime:     j.EndTime,
 		AddTime:     j.AddTime,
-		Error:       j.Error,
+		Error:       jobError,
 	}
 
 	if j.Progress != -1 {

--- a/internal/api/resolver_subscription_logging.go
+++ b/internal/api/resolver_subscription_logging.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stashapp/stash/internal/log"
 	"github.com/stashapp/stash/internal/manager"
@@ -33,7 +34,7 @@ func logEntriesFromLogItems(logItems []log.LogItem) []*LogEntry {
 		ret[i] = &LogEntry{
 			Time:    entry.Time,
 			Level:   getLogLevel(entry.Type),
-			Message: entry.Message,
+			Message: strings.ToValidUTF8(entry.Message, "\uFFFD"),
 		}
 	}
 

--- a/internal/api/resolver_subscription_logging.go
+++ b/internal/api/resolver_subscription_logging.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stashapp/stash/internal/manager"
 )
 
+// sanitiseWebsocketString is used to ensure that any strings sent over the websocket are valid UTF-8.
+// Any invalid UTF-8 sequences will be replaced with the Unicode replacement character (U+FFFD).
+// Invalid UTF-8 sequences can cause the websocket connection to be closed.
+func sanitiseWebsocketString(s string) string {
+	return strings.ToValidUTF8(s, "\uFFFD")
+}
+
 func getLogLevel(logType string) LogLevel {
 	switch logType {
 	case "progress":
@@ -34,7 +41,7 @@ func logEntriesFromLogItems(logItems []log.LogItem) []*LogEntry {
 		ret[i] = &LogEntry{
 			Time:    entry.Time,
 			Level:   getLogLevel(entry.Type),
-			Message: strings.ToValidUTF8(entry.Message, "\uFFFD"),
+			Message: sanitiseWebsocketString(entry.Message),
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Sanitize log messages in `LoggingSubscribe` before sending over WebSocket
- Sanitize job description, subtasks, and error in `jobToJobModel` (used by `JobsSubscribe`, `JobQueue`, and `FindJob`)

## Why
WebSocket text frames must contain valid UTF-8. File paths with non-UTF-8 characters (common with certain media files or filesystem encodings) caused the browser to close the connection with: _"Could not decode a text frame as UTF-8."_

Invalid bytes are replaced with the Unicode replacement character (U+FFFD) so messages remain readable.

Note: the sanitization only applies to the API response layer — it operates on copies of the data structures used for the WebSocket response. The underlying stored data (database records, file paths on disk) is never touched.

## Test plan
- [ ] Scan a library containing files with non-UTF-8 characters in their paths
- [ ] Confirm the WebSocket connection stays open and log/job updates appear normally in the UI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)