### PR TITLE
Expose and filter gallery o_counter (image o_counter sum)

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -576,6 +576,8 @@ input GalleryFilterType {
   performer_age: IntCriterionInput
   "Filter by number of images in this gallery"
   image_count: IntCriterionInput
+  "Filter by o-counter"
+  o_counter: IntCriterionInput
   "Filter by url"
   url: StringCriterionInput
   "Filter by date"

--- a/graphql/schema/types/gallery.graphql
+++ b/graphql/schema/types/gallery.graphql
@@ -26,6 +26,7 @@ type Gallery {
   scenes: [Scene!]!
   studio: Studio
   image_count: Int!
+  o_counter: Int # Resolver
   tags: [Tag!]!
   performers: [Performer!]!
 

--- a/internal/api/resolver_model_gallery.go
+++ b/internal/api/resolver_model_gallery.go
@@ -152,6 +152,18 @@ func (r *galleryResolver) ImageCount(ctx context.Context, obj *models.Gallery) (
 	return ret, nil
 }
 
+func (r *galleryResolver) OCounter(ctx context.Context, obj *models.Gallery) (ret *int, err error) {
+	var count int
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		count, err = r.repository.Image.OCountByGalleryID(ctx, obj.ID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return &count, nil
+}
+
 func (r *galleryResolver) Chapters(ctx context.Context, obj *models.Gallery) (ret []*models.GalleryChapter, err error) {
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 		ret, err = r.repository.GalleryChapter.FindByGalleryID(ctx, obj.ID)

--- a/pkg/models/gallery.go
+++ b/pkg/models/gallery.go
@@ -47,6 +47,8 @@ type GalleryFilterType struct {
 	PerformerAge *IntCriterionInput `json:"performer_age"`
 	// Filter by number of images in this gallery
 	ImageCount *IntCriterionInput `json:"image_count"`
+	// Filter by o-counter
+	OCounter *IntCriterionInput `json:"o_counter"`
 	// Filter by url
 	URL *StringCriterionInput `json:"url"`
 	// Filter by date

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -619,6 +619,34 @@ func (_m *ImageReaderWriter) OCount(ctx context.Context) (int, error) {
 	return r0, r1
 }
 
+// OCountByGalleryID provides a mock function with given fields: ctx, galleryID
+func (_m *ImageReaderWriter) OCountByGalleryID(ctx context.Context, galleryID int) (int, error) {
+	ret := _m.Called(ctx, galleryID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OCountByGalleryID")
+	}
+
+	var r0 int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int) (int, error)); ok {
+		return rf(ctx, galleryID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int) int); ok {
+		r0 = rf(ctx, galleryID)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, galleryID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // OCountByPerformerID provides a mock function with given fields: ctx, performerID
 func (_m *ImageReaderWriter) OCountByPerformerID(ctx context.Context, performerID int) (int, error) {
 	ret := _m.Called(ctx, performerID)

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -37,6 +37,7 @@ type ImageCounter interface {
 	CountByFileID(ctx context.Context, fileID FileID) (int, error)
 	CountByGalleryID(ctx context.Context, galleryID int) (int, error)
 	OCount(ctx context.Context) (int, error)
+	OCountByGalleryID(ctx context.Context, galleryID int) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
 	OCountByStudioID(ctx context.Context, studioID int) (int, error)
 }

--- a/pkg/sqlite/gallery_filter.go
+++ b/pkg/sqlite/gallery_filter.go
@@ -100,6 +100,7 @@ func (qb *galleryFilterHandler) criterionHandler() criterionHandler {
 		qb.performerTagsCriterionHandler(filter.PerformerTags),
 		qb.averageResolutionCriterionHandler(filter.AverageResolution),
 		qb.imageCountCriterionHandler(filter.ImageCount),
+		qb.galleryOCounterCriterionHandler(filter.OCounter),
 		qb.performerFavoriteCriterionHandler(filter.PerformerFavorite),
 		qb.performerAgeCriterionHandler(filter.PerformerAge),
 		&dateCriterionHandler{filter.Date, "galleries.date", nil},
@@ -184,6 +185,24 @@ func (qb *galleryFilterHandler) criterionHandler() criterionHandler {
 			// don't use a subquery; join directly
 			directJoin: true,
 		},
+	}
+}
+
+var selectGalleryOCountSQL = `SELECT COALESCE(SUM(images.o_counter), 0)
+FROM galleries_images
+LEFT JOIN images ON images.id = galleries_images.image_id
+WHERE galleries_images.gallery_id = galleries.id`
+
+func (qb *galleryFilterHandler) galleryOCounterCriterionHandler(count *models.IntCriterionInput) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if count == nil {
+			return
+		}
+
+		lhs := "(" + selectGalleryOCountSQL + ")"
+		clause, args := getIntCriterionWhereClause(lhs, *count)
+
+		f.addWhere(clause, args...)
 	}
 }
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -687,6 +687,19 @@ func (qb *ImageStore) CountByGalleryID(ctx context.Context, galleryID int) (int,
 	return count(ctx, q)
 }
 
+func (qb *ImageStore) OCountByGalleryID(ctx context.Context, galleryID int) (int, error) {
+	table := qb.table()
+	joinTable := galleriesImagesJoinTable
+	q := dialect.Select(goqu.COALESCE(goqu.SUM("o_counter"), 0)).From(table).InnerJoin(joinTable, goqu.On(table.Col(idColumn).Eq(joinTable.Col(imageIDColumn)))).Where(joinTable.Col(galleryIDColumn).Eq(galleryID))
+
+	var ret int
+	if err := querySimple(ctx, q, &ret); err != nil {
+		return 0, err
+	}
+
+	return ret, nil
+}
+
 func (qb *ImageStore) OCountByPerformerID(ctx context.Context, performerID int) (int, error) {
 	table := qb.table()
 	joinTable := performersImagesJoinTable

--- a/ui/v2.5/graphql/data/gallery-slim.graphql
+++ b/ui/v2.5/graphql/data/gallery-slim.graphql
@@ -8,6 +8,7 @@ fragment SlimGalleryData on Gallery {
   photographer
   rating100
   organized
+  o_counter
   files {
     ...GalleryFileData
   }

--- a/ui/v2.5/graphql/data/gallery.graphql
+++ b/ui/v2.5/graphql/data/gallery.graphql
@@ -10,6 +10,7 @@ fragment GalleryData on Gallery {
   photographer
   rating100
   organized
+  o_counter
 
   paths {
     cover

--- a/ui/v2.5/src/models/list-filter/galleries.ts
+++ b/ui/v2.5/src/models/list-filter/galleries.ts
@@ -69,6 +69,7 @@ const criterionOptions = [
   PerformerAgeCriterionOption,
   PerformerFavoriteCriterionOption,
   createMandatoryNumberCriterionOption("image_count"),
+  createMandatoryNumberCriterionOption("o_counter", "o_count"),
   // StudioTagsCriterionOption,
   ScenesCriterionOption,
   StudiosCriterionOption,


### PR DESCRIPTION
Adds support for summing up image `o_counter` values across a gallery and lets you filter galleries based on that total.
Related #2836 and #6088

## Description

- Added an `o_counter` field to the Gallery GraphQL type and updated the UI fragments so you can actually query `Gallery.o_counter`.
- Added `OCounter` to `GalleryFilterType` and wired up a filter handler (`galleryOCounterCriterionHandler`) that runs a SQL subquery to compute `SUM(images.o_counter)` per gallery, then applies integer criteria through the existing `getIntCriterionWhereClause`.
- Added `OCountByGalleryID` to `ImageStore`, which grabs `COALESCE(SUM(o_counter), 0)` for images tied to a gallery. Also updated the `ImageCounter` interface and hooked up the `galleryResolver.OCounter` resolver to call it.
- Updated the image reader/writer mocks to include `OCountByGalleryID`, and exposed `o_counter` as a filterable option in the UI list filters.