### PR TITLE
[Feature] Add configurable default performer gender 

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -420,8 +420,9 @@ input ConfigInterfaceInput {
   "When true, disables all customizations (plugins, CSS, JavaScript, locales) for troubleshooting"
   disableCustomizations: Boolean
 
-  "Default gender to apply when creating a performer without explicit gender"
-  defaultPerformerGender: GenderEnum
+  """Default gender to apply when creating a performer without explicit gender.
+  Send an empty string to clear the setting."""
+  defaultPerformerGender: String
 
   "Interface language"
   language: String

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -420,6 +420,9 @@ input ConfigInterfaceInput {
   "When true, disables all customizations (plugins, CSS, JavaScript, locales) for troubleshooting"
   disableCustomizations: Boolean
 
+  "Default gender to apply when creating a performer without explicit gender"
+  defaultPerformerGender: GenderEnum
+
   "Interface language"
   language: String
 
@@ -496,6 +499,9 @@ type ConfigInterfaceResult {
 
   "When true, disables all customizations (plugins, CSS, JavaScript, locales) for troubleshooting"
   disableCustomizations: Boolean
+
+  "Default gender to apply when creating a performer without explicit gender"
+  defaultPerformerGender: GenderEnum
 
   "Interface language"
   language: String

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -420,9 +420,10 @@ input ConfigInterfaceInput {
   "When true, disables all customizations (plugins, CSS, JavaScript, locales) for troubleshooting"
   disableCustomizations: Boolean
 
-  """Default gender to apply when creating a performer without explicit gender.
-  Send an empty string to clear the setting."""
-  defaultPerformerGender: String
+  "Default gender to apply when creating a performer without explicit gender"
+  defaultPerformerGender: GenderEnum
+  "Clear the stored default performer gender"
+  clearDefaultPerformerGender: Boolean
 
   "Interface language"
   language: String

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -528,6 +528,7 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 	r.setConfigBool(config.CustomLocalesEnabled, input.CustomLocalesEnabled)
 
 	r.setConfigBool(config.DisableCustomizations, input.DisableCustomizations)
+	r.setConfigString(config.DefaultPerformerGender, (*string)(input.DefaultPerformerGender))
 
 	if input.DisableDropdownCreate != nil {
 		ddc := input.DisableDropdownCreate

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -64,8 +64,8 @@ func (r *mutationResolver) setConfigString(key string, value *string) {
 
 // applyDefaultPerformerGenderInput updates or clears DefaultPerformerGender.
 // Omit both fields to leave the stored value unchanged.
-func (r *mutationResolver) applyDefaultPerformerGenderInput(value *models.GenderEnum, clear *bool) error {
-	if clear != nil && *clear {
+func (r *mutationResolver) applyDefaultPerformerGenderInput(value *models.GenderEnum, shouldClear *bool) error {
+	if shouldClear != nil && *shouldClear {
 		if value != nil {
 			return fmt.Errorf("cannot set and clear default performer gender in the same request")
 		}

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/internal/manager/config"
@@ -64,22 +63,22 @@ func (r *mutationResolver) setConfigString(key string, value *string) {
 }
 
 // applyDefaultPerformerGenderInput updates or clears DefaultPerformerGender.
-// Omit the field entirely (nil) to leave the stored value unchanged; send "" to clear it.
-func (r *mutationResolver) applyDefaultPerformerGenderInput(value *string) error {
+// Omit both fields to leave the stored value unchanged.
+func (r *mutationResolver) applyDefaultPerformerGenderInput(value *models.GenderEnum, clear *bool) error {
+	if clear != nil && *clear {
+		if value != nil {
+			return fmt.Errorf("cannot set and clear default performer gender in the same request")
+		}
+		config.GetInstance().SetString(config.DefaultPerformerGender, "")
+		return nil
+	}
 	if value == nil {
 		return nil
 	}
-	c := config.GetInstance()
-	s := strings.TrimSpace(*value)
-	if s == "" {
-		c.SetString(config.DefaultPerformerGender, "")
-		return nil
+	if !value.IsValid() {
+		return fmt.Errorf("invalid default performer gender %q", *value)
 	}
-	g := models.GenderEnum(s)
-	if !g.IsValid() {
-		return fmt.Errorf("invalid default performer gender %q", s)
-	}
-	c.SetString(config.DefaultPerformerGender, s)
+	config.GetInstance().SetString(config.DefaultPerformerGender, value.String())
 	return nil
 }
 
@@ -549,7 +548,7 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 	r.setConfigBool(config.CustomLocalesEnabled, input.CustomLocalesEnabled)
 
 	r.setConfigBool(config.DisableCustomizations, input.DisableCustomizations)
-	if err := r.applyDefaultPerformerGenderInput(input.DefaultPerformerGender); err != nil {
+	if err := r.applyDefaultPerformerGenderInput(input.DefaultPerformerGender, input.ClearDefaultPerformerGender); err != nil {
 		return makeConfigInterfaceResult(), err
 	}
 

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/stashapp/stash/internal/manager"
 	"github.com/stashapp/stash/internal/manager/config"
@@ -60,6 +61,26 @@ func (r *mutationResolver) setConfigString(key string, value *string) {
 	if value != nil {
 		c.SetString(key, *value)
 	}
+}
+
+// applyDefaultPerformerGenderInput updates or clears DefaultPerformerGender.
+// Omit the field entirely (nil) to leave the stored value unchanged; send "" to clear it.
+func (r *mutationResolver) applyDefaultPerformerGenderInput(value *string) error {
+	if value == nil {
+		return nil
+	}
+	c := config.GetInstance()
+	s := strings.TrimSpace(*value)
+	if s == "" {
+		c.SetString(config.DefaultPerformerGender, "")
+		return nil
+	}
+	g := models.GenderEnum(s)
+	if !g.IsValid() {
+		return fmt.Errorf("invalid default performer gender %q", s)
+	}
+	c.SetString(config.DefaultPerformerGender, s)
+	return nil
 }
 
 func (r *mutationResolver) setConfigBool(key string, value *bool) {
@@ -528,7 +549,9 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 	r.setConfigBool(config.CustomLocalesEnabled, input.CustomLocalesEnabled)
 
 	r.setConfigBool(config.DisableCustomizations, input.DisableCustomizations)
-	r.setConfigString(config.DefaultPerformerGender, (*string)(input.DefaultPerformerGender))
+	if err := r.applyDefaultPerformerGenderInput(input.DefaultPerformerGender); err != nil {
+		return makeConfigInterfaceResult(), err
+	}
 
 	if input.DisableDropdownCreate != nil {
 		ddc := input.DisableDropdownCreate

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/performer"
 	"github.com/stashapp/stash/pkg/plugin/hook"
@@ -20,6 +21,14 @@ const (
 	twitterURL   = "https://twitter.com"
 	instagramURL = "https://instagram.com"
 )
+
+func performerGenderOrDefault(gender *models.GenderEnum) *models.GenderEnum {
+	if gender != nil {
+		return gender
+	}
+
+	return config.GetInstance().GetDefaultPerformerGender()
+}
 
 // used to refetch performer after hooks run
 func (r *mutationResolver) getPerformer(ctx context.Context, id int) (ret *models.Performer, err error) {
@@ -44,7 +53,7 @@ func (r *mutationResolver) PerformerCreate(ctx context.Context, input models.Per
 	newPerformer.Name = strings.TrimSpace(input.Name)
 	newPerformer.Disambiguation = translator.string(input.Disambiguation)
 	newPerformer.Aliases = models.NewRelatedStrings(stringslice.UniqueExcludeFold(stringslice.TrimSpace(input.AliasList), newPerformer.Name))
-	newPerformer.Gender = input.Gender
+	newPerformer.Gender = performerGenderOrDefault(input.Gender)
 	newPerformer.Ethnicity = translator.string(input.Ethnicity)
 	newPerformer.Country = translator.string(input.Country)
 	newPerformer.EyeColor = translator.string(input.EyeColor)

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -162,6 +162,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 	customLocales := config.GetCustomLocales()
 	customLocalesEnabled := config.GetCustomLocalesEnabled()
 	disableCustomizations := config.GetDisableCustomizations()
+	defaultPerformerGender := config.GetDefaultPerformerGender()
 	language := config.GetLanguage()
 	handyKey := config.GetHandyKey()
 	scriptOffset := config.GetFunscriptOffset()
@@ -190,6 +191,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 		CustomLocales:                &customLocales,
 		CustomLocalesEnabled:         &customLocalesEnabled,
 		DisableCustomizations:        &disableCustomizations,
+		DefaultPerformerGender:       defaultPerformerGender,
 		Language:                     &language,
 
 		ImageLightbox: &imageLightboxOptions,

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -1313,8 +1313,14 @@ func (i *Config) GetShowStudioAsText() bool {
 }
 
 func (i *Config) GetDefaultPerformerGender() *models.GenderEnum {
-	g := models.GenderEnum(i.getString(DefaultPerformerGender))
+	s := i.getString(DefaultPerformerGender)
+	if s == "" {
+		return nil
+	}
+
+	g := models.GenderEnum(s)
 	if !g.IsValid() {
+		logger.Warnf("invalid default performer gender: %q", s)
 		return nil
 	}
 

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -206,6 +206,7 @@ const (
 	autostartVideoOnPlaySelectedDefault = true
 	ContinuePlaylistDefault             = "continue_playlist_default"
 	ShowStudioAsText                    = "show_studio_as_text"
+	DefaultPerformerGender              = "default_performer_gender"
 	CSSEnabled                          = "cssenabled"
 	JavascriptEnabled                   = "javascriptenabled"
 	CustomLocalesEnabled                = "customlocalesenabled"
@@ -1309,6 +1310,15 @@ func (i *Config) GetContinuePlaylistDefault() bool {
 
 func (i *Config) GetShowStudioAsText() bool {
 	return i.getBool(ShowStudioAsText)
+}
+
+func (i *Config) GetDefaultPerformerGender() *models.GenderEnum {
+	g := models.GenderEnum(i.getString(DefaultPerformerGender))
+	if !g.IsValid() {
+		return nil
+	}
+
+	return &g
 }
 
 func (i *Config) getSlideshowDelay() int {

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -98,6 +98,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   customLocales
   customLocalesEnabled
   disableCustomizations
+  defaultPerformerGender
   language
   imageLightbox {
     slideshowDelay

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -59,12 +59,12 @@ const isScraper = (
 ): scraper is GQL.Scraper => (scraper as GQL.Scraper).id !== undefined;
 
 function withScrapedPerformerDefaultGender<
-  T extends { gender?: GQL.GenderEnum | null }
+  T extends { gender?: string | null }
 >(scraped: T, defaultGender: GQL.GenderEnum | null | undefined): T {
   if (scraped.gender || !defaultGender) {
     return scraped;
   }
-  return { ...scraped, gender: defaultGender };
+  return { ...scraped, gender: defaultGender } as T;
 }
 
 interface IPerformerDetails {

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -97,6 +97,8 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
   const [scrapedPerformer, setScrapedPerformer] =
     useState<GQL.ScrapedPerformer>();
   const { configuration: stashConfig } = useConfigurationContext();
+  const defaultPerformerGender =
+    stashConfig?.interface.defaultPerformerGender ?? null;
 
   const intl = useIntl();
 
@@ -134,7 +136,7 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     name: performer.name ?? "",
     disambiguation: performer.disambiguation ?? "",
     alias_list: performer.alias_list ?? [],
-    gender: performer.gender ?? null,
+    gender: performer.gender ?? (isNew ? defaultPerformerGender : null),
     birthdate: performer.birthdate ?? "",
     death_date: performer.death_date ?? "",
     country: performer.country ?? "",
@@ -424,16 +426,23 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
       const result = await queryScrapePerformer(selectedScraper.id, ret);
       if (!result?.data?.scrapeSinglePerformer?.length) return;
+      const withDefaultGender = (
+        scrapedPerformerData: GQL.ScrapedPerformerDataFragment
+      ) =>
+        !scrapedPerformerData.gender && defaultPerformerGender
+          ? { ...scrapedPerformerData, gender: defaultPerformerGender }
+          : scrapedPerformerData;
+      const scrapedResult = withDefaultGender(
+        result.data.scrapeSinglePerformer[0]
+      );
 
       // assume one result
       // if this is a new performer, just dump the data
       if (isNew) {
-        updatePerformerEditStateFromScraper(
-          result.data.scrapeSinglePerformer[0]
-        );
+        updatePerformerEditStateFromScraper(scrapedResult);
         setScraper(undefined);
       } else {
-        setScrapedPerformer(result.data.scrapeSinglePerformer[0]);
+        setScrapedPerformer(scrapedResult);
       }
     } catch (e) {
       Toast.error(e);
@@ -451,11 +460,19 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         return;
       }
 
+      const scrapedResult =
+        !result.data.scrapePerformerURL.gender && defaultPerformerGender
+          ? {
+              ...result.data.scrapePerformerURL,
+              gender: defaultPerformerGender,
+            }
+          : result.data.scrapePerformerURL;
+
       // if this is a new performer, just dump the data
       if (isNew) {
-        updatePerformerEditStateFromScraper(result.data.scrapePerformerURL);
+        updatePerformerEditStateFromScraper(scrapedResult);
       } else {
-        setScrapedPerformer(result.data.scrapePerformerURL);
+        setScrapedPerformer(scrapedResult);
       }
     } catch (e) {
       Toast.error(e);

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -59,7 +59,7 @@ const isScraper = (
 ): scraper is GQL.Scraper => (scraper as GQL.Scraper).id !== undefined;
 
 function withScrapedPerformerDefaultGender<
-  T extends { gender?: GQL.GenderEnum | null },
+  T extends { gender?: GQL.GenderEnum | null }
 >(scraped: T, defaultGender: GQL.GenderEnum | null | undefined): T {
   if (scraped.gender || !defaultGender) {
     return scraped;

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -58,6 +58,15 @@ const isScraper = (
   scraper: GQL.Scraper | GQL.StashBox
 ): scraper is GQL.Scraper => (scraper as GQL.Scraper).id !== undefined;
 
+function withScrapedPerformerDefaultGender<
+  T extends { gender?: GQL.GenderEnum | null },
+>(scraped: T, defaultGender: GQL.GenderEnum | null | undefined): T {
+  if (scraped.gender || !defaultGender) {
+    return scraped;
+  }
+  return { ...scraped, gender: defaultGender };
+}
+
 interface IPerformerDetails {
   performer: Partial<GQL.PerformerDataFragment>;
   isVisible: boolean;
@@ -426,14 +435,9 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
       const result = await queryScrapePerformer(selectedScraper.id, ret);
       if (!result?.data?.scrapeSinglePerformer?.length) return;
-      const withDefaultGender = (
-        scrapedPerformerData: GQL.ScrapedPerformerDataFragment
-      ) =>
-        !scrapedPerformerData.gender && defaultPerformerGender
-          ? { ...scrapedPerformerData, gender: defaultPerformerGender }
-          : scrapedPerformerData;
-      const scrapedResult = withDefaultGender(
-        result.data.scrapeSinglePerformer[0]
+      const scrapedResult = withScrapedPerformerDefaultGender(
+        result.data.scrapeSinglePerformer[0],
+        defaultPerformerGender
       );
 
       // assume one result
@@ -460,13 +464,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
         return;
       }
 
-      const scrapedResult =
-        !result.data.scrapePerformerURL.gender && defaultPerformerGender
-          ? {
-              ...result.data.scrapePerformerURL,
-              gender: defaultPerformerGender,
-            }
-          : result.data.scrapePerformerURL;
+      const scrapedResult = withScrapedPerformerDefaultGender(
+        result.data.scrapePerformerURL,
+        defaultPerformerGender
+      );
 
       // if this is a new performer, just dump the data
       if (isNew) {

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -542,7 +542,7 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             {genderList.map((gender) => (
               <option key={gender} value={gender}>
                 {intl.formatMessage({
-                  id: `gender_types.${gender.toLowerCase()}`,
+                  id: `gender_types.${gender}`,
                 })}
               </option>
             ))}

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -43,7 +43,10 @@ import {
   defaultImageWallMargin,
 } from "src/utils/imageWall";
 import { genderList } from "src/utils/gender";
-import { defaultMaxOptionsShown, defaultPreviewVolume } from "src/core/config";
+import {
+  defaultMaxOptionsShown,
+  defaultPreviewVolume,
+} from "src/core/config";
 import { PatchComponent } from "src/patch";
 
 const allMenuItems = [

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -42,6 +42,7 @@ import {
   defaultImageWallDirection,
   defaultImageWallMargin,
 } from "src/utils/imageWall";
+import { genderList } from "src/utils/gender";
 import { defaultMaxOptionsShown, defaultPreviewVolume } from "src/core/config";
 import { PatchComponent } from "src/patch";
 
@@ -525,6 +526,27 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             checked={ui.showLinksOnPerformerCard ?? undefined}
             onChange={(v) => saveUI({ showLinksOnPerformerCard: v })}
           />
+          <SelectSetting
+            id="default-performer-gender"
+            headingID="config.ui.performer_list.options.default_gender.heading"
+            subHeadingID="config.ui.performer_list.options.default_gender.description"
+            value={iface.defaultPerformerGender ?? ""}
+            onChange={(v) =>
+              saveInterface({
+                defaultPerformerGender:
+                  v === "" ? null : (v as GQL.GenderEnum),
+              })
+            }
+          >
+            <option value="">{intl.formatMessage({ id: "none" })}</option>
+            {genderList.map((gender) => (
+              <option key={gender} value={gender}>
+                {intl.formatMessage({
+                  id: `gender_types.${gender.toLowerCase()}`,
+                })}
+              </option>
+            ))}
+          </SelectSetting>
         </SettingSection>
 
         <SettingSection headingID="config.ui.image_wall.heading">

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -531,11 +531,7 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             headingID="config.ui.performer_list.options.default_gender.heading"
             subHeadingID="config.ui.performer_list.options.default_gender.description"
             value={iface.defaultPerformerGender ?? ""}
-            onChange={(v) =>
-              saveInterface({
-                defaultPerformerGender: v === "" ? null : (v as GQL.GenderEnum),
-              })
-            }
+            onChange={(v) => saveInterface({ defaultPerformerGender: v })}
           >
             <option value="">{intl.formatMessage({ id: "none" })}</option>
             {genderList.map((gender) => (

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -152,6 +152,20 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
       });
     }
 
+    function saveDefaultPerformerGender(v: string) {
+      saveInterface(
+        v === ""
+          ? {
+              clearDefaultPerformerGender: true,
+              defaultPerformerGender: null,
+            }
+          : {
+              clearDefaultPerformerGender: false,
+              defaultPerformerGender: v as GQL.GenderEnum,
+            }
+      );
+    }
+
     function validateLocaleString(v: string) {
       if (!v) return;
       try {
@@ -531,7 +545,7 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             headingID="config.ui.performer_list.options.default_gender.heading"
             subHeadingID="config.ui.performer_list.options.default_gender.description"
             value={iface.defaultPerformerGender ?? ""}
-            onChange={(v) => saveInterface({ defaultPerformerGender: v })}
+            onChange={(v) => saveDefaultPerformerGender(v)}
           >
             <option value="">{intl.formatMessage({ id: "none" })}</option>
             {genderList.map((gender) => (

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -43,10 +43,7 @@ import {
   defaultImageWallMargin,
 } from "src/utils/imageWall";
 import { genderList } from "src/utils/gender";
-import {
-  defaultMaxOptionsShown,
-  defaultPreviewVolume,
-} from "src/core/config";
+import { defaultMaxOptionsShown, defaultPreviewVolume } from "src/core/config";
 import { PatchComponent } from "src/patch";
 
 const allMenuItems = [
@@ -536,8 +533,7 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             value={iface.defaultPerformerGender ?? ""}
             onChange={(v) =>
               saveInterface({
-                defaultPerformerGender:
-                  v === "" ? null : (v as GQL.GenderEnum),
+                defaultPerformerGender: v === "" ? null : (v as GQL.GenderEnum),
               })
             }
           >

--- a/ui/v2.5/src/docs/en/Manual/Configuration.md
+++ b/ui/v2.5/src/docs/en/Manual/Configuration.md
@@ -149,6 +149,12 @@ Some scrapers require a Chrome instance to function correctly. If left empty, st
 
 > **⚠️ Important:** As of Chrome 136 you need to specify `--user-data-dir` alongside `--remote-debugging-port`. Read more on their [official post](https://developer.chrome.com/blog/remote-debugging-port). 
 
+### Default Performer Gender 
+
+**Default performer gender** is edited under `Settings → Interface`
+
+When set, performers will be assumed to be of the identified gender when no gender is supplied by scraper or other means.  Also sets the gender in the create performer dialog to this gender by default.
+
 ## Authentication
 
 By default, stash is not configured with any sort of password protection. To enable password protection, both `Username` and `Password` must be populated. Note that when entering a new username and password where none was set previously, the system will immediately request these credentials to log you in.

--- a/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
+++ b/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
@@ -964,7 +964,7 @@ Weight
 
 > **⚠️ Important:** `Name` field is required. 
 
-> **⚠️ Note:** `Gender` must be one of `male`, `female`, `transgender_male`, `transgender_female`, `intersex`, `non_binary` (case insensitive).
+> **⚠️ Note:** `Gender` must be one of `male`, `female`, `transgender_male`, `transgender_female`, `intersex`, `non_binary` (case insensitive).  If gender is not set, gender will be observed by **default performer gender** (`Settings → Interface`) if set.
 
 ### Scene
 

--- a/ui/v2.5/src/docs/en/Manual/Scraping.md
+++ b/ui/v2.5/src/docs/en/Manual/Scraping.md
@@ -89,6 +89,10 @@ Click on the 🔍 button in the `edit` tab of an item. You will be presented wit
 
 Enter the URL in the `edit` tab of an Item. If a scraper is installed that supports that url, then a button will appear to scrape the metadata.
 
+### Performer scraping and default gender
+
+For **performers**, if the scraped result does not supply a **gender** but **default performer gender** (`Settings → Interface`) is configured, Stash fills that gender when applying the scrape in the performer. Any gender returned by the scrape is kept.
+
 ## Tagger view
 
 The Tagger view is accessed from the scenes page. It allows the user to run scrapers on all items on the current page. The Tagger presents the user with potential matches for an item from a selected stash-box instance or metadata source if supported. The user needs to select the correct metadata information to save. 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -894,6 +894,10 @@
       "performer_list": {
         "heading": "Performer List",
         "options": {
+          "default_gender": {
+            "description": "Sets the default gender for new performers when the scraper does not provide a gender.",
+            "heading": "Default performer gender"
+          },
           "show_links_on_grid_card": {
             "heading": "Display links on performer grid cards"
           }


### PR DESCRIPTION
Fixes #3751 
## Summary
- add a new interface setting `defaultPerformerGender` (None + all gender enum values)
- apply the setting as a fallback when creating performers without explicit gender
- preselect default gender in new performer form, and apply it to non-stash scraper results when scraper gender is missing
- keep explicit user/scraper gender precedence and avoid mutating existing performers
## Backend
- extend config GraphQL schema for interface input/result
- add config key/getter and wire configure/query plumbing
- apply fallback in performer create path
- add tests for explicit-vs-default precedence helper behavior
## UI
- add setting in Interface > Performer List
- reuse shared gender list source
- fix locale key usage so dropdown shows localized labels (not raw keys)
- add English locale strings and changelog entry

<img width="786" height="345" alt="image" src="https://github.com/user-attachments/assets/56e0f493-c6d7-4cf4-8a31-be3d85c0d144" />
