### PR TITLE
Add depth support to tag scene_count filter for hierarchical sidebar display

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -635,6 +635,9 @@ input TagFilterType {
   "Filter by number of scenes with this tag"
   scene_count: IntCriterionInput
 
+  "Depth for scene count filter (0/nil = direct only, -1 = all descendants, N = N levels)"
+  scene_count_depth: Int
+
   "Filter by number of images with this tag"
   image_count: IntCriterionInput
 

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -16,6 +16,8 @@ type TagFilterType struct {
 	IsMissing *string `json:"is_missing"`
 	// Filter by number of scenes with this tag
 	SceneCount *IntCriterionInput `json:"scene_count"`
+	// Depth for scene count filter (0/nil = direct only, -1 = all descendants, N = N levels)
+	SceneCountDepth *int `json:"scene_count_depth"`
 	// Filter by number of images with this tag
 	ImageCount *IntCriterionInput `json:"image_count"`
 	// Filter by number of galleries with this tag

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -220,12 +221,62 @@ func (qb *tagFilterHandler) isMissingCriterionHandler(isMissing *string) criteri
 func (qb *tagFilterHandler) sceneCountCriterionHandler(sceneCount *models.IntCriterionInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
 		if sceneCount != nil {
-			f.addLeftJoin("scenes_tags", "", "scenes_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct scenes_tags.scene_id)", *sceneCount)
+			depth := 0
+			if qb.tagFilter.SceneCountDepth != nil {
+				depth = *qb.tagFilter.SceneCountDepth
+			}
 
-			f.addHaving(clause, args...)
+			if depth == 0 {
+				// Direct scene count only - existing logic
+				f.addLeftJoin("scenes_tags", "", "scenes_tags.tag_id = tags.id")
+				clause, args := getIntCriterionWhereClause("count(distinct scenes_tags.scene_id)", *sceneCount)
+				f.addHaving(clause, args...)
+			} else {
+				// Hierarchical scene count using recursive CTE
+				qb.sceneCountWithDepth(ctx, f, sceneCount, depth)
+			}
 		}
 	}
+}
+
+func (qb *tagFilterHandler) sceneCountWithDepth(ctx context.Context, f *filterBuilder, sceneCount *models.IntCriterionInput, depth int) {
+	// Build recursive CTE to get all descendant tags up to specified depth
+	// depth = -1 means all descendants (no limit)
+	// depth = N means up to N levels down
+
+	depthCondition := ""
+	if depth > 0 {
+		depthCondition = fmt.Sprintf("AND depth < %d", depth)
+	}
+
+	// Create a CTE that combines:
+	// 1. The tag itself (depth 0) with its own ID as both root and descendant
+	// 2. All descendants from tags_relations
+	// This gives us a complete mapping of (root_tag, descendant_tag, depth)
+	withClause := fmt.Sprintf(`tag_hierarchy AS (
+		-- Root tags (depth 0): each tag is its own root
+		SELECT id AS root_id, id AS descendant_id, 0 AS depth FROM tags
+		UNION ALL
+		-- Descendants from tags_relations
+		SELECT parent_id AS root_id, child_id AS descendant_id, 1 AS depth FROM tags_relations
+		UNION ALL
+		-- Recursive step for deeper descendants
+		SELECT th.root_id, tr.child_id, th.depth + 1
+		FROM tag_hierarchy th
+		INNER JOIN tags_relations tr ON tr.parent_id = th.descendant_id
+		WHERE th.depth > 0 %s
+	)`, depthCondition)
+
+	f.addRecursiveWith(withClause)
+
+	// Join scenes through the hierarchy CTE
+	// For each tag (as root), join to its descendants in the CTE, then to their scenes
+	f.addLeftJoin("tag_hierarchy", "th", "th.root_id = tags.id")
+	f.addLeftJoin("scenes_tags", "hierarchy_scenes_tags", "hierarchy_scenes_tags.tag_id = th.descendant_id")
+
+	// Count distinct scenes across the entire hierarchy for each tag
+	clause, args := getIntCriterionWhereClause("count(distinct hierarchy_scenes_tags.scene_id)", *sceneCount)
+	f.addHaving(clause, args...)
 }
 
 func (qb *tagFilterHandler) imageCountCriterionHandler(imageCount *models.IntCriterionInput) criterionHandlerFunc {

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -594,6 +594,89 @@ func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionIn
 	})
 }
 
+func TestTagQuerySceneCountWithDepth(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		qb := db.Tag
+
+		// Test hierarchy:
+		// tagIdxWithGrandParent (grandparent)
+		//   -> tagIdxWithParentAndChild (parent)
+		//        -> tagIdxWithGrandChild (child with scene)
+		//
+		// tagIdxWithParentTag (parent)
+		//   -> tagIdxWithChildTag (child with scene)
+		//
+		// Note: The test data sceneTags has scenes tagged with specific tags,
+		// but the hierarchy tags (parent/child/grandparent) may not have direct scenes.
+		// We need to verify the depth parameter works correctly.
+
+		// Test 1: Without depth (depth=0 or nil), only direct scene counts
+		sceneCountCriterion := models.IntCriterionInput{
+			Modifier: models.CriterionModifierGreaterThan,
+			Value:    0,
+		}
+		tagFilter := models.TagFilterType{
+			SceneCount:      &sceneCountCriterion,
+			SceneCountDepth: nil, // Explicitly nil = direct only
+		}
+
+		tags, _, err := qb.Query(ctx, &tagFilter, nil)
+		if err != nil {
+			t.Errorf("Error querying tags: %s", err.Error())
+		}
+
+		// Without depth, parent tags without direct scenes should not appear
+		// Only tags with directly associated scenes should be returned
+		assert.NotNil(t, tags)
+
+		// Test 2: With depth=-1 (all descendants), parent tags with scenes on children should appear
+		depthAll := -1
+		tagFilter.SceneCountDepth = &depthAll
+
+		tagsWithDepth, _, err := qb.Query(ctx, &tagFilter, nil)
+		if err != nil {
+			t.Errorf("Error querying tags with depth: %s", err.Error())
+		}
+
+		// With depth=-1, more tags should be returned (parents with child scenes)
+		// The exact count depends on the test data setup
+		assert.NotNil(t, tagsWithDepth)
+		assert.GreaterOrEqual(t, len(tagsWithDepth), len(tags), "depth=-1 should return at least as many tags as depth=0")
+
+		// Test 3: Verify specific hierarchy tags are included with depth
+		// Check that grandparent tag is in the results if any descendant has scenes
+		grandparentID := tagIDs[tagIdxWithGrandParent]
+		foundGrandparent := false
+		for _, tag := range tagsWithDepth {
+			if tag.ID == grandparentID {
+				foundGrandparent = true
+				break
+			}
+		}
+
+		// If grandchild has a scene, grandparent should appear with depth=-1
+		// This depends on the test data setup
+		if getTagSceneCount(tagIDs[tagIdxWithGrandChild]) > 0 {
+			assert.True(t, foundGrandparent, "Grandparent tag should appear when grandchild has scenes and depth=-1")
+		}
+
+		// Test 4: depth=1 (immediate children only)
+		depth1 := 1
+		tagFilter.SceneCountDepth = &depth1
+
+		tagsDepth1, _, err := qb.Query(ctx, &tagFilter, nil)
+		if err != nil {
+			t.Errorf("Error querying tags with depth=1: %s", err.Error())
+		}
+
+		assert.NotNil(t, tagsDepth1)
+		// depth=1 should return more than depth=0 but possibly less than depth=-1
+		assert.GreaterOrEqual(t, len(tagsDepth1), len(tags), "depth=1 should return at least as many tags as depth=0")
+
+		return nil
+	})
+}
+
 func TestTagQueryMarkerCount(t *testing.T) {
 	countCriterion := models.IntCriterionInput{
 		Value:    1,

--- a/ui/v2.5/src/components/List/Filters/TagsFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/TagsFilter.tsx
@@ -48,6 +48,10 @@ function queryVariables(query: string, f?: ListFilterModel) {
     }
 
     setObjectFilter(tagFilter, f.mode, filterOutput);
+
+    // Enable hierarchical scene counting to show parent tags with scenes on children
+    // This fixes the issue where empty parent tags don't appear in the sidebar
+    tagFilter.scene_count_depth = -1; // All depths
   }
 
   return makeQueryVariables(query, { tag_filter: tagFilter });


### PR DESCRIPTION
Fixes #6797

Added `scene_count_depth: Int` to` TagFilterType` in the GraphQL schema, backend model, and filter handler. The filter now supports a recursive CTE to count scenes across descendant tags. The sidebar query uses `scene_count_depth: -1` to include all descendants.

Files changed:

`graphql/schema/types/filters.graphql` — added `scene_count_depth` field
`pkg/models/tag.go` — added `SceneCountDepth` to struct
`pkg/sqlite/tag_filter.go` — added depth-aware scene count with recursive CTE
`ui/v2.5/src/components/List/Filters/TagsFilter.tsx` — set `scene_count_depth: -1` for sidebar queries
`pkg/sqlite/tag_test.go` — added tests for depth=nil, depth=-1, depth=1