### PR TITLE
Fix gallery tab content not loading on performer page when opened in new tab

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -119,7 +119,7 @@ const PerformerTabs: React.FC<{
       id="performer-tabs"
       mountOnEnter
       unmountOnExit
-      activeKey={tabKey}
+      activeKey={tabKey ?? populatedDefaultTab}
       onSelect={setTabKey}
     >
       <Tab


### PR DESCRIPTION
Fixes #6798

`activeKey={tabKey ?? populatedDefaultTab}` ensures the correct tab is shown on the very first render, before the URL is updated.

Tested with one and two filters and both worked.