### PR TITLE
Align release Dockerfiles with Go 1.25 for backend builds.

### DIFF
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -18,7 +18,7 @@ ARG STASH_VERSION
 RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui-only
 
 # Build Backend
-FROM golang:1.24.3-alpine AS backend
+FROM golang:1.25.9-alpine AS backend
 RUN apk add --no-cache make alpine-sdk
 WORKDIR /stash
 COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -19,7 +19,7 @@ ARG STASH_VERSION
 RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui-only
 
 # Build Backend
-FROM golang:1.24.3-bullseye AS backend
+FROM golang:1.25.9-bullseye AS backend
 RUN apt update && apt install -y build-essential golang
 WORKDIR /stash
 COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/


### PR DESCRIPTION
The x86_64 and CUDA backend stages still used golang:1.24.3 while go.mod requires Go 1.25, which broke make docker-build under GOTOOLCHAIN=local. Bump both images to golang:1.25.9 to match docker/compiler/Dockerfile and PR #6869.

Verified with: make docker-build

Fixes #6888 