### PR TITLE
Fix tab content not rendering when first tab has no content

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -114,6 +114,10 @@ const PerformerTabs: React.FC<{
     };
   });
 
+  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
+  // when it is subsequently set to a valid value.
+  if (!tabKey) return null;
+
   return (
     <Tabs
       id="performer-tabs"

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -148,6 +148,10 @@ const StudioTabs: React.FC<{
     );
   }, [showAllDetails, studio.child_studios.length]);
 
+  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
+  // when it is subsequently set to a valid value.
+  if (!tabKey) return null;
+
   return (
     <Tabs
       id="studio-tabs"

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -151,6 +151,10 @@ const TagTabs: React.FC<{
     );
   }, [showAllDetails, tag.children.length]);
 
+  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
+  // when it is subsequently set to a valid value.
+  if (!tabKey) return null;
+
   return (
     <Tabs
       id="tag-tabs"


### PR DESCRIPTION
Resolves #6798

I'm not sure why it doesn't render the content if it is initially unset then set to a valid key, so I've sidestepped the issue by not rendering the `Tabs` control until `tabKey` is set.

Supercedes #6919 