### PR TITLE
Fix: Correct stash ID links in merge dialogs

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerMergeDialog.tsx
@@ -614,9 +614,17 @@ const PerformerMergeDetails: React.FC<IPerformerMergeDetailsProps> = ({
           title={intl.formatMessage({ id: "stash_id" })}
           result={stashIDs}
           originalField={
-            <StashIDsField values={stashIDs?.originalValue ?? []} />
+            <StashIDsField
+              values={stashIDs?.originalValue ?? []}
+              linkType="performers"
+            />
           }
-          newField={<StashIDsField values={stashIDs?.newValue ?? []} />}
+          newField={
+            <StashIDsField
+              values={stashIDs?.newValue ?? []}
+              linkType="performers"
+            />
+          }
           onChange={(value) => setStashIDs(value)}
           alwaysShow={
             !!stashIDs.originalValue?.length || !!stashIDs.newValue?.length

--- a/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMergeDialog.tsx
@@ -587,9 +587,17 @@ const SceneMergeDetails: React.FC<ISceneMergeDetailsProps> = ({
           title={intl.formatMessage({ id: "stash_id" })}
           result={stashIDs}
           originalField={
-            <StashIDsField values={stashIDs?.originalValue ?? []} />
+            <StashIDsField
+              values={stashIDs?.originalValue ?? []}
+              linkType="scenes"
+            />
           }
-          newField={<StashIDsField values={stashIDs?.newValue ?? []} />}
+          newField={
+            <StashIDsField
+              values={stashIDs?.newValue ?? []}
+              linkType="scenes"
+            />
+          }
           onChange={(value) => setStashIDs(value)}
           alwaysShow={
             !!stashIDs.originalValue?.length || !!stashIDs.newValue?.length

--- a/ui/v2.5/src/components/Shared/StashID.tsx
+++ b/ui/v2.5/src/components/Shared/StashID.tsx
@@ -34,16 +34,20 @@ export const StashIDPill: React.FC<{
 
 interface IStashIDsField {
   values: StashId[];
+  linkType: LinkType;
 }
 
-export const StashIDsField: React.FC<IStashIDsField> = ({ values }) => {
+export const StashIDsField: React.FC<IStashIDsField> = ({
+  values,
+  linkType,
+}) => {
   if (!values.length) return null;
 
   return (
     <ul className="pl-0 mw-100">
       {values.map((v) => (
         <li key={v.stash_id} className="row no-gutters">
-          <StashIDPill linkType="scenes" stashID={v} />
+          <StashIDPill linkType={linkType} stashID={v} />
         </li>
       ))}
     </ul>

--- a/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
@@ -321,9 +321,17 @@ const TagMergeDetails: React.FC<ITagMergeDetailsProps> = ({
           title={intl.formatMessage({ id: "stash_id" })}
           result={stashIDs}
           originalField={
-            <StashIDsField values={stashIDs?.originalValue ?? []} />
+            <StashIDsField
+              values={stashIDs?.originalValue ?? []}
+              linkType="tags"
+            />
           }
-          newField={<StashIDsField values={stashIDs?.newValue ?? []} />}
+          newField={
+            <StashIDsField
+              values={stashIDs?.newValue ?? []}
+              linkType="tags"
+            />
+          }
           onChange={(value) => setStashIDs(value)}
           alwaysShow={
             !!stashIDs.originalValue?.length || !!stashIDs.newValue?.length

--- a/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
+++ b/ui/v2.5/src/components/Tags/TagMergeDialog.tsx
@@ -327,10 +327,7 @@ const TagMergeDetails: React.FC<ITagMergeDetailsProps> = ({
             />
           }
           newField={
-            <StashIDsField
-              values={stashIDs?.newValue ?? []}
-              linkType="tags"
-            />
+            <StashIDsField values={stashIDs?.newValue ?? []} linkType="tags" />
           }
           onChange={(value) => setStashIDs(value)}
           alwaysShow={


### PR DESCRIPTION
The <StashIDsField/> element hardcoded a link type of "scenes", so the tag and performer merge dialogs had incorrect links.

Reported in Discord #bugs