### PR TITLE
Refresh file info counter after deleting a file

### DIFF
--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2264,6 +2264,9 @@ export const mutateDeleteFiles = (ids: string[]) =>
       }
 
       evictQueries(cache, [
+        GQL.FindSceneDocument, // files list on scene detail
+        GQL.FindImageDocument, // files list on image detail
+        GQL.FindGalleryDocument, // files list on gallery detail
         GQL.FindScenesDocument, // filter by file count
         GQL.FindImagesDocument, // filter by file count
         GQL.FindGalleriesDocument, // filter by file count


### PR DESCRIPTION
## Summary

The "File Info" counter on Scene, Image, and Gallery detail pages did not update after deleting a file — users had to manually refresh to see the new count.

The Apollo `update` handler in `mutateDeleteFiles` was evicting the plural list queries (`findScenes`, `findImages`, `findGalleries`) and the file objects themselves, but not the *singular* detail queries (`findScene`, `findImage`, `findGallery`) that drive the counters on the detail pages. Adding those to the `evictQueries` list triggers a refetch next time the detail page reads the cache.

## Test plan

- [ ] Open a scene with multiple files, delete one via the File Info panel — counter in the nav tab updates without a page refresh.
- [ ] Same for an image with multiple visual files.
- [ ] Same for a gallery with multiple files.
- [ ] Scene / image / gallery list pages still reflect the change.