### PR TITLE
Add 'aliases' filter to Group (GraphQL, backend, tests, and UI)

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -423,6 +423,8 @@ input GroupFilterType {
   NOT: GroupFilterType
 
   name: StringCriterionInput
+  "Filter by aliases"
+  aliases: StringCriterionInput
   director: StringCriterionInput
   synopsis: StringCriterionInput
 

--- a/pkg/models/group.go
+++ b/pkg/models/group.go
@@ -3,6 +3,7 @@ package models
 type GroupFilterType struct {
 	OperatorFilter[GroupFilterType]
 	Name     *StringCriterionInput `json:"name"`
+	Aliases  *StringCriterionInput `json:"aliases"`
 	Director *StringCriterionInput `json:"director"`
 	Synopsis *StringCriterionInput `json:"synopsis"`
 	// Filter by duration (in seconds)

--- a/pkg/sqlite/group_filter.go
+++ b/pkg/sqlite/group_filter.go
@@ -64,6 +64,7 @@ func (qb *groupFilterHandler) criterionHandler() criterionHandler {
 	groupFilter := qb.groupFilter
 	return compoundHandler{
 		stringCriterionHandler(groupFilter.Name, "groups.name"),
+		stringCriterionHandler(groupFilter.Aliases, "groups.aliases"),
 		stringCriterionHandler(groupFilter.Director, "groups.director"),
 		stringCriterionHandler(groupFilter.Synopsis, "groups.description"),
 		intCriterionHandler(groupFilter.Rating100, "groups.rating", nil),

--- a/pkg/sqlite/group_test.go
+++ b/pkg/sqlite/group_test.go
@@ -885,6 +885,52 @@ func TestGroupQueryURL(t *testing.T) {
 	verifyGroupQuery(t, filter, verifyFn)
 }
 
+func TestGroupQueryAliases(t *testing.T) {
+	const groupIdx = 1
+	groupAliases := getGroupStringValue(groupIdx, aliasesField)
+
+	aliasesCriterion := models.StringCriterionInput{
+		Value:    groupAliases,
+		Modifier: models.CriterionModifierEquals,
+	}
+
+	filter := models.GroupFilterType{
+		Aliases: &aliasesCriterion,
+	}
+
+	verifyFn := func(n *models.Group) {
+		t.Helper()
+		verifyString(t, n.Aliases, aliasesCriterion)
+	}
+
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierNotEquals
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierIncludes
+	aliasesCriterion.Value = "oup_1_alia"
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierExcludes
+	aliasesCriterion.Value = "not-present-alias-substring"
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierMatchesRegex
+	aliasesCriterion.Value = "group_.*1_aliases"
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierNotMatchesRegex
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierIsNull
+	aliasesCriterion.Value = ""
+	verifyGroupQuery(t, filter, verifyFn)
+
+	aliasesCriterion.Modifier = models.CriterionModifierNotNull
+	verifyGroupQuery(t, filter, verifyFn)
+}
+
 func TestGroupQueryURLExcludes(t *testing.T) {
 	withRollbackTxn(func(ctx context.Context) error {
 		mqb := db.Group

--- a/pkg/sqlite/group_test.go
+++ b/pkg/sqlite/group_test.go
@@ -915,7 +915,7 @@ func TestGroupQueryAliases(t *testing.T) {
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierIncludes
-	aliasesCriterion.Value = "oup_0001_A"
+	aliasesCriterion.Value = "0001_Ali"
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierExcludes

--- a/pkg/sqlite/group_test.go
+++ b/pkg/sqlite/group_test.go
@@ -915,7 +915,7 @@ func TestGroupQueryAliases(t *testing.T) {
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierIncludes
-	aliasesCriterion.Value = "oup_1_alia"
+	aliasesCriterion.Value = "oup_0001_A"
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierExcludes
@@ -923,7 +923,7 @@ func TestGroupQueryAliases(t *testing.T) {
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierMatchesRegex
-	aliasesCriterion.Value = "group_.*1_aliases"
+	aliasesCriterion.Value = "group_.*1_Aliases"
 	verifyGroupQuery(t, filter, verifyFn)
 
 	aliasesCriterion.Modifier = models.CriterionModifierNotMatchesRegex

--- a/pkg/sqlite/group_test.go
+++ b/pkg/sqlite/group_test.go
@@ -328,6 +328,7 @@ func emptyGroup(idx int) models.Group {
 	return models.Group{
 		ID:               groupIDs[idx],
 		Name:             groupNames[idx],
+		Aliases:          "",
 		TagIDs:           models.NewRelatedIDs([]int{}),
 		ContainingGroups: models.NewRelatedGroupDescriptions([]models.GroupIDDescription{}),
 		SubGroups:        models.NewRelatedGroupDescriptions([]models.GroupIDDescription{}),
@@ -452,8 +453,9 @@ func Test_groupQueryBuilder_UpdatePartial(t *testing.T) {
 				},
 			},
 			models.Group{
-				ID:   groupIDs[groupIdxWithParent],
-				Name: groupNames[groupIdxWithParent],
+				ID:      groupIDs[groupIdxWithParent],
+				Name:    groupNames[groupIdxWithParent],
+				Aliases: getGroupEmptyString(groupIdxWithParent, "Aliases"),
 				ContainingGroups: models.NewRelatedGroupDescriptions([]models.GroupIDDescription{
 					{GroupID: groupIDs[groupIdxWithChild]},
 					{GroupID: groupIDs[groupIdxWithScene], Description: containingGroupDescription},
@@ -473,8 +475,9 @@ func Test_groupQueryBuilder_UpdatePartial(t *testing.T) {
 				},
 			},
 			models.Group{
-				ID:   groupIDs[groupIdxWithChild],
-				Name: groupNames[groupIdxWithChild],
+				ID:      groupIDs[groupIdxWithChild],
+				Name:    groupNames[groupIdxWithChild],
+				Aliases: getGroupEmptyString(groupIdxWithChild, "Aliases"),
 				SubGroups: models.NewRelatedGroupDescriptions([]models.GroupIDDescription{
 					{GroupID: groupIDs[groupIdxWithParent]},
 					{GroupID: groupIDs[groupIdxWithScene], Description: subGroupDescription},
@@ -496,6 +499,7 @@ func Test_groupQueryBuilder_UpdatePartial(t *testing.T) {
 			models.Group{
 				ID:               groupIDs[groupIdxWithParent],
 				Name:             groupNames[groupIdxWithParent],
+				Aliases:          getGroupEmptyString(groupIdxWithParent, "Aliases"),
 				ContainingGroups: models.NewRelatedGroupDescriptions([]models.GroupIDDescription{}),
 			},
 			false,
@@ -514,6 +518,7 @@ func Test_groupQueryBuilder_UpdatePartial(t *testing.T) {
 			models.Group{
 				ID:        groupIDs[groupIdxWithChild],
 				Name:      groupNames[groupIdxWithChild],
+				Aliases:   getGroupEmptyString(groupIdxWithChild, "Aliases"),
 				SubGroups: models.NewRelatedGroupDescriptions([]models.GroupIDDescription{}),
 			},
 			false,

--- a/pkg/sqlite/group_test.go
+++ b/pkg/sqlite/group_test.go
@@ -887,6 +887,7 @@ func TestGroupQueryURL(t *testing.T) {
 
 func TestGroupQueryAliases(t *testing.T) {
 	const groupIdx = 1
+	const aliasesField = "Aliases"
 	groupAliases := getGroupStringValue(groupIdx, aliasesField)
 
 	aliasesCriterion := models.StringCriterionInput{

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2787,6 +2787,10 @@ func verifyString(t *testing.T, value string, criterion models.StringCriterionIn
 		assert.Equal(criterion.Value, value)
 	case models.CriterionModifierNotEquals:
 		assert.NotEqual(criterion.Value, value)
+	case models.CriterionModifierIncludes:
+		assert.Contains(value, criterion.Value)
+	case models.CriterionModifierExcludes:
+		assert.NotContains(value, criterion.Value)
 	case models.CriterionModifierMatchesRegex:
 		assert.Regexp(regexp.MustCompile(criterion.Value), value)
 	case models.CriterionModifierNotMatchesRegex:

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1527,9 +1527,10 @@ func createGroups(ctx context.Context, mqb models.GroupReaderWriter, n int, o in
 		// groups [ i ] and [ n + o - i - 1  ] should have similar names with only the Name!=NaMe part different
 
 		name = getGroupStringValue(index, name)
+		aliases := getGroupEmptyString(i, "Aliases")
 		group := models.Group{
 			Name:    name,
-			Aliases: getGroupStringValue(i, "Aliases"),
+			Aliases: aliases,
 			URLs: models.NewRelatedStrings([]string{
 				getGroupEmptyString(i, urlField),
 			}),

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1528,7 +1528,8 @@ func createGroups(ctx context.Context, mqb models.GroupReaderWriter, n int, o in
 
 		name = getGroupStringValue(index, name)
 		group := models.Group{
-			Name: name,
+			Name:    name,
+			Aliases: getGroupStringValue(i, "Aliases"),
 			URLs: models.NewRelatedStrings([]string{
 				getGroupEmptyString(i, urlField),
 			}),

--- a/ui/v2.5/src/models/list-filter/groups.ts
+++ b/ui/v2.5/src/models/list-filter/groups.ts
@@ -50,6 +50,7 @@ const criterionOptions = [
   GroupIsMissingCriterionOption,
   createStringCriterionOption("url"),
   createStringCriterionOption("name"),
+  createStringCriterionOption("aliases"),
   createStringCriterionOption("director"),
   createStringCriterionOption("synopsis"),
   createDurationCriterionOption("duration"),


### PR DESCRIPTION
Closes #4383

### Motivation
- Enable filtering groups by their aliases end-to-end so users can query and list groups by alias values. 
- Expose the new filter in the GraphQL schema and support it in the SQLite query builder. 
- Surface the option in the UI list filter so users can create alias-based criteria.

### Description
- Added `aliases: StringCriterionInput` to the GraphQL `GroupFilterType` in `filters.graphql`.
- Added `Aliases *StringCriterionInput` to the Go `models.GroupFilterType` and wired a `stringCriterionHandler` for `groups.aliases` in the SQLite group filter handler.
- Added unit test `TestGroupQueryAliases` in `pkg/sqlite/group_test.go` to validate alias filtering with multiple criterion modifiers.
- Exposed `aliases` in the UI list filter options by adding `createStringCriterionOption("aliases")` in `ui/v2.5/src/models/list-filter/groups.ts`.