### PR TITLE
fix(sqlite): use LEFT JOIN for string-list criteria to fix OR filtering

### DIFF
--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -629,10 +629,7 @@ func (m *stringListCriterionHandlerBuilder) handler(criterion *models.StringCrit
 				// 	Modifier: models.CriterionModifierNotNull,
 				// }, m.joinTable+"."+m.stringColumn)(ctx, f)
 			} else {
-				joinType := joinTypeInner
-				if criterion.Modifier == models.CriterionModifierIsNull || criterion.Modifier == models.CriterionModifierNotMatchesRegex {
-					joinType = joinTypeLeft
-				}
+				joinType := joinTypeLeft
 				m.addJoinTable(f, joinType)
 				stringCriterionHandler(criterion, m.joinTable+"."+m.stringColumn)(ctx, f)
 			}


### PR DESCRIPTION
Fixes #6914

## Problem

`findTags` (and equivalent queries for other entity types) silently dropped results when an OR filter combined a `name` condition with an `aliases` condition, and the matched entity had no aliases.

Root cause: `stringListCriterionHandlerBuilder.handler()` used `joinTypeInner` as the default join type for string-list tables (`tag_aliases`, `performer_urls`, etc.). In OR contexts, this caused the join to eliminate all rows without alias entries before the WHERE clause could evaluate the OR — making the `name` branch unreachable for those rows.

The bug was amplified by the join-merging pipeline in `filterBuilder.getAllJoins()` (`filter.go:425–436`): sub-filter joins are merged into the main query via `joins.addUnique()`, which upgrades any existing LEFT JOIN to INNER if an INNER join on the same table is encountered (`filter.go:157–159`). This meant even a correctly written outer query would inherit the INNER JOIN from the OR sub-filter.

Generated SQL (before):
```sql
SELECT DISTINCT tags.id FROM tags
INNER JOIN tag_aliases ON tag_aliases.tag_id = tags.id
WHERE (tags.name LIKE ?) OR (tag_aliases.alias LIKE ?)
```

Tags with no aliases produce no rows in `tag_aliases`, so they are eliminated before the WHERE clause runs — the `tags.name` branch never gets evaluated.

## Fix

Changed the default join type from `joinTypeInner` to `joinTypeLeft` in `stringListCriterionHandlerBuilder.handler()`.

Removed the now-redundant special case for `IsNull` and `NotMatchesRegex` modifiers — these existed solely to override the old `joinTypeInner` default. With `joinTypeLeft` as the default, both modifiers work correctly out of the box: the LEFT JOIN guarantees a row exists for every entity, so `(column IS NULL OR ...)` in the WHERE clause can reach entities without any list entries.

Generated SQL (after):
```sql
SELECT DISTINCT tags.id FROM tags
LEFT JOIN tag_aliases ON tag_aliases.tag_id = tags.id
WHERE (tags.name LIKE ?) OR (tag_aliases.alias LIKE ?)
```

## Safety

`LEFT JOIN + WHERE col = value` and `INNER JOIN + WHERE col = value` produce identical results in non-OR queries: `NULL = 'x'` evaluates to `NULL` (falsy), so rows without list entries are still filtered out. The behavioral difference only surfaces in OR contexts, which is exactly the bug being fixed.

## Scope

Affects all callers of `stringListCriterionHandlerBuilder` — tags, performers, studios, scenes, images, galleries, and files — all receive the same fix for their respective string-list fields (aliases, URLs, captions, fingerprints, etc.).