### PR TITLE
Fix: Release DB Lock on Large Image Libraries

### DIFF
--- a/internal/manager/task_generate.go
+++ b/internal/manager/task_generate.go
@@ -262,7 +262,9 @@ func (j *GenerateJob) Execute(ctx context.Context, progress *job.Progress) error
 
 	for f := range queue {
 		if job.IsCancelled(ctx) {
-			break
+			// keep draining the queue so the producer goroutine can finish
+			// and release its read transaction, otherwise the DB stays locked
+			continue
 		}
 
 		wg.Add()


### PR DESCRIPTION
When cancelling an image phash generation task on a library with more than 200K images, the consumer breaks out of the queue loop while the producer is still inside a read transaction queuing items. Once the 200K buffer fills, the producer blocks on send indefinitely, holding the database lock.

This is untested in a real situation as I don't have that many images. I would request that @BonerFide test this out for me.

fixes: https://github.com/stashapp/stash/issues/6842