### PR TITLE
Stop pagination footer blocking clicks on elements horizontal to it

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1065,6 +1065,8 @@ ul.selectable-list {
 }
 
 .pagination-footer-container {
+  width: fit-content;
+  margin: auto;
   background-color: transparent;
   bottom: $navbar-height;
   position: sticky;

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1065,11 +1065,11 @@ ul.selectable-list {
 }
 
 .pagination-footer-container {
-  width: fit-content;
-  margin: auto;
   background-color: transparent;
   bottom: $navbar-height;
+  margin: auto;
   position: sticky;
+  width: fit-content;
   z-index: 10;
 
   @include media-breakpoint-up(sm) {


### PR DESCRIPTION
When using the Tagger to update scenes the Save button is often under the `.pagination-footer-container` which blocks the click from propagating as it spans the whole page width. I have added `width: fit-content` so it is only as wide as the `.pagination-footer` and `margin: auto` to center it horizontally.