### PR TITLE
Move lightbox animation/scroll settings to LocalForage

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -361,8 +361,6 @@ input ConfigImageLightboxInput {
   scaleUp: Boolean
   resetZoomOnNav: Boolean
   scrollMode: ImageLightboxScrollMode
-  scrollAttemptsBeforeChange: Int
-  disableAnimation: Boolean
 }
 
 type ConfigImageLightboxResult {
@@ -371,8 +369,6 @@ type ConfigImageLightboxResult {
   scaleUp: Boolean
   resetZoomOnNav: Boolean
   scrollMode: ImageLightboxScrollMode
-  scrollAttemptsBeforeChange: Int!
-  disableAnimation: Boolean
 }
 
 input ConfigInterfaceInput {

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -503,10 +503,6 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 		r.setConfigBool(config.ImageLightboxScaleUp, options.ScaleUp)
 		r.setConfigBool(config.ImageLightboxResetZoomOnNav, options.ResetZoomOnNav)
 		r.setConfigString(config.ImageLightboxScrollModeKey, (*string)(options.ScrollMode))
-
-		r.setConfigInt(config.ImageLightboxScrollAttemptsBeforeChange, options.ScrollAttemptsBeforeChange)
-
-		r.setConfigBool(config.ImageLightboxDisableAnimation, options.DisableAnimation)
 	}
 
 	if input.CSS != nil {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -224,8 +224,6 @@ const (
 	ImageLightboxScaleUp                    = "image_lightbox.scale_up"
 	ImageLightboxResetZoomOnNav             = "image_lightbox.reset_zoom_on_nav"
 	ImageLightboxScrollModeKey              = "image_lightbox.scroll_mode"
-	ImageLightboxScrollAttemptsBeforeChange = "image_lightbox.scroll_attempts_before_change"
-	ImageLightboxDisableAnimation           = "image_lightbox.disable_animation"
 
 	UI = "ui"
 
@@ -1355,14 +1353,6 @@ func (i *Config) GetImageLightboxOptions() ConfigImageLightboxResult {
 		mode := ImageLightboxScrollMode(v.String(ImageLightboxScrollModeKey))
 		ret.ScrollMode = &mode
 	}
-	if v := i.with(ImageLightboxScrollAttemptsBeforeChange); v != nil {
-		ret.ScrollAttemptsBeforeChange = v.Int(ImageLightboxScrollAttemptsBeforeChange)
-	}
-	if v := i.with(ImageLightboxDisableAnimation); v != nil {
-		value := v.Bool(ImageLightboxDisableAnimation)
-		ret.DisableAnimation = &value
-	}
-
 	return ret
 }
 

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -218,12 +218,12 @@ const (
 	defaultWallPlayback = "video"
 
 	// Image lightbox options
-	legacyImageLightboxSlideshowDelay       = "slideshow_delay"
-	ImageLightboxSlideshowDelay             = "image_lightbox.slideshow_delay"
-	ImageLightboxDisplayModeKey             = "image_lightbox.display_mode"
-	ImageLightboxScaleUp                    = "image_lightbox.scale_up"
-	ImageLightboxResetZoomOnNav             = "image_lightbox.reset_zoom_on_nav"
-	ImageLightboxScrollModeKey              = "image_lightbox.scroll_mode"
+	legacyImageLightboxSlideshowDelay = "slideshow_delay"
+	ImageLightboxSlideshowDelay       = "image_lightbox.slideshow_delay"
+	ImageLightboxDisplayModeKey       = "image_lightbox.display_mode"
+	ImageLightboxScaleUp              = "image_lightbox.scale_up"
+	ImageLightboxResetZoomOnNav       = "image_lightbox.reset_zoom_on_nav"
+	ImageLightboxScrollModeKey        = "image_lightbox.scroll_mode"
 
 	UI = "ui"
 

--- a/internal/manager/config/ui.go
+++ b/internal/manager/config/ui.go
@@ -7,13 +7,11 @@ import (
 )
 
 type ConfigImageLightboxResult struct {
-	SlideshowDelay             *int                      `json:"slideshowDelay"`
-	DisplayMode                *ImageLightboxDisplayMode `json:"displayMode"`
-	ScaleUp                    *bool                     `json:"scaleUp"`
-	ResetZoomOnNav             *bool                     `json:"resetZoomOnNav"`
-	ScrollMode                 *ImageLightboxScrollMode  `json:"scrollMode"`
-	ScrollAttemptsBeforeChange int                       `json:"scrollAttemptsBeforeChange"`
-	DisableAnimation           *bool                     `json:"disableAnimation"`
+	SlideshowDelay *int                      `json:"slideshowDelay"`
+	DisplayMode    *ImageLightboxDisplayMode `json:"displayMode"`
+	ScaleUp        *bool                     `json:"scaleUp"`
+	ResetZoomOnNav *bool                     `json:"resetZoomOnNav"`
+	ScrollMode     *ImageLightboxScrollMode  `json:"scrollMode"`
 }
 
 type ImageLightboxDisplayMode string

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -105,8 +105,6 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
     scaleUp
     resetZoomOnNav
     scrollMode
-    scrollAttemptsBeforeChange
-    disableAnimation
   }
   disableDropdownCreate {
     performer

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -95,7 +95,8 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
       sync: interactiveSync,
     } = React.useContext(InteractiveContext);
 
-    const [, setInterfaceLocalForage] = useInterfaceLocalForage();
+    const [interfaceLocalForage, setInterfaceLocalForage] =
+      useInterfaceLocalForage();
 
     function saveLightboxSettings(v: Partial<GQL.ConfigImageLightboxInput>) {
       // save in local forage as well for consistency
@@ -623,17 +624,37 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
           <NumberSetting
             headingID="config.ui.scroll_attempts_before_change.heading"
             subHeadingID="config.ui.scroll_attempts_before_change.description"
-            value={iface.imageLightbox?.scrollAttemptsBeforeChange ?? 0}
+            value={
+              interfaceLocalForage.data?.imageLightbox
+                ?.scrollAttemptsBeforeChange ?? 0
+            }
             onChange={(v) =>
-              saveLightboxSettings({ scrollAttemptsBeforeChange: v })
+              setInterfaceLocalForage((prev) => ({
+                ...prev,
+                imageLightbox: {
+                  ...prev.imageLightbox,
+                  scrollAttemptsBeforeChange: v,
+                },
+              }))
             }
           />
 
           <BooleanSetting
             id="lightbox_disable_animation"
             headingID="dialogs.lightbox.disable_animation"
-            checked={iface.imageLightbox?.disableAnimation ?? false}
-            onChange={(v) => saveLightboxSettings({ disableAnimation: v })}
+            checked={
+              interfaceLocalForage.data?.imageLightbox?.disableAnimation ??
+              false
+            }
+            onChange={(v) =>
+              setInterfaceLocalForage((prev) => ({
+                ...prev,
+                imageLightbox: {
+                  ...prev.imageLightbox,
+                  disableAnimation: v,
+                },
+              }))
+            }
           />
         </SettingSection>
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -160,6 +160,47 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const lightboxSettings = interfaceLocalForage.data?.imageLightbox;
 
+  const migrationDone = useRef(false);
+
+  useEffect(() => {
+    if (
+      migrationDone.current ||
+      interfaceLocalForage.data === undefined ||
+      !config
+    ) {
+      return;
+    }
+
+    const updates: Partial<GQL.ConfigImageLightboxInput> = {};
+
+    if (lightboxSettings?.scrollAttemptsBeforeChange === undefined) {
+      updates.scrollAttemptsBeforeChange =
+        config.interface.imageLightbox.scrollAttemptsBeforeChange;
+    }
+    if (lightboxSettings?.disableAnimation === undefined) {
+      updates.disableAnimation =
+        config.interface.imageLightbox.disableAnimation;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      setInterfaceLocalForage((prev) => ({
+        ...prev,
+        imageLightbox: {
+          ...prev.imageLightbox,
+          ...updates,
+        },
+      }));
+    }
+
+    migrationDone.current = true;
+  }, [
+    interfaceLocalForage.data,
+    config,
+    lightboxSettings?.scrollAttemptsBeforeChange,
+    lightboxSettings?.disableAnimation,
+    setInterfaceLocalForage,
+  ]);
+
   function setLightboxSettings(v: Partial<GQL.ConfigImageLightboxInput>) {
     setInterfaceLocalForage((prev) => {
       return {

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -197,10 +197,10 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const scrollAttemptsBeforeChange = Math.max(
     0,
-    config?.interface.imageLightbox.scrollAttemptsBeforeChange ?? 0
+    lightboxSettings?.scrollAttemptsBeforeChange ?? 0
   );
 
-  const disableAnimation = config?.interface.imageLightbox.disableAnimation;
+  const disableAnimation = lightboxSettings?.disableAnimation;
 
   function setSlideshowDelay(v: number) {
     setLightboxSettings({ slideshowDelay: v });

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -171,7 +171,7 @@ export const LightboxComponent: React.FC<IProps> = ({
       return;
     }
 
-    const updates: Partial<GQL.ConfigImageLightboxInput> = {};
+    const updates: { scrollAttemptsBeforeChange?: number; disableAnimation?: boolean } = {};
 
     if (lightboxSettings?.scrollAttemptsBeforeChange === undefined) {
       updates.scrollAttemptsBeforeChange =

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -160,47 +160,6 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const lightboxSettings = interfaceLocalForage.data?.imageLightbox;
 
-  const migrationDone = useRef(false);
-
-  useEffect(() => {
-    if (
-      migrationDone.current ||
-      interfaceLocalForage.data === undefined ||
-      !config
-    ) {
-      return;
-    }
-
-    const updates: { scrollAttemptsBeforeChange?: number; disableAnimation?: boolean } = {};
-
-    if (lightboxSettings?.scrollAttemptsBeforeChange === undefined) {
-      updates.scrollAttemptsBeforeChange =
-        config.interface.imageLightbox.scrollAttemptsBeforeChange;
-    }
-    if (lightboxSettings?.disableAnimation === undefined) {
-      updates.disableAnimation =
-        config.interface.imageLightbox.disableAnimation;
-    }
-
-    if (Object.keys(updates).length > 0) {
-      setInterfaceLocalForage((prev) => ({
-        ...prev,
-        imageLightbox: {
-          ...prev.imageLightbox,
-          ...updates,
-        },
-      }));
-    }
-
-    migrationDone.current = true;
-  }, [
-    interfaceLocalForage.data,
-    config,
-    lightboxSettings?.scrollAttemptsBeforeChange,
-    lightboxSettings?.disableAnimation,
-    setInterfaceLocalForage,
-  ]);
-
   function setLightboxSettings(v: Partial<GQL.ConfigImageLightboxInput>) {
     setInterfaceLocalForage((prev) => {
       return {

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -195,10 +195,11 @@ export const LightboxComponent: React.FC<IProps> = ({
   const slideshowDelay =
     savedDelay ?? configuredDelay ?? DEFAULT_SLIDESHOW_DELAY;
 
-  const scrollAttemptsBeforeChange = Math.max(
-    0,
-    lightboxSettings?.scrollAttemptsBeforeChange ?? 0
-  );
+  const rawScrollAttempts = lightboxSettings?.scrollAttemptsBeforeChange;
+  const scrollAttemptsBeforeChange =
+    typeof rawScrollAttempts === "number" && Number.isFinite(rawScrollAttempts)
+      ? Math.max(0, rawScrollAttempts)
+      : 0;
 
   const disableAnimation = lightboxSettings?.disableAnimation;
 

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -2,7 +2,7 @@ import localForage from "localforage";
 import isEqual from "lodash-es/isEqual";
 import React, { Dispatch, SetStateAction, useEffect } from "react";
 import { View } from "src/components/List/views";
-import { ConfigImageLightboxInput } from "src/core/generated-graphql";
+import { ImageLightboxDisplayMode, ImageLightboxScrollMode } from "src/core/generated-graphql";
 
 interface IInterfaceQueryConfig {
   filter: string;
@@ -16,9 +16,19 @@ export interface IViewConfig {
 
 type IQueryConfig = Record<string, IInterfaceQueryConfig>;
 
+interface ILightboxConfig {
+  disableAnimation?: boolean;
+  displayMode?: ImageLightboxDisplayMode;
+  resetZoomOnNav?: boolean;
+  scaleUp?: boolean;
+  scrollAttemptsBeforeChange?: number;
+  scrollMode?: ImageLightboxScrollMode;
+  slideshowDelay?: number;
+}
+
 interface IInterfaceConfig {
   queryConfig: IQueryConfig;
-  imageLightbox: ConfigImageLightboxInput;
+  imageLightbox: ILightboxConfig;
   // Partial is required because using View makes the key mandatory
   viewConfig: Partial<Record<View, IViewConfig>>;
 }

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -18,12 +18,12 @@ type IQueryConfig = Record<string, IInterfaceQueryConfig>;
 
 interface ILightboxConfig {
   disableAnimation?: boolean;
-  displayMode?: ImageLightboxDisplayMode;
-  resetZoomOnNav?: boolean;
-  scaleUp?: boolean;
+  displayMode?: ImageLightboxDisplayMode | null;
+  resetZoomOnNav?: boolean | null;
+  scaleUp?: boolean | null;
   scrollAttemptsBeforeChange?: number;
-  scrollMode?: ImageLightboxScrollMode;
-  slideshowDelay?: number;
+  scrollMode?: ImageLightboxScrollMode | null;
+  slideshowDelay?: number | null;
 }
 
 interface IInterfaceConfig {

--- a/ui/v2.5/src/hooks/LocalForage.ts
+++ b/ui/v2.5/src/hooks/LocalForage.ts
@@ -2,7 +2,10 @@ import localForage from "localforage";
 import isEqual from "lodash-es/isEqual";
 import React, { Dispatch, SetStateAction, useEffect } from "react";
 import { View } from "src/components/List/views";
-import { ImageLightboxDisplayMode, ImageLightboxScrollMode } from "src/core/generated-graphql";
+import {
+  ImageLightboxDisplayMode,
+  ImageLightboxScrollMode,
+} from "src/core/generated-graphql";
 
 interface IInterfaceQueryConfig {
   filter: string;


### PR DESCRIPTION
Closes #6864

### Changes

- Removed `disableAnimation` and `scrollAttemptsBeforeChange` from `ConfigImageLightboxInput` and `ConfigImageLightboxResult` GraphQL types
- Removed `ImageLightboxDisableAnimation` and `ImageLightboxScrollAttemptsBeforeChange` constants and their reading logic from the backend config
- Removed `DisableAnimation` and `ScrollAttemptsBeforeChange` fields from the `ConfigImageLightboxResult` Go struct
- Removed the corresponding `setConfigBool`/`setConfigInt` calls from the `ConfigureInterface` mutation resolver
- Removed these fields from the frontend GraphQL query in `graphql/data/config.graphql`
- Updated `SettingsInterfacePanel.tsx` to read/write these settings via LocalForage instead of the GraphQL mutation
- Updated `Lightbox.tsx` to read these settings from LocalForage instead of server config
- Added `ILightboxConfig` local interface in `LocalForage.ts` to decouple LocalForage storage from GraphQL types

### Note

Users who had previously set non-default values for `scrollAttemptsBeforeChange` or `disableAnimation` will need to reconfigure these settings locally via the Settings UI after upgrading. A server-to-client migration was considered but is not feasible since these fields were removed from the GraphQL query.