### PR TITLE
New: Add Merge Support Option to Tags Tagger

### DIFF
--- a/ui/v2.5/src/components/Tagger/tags/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/StashSearchResult.tsx
@@ -7,8 +7,10 @@ import TagModal from "./TagModal";
 import { faTags } from "@fortawesome/free-solid-svg-icons";
 import { useIntl } from "react-intl";
 import { mergeTagStashIDs } from "../utils";
+import { TagOperation } from "../constants";
 import { useTagCreate } from "src/core/StashService";
 import { apolloError } from "src/utils";
+import { uniq } from "lodash-es";
 
 interface IStashSearchResultProps {
   tag: GQL.TagListDataFragment;
@@ -19,6 +21,7 @@ interface IStashSearchResultProps {
       Partial<Omit<GQL.TagListDataFragment, "id">>
   ) => void;
   excludedTagFields: string[];
+  tagOperation: TagOperation;
 }
 
 const StashSearchResult: React.FC<IStashSearchResultProps> = ({
@@ -27,6 +30,7 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
   onTagTagged,
   excludedTagFields,
   endpoint,
+  tagOperation,
 }) => {
   const intl = useIntl();
 
@@ -88,6 +92,15 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
       tag.id,
       input.stash_ids ?? []
     );
+
+    if (input.aliases) {
+      if (tagOperation === "merge") {
+        const existingAliases = tag.aliases ?? [];
+        updateData.aliases = uniq(existingAliases.concat(input.aliases));
+      } else {
+        updateData.aliases = input.aliases;
+      }
+    }
 
     const res = await updateTag(updateData);
 

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -17,7 +17,7 @@ import { useConfigurationContext } from "src/hooks/Config";
 
 import StashSearchResult from "./StashSearchResult";
 import TaggerConfig, { ConfigButton } from "../TaggerConfig";
-import { ITaggerConfig, TAG_FIELDS } from "../constants";
+import { ITaggerConfig, TAG_FIELDS, TagOperation } from "../constants";
 import { useUpdateTag } from "../queries";
 import { ExternalLink } from "src/components/Shared/ExternalLink";
 import { mergeTagStashIDs } from "../utils";
@@ -247,6 +247,15 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
         input.stash_ids ?? []
       );
 
+      if (input.aliases) {
+        if (config.tagOperation === "merge") {
+          const existingAliases = existingTag.aliases ?? [];
+          updateData.aliases = uniq(existingAliases.concat(input.aliases));
+        } else {
+          updateData.aliases = input.aliases;
+        }
+      }
+
       const res = await updateTag(updateData);
       if (!res?.data?.tagUpdate)
         handleSaveError(tagID, tag.name ?? "", res?.errors?.[0]?.message ?? "");
@@ -394,6 +403,7 @@ const TagTaggerList: React.FC<ITagTaggerListProps> = ({
             endpoint={selectedEndpoint.endpoint}
             onTagTagged={handleTaggedTag}
             excludedTagFields={config.excludedTagFields ?? []}
+            tagOperation={config.tagOperation}
           />
         );
       }
@@ -481,6 +491,7 @@ interface ITaggerProps {
 }
 
 export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
+  const intl = useIntl();
   const jobsSubscribe = useJobsSubscribe();
   const { configuration: stashConfig } = useConfigurationContext();
   const { config, setConfig } = useTaggerConfig();
@@ -668,26 +679,53 @@ export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
             fields={TAG_FIELDS}
             entityName="tags"
             extraConfig={
-              <Form.Group
-                controlId="config-create-parent"
-                className="align-items-center"
-              >
-                <Form.Check
-                  label={
-                    <FormattedMessage id="tag_tagger.config.create_parent_label" />
-                  }
-                  checked={config.createParentTags}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setConfig({
-                      ...config,
-                      createParentTags: e.currentTarget.checked,
-                    })
-                  }
-                />
-                <Form.Text>
-                  <FormattedMessage id="tag_tagger.config.create_parent_desc" />
-                </Form.Text>
-              </Form.Group>
+              <>
+                <Form.Group
+                  controlId="config-create-parent"
+                  className="align-items-center"
+                >
+                  <Form.Check
+                    label={
+                      <FormattedMessage id="tag_tagger.config.create_parent_label" />
+                    }
+                    checked={config.createParentTags}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setConfig({
+                        ...config,
+                        createParentTags: e.currentTarget.checked,
+                      })
+                    }
+                  />
+                  <Form.Text>
+                    <FormattedMessage id="tag_tagger.config.create_parent_desc" />
+                  </Form.Text>
+                </Form.Group>
+                <Form.Group controlId="config-alias-operation">
+                  <div className="d-flex align-items-center">
+                    <Form.Label className="mr-4 mb-0">
+                      <FormattedMessage id="aliases" />
+                    </Form.Label>
+                    <Form.Control
+                      className="col-md-2 col-3 input-control"
+                      as="select"
+                      value={config.tagOperation}
+                      onChange={(e) =>
+                        setConfig({
+                          ...config,
+                          tagOperation: e.currentTarget.value as TagOperation,
+                        })
+                      }
+                    >
+                      <option value="merge">
+                        {intl.formatMessage({ id: "actions.merge" })}
+                      </option>
+                      <option value="overwrite">
+                        {intl.formatMessage({ id: "actions.overwrite" })}
+                      </option>
+                    </Form.Control>
+                  </div>
+                </Form.Group>
+              </>
             }
           />
         </div>


### PR DESCRIPTION
This mimics the current infastructure for allowing Aliases to be merged or overwritten from stash boxes. Currently it defaults to merge to prevent data deletion.

Tested both settings in dev env and it worked as expected.

UI:
<img width="801" height="320" alt="image" src="https://github.com/user-attachments/assets/01596a87-0d0e-40cb-8e90-45fbbad8fffb" />

fixes: https://github.com/stashapp/stash/issues/6659