### PR TITLE
feat(studio): add child_ids support to Studio API and UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,15 +97,7 @@ jobs:
         go-version-file: 'go.mod'
 
     # Places generated Go files + UI build into the working tree so the build compiles
-    - name: Download generated artifacts (attempt 1)
-      uses: actions/download-artifact@v8
-      id: download-generated-test-1
-      continue-on-error: true
-      with:
-        name: generated
-
-    - name: Download generated artifacts (attempt 2)
-      if: steps.download-generated-test-1.outcome == 'failure'
+    - name: Download generated artifacts
       uses: actions/download-artifact@v8
       with:
         name: generated
@@ -168,15 +160,7 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Download generated artifacts (attempt 1)
-      uses: actions/download-artifact@v8
-      id: download-generated-build-1
-      continue-on-error: true
-      with:
-        name: generated
-
-    - name: Download generated artifacts (attempt 2)
-      if: steps.download-generated-build-1.outcome == 'failure'
+    - name: Download generated artifacts
       uses: actions/download-artifact@v8
       with:
         name: generated
@@ -224,15 +208,7 @@ jobs:
         fetch-tags: true
 
     # Downloads all artifacts (generated + 7 platform builds) into artifacts/ subdirectories
-    - name: Download all build artifacts (attempt 1)
-      uses: actions/download-artifact@v8
-      id: download-all-release-1
-      continue-on-error: true
-      with:
-        path: artifacts
-
-    - name: Download all build artifacts (attempt 2)
-      if: steps.download-all-release-1.outcome == 'failure'
+    - name: Download all build artifacts
       uses: actions/download-artifact@v8
       with:
         path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,15 @@ jobs:
         go-version-file: 'go.mod'
 
     # Places generated Go files + UI build into the working tree so the build compiles
-    - name: Download generated artifacts
+    - name: Download generated artifacts (attempt 1)
+      uses: actions/download-artifact@v8
+      id: download-generated-test-1
+      continue-on-error: true
+      with:
+        name: generated
+
+    - name: Download generated artifacts (attempt 2)
+      if: steps.download-generated-test-1.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: generated
@@ -160,7 +168,15 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Download generated artifacts
+    - name: Download generated artifacts (attempt 1)
+      uses: actions/download-artifact@v8
+      id: download-generated-build-1
+      continue-on-error: true
+      with:
+        name: generated
+
+    - name: Download generated artifacts (attempt 2)
+      if: steps.download-generated-build-1.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         name: generated
@@ -208,7 +224,15 @@ jobs:
         fetch-tags: true
 
     # Downloads all artifacts (generated + 7 platform builds) into artifacts/ subdirectories
-    - name: Download all build artifacts
+    - name: Download all build artifacts (attempt 1)
+      uses: actions/download-artifact@v8
+      id: download-all-release-1
+      continue-on-error: true
+      with:
+        path: artifacts
+
+    - name: Download all build artifacts (attempt 2)
+      if: steps.download-all-release-1.outcome == 'failure'
       uses: actions/download-artifact@v8
       with:
         path: artifacts

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -36,6 +36,7 @@ input StudioCreateInput {
   url: String @deprecated(reason: "Use urls")
   urls: [String!]
   parent_id: ID
+  child_ids: [ID!]
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]
@@ -58,6 +59,7 @@ input StudioUpdateInput {
   url: String @deprecated(reason: "Use urls")
   urls: [String!]
   parent_id: ID
+  child_ids: [ID!]
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]

--- a/internal/api/resolver_mutation_studio.go
+++ b/internal/api/resolver_mutation_studio.go
@@ -15,9 +15,36 @@ import (
 
 // used to refetch studio after hooks run
 
-func setChildStudios(ctx context.Context, qb models.StudioReaderWriter, parentStudioID int, childStudioIDs []int) error {
+func clearRemovedChildStudios(ctx context.Context, qb models.StudioReaderWriter, parentStudioID int, childStudioIDs []int) error {
 	currentChildren, err := qb.FindChildren(ctx, parentStudioID)
 	if err != nil {
+		return err
+	}
+
+	newChildStudioIDs := make(map[int]struct{}, len(childStudioIDs))
+	for _, childStudioID := range childStudioIDs {
+		newChildStudioIDs[childStudioID] = struct{}{}
+	}
+
+	for _, currentChild := range currentChildren {
+		if _, keep := newChildStudioIDs[currentChild.ID]; keep {
+			continue
+		}
+
+		clearParentPartial := models.NewStudioPartial()
+		clearParentPartial.ID = currentChild.ID
+		clearParentPartial.ParentID = models.NewOptionalIntPtr(nil)
+
+		if _, err := qb.UpdatePartial(ctx, clearParentPartial); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setChildStudios(ctx context.Context, qb models.StudioReaderWriter, parentStudioID int, childStudioIDs []int) error {
+	if err := clearRemovedChildStudios(ctx, qb, parentStudioID, childStudioIDs); err != nil {
 		return err
 	}
 
@@ -37,20 +64,6 @@ func setChildStudios(ctx context.Context, qb models.StudioReaderWriter, parentSt
 		}
 
 		if _, err := qb.UpdatePartial(ctx, childPartial); err != nil {
-			return err
-		}
-	}
-
-	for _, currentChild := range currentChildren {
-		if _, keep := newChildStudioIDs[currentChild.ID]; keep {
-			continue
-		}
-
-		clearParentPartial := models.NewStudioPartial()
-		clearParentPartial.ID = currentChild.ID
-		clearParentPartial.ParentID = models.NewOptionalIntPtr(nil)
-
-		if _, err := qb.UpdatePartial(ctx, clearParentPartial); err != nil {
 			return err
 		}
 	}
@@ -254,6 +267,12 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 				sanitized := stringslice.UniqueExcludeFold(effectiveAliases, name)
 				updatedStudio.Aliases.Values = sanitized
 				updatedStudio.Aliases.Mode = models.RelationshipUpdateModeSet
+			}
+		}
+
+		if translator.hasField("child_ids") {
+			if err := clearRemovedChildStudios(ctx, qb, studioID, childStudioIDs); err != nil {
+				return err
 			}
 		}
 

--- a/internal/api/resolver_mutation_studio.go
+++ b/internal/api/resolver_mutation_studio.go
@@ -14,6 +14,50 @@ import (
 )
 
 // used to refetch studio after hooks run
+
+func setChildStudios(ctx context.Context, qb models.StudioReaderWriter, parentStudioID int, childStudioIDs []int) error {
+	currentChildren, err := qb.FindChildren(ctx, parentStudioID)
+	if err != nil {
+		return err
+	}
+
+	newChildStudioIDs := make(map[int]struct{}, len(childStudioIDs))
+	for _, childStudioID := range childStudioIDs {
+		if _, found := newChildStudioIDs[childStudioID]; found {
+			continue
+		}
+		newChildStudioIDs[childStudioID] = struct{}{}
+
+		childPartial := models.NewStudioPartial()
+		childPartial.ID = childStudioID
+		childPartial.ParentID = models.NewOptionalInt(parentStudioID)
+
+		if err := studio.ValidateModify(ctx, childPartial, qb); err != nil {
+			return err
+		}
+
+		if _, err := qb.UpdatePartial(ctx, childPartial); err != nil {
+			return err
+		}
+	}
+
+	for _, currentChild := range currentChildren {
+		if _, keep := newChildStudioIDs[currentChild.ID]; keep {
+			continue
+		}
+
+		clearParentPartial := models.NewStudioPartial()
+		clearParentPartial.ID = currentChild.ID
+		clearParentPartial.ParentID = models.NewOptionalIntPtr(nil)
+
+		if _, err := qb.UpdatePartial(ctx, clearParentPartial); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *mutationResolver) getStudio(ctx context.Context, id int) (ret *models.Studio, err error) {
 	if err := r.withTxn(ctx, func(ctx context.Context) error {
 		ret, err = r.repository.Studio.Find(ctx, id)
@@ -62,6 +106,11 @@ func (r *mutationResolver) StudioCreate(ctx context.Context, input models.Studio
 	if err != nil {
 		return nil, fmt.Errorf("converting tag ids: %w", err)
 	}
+
+	childStudioIDs, err := stringslice.StringSliceToIntSlice(input.ChildIds)
+	if err != nil {
+		return nil, fmt.Errorf("converting child ids: %w", err)
+	}
 	newStudio.CustomFields = convertMapJSONNumbers(input.CustomFields)
 
 	// Process the base 64 encoded image string
@@ -89,6 +138,12 @@ func (r *mutationResolver) StudioCreate(ctx context.Context, input models.Studio
 
 		if len(imageData) > 0 {
 			if err := qb.UpdateImage(ctx, newStudio.ID, imageData); err != nil {
+				return err
+			}
+		}
+
+		if input.ChildIds != nil {
+			if err := setChildStudios(ctx, qb, newStudio.ID, childStudioIDs); err != nil {
 				return err
 			}
 		}
@@ -133,6 +188,11 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 	updatedStudio.TagIDs, err = translator.updateIds(input.TagIds, "tag_ids")
 	if err != nil {
 		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	childStudioIDs, err := stringslice.StringSliceToIntSlice(input.ChildIds)
+	if err != nil {
+		return nil, fmt.Errorf("converting child ids: %w", err)
 	}
 
 	if translator.hasField("urls") {
@@ -208,6 +268,12 @@ func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.Studio
 
 		if imageIncluded {
 			if err := qb.UpdateImage(ctx, studioID, imageData); err != nil {
+				return err
+			}
+		}
+
+		if translator.hasField("child_ids") {
+			if err := setChildStudios(ctx, qb, studioID, childStudioIDs); err != nil {
 				return err
 			}
 		}

--- a/pkg/models/studio.go
+++ b/pkg/models/studio.go
@@ -62,6 +62,7 @@ type StudioCreateInput struct {
 	URL      *string  `json:"url"` // deprecated
 	Urls     []string `json:"urls"`
 	ParentID *string  `json:"parent_id"`
+	ChildIds []string `json:"child_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`
@@ -82,6 +83,7 @@ type StudioUpdateInput struct {
 	URL      *string  `json:"url"` // deprecated
 	Urls     []string `json:"urls"`
 	ParentID *string  `json:"parent_id"`
+	ChildIds []string `json:"child_ids"`
 	// This should be a URL or a base64 encoded data URL
 	Image         *string        `json:"image"`
 	StashIds      []StashIDInput `json:"stash_ids"`

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -237,7 +237,9 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
       <StudioSelect
         isMulti
         onSelect={onSetChildStudios}
-        values={childStudios}
+        values={childStudios.filter((childStudio) =>
+          formik.values.child_ids.includes(childStudio.id)
+        )}
         excludeIds={[
           ...(studio?.id ? [studio.id] : []),
           ...(formik.values.parent_id ? [formik.values.parent_id] : []),

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -57,12 +57,14 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const [parentStudio, setParentStudio] = useState<Studio | null>(null);
+  const [childStudios, setChildStudios] = useState<Studio[]>([]);
 
   const schema = yup.object({
     name: yup.string().required(),
     urls: yup.array(yup.string().required()).defined(),
     details: yup.string().ensure(),
     parent_id: yup.string().required().nullable(),
+    child_ids: yup.array(yup.string().required()).defined(),
     aliases: yupRequiredStringArray(intl).defined(),
     tag_ids: yup.array(yup.string().required()).defined(),
     ignore_auto_tag: yup.boolean().defined(),
@@ -77,6 +79,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     urls: studio.urls ?? [],
     details: studio.details ?? "",
     parent_id: studio.parent_studio?.id ?? null,
+    child_ids: (studio.child_studios ?? []).map((child) => child.id),
     aliases: studio.aliases ?? [],
     tag_ids: (studio.tags ?? []).map((t) => t.id),
     ignore_auto_tag: studio.ignore_auto_tag ?? false,
@@ -112,6 +115,14 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     formik.setFieldValue("parent_id", item ? item.id : null);
   }
 
+  function onSetChildStudios(items: Studio[]) {
+    setChildStudios(items);
+    formik.setFieldValue(
+      "child_ids",
+      items.map((item) => item.id)
+    );
+  }
+
   const encodingImage = ImageUtils.usePasteImage((imageData) =>
     formik.setFieldValue("image", imageData)
   );
@@ -127,6 +138,10 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         : null
     );
   }, [studio.parent_studio]);
+
+  useEffect(() => {
+    setChildStudios(studio.child_studios ?? []);
+  }, [studio.child_studios]);
 
   useEffect(() => {
     setImage(formik.values.image);
@@ -205,6 +220,20 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     return renderField("parent_id", title, control);
   }
 
+  function renderSubStudiosField() {
+    const title = intl.formatMessage({ id: "subsidiary_studios" });
+    const control = (
+      <StudioSelect
+        isMulti
+        onSelect={onSetChildStudios}
+        values={childStudios}
+        excludeIds={[...(studio?.id ? [studio.id] : []), ...(formik.values.parent_id ? [formik.values.parent_id] : [])]}
+      />
+    );
+
+    return renderField("child_ids", title, control);
+  }
+
   function renderTagsField() {
     const title = intl.formatMessage({ id: "tags" });
     return renderField("tag_ids", title, tagsControl());
@@ -246,6 +275,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         {renderStringListField("urls")}
         {renderInputField("details", "textarea")}
         {renderParentStudioField()}
+        {renderSubStudiosField()}
         {renderTagsField()}
         {renderStashIDsField(
           "stash_ids",

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -221,6 +221,10 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
           onSetParentStudio(items.length > 0 ? items[0] : null)
         }
         values={parentStudio ? [parentStudio] : []}
+        excludeIds={[
+          ...(studio?.id ? [studio.id] : []),
+          ...formik.values.child_ids,
+        ]}
       />
     );
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -234,7 +234,10 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
         isMulti
         onSelect={onSetChildStudios}
         values={childStudios}
-        excludeIds={[...(studio?.id ? [studio.id] : []), ...(formik.values.parent_id ? [formik.values.parent_id] : [])]}
+        excludeIds={[
+          ...(studio?.id ? [studio.id] : []),
+          ...(formik.values.parent_id ? [formik.values.parent_id] : []),
+        ]}
       />
     );
 

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -140,7 +140,14 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
   }, [studio.parent_studio]);
 
   useEffect(() => {
-    setChildStudios(studio.child_studios ?? []);
+    setChildStudios(
+      (studio.child_studios ?? []).map((childStudio) => ({
+        id: childStudio.id,
+        name: childStudio.name,
+        aliases: [],
+        image_path: childStudio.image_path,
+      }))
+    );
   }, [studio.child_studios]);
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

Adds first-class support for managing child/subsidiary studios directly through the Studio API and UI.
Resolves #3271.

### Changes

#### GraphQL Schema (studio.graphql)

Added child\_ids: \[ID!\] field to both StudioCreateInput and StudioUpdateInput, making it possible to specify child studios when creating or updating a studio via the API.

#### Go Models (pkg/models/studio.go)

Added the corresponding ChildIds \[\]string field to the StudioCreateInput and StudioUpdateInput Go structs with the appropriate json:"child\_ids" tag.

#### Backend Resolver (resolver\_mutation\_studio.go)

Introduced two new helper functions:

*   clearRemovedChildStudios — fetches the current children of a studio and clears the parent\_id of any child that is no longer in the new list, ensuring removed relationships are cleaned up properly.
    
*   setChildStudios — orchestrates the full update: first calls clearRemovedChildStudios, then iterates over the new child IDs, validates each via studio.ValidateModify, and sets their parent\_id to the current studio. Duplicate IDs are deduplicated.
    

Both StudioCreate and StudioUpdate mutations now convert child\_ids string slices to integer slices and invoke these helpers when child\_ids is present in the input. In the update flow, clearRemovedChildStudios is also called before ValidateModify to ensure the parent relationship is cleaned up atomically before the studio itself is validated and saved.

#### React UI (StudioEditPanel.tsx)

*   Added a childStudios state array to track selected child studio objects locally.
    
*   Extended the Formik schema and initial values to include child\_ids, populated from studio.child\_studios on load.
    
*   Added a useEffect to sync the childStudios display state when studio.child\_studios changes.
    
*   Added onSetChildStudios handler that updates both the local childStudios state and the child\_ids Formik field simultaneously, keeping the picker display in sync with form state.
    
*   Added renderSubStudiosField() which renders a multi-select StudioSelect for subsidiary studios. The picker excludes the studio itself and its current parent to prevent invalid circular relationships.
    
*   Updated the parent studio picker to also exclude studios already selected as children.
    
*   Wired renderSubStudiosField() into the form layout, below the parent studio field.