### PR TITLE
[ci] add explicit flow for makefile, add make install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         cache-dependency-path: ui/v2.5/pnpm-lock.yaml
 
     - name: Install UI dependencies
-      run: cd ui/v2.5 && pnpm install --frozen-lockfile
+      run: make pre-ui
 
     - name: Generate
       run: make generate

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ ifdef IS_WIN_SHELL
   RM := del /s /q
   RMDIR := rmdir /s /q
   NOOP := @@
-	PREFIX := $(USERPROFILE)\\bin
+  PREFIX := $(USERPROFILE)\\bin
 else
   RM := rm -f
   RMDIR := rm -rf
   NOOP := @:
-	PREFIX := $(HOME)/.local
+  PREFIX := $(HOME)/.local
 endif
 
 # set LDFLAGS environment variable to any extra ldflags required

--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,10 @@ build-cc-all:
 touch-ui:
 ifdef IS_WIN_SHELL
 	@if not exist "ui\\v2.5\\build" mkdir ui\\v2.5\\build
+	@type nul >> ui/v2.5/build/index.html
 else
 	@mkdir -p ui/v2.5/build
+	@touch ui/v2.5/build/index.html
 endif
 
 # Regenerates GraphQL files

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ test:
 
 # runs all tests - including integration tests
 .PHONY: it
-it: generate
+it:
 	$(eval GO_BUILD_TAGS += integration)
 	go test -tags "$(GO_BUILD_TAGS)" ./...
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ ifdef IS_WIN_SHELL
   RM := del /s /q
   RMDIR := rmdir /s /q
   NOOP := @@
+	PREFIX := $(USERPROFILE)\\bin
 else
   RM := rm -f
   RMDIR := rm -rf
   NOOP := @:
+	PREFIX := $(HOME)/.local
 endif
 
 # set LDFLAGS environment variable to any extra ldflags required
@@ -39,9 +41,6 @@ GO_BUILD_FLAGS := $(GO_BUILD_FLAGS)
 # set GO_BUILD_TAGS environment variable to any extra build tags required
 GO_BUILD_TAGS := $(GO_BUILD_TAGS)
 GO_BUILD_TAGS += sqlite_stat4 sqlite_math_functions
-
-# set STASH_NOLEGACY environment variable or uncomment to disable legacy browser support
-# STASH_NOLEGACY := true
 
 # set STASH_SOURCEMAPS environment variable or uncomment to enable UI sourcemaps
 # STASH_SOURCEMAPS := true
@@ -271,10 +270,8 @@ build-cc-all:
 touch-ui:
 ifdef IS_WIN_SHELL
 	@if not exist "ui\\v2.5\\build" mkdir ui\\v2.5\\build
-	@type nul >> ui/v2.5/build/index.html
 else
 	@mkdir -p ui/v2.5/build
-	@touch ui/v2.5/build/index.html
 endif
 
 # Regenerates GraphQL files
@@ -282,7 +279,7 @@ endif
 generate: generate-backend generate-ui
 
 .PHONY: generate-ui
-generate-ui:
+generate-ui: pre-ui
 	cd ui/v2.5 && npm run gqlgen
 
 .PHONY: generate-backend
@@ -318,7 +315,7 @@ test:
 
 # runs all tests - including integration tests
 .PHONY: it
-it:
+it: generate
 	$(eval GO_BUILD_TAGS += integration)
 	go test -tags "$(GO_BUILD_TAGS)" ./...
 
@@ -365,18 +362,15 @@ ui-env: build-info
 	$(eval export VITE_APP_DATE := $(BUILD_DATE))
 	$(eval export VITE_APP_GITHASH := $(GITHASH))
 	$(eval export VITE_APP_STASH_VERSION := $(STASH_VERSION))
-ifdef STASH_NOLEGACY
-	$(eval export VITE_APP_NOLEGACY := true)
-endif
 ifdef STASH_SOURCEMAPS
 	$(eval export VITE_APP_SOURCEMAPS := true)
 endif
 
 .PHONY: ui
-ui: ui-only generate-login-locale
+ui: pre-ui generate ui-only generate-login-locale
 
 .PHONY: ui-only
-ui-only: ui-env
+ui-only: ui-env generate ui
 	cd ui/v2.5 && npm run build
 
 .PHONY: zip-ui
@@ -394,7 +388,7 @@ fmt-ui:
 
 # runs all of the frontend PR-acceptance steps
 .PHONY: validate-ui
-validate-ui:
+validate-ui: pre-ui generate
 	cd ui/v2.5 && npm run validate
 
 # these targets run the same steps as fmt-ui and validate-ui, but only on files that have changed
@@ -445,3 +439,13 @@ start-compiler-container:
 .PHONY: remove-compiler-container
 remove-compiler-container:
 	docker rm -f -v build
+
+.PHONY: install
+install: build-release
+ifdef IS_WIN_SHELL
+	@if not exist "$(PREFIX)" mkdir $(PREFIX)
+	@copy "dist\\stash-win.exe" "$(PREFIX)\\stash-win.exe"
+else
+	@mkdir -p $(PREFIX)/bin
+	@install -m 755 $(STASH_OUTPUT) $(PREFIX)/bin/stash
+endif


### PR DESCRIPTION
- replaces explicit run in build.yml with `make pre-ui`
- remove NOLEGACY (was removed in https://github.com/stashapp/stash/pull/6777)
- add make install to comply with homebrew
  - `C:\Users\$Username\bin\stash-win.exe` on windows (tested)
  - `~/.local/bin/stash` on linux (untested)

supercedes #5701
closes #5673
closes #5674
related: https://github.com/Homebrew/homebrew-core/pull/203821

will open up a PR once release hits so they're in the build artifacts