### PR TITLE
simplify makefile

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
 
       # generate-backend runs natively (just go generate + touch-ui) — no Docker needed
       - name: Generate Backend
-        run: make generate-backend
+        run: make touch-ui generate-backend
 
       ## WARN
       ## using v1, update in a later PR

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ build: stash
 
 # builds dynamically-linked PIE release binaries
 .PHONY: build-release
-build-release: generate-backend flags-release flags-pie build
+build-release: generate-backend-release flags-release flags-pie build
 
 # compile and bundle into Stash.app
 # for when on macOS itself
@@ -295,8 +295,11 @@ generate-ui: pre-ui
 .PHONY: generate-backend
 generate-backend: $(BACKEND_GENERATE_SENTINEL)
 
-$(BACKEND_GENERATE_SENTINEL) &: $(UI_SENTINEL)
+$(BACKEND_GENERATE_SENTINEL) &:
 	go generate ./cmd/stash
+
+.PHONY: generate-backend-release
+generate-backend-release: $(UI_SENTINEL) generate-backend
 
 .PHONY: generate-login-locale
 generate-login-locale:

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,16 @@ ifdef IS_WIN_SHELL
   RM := del /s /q
   RMDIR := rmdir /s /q
   NOOP := @@
-  PREFIX := $(USERPROFILE)\\bin
+  DEFAULT_PREFIX  := $(USERPROFILE)\\bin
 else
   RM := rm -f
   RMDIR := rm -rf
   NOOP := @:
-  PREFIX := $(HOME)/.local
+  DEFAULT_PREFIX  := $(HOME)/.local
 endif
+
+# PREFIX from homebrew
+PREFIX ?= $(DEFAULT_PREFIX)
 
 # set LDFLAGS environment variable to any extra ldflags required
 LDFLAGS := $(LDFLAGS)
@@ -46,6 +49,11 @@ GO_BUILD_TAGS += sqlite_stat4 sqlite_math_functions
 # STASH_SOURCEMAPS := true
 
 export CGO_ENABLED := 1
+
+# sentinel prerequisite files
+# can be used as a dependency to enforce parallel builds
+UI_SENTINEL := ui/v2.5/build/index.html
+BACKEND_GENERATE_SENTINEL := internal/api/generated_exec.go internal/api/generated_models.go
 
 # define COMPILER_IMAGE for cross-compilation docker container
 ifndef COMPILER_IMAGE
@@ -119,7 +127,7 @@ build-flags: build-info
 	$(eval BUILD_FLAGS := -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(BUILD_LDFLAGS)")
 
 .PHONY: stash
-stash: build-flags
+stash: $(BACKEND_GENERATE_SENTINEL) build-flags
 	go build $(STASH_OUTPUT) $(BUILD_FLAGS) ./cmd/stash
 
 .PHONY: phasher
@@ -132,7 +140,7 @@ build: stash
 
 # builds dynamically-linked PIE release binaries
 .PHONY: build-release
-build-release: flags-release flags-pie build
+build-release: generate-backend flags-release flags-pie build
 
 # compile and bundle into Stash.app
 # for when on macOS itself
@@ -282,10 +290,12 @@ generate: generate-backend generate-ui
 
 .PHONY: generate-ui
 generate-ui: pre-ui
-	cd ui/v2.5 && npm run gqlgen
+	cd ui/v2.5 && pnpm run gqlgen
 
 .PHONY: generate-backend
-generate-backend: touch-ui
+generate-backend: $(BACKEND_GENERATE_SENTINEL)
+
+$(BACKEND_GENERATE_SENTINEL) &: $(UI_SENTINEL)
 	go generate ./cmd/stash
 
 .PHONY: generate-login-locale
@@ -369,11 +379,13 @@ ifdef STASH_SOURCEMAPS
 endif
 
 .PHONY: ui
-ui: pre-ui generate ui-only generate-login-locale
+ui: $(UI_SENTINEL) generate-login-locale
 
 .PHONY: ui-only
-ui-only: ui-env generate ui
-	cd ui/v2.5 && npm run build
+ui-only: $(UI_SENTINEL)
+
+$(UI_SENTINEL): pre-ui generate-ui ui-env
+	cd ui/v2.5 && pnpm run build
 
 .PHONY: zip-ui
 zip-ui:
@@ -382,23 +394,23 @@ zip-ui:
 
 .PHONY: ui-start
 ui-start: ui-env
-	cd ui/v2.5 && npm run start -- --host
+	cd ui/v2.5 && pnpm run start -- --host
 
 .PHONY: fmt-ui
 fmt-ui:
-	cd ui/v2.5 && npm run format
+	cd ui/v2.5 && pnpm run format
 
 # runs all of the frontend PR-acceptance steps
 .PHONY: validate-ui
 validate-ui: pre-ui generate
-	cd ui/v2.5 && npm run validate
+	cd ui/v2.5 && pnpm run validate
 
 # these targets run the same steps as fmt-ui and validate-ui, but only on files that have changed
 fmt-ui-quick:
 	cd ui/v2.5 && \
 	files=$$(git diff --name-only --relative --diff-filter d . ../../graphql); \
 	if [ -n "$$files" ]; then \
-	  npm run prettier -- --write $$files; \
+	  pnpm run prettier -- --write $$files; \
 	fi
 
 # does not run tsc checks, as they are slow
@@ -407,9 +419,9 @@ validate-ui-quick:
 	tsfiles=$$(git diff --name-only --relative --diff-filter d src | grep -e "\.tsx\?\$$"); \
 	scssfiles=$$(git diff --name-only --relative --diff-filter d src | grep "\.scss"); \
 	prettyfiles=$$(git diff --name-only --relative --diff-filter d . ../../graphql); \
-	if [ -n "$$tsfiles" ]; then npm run eslint -- $$tsfiles; fi && \
-	if [ -n "$$scssfiles" ]; then npm run stylelint -- $$scssfiles; fi && \
-	if [ -n "$$prettyfiles" ]; then npm run prettier -- --check $$prettyfiles; fi
+	if [ -n "$$tsfiles" ]; then pnpm run eslint -- $$tsfiles; fi && \
+	if [ -n "$$scssfiles" ]; then pnpm run stylelint -- $$scssfiles; fi && \
+	if [ -n "$$prettyfiles" ]; then pnpm run prettier -- --check $$prettyfiles; fi
 
 # runs all of the backend PR-acceptance steps
 .PHONY: validate-backend
@@ -443,11 +455,11 @@ remove-compiler-container:
 	docker rm -f -v build
 
 .PHONY: install
-install: build-release
+install:
 ifdef IS_WIN_SHELL
 	@if not exist "$(PREFIX)" mkdir $(PREFIX)
 	@copy "dist\\stash-win.exe" "$(PREFIX)\\stash-win.exe"
 else
 	@mkdir -p $(PREFIX)/bin
-	@install -m 755 $(STASH_OUTPUT) $(PREFIX)/bin/stash
+	@install -m 755 stash $(PREFIX)/bin/stash
 endif


### PR DESCRIPTION
struggled tremendously to get this working properly with homebrew

notable changes
- added "dependency files" instead of trying to chain together ui/generate
  - this drops touch-ui as a hard dependency and will build properly instead
- replace `npm run` with `pnpm run`
- drop build-release from install, use static name

fixes #6877 