### PR TITLE
Fix Performer Popover Placement in Scene Scrape Results

### DIFF
--- a/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
+++ b/ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx
@@ -273,6 +273,7 @@ export const ScrapedPerformersRow: React.FC<
         }}
         values={selectValue}
         ageFromDate={ageFromDate}
+        hoverPlacementLabel="bottom"
       />
     );
   }


### PR DESCRIPTION

## Summary

Addresses cutoff performer pop-over in scraper UI where the performer card extended to the top of the page and was largely cutoff.
<img width="364" height="323" alt="image" src="https://github.com/user-attachments/assets/d5d836fd-0cf6-46e4-9d9f-f79b7870eec0" />


## Why

In Scene Tagger scrape results, performer hover cards were appearing above chips in a way that clipped content in most layouts.  
This change gives the performer chips in this specific flow an explicit bottom placement request to improve readability and reduce visual overlap.

## Files Changed

- `ui/v2.5/src/components/Shared/ScrapeDialog/ScrapedObjectsRow.tsx`
  - Add `hoverPlacementLabel="bottom"` to `PerformerSelect` in `ScrapedPerformersRow`.
  
<img width="359" height="689" alt="image" src="https://github.com/user-attachments/assets/56a73917-fde9-4682-9c6a-0ea9a3f9c597" />


## Risk / Notes

- Very low risk: one prop added in one usage site.
- No API/schema/data changes.
- No backend changes.

Closes #6886 