### PR TITLE
Use accurate seek fallback for scene screenshot generation

### DIFF
--- a/pkg/ffmpeg/transcoder/screenshot.go
+++ b/pkg/ffmpeg/transcoder/screenshot.go
@@ -20,9 +20,8 @@ type ScreenshotOptions struct {
 
 	UseSelectFilter bool
 
-	// ScreenshotSeekMode is the ffpmeg seek mode to use (Fast vs Accurate).
-	// Defaults to Fast Seek
-	SeekMode ScreenshotSeekMode
+	// SlowSeek uses accurate seek by placing -ss after the input.
+	SlowSeek bool
 }
 
 func (o *ScreenshotOptions) setDefaults() {
@@ -35,15 +34,6 @@ type ScreenshotOutputType struct {
 	codec  *ffmpeg.VideoCodec
 	format ffmpeg.Format
 }
-
-type ScreenshotSeekMode int
-
-const (
-	// ScreenshotSeekFast seeks before opening the input. This preserves the existing screenshot behavior.
-	ScreenshotSeekFast ScreenshotSeekMode = iota
-	// ScreenshotSeekAccurate seeks after opening the input. This is slower, but can handle some files where fast seek fails.
-	ScreenshotSeekAccurate
-)
 
 func (t ScreenshotOutputType) Args() []string {
 	var ret []string
@@ -74,11 +64,11 @@ func ScreenshotTime(input string, t float64, options ScreenshotOptions) ffmpeg.A
 	args = args.LogLevel(options.Verbosity)
 	args = args.Overwrite()
 
-	if options.SeekMode != ScreenshotSeekAccurate {
+	if !options.SlowSeek {
 		args = args.Seek(t)
 	}
 	args = args.Input(input)
-	if options.SeekMode == ScreenshotSeekAccurate {
+	if options.SlowSeek {
 		args = args.Seek(t)
 	}
 	args = args.VideoFrames(1)

--- a/pkg/ffmpeg/transcoder/screenshot.go
+++ b/pkg/ffmpeg/transcoder/screenshot.go
@@ -19,6 +19,10 @@ type ScreenshotOptions struct {
 	Verbosity ffmpeg.LogLevel
 
 	UseSelectFilter bool
+
+	// ScreenshotSeekMode is the ffpmeg seek mode to use (Fast vs Accurate).
+	// Defaults to Fast Seek
+	SeekMode ScreenshotSeekMode
 }
 
 func (o *ScreenshotOptions) setDefaults() {
@@ -31,6 +35,15 @@ type ScreenshotOutputType struct {
 	codec  *ffmpeg.VideoCodec
 	format ffmpeg.Format
 }
+
+type ScreenshotSeekMode int
+
+const (
+	// ScreenshotSeekFast seeks before opening the input. This preserves the existing screenshot behavior.
+	ScreenshotSeekFast ScreenshotSeekMode = iota
+	// ScreenshotSeekAccurate seeks after opening the input. This is slower, but can handle some files where fast seek fails.
+	ScreenshotSeekAccurate
+)
 
 func (t ScreenshotOutputType) Args() []string {
 	var ret []string
@@ -60,9 +73,14 @@ func ScreenshotTime(input string, t float64, options ScreenshotOptions) ffmpeg.A
 	var args ffmpeg.Args
 	args = args.LogLevel(options.Verbosity)
 	args = args.Overwrite()
-	args = args.Seek(t)
 
+	if options.SeekMode != ScreenshotSeekAccurate {
+		args = args.Seek(t)
+	}
 	args = args.Input(input)
+	if options.SeekMode == ScreenshotSeekAccurate {
+		args = args.Seek(t)
+	}
 	args = args.VideoFrames(1)
 
 	if options.Quality > 0 {

--- a/pkg/ffmpeg/transcoder/screenshot_test.go
+++ b/pkg/ffmpeg/transcoder/screenshot_test.go
@@ -1,0 +1,51 @@
+package transcoder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScreenshotTimeDefaultUsesFastSeek(t *testing.T) {
+	options := ScreenshotOptions{
+		OutputPath: "out.jpg",
+		OutputType: ScreenshotOutputTypeImage2,
+	}
+
+	got := ScreenshotTime("input.webm", 12.5, options)
+	want := []string{
+		"-v", "error",
+		"-y",
+		"-ss", "12.5",
+		"-i", "input.webm",
+		"-frames:v", "1",
+		"-f", "image2",
+		"out.jpg",
+	}
+
+	if !reflect.DeepEqual([]string(got), want) {
+		t.Fatalf("ScreenshotTime() = %#v, want %#v", []string(got), want)
+	}
+}
+
+func TestScreenshotTimeAccurateSeek(t *testing.T) {
+	options := ScreenshotOptions{
+		OutputPath: "out.jpg",
+		OutputType: ScreenshotOutputTypeImage2,
+		SeekMode:   ScreenshotSeekAccurate,
+	}
+
+	got := ScreenshotTime("input.webm", 12.5, options)
+	want := []string{
+		"-v", "error",
+		"-y",
+		"-i", "input.webm",
+		"-ss", "12.5",
+		"-frames:v", "1",
+		"-f", "image2",
+		"out.jpg",
+	}
+
+	if !reflect.DeepEqual([]string(got), want) {
+		t.Fatalf("ScreenshotTime() = %#v, want %#v", []string(got), want)
+	}
+}

--- a/pkg/ffmpeg/transcoder/screenshot_test.go
+++ b/pkg/ffmpeg/transcoder/screenshot_test.go
@@ -27,11 +27,11 @@ func TestScreenshotTimeDefaultUsesFastSeek(t *testing.T) {
 	}
 }
 
-func TestScreenshotTimeAccurateSeek(t *testing.T) {
+func TestScreenshotTimeSlowSeek(t *testing.T) {
 	options := ScreenshotOptions{
 		OutputPath: "out.jpg",
 		OutputType: ScreenshotOutputTypeImage2,
-		SeekMode:   ScreenshotSeekAccurate,
+		SlowSeek:   true,
 	}
 
 	got := ScreenshotTime("input.webm", 12.5, options)

--- a/pkg/hash/videophash/phash.go
+++ b/pkg/hash/videophash/phash.go
@@ -47,7 +47,14 @@ func generateSpriteScreenshot(encoder *ffmpeg.FFMpeg, input string, t float64) (
 	args := transcoder.ScreenshotTime(input, t, options)
 	data, err := encoder.GenerateOutput(context.Background(), args, nil)
 	if err != nil {
-		return nil, err
+		logger.Warnf("[generator] fast phash screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, t, err)
+
+		options.SeekMode = transcoder.ScreenshotSeekAccurate
+		args = transcoder.ScreenshotTime(input, t, options)
+		data, err = encoder.GenerateOutput(context.Background(), args, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	reader := bytes.NewReader(data)

--- a/pkg/hash/videophash/phash.go
+++ b/pkg/hash/videophash/phash.go
@@ -37,24 +37,18 @@ func Generate(encoder *ffmpeg.FFMpeg, videoFile *models.VideoFile) (*uint64, err
 	return &hashValue, nil
 }
 
-func generateSpriteScreenshot(encoder *ffmpeg.FFMpeg, input string, t float64) (image.Image, error) {
+func generateSpriteScreenshot(encoder *ffmpeg.FFMpeg, input string, t float64, slowSeek bool) (image.Image, error) {
 	options := transcoder.ScreenshotOptions{
 		Width:      screenshotSize,
 		OutputPath: "-",
 		OutputType: transcoder.ScreenshotOutputTypeBMP,
+		SlowSeek:   slowSeek,
 	}
 
 	args := transcoder.ScreenshotTime(input, t, options)
 	data, err := encoder.GenerateOutput(context.Background(), args, nil)
 	if err != nil {
-		logger.Warnf("[generator] fast phash screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, t, err)
-
-		options.SeekMode = transcoder.ScreenshotSeekAccurate
-		args = transcoder.ScreenshotTime(input, t, options)
-		data, err = encoder.GenerateOutput(context.Background(), args, nil)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	reader := bytes.NewReader(data)
@@ -91,10 +85,18 @@ func generateSprite(encoder *ffmpeg.FFMpeg, videoFile *models.VideoFile) (image.
 	offset := 0.05 * videoFile.Duration
 	stepSize := (0.9 * videoFile.Duration) / float64(chunkCount)
 	var images []image.Image
+	slowSeek := false
+
 	for i := 0; i < chunkCount; i++ {
 		time := offset + (float64(i) * stepSize)
 
-		img, err := generateSpriteScreenshot(encoder, videoFile.Path, time)
+		img, err := generateSpriteScreenshot(encoder, videoFile.Path, time, slowSeek)
+		if err != nil && !slowSeek {
+			logger.Warnf("[generator] fast phash screenshot seek failed for %s at %.3fs, retrying with accurate seek for remaining phash screenshots: %v", videoFile.Path, time, err)
+
+			slowSeek = true
+			img, err = generateSpriteScreenshot(encoder, videoFile.Path, time, slowSeek)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("generating sprite screenshot: %w", err)
 		}

--- a/pkg/scene/generate/screenshot.go
+++ b/pkg/scene/generate/screenshot.go
@@ -60,7 +60,14 @@ func (g Generator) screenshot(input string, options screenshotOptions) generateF
 		}
 
 		args := transcoder.ScreenshotTime(input, options.Time, ssOptions)
+		if err := g.generate(lockCtx, args); err != nil {
+			logger.Warnf("[generator] fast screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, options.Time, err)
 
-		return g.generate(lockCtx, args)
+			ssOptions.SeekMode = transcoder.ScreenshotSeekAccurate
+			args = transcoder.ScreenshotTime(input, options.Time, ssOptions)
+			return g.generate(lockCtx, args)
+		}
+
+		return nil
 	}
 }

--- a/pkg/scene/generate/screenshot.go
+++ b/pkg/scene/generate/screenshot.go
@@ -63,7 +63,7 @@ func (g Generator) screenshot(input string, options screenshotOptions) generateF
 		if err := g.generate(lockCtx, args); err != nil {
 			logger.Warnf("[generator] fast screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, options.Time, err)
 
-			ssOptions.SeekMode = transcoder.ScreenshotSeekAccurate
+			ssOptions.SlowSeek = true
 			args = transcoder.ScreenshotTime(input, options.Time, ssOptions)
 			return g.generate(lockCtx, args)
 		}

--- a/pkg/scene/generate/sprite.go
+++ b/pkg/scene/generate/sprite.go
@@ -39,7 +39,7 @@ func (g Generator) SpriteScreenshot(ctx context.Context, input string, seconds f
 	if err != nil {
 		logger.Warnf("[generator] fast sprite screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, seconds, err)
 
-		ssOptions.SeekMode = transcoder.ScreenshotSeekAccurate
+		ssOptions.SlowSeek = true
 		args = transcoder.ScreenshotTime(input, seconds, ssOptions)
 		return g.generateImage(lockCtx, args)
 	}

--- a/pkg/scene/generate/sprite.go
+++ b/pkg/scene/generate/sprite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stashapp/stash/pkg/ffmpeg"
 	"github.com/stashapp/stash/pkg/ffmpeg/transcoder"
 	"github.com/stashapp/stash/pkg/fsutil"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/utils"
 )
 
@@ -34,8 +35,16 @@ func (g Generator) SpriteScreenshot(ctx context.Context, input string, seconds f
 	}
 
 	args := transcoder.ScreenshotTime(input, seconds, ssOptions)
+	img, err := g.generateImage(lockCtx, args)
+	if err != nil {
+		logger.Warnf("[generator] fast sprite screenshot seek failed for %s at %.3fs, retrying with accurate seek: %v", input, seconds, err)
 
-	return g.generateImage(lockCtx, args)
+		ssOptions.SeekMode = transcoder.ScreenshotSeekAccurate
+		args = transcoder.ScreenshotTime(input, seconds, ssOptions)
+		return g.generateImage(lockCtx, args)
+	}
+
+	return img, nil
 }
 
 func (g Generator) SpriteScreenshotSlow(ctx context.Context, input string, frame int, width int) (image.Image, error) {


### PR DESCRIPTION
Fixes #6499 

## Summary
- keep existing fast-seek behavior as the default for ScreenshotTime
- retry scene cover, scrubber sprite, and video phash screenshot generation with accurate seek only after ffmpeg failure
- add tests covering fast vs accurate seek argument order

## Compatibility
Fast seek remains the first attempt, preserving existing screenshot/phash parity for files that already worked.

## Testing
- go test ./pkg/ffmpeg/transcoder ./pkg/scene/generate ./pkg/hash/videophash
- Manually ran scan + generate on a set of both problem and previously working webm's and mp4's and confirmed that the generate ran as expected.  Also compared the PHash on the previously working files against a release build to ensure they hadn't changed and the warning announcing the fallback hadn't triggered when not expected.

## Notes
- Worth mentioning that I don't have much experience with Go so I wrote this referencing surrounding code and other implementations of fallbacks.  Also had codex do a review of it (and it wrote the test file to ensure the ffmpeg command args form properly).  Feel free to ping on discord as well for discussion.
- Possible concerns I can think of include:
   - Do we need to handle errors starting ffmpeg differently than running it? 
   - The fallback is implemented on each screen shot attempt for cover, scrubber sprites, and phash with warnings which means generating the scrubber sprites/phash can be very verbose in logs if the entire video is failing.
   - If ffmpeg fixes issues with webm fast seek in the future, this might cause issues with phash generations with videos that don't fallback anymore.