### PR TITLE
Bugfix: Tags Export Should Export Tags

### DIFF
--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -290,7 +290,7 @@ export const FilteredTagList = PatchComponent(
       showModal(
         <ExportDialog
           exportInput={{
-            studios: {
+            tags: {
               ids: Array.from(selectedIds.values()),
               all: all,
             },


### PR DESCRIPTION
Verified bug with reproduction steps on my prod machine. Simple copy and paste error that didn't get caught. Verified fix on dev machine that it now exports tags as expected. 

closes: https://github.com/stashapp/stash/issues/6818