### PR TITLE
New: Add File Paths to Image Scraper Input

### DIFF
--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -79,7 +79,6 @@ type ImageUpdateInput struct {
 	Urls             []string           `json:"urls"`
 	Date             *string            `json:"date"`
 	Details          *string            `json:"details"`
-	Path             *string            `json:"path"`
 	Photographer     *string            `json:"photographer"`
 	Rating100        *int               `json:"rating100"`
 	Organized        *bool              `json:"organized"`

--- a/pkg/models/image.go
+++ b/pkg/models/image.go
@@ -79,6 +79,7 @@ type ImageUpdateInput struct {
 	Urls             []string           `json:"urls"`
 	Date             *string            `json:"date"`
 	Details          *string            `json:"details"`
+	Path             *string            `json:"path"`
 	Photographer     *string            `json:"photographer"`
 	Rating100        *int               `json:"rating100"`
 	Organized        *bool              `json:"organized"`

--- a/pkg/scraper/script.go
+++ b/pkg/scraper/script.go
@@ -205,6 +205,52 @@ func galleryInputFromGallery(gallery *models.Gallery) galleryInput {
 	return ret
 }
 
+type imageInput struct {
+	ID      string   `json:"id"`
+	Title   string   `json:"title"`
+	Urls    []string `json:"urls"`
+	Date    *string  `json:"date"`
+	Details string   `json:"details"`
+
+	Code         string `json:"code,omitempty"`
+	Photographer string `json:"photographer,omitempty"`
+
+	Files []fileInput `json:"files,omitempty"`
+}
+
+func imageInputFromImage(image *models.Image) imageInput {
+	dateToStringPtr := func(s *models.Date) *string {
+		if s != nil {
+			v := s.String()
+			return &v
+		}
+
+		return nil
+	}
+
+	// fallback to file basename if title is empty
+	title := image.GetTitle()
+	urls := image.URLs.List()
+
+	ret := imageInput{
+		ID:      strconv.Itoa(image.ID),
+		Title:   title,
+		Urls:    urls,
+		Details: image.Details,
+		Date:    dateToStringPtr(image.Date),
+
+		Code:         image.Code,
+		Photographer: image.Photographer,
+	}
+
+	for _, f := range image.Files.List() {
+		fi := fileInputFromFile(*f.Base())
+		ret.Files = append(ret.Files, fi)
+	}
+
+	return ret
+}
+
 var ErrScraperScript = errors.New("scraper script error")
 
 type scriptScraper struct {
@@ -392,6 +438,9 @@ func (s *scriptFragmentScraper) scrapeByFragment(ctx context.Context, input Inpu
 	case input.Scene != nil:
 		inString, err = json.Marshal(*input.Scene)
 		ty = ScrapeContentTypeScene
+	case input.Image != nil:
+		inString, err = json.Marshal(*input.Image)
+		ty = ScrapeContentTypeImage
 	}
 
 	if err != nil {
@@ -430,7 +479,7 @@ func (s *scriptFragmentScraper) scrapeGalleryByGallery(ctx context.Context, gall
 }
 
 func (s *scriptFragmentScraper) scrapeImageByImage(ctx context.Context, image *models.Image) (*models.ScrapedImage, error) {
-	inString, err := json.Marshal(imageToUpdateInput(image))
+	inString, err := json.Marshal(imageInputFromImage(image))
 
 	if err != nil {
 		return nil, err

--- a/pkg/scraper/script_test.go
+++ b/pkg/scraper/script_test.go
@@ -1,0 +1,52 @@
+package scraper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_imageInputFromImage_worksWithMultipleFiles(t *testing.T) {
+
+	date, _ := models.ParseDate("2020-01-01")
+	model := models.Image{
+		ID:           1,
+		Title:        "Test Image",
+		URLs:         models.NewRelatedStrings([]string{"https://example.com/image.png"}),
+		Date:         &date,
+		Code:         "Code",
+		Photographer: "Photographer",
+		Files: models.NewRelatedFiles([]models.File{
+			makeImageFile(1),
+			makeImageFile(2),
+		}),
+	}
+
+	input := imageInputFromImage(&model)
+
+	assert.Equal(t, "1", input.ID)
+	assert.Equal(t, "Test Image", input.Title)
+	assert.Equal(t, "https://example.com/image.png", input.Urls[0])
+	assert.Equal(t, "2020-01-01", *input.Date)
+	assert.Equal(t, "Code", input.Code)
+	assert.Equal(t, "Photographer", input.Photographer)
+	assert.Equal(t, "/data/images/image_0001_.png", input.Files[0].Path)
+	assert.Equal(t, "/data/images/image_0002_.png", input.Files[1].Path)
+}
+
+func getImageStringValue(index int, field string) string {
+	return fmt.Sprintf("image_%04d_%s", index, field)
+}
+
+func makeImageFile(i int) *models.ImageFile {
+	return &models.ImageFile{
+		BaseFile: &models.BaseFile{
+			Path:     "/data/images/" + getImageStringValue(i, ".png"),
+			Basename: getImageStringValue(i, ".png"),
+		},
+		Height: 200,
+		Width:  300,
+	}
+}

--- a/pkg/scraper/stash.go
+++ b/pkg/scraper/stash.go
@@ -459,5 +459,6 @@ func imageToUpdateInput(gallery *models.Image) models.ImageUpdateInput {
 		Details: &gallery.Details,
 		Urls:    urls,
 		Date:    dateToStringPtr(gallery.Date),
+		Path:    &gallery.Path,
 	}
 }

--- a/pkg/scraper/stash.go
+++ b/pkg/scraper/stash.go
@@ -438,27 +438,3 @@ func (s *stashScraper) scrapeImageByImage(ctx context.Context, image *models.Ima
 func (s *stashScraper) scrapeByURL(_ context.Context, _ string, _ ScrapeContentType) (ScrapedContent, error) {
 	return nil, ErrNotSupported
 }
-
-func imageToUpdateInput(gallery *models.Image) models.ImageUpdateInput {
-	dateToStringPtr := func(s *models.Date) *string {
-		if s != nil {
-			v := s.String()
-			return &v
-		}
-
-		return nil
-	}
-
-	// fallback to file basename if title is empty
-	title := gallery.GetTitle()
-	urls := gallery.URLs.List()
-
-	return models.ImageUpdateInput{
-		ID:      strconv.Itoa(gallery.ID),
-		Title:   &title,
-		Details: &gallery.Details,
-		Urls:    urls,
-		Date:    dateToStringPtr(gallery.Date),
-		Path:    &gallery.Path,
-	}
-}


### PR DESCRIPTION
Tools like `gallery-dl --write-metadata` provide additional metadata to the download as separate file, i.e. `/stash/pic.png` gets an accompanying `/stash/pic.png.json`. 

Adding a `Path` field to the scraper args will allow scrapers to find such metadata files. This seems in line with scenes/galleries passing their Filename(s) to their scraper args.