### PR TITLE
Add gallery sorting by performer age

### DIFF
--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -860,10 +860,12 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 	case "performer_count":
 		query.sortAndPagination += getCountSort(galleryTable, performersGalleriesTable, galleryIDColumn, direction)
 	case "performer_age":
-		// Looking at the youngest performer by default.
+		// Multi-performer semantics:
+		// - ASC sorts by the youngest performer in each gallery (MIN age)
+		// - DESC sorts by the oldest performer in each gallery (MAX age)
 		aggregation := "MIN"
 		if direction == "DESC" {
-			// When sorting by performer age DESC, consider oldest performer instead.
+			// DESC uses oldest performer age for each gallery.
 			aggregation = "MAX"
 		}
 		fallback := "-9223372036854775808"

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -866,10 +866,13 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 			// When sorting by performer age DESC, consider oldest performer instead.
 			aggregation = "MAX"
 		}
-		fallback := "NULL"
+		fallback := "-9223372036854775808"
 		if direction == "ASC" {
 			// ASC puts NULL first by default, so coalesce to sqlite max int.
 			fallback = "9223372036854775807"
+		} else {
+			// DESC puts larger values first; coalesce NULL to sqlite min int to keep NULLs last.
+			fallback = "-9223372036854775808"
 		}
 		query.sortAndPagination += fmt.Sprintf(
 			" ORDER BY (SELECT COALESCE(%s(JulianDay(galleries.date) - JulianDay(performers.birthdate)), %s) FROM %s as performers INNER JOIN %s AS aggregation WHERE performers.id = aggregation.%s AND aggregation.%s = %s.id) %s",

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -797,6 +797,7 @@ var gallerySortOptions = sortOptions{
 	"id",
 	"images_count",
 	"path",
+	"performer_age",
 	"performer_count",
 	"random",
 	"rating",
@@ -858,6 +859,29 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 		query.sortAndPagination += getCountSort(galleryTable, galleriesTagsTable, galleryIDColumn, direction)
 	case "performer_count":
 		query.sortAndPagination += getCountSort(galleryTable, performersGalleriesTable, galleryIDColumn, direction)
+	case "performer_age":
+		// Looking at the youngest performer by default.
+		aggregation := "MIN"
+		if direction == "DESC" {
+			// When sorting by performer age DESC, consider oldest performer instead.
+			aggregation = "MAX"
+		}
+		fallback := "NULL"
+		if direction == "ASC" {
+			// ASC puts NULL first by default, so coalesce to sqlite max int.
+			fallback = "9223372036854775807"
+		}
+		query.sortAndPagination += fmt.Sprintf(
+			" ORDER BY (SELECT COALESCE(%s(JulianDay(galleries.date) - JulianDay(performers.birthdate)), %s) FROM %s as performers INNER JOIN %s AS aggregation WHERE performers.id = aggregation.%s AND aggregation.%s = %s.id) %s",
+			aggregation,
+			fallback,
+			performerTable,
+			performersGalleriesTable,
+			performerIDColumn,
+			galleryIDColumn,
+			galleryTable,
+			getSortDirection(direction),
+		)
 	case "path":
 		// special handling for path
 		addFileTable()

--- a/pkg/sqlite/gallery.go
+++ b/pkg/sqlite/gallery.go
@@ -868,7 +868,7 @@ func (qb *GalleryStore) setGallerySort(query *queryBuilder, findFilter *models.F
 			// DESC uses oldest performer age for each gallery.
 			aggregation = "MAX"
 		}
-		fallback := "-9223372036854775808"
+		var fallback string
 		if direction == "ASC" {
 			// ASC puts NULL first by default, so coalesce to sqlite max int.
 			fallback = "9223372036854775807"

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2825,6 +2825,20 @@ func TestGalleryQuerySorting(t *testing.T) {
 			-1,
 			-1,
 		},
+		{
+			"performer age asc",
+			"performer_age",
+			models.SortDirectionEnumAsc,
+			-1,
+			-1,
+		},
+		{
+			"performer age desc",
+			"performer_age",
+			models.SortDirectionEnumDesc,
+			-1,
+			-1,
+		},
 	}
 
 	qb := db.Gallery

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2876,6 +2876,90 @@ func TestGalleryQuerySorting(t *testing.T) {
 	}
 }
 
+func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
+	runWithRollbackTxn(t, "performer age null handling", func(t *testing.T, ctx context.Context) {
+		assert := assert.New(t)
+
+		knownBirthdate, err := models.ParseDate("1990-01-01")
+		require.NoError(t, err)
+
+		knownPerformer := models.Performer{
+			Name:      "performer-known-birthdate",
+			Birthdate: &knownBirthdate,
+		}
+		require.NoError(t, db.Performer.Create(ctx, &models.CreatePerformerInput{Performer: &knownPerformer}))
+
+		unknownPerformer := models.Performer{
+			Name: "performer-unknown-birthdate",
+		}
+		require.NoError(t, db.Performer.Create(ctx, &models.CreatePerformerInput{Performer: &unknownPerformer}))
+
+		knownOnlyGallery := models.Gallery{
+			Title: "gallery-known-only",
+			Date:  models.NewString("2020-01-01"),
+			PerformerIDs: models.NewRelatedIDs([]int{
+				knownPerformer.ID,
+			}),
+		}
+		require.NoError(t, db.Gallery.Create(ctx, &models.CreateGalleryInput{Gallery: &knownOnlyGallery}))
+
+		mixedGallery := models.Gallery{
+			Title: "gallery-known-and-unknown",
+			Date:  models.NewString("2020-01-01"),
+			PerformerIDs: models.NewRelatedIDs([]int{
+				knownPerformer.ID,
+				unknownPerformer.ID,
+			}),
+		}
+		require.NoError(t, db.Gallery.Create(ctx, &models.CreateGalleryInput{Gallery: &mixedGallery}))
+
+		unknownOnlyGallery := models.Gallery{
+			Title: "gallery-unknown-only",
+			Date:  models.NewString("2020-01-01"),
+			PerformerIDs: models.NewRelatedIDs([]int{
+				unknownPerformer.ID,
+			}),
+		}
+		require.NoError(t, db.Gallery.Create(ctx, &models.CreateGalleryInput{Gallery: &unknownOnlyGallery}))
+
+		findIndex := func(galleries []*models.Gallery, id int) int {
+			for i, g := range galleries {
+				if g.ID == id {
+					return i
+				}
+			}
+			return -1
+		}
+
+		asc := models.SortDirectionEnumAsc
+		sortBy := "performer_age"
+		ascGot, _, err := db.Gallery.Query(ctx, nil, &models.FindFilterType{Sort: &sortBy, Direction: &asc})
+		require.NoError(t, err)
+
+		ascKnownOnly := findIndex(ascGot, knownOnlyGallery.ID)
+		ascMixed := findIndex(ascGot, mixedGallery.ID)
+		ascUnknownOnly := findIndex(ascGot, unknownOnlyGallery.ID)
+		assert.NotEqual(-1, ascKnownOnly)
+		assert.NotEqual(-1, ascMixed)
+		assert.NotEqual(-1, ascUnknownOnly)
+		assert.Less(ascKnownOnly, ascUnknownOnly)
+		assert.Less(ascMixed, ascUnknownOnly)
+
+		desc := models.SortDirectionEnumDesc
+		descGot, _, err := db.Gallery.Query(ctx, nil, &models.FindFilterType{Sort: &sortBy, Direction: &desc})
+		require.NoError(t, err)
+
+		descKnownOnly := findIndex(descGot, knownOnlyGallery.ID)
+		descMixed := findIndex(descGot, mixedGallery.ID)
+		descUnknownOnly := findIndex(descGot, unknownOnlyGallery.ID)
+		assert.NotEqual(-1, descKnownOnly)
+		assert.NotEqual(-1, descMixed)
+		assert.NotEqual(-1, descUnknownOnly)
+		assert.Less(descKnownOnly, descUnknownOnly)
+		assert.Less(descMixed, descUnknownOnly)
+	})
+}
+
 func TestGalleryStore_AddImages(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -2960,6 +2960,75 @@ func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
 	})
 }
 
+func TestGalleryQuerySortingPerformerAgeMultiPerformerAggregation(t *testing.T) {
+	runWithRollbackTxn(t, "performer age multi performer aggregation", func(t *testing.T, ctx context.Context) {
+		assert := assert.New(t)
+
+		youngBirthdate, err := models.ParseDate("2000-01-01")
+		require.NoError(t, err)
+		midBirthdate, err := models.ParseDate("1990-01-01")
+		require.NoError(t, err)
+		oldBirthdate, err := models.ParseDate("1980-01-01")
+		require.NoError(t, err)
+
+		young := models.Performer{Name: "performer-young", Birthdate: &youngBirthdate}
+		mid := models.Performer{Name: "performer-mid", Birthdate: &midBirthdate}
+		old := models.Performer{Name: "performer-old", Birthdate: &oldBirthdate}
+		require.NoError(t, db.Performer.Create(ctx, &models.CreatePerformerInput{Performer: &young}))
+		require.NoError(t, db.Performer.Create(ctx, &models.CreatePerformerInput{Performer: &mid}))
+		require.NoError(t, db.Performer.Create(ctx, &models.CreatePerformerInput{Performer: &old}))
+
+		galleryYoungAndOld := models.Gallery{
+			Title: "gallery-young-and-old",
+			Date:  models.NewString("2020-01-01"),
+			PerformerIDs: models.NewRelatedIDs([]int{
+				young.ID,
+				old.ID,
+			}),
+		}
+		require.NoError(t, db.Gallery.Create(ctx, &models.CreateGalleryInput{Gallery: &galleryYoungAndOld}))
+
+		galleryMidOnly := models.Gallery{
+			Title: "gallery-mid-only",
+			Date:  models.NewString("2020-01-01"),
+			PerformerIDs: models.NewRelatedIDs([]int{
+				mid.ID,
+			}),
+		}
+		require.NoError(t, db.Gallery.Create(ctx, &models.CreateGalleryInput{Gallery: &galleryMidOnly}))
+
+		findIndex := func(galleries []*models.Gallery, id int) int {
+			for i, g := range galleries {
+				if g.ID == id {
+					return i
+				}
+			}
+			return -1
+		}
+
+		sortBy := "performer_age"
+		asc := models.SortDirectionEnumAsc
+		ascGot, _, err := db.Gallery.Query(ctx, nil, &models.FindFilterType{Sort: &sortBy, Direction: &asc})
+		require.NoError(t, err)
+		ascYoungAndOld := findIndex(ascGot, galleryYoungAndOld.ID)
+		ascMidOnly := findIndex(ascGot, galleryMidOnly.ID)
+		assert.NotEqual(-1, ascYoungAndOld)
+		assert.NotEqual(-1, ascMidOnly)
+		// ASC uses MIN(age), so gallery with youngest performer should come first.
+		assert.Less(ascYoungAndOld, ascMidOnly)
+
+		desc := models.SortDirectionEnumDesc
+		descGot, _, err := db.Gallery.Query(ctx, nil, &models.FindFilterType{Sort: &sortBy, Direction: &desc})
+		require.NoError(t, err)
+		descYoungAndOld := findIndex(descGot, galleryYoungAndOld.ID)
+		descMidOnly := findIndex(descGot, galleryMidOnly.ID)
+		assert.NotEqual(-1, descYoungAndOld)
+		assert.NotEqual(-1, descMidOnly)
+		// DESC uses MAX(age), so gallery with oldest performer should come first.
+		assert.Less(descYoungAndOld, descMidOnly)
+	})
+}
+
 func TestGalleryStore_AddImages(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var invalidID = -1
@@ -2882,6 +2883,8 @@ func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
 
 		knownBirthdate, err := models.ParseDate("1990-01-01")
 		require.NoError(t, err)
+		galleryDate, err := models.ParseDate("2020-01-01")
+		require.NoError(t, err)
 
 		knownPerformer := models.Performer{
 			Name:      "performer-known-birthdate",
@@ -2896,7 +2899,7 @@ func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
 
 		knownOnlyGallery := models.Gallery{
 			Title: "gallery-known-only",
-			Date:  models.NewString("2020-01-01"),
+			Date:  &galleryDate,
 			PerformerIDs: models.NewRelatedIDs([]int{
 				knownPerformer.ID,
 			}),
@@ -2905,7 +2908,7 @@ func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
 
 		mixedGallery := models.Gallery{
 			Title: "gallery-known-and-unknown",
-			Date:  models.NewString("2020-01-01"),
+			Date:  &galleryDate,
 			PerformerIDs: models.NewRelatedIDs([]int{
 				knownPerformer.ID,
 				unknownPerformer.ID,
@@ -2915,7 +2918,7 @@ func TestGalleryQuerySortingPerformerAgeNullHandling(t *testing.T) {
 
 		unknownOnlyGallery := models.Gallery{
 			Title: "gallery-unknown-only",
-			Date:  models.NewString("2020-01-01"),
+			Date:  &galleryDate,
 			PerformerIDs: models.NewRelatedIDs([]int{
 				unknownPerformer.ID,
 			}),
@@ -2970,6 +2973,8 @@ func TestGalleryQuerySortingPerformerAgeMultiPerformerAggregation(t *testing.T) 
 		require.NoError(t, err)
 		oldBirthdate, err := models.ParseDate("1980-01-01")
 		require.NoError(t, err)
+		galleryDate, err := models.ParseDate("2020-01-01")
+		require.NoError(t, err)
 
 		young := models.Performer{Name: "performer-young", Birthdate: &youngBirthdate}
 		mid := models.Performer{Name: "performer-mid", Birthdate: &midBirthdate}
@@ -2980,7 +2985,7 @@ func TestGalleryQuerySortingPerformerAgeMultiPerformerAggregation(t *testing.T) 
 
 		galleryYoungAndOld := models.Gallery{
 			Title: "gallery-young-and-old",
-			Date:  models.NewString("2020-01-01"),
+			Date:  &galleryDate,
 			PerformerIDs: models.NewRelatedIDs([]int{
 				young.ID,
 				old.ID,
@@ -2990,7 +2995,7 @@ func TestGalleryQuerySortingPerformerAgeMultiPerformerAggregation(t *testing.T) 
 
 		galleryMidOnly := models.Gallery{
 			Title: "gallery-mid-only",
-			Date:  models.NewString("2020-01-01"),
+			Date:  &galleryDate,
 			PerformerIDs: models.NewRelatedIDs([]int{
 				mid.ID,
 			}),

--- a/ui/v2.5/src/models/list-filter/galleries.ts
+++ b/ui/v2.5/src/models/list-filter/galleries.ts
@@ -30,6 +30,10 @@ const sortByOptions = ["date", ...MediaSortByOptions]
   .map(ListFilterOptions.createSortBy)
   .concat([
     {
+      messageID: "performer_age",
+      value: "performer_age",
+    },
+    {
       messageID: "image_count",
       value: "images_count",
     },


### PR DESCRIPTION
Provides the ability to sort galleries by performer age so users can find galleries based on the youngest or oldest performers associated with a gallery. Related #2956 and #5788 

### Description

- Add `performer_age` to `gallerySortOptions` and implement sorting logic in `setGallerySort` that uses a subquery to compute performer age with `MIN`/`MAX` aggregation and `COALESCE` fallbacks based on sort direction. 
- Add test cases for `performer_age` ascending and descending to `TestGalleryQuerySorting` in `gallery_test.go`.
- Expose the sort option in the frontend by adding the `performer_age` entry to `sortByOptions` and creating `PerformerAgeCriterionOption` in `ui/v2.5/src/models/list-filter/galleries.ts`.

### Testing

- Ran the targeted backend unit test `go test ./pkg/sqlite -run TestGalleryQuerySorting` which includes the new `performer_age` cases and it passed. 
- Ran the full backend test suite `go test ./...` and it completed successfully.
