### PR TITLE
fix: path filter for nested folders; scene player loop on source change

### DIFF
--- a/pkg/sqlite/gallery_filter.go
+++ b/pkg/sqlite/gallery_filter.go
@@ -3,8 +3,6 @@ package sqlite
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-	"regexp"
 
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -216,66 +214,8 @@ func (qb *galleryFilterHandler) pathCriterionHandler(c *models.StringCriterionIn
 	return func(ctx context.Context, f *filterBuilder) {
 		if c != nil {
 			galleryRepository.addFoldersTable(f)
-			f.addLeftJoin(folderTable, "gallery_folder", "galleries.folder_id = gallery_folder.id")
-
-			const pathColumn = "folders.path"
-			const basenameColumn = "files.basename"
-			const folderPathColumn = "gallery_folder.path"
-
-			addWildcards := true
-			not := false
-
-			if modifier := c.Modifier; c.Modifier.IsValid() {
-				switch modifier {
-				case models.CriterionModifierIncludes:
-					clause := getPathSearchClauseMany(pathColumn, basenameColumn, c.Value, addWildcards, not)
-					clause2 := getStringSearchClause([]string{folderPathColumn}, c.Value, false)
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				case models.CriterionModifierExcludes:
-					not = true
-					clause := getPathSearchClauseMany(pathColumn, basenameColumn, c.Value, addWildcards, not)
-					clause2 := getStringSearchClause([]string{folderPathColumn}, c.Value, true)
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				case models.CriterionModifierEquals:
-					addWildcards = false
-					clause := getPathSearchClause(pathColumn, basenameColumn, c.Value, addWildcards, not)
-					clause2 := makeClause(folderPathColumn+" LIKE ?", c.Value)
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				case models.CriterionModifierNotEquals:
-					addWildcards = false
-					not = true
-					clause := getPathSearchClause(pathColumn, basenameColumn, c.Value, addWildcards, not)
-					clause2 := makeClause(folderPathColumn+" NOT LIKE ?", c.Value)
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				case models.CriterionModifierMatchesRegex:
-					if _, err := regexp.Compile(c.Value); err != nil {
-						f.setError(err)
-						return
-					}
-					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
-					clause := makeClause(fmt.Sprintf("%s IS NOT NULL AND %s IS NOT NULL AND %s regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
-					clause2 := makeClause(fmt.Sprintf("%s IS NOT NULL AND %[1]s regexp ?", folderPathColumn), c.Value)
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				case models.CriterionModifierNotMatchesRegex:
-					if _, err := regexp.Compile(c.Value); err != nil {
-						f.setError(err)
-						return
-					}
-					filepathColumn := fmt.Sprintf("%s || '%s' || %s", pathColumn, string(filepath.Separator), basenameColumn)
-					f.addWhere(fmt.Sprintf("%s IS NULL OR %s IS NULL OR %s NOT regexp ?", pathColumn, basenameColumn, filepathColumn), c.Value)
-					f.addWhere(fmt.Sprintf("%s IS NULL OR %[1]s NOT regexp ?", folderPathColumn), c.Value)
-				case models.CriterionModifierIsNull:
-					f.addWhere(fmt.Sprintf("%s IS NULL OR TRIM(%[1]s) = '' OR %s IS NULL OR TRIM(%[2]s) = ''", pathColumn, basenameColumn))
-					f.addWhere(fmt.Sprintf("%s IS NULL OR TRIM(%[1]s) = ''", folderPathColumn))
-				case models.CriterionModifierNotNull:
-					clause := makeClause(fmt.Sprintf("%s IS NOT NULL AND TRIM(%[1]s) != '' AND %s IS NOT NULL AND TRIM(%[2]s) != ''", pathColumn, basenameColumn))
-					clause2 := makeClause(fmt.Sprintf("%s IS NOT NULL AND TRIM(%[1]s) != ''", folderPathColumn))
-					f.whereClauses = append(f.whereClauses, orClauses(clause, clause2))
-				default:
-					panic("unsupported string filter modifier")
-				}
-			}
 		}
+		stringCriterionHandler(c, "folders.path || '/' || files.basename")(ctx, f)
 	}
 }
 

--- a/pkg/sqlite/scene_filter.go
+++ b/pkg/sqlite/scene_filter.go
@@ -55,7 +55,12 @@ func (qb *sceneFilterHandler) criterionHandler() criterionHandler {
 	sceneFilter := qb.sceneFilter
 	return compoundHandler{
 		intCriterionHandler(sceneFilter.ID, "scenes.id", nil),
-		pathCriterionHandler(sceneFilter.Path, "folders.path", "files.basename", qb.addFoldersTable),
+		criterionHandlerFunc(func(ctx context.Context, f *filterBuilder) {
+			if sceneFilter.Path != nil {
+				qb.addFoldersTable(f, joinTypeInner)
+			}
+			stringCriterionHandler(sceneFilter.Path, "folders.path || '/' || files.basename")(ctx, f)
+		}),
 		qb.fileCountCriterionHandler(sceneFilter.FileCount),
 		stringCriterionHandler(sceneFilter.Title, "scenes.title"),
 		stringCriterionHandler(sceneFilter.Code, "scenes.code"),

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -26,6 +26,8 @@ import "./vrmode";
 import "./media-session";
 import "./wake-sentinel";
 import cx from "classnames";
+import { faRepeat } from "@fortawesome/free-solid-svg-icons";
+import { Icon } from "src/components/Shared/Icon";
 import {
   useSceneSaveActivity,
   useSceneIncrementPlayCount,
@@ -266,6 +268,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
 
     const [fullscreen, setFullscreen] = useState(false);
     const [showScrubber, setShowScrubber] = useState(false);
+    const [loopEnabled, setLoopEnabled] = useState(false);
 
     const started = useRef(false);
     const auto = useRef(false);
@@ -714,6 +717,9 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       player.ready(() => {
         player.vttThumbnails().src(scene.paths.vtt ?? null);
 
+        player.loop(looping);
+        setLoopEnabled(looping);
+
         if (startPosition) {
           player.currentTime(startPosition);
         }
@@ -726,6 +732,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       scene,
       interactiveClient,
       autoplay,
+      looping,
       interfaceConfig?.autostartVideo,
       uiConfig?.alwaysStartFromBeginning,
       uiConfig?.disableMobileMediaAutoRotateEnabled,
@@ -997,6 +1004,19 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
             onScroll={onScrubberScroll}
           />
         )}
+        <button
+          className={cx("loop-toggle", { active: loopEnabled })}
+          title="Toggle loop"
+          onClick={() => {
+            const player = getPlayer();
+            if (!player) return;
+            const next = !loopEnabled;
+            player.loop(next);
+            setLoopEnabled(next);
+          }}
+        >
+          <Icon icon={faRepeat} />
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **Path filter broken for nested folders** (`pkg/sqlite/scene_filter.go`, `pkg/sqlite/gallery_filter.go`): the previous implementation compared `folders.path` and `files.basename` as two separate columns, so a filter value like `/media/movies/foo` would not match a file whose DB row has `folders.path = /media/movies` and `files.basename = foo`. Replace the split logic with a single `stringCriterionHandler` on the concatenated SQL expression `folders.path || '/' || files.basename`, matching the full path as one string. The same fix is applied to `galleryFilterHandler.pathCriterionHandler`, which had the same pattern plus a separate `gallery_folder.path` branch. Unused `path/filepath` and `regexp` imports are also removed from `gallery_filter.go`.

- **Auto-repeat/loop not working** (`ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx`): video.js resets the `loop` attribute when new sources are loaded. The existing `useEffect` that calls `player.loop(looping)` only re-fires when `looping` changes value; if two consecutive scenes have the same computed loop value the effect is skipped and the player ends up with loop disabled. Fix by calling `player.loop(looping)` inside the `player.ready()` callback of the scene-load effect so it is applied on every scene load. Also adds a `loopEnabled` useState (kept in sync from `player.ready`) and a visible loop-toggle button with `faRepeat` icon below the scrubber so users can override the setting per-session.

## Test plan

- [ ] Filter scenes/galleries by path using `includes`, `equals`, `regex`, and `not` modifiers on paths with multiple folder levels — confirm results match the full path string
- [ ] Set `maximumLoopDuration` in Settings → Interface; play a short scene, confirm it loops; navigate to a second short scene and confirm it also loops without needing a page reload
- [ ] Click the loop-toggle button; confirm it overrides the config-derived default and the player respects the new value
- [ ] Confirm the loop button shows correct active/inactive state on scene change

🤖 Generated with [Claude Code](https://claude.com/claude-code)