### PR TITLE
Add missing (empty) dependency array to `useEffect()`

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryChaptersPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryChaptersPanel.tsx
@@ -30,7 +30,7 @@ export const GalleryChapterPanel: React.FC<IGalleryChapterPanelProps> = ({
     return () => {
       Mousetrap.unbind("n");
     };
-  });
+  }, [isVisible]);
 
   function onOpenEditor(chapter?: GQL.GalleryChapterDataFragment) {
     setIsEditorOpen(true);

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -324,7 +324,7 @@ export const FilteredGalleryList = PatchComponent(
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       };
-    });
+    }, []);
 
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,

--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -243,7 +243,7 @@ const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
       Mousetrap.unbind("e");
       Mousetrap.unbind("d d");
     };
-  });
+  }, []);
 
   useRatingKeybinds(
     true,

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
@@ -172,7 +172,7 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
       // Mousetrap.unbind("u");
       Mousetrap.unbind("s s");
     };
-  });
+  }, []);
 
   function updateGroupEditStateFromScraper(
     state: Partial<GQL.ScrapedGroupDataFragment>

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -288,7 +288,7 @@ export const FilteredGroupList = PatchComponent(
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       };
-    });
+    }, []);
 
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,

--- a/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/Image.tsx
@@ -298,7 +298,7 @@ const ImagePage: React.FC<IProps> = ({ image }) => {
       Mousetrap.unbind("f");
       Mousetrap.unbind("o");
     };
-  });
+  }, []);
 
   const file = useMemo(
     () => (image.visual_files.length > 0 ? image.visual_files[0] : undefined),

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -177,7 +177,7 @@ export const ImageEditPanel: React.FC<IProps> = ({
         Mousetrap.unbind("d d");
       };
     }
-  });
+  }, []);
 
   const fragmentScrapers = useMemo(() => {
     return (scrapers?.data?.listScrapers ?? []).filter((s) =>

--- a/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
+++ b/ui/v2.5/src/components/Images/ImageDetails/ImageEditPanel.tsx
@@ -177,7 +177,7 @@ export const ImageEditPanel: React.FC<IProps> = ({
         Mousetrap.unbind("d d");
       };
     }
-  }, []);
+  }, [isVisible]);
 
   const fragmentScrapers = useMemo(() => {
     return (scrapers?.data?.listScrapers ?? []).filter((s) =>

--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -359,7 +359,7 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
     return () => {
       Mousetrap.unbind("/");
     };
-  });
+  }, []);
 
   async function updatePinnedFilters(filters: string[]) {
     const configKey = filterModeToConfigKey(currentFilter.mode);

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -86,7 +86,7 @@ export const SearchTermInput: React.FC<{
     return () => {
       Mousetrap.unbind("/");
     };
-  });
+  }, []);
 
   function onSetQuery(value: string) {
     setLocalInput(value);

--- a/ui/v2.5/src/components/List/ListViewOptions.tsx
+++ b/ui/v2.5/src/components/List/ListViewOptions.tsx
@@ -105,7 +105,7 @@ export const ListViewOptions: React.FC<IListViewOptionsProps> = ({
       Mousetrap.unbind("v w");
       Mousetrap.unbind("v t");
     };
-  });
+  }, []);
 
   function onChangeZoom(v: number) {
     if (onSetZoom) {

--- a/ui/v2.5/src/components/List/ZoomSlider.tsx
+++ b/ui/v2.5/src/components/List/ZoomSlider.tsx
@@ -26,7 +26,7 @@ export function useZoomKeybinds(props: {
       Mousetrap.unbind("+");
       Mousetrap.unbind("-");
     };
-  });
+  }, []);
 }
 
 export interface IZoomSelectProps {

--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -276,7 +276,7 @@ export const MainNavbar: React.FC = () => {
         Mousetrap.unbind("n");
       }
     };
-  });
+  }, []);
 
   function maybeRenderLogout() {
     if (SessionUtils.isLoggedIn()) {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -112,7 +112,7 @@ const PerformerTabs: React.FC<{
       Mousetrap.unbind("g");
       Mousetrap.unbind("m");
     };
-  });
+  }, []);
 
   return (
     <Tabs
@@ -331,7 +331,7 @@ const PerformerPage: React.FC<IProps> = PatchComponent(
         Mousetrap.unbind("f");
         Mousetrap.unbind(",");
       };
-    });
+    }, []);
 
     async function onSave(input: GQL.PerformerCreateInput) {
       await updatePerformer({

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -383,7 +383,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         }
       };
     }
-  }, []);
+  }, [isVisible]);
 
   useEffect(() => {
     const newQueryableScrapers = (Scrapers?.data?.listScrapers ?? []).filter(

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -383,7 +383,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         }
       };
     }
-  });
+  }, []);
 
   useEffect(() => {
     const newQueryableScrapers = (Scrapers?.data?.listScrapers ?? []).filter(

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -447,7 +447,7 @@ export const FilteredPerformerList = PatchComponent(
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       };
-    });
+    }, []);
 
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -280,7 +280,7 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       Mousetrap.unbind("c c");
       Mousetrap.unbind("c d");
     };
-  });
+  }, []);
 
   async function onSave(input: GQL.SceneCreateInput) {
     await updateScene({

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -257,7 +257,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
         Mousetrap.unbind("d d");
       };
     }
-  }, []);
+  }, [isVisible]);
 
   useEffect(() => {
     const toFilter = Scrapers?.data?.listScrapers ?? [];

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -257,7 +257,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
         Mousetrap.unbind("d d");
       };
     }
-  });
+  }, []);
 
   useEffect(() => {
     const toFilter = Scrapers?.data?.listScrapers ?? [];

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
@@ -36,7 +36,7 @@ export const SceneMarkersPanel: React.FC<ISceneMarkersPanelProps> = ({
     return () => {
       Mousetrap.unbind("n");
     };
-  }, []);
+  }, [isVisible]);
 
   if (loading) return null;
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneMarkersPanel.tsx
@@ -36,7 +36,7 @@ export const SceneMarkersPanel: React.FC<ISceneMarkersPanelProps> = ({
     return () => {
       Mousetrap.unbind("n");
     };
-  });
+  }, []);
 
   if (loading) return null;
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -354,7 +354,7 @@ const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
       Mousetrap.unbind(",");
       Mousetrap.unbind("f");
     };
-  });
+  }, []);
 
   useRatingKeybinds(
     true,

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -147,7 +147,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     return () => {
       Mousetrap.unbind("s s");
     };
-  });
+  }, []);
 
   async function onSave(input: InputValues, andNew?: boolean) {
     setIsLoading(true);

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -274,7 +274,7 @@ export const FilteredStudioList = PatchComponent(
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       };
-    });
+    }, []);
 
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -359,7 +359,7 @@ const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
       Mousetrap.unbind(",");
       Mousetrap.unbind("f");
     };
-  });
+  }, []);
 
   async function onSave(input: GQL.TagCreateInput) {
     const oldRelations = {

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -276,7 +276,7 @@ export const FilteredTagList = PatchComponent(
         Mousetrap.unbind("e");
         Mousetrap.unbind("d d");
       };
-    });
+    }, []);
 
     const onCloseEditDelete = useCloseEditDelete({
       closeModal,

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -83,7 +83,7 @@ export function useLocalForage<T extends {}>(
       };
       localForage.setItem(key, Cache[key]);
     }
-  });
+  }, []);
 
   const isLoading = loading || loading === undefined;
 

--- a/ui/v2.5/src/hooks/keybinds.ts
+++ b/ui/v2.5/src/hooks/keybinds.ts
@@ -81,5 +81,5 @@ export function useRatingKeybinds(
     return () => {
       Mousetrap.unbind("r");
     };
-  });
+  }, [isVisible]);
 }

--- a/ui/v2.5/src/utils/form.tsx
+++ b/ui/v2.5/src/utils/form.tsx
@@ -67,7 +67,7 @@ export function useStopWheelScroll(ref: React.RefObject<HTMLElement>) {
         current.removeEventListener("wheel", stopWheelScroll);
       }
     };
-  });
+  }, []);
 }
 
 // NumberField is a wrapper around Form.Control that prevents wheel events from scrolling the window.


### PR DESCRIPTION
`useEffect` without a dependency array is re-evaluated on [every single render](https://react.dev/reference/react/useEffect#specifying-reactive-dependencies:~:text=fix%20your%20logic.-,My%20Effect%20runs%20after%20every%20re%2Drender,First%2C%20check%20that%20you%20haven%E2%80%99t%20forgotten%20to%20specify%20the%20dependency%20array%3A,-useEffect).

Most of these are just binding (and unbinding) keyboard shortcuts, so should be pretty safe to update in bulk.

I did spot a couple that skip keybind listeners if `!isVisible`, so set as a dependency so they'll still get installed.

There's an [eslint check](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) which can flag this (and other deps issues) - but the version of `eslint-plugin-react-hooks` configured is ancient and doesn't seem to have it. I briefly tried upgrading and enabling, but `eslint-config-airbnb` complains it's too new, and it surfaces 57 new lint errors (222 with with full `react-hooks/recommended` enabled). 