### PR TITLE
Optimization: Large library differential scan

### DIFF
--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -9,6 +9,10 @@ https://docs.docker.com/engine/install/
 
 On some distributions, `docker compose` is shipped seperately, usually as `docker-cli-compose`. docker-compose is not recommended.
 
+### Library storage (bind mounts)
+
+For reliable metadata scans and best performance on warm rescans, **mount your media library from the host** into the container (as in the sample `docker-compose.yml`: a host path on the left, container path on the right). That keeps the library on your normal disk filesystem (for example ext4, xfs, or NTFS on the host). Stash enables folder modtime-based scan optimizations when it trusts directory timestamps from the filesystem at the library path; bind mounts preserve those semantics.
+
 ### Get the docker-compose.yml file
 
 Now you can either navigate to the [docker-compose.yml](https://raw.githubusercontent.com/stashapp/stash/develop/docker/production/docker-compose.yml) in the repository, or if you have curl, you can make your Linux console do it for you:

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
       ## Keep configs, scrapers, and plugins here.
       - ./config:/root/.stash
-      ## Point this at your collection.
+      ## Point this at your collection (bind-mount from host for normal filesystem semantics and scan optimizations).
       ## The left side is where your collection is on your host, the right side is where it will be in stash.
       - ./data:/data
       ## This is where your stash's metadata lives

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -460,7 +460,7 @@ func (i *Config) set(key string, value interface{}) {
 
 	// test for nil interface as well
 	refVal := reflect.ValueOf(value)
-	if refVal.Kind() == reflect.Ptr && refVal.IsNil() {
+	if refVal.Kind() == reflect.Pointer && refVal.IsNil() {
 		return
 	}
 

--- a/internal/manager/scan_check_folder_threshold_test.go
+++ b/internal/manager/scan_check_folder_threshold_test.go
@@ -91,7 +91,7 @@ func TestShouldCheckFolder_Transition(t *testing.T) {
 // returns false, regardless of hit rate or warmup state.
 func TestShouldCheckFolder_RescanBypass(t *testing.T) {
 	j := newTestJob(0.30, true, true) // Rescan=true
-	simulateChecks(j, 200, 0)        // 100% hits, past warmup
+	simulateChecks(j, 200, 0)         // 100% hits, past warmup
 
 	if j.shouldCheckFolder() {
 		t.Fatal("shouldCheckFolder returned true when Rescan=true")

--- a/internal/manager/scan_check_folder_threshold_test.go
+++ b/internal/manager/scan_check_folder_threshold_test.go
@@ -1,0 +1,110 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/stashapp/stash/pkg/file"
+)
+
+func newTestJob(threshold float64, skipUnchanged bool, rescan bool) *ScanJob {
+	j := &ScanJob{
+		scanner:              &file.Scanner{Rescan: rescan},
+		checkFolderThreshold: threshold,
+		skipUnchangedFolders: skipUnchanged,
+	}
+	return j
+}
+
+func simulateChecks(j *ScanJob, hits, misses int) {
+	for i := 0; i < hits; i++ {
+		j.dirCheckAttempts.Add(1)
+		j.dirCheckHits.Add(1)
+	}
+	for i := 0; i < misses; i++ {
+		j.dirCheckAttempts.Add(1)
+	}
+}
+
+// TestShouldCheckFolder_WarmupWindow verifies that the first dirCheckWarmup
+// calls always return true regardless of hit rate.
+func TestShouldCheckFolder_WarmupWindow(t *testing.T) {
+	j := newTestJob(0.30, true, false)
+
+	// Simulate all misses but still within warmup window.
+	for i := 0; i < dirCheckWarmup-1; i++ {
+		j.dirCheckAttempts.Add(1) // all misses
+		if !j.shouldCheckFolder() {
+			t.Fatalf("shouldCheckFolder returned false at attempt %d (within warmup window)", i+1)
+		}
+	}
+}
+
+// TestShouldCheckFolder_AllHits verifies that a 100% hit rate keeps
+// shouldCheckFolder enabled well past the warmup window.
+func TestShouldCheckFolder_AllHits(t *testing.T) {
+	j := newTestJob(0.30, true, false)
+	simulateChecks(j, 200, 0)
+
+	for i := 0; i < 10; i++ {
+		if !j.shouldCheckFolder() {
+			t.Fatal("shouldCheckFolder returned false with 100% hit rate")
+		}
+	}
+}
+
+// TestShouldCheckFolder_AllMisses verifies that a 0% hit rate disables
+// shouldCheckFolder after the warmup window.
+func TestShouldCheckFolder_AllMisses(t *testing.T) {
+	j := newTestJob(0.30, true, false)
+	simulateChecks(j, 0, dirCheckWarmup+10)
+
+	if j.shouldCheckFolder() {
+		t.Fatal("shouldCheckFolder returned true with 0% hit rate after warmup")
+	}
+}
+
+// TestShouldCheckFolder_Transition verifies the transition: starts warm (high
+// hit rate, enabled), then accumulates misses until the rate drops below
+// threshold and the gate disables.
+func TestShouldCheckFolder_Transition(t *testing.T) {
+	j := newTestJob(0.30, true, false)
+
+	// Start warm: fill warmup window with hits.
+	simulateChecks(j, dirCheckWarmup, 0)
+	if !j.shouldCheckFolder() {
+		t.Fatal("shouldCheckFolder returned false with 100% hit rate after warmup")
+	}
+
+	// Add enough misses to push hit rate below threshold (0.30).
+	// After 50 hits + N misses, rate = 50 / (50+N). Want rate < 0.30:
+	// 50 / (50+N) < 0.30 → N > 50/0.30 - 50 ≈ 117.
+	simulateChecks(j, 0, 120)
+	if j.shouldCheckFolder() {
+		total := j.dirCheckAttempts.Load()
+		hits := j.dirCheckHits.Load()
+		t.Fatalf("shouldCheckFolder returned true with hit rate %.2f (below threshold 0.30), total=%d hits=%d",
+			float64(hits)/float64(total), total, hits)
+	}
+}
+
+// TestShouldCheckFolder_RescanBypass verifies that Rescan=true always
+// returns false, regardless of hit rate or warmup state.
+func TestShouldCheckFolder_RescanBypass(t *testing.T) {
+	j := newTestJob(0.30, true, true) // Rescan=true
+	simulateChecks(j, 200, 0)        // 100% hits, past warmup
+
+	if j.shouldCheckFolder() {
+		t.Fatal("shouldCheckFolder returned true when Rescan=true")
+	}
+}
+
+// TestShouldCheckFolder_NetworkFSBypass verifies that skipUnchangedFolders=false
+// (network filesystem) always returns false.
+func TestShouldCheckFolder_NetworkFSBypass(t *testing.T) {
+	j := newTestJob(0.30, false, false) // skipUnchangedFolders=false
+	simulateChecks(j, 200, 0)
+
+	if j.shouldCheckFolder() {
+		t.Fatal("shouldCheckFolder returned true when skipUnchangedFolders=false")
+	}
+}

--- a/internal/manager/scan_filter_exclude_test.go
+++ b/internal/manager/scan_filter_exclude_test.go
@@ -1,0 +1,123 @@
+package manager
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stashapp/stash/internal/manager/config"
+)
+
+// Synthetic absolute paths for shouldSkipDir tests (no relation to the host layout).
+var (
+	testLibraryRoot    = filepath.FromSlash("/stash-test/library/media")
+	testExcludedPrefix = filepath.FromSlash("/stash-test/library/apps")
+	testSiblingPrefix  = filepath.FromSlash("/stash-test/library/appsdata")
+	testWideRoot       = filepath.FromSlash("/stash-test")
+	testNestedLibrary  = filepath.FromSlash("/stash-test/library/apps/nested")
+)
+
+func makeStashConfigs(paths ...string) config.StashConfigs {
+	cfgs := make(config.StashConfigs, len(paths))
+	for i, p := range paths {
+		cfgs[i] = &config.StashConfig{Path: p}
+	}
+	return cfgs
+}
+
+func TestShouldSkipDir_MatchesBothExcludes_NoDescendantRoot(t *testing.T) {
+	dir := testExcludedPrefix
+	s := &config.StashConfig{Path: testLibraryRoot}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps([]string{testExcludedPrefix})
+
+	if !shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=true for excluded dir with no descendant root")
+	}
+}
+
+func TestShouldSkipDir_DirIsLibraryRoot(t *testing.T) {
+	dir := testLibraryRoot
+	s := &config.StashConfig{Path: testLibraryRoot}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps([]string{testLibraryRoot})
+	imageRE := generateRegexps([]string{testLibraryRoot})
+
+	if shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=false when dir is a library root")
+	}
+}
+
+func TestShouldSkipDir_LibraryRootIsDescendant(t *testing.T) {
+	dir := testExcludedPrefix
+	s := &config.StashConfig{Path: testWideRoot}
+	allPaths := makeStashConfigs(testNestedLibrary)
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps([]string{testExcludedPrefix})
+
+	if shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=false when a library root is beneath the excluded dir")
+	}
+}
+
+func TestShouldSkipDir_SiblingMatchesPrefix(t *testing.T) {
+	// Exclude pattern for .../apps also matches .../appsdata — expected regex prefix behavior.
+	dir := testSiblingPrefix
+	s := &config.StashConfig{Path: testLibraryRoot}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps([]string{testExcludedPrefix})
+
+	if !shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=true: prefix match on sibling is expected regex behavior")
+	}
+}
+
+func TestShouldSkipDir_ExcludeImageFlag(t *testing.T) {
+	dir := testExcludedPrefix
+	s := &config.StashConfig{ExcludeImage: true}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps(nil) // no image exclude patterns
+
+	if !shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=true when ExcludeImage=true and video regex matches")
+	}
+}
+
+func TestShouldSkipDir_OnlyVideoExcludeMatches(t *testing.T) {
+	dir := testExcludedPrefix
+	s := &config.StashConfig{ExcludeImage: false}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps(nil) // no image exclude patterns
+
+	if shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=false when only video exclude matches and ExcludeImage=false")
+	}
+}
+
+func TestShouldSkipDir_EmptyExcludes(t *testing.T) {
+	dir := testExcludedPrefix
+	s := &config.StashConfig{}
+	allPaths := makeStashConfigs(testLibraryRoot)
+	videoRE := generateRegexps(nil)
+	imageRE := generateRegexps(nil)
+
+	if shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=false when no exclude patterns")
+	}
+}
+
+func TestShouldSkipDir_TrailingSeparatorOnRoot(t *testing.T) {
+	// allPaths entry has a trailing separator; filepath.Clean normalises it.
+	dir := testExcludedPrefix
+	s := &config.StashConfig{}
+	allPaths := makeStashConfigs(testExcludedPrefix + string(filepath.Separator)) // trailing sep
+	videoRE := generateRegexps([]string{testExcludedPrefix})
+	imageRE := generateRegexps([]string{testExcludedPrefix})
+
+	if shouldSkipDir(dir, s, allPaths, videoRE, imageRE) {
+		t.Error("expected shouldSkipDir=false: trailing separator on root path should be cleaned")
+	}
+}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -59,6 +59,28 @@ type ScanJob struct {
 	checkFolderThreshold float64
 }
 
+// CheckFolder hit-rate gating — assumptions and context:
+//
+//   - After warmup, cumulative hits/attempts proxies whether more CheckFolder
+//     calls pay off; walk order can skew this (single global ratio).
+//
+//   - A hit is CheckFolder returning unchanged: DB's folder ModTime equals this
+//     directory's ModTime from disk (see Scanner.CheckFolder). Skipping enqueue for
+//     direct files then assumes that invariant means nothing relevant changed among
+//     those children. This is safe for local filesystems, but not for network or
+//     coarse-modtime filesystems.
+//
+//   - When hits are rare (cold scan / folders absent or changed in DB), extra
+//     CheckFolder calls are mostly overhead versus processing dirs/files without this
+//     shortcut.
+//
+//   - Warmup assumes the first dirCheckWarmup CheckFolder calls are a representative
+//     sample of folder outcomes for this walk. It is treated as forecasting the whole
+//     job's hit rate. After warmup, a low cumulative rate stops further CheckFolder
+//     (e.g. first scan where almost every folder is new).
+//
+// Basic idea: we always CheckFolder until `dirCheckWarmup` folders have been checked,
+// then we continue to do so as long as the hit rate remains >= checkFolderHitRateThreshold
 const (
 	// dirCheckWarmup is the number of CheckFolder calls made before the
 	// hit-rate signal is trusted. Keeps the first few directories enabled

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -54,8 +54,8 @@ type ScanJob struct {
 	// dirCheckAttempts and dirCheckHits track the rolling hit rate of
 	// CheckFolder calls. shouldCheckFolder uses these to gate calls once the
 	// hit rate drops below checkFolderThreshold.
-	dirCheckAttempts    atomic.Int64
-	dirCheckHits        atomic.Int64
+	dirCheckAttempts     atomic.Int64
+	dirCheckHits         atomic.Int64
 	checkFolderThreshold float64
 }
 

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler/lru"
@@ -35,9 +36,56 @@ type ScanJob struct {
 	subscriptions *subscriptionManager
 
 	fileQueue chan file.ScannedFile
+	dirQueue  chan file.ScannedFile
 	count     int
 
 	unmatchedCaptionFiles utils.MutexField[[]string]
+
+	// unchangedDirs records directories whose set of direct children has not
+	// changed since the last scan. Files directly inside these directories are
+	// skipped to avoid unnecessary DB lookups. Subdirectories are still walked
+	// recursively so that deeper changes (new files, renamed dirs) are found.
+	unchangedDirs sync.Map
+
+	// skipUnchangedFolders is set per-path before walking; false for network
+	// filesystems where ModTime may not be reliable.
+	skipUnchangedFolders bool
+
+	// dirCheckAttempts and dirCheckHits track the rolling hit rate of
+	// CheckFolder calls. shouldCheckFolder uses these to gate calls once the
+	// hit rate drops below checkFolderThreshold.
+	dirCheckAttempts    atomic.Int64
+	dirCheckHits        atomic.Int64
+	checkFolderThreshold float64
+}
+
+const (
+	// dirCheckWarmup is the number of CheckFolder calls made before the
+	// hit-rate signal is trusted. Keeps the first few directories enabled
+	// unconditionally so the estimate is not dominated by noise.
+	dirCheckWarmup = 50
+
+	// checkFolderHitRateThreshold is the minimum hit rate below which
+	// CheckFolder is skipped. Derived from benchmarks: break-even is ~0.50
+	// (C_check_windows ≈ 139ms, C_save_per_dir ≈ 280ms); 0.30 is conservative,
+	// favouring the warm-scan optimisation in mixed-state libraries.
+	checkFolderHitRateThreshold = 0.30
+)
+
+// shouldCheckFolder returns true when calling CheckFolder is expected to pay
+// for itself. It is always true during the warm-up window. After that it
+// returns true only while the cumulative hit rate is at or above the threshold.
+// Returns false unconditionally when the modtime optimisation is disabled
+// (network FS) or when a forced rescan is requested (Rescan flag).
+func (j *ScanJob) shouldCheckFolder() bool {
+	if !j.skipUnchangedFolders || j.scanner.Rescan {
+		return false
+	}
+	total := j.dirCheckAttempts.Load()
+	if total < dirCheckWarmup {
+		return true
+	}
+	return float64(j.dirCheckHits.Load())/float64(total) >= j.checkFolderThreshold
 }
 
 func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
@@ -95,14 +143,14 @@ func (j *ScanJob) Execute(ctx context.Context, progress *job.Progress) error {
 }
 
 func (j *ScanJob) runJob(ctx context.Context, paths []string, nTasks int, progress *job.Progress) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	j.fileQueue = make(chan file.ScannedFile, scanQueueSize)
+	j.dirQueue = make(chan file.ScannedFile, scanQueueSize)
 
+	var walkWg sync.WaitGroup
+	walkWg.Add(1)
 	go func() {
 		defer func() {
-			wg.Done()
+			walkWg.Done()
 
 			// handle panics in goroutine
 			if p := recover(); p != nil {
@@ -123,7 +171,27 @@ func (j *ScanJob) runJob(ctx context.Context, paths []string, nTasks int, progre
 		logger.Infof("Finished adding files to queue. %d files queued", j.count)
 	}()
 
-	defer wg.Wait()
+	// dir writer: single goroutine drains dirQueue sequentially, preserving DFS
+	// order so parent directories are always committed before their children.
+	var dirWg sync.WaitGroup
+	dirWg.Add(1)
+	go func() {
+		defer func() {
+			dirWg.Done()
+
+			if p := recover(); p != nil {
+				logger.Errorf("panic while processing dir queue: %v", p)
+				logger.Errorf(string(debug.Stack()))
+			}
+		}()
+
+		for d := range j.dirQueue {
+			j.processQueueItem(ctx, d, progress)
+		}
+	}()
+
+	defer walkWg.Wait()
+	defer dirWg.Wait()
 
 	j.processQueue(ctx, nTasks, progress)
 }
@@ -135,6 +203,7 @@ func (j *ScanJob) queueFiles(ctx context.Context, paths []string, progress *job.
 
 	defer func() {
 		close(j.fileQueue)
+		close(j.dirQueue)
 
 		progress.AddTotal(j.count)
 		progress.Definite()
@@ -142,7 +211,32 @@ func (j *ScanJob) queueFiles(ctx context.Context, paths []string, progress *job.
 
 	var err error
 	progress.ExecuteTask("Walking directory tree", func() {
+		j.dirCheckAttempts.Store(0)
+		j.dirCheckHits.Store(0)
+
 		for _, p := range paths {
+			skipUnchanged := true
+			isNet, netErr := fsutil.IsNetworkFS(p)
+			if netErr != nil {
+				logger.Warnf("Could not detect FS type for %s, disabling folder skip optimisation: %v", p, netErr)
+				skipUnchanged = false
+			} else if isNet {
+				logger.Infof("Network filesystem detected for %s; disabling folder ModTime skip optimisation", p)
+				skipUnchanged = false
+			}
+			if skipUnchanged {
+				coarse, coarseErr := fsutil.CoarseModtimeFilesystem(p)
+				if coarseErr != nil {
+					logger.Warnf("Could not detect coarse-modtime filesystem for %s, disabling folder skip optimisation: %v", p, coarseErr)
+					skipUnchanged = false
+				} else if coarse {
+					logger.Infof("FAT/exFAT or coarse-modtime filesystem detected for %s; disabling folder ModTime skip optimisation", p)
+					skipUnchanged = false
+				}
+			}
+			j.skipUnchangedFolders = skipUnchanged
+			j.checkFolderThreshold = checkFolderHitRateThreshold
+
 			err = file.SymWalk(fs, p, j.queueFileFunc(ctx, fs, nil, progress))
 			if err != nil {
 				return
@@ -226,17 +320,34 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 		}
 
 		if info.IsDir() {
-			// handle folders immediately
-			if err := j.handleFolder(ctx, ff, progress); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					logger.Errorf("error processing %q: %v", path, err)
+			if j.shouldCheckFolder() {
+				j.dirCheckAttempts.Add(1)
+				_, unchanged, err := j.scanner.CheckFolder(ctx, ff)
+				if err != nil {
+					if !errors.Is(err, context.Canceled) {
+						logger.Errorf("error checking folder %q: %v", path, err)
+					}
+					return fs.SkipDir
 				}
-
-				// skip the directory since we won't be able to process the files anyway
-				return fs.SkipDir
+				if unchanged {
+					j.dirCheckHits.Add(1)
+					j.unchangedDirs.Store(ff.Path, struct{}{})
+					return nil
+				}
 			}
-
+			j.dirQueue <- ff
 			return nil
+		}
+
+		// Skip files whose containing directory is known-unchanged. Their set
+		// of direct children has not changed, so no file was added here. We
+		// still walked into the parent to allow deeper subdirectories to be
+		// checked. Use Rescan to force re-examining file content.
+		if j.skipUnchangedFolders && !j.scanner.Rescan {
+			if _, isUnchanged := j.unchangedDirs.Load(filepath.Dir(path)); isUnchanged {
+				logger.Tracef("Skipping file %s in unchanged directory", path)
+				return nil
+			}
 		}
 
 		// if zip file is present, we handle immediately
@@ -319,9 +430,17 @@ func (j *ScanJob) handleFolder(ctx context.Context, f file.ScannedFile, progress
 		defer progress.Increment()
 	}
 
-	_, err := j.scanner.ScanFolder(ctx, f)
+	_, changed, err := j.scanner.ScanFolder(ctx, f)
 	if err != nil {
 		return err
+	}
+
+	// Record unchanged directories so their direct file children can be
+	// skipped. We never return fs.SkipDir here: subdirectories must still be
+	// walked because their own modtime may have changed (a new file added to
+	// /a/b only updates /a/b/'s modtime, not /a/'s).
+	if !changed && j.skipUnchangedFolders && !j.scanner.Rescan {
+		j.unchangedDirs.Store(f.Path, struct{}{})
 	}
 
 	return nil
@@ -559,6 +678,29 @@ type scanFilter struct {
 	stashIgnoreFilter *file.StashIgnoreFilter
 }
 
+// shouldSkipDir returns true if dir matches the video (and image) exclude patterns
+// and no configured stash root is at or beneath dir.
+func shouldSkipDir(dir string, s *config.StashConfig, allPaths config.StashConfigs, videoRE, imageRE []*regexp.Regexp) bool {
+	test := dir + string(filepath.Separator)
+
+	if !matchFileRegex(test, videoRE) {
+		return false
+	}
+
+	if !s.ExcludeImage && !matchFileRegex(test, imageRE) {
+		return false
+	}
+
+	cleanDir := filepath.Clean(dir)
+	for _, sc := range allPaths {
+		if fsutil.IsPathInDir(cleanDir, filepath.Clean(sc.Path)) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func newScanFilter(c *config.Config, repo models.Repository, minModTime time.Time) *scanFilter {
 	return &scanFilter{
 		extensionConfig:   newExtensionConfig(c),
@@ -610,11 +752,8 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo, 
 		return false
 	}
 
-	// shortcut: skip the directory entirely if it matches both exclusion patterns
-	// add a trailing separator so that it correctly matches against patterns like path/.*
-	pathExcludeTest := path + string(filepath.Separator)
-	if (matchFileRegex(pathExcludeTest, f.videoExcludeRegex)) && (s.ExcludeImage || matchFileRegex(pathExcludeTest, f.imageExcludeRegex)) {
-		logger.Debugf("Skipping directory %s as it matches video and image exclusion patterns", path)
+	if info.IsDir() && shouldSkipDir(path, s, f.stashPaths, f.videoExcludeRegex, f.imageExcludeRegex) {
+		logger.Debugf("Skipping directory %s as it matches exclude patterns", path)
 		return false
 	}
 

--- a/internal/manager/task_scan_dir_queue_test.go
+++ b/internal/manager/task_scan_dir_queue_test.go
@@ -1,0 +1,162 @@
+package manager
+
+import (
+	"context"
+	"io/fs"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stashapp/stash/pkg/file"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// fakeFileInfo implements fs.FileInfo for test directory entries.
+type fakeFileInfo struct {
+	name    string
+	isDir   bool
+	modTime time.Time
+	size    int64
+	mode    fs.FileMode
+}
+
+func (f *fakeFileInfo) Name() string       { return f.name }
+func (f *fakeFileInfo) Size() int64        { return f.size }
+func (f *fakeFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f *fakeFileInfo) ModTime() time.Time { return f.modTime }
+func (f *fakeFileInfo) IsDir() bool        { return f.isDir }
+func (f *fakeFileInfo) Sys() any           { return nil }
+
+// fakeDirEntry implements fs.DirEntry backed by a fakeFileInfo.
+type fakeDirEntry struct{ info *fakeFileInfo }
+
+func (d *fakeDirEntry) Name() string               { return d.info.name }
+func (d *fakeDirEntry) IsDir() bool                { return d.info.isDir }
+func (d *fakeDirEntry) Type() fs.FileMode          { return d.info.mode }
+func (d *fakeDirEntry) Info() (fs.FileInfo, error) { return d.info, nil }
+
+// TestDirQueue_DirectoryGoesToDirQueue verifies that queueFileFunc sends
+// a new (cold-scan) directory to dirQueue, not fileQueue.
+func TestDirQueue_DirectoryGoesToDirQueue(t *testing.T) {
+	scanner := makeTestScanner(t, nil /* folder not found → new dir */, false)
+	j := makeTestScanJob(scanner, false)
+
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	info := &fakeFileInfo{
+		name:    "sub",
+		isDir:   true,
+		modTime: modTime,
+		mode:    fs.ModeDir | 0o755,
+	}
+
+	fn := j.queueFileFunc(context.Background(), &fakeTaskFS{}, nil, nil)
+	if err := fn("/root/sub", &fakeDirEntry{info}, nil); err != nil {
+		t.Fatalf("queueFileFunc returned error: %v", err)
+	}
+
+	select {
+	case got := <-j.dirQueue:
+		if got.Path != "/root/sub" {
+			t.Errorf("dirQueue got path %q, want %q", got.Path, "/root/sub")
+		}
+	default:
+		t.Error("expected directory to be sent to dirQueue, but dirQueue is empty")
+	}
+
+	select {
+	case f := <-j.fileQueue:
+		t.Errorf("directory was unexpectedly sent to fileQueue: %s", f.Path)
+	default:
+		// good — fileQueue is empty
+	}
+}
+
+// TestDirQueue_UnchangedDirNotQueued verifies that an unchanged directory
+// (skipUnchangedFolders=true, same modtime) is stored in unchangedDirs
+// and not sent to dirQueue.
+func TestDirQueue_UnchangedDirNotQueued(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(1)
+	existingFolder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: modTime},
+		Path:           "/root/sub",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, existingFolder, true)
+	j := makeTestScanJob(scanner, true)
+
+	info := &fakeFileInfo{
+		name:    "sub",
+		isDir:   true,
+		modTime: modTime,
+		mode:    fs.ModeDir | 0o755,
+	}
+
+	fn := j.queueFileFunc(context.Background(), &fakeTaskFS{}, nil, nil)
+	if err := fn("/root/sub", &fakeDirEntry{info}, nil); err != nil {
+		t.Fatalf("queueFileFunc returned error: %v", err)
+	}
+
+	select {
+	case f := <-j.dirQueue:
+		t.Errorf("unchanged directory was unexpectedly sent to dirQueue: %s", f.Path)
+	default:
+		// good
+	}
+
+	if _, stored := j.unchangedDirs.Load("/root/sub"); !stored {
+		t.Error("expected /root/sub in unchangedDirs for unchanged folder")
+	}
+}
+
+// TestDirQueue_WriterDrainsAll verifies that a dir writer goroutine
+// processes every item sent to dirQueue by calling handleFolder for each.
+func TestDirQueue_WriterDrainsAll(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(1)
+	folder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: modTime},
+		Path:           "/root",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, folder, false)
+	j := makeTestScanJob(scanner, false)
+
+	dirs := []string{"/root/a", "/root/b", "/root/c"}
+	for _, p := range dirs {
+		sf := file.ScannedFile{
+			BaseFile: &models.BaseFile{
+				DirEntry: models.DirEntry{ModTime: modTime},
+				Path:     p,
+				Basename: "x",
+			},
+			FS:   &fakeTaskFS{},
+			Info: &fakeFileInfo{name: "x", isDir: true, modTime: modTime, mode: fs.ModeDir | 0o755},
+		}
+		j.dirQueue <- sf
+	}
+	close(j.dirQueue)
+
+	var mu sync.Mutex
+	var processed []string
+
+	// Simulate the dir writer loop the implementation uses.
+	for d := range j.dirQueue {
+		mu.Lock()
+		processed = append(processed, d.Path)
+		mu.Unlock()
+		// exercise handleFolder integration; errors are non-fatal here
+		_ = j.handleFolder(context.Background(), d, nil)
+	}
+
+	if len(processed) != len(dirs) {
+		t.Errorf("dir writer processed %d dirs, want %d", len(processed), len(dirs))
+	}
+	for i, p := range dirs {
+		if processed[i] != p {
+			t.Errorf("dir writer processed[%d] = %q, want %q", i, processed[i], p)
+		}
+	}
+}

--- a/internal/manager/task_scan_skip_test.go
+++ b/internal/manager/task_scan_skip_test.go
@@ -62,7 +62,7 @@ func (s *fixedFolderStore) Create(_ context.Context, f *models.Folder) error {
 	f.ID = 1
 	return nil
 }
-func (s *fixedFolderStore) Update(_ context.Context, _ *models.Folder) error { return nil }
+func (s *fixedFolderStore) Update(_ context.Context, _ *models.Folder) error   { return nil }
 func (s *fixedFolderStore) Destroy(_ context.Context, _ models.FolderID) error { return nil }
 
 // fakeTaskFS is a minimal FS that returns ErrNotExist for all operations.

--- a/internal/manager/task_scan_skip_test.go
+++ b/internal/manager/task_scan_skip_test.go
@@ -1,0 +1,203 @@
+package manager
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stashapp/stash/pkg/file"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// fakeTxnMgr runs functions directly without a database.
+type fakeTxnMgr struct{}
+
+func (m *fakeTxnMgr) Begin(ctx context.Context, _ bool) (context.Context, error) {
+	return ctx, nil
+}
+func (m *fakeTxnMgr) Commit(_ context.Context) error   { return nil }
+func (m *fakeTxnMgr) Rollback(_ context.Context) error { return nil }
+func (m *fakeTxnMgr) IsLocked(_ error) bool            { return false }
+func (m *fakeTxnMgr) WithDatabase(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+// fixedFolderStore returns a pre-configured folder for FindByPath.
+type fixedFolderStore struct {
+	folder *models.Folder
+}
+
+func (s *fixedFolderStore) Find(_ context.Context, _ models.FolderID) (*models.Folder, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) FindMany(_ context.Context, _ []models.FolderID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) FindAllInPaths(_ context.Context, _ []string, _ bool, _, _ int) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) FindByPath(_ context.Context, _ string, _ bool) (*models.Folder, error) {
+	return s.folder, nil
+}
+func (s *fixedFolderStore) FindByZipFileID(_ context.Context, _ models.FileID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) FindByParentFolderID(_ context.Context, _ models.FolderID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) GetManyParentFolderIDs(_ context.Context, _ []models.FolderID) ([][]models.FolderID, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) GetManySubFolderIDs(_ context.Context, _ []models.FolderID) ([][]models.FolderID, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) Query(_ context.Context, _ models.FolderQueryOptions) (*models.FolderQueryResult, error) {
+	return nil, nil
+}
+func (s *fixedFolderStore) CountAllInPaths(_ context.Context, _ []string) (int, error) {
+	return 0, nil
+}
+func (s *fixedFolderStore) Create(_ context.Context, f *models.Folder) error {
+	f.ID = 1
+	return nil
+}
+func (s *fixedFolderStore) Update(_ context.Context, _ *models.Folder) error { return nil }
+func (s *fixedFolderStore) Destroy(_ context.Context, _ models.FolderID) error { return nil }
+
+// fakeTaskFS is a minimal FS that returns ErrNotExist for all operations.
+type fakeTaskFS struct{}
+
+func (f *fakeTaskFS) Lstat(_ string) (fs.FileInfo, error)             { return nil, fs.ErrNotExist }
+func (f *fakeTaskFS) Stat(_ string) (fs.FileInfo, error)              { return nil, fs.ErrNotExist }
+func (f *fakeTaskFS) Open(_ string) (fs.ReadDirFile, error)           { return nil, fs.ErrNotExist }
+func (f *fakeTaskFS) OpenZip(_ string, _ int64) (models.ZipFS, error) { return nil, nil }
+func (f *fakeTaskFS) IsPathCaseSensitive(_ string) (bool, error)      { return true, nil }
+
+func makeTestScanner(t *testing.T, folder *models.Folder, _ bool) *file.Scanner {
+	t.Helper()
+	return &file.Scanner{
+		FS: &fakeTaskFS{},
+		Repository: file.Repository{
+			TxnManager: &fakeTxnMgr{},
+			Folder:     &fixedFolderStore{folder: folder},
+		},
+		RootPaths: []string{"/root"},
+	}
+}
+
+func makeTestScanJob(scanner *file.Scanner, skipUnchangedFolders bool) *ScanJob {
+	return &ScanJob{
+		scanner:              scanner,
+		fileQueue:            make(chan file.ScannedFile, 10),
+		dirQueue:             make(chan file.ScannedFile, 10),
+		skipUnchangedFolders: skipUnchangedFolders,
+	}
+}
+
+func makeTestScannedFolder(path string, modTime time.Time) file.ScannedFile {
+	return file.ScannedFile{
+		BaseFile: &models.BaseFile{
+			DirEntry: models.DirEntry{ModTime: modTime},
+			Path:     path,
+			Basename: "test",
+		},
+		FS: &fakeTaskFS{},
+	}
+}
+
+func TestHandleFolder_UnchangedSkip(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	folder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: modTime},
+		Path:           "/root/sub",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, folder, true)
+	job := makeTestScanJob(scanner, true)
+
+	scanned := makeTestScannedFolder("/root/sub", modTime)
+	err := job.handleFolder(context.Background(), scanned, nil)
+
+	// handleFolder must NOT return fs.SkipDir — subdirectories must be walked
+	// so that nested new files are discovered. Instead, the path is stored in
+	// unchangedDirs for file-level skipping.
+	if err != nil {
+		t.Errorf("expected nil from handleFolder for unchanged folder, got %v", err)
+	}
+
+	if _, stored := job.unchangedDirs.Load("/root/sub"); !stored {
+		t.Error("expected /root/sub to be recorded in unchangedDirs")
+	}
+}
+
+func TestHandleFolder_UnchangedFilesSkipped(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	folder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: modTime},
+		Path:           "/root/sub",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, folder, true)
+	job := makeTestScanJob(scanner, true)
+
+	scanned := makeTestScannedFolder("/root/sub", modTime)
+	if err := job.handleFolder(context.Background(), scanned, nil); err != nil {
+		t.Fatalf("handleFolder: %v", err)
+	}
+
+	// A file inside the unchanged directory should be in unchangedDirs
+	_, stored := job.unchangedDirs.Load("/root/sub")
+	if !stored {
+		t.Fatal("expected /root/sub in unchangedDirs")
+	}
+}
+
+func TestHandleFolder_ChangedNoSkip(t *testing.T) {
+	oldTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	folder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: oldTime},
+		Path:           "/root/sub",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, folder, true)
+	job := makeTestScanJob(scanner, true)
+
+	scanned := makeTestScannedFolder("/root/sub", newTime)
+	err := job.handleFolder(context.Background(), scanned, nil)
+
+	if err != nil {
+		t.Errorf("expected no error for changed folder, got %v", err)
+	}
+}
+
+func TestHandleFolder_SkipUnchangedFolders_Disabled(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	folder := &models.Folder{
+		DirEntry:       models.DirEntry{ModTime: modTime},
+		Path:           "/root/sub",
+		ParentFolderID: &parentID,
+	}
+
+	scanner := makeTestScanner(t, folder, false) // disabled
+	job := makeTestScanJob(scanner, false)
+
+	scanned := makeTestScannedFolder("/root/sub", modTime)
+	err := job.handleFolder(context.Background(), scanned, nil)
+
+	if err != nil {
+		t.Errorf("expected no skip when SkipUnchangedFolders=false, got %v", err)
+	}
+}

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -148,10 +148,12 @@ func (s *Scanner) getFolderID(ctx context.Context, path string) (*models.FolderI
 	return &ret.ID, nil
 }
 
-// ScanFolder scans the provided folder into the database, returning the folder entry.
-// If the folder already exists, it is updated if necessary.
-func (s *Scanner) ScanFolder(ctx context.Context, file ScannedFile) (*models.Folder, error) {
+// ScanFolder persists folder metadata (creating or updating the row as needed).
+// It returns the folder, whether it was new or had metadata changes, and any error.
+// On success it updates folderPathToID so subsequent lookups use the cached ID.
+func (s *Scanner) ScanFolder(ctx context.Context, file ScannedFile) (*models.Folder, bool, error) {
 	var f *models.Folder
+	var changed bool
 	var err error
 	path := file.Path
 
@@ -180,8 +182,9 @@ func (s *Scanner) ScanFolder(ctx context.Context, file ScannedFile) (*models.Fol
 		// if folder not exists, create it
 		if f == nil {
 			f, err = s.onNewFolder(ctx, file)
+			changed = true
 		} else {
-			f, err = s.onExistingFolder(ctx, file, f)
+			f, changed, err = s.onExistingFolder(ctx, file, f)
 		}
 
 		if err != nil {
@@ -195,7 +198,7 @@ func (s *Scanner) ScanFolder(ctx context.Context, file ScannedFile) (*models.Fol
 		return nil
 	})
 
-	return f, err
+	return f, changed, err
 }
 
 func (s *Scanner) isRootPath(path string) bool {
@@ -288,7 +291,7 @@ func (s *Scanner) handleFolderRename(ctx context.Context, file ScannedFile) (*mo
 	return renamedFrom, nil
 }
 
-func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing *models.Folder) (*models.Folder, error) {
+func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing *models.Folder) (*models.Folder, bool, error) {
 	update := false
 
 	// update if mod time is changed
@@ -326,7 +329,7 @@ func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing 
 		// create full folder hierarchy if parent folder doesn't exist, and set parent folder ID
 		parentFolder, err := GetOrCreateFolderHierarchy(ctx, s.Repository.Folder, filepath.Dir(f.Path), s.RootPaths)
 		if err != nil {
-			return nil, fmt.Errorf("getting parent folder for %q: %w", f.Path, err)
+			return nil, false, fmt.Errorf("getting parent folder for %q: %w", f.Path, err)
 		}
 		existing.ParentFolderID = &parentFolder.ID
 		update = true
@@ -335,11 +338,50 @@ func (s *Scanner) onExistingFolder(ctx context.Context, f ScannedFile, existing 
 	if update {
 		var err error
 		if err = s.Repository.Folder.Update(ctx, existing); err != nil {
-			return nil, fmt.Errorf("updating folder %q: %w", f.Path, err)
+			return nil, false, fmt.Errorf("updating folder %q: %w", f.Path, err)
 		}
 	}
 
-	return existing, nil
+	return existing, update, nil
+}
+
+// CheckFolder checks whether the directory already exists in the database and
+// whether its modtime has changed. It populates folderPathToID if the directory
+// is found. It does not write to the database.
+func (s *Scanner) CheckFolder(ctx context.Context, file ScannedFile) (existing *models.Folder, unchanged bool, err error) {
+	path := file.Path
+
+	err = s.Repository.WithReadTxn(ctx, func(ctx context.Context) error {
+		var findErr error
+		existing, findErr = s.Repository.Folder.FindByPath(ctx, path, true)
+		if findErr != nil {
+			return fmt.Errorf("checking for existing folder %q: %w", path, findErr)
+		}
+
+		if existing == nil && file.ZipFileID == nil {
+			caseSensitive, _ := file.FS.IsPathCaseSensitive(path)
+			if !caseSensitive {
+				existing, findErr = s.Repository.Folder.FindByPath(ctx, path, false)
+				if findErr != nil {
+					return fmt.Errorf("checking for existing folder %q: %w", path, findErr)
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	if existing == nil {
+		return nil, false, nil
+	}
+
+	s.folderPathToID.Store(existing.Path, existing.ID)
+
+	unchanged = existing.ModTime.Equal(file.ModTime)
+	return existing, unchanged, nil
 }
 
 type ScanFileResult struct {

--- a/pkg/file/scan_skip_test.go
+++ b/pkg/file/scan_skip_test.go
@@ -16,9 +16,9 @@ type fakeTxnManager struct{}
 func (m *fakeTxnManager) Begin(ctx context.Context, _ bool) (context.Context, error) {
 	return ctx, nil
 }
-func (m *fakeTxnManager) Commit(_ context.Context) error    { return nil }
-func (m *fakeTxnManager) Rollback(_ context.Context) error  { return nil }
-func (m *fakeTxnManager) IsLocked(_ error) bool             { return false }
+func (m *fakeTxnManager) Commit(_ context.Context) error   { return nil }
+func (m *fakeTxnManager) Rollback(_ context.Context) error { return nil }
+func (m *fakeTxnManager) IsLocked(_ error) bool            { return false }
 func (m *fakeTxnManager) WithDatabase(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
@@ -75,11 +75,11 @@ func (s *fakeFolderStore) Destroy(_ context.Context, _ models.FolderID) error { 
 // Lstat always returns os.ErrNotExist so detectFolderMove aborts gracefully.
 type fakeFS struct{}
 
-func (f *fakeFS) Lstat(_ string) (fs.FileInfo, error)              { return nil, fs.ErrNotExist }
-func (f *fakeFS) Stat(_ string) (fs.FileInfo, error)               { return nil, fs.ErrNotExist }
-func (f *fakeFS) Open(_ string) (fs.ReadDirFile, error)            { return nil, fs.ErrNotExist }
-func (f *fakeFS) OpenZip(_ string, _ int64) (models.ZipFS, error)  { return nil, nil }
-func (f *fakeFS) IsPathCaseSensitive(_ string) (bool, error)       { return true, nil }
+func (f *fakeFS) Lstat(_ string) (fs.FileInfo, error)             { return nil, fs.ErrNotExist }
+func (f *fakeFS) Stat(_ string) (fs.FileInfo, error)              { return nil, fs.ErrNotExist }
+func (f *fakeFS) Open(_ string) (fs.ReadDirFile, error)           { return nil, fs.ErrNotExist }
+func (f *fakeFS) OpenZip(_ string, _ int64) (models.ZipFS, error) { return nil, nil }
+func (f *fakeFS) IsPathCaseSensitive(_ string) (bool, error)      { return true, nil }
 
 func makeTestScanner(store *fakeFolderStore) *file.Scanner {
 	return &file.Scanner{

--- a/pkg/file/scan_skip_test.go
+++ b/pkg/file/scan_skip_test.go
@@ -1,0 +1,242 @@
+package file_test
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stashapp/stash/pkg/file"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// fakeTxnManager runs the function directly without a real database.
+type fakeTxnManager struct{}
+
+func (m *fakeTxnManager) Begin(ctx context.Context, _ bool) (context.Context, error) {
+	return ctx, nil
+}
+func (m *fakeTxnManager) Commit(_ context.Context) error    { return nil }
+func (m *fakeTxnManager) Rollback(_ context.Context) error  { return nil }
+func (m *fakeTxnManager) IsLocked(_ error) bool             { return false }
+func (m *fakeTxnManager) WithDatabase(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+// fakeFolderStore records calls and returns configurable results.
+type fakeFolderStore struct {
+	existing *models.Folder
+	created  []*models.Folder
+	updated  []*models.Folder
+}
+
+func (s *fakeFolderStore) Find(_ context.Context, _ models.FolderID) (*models.Folder, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) FindMany(_ context.Context, _ []models.FolderID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) FindAllInPaths(_ context.Context, _ []string, _ bool, _, _ int) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) FindByPath(_ context.Context, _ string, _ bool) (*models.Folder, error) {
+	return s.existing, nil
+}
+func (s *fakeFolderStore) FindByZipFileID(_ context.Context, _ models.FileID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) FindByParentFolderID(_ context.Context, _ models.FolderID) ([]*models.Folder, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) GetManyParentFolderIDs(_ context.Context, _ []models.FolderID) ([][]models.FolderID, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) GetManySubFolderIDs(_ context.Context, _ []models.FolderID) ([][]models.FolderID, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) Query(_ context.Context, _ models.FolderQueryOptions) (*models.FolderQueryResult, error) {
+	return nil, nil
+}
+func (s *fakeFolderStore) CountAllInPaths(_ context.Context, _ []string) (int, error) {
+	return 0, nil
+}
+func (s *fakeFolderStore) Create(_ context.Context, f *models.Folder) error {
+	s.created = append(s.created, f)
+	f.ID = 1
+	return nil
+}
+func (s *fakeFolderStore) Update(_ context.Context, f *models.Folder) error {
+	s.updated = append(s.updated, f)
+	return nil
+}
+func (s *fakeFolderStore) Destroy(_ context.Context, _ models.FolderID) error { return nil }
+
+// fakeFS is a minimal FS that reports paths as case-sensitive.
+// Lstat always returns os.ErrNotExist so detectFolderMove aborts gracefully.
+type fakeFS struct{}
+
+func (f *fakeFS) Lstat(_ string) (fs.FileInfo, error)              { return nil, fs.ErrNotExist }
+func (f *fakeFS) Stat(_ string) (fs.FileInfo, error)               { return nil, fs.ErrNotExist }
+func (f *fakeFS) Open(_ string) (fs.ReadDirFile, error)            { return nil, fs.ErrNotExist }
+func (f *fakeFS) OpenZip(_ string, _ int64) (models.ZipFS, error)  { return nil, nil }
+func (f *fakeFS) IsPathCaseSensitive(_ string) (bool, error)       { return true, nil }
+
+func makeTestScanner(store *fakeFolderStore) *file.Scanner {
+	return &file.Scanner{
+		FS: &fakeFS{},
+		Repository: file.Repository{
+			TxnManager: &fakeTxnManager{},
+			Folder:     store,
+		},
+		RootPaths: []string{"/root"},
+	}
+}
+
+func makeScannedFolder(path string, modTime time.Time) file.ScannedFile {
+	return file.ScannedFile{
+		BaseFile: &models.BaseFile{
+			DirEntry: models.DirEntry{
+				ModTime: modTime,
+			},
+			Path:     path,
+			Basename: "test",
+		},
+		FS: &fakeFS{},
+	}
+}
+
+func TestCheckFolder_ExistingUnchanged_ReturnsUnchangedTrue(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	store := &fakeFolderStore{
+		existing: &models.Folder{
+			ID:             models.FolderID(1),
+			DirEntry:       models.DirEntry{ModTime: modTime},
+			Path:           "/root/sub",
+			ParentFolderID: &parentID,
+		},
+	}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/sub", modTime)
+
+	_, unchanged, err := scanner.CheckFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !unchanged {
+		t.Error("expected unchanged=true for matching modtime, got unchanged=false")
+	}
+}
+
+func TestCheckFolder_ExistingChanged_ReturnsUnchangedFalse(t *testing.T) {
+	oldTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	store := &fakeFolderStore{
+		existing: &models.Folder{
+			ID:             models.FolderID(1),
+			DirEntry:       models.DirEntry{ModTime: oldTime},
+			Path:           "/root/sub",
+			ParentFolderID: &parentID,
+		},
+	}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/sub", newTime)
+
+	_, unchanged, err := scanner.CheckFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("expected unchanged=false for changed modtime, got unchanged=true")
+	}
+}
+
+func TestCheckFolder_NotFound_ReturnsNilUnchangedFalse(t *testing.T) {
+	store := &fakeFolderStore{existing: nil}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/new", time.Now())
+
+	existing, unchanged, err := scanner.CheckFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if existing != nil {
+		t.Error("expected existing=nil for unknown folder")
+	}
+	if unchanged {
+		t.Error("expected unchanged=false for unknown folder")
+	}
+}
+
+func TestScanFolder_ExistingUnchanged_ReturnsChangedFalse(t *testing.T) {
+	modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	store := &fakeFolderStore{
+		existing: &models.Folder{
+			DirEntry:       models.DirEntry{ModTime: modTime},
+			Path:           "/root/sub",
+			ParentFolderID: &parentID,
+		},
+	}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/sub", modTime)
+
+	_, changed, err := scanner.ScanFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for unchanged folder, got changed=true")
+	}
+	if len(store.updated) != 0 {
+		t.Errorf("expected no updates, got %d", len(store.updated))
+	}
+}
+
+func TestScanFolder_ExistingChanged_ReturnsChangedTrue(t *testing.T) {
+	oldTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	parentID := models.FolderID(99)
+
+	store := &fakeFolderStore{
+		existing: &models.Folder{
+			DirEntry:       models.DirEntry{ModTime: oldTime},
+			Path:           "/root/sub",
+			ParentFolderID: &parentID,
+		},
+	}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/sub", newTime)
+
+	_, changed, err := scanner.ScanFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true for modified folder, got changed=false")
+	}
+}
+
+func TestScanFolder_NewFolder_ReturnsChangedTrue(t *testing.T) {
+	store := &fakeFolderStore{existing: nil}
+	scanner := makeTestScanner(store)
+
+	scanned := makeScannedFolder("/root/brandnew", time.Now())
+
+	_, changed, err := scanner.ScanFolder(context.Background(), scanned)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true for new folder, got changed=false")
+	}
+}

--- a/pkg/fsutil/coarse_modtime_darwin.go
+++ b/pkg/fsutil/coarse_modtime_darwin.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package fsutil
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// CoarseModtimeFilesystem reports whether path is on FAT, exFAT, or another
+// filesystem where directory modification time is too coarse or unreliable for
+// Stash's folder modtime scan optimization.
+func CoarseModtimeFilesystem(path string) (bool, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(path, &s); err != nil {
+		return false, err
+	}
+
+	b := make([]byte, 0, len(s.Fstypename))
+	for _, c := range s.Fstypename {
+		if c == 0 {
+			break
+		}
+		b = append(b, byte(c))
+	}
+	name := strings.ToLower(string(b))
+
+	switch name {
+	case "msdos", "exfat":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/pkg/fsutil/coarse_modtime_linux.go
+++ b/pkg/fsutil/coarse_modtime_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Magic numbers from Linux uapi/linux/magic.h (statfs.f_type).
+const (
+	msdosSuperMagic = 0x4d44       // FAT / VFAT (msdos)
+	fatSuperMagic   = 0x4006       // legacy FAT magic (rare)
+	exfatSuperMagic = 0x2011BAB0   // exFAT
+)
+
+// CoarseModtimeFilesystem reports whether path is on FAT, exFAT, or another
+// filesystem where directory modification time is too coarse or unreliable for
+// Stash's folder modtime scan optimization.
+func CoarseModtimeFilesystem(path string) (bool, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(path, &s); err != nil {
+		return false, err
+	}
+
+	switch s.Type {
+	case msdosSuperMagic, fatSuperMagic, exfatSuperMagic:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/pkg/fsutil/coarse_modtime_linux.go
+++ b/pkg/fsutil/coarse_modtime_linux.go
@@ -8,9 +8,9 @@ import (
 
 // Magic numbers from Linux uapi/linux/magic.h (statfs.f_type).
 const (
-	msdosSuperMagic = 0x4d44       // FAT / VFAT (msdos)
-	fatSuperMagic   = 0x4006       // legacy FAT magic (rare)
-	exfatSuperMagic = 0x2011BAB0   // exFAT
+	msdosSuperMagic = 0x4d44     // FAT / VFAT (msdos)
+	fatSuperMagic   = 0x4006     // legacy FAT magic (rare)
+	exfatSuperMagic = 0x2011BAB0 // exFAT
 )
 
 // CoarseModtimeFilesystem reports whether path is on FAT, exFAT, or another

--- a/pkg/fsutil/coarse_modtime_test.go
+++ b/pkg/fsutil/coarse_modtime_test.go
@@ -1,0 +1,18 @@
+package fsutil_test
+
+import (
+	"testing"
+
+	"github.com/stashapp/stash/pkg/fsutil"
+)
+
+func TestCoarseModtimeFilesystem_LocalTempDirNotMarkedCoarse(t *testing.T) {
+	dir := t.TempDir()
+	coarse, err := fsutil.CoarseModtimeFilesystem(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if coarse {
+		t.Fatal("expected a local temp directory not to be classified as coarse-modtime FS")
+	}
+}

--- a/pkg/fsutil/coarse_modtime_unsupported.go
+++ b/pkg/fsutil/coarse_modtime_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package fsutil
+
+// CoarseModtimeFilesystem reports whether path is on FAT, exFAT, or another
+// filesystem where directory modification time is too coarse or unreliable for
+// Stash's folder modtime scan optimization.
+//
+// On platforms without detection logic, this always returns false so that the
+// folder ModTime skip optimisation is not inhibited by missing classification.
+func CoarseModtimeFilesystem(_ string) (bool, error) {
+	return false, nil
+}

--- a/pkg/fsutil/coarse_modtime_windows.go
+++ b/pkg/fsutil/coarse_modtime_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package fsutil
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// CoarseModtimeFilesystem reports whether path is on FAT, exFAT, or another
+// filesystem where directory modification time is too coarse or unreliable for
+// Stash's folder modtime scan optimization.
+func CoarseModtimeFilesystem(path string) (bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+
+	vol := filepath.VolumeName(abs)
+	if vol == "" {
+		return false, nil
+	}
+
+	root := vol
+	if !strings.HasSuffix(root, `\`) {
+		root += `\`
+	}
+
+	rootUTF16, err := windows.UTF16PtrFromString(root)
+	if err != nil {
+		return false, err
+	}
+
+	var fsName [windows.MAX_PATH + 1]uint16
+	err = windows.GetVolumeInformation(rootUTF16, nil, 0, nil, nil, nil, &fsName[0], windows.MAX_PATH+1)
+	if err != nil {
+		return false, err
+	}
+
+	name := strings.ToLower(strings.TrimSpace(windows.UTF16ToString(fsName[:])))
+	switch name {
+	case "fat", "fat32", "exfat":
+		return true, nil
+	default:
+		if strings.HasPrefix(name, "fat") {
+			return true, nil
+		}
+		return false, nil
+	}
+}

--- a/pkg/fsutil/netfs_darwin.go
+++ b/pkg/fsutil/netfs_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+
+package fsutil
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// networkFSTypes are fstypenames that indicate a network or FUSE filesystem.
+var networkFSTypes = []string{
+	"nfs",
+	"smbfs",
+	"afpfs",
+	"webdav",
+	"osxfuse",
+	"macfuse",
+	"fuse",
+}
+
+// IsNetworkFS reports whether path resides on a network (or FUSE) filesystem.
+// On macOS, it uses statfs(2) f_fstypename. FUSE filesystems are treated as
+// network filesystems because they may not provide reliable ModTime semantics.
+func IsNetworkFS(path string) (bool, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(path, &s); err != nil {
+		return false, err
+	}
+
+	// f_fstypename is a [16]int8; convert to string
+	b := make([]byte, 0, len(s.Fstypename))
+	for _, c := range s.Fstypename {
+		if c == 0 {
+			break
+		}
+		b = append(b, byte(c))
+	}
+	name := strings.ToLower(string(b))
+
+	for _, t := range networkFSTypes {
+		if name == t || strings.HasPrefix(name, t) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/fsutil/netfs_linux.go
+++ b/pkg/fsutil/netfs_linux.go
@@ -30,7 +30,8 @@ func IsNetworkFS(path string) (bool, error) {
 		return false, err
 	}
 
-	switch s.Type {
+	// Type is int32 on e.g. linux/arm; SMB/CIFS f_type magics exceed MaxInt32 — compare as uint32.
+	switch uint32(s.Type) {
 	case nfsMagic, smbMagic, smb2Magic, cifsMagic, afsNetMagic, ncpMagic, cephMagic, fuseMagic:
 		return true, nil
 	}

--- a/pkg/fsutil/netfs_linux.go
+++ b/pkg/fsutil/netfs_linux.go
@@ -9,13 +9,13 @@ import (
 // Network FS magic numbers from statfs(2)
 const (
 	// nfsSuper and related remote FS magic numbers
-	nfsMagic    = 0x6969
-	smbMagic    = 0xFF534D42 // SMBv1 / CIFS
-	smb2Magic   = 0xFE534D42 // SMBv2
-	cifsMagic   = 0x517B
-	afsNetMagic = 0x5346414F // AFS
-	ncpMagic    = 0x564C      // Novell NCP
-	cephMagic   = 0x00C36400
+	nfsMagic     = 0x6969
+	smbMagic     = 0xFF534D42 // SMBv1 / CIFS
+	smb2Magic    = 0xFE534D42 // SMBv2
+	cifsMagic    = 0x517B
+	afsNetMagic  = 0x5346414F // AFS
+	ncpMagic     = 0x564C     // Novell NCP
+	cephMagic    = 0x00C36400
 	glusterMagic = 0x65735546 // also FUSE magic — treat conservatively as unknown (network)
 	// FUSE magic covers e.g. sshfs, gvfs — conservatively treated as network
 	fuseMagic = 0x65735546

--- a/pkg/fsutil/netfs_linux.go
+++ b/pkg/fsutil/netfs_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Network FS magic numbers from statfs(2)
+const (
+	// nfsSuper and related remote FS magic numbers
+	nfsMagic    = 0x6969
+	smbMagic    = 0xFF534D42 // SMBv1 / CIFS
+	smb2Magic   = 0xFE534D42 // SMBv2
+	cifsMagic   = 0x517B
+	afsNetMagic = 0x5346414F // AFS
+	ncpMagic    = 0x564C      // Novell NCP
+	cephMagic   = 0x00C36400
+	glusterMagic = 0x65735546 // also FUSE magic — treat conservatively as unknown (network)
+	// FUSE magic covers e.g. sshfs, gvfs — conservatively treated as network
+	fuseMagic = 0x65735546
+)
+
+// IsNetworkFS reports whether path resides on a network (or FUSE) filesystem.
+// On Linux, it uses statfs(2) magic numbers. FUSE filesystems are treated as
+// network filesystems because they may not provide reliable ModTime semantics.
+func IsNetworkFS(path string) (bool, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(path, &s); err != nil {
+		return false, err
+	}
+
+	switch s.Type {
+	case nfsMagic, smbMagic, smb2Magic, cifsMagic, afsNetMagic, ncpMagic, cephMagic, fuseMagic:
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/fsutil/netfs_other.go
+++ b/pkg/fsutil/netfs_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin && !windows
+
+package fsutil
+
+// IsNetworkFS reports whether path resides on a network filesystem.
+// On unsupported platforms we cannot classify mounts, so we always return
+// true (treat as network) and disable the folder ModTime skip optimisation.
+func IsNetworkFS(_ string) (bool, error) {
+	return true, nil
+}

--- a/pkg/fsutil/netfs_test.go
+++ b/pkg/fsutil/netfs_test.go
@@ -1,0 +1,18 @@
+package fsutil_test
+
+import (
+	"testing"
+
+	"github.com/stashapp/stash/pkg/fsutil"
+)
+
+func TestIsNetworkFS_LocalPath(t *testing.T) {
+	dir := t.TempDir()
+	isNet, err := fsutil.IsNetworkFS(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isNet {
+		t.Error("expected a local temp directory not to be classified as a network FS")
+	}
+}

--- a/pkg/fsutil/netfs_windows.go
+++ b/pkg/fsutil/netfs_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package fsutil
+
+import (
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsNetworkFS reports whether path resides on a network filesystem.
+// On Windows, it uses GetDriveType to detect DRIVE_REMOTE volumes.
+func IsNetworkFS(path string) (bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+
+	// GetDriveType wants a root path like "\\server\share\" or "C:\"
+	vol := filepath.VolumeName(abs)
+	if vol == "" {
+		return false, nil
+	}
+
+	root := vol + `\`
+	rootPtr, err := windows.UTF16PtrFromString(root)
+	if err != nil {
+		return false, err
+	}
+
+	driveType := windows.GetDriveType(rootPtr)
+	return driveType == windows.DRIVE_REMOTE, nil
+}

--- a/pkg/sqlite/folder.go
+++ b/pkg/sqlite/folder.go
@@ -127,14 +127,36 @@ func (qb *FolderStore) Create(ctx context.Context, f *models.Folder) error {
 	var r folderRow
 	r.fromFolder(*f)
 
-	id, err := qb.tableMgr.insertID(ctx, r)
+	q := dialect.Insert(qb.tableMgr.table).Prepared(true).Rows(r).OnConflict(goqu.DoNothing())
+	result, err := exec(ctx, q)
 	if err != nil {
-		return err
+		return fmt.Errorf("inserting folder %q: %w", f.Path, err)
 	}
 
-	// only assign id once we are successful
-	f.ID = models.FolderID(id)
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("getting rows affected for folder %q: %w", f.Path, err)
+	}
 
+	if affected == 0 {
+		// INSERT OR IGNORE was a no-op: row already exists, re-read the existing ID
+		existing, err := qb.FindByPath(ctx, f.Path, true)
+		if err != nil {
+			return fmt.Errorf("re-reading existing folder %q after insert conflict: %w", f.Path, err)
+		}
+		if existing == nil {
+			return fmt.Errorf("folder %q not found after insert conflict", f.Path)
+		}
+		f.ID = existing.ID
+		return nil
+	}
+
+	lastID, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("getting last insert id for folder %q: %w", f.Path, err)
+	}
+
+	f.ID = models.FolderID(lastID)
 	return nil
 }
 

--- a/pkg/sqlite/folder_bench_test.go
+++ b/pkg/sqlite/folder_bench_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+// +build integration
+
+package sqlite_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/txn"
+)
+
+// BenchmarkFolderFindByPath_Empty measures the cost of a FindByPath miss on an
+// empty folders table — the dominant per-directory cost on a cold scan.
+// Wrap in WithReadTxn to match CheckFolder's exact call path.
+func BenchmarkFolderFindByPath_Empty(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = txn.WithReadTxn(ctx, db, func(ctx context.Context) error {
+			_, err := db.Folder.FindByPath(ctx, "/nonexistent/benchmark/path", true)
+			return err
+		})
+	}
+}
+
+// BenchmarkFolderFindByPath_Populated measures the cost of a FindByPath hit on
+// a table with ~1000 folders — the warm-scan case.
+func BenchmarkFolderFindByPath_Populated(b *testing.B) {
+	ctx := context.Background()
+
+	// Pre-populate 1000 folders in a write transaction, then roll back after
+	// the benchmark so we don't pollute other tests.
+	const folderCount = 1000
+	paths := make([]string, folderCount)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("/bench/library/dir%04d", i)
+	}
+
+	// Insert outside the timed region.
+	if err := withTxn(func(ctx context.Context) error {
+		for _, p := range paths {
+			f := models.Folder{
+				Path:     p,
+				DirEntry: models.DirEntry{ModTime: time.Now()},
+			}
+			if err := db.Folder.Create(ctx, &f); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		b.Fatalf("setup: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = txn.WithReadTxn(ctx, db, func(ctx context.Context) error {
+			_, err := db.Folder.FindByPath(ctx, paths[i%folderCount], true)
+			return err
+		})
+	}
+	b.StopTimer()
+
+	// Clean up inserted rows.
+	_ = withTxn(func(ctx context.Context) error {
+		for _, p := range paths {
+			f, err := db.Folder.FindByPath(ctx, p, true)
+			if err != nil || f == nil {
+				continue
+			}
+			if err := db.Folder.Destroy(ctx, f.ID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/utils/reflect.go
+++ b/pkg/utils/reflect.go
@@ -18,7 +18,7 @@ func NotNilFields(subject interface{}, tag string) []string {
 		field := value.Field(i)
 
 		kind := field.Type().Kind()
-		if (kind == reflect.Ptr || kind == reflect.Slice) && !field.IsNil() {
+		if (kind == reflect.Pointer || kind == reflect.Slice) && !field.IsNil() {
 			tagValue := structType.Field(i).Tag.Get(tag)
 			if tagValue != "" {
 				ret = append(ret, tagValue)


### PR DESCRIPTION
### Summary

Stash's metadata scan walks configured library folders and reconciles files on disk with the SQLite database (new files, moves, deletions). On large libraries, doing that work repeatedly is expensive.

#### Current state (`develop@01a75833`)

An ordinary scan still walks and visits essentially the whole tree, and runs `ScanFile` for each candidate file, but unchanged files (same path modtime/basename, no Rescan) take a cheap path: SQLite lookup plus light bookkeeping, not a full fingerprint re-hash or full decorator/handler pass. So `develop` already avoids "re-processing every file" in the "heavy" sense, while elapsed time often still scales with library size because of enumeration and per-file reconciliation.

#### What this PR adds

We extend that modtime pattern to a folder-level shortcut: cheap SQLite `CheckFolder` reads (path + stored folder modtime vs disk) with adaptive hit-rate gating let us skip enqueueing files whose parent directory is known unchanged. We also add walk-time pruning of excluded directories, and related fixes (network / coarse-modtime automatic opt-out, hit-rate state reset between jobs). Deep trees are still walked; unchanged parents do not allow skipping descent, because changes deeper in the tree may not bump ancestor mtimes; so this is not "only touch what changed on disk" in the filesystem sense; it reduces queued work and DB-heavy paths when the shortcuts apply.

Impact is strongest on normal (non-Rescan) scans of a large, mostly-stable library on local disk, where content changes stay localized so many folders stay unchanged between scans.

### Design

1. During a scan, the scanner tracks how reliable cheap folder checks are (read-only SQLite folder lookup + directory modtime compare) and adaptively gates `CheckFolder` when the cumulative hit rate suggests those checks are no longer worth it; then processing falls back toward `develop`-like folder handling for subsequent paths in that run.
2. When `CheckFolder` reports an unchanged folder (DB modtime matches disk), we record that folder and omit enqueueing regular files located directly in that folder (subdirectories are still entered so deeper edits remain visible).
3. Hit-rate and related state are reset between scan jobs so one cold or noisy run does not permanently skew the next.

Parallel metadata scans can race when creating the same folder row. `FolderStore.Create` uses insert-or-ignore on the unique folder path and re-reads the existing folder ID when another worker already inserted it, so we avoid SQLite constraint failures without changing how folder rows are modeled.

To be clear: the runtime heuristic applies only to _whether we even attempt this new optimization_. If we're in a regime where most folders have changes, we don't bother continuing to check every folder, as the overhead outweighs the benefit (mostly on first-time library scans)

Expectations: warm rescans on a mostly idle library should spend far less time in parallel file processing (fewer files reach `ScanFile`) when many folders are unchanged, while directory listing / walk overhead remains. Adding a handful of new files still walks the tree but should remain closer to "cost driven by touched folders" than "every file pays full queue latency". Rescan and unreliable-modtime filesystems disable the shortcuts so behavior stays conservative.

### Note on Upgrading

**No migration or "onboarding" scan is required.** The bookkeeping used here is computed during each scan (it is not a new persisted setting you have to prime). If your library is already indexed in SQLite from normal use, the next metadata scan after upgrading uses the new behavior automatically.

### "Rescan"s

If you enable Rescan for a metadata scan, this optimization is turned off for that run: the cheap `CheckFolder` / hit-rate path is not used, and Stash falls back to the same full, conservative directory and file handling Rescan already implied (no skipping files just because a folder looked unchanged). Use a normal scan without Rescan for the fast path.

### Edge cases

The shortcut hinges on directory modification time: `CheckFolder` looks up the folder by path in SQLite and compares the row's stored `ModTime` (last persisted when Stash wrote that folder record) to the directory's current `mtime`. Equal timestamps mean no change to that folder row's notion of the directory, which we use to skip queueing files that are direct children of that directory (not to skip walking into child directories; descendant-only changes may not update the parent's mtime). If directory mtimes are stale, coarse, or inconsistent with what actually changed underneath, relying on them could hide real deltas; so the optimization is only safe when the OS and filesystem type give believable directory timestamps. This is usually the case on typical local filesystems; exceptions are detected and opted out automatically.

Note that Stash already assumed accurate modification times before this branch: unchanged-file fast paths on `develop` compare each file's path modtime (and related signals) to what SQLite stores, so trusting mtimes for “nothing changed here” is not new. However:

#### Automatic opt-out

We disable the optimization when directory mtimes are likely unreliable: network filesystems and FUSE on Linux (`statfs` / remote volume detection), plus FAT / exFAT (and similar coarse layouts) per OS. For example, `statfs` magic on Linux, volume filesystem name on Windows, `statfs` fstypename on macOS, so removable/USB-FAT-style libraries opt out without manual tuning. If classification fails for a path, we disable the optimization for all subpaths under it (as a conservative but correct default).

### Benchmarks

Results compare this branch against merge root `develop@01a75833` on one machine, one library root (13k files), same sequence every time so numbers are paired (apples-to-apples for each phase).

For each build we measure three situations:


| Phase                          | Meaning                                                                                                                                                          |
| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Cold                           | Scan after the usual full startup cost for that run (baseline for "heavy" work).                                                                                 |
| Warm, no changes               | Trigger another metadata scan without adding or altering library files; repeat several times and take the median warm time (first rep is often noisier). |
| Warm, controlled additions     | Run the scenario where new content is added so the scanner must notice real deltas (not an idle library).                                                    |

Scan settings: Each run uses GraphQL `metadataScan` with Rescan off (default), the benchmark library path as the only `paths` entry, and all scan-time generation disabled (`scanGenerateCovers`, `scanGeneratePreviews`, `scanGenerateImagePreviews`, `scanGenerateSprites`, `scanGeneratePhashes`, `scanGenerateThumbnails`, `scanGenerateClipPreviews` all `false`) so timings reflect metadata reconciliation, not thumbnail/preview generation. Both images and videos were included in the scan.

The environment was Windows with the library on NTFS (large collection on spinning disk); builds were native Windows binaries. These choices reflect a real desktop + HDD setup, so expect some variance. I'm too lazy to get lab-grade microbenchmarks.

### Benchmark results

Windows `.exe` on a single (NTFS, HDD) drive, same generated config as above (`video_file_naming_algorithm: OSHASH`, generation flags off). Warm no-change is the **median of five** warm samples.

| Phase | `develop` (ms) | `develop` (human) | Branch (ms) | Branch (human) | Ratio (parent / branch) |
|--------|-------------------------|------------------|------------------------|----------------|-------------------------|
| **Cold** | 479 212 | ~8.0 min | 505 247 | ~8.4 min | **~0.95×** (`develop` marginally faster) |
| **Warm, no changes** | 3 188 | ~3.2 s | 396 | ~0.40 s | **~8.1×** faster on branch |
| **Warm, additions** | 4 565 | ~4.6 s | 1 547 | ~1.5 s | **~3.0×** faster on branch |

Warm idle rescans were **sub-second** on the branch vs **~3 s** on the parent build; cold was **disk-heavy** and slightly slower on the branch, but a cold scan only happens once in normal usage.
