### PR TITLE
feat(api): add scene_filter parameter to findDuplicateScenes

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -51,6 +51,7 @@ type Query {
     Fractional seconds are ok: 0.5 will mean only files that have durations within 0.5 seconds between them will be matched based on PHash distance.
     """
     duration_diff: Float
+    scene_filter: SceneFilterType
   ): [[Scene!]!]!
 
   "Return valid stream paths"

--- a/internal/api/resolver_query_find_scene.go
+++ b/internal/api/resolver_query_find_scene.go
@@ -227,7 +227,7 @@ func (r *queryResolver) ParseSceneFilenames(ctx context.Context, filter *models.
 	return ret, nil
 }
 
-func (r *queryResolver) FindDuplicateScenes(ctx context.Context, distance *int, durationDiff *float64) (ret [][]*models.Scene, err error) {
+func (r *queryResolver) FindDuplicateScenes(ctx context.Context, distance *int, durationDiff *float64, sceneFilter *models.SceneFilterType) (ret [][]*models.Scene, err error) {
 	dist := 0
 	durDiff := -1.
 	if distance != nil {
@@ -237,7 +237,7 @@ func (r *queryResolver) FindDuplicateScenes(ctx context.Context, distance *int, 
 		durDiff = *durationDiff
 	}
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		ret, err = r.repository.Scene.FindDuplicates(ctx, dist, durDiff)
+		ret, err = r.repository.Scene.FindDuplicates(ctx, dist, durDiff, sceneFilter)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/models/mocks/SceneReaderWriter.go
+++ b/pkg/models/mocks/SceneReaderWriter.go
@@ -664,13 +664,13 @@ func (_m *SceneReaderWriter) FindByPrimaryFileID(ctx context.Context, fileID mod
 	return r0, r1
 }
 
-// FindDuplicates provides a mock function with given fields: ctx, distance, durationDiff
-func (_m *SceneReaderWriter) FindDuplicates(ctx context.Context, distance int, durationDiff float64) ([][]*models.Scene, error) {
-	ret := _m.Called(ctx, distance, durationDiff)
+// FindDuplicates provides a mock function with given fields: ctx, distance, durationDiff, filter
+func (_m *SceneReaderWriter) FindDuplicates(ctx context.Context, distance int, durationDiff float64, filter *models.SceneFilterType) ([][]*models.Scene, error) {
+	ret := _m.Called(ctx, distance, durationDiff, filter)
 
 	var r0 [][]*models.Scene
-	if rf, ok := ret.Get(0).(func(context.Context, int, float64) [][]*models.Scene); ok {
-		r0 = rf(ctx, distance, durationDiff)
+	if rf, ok := ret.Get(0).(func(context.Context, int, float64, *models.SceneFilterType) [][]*models.Scene); ok {
+		r0 = rf(ctx, distance, durationDiff, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([][]*models.Scene)
@@ -678,8 +678,8 @@ func (_m *SceneReaderWriter) FindDuplicates(ctx context.Context, distance int, d
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int, float64) error); ok {
-		r1 = rf(ctx, distance, durationDiff)
+	if rf, ok := ret.Get(1).(func(context.Context, int, float64, *models.SceneFilterType) error); ok {
+		r1 = rf(ctx, distance, durationDiff, filter)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/models/repository_scene.go
+++ b/pkg/models/repository_scene.go
@@ -27,7 +27,7 @@ type SceneFinder interface {
 	FindByPerformerID(ctx context.Context, performerID int) ([]*Scene, error)
 	FindByGalleryID(ctx context.Context, performerID int) ([]*Scene, error)
 	FindByGroupID(ctx context.Context, groupID int) ([]*Scene, error)
-	FindDuplicates(ctx context.Context, distance int, durationDiff float64) ([][]*Scene, error)
+	FindDuplicates(ctx context.Context, distance int, durationDiff float64, filter *SceneFilterType) ([][]*Scene, error)
 }
 
 // SceneQueryer provides methods to query scenes.

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1430,11 +1430,58 @@ func (qb *SceneStore) GetStashIDs(ctx context.Context, sceneID int) ([]models.St
 	return sceneRepository.stashIDs.get(ctx, sceneID)
 }
 
-func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, durationDiff float64) ([][]*models.Scene, error) {
+func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, durationDiff float64, filter *models.SceneFilterType) ([][]*models.Scene, error) {
 	var dupeIds [][]int
+
+	query, err := qb.makeQuery(ctx, filter, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add necessary joins for duplicate checking
+	query.addJoins(
+		join{
+			table:    scenesFilesTable,
+			onClause: "scenes.id = scenes_files.scene_id",
+		},
+		join{
+			table:    fileTable,
+			onClause: "scenes_files.file_id = files.id",
+		},
+		join{
+			table:    fingerprintTable,
+			onClause: "scenes_files.file_id = files_fingerprints.file_id AND files_fingerprints.type = 'phash'",
+		},
+		join{
+			table:    videoFileTable,
+			onClause: "files.id = video_files.file_id",
+		},
+	)
+
 	if distance == 0 {
+		query.columns = []string{
+			"scenes.id as scene_id",
+			"video_files.duration as file_duration",
+			"files.size as file_size",
+			"files_fingerprints.fingerprint as phash",
+			"abs(max(video_files.duration) OVER (PARTITION by files_fingerprints.fingerprint) - video_files.duration) as durationDiff",
+		}
+		
+		sqlStr := query.toSQL(false)
+		
+		finalQuery := `
+SELECT GROUP_CONCAT(DISTINCT scene_id) as ids
+FROM (` + sqlStr + `)
+WHERE durationDiff <= ?
+    OR ? < 0
+GROUP BY phash
+HAVING COUNT(phash) > 1
+	AND COUNT(DISTINCT scene_id) > 1
+ORDER BY SUM(file_size) DESC;
+`
 		var ids []string
-		if err := dbWrapper.Select(ctx, &ids, findExactDuplicateQuery, durationDiff); err != nil {
+		args := append(query.allArgs(), durationDiff, durationDiff)
+		if err := dbWrapper.Select(ctx, &ids, finalQuery, args...); err != nil {
 			return nil, err
 		}
 
@@ -1452,9 +1499,18 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, duration
 			}
 		}
 	} else {
+		query.columns = []string{
+			"scenes.id as id",
+			"files_fingerprints.fingerprint as phash",
+			"video_files.duration as duration",
+		}
+		query.sortAndPagination = " ORDER BY files.size DESC"
+
+		sqlStr := query.toSQL(true)
+
 		var hashes []*utils.Phash
 
-		if err := sceneRepository.queryFunc(ctx, findAllPhashesQuery, nil, false, func(rows *sqlx.Rows) error {
+		if err := sceneRepository.queryFunc(ctx, sqlStr, query.allArgs(), false, func(rows *sqlx.Rows) error {
 			phash := utils.Phash{
 				Bucket:   -1,
 				Duration: -1,

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1439,7 +1439,8 @@ SELECT GROUP_CONCAT(DISTINCT scene_id) as ids
 FROM (` + sqlStr + `)
 WHERE phash IS NOT NULL
     AND (durationDiff <= ?
-    OR ? < 0)
+    OR ? < 0)  -- Always TRUE if the parameter is negative.
+               -- That will disable the durationDiff checking.
 GROUP BY phash
 HAVING COUNT(phash) > 1
 	AND COUNT(DISTINCT scene_id) > 1

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1471,6 +1471,7 @@ ORDER BY SUM(file_size) DESC;
 			"files_fingerprints.fingerprint as phash",
 			"video_files.duration as duration",
 		}
+		query.addWhere("files_fingerprints.fingerprint IS NOT NULL")
 		query.sortAndPagination = " ORDER BY files.size DESC"
 
 		sqlStr := query.toSQL(true)

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -41,41 +41,6 @@ const (
 	sceneCoverBlobColumn = "cover_blob"
 )
 
-var findExactDuplicateQuery = `
-SELECT GROUP_CONCAT(DISTINCT scene_id) as ids
-FROM (
-	SELECT scenes.id as scene_id
-		, video_files.duration as file_duration
-		, files.size as file_size
-		, files_fingerprints.fingerprint as phash
-		, abs(max(video_files.duration) OVER (PARTITION by files_fingerprints.fingerprint) - video_files.duration) as durationDiff
-	FROM scenes
-	INNER JOIN scenes_files ON (scenes.id = scenes_files.scene_id)
-	INNER JOIN files ON (scenes_files.file_id = files.id)
-	INNER JOIN files_fingerprints ON (scenes_files.file_id = files_fingerprints.file_id AND files_fingerprints.type = 'phash')
-	INNER JOIN video_files ON (files.id == video_files.file_id)
-)
-WHERE durationDiff <= ?1
-    OR ?1 < 0   --  Always TRUE if the parameter is negative.
-                --  That will disable the durationDiff checking.
-GROUP BY phash
-HAVING COUNT(phash) > 1
-	AND COUNT(DISTINCT scene_id) > 1
-ORDER BY SUM(file_size) DESC;
-`
-
-var findAllPhashesQuery = `
-SELECT scenes.id as id
-    , files_fingerprints.fingerprint as phash
-    , video_files.duration as duration
-FROM scenes
-INNER JOIN scenes_files ON (scenes.id = scenes_files.scene_id)
-INNER JOIN files ON (scenes_files.file_id = files.id)
-INNER JOIN files_fingerprints ON (scenes_files.file_id = files_fingerprints.file_id AND files_fingerprints.type = 'phash')
-INNER JOIN video_files ON (files.id == video_files.file_id)
-ORDER BY files.size DESC;
-`
-
 type sceneRow struct {
 	ID            int         `db:"id" goqu:"skipinsert"`
 	Title         zero.String `db:"title"`

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1466,9 +1466,9 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, duration
 			"files_fingerprints.fingerprint as phash",
 			"abs(max(video_files.duration) OVER (PARTITION by files_fingerprints.fingerprint) - video_files.duration) as durationDiff",
 		}
-		
+
 		sqlStr := query.toSQL(false)
-		
+
 		finalQuery := `
 SELECT GROUP_CONCAT(DISTINCT scene_id) as ids
 FROM (` + sqlStr + `)

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1437,13 +1437,15 @@ func (qb *SceneStore) FindDuplicates(ctx context.Context, distance int, duration
 		finalQuery := `
 SELECT GROUP_CONCAT(DISTINCT scene_id) as ids
 FROM (` + sqlStr + `)
-WHERE durationDiff <= ?
-    OR ? < 0
+WHERE phash IS NOT NULL
+    AND (durationDiff <= ?
+    OR ? < 0)
 GROUP BY phash
 HAVING COUNT(phash) > 1
 	AND COUNT(DISTINCT scene_id) > 1
 ORDER BY SUM(file_size) DESC;
 `
+
 		var ids []string
 		args := append(query.allArgs(), durationDiff, durationDiff)
 		if err := dbWrapper.Select(ctx, &ids, finalQuery, args...); err != nil {

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -4631,7 +4631,7 @@ func TestSceneStore_FindDuplicates(t *testing.T) {
 	withRollbackTxn(func(ctx context.Context) error {
 		distance := 0
 		durationDiff := -1.
-		got, err := qb.FindDuplicates(ctx, distance, durationDiff)
+		got, err := qb.FindDuplicates(ctx, distance, durationDiff, nil)
 		if err != nil {
 			t.Errorf("SceneStore.FindDuplicates() error = %v", err)
 			return nil
@@ -4641,7 +4641,7 @@ func TestSceneStore_FindDuplicates(t *testing.T) {
 
 		distance = 1
 		durationDiff = -1.
-		got, err = qb.FindDuplicates(ctx, distance, durationDiff)
+		got, err = qb.FindDuplicates(ctx, distance, durationDiff, nil)
 		if err != nil {
 			t.Errorf("SceneStore.FindDuplicates() error = %v", err)
 			return nil

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -4653,6 +4653,214 @@ func TestSceneStore_FindDuplicates(t *testing.T) {
 	})
 }
 
+func TestSceneStore_FindDuplicatesWithFilter(t *testing.T) {
+	qb := db.Scene
+
+	// Helper to create a scene with a specific phash and optional title prefix
+	createDupeScene := func(ctx context.Context, name string, phash int64) (*models.Scene, error) {
+		sceneFile := &models.VideoFile{
+			BaseFile: &models.BaseFile{
+				Basename:       name,
+				ParentFolderID: folderIDs[folderIdxWithSceneFiles],
+				Fingerprints: models.Fingerprints{
+					{Type: models.FingerprintTypeMD5, Fingerprint: name + "_md5"},
+					{Type: models.FingerprintTypeOshash, Fingerprint: name + "_oshash"},
+					{Type: models.FingerprintTypePhash, Fingerprint: phash},
+				},
+			},
+			Duration: 100.0,
+			Width:    1920,
+			Height:   1080,
+		}
+
+		if err := db.File.Create(ctx, sceneFile); err != nil {
+			return nil, err
+		}
+
+		scene := &models.Scene{
+			Title: name,
+		}
+
+		if err := qb.Create(ctx, scene, []models.FileID{sceneFile.ID}); err != nil {
+			return nil, err
+		}
+
+		return scene, nil
+	}
+
+	// Helper to add tags to a scene
+	addSceneTags := func(ctx context.Context, sceneID int, tagIDsToAdd []int) error {
+		_, err := qb.UpdatePartial(ctx, sceneID, models.ScenePartial{
+			TagIDs: &models.UpdateIDs{
+				Mode: models.RelationshipUpdateModeSet,
+				IDs:  tagIDsToAdd,
+			},
+		})
+		return err
+	}
+
+	withRollbackTxn(func(ctx context.Context) error {
+		// Create a test tag to use for filtering
+		err := db.Tag.Create(ctx, &models.CreateTagInput{
+			Tag: &models.Tag{
+				Name: "FindDuplicatesFilterTestTag",
+			},
+		})
+		if err != nil {
+			t.Errorf("failed to create test tag: %v", err)
+			return nil
+		}
+
+		// fetch the tag we just created
+		tagName := "FindDuplicatesFilterTestTag"
+		tags, _, err := db.Tag.Query(ctx, &models.TagFilterType{
+			Name: &models.StringCriterionInput{
+				Value:    tagName,
+				Modifier: models.CriterionModifierEquals,
+			},
+		}, &models.FindFilterType{
+			PerPage: intPtr(1),
+		})
+		if err != nil || len(tags) == 0 {
+			t.Errorf("failed to find test tag: %v", err)
+			return nil
+		}
+		testTagID := tags[0].ID
+
+		// Create two pairs of duplicate scenes:
+		// Pair A: sceneA1 and sceneA2 have the same phash and share a tag
+		// Pair B: sceneB1 and sceneB2 have the same phash but no tag
+
+		const sharedPhash int64 = 999999
+
+		sceneA1, err := createDupeScene(ctx, "FilterTest_A1", sharedPhash)
+		if err != nil {
+			t.Errorf("failed to create sceneA1: %v", err)
+			return nil
+		}
+		sceneA2, err := createDupeScene(ctx, "FilterTest_A2", sharedPhash)
+		if err != nil {
+			t.Errorf("failed to create sceneA2: %v", err)
+			return nil
+		}
+
+		const otherPhash int64 = 888888
+
+		sceneB1, err := createDupeScene(ctx, "FilterTest_B1", otherPhash)
+		if err != nil {
+			t.Errorf("failed to create sceneB1: %v", err)
+			return nil
+		}
+		sceneB2, err := createDupeScene(ctx, "FilterTest_B2", otherPhash)
+		if err != nil {
+			t.Errorf("failed to create sceneB2: %v", err)
+			return nil
+		}
+
+		// Add tag only to pair A
+		if err := addSceneTags(ctx, sceneA1.ID, []int{testTagID}); err != nil {
+			t.Errorf("failed to add tag to sceneA1: %v", err)
+			return nil
+		}
+		if err := addSceneTags(ctx, sceneA2.ID, []int{testTagID}); err != nil {
+			t.Errorf("failed to add tag to sceneA2: %v", err)
+			return nil
+		}
+
+		// Test 1: No filter - should find all duplicates (2 pairs: original + our new ones)
+		distance := 0
+		durationDiff := -1.0
+		got, err := qb.FindDuplicates(ctx, distance, durationDiff, nil)
+		if err != nil {
+			t.Errorf("FindDuplicates(nil filter) error = %v", err)
+			return nil
+		}
+		// Should find at least our 2 new pairs (may find more from pre-populated data)
+		assert.GreaterOrEqual(t, len(got), 2, "nil filter should find at least our 2 new duplicate pairs")
+
+		// Test 2: Filter by tag - should only find pair A (the tagged pair)
+		got, err = qb.FindDuplicates(ctx, distance, durationDiff, &models.SceneFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(testTagID)},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		})
+		if err != nil {
+			t.Errorf("FindDuplicates(tag filter) error = %v", err)
+			return nil
+		}
+		// Should find exactly 1 duplicate pair (pair A)
+		assert.Len(t, got, 1, "tag filter should find exactly 1 duplicate pair")
+
+		// Verify the found pair contains our tagged scenes
+		if len(got) == 1 {
+			foundIDs := map[int]bool{}
+			for _, s := range got[0] {
+				foundIDs[s.ID] = true
+			}
+			assert.True(t, foundIDs[sceneA1.ID], "pair A scene 1 should be in results")
+			assert.True(t, foundIDs[sceneA2.ID], "pair A scene 2 should be in results")
+			// Pair B (untagged) should NOT be in the results
+			assert.False(t, foundIDs[sceneB1.ID], "pair B scene 1 should NOT be in tag-filtered results")
+			assert.False(t, foundIDs[sceneB2.ID], "pair B scene 2 should NOT be in tag-filtered results")
+		}
+
+		// Test 3: Filter by tag that no duplicate scene has - should find nothing
+		err = db.Tag.Create(ctx, &models.CreateTagInput{
+			Tag: &models.Tag{
+				Name: "FindDuplicatesFilterTestTag_NonExistent",
+			},
+		})
+		if err != nil {
+			t.Errorf("failed to create non-existent tag: %v", err)
+			return nil
+		}
+		nonExistentTagName := "FindDuplicatesFilterTestTag_NonExistent"
+		tags2, _, err := db.Tag.Query(ctx, &models.TagFilterType{
+			Name: &models.StringCriterionInput{
+				Value:    nonExistentTagName,
+				Modifier: models.CriterionModifierEquals,
+			},
+		}, &models.FindFilterType{
+			PerPage: intPtr(1),
+		})
+		if err != nil || len(tags2) == 0 {
+			t.Errorf("failed to find non-existent tag: %v", err)
+			return nil
+		}
+		nonExistentTagID := tags2[0].ID
+
+		got, err = qb.FindDuplicates(ctx, distance, durationDiff, &models.SceneFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(nonExistentTagID)},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		})
+		if err != nil {
+			t.Errorf("FindDuplicates(non-existent tag filter) error = %v", err)
+			return nil
+		}
+		assert.Len(t, got, 0, "non-existent tag filter should find no duplicates")
+
+		// Test 4: Fuzzy match (distance=1) with filter
+		distance = 1
+		got, err = qb.FindDuplicates(ctx, distance, durationDiff, &models.SceneFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(testTagID)},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		})
+		if err != nil {
+			t.Errorf("FindDuplicates(fuzzy + tag filter) error = %v", err)
+			return nil
+		}
+		// Should still find pair A with fuzzy matching
+		assert.Len(t, got, 1, "fuzzy + tag filter should find exactly 1 duplicate pair")
+
+		return nil
+	})
+}
+
 func TestSceneStore_AssignFiles(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -600,6 +600,10 @@ func indexesToIDPtrs[T any](ids []T, indexes []int) []*T {
 	return ret
 }
 
+func intPtr(i int) *int {
+	return &i
+}
+
 func indexToIDPtr[T any](ids []T, idx int) *T {
 	if idx < 0 {
 		return nil


### PR DESCRIPTION
## Description

~~Closes~~ Related to #3573 (WithoutPants edit: does not include UI changes)

Adds `scene_filter` parameter support to the `findDuplicateScenes` query, allowing users to exclude specific scenes from duplicate checking results.

For example, a user can now filter out scenes by path, tag, or any other supported scene filter criteria. This means scenes they intentionally want to keep (e.g. deepfakes, alternate versions) will no longer appear as unwanted noise in the duplicate checker.

## Changes

- **Schema**: Added optional `scene_filter` argument to `findDuplicateScenes`
- **Backend**: Updated `SceneReaderWriter` interface and mock to accept a `SceneFilterType`
- **API**: Passes the scene filter from the resolver down to the duplicate checking repository
- **SQLite**: `FindDuplicates` query is now dynamically built based on the provided filter
- **Tests**: Updated SQLite-level duplicate checking tests to cover filtered queries

> **Note**: This PR implements the backend and GraphQL API only. 
> Frontend integration (adding filter UI to the duplicate checker) is not included.