### PR TITLE
feat: Add depth support to tag count filters for hierarchical sidebar display

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -632,29 +632,29 @@ input TagFilterType {
   "Filter to only include tags missing this property"
   is_missing: String
 
-  "Filter by number of scenes with this tag"
-  scene_count: IntCriterionInput
+  "Filter by number of scenes with this tag. Depth controls whether descendant tags are included."
+  scene_count: HierarchicalCountInput
 
-  "Filter by number of images with this tag"
-  image_count: IntCriterionInput
+  "Filter by number of images with this tag. Depth controls whether descendant tags are included."
+  image_count: HierarchicalCountInput
 
-  "Filter by number of galleries with this tag"
-  gallery_count: IntCriterionInput
+  "Filter by number of galleries with this tag. Depth controls whether descendant tags are included."
+  gallery_count: HierarchicalCountInput
 
-  "Filter by number of performers with this tag"
-  performer_count: IntCriterionInput
+  "Filter by number of performers with this tag. Depth controls whether descendant tags are included."
+  performer_count: HierarchicalCountInput
 
-  "Filter by number of studios with this tag"
-  studio_count: IntCriterionInput
+  "Filter by number of studios with this tag. Depth controls whether descendant tags are included."
+  studio_count: HierarchicalCountInput
 
-  "Filter by number of movies with this tag"
-  movie_count: IntCriterionInput
+  "Filter by number of movies with this tag. Depth controls whether descendant tags are included."
+  movie_count: HierarchicalCountInput
 
-  "Filter by number of group with this tag"
-  group_count: IntCriterionInput
+  "Filter by number of group with this tag. Depth controls whether descendant tags are included."
+  group_count: HierarchicalCountInput
 
-  "Filter by number of markers with this tag"
-  marker_count: IntCriterionInput
+  "Filter by number of markers with this tag. Depth controls whether descendant tags are included."
+  marker_count: HierarchicalCountInput
 
   "Filter by parent tags"
   parents: HierarchicalMultiCriterionInput
@@ -912,6 +912,13 @@ input IntCriterionInput {
   value: Int!
   value2: Int
   modifier: CriterionModifier!
+}
+
+input HierarchicalCountInput {
+  value: Int!
+  value2: Int
+  modifier: CriterionModifier!
+  depth: Int
 }
 
 input FloatCriterionInput {

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -632,28 +632,28 @@ input TagFilterType {
   "Filter to only include tags missing this property"
   is_missing: String
 
-  "Filter by number of scenes with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of scenes with this tag"
   scene_count: HierarchicalCountInput
 
-  "Filter by number of images with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of images with this tag"
   image_count: HierarchicalCountInput
 
-  "Filter by number of galleries with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of galleries with this tag"
   gallery_count: HierarchicalCountInput
 
-  "Filter by number of performers with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of performers with this tag"
   performer_count: HierarchicalCountInput
 
-  "Filter by number of studios with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of studios with this tag"
   studio_count: HierarchicalCountInput
 
-  "Filter by number of movies with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of movies with this tag"
   movie_count: HierarchicalCountInput
 
-  "Filter by number of group with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of group with this tag"
   group_count: HierarchicalCountInput
 
-  "Filter by number of markers with this tag. Depth controls whether descendant tags are included."
+  "Filter by number of markers with this tag"
   marker_count: HierarchicalCountInput
 
   "Filter by parent tags"
@@ -918,6 +918,7 @@ input HierarchicalCountInput {
   value: Int!
   value2: Int
   modifier: CriterionModifier!
+  "Number of descendant levels to include. Negative values include all descendants."
   depth: Int
 }
 

--- a/pkg/models/filter.go
+++ b/pkg/models/filter.go
@@ -130,6 +130,21 @@ func (i IntCriterionInput) ValidModifier() bool {
 	return false
 }
 
+type HierarchicalCountInput struct {
+	Value    int               `json:"value"`
+	Value2   *int              `json:"value2"`
+	Modifier CriterionModifier `json:"modifier"`
+	Depth    *int              `json:"depth"`
+}
+
+func (i HierarchicalCountInput) ValidModifier() bool {
+	switch i.Modifier {
+	case CriterionModifierEquals, CriterionModifierNotEquals, CriterionModifierGreaterThan, CriterionModifierLessThan, CriterionModifierIsNull, CriterionModifierNotNull, CriterionModifierBetween, CriterionModifierNotBetween:
+		return true
+	}
+	return false
+}
+
 type FloatCriterionInput struct {
 	Value    float64           `json:"value"`
 	Value2   *float64          `json:"value2"`

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -15,21 +15,21 @@ type TagFilterType struct {
 	// Filter to only include tags missing this property
 	IsMissing *string `json:"is_missing"`
 	// Filter by number of scenes with this tag
-	SceneCount *IntCriterionInput `json:"scene_count"`
+	SceneCount *HierarchicalCountInput `json:"scene_count"`
 	// Filter by number of images with this tag
-	ImageCount *IntCriterionInput `json:"image_count"`
+	ImageCount *HierarchicalCountInput `json:"image_count"`
 	// Filter by number of galleries with this tag
-	GalleryCount *IntCriterionInput `json:"gallery_count"`
+	GalleryCount *HierarchicalCountInput `json:"gallery_count"`
 	// Filter by number of performers with this tag
-	PerformerCount *IntCriterionInput `json:"performer_count"`
+	PerformerCount *HierarchicalCountInput `json:"performer_count"`
 	// Filter by number of studios with this tag
-	StudioCount *IntCriterionInput `json:"studio_count"`
+	StudioCount *HierarchicalCountInput `json:"studio_count"`
 	// Filter by number of groups with this tag
-	GroupCount *IntCriterionInput `json:"group_count"`
+	GroupCount *HierarchicalCountInput `json:"group_count"`
 	// Filter by number of movies with this tag
-	MovieCount *IntCriterionInput `json:"movie_count"`
+	MovieCount *HierarchicalCountInput `json:"movie_count"`
 	// Filter by number of markers with this tag
-	MarkerCount *IntCriterionInput `json:"marker_count"`
+	MarkerCount *HierarchicalCountInput `json:"marker_count"`
 	// Filter by parent tags
 	Parents *HierarchicalMultiCriterionInput `json:"parents"`
 	// Filter by child tags

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -1504,6 +1504,7 @@ func galleryQueryQ(ctx context.Context, t *testing.T, q string, expectedGalleryI
 
 	// no Q should return all results
 	filter.Q = nil
+	filter.PerPage = ptr(-1)
 	galleries, _, err = qb.Query(ctx, nil, &filter)
 	if err != nil {
 		t.Errorf("Error querying gallery: %s", err.Error())

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -4162,7 +4162,10 @@ func TestSceneQueryPhashDuplicated(t *testing.T) {
 
 		duplicated = false
 
-		scenes = queryScene(ctx, t, sqb, &sceneFilter, nil)
+		findFilter := models.FindFilterType{
+			PerPage: ptr(-1),
+		}
+		scenes = queryScene(ctx, t, sqb, &sceneFilter, &findFilter)
 		// -1 for missing phash
 		assert.Len(t, scenes, totalScenes-(dupeScenePhashes*2)-1)
 

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -84,6 +84,8 @@ const (
 	sceneIdxMissingPhash
 	sceneIdxWithPerformerParentTag
 	sceneIdxWithGroupWithParent
+	sceneIdxWithChildTag
+	sceneIdxWithGrandChildTag
 	// new indexes above
 	lastSceneIdx
 
@@ -378,6 +380,8 @@ var (
 		sceneIdxWithThreeTags:     {tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
 		sceneIdxWithMarkerAndTag:  {tagIdx3WithScene},
 		sceneIdxWithMarkerTwoTags: {tagIdx2WithScene, tagIdx3WithScene},
+		sceneIdxWithChildTag:      {tagIdxWithParentTag},
+		sceneIdxWithGrandChildTag: {tagIdxWithGrandParent},
 	}
 
 	scenePerformers = linkMap{
@@ -603,6 +607,10 @@ func indexFromID(ids []int, id int) int {
 	}
 
 	return -1
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 var db *sqlite.Database

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -117,6 +117,7 @@ const (
 	imageIdxWithPerformerTwoTags
 	imageIdxWithGrandChildStudio
 	imageIdxWithPerformerParentTag
+	imageIdxWithGrandChildTag
 	// new indexes above
 	totalImages
 )
@@ -169,6 +170,7 @@ const (
 	groupIdxWithGrandParent
 	groupIdxWithParentAndScene
 	groupIdxWithChildWithScene
+	groupIdxWithGrandChildTag
 	// groups with dup names start from the end
 	groupIdxWithDupName
 
@@ -201,6 +203,7 @@ const (
 	galleryIdxWithGrandChildStudio
 	galleryIdxWithoutFile
 	galleryIdxWithPerformerParentTag
+	galleryIdxWithGrandChildTag
 	// new indexes above
 	lastGalleryIdx
 
@@ -434,6 +437,7 @@ var (
 		{sceneIdxWithMarkers, tagIdxWithPrimaryMarkers, []int{tagIdxWithMarkers, tagIdx2WithMarkers}},
 		{sceneIdxWithMarkerAndTag, tagIdxWithPrimaryMarkers, nil},
 		{sceneIdxWithMarkerTwoTags, tagIdxWithPrimaryMarkers, nil},
+		{sceneIdxWithGrandChildTag, tagIdxWithGrandParent, nil},
 	}
 )
 
@@ -465,9 +469,10 @@ var (
 		imageIdxWithGrandChildStudio: studioIdxWithGrandParent,
 	}
 	imageTags = linkMap{
-		imageIdxWithTag:       {tagIdxWithImage},
-		imageIdxWithTwoTags:   {tagIdx1WithImage, tagIdx2WithImage},
-		imageIdxWithThreeTags: {tagIdx1WithImage, tagIdx2WithImage, tagIdx3WithImage},
+		imageIdxWithTag:           {tagIdxWithImage},
+		imageIdxWithTwoTags:       {tagIdx1WithImage, tagIdx2WithImage},
+		imageIdxWithThreeTags:     {tagIdx1WithImage, tagIdx2WithImage, tagIdx3WithImage},
+		imageIdxWithGrandChildTag: {tagIdxWithGrandParent},
 	}
 	imagePerformers = linkMap{
 		imageIdxWithPerformer:          {performerIdxWithImage},
@@ -506,9 +511,10 @@ var (
 	}
 
 	galleryTags = linkMap{
-		galleryIdxWithTag:       {tagIdxWithGallery},
-		galleryIdxWithTwoTags:   {tagIdx1WithGallery, tagIdx2WithGallery},
-		galleryIdxWithThreeTags: {tagIdx1WithGallery, tagIdx2WithGallery, tagIdx3WithGallery},
+		galleryIdxWithTag:           {tagIdxWithGallery},
+		galleryIdxWithTwoTags:       {tagIdx1WithGallery, tagIdx2WithGallery},
+		galleryIdxWithThreeTags:     {tagIdx1WithGallery, tagIdx2WithGallery, tagIdx3WithGallery},
+		galleryIdxWithGrandChildTag: {tagIdxWithGrandParent},
 	}
 )
 
@@ -518,9 +524,10 @@ var (
 	}
 
 	groupTags = linkMap{
-		groupIdxWithTag:       {tagIdxWithGroup},
-		groupIdxWithTwoTags:   {tagIdx1WithGroup, tagIdx2WithGroup},
-		groupIdxWithThreeTags: {tagIdx1WithGroup, tagIdx2WithGroup, tagIdx3WithGroup},
+		groupIdxWithTag:           {tagIdxWithGroup},
+		groupIdxWithTwoTags:       {tagIdx1WithGroup, tagIdx2WithGroup},
+		groupIdxWithThreeTags:     {tagIdx1WithGroup, tagIdx2WithGroup, tagIdx3WithGroup},
+		groupIdxWithGrandChildTag: {tagIdxWithGrandParent},
 	}
 )
 

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -222,19 +222,28 @@ func (qb *tagFilterHandler) isMissingCriterionHandler(isMissing *string) criteri
 // depth < 0 includes all descendant levels (unlimited recursion).
 // depth >= 0 limits the recursion to that many levels from the root tag.
 func (qb *tagFilterHandler) addHierarchicalCountCTE(f *filterBuilder, cteAlias string, depth int) {
-	var depthCondition string
-	if depth >= 0 {
-		depthCondition = fmt.Sprintf(" WHERE depth < %d", depth)
+	if depth < 0 {
+		// unlimited recursion — no depth tracking needed
+		f.addRecursiveWith(fmt.Sprintf(
+			`%[1]s(root_id, descendant_id) AS (
+				SELECT id, id FROM tags
+				UNION ALL
+				SELECT td.root_id, tr.child_id
+				FROM tags_relations tr
+				INNER JOIN %[1]s td ON td.descendant_id = tr.parent_id
+			)`, cteAlias))
+	} else {
+		// depth-limited: track recursion level as a CTE column
+		f.addRecursiveWith(fmt.Sprintf(
+			`%[1]s(root_id, descendant_id, depth) AS (
+				SELECT id, id, 0 FROM tags
+				UNION ALL
+				SELECT td.root_id, tr.child_id, td.depth + 1
+				FROM tags_relations tr
+				INNER JOIN %[1]s td ON td.descendant_id = tr.parent_id
+				WHERE td.depth < %[2]d
+			)`, cteAlias, depth))
 	}
-
-	f.addRecursiveWith(fmt.Sprintf(
-		`%[1]s(root_id, descendant_id) AS (
-			SELECT id, id FROM tags
-			UNION ALL
-			SELECT td.root_id, tr.child_id
-			FROM tags_relations tr
-			INNER JOIN %[1]s td ON td.descendant_id = tr.parent_id%[2]s
-		)`, cteAlias, depthCondition))
 }
 
 func (qb *tagFilterHandler) hierarchicalCountHandler(input *models.HierarchicalCountInput, joinTable, entityIDCol string) criterionHandlerFunc {

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -218,6 +218,9 @@ func (qb *tagFilterHandler) isMissingCriterionHandler(isMissing *string) criteri
 	}
 }
 
+// addHierarchicalCountCTE adds a recursive CTE to walk the tag hierarchy.
+// depth < 0 includes all descendant levels (unlimited recursion).
+// depth >= 0 limits the recursion to that many levels from the root tag.
 func (qb *tagFilterHandler) addHierarchicalCountCTE(f *filterBuilder, cteAlias string, depth int) {
 	var depthCondition string
 	if depth >= 0 {

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -217,80 +218,100 @@ func (qb *tagFilterHandler) isMissingCriterionHandler(isMissing *string) criteri
 	}
 }
 
-func (qb *tagFilterHandler) sceneCountCriterionHandler(sceneCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if sceneCount != nil {
-			f.addLeftJoin("scenes_tags", "", "scenes_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct scenes_tags.scene_id)", *sceneCount)
+func (qb *tagFilterHandler) addHierarchicalCountCTE(f *filterBuilder, cteAlias string, depth int) {
+	var depthCondition string
+	if depth >= 0 {
+		depthCondition = fmt.Sprintf(" WHERE depth < %d", depth)
+	}
 
-			f.addHaving(clause, args...)
+	f.addRecursiveWith(fmt.Sprintf(
+		`%[1]s(root_id, descendant_id) AS (
+			SELECT id, id FROM tags
+			UNION ALL
+			SELECT td.root_id, tr.child_id
+			FROM tags_relations tr
+			INNER JOIN %[1]s td ON td.descendant_id = tr.parent_id%[2]s
+		)`, cteAlias, depthCondition))
+}
+
+func (qb *tagFilterHandler) hierarchicalCountHandler(input *models.HierarchicalCountInput, joinTable, entityIDCol string) criterionHandlerFunc {
+	return qb.hierarchicalCountHandlerOnCol(input, joinTable, "tag_id", entityIDCol)
+}
+
+func (qb *tagFilterHandler) hierarchicalCountHandlerOnCol(input *models.HierarchicalCountInput, joinTable, tagCol, entityIDCol string) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if input == nil {
+			return
 		}
+
+		intInput := models.IntCriterionInput{
+			Value:    input.Value,
+			Value2:   input.Value2,
+			Modifier: input.Modifier,
+		}
+
+		if input.Depth != nil {
+			cteAlias := joinTable + "_desc"
+			qb.addHierarchicalCountCTE(f, cteAlias, *input.Depth)
+			f.addLeftJoin(cteAlias, "", fmt.Sprintf("%s.root_id = tags.id", cteAlias))
+			f.addLeftJoin(joinTable, "", fmt.Sprintf("%[1]s.%[2]s = %[3]s.descendant_id", joinTable, tagCol, cteAlias))
+		} else {
+			f.addLeftJoin(joinTable, "", fmt.Sprintf("%s.%s = tags.id", joinTable, tagCol))
+		}
+
+		clause, args := getIntCriterionWhereClause(fmt.Sprintf("count(distinct %s.%s)", joinTable, entityIDCol), intInput)
+		f.addHaving(clause, args...)
 	}
 }
 
-func (qb *tagFilterHandler) imageCountCriterionHandler(imageCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if imageCount != nil {
-			f.addLeftJoin("images_tags", "", "images_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct images_tags.image_id)", *imageCount)
-
-			f.addHaving(clause, args...)
-		}
-	}
+func (qb *tagFilterHandler) sceneCountCriterionHandler(sceneCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(sceneCount, "scenes_tags", "scene_id")
 }
 
-func (qb *tagFilterHandler) galleryCountCriterionHandler(galleryCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if galleryCount != nil {
-			f.addLeftJoin("galleries_tags", "", "galleries_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct galleries_tags.gallery_id)", *galleryCount)
-
-			f.addHaving(clause, args...)
-		}
-	}
+func (qb *tagFilterHandler) imageCountCriterionHandler(imageCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(imageCount, "images_tags", "image_id")
 }
 
-func (qb *tagFilterHandler) performerCountCriterionHandler(performerCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if performerCount != nil {
-			f.addLeftJoin("performers_tags", "", "performers_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct performers_tags.performer_id)", *performerCount)
-
-			f.addHaving(clause, args...)
-		}
-	}
+func (qb *tagFilterHandler) galleryCountCriterionHandler(galleryCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(galleryCount, "galleries_tags", "gallery_id")
 }
 
-func (qb *tagFilterHandler) studioCountCriterionHandler(studioCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if studioCount != nil {
-			f.addLeftJoin("studios_tags", "", "studios_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct studios_tags.studio_id)", *studioCount)
-
-			f.addHaving(clause, args...)
-		}
-	}
+func (qb *tagFilterHandler) performerCountCriterionHandler(performerCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(performerCount, "performers_tags", "performer_id")
 }
 
-func (qb *tagFilterHandler) groupCountCriterionHandler(groupCount *models.IntCriterionInput) criterionHandlerFunc {
-	return func(ctx context.Context, f *filterBuilder) {
-		if groupCount != nil {
-			f.addLeftJoin("groups_tags", "", "groups_tags.tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct groups_tags.group_id)", *groupCount)
-
-			f.addHaving(clause, args...)
-		}
-	}
+func (qb *tagFilterHandler) studioCountCriterionHandler(studioCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(studioCount, "studios_tags", "studio_id")
 }
 
-func (qb *tagFilterHandler) markerCountCriterionHandler(markerCount *models.IntCriterionInput) criterionHandlerFunc {
+func (qb *tagFilterHandler) groupCountCriterionHandler(groupCount *models.HierarchicalCountInput) criterionHandlerFunc {
+	return qb.hierarchicalCountHandler(groupCount, "groups_tags", "group_id")
+}
+
+func (qb *tagFilterHandler) markerCountCriterionHandler(markerCount *models.HierarchicalCountInput) criterionHandlerFunc {
 	return func(ctx context.Context, f *filterBuilder) {
-		if markerCount != nil {
+		if markerCount == nil {
+			return
+		}
+
+		intInput := models.IntCriterionInput{
+			Value:    markerCount.Value,
+			Value2:   markerCount.Value2,
+			Modifier: markerCount.Modifier,
+		}
+
+		if markerCount.Depth != nil {
+			cteAlias := "scene_markers_desc"
+			qb.addHierarchicalCountCTE(f, cteAlias, *markerCount.Depth)
+			f.addLeftJoin(cteAlias, "", fmt.Sprintf("%s.root_id = tags.id", cteAlias))
+			f.addLeftJoin("scene_markers_tags", "", fmt.Sprintf("scene_markers_tags.tag_id = %s.descendant_id", cteAlias))
+			f.addLeftJoin("scene_markers", "", "scene_markers_tags.scene_marker_id = scene_markers.id OR scene_markers.primary_tag_id = "+cteAlias+".descendant_id")
+		} else {
 			f.addLeftJoin("scene_markers_tags", "", "scene_markers_tags.tag_id = tags.id")
 			f.addLeftJoin("scene_markers", "", "scene_markers_tags.scene_marker_id = scene_markers.id OR scene_markers.primary_tag_id = tags.id")
-			clause, args := getIntCriterionWhereClause("count(distinct scene_markers.id)", *markerCount)
-
-			f.addHaving(clause, args...)
 		}
+
+		clause, args := getIntCriterionWhereClause("count(distinct scene_markers.id)", intInput)
+		f.addHaving(clause, args...)
 	}
 }

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -589,8 +589,8 @@ func TestTagQueryCounts(t *testing.T) {
 				Modifier: models.CriterionModifierEquals,
 				Depth:    ptr(1),
 			}},
-			includeIdxs: []int{tagIdxWithScene, tagIdxWithParentTag, tagIdxWithChildTag},
-			excludeIdxs: []int{tagIdxWithGrandParent, tagIdx1WithNothing, tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+			includeIdxs: []int{tagIdxWithScene, tagIdxWithParentTag, tagIdxWithChildTag, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithNothing, tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
 		},
 		{
 			name:        "marker_count_equals_2",
@@ -633,6 +633,116 @@ func TestTagQueryCounts(t *testing.T) {
 			buildFilter: models.TagFilterType{ChildCount: &models.IntCriterionInput{Value: 1, Modifier: models.CriterionModifierEquals}},
 			includeIdxs: []int{tagIdxWithChildTag, tagIdxWithGrandChild, tagIdxWithParentAndChild},
 			excludeIdxs: []int{tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name: "scene_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{SceneCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithScene, tagIdxWithChildTag, tagIdxWithParentTag, tagIdxWithGrandChild, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+		},
+		{
+			name: "image_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{ImageCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithImage, tagIdx3WithImage, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithImage, tagIdx2WithImage},
+		},
+		{
+			name: "image_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{ImageCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithImage, tagIdx3WithImage, tagIdxWithGrandChild, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithImage, tagIdx2WithImage},
+		},
+		{
+			name: "gallery_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{GalleryCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithGallery, tagIdx3WithGallery, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithGallery, tagIdx2WithGallery},
+		},
+		{
+			name: "gallery_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{GalleryCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithGallery, tagIdx3WithGallery, tagIdxWithGrandChild, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithGallery, tagIdx2WithGallery},
+		},
+		{
+			name: "performer_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{PerformerCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithPerformer, tagIdx1WithPerformer, tagIdxWithGrandChild, tagIdxWithParentAndChild},
+			excludeIdxs: []int{tagIdx2WithPerformer},
+		},
+		{
+			name: "performer_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{PerformerCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithPerformer, tagIdx1WithPerformer, tagIdxWithGrandChild, tagIdxWithParentAndChild},
+			excludeIdxs: []int{tagIdx2WithPerformer},
+		},
+		{
+			name: "marker_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{MarkerCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdxWithPrimaryMarkers, tagIdxWithMarkers, tagIdx2WithMarkers},
+		},
+		{
+			name: "marker_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{MarkerCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithGrandChild, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdxWithPrimaryMarkers, tagIdxWithMarkers, tagIdx2WithMarkers},
+		},
+		{
+			name: "group_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{GroupCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithGroup, tagIdx3WithGroup, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithGroup, tagIdx2WithGroup},
+		},
+		{
+			name: "group_count_equals_1_depth_-1",
+			buildFilter: models.TagFilterType{GroupCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(-1),
+			}},
+			includeIdxs: []int{tagIdxWithGroup, tagIdx3WithGroup, tagIdxWithGrandChild, tagIdxWithParentAndChild, tagIdxWithGrandParent},
+			excludeIdxs: []int{tagIdx1WithGroup, tagIdx2WithGroup},
 		},
 	}
 

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -583,6 +583,16 @@ func TestTagQueryCounts(t *testing.T) {
 			excludeIdxs: []int{tagIdx1WithNothing, tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
 		},
 		{
+			name: "scene_count_equals_1_depth_1",
+			buildFilter: models.TagFilterType{SceneCount: &models.HierarchicalCountInput{
+				Value:    1,
+				Modifier: models.CriterionModifierEquals,
+				Depth:    ptr(1),
+			}},
+			includeIdxs: []int{tagIdxWithScene, tagIdxWithParentTag, tagIdxWithChildTag},
+			excludeIdxs: []int{tagIdxWithGrandParent, tagIdx1WithNothing, tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+		},
+		{
 			name:        "marker_count_equals_2",
 			buildFilter: models.TagFilterType{MarkerCount: &models.HierarchicalCountInput{Value: 2, Modifier: models.CriterionModifierEquals}},
 			includeIdxs: []int{tagIdxWithMarkers, tagIdx2WithMarkers},

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -569,318 +569,86 @@ func TestTagQueryIsMissingImage(t *testing.T) {
 	})
 }
 
-func TestTagQuerySceneCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
+func TestTagQueryCounts(t *testing.T) {
+	tests := []struct {
+		name        string
+		buildFilter models.TagFilterType
+		includeIdxs []int
+		excludeIdxs []int
+	}{
+		{
+			name:        "scene_count_equals_1",
+			buildFilter: models.TagFilterType{SceneCount: &models.HierarchicalCountInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithScene},
+			excludeIdxs: []int{tagIdx1WithNothing, tagIdx1WithScene, tagIdx2WithScene, tagIdx3WithScene},
+		},
+		{
+			name:        "marker_count_equals_2",
+			buildFilter: models.TagFilterType{MarkerCount: &models.HierarchicalCountInput{Value: 2, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithMarkers, tagIdx2WithMarkers},
+			excludeIdxs: []int{tagIdxWithPrimaryMarkers, tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "image_count_equals_1",
+			buildFilter: models.TagFilterType{ImageCount: &models.HierarchicalCountInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithImage, tagIdx3WithImage},
+			excludeIdxs: []int{tagIdx1WithImage, tagIdx2WithImage, tagIdxWithCoverImage, tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "gallery_count_equals_1",
+			buildFilter: models.TagFilterType{GalleryCount: &models.HierarchicalCountInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithGallery, tagIdx3WithGallery},
+			excludeIdxs: []int{tagIdx1WithGallery, tagIdx2WithGallery, tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "performer_count_equals_1",
+			buildFilter: models.TagFilterType{PerformerCount: &models.HierarchicalCountInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithPerformer, tagIdx1WithPerformer, tagIdxWithParentAndChild},
+			excludeIdxs: []int{tagIdx2WithPerformer, tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "studio_count_equals_1",
+			buildFilter: models.TagFilterType{StudioCount: &models.HierarchicalCountInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithStudio, tagIdx1WithStudio},
+			excludeIdxs: []int{tagIdx2WithStudio, tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "parent_count_equals_1",
+			buildFilter: models.TagFilterType{ParentCount: &models.IntCriterionInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithParentTag, tagIdxWithGrandParent, tagIdxWithParentAndChild},
+			excludeIdxs: []int{tagIdx1WithNothing, tagIdx2WithNothing},
+		},
+		{
+			name:        "child_count_equals_1",
+			buildFilter: models.TagFilterType{ChildCount: &models.IntCriterionInput{Value: 1, Modifier: models.CriterionModifierEquals}},
+			includeIdxs: []int{tagIdxWithChildTag, tagIdxWithGrandChild, tagIdxWithParentAndChild},
+			excludeIdxs: []int{tagIdx1WithNothing, tagIdx2WithNothing},
+		},
 	}
 
-	verifyTagSceneCount(t, countCriterion)
+	for _, tt := range tests {
+		runWithRollbackTxn(t, tt.name, func(t *testing.T, ctx context.Context) {
+			qb := db.Tag
+			tagFilter := &tt.buildFilter
 
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagSceneCount(t, countCriterion)
+			tags, _, err := qb.Query(ctx, tagFilter, nil)
+			if err != nil {
+				t.Fatalf("%s: Error querying tag: %v", tt.name, err)
+			}
 
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagSceneCount(t, countCriterion)
+			ids := tagsToIDs(tags)
+			include := indexesToIDs(tagIDs, tt.includeIdxs)
+			exclude := indexesToIDs(tagIDs, tt.excludeIdxs)
 
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagSceneCount(t, countCriterion)
-}
+			for _, id := range include {
+				assert.Contains(t, ids, id, "%s: expected id %d to be included", tt.name, id)
+			}
 
-func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			SceneCount: &sceneCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagSceneCount(tag.ID), models.IntCriterionInput{Value: sceneCountCriterion.Value, Modifier: sceneCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryMarkerCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
+			for _, id := range exclude {
+				assert.NotContains(t, ids, id, "%s: expected id %d to be excluded", tt.name, id)
+			}
+		})
 	}
-
-	verifyTagMarkerCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagMarkerCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagMarkerCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagMarkerCount(t, countCriterion)
-}
-
-func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			MarkerCount: &markerCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagMarkerCount(tag.ID), models.IntCriterionInput{Value: markerCountCriterion.Value, Modifier: markerCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryImageCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagImageCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagImageCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagImageCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagImageCount(t, countCriterion)
-}
-
-func verifyTagImageCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			ImageCount: &imageCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagImageCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryGalleryCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagGalleryCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagGalleryCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagGalleryCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagGalleryCount(t, countCriterion)
-}
-
-func verifyTagGalleryCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			GalleryCount: &imageCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagGalleryCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryPerformerCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagPerformerCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagPerformerCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagPerformerCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagPerformerCount(t, countCriterion)
-}
-
-func verifyTagPerformerCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			PerformerCount: &imageCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagPerformerCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryStudioCount(t *testing.T) {
-	countCriterion := models.HierarchicalCountInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagStudioCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagStudioCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagStudioCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagStudioCount(t, countCriterion)
-}
-
-func verifyTagStudioCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			StudioCount: &imageCountCriterion,
-		}
-
-		tags, _, err := qb.Query(ctx, &tagFilter, nil)
-		if err != nil {
-			t.Errorf("Error querying tag: %s", err.Error())
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagStudioCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryParentCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagParentCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagParentCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagParentCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagParentCount(t, countCriterion)
-}
-
-func verifyTagParentCount(t *testing.T, sceneCountCriterion models.IntCriterionInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			ParentCount: &sceneCountCriterion,
-		}
-
-		tags := queryTags(ctx, t, qb, &tagFilter, nil)
-
-		if len(tags) == 0 {
-			t.Error("Expected at least one tag")
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagParentCount(tag.ID), sceneCountCriterion)
-		}
-
-		return nil
-	})
-}
-
-func TestTagQueryChildCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
-		Value:    1,
-		Modifier: models.CriterionModifierEquals,
-	}
-
-	verifyTagChildCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierNotEquals
-	verifyTagChildCount(t, countCriterion)
-
-	countCriterion.Modifier = models.CriterionModifierLessThan
-	verifyTagChildCount(t, countCriterion)
-
-	countCriterion.Value = 0
-	countCriterion.Modifier = models.CriterionModifierGreaterThan
-	verifyTagChildCount(t, countCriterion)
-}
-
-func verifyTagChildCount(t *testing.T, sceneCountCriterion models.IntCriterionInput) {
-	withTxn(func(ctx context.Context) error {
-		qb := db.Tag
-		tagFilter := models.TagFilterType{
-			ChildCount: &sceneCountCriterion,
-		}
-
-		tags := queryTags(ctx, t, qb, &tagFilter, nil)
-
-		if len(tags) == 0 {
-			t.Error("Expected at least one tag")
-		}
-
-		for _, tag := range tags {
-			verifyInt(t, getTagChildCount(tag.ID), sceneCountCriterion)
-		}
-
-		return nil
-	})
 }
 
 func TestTagQueryParent(t *testing.T) {

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -570,7 +570,7 @@ func TestTagQueryIsMissingImage(t *testing.T) {
 }
 
 func TestTagQuerySceneCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -588,7 +588,7 @@ func TestTagQuerySceneCount(t *testing.T) {
 	verifyTagSceneCount(t, countCriterion)
 }
 
-func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionInput) {
+func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -601,7 +601,7 @@ func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionIn
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagSceneCount(tag.ID), sceneCountCriterion)
+			verifyInt(t, getTagSceneCount(tag.ID), models.IntCriterionInput{Value: sceneCountCriterion.Value, Modifier: sceneCountCriterion.Modifier})
 		}
 
 		return nil
@@ -609,7 +609,7 @@ func verifyTagSceneCount(t *testing.T, sceneCountCriterion models.IntCriterionIn
 }
 
 func TestTagQueryMarkerCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -627,7 +627,7 @@ func TestTagQueryMarkerCount(t *testing.T) {
 	verifyTagMarkerCount(t, countCriterion)
 }
 
-func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.IntCriterionInput) {
+func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -640,7 +640,7 @@ func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.IntCriterion
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagMarkerCount(tag.ID), markerCountCriterion)
+			verifyInt(t, getTagMarkerCount(tag.ID), models.IntCriterionInput{Value: markerCountCriterion.Value, Modifier: markerCountCriterion.Modifier})
 		}
 
 		return nil
@@ -648,7 +648,7 @@ func verifyTagMarkerCount(t *testing.T, markerCountCriterion models.IntCriterion
 }
 
 func TestTagQueryImageCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -666,7 +666,7 @@ func TestTagQueryImageCount(t *testing.T) {
 	verifyTagImageCount(t, countCriterion)
 }
 
-func verifyTagImageCount(t *testing.T, imageCountCriterion models.IntCriterionInput) {
+func verifyTagImageCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -679,7 +679,7 @@ func verifyTagImageCount(t *testing.T, imageCountCriterion models.IntCriterionIn
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagImageCount(tag.ID), imageCountCriterion)
+			verifyInt(t, getTagImageCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
 		}
 
 		return nil
@@ -687,7 +687,7 @@ func verifyTagImageCount(t *testing.T, imageCountCriterion models.IntCriterionIn
 }
 
 func TestTagQueryGalleryCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -705,7 +705,7 @@ func TestTagQueryGalleryCount(t *testing.T) {
 	verifyTagGalleryCount(t, countCriterion)
 }
 
-func verifyTagGalleryCount(t *testing.T, imageCountCriterion models.IntCriterionInput) {
+func verifyTagGalleryCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -718,7 +718,7 @@ func verifyTagGalleryCount(t *testing.T, imageCountCriterion models.IntCriterion
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagGalleryCount(tag.ID), imageCountCriterion)
+			verifyInt(t, getTagGalleryCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
 		}
 
 		return nil
@@ -726,7 +726,7 @@ func verifyTagGalleryCount(t *testing.T, imageCountCriterion models.IntCriterion
 }
 
 func TestTagQueryPerformerCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -744,7 +744,7 @@ func TestTagQueryPerformerCount(t *testing.T) {
 	verifyTagPerformerCount(t, countCriterion)
 }
 
-func verifyTagPerformerCount(t *testing.T, imageCountCriterion models.IntCriterionInput) {
+func verifyTagPerformerCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -757,7 +757,7 @@ func verifyTagPerformerCount(t *testing.T, imageCountCriterion models.IntCriteri
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagPerformerCount(tag.ID), imageCountCriterion)
+			verifyInt(t, getTagPerformerCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
 		}
 
 		return nil
@@ -765,7 +765,7 @@ func verifyTagPerformerCount(t *testing.T, imageCountCriterion models.IntCriteri
 }
 
 func TestTagQueryStudioCount(t *testing.T) {
-	countCriterion := models.IntCriterionInput{
+	countCriterion := models.HierarchicalCountInput{
 		Value:    1,
 		Modifier: models.CriterionModifierEquals,
 	}
@@ -783,7 +783,7 @@ func TestTagQueryStudioCount(t *testing.T) {
 	verifyTagStudioCount(t, countCriterion)
 }
 
-func verifyTagStudioCount(t *testing.T, imageCountCriterion models.IntCriterionInput) {
+func verifyTagStudioCount(t *testing.T, imageCountCriterion models.HierarchicalCountInput) {
 	withTxn(func(ctx context.Context) error {
 		qb := db.Tag
 		tagFilter := models.TagFilterType{
@@ -796,7 +796,7 @@ func verifyTagStudioCount(t *testing.T, imageCountCriterion models.IntCriterionI
 		}
 
 		for _, tag := range tags {
-			verifyInt(t, getTagStudioCount(tag.ID), imageCountCriterion)
+			verifyInt(t, getTagStudioCount(tag.ID), models.IntCriterionInput{Value: imageCountCriterion.Value, Modifier: imageCountCriterion.Modifier})
 		}
 
 		return nil

--- a/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
@@ -20,9 +20,9 @@ import {
   FilterMode,
   GalleryFilterType,
   GroupFilterType,
+  HierarchicalCountInput,
   ImageFilterType,
   InputMaybe,
-  IntCriterionInput,
   PerformerFilterType,
   SceneFilterType,
   SceneMarkerFilterType,
@@ -520,18 +520,18 @@ export function makeQueryVariables(query: string, extraProps: {}) {
 
 interface IFilterType {
   scenes_filter?: InputMaybe<SceneFilterType>;
-  scene_count?: InputMaybe<IntCriterionInput>;
+  scene_count?: InputMaybe<HierarchicalCountInput>;
   performers_filter?: InputMaybe<PerformerFilterType>;
-  performer_count?: InputMaybe<IntCriterionInput>;
+  performer_count?: InputMaybe<HierarchicalCountInput>;
   galleries_filter?: InputMaybe<GalleryFilterType>;
-  gallery_count?: InputMaybe<IntCriterionInput>;
+  gallery_count?: InputMaybe<HierarchicalCountInput>;
   images_filter?: InputMaybe<ImageFilterType>;
-  image_count?: InputMaybe<IntCriterionInput>;
+  image_count?: InputMaybe<HierarchicalCountInput>;
   groups_filter?: InputMaybe<GroupFilterType>;
-  group_count?: InputMaybe<IntCriterionInput>;
+  group_count?: InputMaybe<HierarchicalCountInput>;
   studios_filter?: InputMaybe<StudioFilterType>;
-  studio_count?: InputMaybe<IntCriterionInput>;
-  marker_count?: InputMaybe<IntCriterionInput>;
+  studio_count?: InputMaybe<HierarchicalCountInput>;
+  marker_count?: InputMaybe<HierarchicalCountInput>;
   markers_filter?: InputMaybe<SceneMarkerFilterType>;
 }
 
@@ -554,6 +554,7 @@ export function setObjectFilter(
         out.scene_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -565,6 +566,7 @@ export function setObjectFilter(
         out.performer_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -576,6 +578,7 @@ export function setObjectFilter(
         out.gallery_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -587,6 +590,7 @@ export function setObjectFilter(
         out.image_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -598,6 +602,7 @@ export function setObjectFilter(
         out.group_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -609,6 +614,7 @@ export function setObjectFilter(
         out.studio_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }
@@ -620,6 +626,7 @@ export function setObjectFilter(
         out.marker_count = {
           modifier: CriterionModifier.GreaterThan,
           value: 0,
+          depth: -1,
         };
         break;
       }


### PR DESCRIPTION
## Description
Second attempt to fix #6797

Parent tags with no directly-tagged content now appear in the sidebar because the `scene_count` (and `image_count`, `gallery_count`, etc.) filters use `depth: -1` to include descendant tags.
- Introduced `HierarchicalCountInput` (identical to `IntCriterionInput` + optional `depth`) in the GraphQL schema and Go model
- Changed all 8 `TagFilterType` count fields to use the new input type
- Tag count filter handlers use a recursive CTE when `depth` is set, walking `tags_relations` to aggregate across descendant tags
- Sidebar query passes `depth: -1` so parent tags show up even without direct content