### PR TITLE
Add recursive sort by performer_count and o_counter for studios, o_counter depth parameter, display updates

### DIFF
--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -26,8 +26,7 @@ type Studio {
   updated_at: Time!
   groups: [Group!]!
   movies: [Movie!]! @deprecated(reason: "use groups instead")
-  o_counter: Int
-
+  o_counter(depth: Int): Int! # Resolver
   custom_fields: Map!
 }
 

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -11,12 +11,15 @@ type Studio {
   organized: Boolean!
 
   image_path: String # Resolver
+  
   scene_count(depth: Int): Int! # Resolver
   image_count(depth: Int): Int! # Resolver
   gallery_count(depth: Int): Int! # Resolver
   performer_count(depth: Int): Int! # Resolver
   group_count(depth: Int): Int! # Resolver
   movie_count(depth: Int): Int! @deprecated(reason: "use group_count instead") # Resolver
+  o_counter(depth: Int): Int! # Resolver
+
   stash_ids: [StashID!]!
   # rating expressed as 1-100
   rating100: Int
@@ -26,8 +29,6 @@ type Studio {
   updated_at: Time!
   groups: [Group!]!
   movies: [Movie!]! @deprecated(reason: "use groups instead")
-  # o_counter with depth: Int (default 0, flat count). Pass depth: -1 for recursive count across all sub-studios.
-  o_counter(depth: Int): Int! # Resolver
   custom_fields: Map!
 }
 

--- a/graphql/schema/types/studio.graphql
+++ b/graphql/schema/types/studio.graphql
@@ -26,6 +26,7 @@ type Studio {
   updated_at: Time!
   groups: [Group!]!
   movies: [Movie!]! @deprecated(reason: "use groups instead")
+  # o_counter with depth: Int (default 0, flat count). Pass depth: -1 for recursive count across all sub-studios.
   o_counter(depth: Int): Int! # Resolver
   custom_fields: Map!
 }

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -146,12 +146,16 @@ func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio, dep
 func (r *studioResolver) OCounter(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	var res_scene int
 	var res_image int
+	depthVal := 0
+	if depth != nil {
+		depthVal = *depth
+	}
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res_scene, err = r.repository.Scene.OCountByStudioID(ctx, obj.ID, depth)
+		res_scene, err = r.repository.Scene.OCountByStudioID(ctx, obj.ID, depthVal)
 		if err != nil {
 			return err
 		}
-		res_image, err = r.repository.Image.OCountByStudioID(ctx, obj.ID, depth)
+		res_image, err = r.repository.Image.OCountByStudioID(ctx, obj.ID, depthVal)
 		return err
 	}); err != nil {
 		return 0, err

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -143,22 +143,20 @@ func (r *studioResolver) MovieCount(ctx context.Context, obj *models.Studio, dep
 	return r.GroupCount(ctx, obj, depth)
 }
 
-func (r *studioResolver) OCounter(ctx context.Context, obj *models.Studio) (ret *int, err error) {
+func (r *studioResolver) OCounter(ctx context.Context, obj *models.Studio, depth *int) (ret int, err error) {
 	var res_scene int
 	var res_image int
-	var res int
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
-		res_scene, err = r.repository.Scene.OCountByStudioID(ctx, obj.ID)
+		res_scene, err = r.repository.Scene.OCountByStudioID(ctx, obj.ID, depth)
 		if err != nil {
 			return err
 		}
-		res_image, err = r.repository.Image.OCountByStudioID(ctx, obj.ID)
+		res_image, err = r.repository.Image.OCountByStudioID(ctx, obj.ID, depth)
 		return err
 	}); err != nil {
-		return nil, err
+		return 0, err
 	}
-	res = res_scene + res_image
-	return &res, nil
+	return res_scene + res_image, nil
 }
 
 func (r *studioResolver) ParentStudio(ctx context.Context, obj *models.Studio) (ret *models.Studio, err error) {

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -664,18 +664,18 @@ func (_m *ImageReaderWriter) OCountByPerformerID(ctx context.Context, performerI
 }
 
 // OCountByStudioID provides a mock function with given fields: ctx, studioID, depth
-func (_m *ImageReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+func (_m *ImageReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error) {
 	ret := _m.Called(ctx, studioID, depth)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(context.Context, int, *int) int); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) int); ok {
 		r0 = rf(ctx, studioID, depth)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int, *int) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
 		r1 = rf(ctx, studioID, depth)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/models/mocks/ImageReaderWriter.go
+++ b/pkg/models/mocks/ImageReaderWriter.go
@@ -663,20 +663,20 @@ func (_m *ImageReaderWriter) OCountByPerformerID(ctx context.Context, performerI
 	return r0, r1
 }
 
-// OCountByStudioID provides a mock function with given fields: ctx, studioID
-func (_m *ImageReaderWriter) OCountByStudioID(ctx context.Context, studioID int) (int, error) {
-	ret := _m.Called(ctx, studioID)
+// OCountByStudioID provides a mock function with given fields: ctx, studioID, depth
+func (_m *ImageReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+	ret := _m.Called(ctx, studioID, depth)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(context.Context, int) int); ok {
-		r0 = rf(ctx, studioID)
+	if rf, ok := ret.Get(0).(func(context.Context, int, *int) int); ok {
+		r0 = rf(ctx, studioID, depth)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
-		r1 = rf(ctx, studioID)
+	if rf, ok := ret.Get(1).(func(context.Context, int, *int) error); ok {
+		r1 = rf(ctx, studioID, depth)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/models/mocks/SceneReaderWriter.go
+++ b/pkg/models/mocks/SceneReaderWriter.go
@@ -1252,20 +1252,20 @@ func (_m *SceneReaderWriter) OCountByPerformerID(ctx context.Context, performerI
 	return r0, r1
 }
 
-// OCountByStudioID provides a mock function with given fields: ctx, studioID
-func (_m *SceneReaderWriter) OCountByStudioID(ctx context.Context, studioID int) (int, error) {
-	ret := _m.Called(ctx, studioID)
+// OCountByStudioID provides a mock function with given fields: ctx, studioID, depth
+func (_m *SceneReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+	ret := _m.Called(ctx, studioID, depth)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(context.Context, int) int); ok {
-		r0 = rf(ctx, studioID)
+	if rf, ok := ret.Get(0).(func(context.Context, int, *int) int); ok {
+		r0 = rf(ctx, studioID, depth)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
-		r1 = rf(ctx, studioID)
+	if rf, ok := ret.Get(1).(func(context.Context, int, *int) error); ok {
+		r1 = rf(ctx, studioID, depth)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/models/mocks/SceneReaderWriter.go
+++ b/pkg/models/mocks/SceneReaderWriter.go
@@ -1253,18 +1253,18 @@ func (_m *SceneReaderWriter) OCountByPerformerID(ctx context.Context, performerI
 }
 
 // OCountByStudioID provides a mock function with given fields: ctx, studioID, depth
-func (_m *SceneReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+func (_m *SceneReaderWriter) OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error) {
 	ret := _m.Called(ctx, studioID, depth)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(context.Context, int, *int) int); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) int); ok {
 		r0 = rf(ctx, studioID, depth)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int, *int) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
 		r1 = rf(ctx, studioID, depth)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -39,7 +39,7 @@ type ImageCounter interface {
 	CountByGalleryID(ctx context.Context, galleryID int) (int, error)
 	OCount(ctx context.Context) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
-	OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error)
+	OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error)
 }
 
 // ImageCreator provides methods to create images.

--- a/pkg/models/repository_image.go
+++ b/pkg/models/repository_image.go
@@ -39,7 +39,7 @@ type ImageCounter interface {
 	CountByGalleryID(ctx context.Context, galleryID int) (int, error)
 	OCount(ctx context.Context) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
-	OCountByStudioID(ctx context.Context, studioID int) (int, error)
+	OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error)
 }
 
 // ImageCreator provides methods to create images.

--- a/pkg/models/repository_scene.go
+++ b/pkg/models/repository_scene.go
@@ -46,7 +46,7 @@ type SceneCounter interface {
 	CountMissingOSHash(ctx context.Context) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
 	OCountByGroupID(ctx context.Context, groupID int) (int, error)
-	OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error)
+	OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error)
 }
 
 // SceneCreator provides methods to create scenes.

--- a/pkg/models/repository_scene.go
+++ b/pkg/models/repository_scene.go
@@ -46,7 +46,7 @@ type SceneCounter interface {
 	CountMissingOSHash(ctx context.Context) (int, error)
 	OCountByPerformerID(ctx context.Context, performerID int) (int, error)
 	OCountByGroupID(ctx context.Context, groupID int) (int, error)
-	OCountByStudioID(ctx context.Context, studioID int) (int, error)
+	OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error)
 }
 
 // SceneCreator provides methods to create scenes.

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -736,31 +736,7 @@ func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 	var ret int
 
 	if depth != 0 {
-		q := `
-		WITH RECURSIVE sub_studios AS (
-			SELECT id, 0 AS level FROM studios WHERE id = ?
-			UNION ALL
-			SELECT s.id, ss.level + 1 FROM studios s
-			INNER JOIN sub_studios ss ON s.parent_id = ss.id
-			WHERE ss.level < ? OR ? < 0
-		)
-		SELECT COALESCE(SUM(o_counter), 0) FROM images
-		WHERE images.studio_id IN (SELECT id FROM sub_studios)`
-
-		rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
-		if err != nil {
-			return 0, fmt.Errorf("querying image o_count by studio: %w", err)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := rows.Scan(&ret); err != nil {
-				return 0, fmt.Errorf("scanning image o_count: %w", err)
-			}
-		}
-		if err := rows.Err(); err != nil {
-			return 0, fmt.Errorf("iterating image o_count rows: %w", err)
-		}
-		return ret, nil
+		return qb.oCountByStudioIDRecursive(ctx, studioID, depth)
 	}
 
 	table := qb.table()
@@ -784,6 +760,36 @@ func (qb *ImageStore) OCount(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
+	return ret, nil
+}
+
+func (qb *ImageStore) oCountByStudioIDRecursive(ctx context.Context, studioID int, depth int) (int, error) {
+	q := `
+	WITH RECURSIVE sub_studios AS (
+		SELECT id, 0 AS level FROM studios WHERE id = ?
+		UNION ALL
+		SELECT s.id, ss.level + 1 FROM studios s
+		INNER JOIN sub_studios ss ON s.parent_id = ss.id
+		WHERE ss.level < ? OR ? < 0
+	)
+	SELECT COALESCE(SUM(o_counter), 0) FROM images
+	WHERE images.studio_id IN (SELECT id FROM sub_studios)`
+
+	rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
+	if err != nil {
+		return 0, fmt.Errorf("querying image o_count by studio: %w", err)
+	}
+	defer rows.Close()
+
+	var ret int
+	for rows.Next() {
+		if err := rows.Scan(&ret); err != nil {
+			return 0, fmt.Errorf("scanning image o_count: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating image o_count rows: %w", err)
+	}
 	return ret, nil
 }
 

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -738,15 +738,16 @@ func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 	if depth != 0 {
 		q := `
 		WITH RECURSIVE sub_studios AS (
-			SELECT id FROM studios WHERE id = ?
+			SELECT id, 0 AS level FROM studios WHERE id = ?
 			UNION ALL
-			SELECT s.id FROM studios s
+			SELECT s.id, ss.level + 1 FROM studios s
 			INNER JOIN sub_studios ss ON s.parent_id = ss.id
+			WHERE ss.level < ? OR ? < 0
 		)
 		SELECT COALESCE(SUM(o_counter), 0) FROM images
 		WHERE images.studio_id IN (SELECT id FROM sub_studios)`
 
-		rows, err := dbWrapper.QueryxContext(ctx, q, studioID)
+		rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
 		if err != nil {
 			return 0, fmt.Errorf("querying image o_count by studio: %w", err)
 		}

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -732,10 +732,10 @@ func (qb *ImageStore) OCountByPerformerID(ctx context.Context, performerID int) 
 	return ret, nil
 }
 
-func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error) {
 	var ret int
 
-	if depth != nil && *depth != 0 {
+	if depth != 0 {
 		q := `
 		WITH RECURSIVE sub_studios AS (
 			SELECT id FROM studios WHERE id = ?

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -732,13 +732,38 @@ func (qb *ImageStore) OCountByPerformerID(ctx context.Context, performerID int) 
 	return ret, nil
 }
 
-func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int) (int, error) {
+func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+	var ret int
+
+	if depth != nil && *depth != 0 {
+		q := `
+		WITH RECURSIVE sub_studios AS (
+			SELECT id FROM studios WHERE id = ?
+			UNION ALL
+			SELECT s.id FROM studios s
+			INNER JOIN sub_studios ss ON s.parent_id = ss.id
+		)
+		SELECT COALESCE(SUM(o_counter), 0) FROM images
+		WHERE images.studio_id IN (SELECT id FROM sub_studios)`
+
+		rows, err := dbWrapper.QueryxContext(ctx, q, studioID)
+		if err != nil {
+			return 0, fmt.Errorf("querying image o_count by studio: %w", err)
+		}
+		defer rows.Close()
+		if rows.Next() {
+			if err := rows.Scan(&ret); err != nil {
+				return 0, fmt.Errorf("scanning image o_count: %w", err)
+			}
+		}
+		return ret, nil
+	}
+
 	table := qb.table()
 	q := dialect.Select(goqu.COALESCE(goqu.SUM("o_counter"), 0)).From(table).Where(
 		table.Col(studioIDColumn).Eq(studioID),
 	)
 
-	var ret int
 	if err := querySimple(ctx, q, &ret); err != nil {
 		return 0, err
 	}

--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -752,10 +752,13 @@ func (qb *ImageStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 			return 0, fmt.Errorf("querying image o_count by studio: %w", err)
 		}
 		defer rows.Close()
-		if rows.Next() {
+		for rows.Next() {
 			if err := rows.Scan(&ret); err != nil {
 				return 0, fmt.Errorf("scanning image o_count: %w", err)
 			}
+		}
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterating image o_count rows: %w", err)
 		}
 		return ret, nil
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -829,16 +829,17 @@ func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 	if depth != 0 {
 		q := `
 		WITH RECURSIVE sub_studios AS (
-			SELECT id FROM studios WHERE id = ?
+			SELECT id, 0 AS level FROM studios WHERE id = ?
 			UNION ALL
-			SELECT s.id FROM studios s
+			SELECT s.id, ss.level + 1 FROM studios s
 			INNER JOIN sub_studios ss ON s.parent_id = ss.id
+			WHERE ss.level < ? OR ? < 0
 		)
 		SELECT COUNT(*) FROM scenes
 		INNER JOIN scenes_o_dates ON scenes.id = scenes_o_dates.scene_id
 		WHERE scenes.studio_id IN (SELECT id FROM sub_studios)`
 
-		rows, err := dbWrapper.QueryxContext(ctx, q, studioID)
+		rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
 		if err != nil {
 			return 0, fmt.Errorf("querying scene o_count by studio: %w", err)
 		}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -823,7 +823,34 @@ func (qb *SceneStore) OCountByGroupID(ctx context.Context, groupID int) (int, er
 	return ret, nil
 }
 
-func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int) (int, error) {
+func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+	var ret int
+
+	if depth != nil && *depth != 0 {
+		q := `
+		WITH RECURSIVE sub_studios AS (
+			SELECT id FROM studios WHERE id = ?
+			UNION ALL
+			SELECT s.id FROM studios s
+			INNER JOIN sub_studios ss ON s.parent_id = ss.id
+		)
+		SELECT COUNT(*) FROM scenes
+		INNER JOIN scenes_o_dates ON scenes.id = scenes_o_dates.scene_id
+		WHERE scenes.studio_id IN (SELECT id FROM sub_studios)`
+
+		rows, err := dbWrapper.QueryxContext(ctx, q, studioID)
+		if err != nil {
+			return 0, fmt.Errorf("querying scene o_count by studio: %w", err)
+		}
+		defer rows.Close()
+		if rows.Next() {
+			if err := rows.Scan(&ret); err != nil {
+				return 0, fmt.Errorf("scanning scene o_count: %w", err)
+			}
+		}
+		return ret, nil
+	}
+
 	table := qb.table()
 	oHistoryTable := goqu.T(scenesODatesTable)
 
@@ -832,7 +859,6 @@ func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int) (int, 
 		goqu.On(table.Col(idColumn).Eq(oHistoryTable.Col(sceneIDColumn))),
 	).Where(table.Col(studioIDColumn).Eq(studioID))
 
-	var ret int
 	if err := querySimple(ctx, q, &ret); err != nil {
 		return 0, err
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -823,10 +823,10 @@ func (qb *SceneStore) OCountByGroupID(ctx context.Context, groupID int) (int, er
 	return ret, nil
 }
 
-func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth *int) (int, error) {
+func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth int) (int, error) {
 	var ret int
 
-	if depth != nil && *depth != 0 {
+	if depth != 0 {
 		q := `
 		WITH RECURSIVE sub_studios AS (
 			SELECT id FROM studios WHERE id = ?

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -844,10 +844,13 @@ func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 			return 0, fmt.Errorf("querying scene o_count by studio: %w", err)
 		}
 		defer rows.Close()
-		if rows.Next() {
+		for rows.Next() {
 			if err := rows.Scan(&ret); err != nil {
 				return 0, fmt.Errorf("scanning scene o_count: %w", err)
 			}
+		}
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterating scene o_count rows: %w", err)
 		}
 		return ret, nil
 	}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -827,32 +827,7 @@ func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 	var ret int
 
 	if depth != 0 {
-		q := `
-		WITH RECURSIVE sub_studios AS (
-			SELECT id, 0 AS level FROM studios WHERE id = ?
-			UNION ALL
-			SELECT s.id, ss.level + 1 FROM studios s
-			INNER JOIN sub_studios ss ON s.parent_id = ss.id
-			WHERE ss.level < ? OR ? < 0
-		)
-		SELECT COUNT(*) FROM scenes
-		INNER JOIN scenes_o_dates ON scenes.id = scenes_o_dates.scene_id
-		WHERE scenes.studio_id IN (SELECT id FROM sub_studios)`
-
-		rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
-		if err != nil {
-			return 0, fmt.Errorf("querying scene o_count by studio: %w", err)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := rows.Scan(&ret); err != nil {
-				return 0, fmt.Errorf("scanning scene o_count: %w", err)
-			}
-		}
-		if err := rows.Err(); err != nil {
-			return 0, fmt.Errorf("iterating scene o_count rows: %w", err)
-		}
-		return ret, nil
+		return qb.oCountByStudioIDRecursive(ctx, studioID, depth)
 	}
 
 	table := qb.table()
@@ -867,6 +842,37 @@ func (qb *SceneStore) OCountByStudioID(ctx context.Context, studioID int, depth 
 		return 0, err
 	}
 
+	return ret, nil
+}
+
+func (qb *SceneStore) oCountByStudioIDRecursive(ctx context.Context, studioID int, depth int) (int, error) {
+	q := `
+	WITH RECURSIVE sub_studios AS (
+		SELECT id, 0 AS level FROM studios WHERE id = ?
+		UNION ALL
+		SELECT s.id, ss.level + 1 FROM studios s
+		INNER JOIN sub_studios ss ON s.parent_id = ss.id
+		WHERE ss.level < ? OR ? < 0
+	)
+	SELECT COUNT(*) FROM scenes
+	INNER JOIN scenes_o_dates ON scenes.id = scenes_o_dates.scene_id
+	WHERE scenes.studio_id IN (SELECT id FROM sub_studios)`
+
+	rows, err := dbWrapper.QueryxContext(ctx, q, studioID, depth, depth)
+	if err != nil {
+		return 0, fmt.Errorf("querying scene o_count by studio: %w", err)
+	}
+	defer rows.Close()
+
+	var ret int
+	for rows.Next() {
+		if err := rows.Scan(&ret); err != nil {
+			return 0, fmt.Errorf("scanning scene o_count: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating scene o_count rows: %w", err)
+	}
 	return ret, nil
 }
 

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -658,6 +658,62 @@ func (qb *StudioStore) sortByLatestScene(direction string) string {
 	return " ORDER BY (" + selectStudioLatestSceneSQL + ") " + direction
 }
 
+func (qb *StudioStore) sortByPerformerCount(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		SELECT COUNT(DISTINCT %[2]s.performer_id)
+		FROM %[4]s
+		INNER JOIN %[2]s ON %[2]s.scene_id = %[4]s.id
+		WHERE %[4]s.%[3]s = %[1]s.id
+	) %[5]s`, studioTable, performersScenesTable, studioIDColumn, sceneTable, getSortDirection(direction))
+}
+
+func (qb *StudioStore) sortByPerformerCountAll(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		WITH RECURSIVE sub_studios AS (
+			SELECT id FROM %[1]s WHERE id = %[1]s.id
+			UNION ALL
+			SELECT s.id FROM %[1]s s
+			INNER JOIN sub_studios ss ON s.parent_id = ss.id
+		)
+		SELECT COUNT(DISTINCT %[2]s.performer_id)
+		FROM sub_studios ss
+		INNER JOIN %[4]s sc ON sc.%[3]s = ss.id
+		INNER JOIN %[2]s ON %[2]s.scene_id = sc.id
+	) %[5]s`, studioTable, performersScenesTable, studioIDColumn, sceneTable, getSortDirection(direction))
+}
+
+func (qb *StudioStore) sortByOCounter(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		SELECT COALESCE((
+			SELECT COUNT(*) FROM %[3]s
+			INNER JOIN %[4]s ON %[3]s.id = %[4]s.scene_id
+			WHERE %[3]s.%[2]s = %[1]s.id
+		), 0) + COALESCE((
+			SELECT SUM(o_counter) FROM %[5]s
+			WHERE %[5]s.%[2]s = %[1]s.id
+		), 0)
+	) %[6]s`, studioTable, studioIDColumn, sceneTable, scenesODatesTable, imageTable, getSortDirection(direction))
+}
+
+func (qb *StudioStore) sortByOCounterAll(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		WITH RECURSIVE sub_studios AS (
+			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
+			UNION ALL
+			SELECT ch.id FROM %[1]s ch
+			INNER JOIN sub_studios ss ON ch.parent_id = ss.id
+		)
+		SELECT COALESCE((
+			SELECT COUNT(*) FROM %[3]s
+			INNER JOIN %[4]s ON %[3]s.id = %[4]s.scene_id
+			WHERE %[3]s.%[2]s IN (SELECT id FROM sub_studios)
+		), 0) + COALESCE((
+			SELECT SUM(o_counter) FROM %[5]s
+			WHERE %[5]s.%[2]s IN (SELECT id FROM sub_studios)
+		), 0)
+	) %[6]s`, studioTable, studioIDColumn, sceneTable, scenesODatesTable, imageTable, getSortDirection(direction))
+}
+
 var studioSortOptions = sortOptions{
 	"child_count",
 	"created_at",
@@ -666,6 +722,10 @@ var studioSortOptions = sortOptions{
 	"images_count",
 	"latest_scene",
 	"name",
+	"o_counter",
+	"o_counter_all",
+	"performer_count",
+	"performer_count_all",
 	"scenes_count",
 	"scenes_duration",
 	"scenes_size",
@@ -709,6 +769,14 @@ func (qb *StudioStore) getStudioSort(findFilter *models.FindFilterType) (string,
 		sortQuery += getCountSort(studioTable, studioTable, studioParentIDColumn, direction)
 	case "latest_scene":
 		sortQuery += qb.sortByLatestScene(direction)
+	case "o_counter":
+		sortQuery += qb.sortByOCounter(direction)
+	case "o_counter_all":
+		sortQuery += qb.sortByOCounterAll(direction)
+	case "performer_count":
+		sortQuery += qb.sortByPerformerCount(direction)
+	case "performer_count_all":
+		sortQuery += qb.sortByPerformerCountAll(direction)
 	default:
 		sortQuery += getSort(sort, direction, "studios")
 	}

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -658,40 +658,6 @@ func (qb *StudioStore) sortByLatestScene(direction string) string {
 	return " ORDER BY (" + selectStudioLatestSceneSQL + ") " + direction
 }
 
-func (qb *StudioStore) sortByPerformerCount(direction string) string {
-	return fmt.Sprintf(` ORDER BY (
-		WITH RECURSIVE sub_studios AS (
-			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
-			UNION ALL
-			SELECT ch.id FROM %[1]s ch
-			INNER JOIN sub_studios ss ON ch.parent_id = ss.id
-		)
-		SELECT COUNT(DISTINCT %[2]s.performer_id)
-		FROM sub_studios ss
-		INNER JOIN %[4]s sc ON sc.%[3]s = ss.id
-		INNER JOIN %[2]s ON %[2]s.scene_id = sc.id
-	) %[5]s`, studioTable, performersScenesTable, studioIDColumn, sceneTable, getSortDirection(direction))
-}
-
-func (qb *StudioStore) sortByOCounter(direction string) string {
-	return fmt.Sprintf(` ORDER BY (
-		WITH RECURSIVE sub_studios AS (
-			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
-			UNION ALL
-			SELECT ch.id FROM %[1]s ch
-			INNER JOIN sub_studios ss ON ch.parent_id = ss.id
-		)
-		SELECT COALESCE((
-			SELECT COUNT(*) FROM %[3]s
-			INNER JOIN %[4]s ON %[3]s.id = %[4]s.scene_id
-			WHERE %[3]s.%[2]s IN (SELECT id FROM sub_studios)
-		), 0) + COALESCE((
-			SELECT SUM(o_counter) FROM %[5]s
-			WHERE %[5]s.%[2]s IN (SELECT id FROM sub_studios)
-		), 0)
-	) %[6]s`, studioTable, studioIDColumn, sceneTable, scenesODatesTable, imageTable, getSortDirection(direction))
-}
-
 var studioSortOptions = sortOptions{
 	"child_count",
 	"created_at",
@@ -700,8 +666,6 @@ var studioSortOptions = sortOptions{
 	"images_count",
 	"latest_scene",
 	"name",
-	"o_counter",
-	"performer_count",
 	"scenes_count",
 	"scenes_duration",
 	"scenes_size",
@@ -745,10 +709,6 @@ func (qb *StudioStore) getStudioSort(findFilter *models.FindFilterType) (string,
 		sortQuery += getCountSort(studioTable, studioTable, studioParentIDColumn, direction)
 	case "latest_scene":
 		sortQuery += qb.sortByLatestScene(direction)
-	case "o_counter":
-		sortQuery += qb.sortByOCounter(direction)
-	case "performer_count":
-		sortQuery += qb.sortByPerformerCount(direction)
 	default:
 		sortQuery += getSort(sort, direction, "studios")
 	}

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -670,7 +670,7 @@ func (qb *StudioStore) sortByPerformerCount(direction string) string {
 func (qb *StudioStore) sortByPerformerCountAll(direction string) string {
 	return fmt.Sprintf(` ORDER BY (
 		WITH RECURSIVE sub_studios AS (
-			SELECT id FROM %[1]s WHERE id = %[1]s.id
+			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
 			UNION ALL
 			SELECT s.id FROM %[1]s s
 			INNER JOIN sub_studios ss ON s.parent_id = ss.id

--- a/pkg/sqlite/studio.go
+++ b/pkg/sqlite/studio.go
@@ -658,6 +658,40 @@ func (qb *StudioStore) sortByLatestScene(direction string) string {
 	return " ORDER BY (" + selectStudioLatestSceneSQL + ") " + direction
 }
 
+func (qb *StudioStore) sortByPerformerCount(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		WITH RECURSIVE sub_studios AS (
+			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
+			UNION ALL
+			SELECT ch.id FROM %[1]s ch
+			INNER JOIN sub_studios ss ON ch.parent_id = ss.id
+		)
+		SELECT COUNT(DISTINCT %[2]s.performer_id)
+		FROM sub_studios ss
+		INNER JOIN %[4]s sc ON sc.%[3]s = ss.id
+		INNER JOIN %[2]s ON %[2]s.scene_id = sc.id
+	) %[5]s`, studioTable, performersScenesTable, studioIDColumn, sceneTable, getSortDirection(direction))
+}
+
+func (qb *StudioStore) sortByOCounter(direction string) string {
+	return fmt.Sprintf(` ORDER BY (
+		WITH RECURSIVE sub_studios AS (
+			SELECT s.id FROM %[1]s s WHERE s.id = %[1]s.id
+			UNION ALL
+			SELECT ch.id FROM %[1]s ch
+			INNER JOIN sub_studios ss ON ch.parent_id = ss.id
+		)
+		SELECT COALESCE((
+			SELECT COUNT(*) FROM %[3]s
+			INNER JOIN %[4]s ON %[3]s.id = %[4]s.scene_id
+			WHERE %[3]s.%[2]s IN (SELECT id FROM sub_studios)
+		), 0) + COALESCE((
+			SELECT SUM(o_counter) FROM %[5]s
+			WHERE %[5]s.%[2]s IN (SELECT id FROM sub_studios)
+		), 0)
+	) %[6]s`, studioTable, studioIDColumn, sceneTable, scenesODatesTable, imageTable, getSortDirection(direction))
+}
+
 var studioSortOptions = sortOptions{
 	"child_count",
 	"created_at",
@@ -666,6 +700,8 @@ var studioSortOptions = sortOptions{
 	"images_count",
 	"latest_scene",
 	"name",
+	"o_counter",
+	"performer_count",
 	"scenes_count",
 	"scenes_duration",
 	"scenes_size",
@@ -709,6 +745,10 @@ func (qb *StudioStore) getStudioSort(findFilter *models.FindFilterType) (string,
 		sortQuery += getCountSort(studioTable, studioTable, studioParentIDColumn, direction)
 	case "latest_scene":
 		sortQuery += qb.sortByLatestScene(direction)
+	case "o_counter":
+		sortQuery += qb.sortByOCounter(direction)
+	case "performer_count":
+		sortQuery += qb.sortByPerformerCount(direction)
 	default:
 		sortQuery += getSort(sort, direction, "studios")
 	}

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -1942,12 +1942,110 @@ func TestStudioQueryCustomFields(t *testing.T) {
 	}
 }
 
-// TODO Create
-// TODO Update
-// TODO Destroy
-// TODO Find
-// TODO FindBySceneID
-// TODO Count
-// TODO All
-// TODO AllSlim
-// TODO Query
+func TestStudioOCountByStudioID(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		// studioIdxWithTwoImages has images 13 and 14 with o_counter 1 and 2
+		count, err := db.Image.OCountByStudioID(ctx, studioIDs[studioIdxWithTwoImages], 0)
+		if err != nil {
+			t.Errorf("Error getting image o_count: %s", err.Error())
+		}
+		assert.Equal(t, 3, count)
+
+		// studio with no images
+		count, err = db.Image.OCountByStudioID(ctx, studioIDs[studioIdxWithNothing], 0)
+		if err != nil {
+			t.Errorf("Error getting image o_count: %s", err.Error())
+		}
+		assert.Equal(t, 0, count)
+
+		// scene o_count should be 0 (no o_date entries in test data)
+		count, err = db.Scene.OCountByStudioID(ctx, studioIDs[studioIdxWithGrandParent], 0)
+		if err != nil {
+			t.Errorf("Error getting scene o_count: %s", err.Error())
+		}
+		assert.Equal(t, 0, count)
+
+		// recursive should return same when no child studios have data
+		count, err = db.Image.OCountByStudioID(ctx, studioIDs[studioIdxWithGrandParent], -1)
+		if err != nil {
+			t.Errorf("Error getting image o_count: %s", err.Error())
+		}
+		assert.Equal(t, 2, count)
+
+		return nil
+	})
+}
+
+func TestStudioQuerySortOCounter(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		sortBy := "o_counter"
+		direction := models.SortDirectionEnumDesc
+		findFilter := &models.FindFilterType{
+			Sort:      &sortBy,
+			Direction: &direction,
+		}
+
+		// studioIdxWithTwoImages has highest image o_counter sum (3)
+		studios := queryStudios(ctx, t, nil, findFilter)
+		assert.True(t, len(studios) > 0)
+		assert.Equal(t, studioIDs[studioIdxWithTwoImages], studios[0].ID)
+
+		// ascending
+		direction = models.SortDirectionEnumAsc
+		studios = queryStudios(ctx, t, nil, findFilter)
+		assert.True(t, len(studios) > 0)
+		assert.Equal(t, studioIDs[studioIdxWithTwoImages], studios[len(studios)-1].ID)
+
+		return nil
+	})
+}
+
+func TestStudioQuerySortOCounterAll(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		sortBy := "o_counter_all"
+		direction := models.SortDirectionEnumDesc
+		findFilter := &models.FindFilterType{
+			Sort:      &sortBy,
+			Direction: &direction,
+		}
+
+		studios := queryStudios(ctx, t, nil, findFilter)
+		assert.True(t, len(studios) > 0)
+		// same as flat since no child studios have additional data
+		assert.Equal(t, studioIDs[studioIdxWithTwoImages], studios[0].ID)
+
+		return nil
+	})
+}
+
+func TestStudioQuerySortPerformerCount(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		sortBy := "performer_count"
+		direction := models.SortDirectionEnumDesc
+		findFilter := &models.FindFilterType{
+			Sort:      &sortBy,
+			Direction: &direction,
+		}
+
+		studios := queryStudios(ctx, t, nil, findFilter)
+		assert.True(t, len(studios) > 0)
+		// multiple studios have 1 performer each; just verify it returns without error
+		return nil
+	})
+}
+
+func TestStudioQuerySortPerformerCountAll(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		sortBy := "performer_count_all"
+		direction := models.SortDirectionEnumDesc
+		findFilter := &models.FindFilterType{
+			Sort:      &sortBy,
+			Direction: &direction,
+		}
+
+		studios := queryStudios(ctx, t, nil, findFilter)
+		assert.True(t, len(studios) > 0)
+
+		return nil
+	})
+}

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -2029,7 +2029,22 @@ func TestStudioQuerySortPerformerCount(t *testing.T) {
 
 		studios := queryStudios(ctx, t, nil, findFilter)
 		assert.True(t, len(studios) > 0)
-		// multiple studios have 1 performer each; just verify it returns without error
+		// studio with performers should appear before studio without
+		firstWithPerf := -1
+		lastWithoutPerf := -1
+		for i, s := range studios {
+			// sceneIdxWithStudioPerformer has performerIdxWithSceneStudio
+			if s.ID == studioIDs[studioIdxWithScenePerformer] && firstWithPerf == -1 {
+				firstWithPerf = i
+			}
+			if s.ID == studioIDs[studioIdxWithNothing] {
+				lastWithoutPerf = i
+			}
+		}
+		assert.Greater(t, firstWithPerf, -1)
+		assert.Greater(t, lastWithoutPerf, -1)
+		assert.Less(t, firstWithPerf, lastWithoutPerf)
+
 		return nil
 	})
 }
@@ -2045,6 +2060,20 @@ func TestStudioQuerySortPerformerCountAll(t *testing.T) {
 
 		studios := queryStudios(ctx, t, nil, findFilter)
 		assert.True(t, len(studios) > 0)
+		// studio with performers should appear before studio without
+		firstWithPerf := -1
+		lastWithoutPerf := -1
+		for i, s := range studios {
+			if s.ID == studioIDs[studioIdxWithScenePerformer] && firstWithPerf == -1 {
+				firstWithPerf = i
+			}
+			if s.ID == studioIDs[studioIdxWithNothing] {
+				lastWithoutPerf = i
+			}
+		}
+		assert.Greater(t, firstWithPerf, -1)
+		assert.Greater(t, lastWithoutPerf, -1)
+		assert.Less(t, firstWithPerf, lastWithoutPerf)
 
 		return nil
 	})

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -1942,6 +1942,16 @@ func TestStudioQueryCustomFields(t *testing.T) {
 	}
 }
 
+// TODO Create
+// TODO Update
+// TODO Destroy
+// TODO Find
+// TODO FindBySceneID
+// TODO Count
+// TODO All
+// TODO AllSlim
+// TODO Query
+
 func TestStudioOCountByStudioID(t *testing.T) {
 	withTxn(func(ctx context.Context) error {
 		// studioIdxWithTwoImages has images 13 and 14 with o_counter 1 and 2

--- a/ui/v2.5/graphql/data/studio.graphql
+++ b/ui/v2.5/graphql/data/studio.graphql
@@ -41,6 +41,7 @@ fragment StudioData on Studio {
     ...SlimTagData
   }
   o_counter
+  o_counter_all: o_counter(depth: -1)
   custom_fields
 }
 

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -13,6 +13,7 @@ import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import { RatingBanner } from "../Shared/RatingBanner";
 import { FavoriteIcon } from "../Shared/FavoriteIcon";
 import { useStudioUpdate } from "src/core/StashService";
+import { useConfigurationContext } from "src/hooks/Config";
 import { faTag, faBox } from "@fortawesome/free-solid-svg-icons";
 import { OCounterButton } from "../Shared/CountButton";
 
@@ -83,6 +84,16 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     onSelectedChanged,
   }) => {
     const [updateStudio] = useStudioUpdate();
+    const { configuration } = useConfigurationContext();
+    const showChildContent = configuration?.ui?.showChildStudioContent ?? false;
+
+    const sceneCount = showChildContent
+      ? studio.scene_count_all
+      : studio.scene_count;
+    const performerCount = showChildContent
+      ? studio.performer_count_all
+      : studio.performer_count;
+    const oCounter = showChildContent ? studio.o_counter_all : studio.o_counter;
 
     function onToggleFavorite(v: boolean) {
       if (studio.id) {
@@ -98,13 +109,13 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderScenesPopoverButton() {
-      if (!studio.scene_count_all) return;
+      if (!sceneCount) return;
 
       return (
         <PopoverCountButton
           className="scene-count"
           type="scene"
-          count={studio.scene_count_all}
+          count={sceneCount}
           url={NavUtils.makeStudioScenesUrl(studio)}
         />
       );
@@ -150,13 +161,13 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderPerformersPopoverButton() {
-      if (!studio.performer_count_all) return;
+      if (!performerCount) return;
 
       return (
         <PopoverCountButton
           className="performer-count"
           type="performer"
-          count={studio.performer_count_all}
+          count={performerCount}
           url={NavUtils.makeStudioPerformersUrl(studio)}
         />
       );
@@ -180,9 +191,9 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderOCounter() {
-      if (!studio.o_counter_all) return;
+      if (!oCounter) return;
 
-      return <OCounterButton value={studio.o_counter_all} />;
+      return <OCounterButton value={oCounter} />;
     }
 
     function maybeRenderOrganized() {
@@ -208,12 +219,12 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
 
     function maybeRenderPopoverButtonGroup() {
       if (
-        studio.scene_count_all ||
+        sceneCount ||
         studio.image_count ||
         studio.gallery_count ||
         studio.group_count ||
-        studio.performer_count_all ||
-        studio.o_counter_all ||
+        performerCount ||
+        oCounter ||
         studio.tags.length > 0 ||
         studio.organized
       ) {

--- a/ui/v2.5/src/components/Studios/StudioCard.tsx
+++ b/ui/v2.5/src/components/Studios/StudioCard.tsx
@@ -98,13 +98,13 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderScenesPopoverButton() {
-      if (!studio.scene_count) return;
+      if (!studio.scene_count_all) return;
 
       return (
         <PopoverCountButton
           className="scene-count"
           type="scene"
-          count={studio.scene_count}
+          count={studio.scene_count_all}
           url={NavUtils.makeStudioScenesUrl(studio)}
         />
       );
@@ -150,13 +150,13 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderPerformersPopoverButton() {
-      if (!studio.performer_count) return;
+      if (!studio.performer_count_all) return;
 
       return (
         <PopoverCountButton
           className="performer-count"
           type="performer"
-          count={studio.performer_count}
+          count={studio.performer_count_all}
           url={NavUtils.makeStudioPerformersUrl(studio)}
         />
       );
@@ -180,9 +180,9 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderOCounter() {
-      if (!studio.o_counter) return;
+      if (!studio.o_counter_all) return;
 
-      return <OCounterButton value={studio.o_counter} />;
+      return <OCounterButton value={studio.o_counter_all} />;
     }
 
     function maybeRenderOrganized() {
@@ -208,12 +208,12 @@ export const StudioCard: React.FC<IProps> = PatchComponent(
 
     function maybeRenderPopoverButtonGroup() {
       if (
-        studio.scene_count ||
+        studio.scene_count_all ||
         studio.image_count ||
         studio.gallery_count ||
         studio.group_count ||
-        studio.performer_count ||
-        studio.o_counter ||
+        studio.performer_count_all ||
+        studio.o_counter_all ||
         studio.tags.length > 0 ||
         studio.organized
       ) {

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -515,9 +515,11 @@ const StudioPage: React.FC<IProps> = PatchComponent(
                     clickToRate
                     withoutContext
                   />
-                  {!!studio.o_counter_all && (
+                  {showAllCounts && !!studio.o_counter_all ? (
                     <OCounterButton value={studio.o_counter_all} />
-                  )}
+                  ) : !showAllCounts && !!studio.o_counter ? (
+                    <OCounterButton value={studio.o_counter} />
+                  ) : null}
                 </div>
                 {!isEditing && (
                   <StudioDetailsPanel

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -99,16 +99,16 @@ const StudioTabs: React.FC<{
 
   const populatedDefaultTab = useMemo(() => {
     let ret: TabKey = "scenes";
-    if (sceneCount == 0) {
-      if (galleryCount != 0) {
+    if (sceneCount === 0) {
+      if (galleryCount !== 0) {
         ret = "galleries";
-      } else if (imageCount != 0) {
+      } else if (imageCount !== 0) {
         ret = "images";
-      } else if (performerCount != 0) {
+      } else if (performerCount !== 0) {
         ret = "performers";
-      } else if (groupCount != 0) {
+      } else if (groupCount !== 0) {
         ret = "groups";
-      } else if (studio.child_studios.length != 0) {
+      } else if (studio.child_studios.length !== 0) {
         ret = "childstudios";
       }
     }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -48,7 +48,6 @@ import { ExternalLinkButtons } from "src/components/Shared/ExternalLinksButton";
 import { AliasList } from "src/components/Shared/DetailsPage/AliasList";
 import { HeaderImage } from "src/components/Shared/DetailsPage/HeaderImage";
 import { goBackOrReplace } from "src/utils/history";
-import { PatchComponent } from "src/patch";
 import { OCounterButton } from "src/components/Shared/CountButton";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
 
@@ -100,16 +99,16 @@ const StudioTabs: React.FC<{
 
   const populatedDefaultTab = useMemo(() => {
     let ret: TabKey = "scenes";
-    if (sceneCount === 0) {
-      if (galleryCount !== 0) {
+    if (sceneCount == 0) {
+      if (galleryCount != 0) {
         ret = "galleries";
-      } else if (imageCount !== 0) {
+      } else if (imageCount != 0) {
         ret = "images";
-      } else if (performerCount !== 0) {
+      } else if (performerCount != 0) {
         ret = "performers";
-      } else if (groupCount !== 0) {
+      } else if (groupCount != 0) {
         ret = "groups";
-      } else if (studio.child_studios.length !== 0) {
+      } else if (studio.child_studios.length != 0) {
         ret = "childstudios";
       }
     }
@@ -265,320 +264,316 @@ const StudioTabs: React.FC<{
   );
 };
 
-const StudioPage: React.FC<IProps> = PatchComponent(
-  "StudioPage",
-  ({ studio, tabKey }) => {
-    const history = useHistory();
-    const Toast = useToast();
-    const intl = useIntl();
+const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
+  const history = useHistory();
+  const Toast = useToast();
+  const intl = useIntl();
 
-    // Configuration settings
-    const { configuration } = useConfigurationContext();
-    const uiConfig = configuration?.ui;
-    const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
-    const enableBackgroundImage =
-      uiConfig?.enableStudioBackgroundImage ?? false;
-    const showAllDetails = uiConfig?.showAllDetails ?? true;
-    const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
+  // Configuration settings
+  const { configuration } = useConfigurationContext();
+  const uiConfig = configuration?.ui;
+  const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+  const enableBackgroundImage = uiConfig?.enableStudioBackgroundImage ?? false;
+  const showAllDetails = uiConfig?.showAllDetails ?? true;
+  const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
-    const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-    const loadStickyHeader = useLoadStickyHeader();
+  const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
+  const loadStickyHeader = useLoadStickyHeader();
 
-    // Editing state
-    const [isEditing, setIsEditing] = useState<boolean>(false);
-    const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+  // Editing state
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
-    // Editing studio state
-    const [image, setImage] = useState<string | null>();
-    const [encodingImage, setEncodingImage] = useState<boolean>(false);
+  // Editing studio state
+  const [image, setImage] = useState<string | null>();
+  const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-    const [updateStudio] = useStudioUpdate();
-    const [deleteStudio] = useStudioDestroy({ id: studio.id });
+  const [updateStudio] = useStudioUpdate();
+  const [deleteStudio] = useStudioDestroy({ id: studio.id });
 
-    const showAllCounts = uiConfig?.showChildStudioContent;
+  const showAllCounts = uiConfig?.showChildStudioContent;
 
-    const studioImage = useMemo(() => {
-      const existingPath = studio.image_path;
-      if (isEditing) {
-        if (image === null && existingPath) {
-          const studioImageURL = new URL(existingPath);
-          studioImageURL.searchParams.set("default", "true");
-          return studioImageURL.toString();
-        } else if (image) {
-          return image;
-        }
-      }
-
-      return existingPath;
-    }, [isEditing, image, studio.image_path]);
-
-    function setFavorite(v: boolean) {
-      if (studio.id) {
-        updateStudio({
-          variables: {
-            input: {
-              id: studio.id,
-              favorite: v,
-            },
-          },
-        });
+  const studioImage = useMemo(() => {
+    const existingPath = studio.image_path;
+    if (isEditing) {
+      if (image === null && existingPath) {
+        const studioImageURL = new URL(existingPath);
+        studioImageURL.searchParams.set("default", "true");
+        return studioImageURL.toString();
+      } else if (image) {
+        return image;
       }
     }
 
-    const [organizedLoading, setOrganizedLoading] = useState(false);
+    return existingPath;
+  }, [isEditing, image, studio.image_path]);
 
-    async function onOrganizedClick() {
-      if (!studio.id) return;
-
-      setOrganizedLoading(true);
-      try {
-        await updateStudio({
-          variables: {
-            input: {
-              id: studio.id,
-              organized: !studio.organized,
-            },
+  function setFavorite(v: boolean) {
+    if (studio.id) {
+      updateStudio({
+        variables: {
+          input: {
+            id: studio.id,
+            favorite: v,
           },
-        });
-      } catch (e) {
-        Toast.error(e);
-      } finally {
-        setOrganizedLoading(false);
-      }
-    }
-
-    // set up hotkeys
-    useEffect(() => {
-      Mousetrap.bind("e", () => toggleEditing());
-      Mousetrap.bind("d d", () => {
-        setIsDeleteAlertOpen(true);
+        },
       });
-      Mousetrap.bind(",", () => setCollapsed(!collapsed));
-      Mousetrap.bind("f", () => setFavorite(!studio.favorite));
+    }
+  }
 
-      return () => {
-        Mousetrap.unbind("e");
-        Mousetrap.unbind("d d");
-        Mousetrap.unbind(",");
-        Mousetrap.unbind("f");
-      };
-    });
+  const [organizedLoading, setOrganizedLoading] = useState(false);
 
-    useRatingKeybinds(
-      true,
-      configuration?.ui.ratingSystemOptions?.type,
-      setRating
-    );
+  async function onOrganizedClick() {
+    if (!studio.id) return;
 
-    async function onSave(input: GQL.StudioCreateInput) {
+    setOrganizedLoading(true);
+    try {
       await updateStudio({
         variables: {
           input: {
             id: studio.id,
-            ...input,
+            organized: !studio.organized,
           },
         },
       });
-      toggleEditing(false);
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.updated_entity" },
-          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
-        )
-      );
+    } catch (e) {
+      Toast.error(e);
+    } finally {
+      setOrganizedLoading(false);
     }
+  }
 
-    async function onAutoTag() {
-      if (!studio.id) return;
-      try {
-        await mutateMetadataAutoTag({ studios: [studio.id] });
-        Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
-      } catch (e) {
-        Toast.error(e);
-      }
-    }
-
-    async function onDelete() {
-      try {
-        await deleteStudio();
-      } catch (e) {
-        Toast.error(e);
-        return;
-      }
-
-      goBackOrReplace(history, "/studios");
-    }
-
-    function renderDeleteAlert() {
-      return (
-        <ModalComponent
-          show={isDeleteAlertOpen}
-          icon={faTrashAlt}
-          accept={{
-            text: intl.formatMessage({ id: "actions.delete" }),
-            variant: "danger",
-            onClick: onDelete,
-          }}
-          cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
-        >
-          <p>
-            <FormattedMessage
-              id="dialogs.delete_confirm"
-              values={{
-                entityName:
-                  studio.name ??
-                  intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
-              }}
-            />
-          </p>
-        </ModalComponent>
-      );
-    }
-
-    function toggleEditing(value?: boolean) {
-      if (value !== undefined) {
-        setIsEditing(value);
-      } else {
-        setIsEditing((e) => !e);
-      }
-      setImage(undefined);
-    }
-
-    function setRating(v: number | null) {
-      if (studio.id) {
-        updateStudio({
-          variables: {
-            input: {
-              id: studio.id,
-              rating100: v,
-            },
-          },
-        });
-      }
-    }
-
-    const headerClassName = cx("detail-header", {
-      edit: isEditing,
-      collapsed,
-      "full-width": !collapsed && !compactExpandedDetails,
+  // set up hotkeys
+  useEffect(() => {
+    Mousetrap.bind("e", () => toggleEditing());
+    Mousetrap.bind("d d", () => {
+      setIsDeleteAlertOpen(true);
     });
+    Mousetrap.bind(",", () => setCollapsed(!collapsed));
+    Mousetrap.bind("f", () => setFavorite(!studio.favorite));
 
-    return (
-      <div id="studio-page" className="row">
-        <Helmet>
-          <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
-        </Helmet>
+    return () => {
+      Mousetrap.unbind("e");
+      Mousetrap.unbind("d d");
+      Mousetrap.unbind(",");
+      Mousetrap.unbind("f");
+    };
+  });
 
-        <div className={headerClassName}>
-          <BackgroundImage
-            imagePath={studio.image_path ?? undefined}
-            show={enableBackgroundImage && !isEditing}
-          />
-          <div className="detail-container">
-            <HeaderImage encodingImage={encodingImage}>
-              {studioImage && (
-                <DetailImage
-                  className="logo"
-                  alt={studio.name}
-                  src={studioImage}
-                />
-              )}
-            </HeaderImage>
-            <div className="row">
-              <div className="studio-head col">
-                <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
-                  {!isEditing && (
-                    <ExpandCollapseButton
-                      collapsed={collapsed}
-                      setCollapsed={(v) => setCollapsed(v)}
-                    />
-                  )}
-                  <span className="name-icons">
-                    <FavoriteIcon
-                      favorite={studio.favorite}
-                      onToggleFavorite={(v) => setFavorite(v)}
-                    />
-                    <OrganizedButton
-                      loading={organizedLoading}
-                      organized={studio.organized}
-                      onClick={onOrganizedClick}
-                    />
-                    <ExternalLinkButtons urls={studio.urls} />
-                  </span>
-                </DetailTitle>
+  useRatingKeybinds(
+    true,
+    configuration?.ui.ratingSystemOptions?.type,
+    setRating
+  );
 
-                <AliasList aliases={studio.aliases} />
-                <div className="quality-group">
-                  <RatingSystem
-                    value={studio.rating100}
-                    onSetRating={(value) => setRating(value)}
-                    clickToRate
-                    withoutContext
-                  />
-                  {!!studio.o_counter && (
-                    <OCounterButton value={studio.o_counter} />
-                  )}
-                </div>
-                {!isEditing && (
-                  <StudioDetailsPanel
-                    studio={studio}
-                    collapsed={collapsed}
-                    fullWidth={!collapsed && !compactExpandedDetails}
-                  />
-                )}
-                {isEditing ? (
-                  <StudioEditPanel
-                    studio={studio}
-                    onSubmit={onSave}
-                    onCancel={() => toggleEditing()}
-                    onDelete={onDelete}
-                    setImage={setImage}
-                    setEncodingImage={setEncodingImage}
-                  />
-                ) : (
-                  <DetailsEditNavbar
-                    objectName={
-                      studio.name ?? intl.formatMessage({ id: "studio" })
-                    }
-                    isNew={false}
-                    isEditing={isEditing}
-                    onToggleEdit={() => toggleEditing()}
-                    onSave={() => {}}
-                    onImageChange={() => {}}
-                    onClearImage={() => {}}
-                    onAutoTag={onAutoTag}
-                    autoTagDisabled={studio.ignore_auto_tag}
-                    onDelete={onDelete}
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {!isEditing && loadStickyHeader && (
-          <CompressedStudioDetailsPanel studio={studio} />
-        )}
-
-        <div className="detail-body">
-          <div className="studio-body">
-            <div className="studio-tabs">
-              {!isEditing && (
-                <StudioTabs
-                  studio={studio}
-                  tabKey={tabKey}
-                  abbreviateCounter={abbreviateCounter}
-                  showAllCounts={showAllCounts}
-                />
-              )}
-            </div>
-          </div>
-        </div>
-        {renderDeleteAlert()}
-      </div>
+  async function onSave(input: GQL.StudioCreateInput) {
+    await updateStudio({
+      variables: {
+        input: {
+          id: studio.id,
+          ...input,
+        },
+      },
+    });
+    toggleEditing(false);
+    Toast.success(
+      intl.formatMessage(
+        { id: "toast.updated_entity" },
+        { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+      )
     );
   }
-);
+
+  async function onAutoTag() {
+    if (!studio.id) return;
+    try {
+      await mutateMetadataAutoTag({ studios: [studio.id] });
+      Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
+    } catch (e) {
+      Toast.error(e);
+    }
+  }
+
+  async function onDelete() {
+    try {
+      await deleteStudio();
+    } catch (e) {
+      Toast.error(e);
+      return;
+    }
+
+    goBackOrReplace(history, "/studios");
+  }
+
+  function renderDeleteAlert() {
+    return (
+      <ModalComponent
+        show={isDeleteAlertOpen}
+        icon={faTrashAlt}
+        accept={{
+          text: intl.formatMessage({ id: "actions.delete" }),
+          variant: "danger",
+          onClick: onDelete,
+        }}
+        cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
+      >
+        <p>
+          <FormattedMessage
+            id="dialogs.delete_confirm"
+            values={{
+              entityName:
+                studio.name ??
+                intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
+            }}
+          />
+        </p>
+      </ModalComponent>
+    );
+  }
+
+  function toggleEditing(value?: boolean) {
+    if (value !== undefined) {
+      setIsEditing(value);
+    } else {
+      setIsEditing((e) => !e);
+    }
+    setImage(undefined);
+  }
+
+  function setRating(v: number | null) {
+    if (studio.id) {
+      updateStudio({
+        variables: {
+          input: {
+            id: studio.id,
+            rating100: v,
+          },
+        },
+      });
+    }
+  }
+
+  const headerClassName = cx("detail-header", {
+    edit: isEditing,
+    collapsed,
+    "full-width": !collapsed && !compactExpandedDetails,
+  });
+
+  return (
+    <div id="studio-page" className="row">
+      <Helmet>
+        <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
+      </Helmet>
+
+      <div className={headerClassName}>
+        <BackgroundImage
+          imagePath={studio.image_path ?? undefined}
+          show={enableBackgroundImage && !isEditing}
+        />
+        <div className="detail-container">
+          <HeaderImage encodingImage={encodingImage}>
+            {studioImage && (
+              <DetailImage
+                className="logo"
+                alt={studio.name}
+                src={studioImage}
+              />
+            )}
+          </HeaderImage>
+          <div className="row">
+            <div className="studio-head col">
+              <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
+                {!isEditing && (
+                  <ExpandCollapseButton
+                    collapsed={collapsed}
+                    setCollapsed={(v) => setCollapsed(v)}
+                  />
+                )}
+                <span className="name-icons">
+                  <FavoriteIcon
+                    favorite={studio.favorite}
+                    onToggleFavorite={(v) => setFavorite(v)}
+                  />
+                  <OrganizedButton
+                    loading={organizedLoading}
+                    organized={studio.organized}
+                    onClick={onOrganizedClick}
+                  />
+                  <ExternalLinkButtons urls={studio.urls} />
+                </span>
+              </DetailTitle>
+
+              <AliasList aliases={studio.aliases} />
+              <div className="quality-group">
+                <RatingSystem
+                  value={studio.rating100}
+                  onSetRating={(value) => setRating(value)}
+                  clickToRate
+                  withoutContext
+                />
+                {!!studio.o_counter_all && (
+                  <OCounterButton value={studio.o_counter_all} />
+                )}
+              </div>
+              {!isEditing && (
+                <StudioDetailsPanel
+                  studio={studio}
+                  collapsed={collapsed}
+                  fullWidth={!collapsed && !compactExpandedDetails}
+                />
+              )}
+              {isEditing ? (
+                <StudioEditPanel
+                  studio={studio}
+                  onSubmit={onSave}
+                  onCancel={() => toggleEditing()}
+                  onDelete={onDelete}
+                  setImage={setImage}
+                  setEncodingImage={setEncodingImage}
+                />
+              ) : (
+                <DetailsEditNavbar
+                  objectName={
+                    studio.name ?? intl.formatMessage({ id: "studio" })
+                  }
+                  isNew={false}
+                  isEditing={isEditing}
+                  onToggleEdit={() => toggleEditing()}
+                  onSave={() => {}}
+                  onImageChange={() => {}}
+                  onClearImage={() => {}}
+                  onAutoTag={onAutoTag}
+                  autoTagDisabled={studio.ignore_auto_tag}
+                  onDelete={onDelete}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {!isEditing && loadStickyHeader && (
+        <CompressedStudioDetailsPanel studio={studio} />
+      )}
+
+      <div className="detail-body">
+        <div className="studio-body">
+          <div className="studio-tabs">
+            {!isEditing && (
+              <StudioTabs
+                studio={studio}
+                tabKey={tabKey}
+                abbreviateCounter={abbreviateCounter}
+                showAllCounts={showAllCounts}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+      {renderDeleteAlert()}
+    </div>
+  );
+};
 
 const StudioLoader: React.FC<RouteComponentProps<IStudioParams>> = ({
   location,

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -48,6 +48,7 @@ import { ExternalLinkButtons } from "src/components/Shared/ExternalLinksButton";
 import { AliasList } from "src/components/Shared/DetailsPage/AliasList";
 import { HeaderImage } from "src/components/Shared/DetailsPage/HeaderImage";
 import { goBackOrReplace } from "src/utils/history";
+import { PatchComponent } from "src/patch";
 import { OCounterButton } from "src/components/Shared/CountButton";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
 
@@ -264,316 +265,320 @@ const StudioTabs: React.FC<{
   );
 };
 
-const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
-  const history = useHistory();
-  const Toast = useToast();
-  const intl = useIntl();
+const StudioPage: React.FC<IProps> = PatchComponent(
+  "StudioPage",
+  ({ studio, tabKey }) => {
+    const history = useHistory();
+    const Toast = useToast();
+    const intl = useIntl();
 
-  // Configuration settings
-  const { configuration } = useConfigurationContext();
-  const uiConfig = configuration?.ui;
-  const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
-  const enableBackgroundImage = uiConfig?.enableStudioBackgroundImage ?? false;
-  const showAllDetails = uiConfig?.showAllDetails ?? true;
-  const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
+    // Configuration settings
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui;
+    const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+    const enableBackgroundImage =
+      uiConfig?.enableStudioBackgroundImage ?? false;
+    const showAllDetails = uiConfig?.showAllDetails ?? true;
+    const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
-  const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const loadStickyHeader = useLoadStickyHeader();
+    const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
+    const loadStickyHeader = useLoadStickyHeader();
 
-  // Editing state
-  const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+    // Editing state
+    const [isEditing, setIsEditing] = useState<boolean>(false);
+    const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
-  // Editing studio state
-  const [image, setImage] = useState<string | null>();
-  const [encodingImage, setEncodingImage] = useState<boolean>(false);
+    // Editing studio state
+    const [image, setImage] = useState<string | null>();
+    const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const [updateStudio] = useStudioUpdate();
-  const [deleteStudio] = useStudioDestroy({ id: studio.id });
+    const [updateStudio] = useStudioUpdate();
+    const [deleteStudio] = useStudioDestroy({ id: studio.id });
 
-  const showAllCounts = uiConfig?.showChildStudioContent;
+    const showAllCounts = uiConfig?.showChildStudioContent;
 
-  const studioImage = useMemo(() => {
-    const existingPath = studio.image_path;
-    if (isEditing) {
-      if (image === null && existingPath) {
-        const studioImageURL = new URL(existingPath);
-        studioImageURL.searchParams.set("default", "true");
-        return studioImageURL.toString();
-      } else if (image) {
-        return image;
+    const studioImage = useMemo(() => {
+      const existingPath = studio.image_path;
+      if (isEditing) {
+        if (image === null && existingPath) {
+          const studioImageURL = new URL(existingPath);
+          studioImageURL.searchParams.set("default", "true");
+          return studioImageURL.toString();
+        } else if (image) {
+          return image;
+        }
+      }
+
+      return existingPath;
+    }, [isEditing, image, studio.image_path]);
+
+    function setFavorite(v: boolean) {
+      if (studio.id) {
+        updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              favorite: v,
+            },
+          },
+        });
       }
     }
 
-    return existingPath;
-  }, [isEditing, image, studio.image_path]);
+    const [organizedLoading, setOrganizedLoading] = useState(false);
 
-  function setFavorite(v: boolean) {
-    if (studio.id) {
-      updateStudio({
-        variables: {
-          input: {
-            id: studio.id,
-            favorite: v,
+    async function onOrganizedClick() {
+      if (!studio.id) return;
+
+      setOrganizedLoading(true);
+      try {
+        await updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              organized: !studio.organized,
+            },
           },
-        },
-      });
+        });
+      } catch (e) {
+        Toast.error(e);
+      } finally {
+        setOrganizedLoading(false);
+      }
     }
-  }
 
-  const [organizedLoading, setOrganizedLoading] = useState(false);
+    // set up hotkeys
+    useEffect(() => {
+      Mousetrap.bind("e", () => toggleEditing());
+      Mousetrap.bind("d d", () => {
+        setIsDeleteAlertOpen(true);
+      });
+      Mousetrap.bind(",", () => setCollapsed(!collapsed));
+      Mousetrap.bind("f", () => setFavorite(!studio.favorite));
 
-  async function onOrganizedClick() {
-    if (!studio.id) return;
+      return () => {
+        Mousetrap.unbind("e");
+        Mousetrap.unbind("d d");
+        Mousetrap.unbind(",");
+        Mousetrap.unbind("f");
+      };
+    });
 
-    setOrganizedLoading(true);
-    try {
+    useRatingKeybinds(
+      true,
+      configuration?.ui.ratingSystemOptions?.type,
+      setRating
+    );
+
+    async function onSave(input: GQL.StudioCreateInput) {
       await updateStudio({
         variables: {
           input: {
             id: studio.id,
-            organized: !studio.organized,
+            ...input,
           },
         },
       });
-    } catch (e) {
-      Toast.error(e);
-    } finally {
-      setOrganizedLoading(false);
+      toggleEditing(false);
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.updated_entity" },
+          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+        )
+      );
     }
-  }
 
-  // set up hotkeys
-  useEffect(() => {
-    Mousetrap.bind("e", () => toggleEditing());
-    Mousetrap.bind("d d", () => {
-      setIsDeleteAlertOpen(true);
+    async function onAutoTag() {
+      if (!studio.id) return;
+      try {
+        await mutateMetadataAutoTag({ studios: [studio.id] });
+        Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
+      } catch (e) {
+        Toast.error(e);
+      }
+    }
+
+    async function onDelete() {
+      try {
+        await deleteStudio();
+      } catch (e) {
+        Toast.error(e);
+        return;
+      }
+
+      goBackOrReplace(history, "/studios");
+    }
+
+    function renderDeleteAlert() {
+      return (
+        <ModalComponent
+          show={isDeleteAlertOpen}
+          icon={faTrashAlt}
+          accept={{
+            text: intl.formatMessage({ id: "actions.delete" }),
+            variant: "danger",
+            onClick: onDelete,
+          }}
+          cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
+        >
+          <p>
+            <FormattedMessage
+              id="dialogs.delete_confirm"
+              values={{
+                entityName:
+                  studio.name ??
+                  intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
+              }}
+            />
+          </p>
+        </ModalComponent>
+      );
+    }
+
+    function toggleEditing(value?: boolean) {
+      if (value !== undefined) {
+        setIsEditing(value);
+      } else {
+        setIsEditing((e) => !e);
+      }
+      setImage(undefined);
+    }
+
+    function setRating(v: number | null) {
+      if (studio.id) {
+        updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              rating100: v,
+            },
+          },
+        });
+      }
+    }
+
+    const headerClassName = cx("detail-header", {
+      edit: isEditing,
+      collapsed,
+      "full-width": !collapsed && !compactExpandedDetails,
     });
-    Mousetrap.bind(",", () => setCollapsed(!collapsed));
-    Mousetrap.bind("f", () => setFavorite(!studio.favorite));
 
-    return () => {
-      Mousetrap.unbind("e");
-      Mousetrap.unbind("d d");
-      Mousetrap.unbind(",");
-      Mousetrap.unbind("f");
-    };
-  });
-
-  useRatingKeybinds(
-    true,
-    configuration?.ui.ratingSystemOptions?.type,
-    setRating
-  );
-
-  async function onSave(input: GQL.StudioCreateInput) {
-    await updateStudio({
-      variables: {
-        input: {
-          id: studio.id,
-          ...input,
-        },
-      },
-    });
-    toggleEditing(false);
-    Toast.success(
-      intl.formatMessage(
-        { id: "toast.updated_entity" },
-        { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
-      )
-    );
-  }
-
-  async function onAutoTag() {
-    if (!studio.id) return;
-    try {
-      await mutateMetadataAutoTag({ studios: [studio.id] });
-      Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
-    } catch (e) {
-      Toast.error(e);
-    }
-  }
-
-  async function onDelete() {
-    try {
-      await deleteStudio();
-    } catch (e) {
-      Toast.error(e);
-      return;
-    }
-
-    goBackOrReplace(history, "/studios");
-  }
-
-  function renderDeleteAlert() {
     return (
-      <ModalComponent
-        show={isDeleteAlertOpen}
-        icon={faTrashAlt}
-        accept={{
-          text: intl.formatMessage({ id: "actions.delete" }),
-          variant: "danger",
-          onClick: onDelete,
-        }}
-        cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
-      >
-        <p>
-          <FormattedMessage
-            id="dialogs.delete_confirm"
-            values={{
-              entityName:
-                studio.name ??
-                intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
-            }}
+      <div id="studio-page" className="row">
+        <Helmet>
+          <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
+        </Helmet>
+
+        <div className={headerClassName}>
+          <BackgroundImage
+            imagePath={studio.image_path ?? undefined}
+            show={enableBackgroundImage && !isEditing}
           />
-        </p>
-      </ModalComponent>
-    );
-  }
-
-  function toggleEditing(value?: boolean) {
-    if (value !== undefined) {
-      setIsEditing(value);
-    } else {
-      setIsEditing((e) => !e);
-    }
-    setImage(undefined);
-  }
-
-  function setRating(v: number | null) {
-    if (studio.id) {
-      updateStudio({
-        variables: {
-          input: {
-            id: studio.id,
-            rating100: v,
-          },
-        },
-      });
-    }
-  }
-
-  const headerClassName = cx("detail-header", {
-    edit: isEditing,
-    collapsed,
-    "full-width": !collapsed && !compactExpandedDetails,
-  });
-
-  return (
-    <div id="studio-page" className="row">
-      <Helmet>
-        <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
-      </Helmet>
-
-      <div className={headerClassName}>
-        <BackgroundImage
-          imagePath={studio.image_path ?? undefined}
-          show={enableBackgroundImage && !isEditing}
-        />
-        <div className="detail-container">
-          <HeaderImage encodingImage={encodingImage}>
-            {studioImage && (
-              <DetailImage
-                className="logo"
-                alt={studio.name}
-                src={studioImage}
-              />
-            )}
-          </HeaderImage>
-          <div className="row">
-            <div className="studio-head col">
-              <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
-                {!isEditing && (
-                  <ExpandCollapseButton
-                    collapsed={collapsed}
-                    setCollapsed={(v) => setCollapsed(v)}
-                  />
-                )}
-                <span className="name-icons">
-                  <FavoriteIcon
-                    favorite={studio.favorite}
-                    onToggleFavorite={(v) => setFavorite(v)}
-                  />
-                  <OrganizedButton
-                    loading={organizedLoading}
-                    organized={studio.organized}
-                    onClick={onOrganizedClick}
-                  />
-                  <ExternalLinkButtons urls={studio.urls} />
-                </span>
-              </DetailTitle>
-
-              <AliasList aliases={studio.aliases} />
-              <div className="quality-group">
-                <RatingSystem
-                  value={studio.rating100}
-                  onSetRating={(value) => setRating(value)}
-                  clickToRate
-                  withoutContext
-                />
-                {!!studio.o_counter_all && (
-                  <OCounterButton value={studio.o_counter_all} />
-                )}
-              </div>
-              {!isEditing && (
-                <StudioDetailsPanel
-                  studio={studio}
-                  collapsed={collapsed}
-                  fullWidth={!collapsed && !compactExpandedDetails}
+          <div className="detail-container">
+            <HeaderImage encodingImage={encodingImage}>
+              {studioImage && (
+                <DetailImage
+                  className="logo"
+                  alt={studio.name}
+                  src={studioImage}
                 />
               )}
-              {isEditing ? (
-                <StudioEditPanel
+            </HeaderImage>
+            <div className="row">
+              <div className="studio-head col">
+                <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
+                  {!isEditing && (
+                    <ExpandCollapseButton
+                      collapsed={collapsed}
+                      setCollapsed={(v) => setCollapsed(v)}
+                    />
+                  )}
+                  <span className="name-icons">
+                    <FavoriteIcon
+                      favorite={studio.favorite}
+                      onToggleFavorite={(v) => setFavorite(v)}
+                    />
+                    <OrganizedButton
+                      loading={organizedLoading}
+                      organized={studio.organized}
+                      onClick={onOrganizedClick}
+                    />
+                    <ExternalLinkButtons urls={studio.urls} />
+                  </span>
+                </DetailTitle>
+
+                <AliasList aliases={studio.aliases} />
+                <div className="quality-group">
+                  <RatingSystem
+                    value={studio.rating100}
+                    onSetRating={(value) => setRating(value)}
+                    clickToRate
+                    withoutContext
+                  />
+                  {!!studio.o_counter_all && (
+                    <OCounterButton value={studio.o_counter_all} />
+                  )}
+                </div>
+                {!isEditing && (
+                  <StudioDetailsPanel
+                    studio={studio}
+                    collapsed={collapsed}
+                    fullWidth={!collapsed && !compactExpandedDetails}
+                  />
+                )}
+                {isEditing ? (
+                  <StudioEditPanel
+                    studio={studio}
+                    onSubmit={onSave}
+                    onCancel={() => toggleEditing()}
+                    onDelete={onDelete}
+                    setImage={setImage}
+                    setEncodingImage={setEncodingImage}
+                  />
+                ) : (
+                  <DetailsEditNavbar
+                    objectName={
+                      studio.name ?? intl.formatMessage({ id: "studio" })
+                    }
+                    isNew={false}
+                    isEditing={isEditing}
+                    onToggleEdit={() => toggleEditing()}
+                    onSave={() => {}}
+                    onImageChange={() => {}}
+                    onClearImage={() => {}}
+                    onAutoTag={onAutoTag}
+                    autoTagDisabled={studio.ignore_auto_tag}
+                    onDelete={onDelete}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {!isEditing && loadStickyHeader && (
+          <CompressedStudioDetailsPanel studio={studio} />
+        )}
+
+        <div className="detail-body">
+          <div className="studio-body">
+            <div className="studio-tabs">
+              {!isEditing && (
+                <StudioTabs
                   studio={studio}
-                  onSubmit={onSave}
-                  onCancel={() => toggleEditing()}
-                  onDelete={onDelete}
-                  setImage={setImage}
-                  setEncodingImage={setEncodingImage}
-                />
-              ) : (
-                <DetailsEditNavbar
-                  objectName={
-                    studio.name ?? intl.formatMessage({ id: "studio" })
-                  }
-                  isNew={false}
-                  isEditing={isEditing}
-                  onToggleEdit={() => toggleEditing()}
-                  onSave={() => {}}
-                  onImageChange={() => {}}
-                  onClearImage={() => {}}
-                  onAutoTag={onAutoTag}
-                  autoTagDisabled={studio.ignore_auto_tag}
-                  onDelete={onDelete}
+                  tabKey={tabKey}
+                  abbreviateCounter={abbreviateCounter}
+                  showAllCounts={showAllCounts}
                 />
               )}
             </div>
           </div>
         </div>
+        {renderDeleteAlert()}
       </div>
-
-      {!isEditing && loadStickyHeader && (
-        <CompressedStudioDetailsPanel studio={studio} />
-      )}
-
-      <div className="detail-body">
-        <div className="studio-body">
-          <div className="studio-tabs">
-            {!isEditing && (
-              <StudioTabs
-                studio={studio}
-                tabKey={tabKey}
-                abbreviateCounter={abbreviateCounter}
-                showAllCounts={showAllCounts}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-      {renderDeleteAlert()}
-    </div>
-  );
-};
+    );
+  }
+);
 
 const StudioLoader: React.FC<RouteComponentProps<IStudioParams>> = ({
   location,

--- a/ui/v2.5/src/components/Studios/StudioListTable.tsx
+++ b/ui/v2.5/src/components/Studios/StudioListTable.tsx
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import * as GQL from "src/core/generated-graphql";
 import { useStudioUpdate } from "src/core/StashService";
 import { useTableColumns } from "src/hooks/useTableColumns";
+import { useConfigurationContext } from "src/hooks/Config";
 import { ListTable, IColumn } from "../List/ListTable";
 import { RatingSystem } from "../Shared/Rating/RatingSystem";
 import { Link } from "react-router-dom";
@@ -24,6 +25,8 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
 }) => {
   const intl = useIntl();
   const [updateStudio] = useStudioUpdate();
+  const { configuration } = useConfigurationContext();
+  const showChildContent = configuration?.ui?.showChildStudioContent ?? false;
 
   function setRating(v: number | null, studioId: string) {
     if (studioId) {
@@ -80,7 +83,9 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
 
   const SceneCountCell = (studio: GQL.StudioDataFragment) => (
     <Link to={NavUtils.makeStudioScenesUrl(studio)}>
-      <span>{studio.scene_count_all}</span>
+      <span>
+        {showChildContent ? studio.scene_count_all : studio.scene_count}
+      </span>
     </Link>
   );
 
@@ -98,12 +103,14 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
 
   const PerformerCountCell = (studio: GQL.StudioDataFragment) => (
     <Link to={NavUtils.makeStudioPerformersUrl(studio)}>
-      <span>{studio.performer_count_all}</span>
+      <span>
+        {showChildContent ? studio.performer_count_all : studio.performer_count}
+      </span>
     </Link>
   );
 
   const OCountCell = (studio: GQL.StudioDataFragment) => (
-    <span>{studio.o_counter_all}</span>
+    <span>{showChildContent ? studio.o_counter_all : studio.o_counter}</span>
   );
 
   const RelatedCell = (studio: GQL.StudioDataFragment) => {

--- a/ui/v2.5/src/components/Studios/StudioListTable.tsx
+++ b/ui/v2.5/src/components/Studios/StudioListTable.tsx
@@ -80,7 +80,7 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
 
   const SceneCountCell = (studio: GQL.StudioDataFragment) => (
     <Link to={NavUtils.makeStudioScenesUrl(studio)}>
-      <span>{studio.scene_count}</span>
+      <span>{studio.scene_count_all}</span>
     </Link>
   );
 
@@ -98,8 +98,12 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
 
   const PerformerCountCell = (studio: GQL.StudioDataFragment) => (
     <Link to={NavUtils.makeStudioPerformersUrl(studio)}>
-      <span>{studio.performer_count}</span>
+      <span>{studio.performer_count_all}</span>
     </Link>
+  );
+
+  const OCountCell = (studio: GQL.StudioDataFragment) => (
+    <span>{studio.o_counter_all}</span>
   );
 
   const RelatedCell = (studio: GQL.StudioDataFragment) => {
@@ -174,6 +178,12 @@ export const StudioListTable: React.FC<IStudioListTableProps> = ({
       label: intl.formatMessage({ id: "galleries" }),
       defaultShow: true,
       render: GalleryCountCell,
+    },
+    {
+      value: "o_counter",
+      label: intl.formatMessage({ id: "o_count" }),
+      defaultShow: true,
+      render: OCountCell,
     },
     {
       value: "performer_count",

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1310,6 +1310,7 @@
   "new": "New",
   "none": "None",
   "o_count": "O Count",
+  "o_count_all": "O Count (All)",
   "o_count_sfw": "Likes",
   "o_history": "O History",
   "o_history_sfw": "Like History",
@@ -1371,6 +1372,7 @@
   "performer": "Performer",
   "performer_age": "Performer Age",
   "performer_count": "Performer Count",
+  "performer_count_all": "Performer Count (All)",
   "performer_favorite": "Performer Favourited",
   "performer_image": "Performer Image",
   "performer_tagger": {

--- a/ui/v2.5/src/models/list-filter/studios.ts
+++ b/ui/v2.5/src/models/list-filter/studios.ts
@@ -40,14 +40,6 @@ const sortByOptions = [
       value: "scenes_count",
     },
     {
-      messageID: "o_count",
-      value: "o_counter",
-    },
-    {
-      messageID: "performer_count",
-      value: "performer_count",
-    },
-    {
       messageID: "subsidiary_studio_count",
       value: "child_count",
     },

--- a/ui/v2.5/src/models/list-filter/studios.ts
+++ b/ui/v2.5/src/models/list-filter/studios.ts
@@ -40,6 +40,22 @@ const sortByOptions = [
       value: "scenes_count",
     },
     {
+      messageID: "o_count",
+      value: "o_counter",
+    },
+    {
+      messageID: "o_count_all",
+      value: "o_counter_all",
+    },
+    {
+      messageID: "performer_count",
+      value: "performer_count",
+    },
+    {
+      messageID: "performer_count_all",
+      value: "performer_count_all",
+    },
+    {
       messageID: "subsidiary_studio_count",
       value: "child_count",
     },

--- a/ui/v2.5/src/models/list-filter/studios.ts
+++ b/ui/v2.5/src/models/list-filter/studios.ts
@@ -40,6 +40,14 @@ const sortByOptions = [
       value: "scenes_count",
     },
     {
+      messageID: "o_count",
+      value: "o_counter",
+    },
+    {
+      messageID: "performer_count",
+      value: "performer_count",
+    },
+    {
       messageID: "subsidiary_studio_count",
       value: "child_count",
     },


### PR DESCRIPTION
Related #6564
## Summary

- **Studio o_counter(depth)**: `o_counter` now accepts a `depth: Int` parameter. Passing `depth: -1` (or any non-zero value) recursively counts o-history across all sub-studios using a `WITH RECURSIVE` CTE. Displayed on cards, list view, and detail page as `o_counter_all`.
- **Recursive sort**: Studios can be sorted by `performer_count` and `o_counter`, both resolved via recursive CTE to include sub-studios.
- **List view**: Added `o_counter` column to the studio list table.
- **Display consistency**: StudioCard, StudioListTable, and Studio details use `_all` variants (`scene_count_all`, `performer_count_all`, `o_counter_all`) for recursive counts across sub-studios.,,

## UI Changes

- Sort options: Studio list filter now has sort by "O-Count" and "Performer Count" options.
- List table: New "O-Count" column showing recursive o-counter with sub-studios included.
- Cards: Parent studio cards now display scene_count_all (scenes + sub-studios), performer_count_all (performers + sub-studios), and o_counter_all instead of flat counts.
- Detail page: The o-counter badge in the parent studio detail card now shows the recursive total (all sub-studios included).

Tested and works.