### PR TITLE
New: Allow Description and Alias on Tag Creation in Scene Tagger

### DIFF
--- a/pkg/stashbox/scene.go
+++ b/pkg/stashbox/scene.go
@@ -204,11 +204,7 @@ func (c Client) sceneFragmentToScrapedScene(ctx context.Context, s *graphql.Scen
 	}
 
 	for _, t := range s.Tags {
-		st := &models.ScrapedTag{
-			Name:         t.Name,
-			RemoteSiteID: &t.ID,
-		}
-		ss.Tags = append(ss.Tags, st)
+		ss.Tags = append(ss.Tags, tagFragmentToScrapedTag(*t))
 	}
 
 	return ss, nil

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -434,7 +434,11 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
     t: GQL.ScrapedTag,
     createInput?: GQL.TagCreateInput
   ) {
-    const toCreate: GQL.TagCreateInput = createInput ?? { name: t.name };
+    const toCreate: GQL.TagCreateInput = createInput ?? {
+      name: t.name,
+      description: t.description ?? undefined,
+      aliases: t.alias_list?.filter((a) => a) ?? undefined,
+    };
 
     // If the tag has a remote_site_id and we have an endpoint, include the stash_id
     const endpoint = currentSource?.sourceInput.stash_box_endpoint;


### PR DESCRIPTION
I thought this was fixed with my other Tags tagger changes... it was not. This will make it so that when users create a tag via the scenes tagger the description and alias comes with it. 

Sorry @smith113-p didn't realize that this got reopened 😅 

closes: https://github.com/stashapp/stash/issues/6585