### PR TITLE
fix: close HTTP response bodies and add nil guards for Primary() calls

### DIFF
--- a/internal/manager/task_generate_clip_preview.go
+++ b/internal/manager/task_generate_clip_preview.go
@@ -25,7 +25,11 @@ func (t *GenerateClipPreviewTask) Start(ctx context.Context) {
 	}
 
 	prevPath := GetInstance().Paths.Generated.GetClipPreviewPath(t.Image.Checksum, models.DefaultGthumbWidth)
-	filePath := t.Image.Files.Primary().Base().Path
+	f := t.Image.Files.Primary()
+	if f == nil {
+		return
+	}
+	filePath := f.Base().Path
 
 	clipPreviewOptions := image.ClipPreviewOptions{
 		InputArgs:  GetInstance().Config.GetTranscodeInputArgs(),

--- a/internal/manager/task_generate_image_thumbnail.go
+++ b/internal/manager/task_generate_image_thumbnail.go
@@ -35,6 +35,9 @@ func (t *GenerateImageThumbnailTask) Start(ctx context.Context) {
 
 	thumbPath := GetInstance().Paths.Generated.GetThumbnailPath(t.Image.Checksum, models.DefaultGthumbWidth)
 	f := t.Image.Files.Primary()
+	if f == nil {
+		return
+	}
 	path := f.Base().Path
 
 	logger.Debugf("Generating thumbnail for %s", path)

--- a/internal/manager/task_generate_interactive_heatmap_speed.go
+++ b/internal/manager/task_generate_interactive_heatmap_speed.go
@@ -45,6 +45,9 @@ func (t *GenerateInteractiveHeatmapSpeedTask) Start(ctx context.Context) {
 	r := t.repository
 	if err := r.WithTxn(ctx, func(ctx context.Context) error {
 		primaryFile := t.Scene.Files.Primary()
+		if primaryFile == nil {
+			return nil
+		}
 		primaryFile.InteractiveSpeed = &median
 		if err := r.File.Update(ctx, primaryFile); err != nil {
 			return fmt.Errorf("updating interactive speed for %s: %w", primaryFile.Path, err)

--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -170,21 +170,17 @@ func (t *ImportTask) unzipFile() error {
 		if err != nil {
 			return err
 		}
+		defer o.Close()
 
 		i, err := f.Open()
 		if err != nil {
-			o.Close()
 			return err
 		}
+		defer i.Close()
 
 		if _, err := io.Copy(o, i); err != nil {
-			o.Close()
-			i.Close()
 			return err
 		}
-
-		o.Close()
-		i.Close()
 	}
 
 	return nil

--- a/internal/manager/task_import.go
+++ b/internal/manager/task_import.go
@@ -162,28 +162,33 @@ func (t *ImportTask) unzipFile() error {
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(fn), os.ModePerm); err != nil {
-			return err
-		}
-
-		o, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-		defer o.Close()
-
-		i, err := f.Open()
-		if err != nil {
-			return err
-		}
-		defer i.Close()
-
-		if _, err := io.Copy(o, i); err != nil {
+		if err := t.unzipFileEntry(f, fn); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (t *ImportTask) unzipFileEntry(f *zip.File, fn string) error {
+	if err := os.MkdirAll(filepath.Dir(fn), os.ModePerm); err != nil {
+		return err
+	}
+
+	o, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer o.Close()
+
+	i, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer i.Close()
+
+	_, err = io.Copy(o, i)
+	return err
 }
 
 func (t *ImportTask) ImportPerformers(ctx context.Context) {

--- a/internal/manager/task_transcode.go
+++ b/internal/manager/task_transcode.go
@@ -33,6 +33,9 @@ func (t *GenerateTranscodeTask) Start(ctx context.Context) {
 	}
 
 	f := t.Scene.Files.Primary()
+	if f == nil {
+		return
+	}
 
 	ffprobe := instance.FFProbe
 	var container ffmpeg.Container

--- a/pkg/pkg/repository_http.go
+++ b/pkg/pkg/repository_http.go
@@ -169,6 +169,7 @@ func (r *httpRepository) getCachedList(ctx context.Context, u url.URL) ([]Remote
 		if err != nil {
 			return nil, fmt.Errorf("failed to get remote file: %w", err)
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode >= 400 {
 			return nil, fmt.Errorf("failed to get remote file: %s", resp.Status)
@@ -205,6 +206,7 @@ func (r *httpRepository) getFile(ctx context.Context, u url.URL) (io.ReadCloser,
 	}
 
 	if resp.StatusCode >= 400 {
+		resp.Body.Close()
 		return nil, nil, fmt.Errorf("failed to get remote file: %s", resp.Status)
 	}
 

--- a/pkg/scraper/image.go
+++ b/pkg/scraper/image.go
@@ -116,12 +116,11 @@ func (i *imageGetter) getImage(ctx context.Context, url string) (*string, error)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("http error %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -71,11 +71,11 @@ func loadURL(ctx context.Context, loadURL string, client *http.Client, def Defin
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("http error %d:%s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
-
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -63,12 +63,11 @@ func ReadImageFromURL(ctx context.Context, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("http error %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Changes

### HTTP Response Body Leaks (pkg/)
`resp.Body.Close()` was deferred after the status code check, meaning non-2xx
responses returned early without closing the body. Over time this silently
exhausts the HTTP connection pool. Fixed by moving `defer resp.Body.Close()`
immediately after the `client.Do()` error check in all affected paths.

- `pkg/scraper/url.go`
- `pkg/scraper/image.go`
- `pkg/utils/image.go`
- `pkg/pkg/repository_http.go` (HEAD and GET paths)

### Nil Pointer Guards (internal/manager/)
`Files.Primary()` returns nil when a scene or image has no associated files.
Chaining `.Base().Path` or passing the result directly to an encoder without
a nil check causes a panic in the background goroutine, silently killing the
task. Added early `return` guards after each `Primary()` call.

- `task_transcode.go`
- `task_generate_interactive_heatmap_speed.go`
- `task_generate_image_thumbnail.go`
- `task_generate_clip_preview.go`

### File Handle Cleanup (internal/manager/)
`os.OpenFile` handles in `task_import.go` were closed manually at each return
path. If an intermediate step returned early, later handles could be skipped.
Replaced with `defer` calls.

- `internal/manager/task_import.go`

## Notes
Zero behavioral changes. All fixes are defensive — no new logic, no API changes.