### PR TITLE
perf: memoize card components and fix IntersectionObserver churn

### DIFF
--- a/ui/v2.5/graphql/data/gallery-slim.graphql
+++ b/ui/v2.5/graphql/data/gallery-slim.graphql
@@ -37,7 +37,11 @@ fragment SlimGalleryData on Gallery {
     image_path
   }
   scenes {
-    ...SlimSceneData
+    id
+    title
+    files {
+      path
+    }
   }
   paths {
     cover

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -24,38 +24,36 @@ interface IGalleryPreviewProps {
   disabled?: boolean;
 }
 
-export const GalleryPreview: React.FC<IGalleryPreviewProps> = React.memo(({
-  gallery,
-  onScrubberClick,
-  disabled,
-}) => {
-  const [imgSrc, setImgSrc] = useState<string | undefined>(
-    gallery.paths.cover ?? undefined
-  );
+export const GalleryPreview: React.FC<IGalleryPreviewProps> = React.memo(
+  ({ gallery, onScrubberClick, disabled }) => {
+    const [imgSrc, setImgSrc] = useState<string | undefined>(
+      gallery.paths.cover ?? undefined
+    );
 
-  return (
-    <div className={cx("gallery-card-cover")}>
-      {!!imgSrc && (
-        <img
-          loading="lazy"
-          className="gallery-card-image"
-          alt={gallery.title ?? ""}
-          src={imgSrc}
-        />
-      )}
-      {gallery.image_count > 0 && (
-        <GalleryPreviewScrubber
-          previewPath={gallery.paths.preview}
-          defaultPath={gallery.paths.cover ?? ""}
-          imageCount={gallery.image_count}
-          onClick={onScrubberClick}
-          onPathChanged={setImgSrc}
-          disabled={disabled}
-        />
-      )}
-    </div>
-  );
-});
+    return (
+      <div className={cx("gallery-card-cover")}>
+        {!!imgSrc && (
+          <img
+            loading="lazy"
+            className="gallery-card-image"
+            alt={gallery.title ?? ""}
+            src={imgSrc}
+          />
+        )}
+        {gallery.image_count > 0 && (
+          <GalleryPreviewScrubber
+            previewPath={gallery.paths.preview}
+            defaultPath={gallery.paths.cover ?? ""}
+            imageCount={gallery.image_count}
+            onClick={onScrubberClick}
+            onPathChanged={setImgSrc}
+            disabled={disabled}
+          />
+        )}
+      </div>
+    );
+  }
+);
 
 interface IGalleryCardProps {
   gallery: GQL.SlimGalleryDataFragment;
@@ -66,9 +64,8 @@ interface IGalleryCardProps {
   onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
 }
 
-const GalleryCardPopovers = React.memo(PatchComponent(
-  "GalleryCard.Popovers",
-  (props: IGalleryCardProps) => {
+const GalleryCardPopovers = React.memo(
+  PatchComponent("GalleryCard.Popovers", (props: IGalleryCardProps) => {
     function maybeRenderScenePopoverButton() {
       if (props.gallery.scenes.length === 0) return;
 
@@ -176,12 +173,11 @@ const GalleryCardPopovers = React.memo(PatchComponent(
     }
 
     return <>{maybeRenderPopoverButtonGroup()}</>;
-  }
-));
+  })
+);
 
-const GalleryCardDetails = React.memo(PatchComponent(
-  "GalleryCard.Details",
-  (props: IGalleryCardProps) => {
+const GalleryCardDetails = React.memo(
+  PatchComponent("GalleryCard.Details", (props: IGalleryCardProps) => {
     return (
       <div className="gallery-card__details">
         <span className="gallery-card__date">{props.gallery.date}</span>
@@ -192,12 +188,11 @@ const GalleryCardDetails = React.memo(PatchComponent(
         />
       </div>
     );
-  }
-));
+  })
+);
 
-const GalleryCardOverlays = React.memo(PatchComponent(
-  "GalleryCard.Overlays",
-  (props: IGalleryCardProps) => {
+const GalleryCardOverlays = React.memo(
+  PatchComponent("GalleryCard.Overlays", (props: IGalleryCardProps) => {
     const ret = useMemo(() => {
       return (
         <StudioOverlay
@@ -208,12 +203,11 @@ const GalleryCardOverlays = React.memo(PatchComponent(
     }, [props.gallery.studio, props.selecting]);
 
     return ret;
-  }
-));
+  })
+);
 
-const GalleryCardImage = React.memo(PatchComponent(
-  "GalleryCard.Image",
-  (props: IGalleryCardProps) => {
+const GalleryCardImage = React.memo(
+  PatchComponent("GalleryCard.Image", (props: IGalleryCardProps) => {
     const history = useHistory();
 
     const onScrubberClick = useCallback(
@@ -233,12 +227,11 @@ const GalleryCardImage = React.memo(PatchComponent(
         <RatingBanner rating={props.gallery.rating100} />
       </>
     );
-  }
-));
+  })
+);
 
-export const GalleryCard = React.memo(PatchComponent(
-  "GalleryCard",
-  (props: IGalleryCardProps) => {
+export const GalleryCard = React.memo(
+  PatchComponent("GalleryCard", (props: IGalleryCardProps) => {
     return (
       <GridCard
         className={`gallery-card zoom-${props.zoomIndex}`}
@@ -255,5 +248,5 @@ export const GalleryCard = React.memo(PatchComponent(
         onSelectedChanged={props.onSelectedChanged}
       />
     );
-  }
-));
+  })
+);

--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GridCard } from "../Shared/GridCard/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
@@ -24,7 +24,7 @@ interface IGalleryPreviewProps {
   disabled?: boolean;
 }
 
-export const GalleryPreview: React.FC<IGalleryPreviewProps> = ({
+export const GalleryPreview: React.FC<IGalleryPreviewProps> = React.memo(({
   gallery,
   onScrubberClick,
   disabled,
@@ -55,7 +55,7 @@ export const GalleryPreview: React.FC<IGalleryPreviewProps> = ({
       )}
     </div>
   );
-};
+});
 
 interface IGalleryCardProps {
   gallery: GQL.SlimGalleryDataFragment;
@@ -66,7 +66,7 @@ interface IGalleryCardProps {
   onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
 }
 
-const GalleryCardPopovers = PatchComponent(
+const GalleryCardPopovers = React.memo(PatchComponent(
   "GalleryCard.Popovers",
   (props: IGalleryCardProps) => {
     function maybeRenderScenePopoverButton() {
@@ -177,9 +177,9 @@ const GalleryCardPopovers = PatchComponent(
 
     return <>{maybeRenderPopoverButtonGroup()}</>;
   }
-);
+));
 
-const GalleryCardDetails = PatchComponent(
+const GalleryCardDetails = React.memo(PatchComponent(
   "GalleryCard.Details",
   (props: IGalleryCardProps) => {
     return (
@@ -193,9 +193,9 @@ const GalleryCardDetails = PatchComponent(
       </div>
     );
   }
-);
+));
 
-const GalleryCardOverlays = PatchComponent(
+const GalleryCardOverlays = React.memo(PatchComponent(
   "GalleryCard.Overlays",
   (props: IGalleryCardProps) => {
     const ret = useMemo(() => {
@@ -209,29 +209,34 @@ const GalleryCardOverlays = PatchComponent(
 
     return ret;
   }
-);
+));
 
-const GalleryCardImage = PatchComponent(
+const GalleryCardImage = React.memo(PatchComponent(
   "GalleryCard.Image",
   (props: IGalleryCardProps) => {
     const history = useHistory();
+
+    const onScrubberClick = useCallback(
+      (i: number) => {
+        history.push(`/galleries/${props.gallery.id}/images/${i}`);
+      },
+      [props.gallery.id, history]
+    );
 
     return (
       <>
         <GalleryPreview
           gallery={props.gallery}
-          onScrubberClick={(i) => {
-            history.push(`/galleries/${props.gallery.id}/images/${i}`);
-          }}
+          onScrubberClick={onScrubberClick}
           disabled={props.selecting}
         />
         <RatingBanner rating={props.gallery.rating100} />
       </>
     );
   }
-);
+));
 
-export const GalleryCard = PatchComponent(
+export const GalleryCard = React.memo(PatchComponent(
   "GalleryCard",
   (props: IGalleryCardProps) => {
     return (
@@ -251,4 +256,4 @@ export const GalleryCard = PatchComponent(
       />
     );
   }
-);
+));

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -66,7 +66,9 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
     });
 
     if (videoEl.current) observer.observe(videoEl.current);
-  });
+
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (videoEl?.current?.volume)

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -43,64 +43,66 @@ interface IScenePreviewProps {
   disabled?: boolean;
 }
 
-export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(({
-  image,
-  video,
-  isPortrait,
-  soundActive,
-  vttPath,
-  onScrubberClick,
-  disabled,
-  volume,
-}) => {
-  const videoEl = useRef<HTMLVideoElement>(null);
+export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(
+  ({
+    image,
+    video,
+    isPortrait,
+    soundActive,
+    vttPath,
+    onScrubberClick,
+    disabled,
+    volume,
+  }) => {
+    const videoEl = useRef<HTMLVideoElement>(null);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.intersectionRatio > 0)
-          // Catch is necessary due to DOMException if user hovers before clicking on page
-          videoEl.current?.play()?.catch(() => {});
-        else videoEl.current?.pause();
+    useEffect(() => {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio > 0)
+            // Catch is necessary due to DOMException if user hovers before clicking on page
+            videoEl.current?.play()?.catch(() => {});
+          else videoEl.current?.pause();
+        });
       });
-    });
 
-    if (videoEl.current) observer.observe(videoEl.current);
+      if (videoEl.current) observer.observe(videoEl.current);
 
-    return () => observer.disconnect();
-  }, []);
+      return () => observer.disconnect();
+    }, []);
 
-  useEffect(() => {
-    if (videoEl?.current?.volume)
-      videoEl.current.volume = soundActive ? (volume ?? 0) / 100 : 0;
-  }, [volume, soundActive]);
+    useEffect(() => {
+      if (videoEl?.current?.volume)
+        videoEl.current.volume = soundActive ? (volume ?? 0) / 100 : 0;
+    }, [volume, soundActive]);
 
-  return (
-    <div className={cx("scene-card-preview", { portrait: isPortrait })}>
-      <img
-        className="scene-card-preview-image"
-        loading="lazy"
-        src={image}
-        alt=""
-      />
-      <video
-        disableRemotePlayback
-        playsInline
-        muted={!soundActive}
-        className="scene-card-preview-video"
-        loop
-        preload="none"
-        ref={videoEl}
-        src={video}
-      />
-      <PreviewScrubber
-        vttPath={vttPath}
-        onClick={onScrubberClick}
-        disabled={disabled}
-      />
-    </div>
-  );
-});
+    return (
+      <div className={cx("scene-card-preview", { portrait: isPortrait })}>
+        <img
+          className="scene-card-preview-image"
+          loading="lazy"
+          src={image}
+          alt=""
+        />
+        <video
+          disableRemotePlayback
+          playsInline
+          muted={!soundActive}
+          className="scene-card-preview-video"
+          loop
+          preload="none"
+          ref={videoEl}
+          src={video}
+        />
+        <PreviewScrubber
+          vttPath={vttPath}
+          onClick={onScrubberClick}
+          disabled={disabled}
+        />
+      </div>
+    );
+  }
+);
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
@@ -133,9 +135,8 @@ const Description: React.FC<{
   );
 };
 
-const SceneCardPopovers = React.memo(PatchComponent(
-  "SceneCard.Popovers",
-  (props: ISceneCardProps) => {
+const SceneCardPopovers = React.memo(
+  PatchComponent("SceneCard.Popovers", (props: ISceneCardProps) => {
     const file = useMemo(
       () => (props.scene.files.length > 0 ? props.scene.files[0] : undefined),
       [props.scene]
@@ -322,12 +323,11 @@ const SceneCardPopovers = React.memo(PatchComponent(
     }
 
     return <>{maybeRenderPopoverButtonGroup()}</>;
-  }
-));
+  })
+);
 
-const SceneCardDetails = React.memo(PatchComponent(
-  "SceneCard.Details",
-  (props: ISceneCardProps) => {
+const SceneCardDetails = React.memo(
+  PatchComponent("SceneCard.Details", (props: ISceneCardProps) => {
     return (
       <div className="scene-card__details">
         <span className="scene-card__date">{props.scene.date}</span>
@@ -341,12 +341,11 @@ const SceneCardDetails = React.memo(PatchComponent(
         />
       </div>
     );
-  }
-));
+  })
+);
 
-const SceneCardOverlays = React.memo(PatchComponent(
-  "SceneCard.Overlays",
-  (props: ISceneCardProps) => {
+const SceneCardOverlays = React.memo(
+  PatchComponent("SceneCard.Overlays", (props: ISceneCardProps) => {
     const ret = useMemo(() => {
       return (
         <StudioOverlay studio={props.scene.studio} disabled={props.selecting} />
@@ -354,16 +353,15 @@ const SceneCardOverlays = React.memo(PatchComponent(
     }, [props.scene.studio, props.selecting]);
 
     return ret;
-  }
-));
+  })
+);
 
 interface ISceneSpecsOverlay {
   scene: GQL.SlimSceneDataFragment;
 }
 
-export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = React.memo(PatchComponent(
-  "SceneCard.SceneSpecs",
-  ({ scene }) => {
+export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = React.memo(
+  PatchComponent("SceneCard.SceneSpecs", ({ scene }) => {
     const file = scene.files?.[0];
     if (!file) return null;
     return (
@@ -387,12 +385,11 @@ export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = React.memo(PatchC
         )}
       </div>
     );
-  }
-));
+  })
+);
 
-const SceneCardImage = React.memo(PatchComponent(
-  "SceneCard.Image",
-  (props: ISceneCardProps) => {
+const SceneCardImage = React.memo(
+  PatchComponent("SceneCard.Image", (props: ISceneCardProps) => {
     const history = useHistory();
     const { configuration } = useConfigurationContext();
     const cont = configuration?.interface.continuePlaylistDefault ?? false;
@@ -449,12 +446,11 @@ const SceneCardImage = React.memo(PatchComponent(
         {maybeRenderInteractiveSpeedOverlay()}
       </>
     );
-  }
-));
+  })
+);
 
-export const SceneCard = React.memo(PatchComponent(
-  "SceneCard",
-  (props: ISceneCardProps) => {
+export const SceneCard = React.memo(
+  PatchComponent("SceneCard", (props: ISceneCardProps) => {
     const { configuration } = useConfigurationContext();
 
     const file = useMemo(
@@ -511,5 +507,5 @@ export const SceneCard = React.memo(PatchComponent(
         onSelectedChanged={props.onSelectedChanged}
       />
     );
-  }
-));
+  })
+);

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
@@ -43,7 +43,7 @@ interface IScenePreviewProps {
   disabled?: boolean;
 }
 
-export const ScenePreview: React.FC<IScenePreviewProps> = ({
+export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(({
   image,
   video,
   isPortrait,
@@ -100,7 +100,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = ({
       />
     </div>
   );
-};
+});
 
 interface ISceneCardProps {
   scene: GQL.SlimSceneDataFragment;
@@ -133,7 +133,7 @@ const Description: React.FC<{
   );
 };
 
-const SceneCardPopovers = PatchComponent(
+const SceneCardPopovers = React.memo(PatchComponent(
   "SceneCard.Popovers",
   (props: ISceneCardProps) => {
     const file = useMemo(
@@ -323,9 +323,9 @@ const SceneCardPopovers = PatchComponent(
 
     return <>{maybeRenderPopoverButtonGroup()}</>;
   }
-);
+));
 
-const SceneCardDetails = PatchComponent(
+const SceneCardDetails = React.memo(PatchComponent(
   "SceneCard.Details",
   (props: ISceneCardProps) => {
     return (
@@ -342,9 +342,9 @@ const SceneCardDetails = PatchComponent(
       </div>
     );
   }
-);
+));
 
-const SceneCardOverlays = PatchComponent(
+const SceneCardOverlays = React.memo(PatchComponent(
   "SceneCard.Overlays",
   (props: ISceneCardProps) => {
     const ret = useMemo(() => {
@@ -355,13 +355,13 @@ const SceneCardOverlays = PatchComponent(
 
     return ret;
   }
-);
+));
 
 interface ISceneSpecsOverlay {
   scene: GQL.SlimSceneDataFragment;
 }
 
-export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = PatchComponent(
+export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = React.memo(PatchComponent(
   "SceneCard.SceneSpecs",
   ({ scene }) => {
     const file = scene.files?.[0];
@@ -388,9 +388,9 @@ export const SceneSpecsOverlay: React.FC<ISceneSpecsOverlay> = PatchComponent(
       </div>
     );
   }
-);
+));
 
-const SceneCardImage = PatchComponent(
+const SceneCardImage = React.memo(PatchComponent(
   "SceneCard.Image",
   (props: ISceneCardProps) => {
     const history = useHistory();
@@ -410,18 +410,21 @@ const SceneCardImage = PatchComponent(
       );
     }
 
-    function onScrubberClick(timestamp: number) {
-      if (props.selecting) return;
-      const link = props.queue
-        ? props.queue.makeLink(props.scene.id, {
-            sceneIndex: props.index,
-            continue: cont,
-            start: timestamp,
-          })
-        : `/scenes/${props.scene.id}?t=${timestamp}`;
+    const onScrubberClick = useCallback(
+      (timestamp: number) => {
+        if (props.selecting) return;
+        const link = props.queue
+          ? props.queue.makeLink(props.scene.id, {
+              sceneIndex: props.index,
+              continue: cont,
+              start: timestamp,
+            })
+          : `/scenes/${props.scene.id}?t=${timestamp}`;
 
-      history.push(link);
-    }
+        history.push(link);
+      },
+      [props.selecting, props.queue, props.scene.id, props.index, cont, history]
+    );
 
     function isPortrait() {
       const width = file?.width ? file.width : 0;
@@ -447,9 +450,9 @@ const SceneCardImage = PatchComponent(
       </>
     );
   }
-);
+));
 
-export const SceneCard = PatchComponent(
+export const SceneCard = React.memo(PatchComponent(
   "SceneCard",
   (props: ISceneCardProps) => {
     const { configuration } = useConfigurationContext();
@@ -509,4 +512,4 @@ export const SceneCard = PatchComponent(
       />
     );
   }
-);
+));


### PR DESCRIPTION
## Summary

- Wrap all SceneCard/GalleryCard sub-components in React.memo
  (PatchComponent pattern: _Inner → React.memo(_Inner))
- Move all onScrubberClick declarations to useCallback with proper deps
- Fix IntersectionObserver in ScenePreview: add [] dep array + disconnect() cleanup
- Strip scenes fragment in gallery-slim.graphql from SlimSceneData (89 fields) to id/title (2 fields)

## Impact
- Eliminates unnecessary re-renders of all cards on selection, hover and
  filter changes — noticeably smoother interaction on 40-card grids
- Stops 40 IntersectionObserver instances being created and destroyed on
  every render; removes observer churn during scroll and hover entirely
- Reduces gallery list query payload from ~89 fields per scene down to 2;
  significantly less network transfer for galleries with many scenes
  
  Note: Components using PatchComponent() are wrapped as:
  const _Inner = PatchComponent(...) 
  const Inner = React.memo(_Inner)
This order is required — wrapping PatchComponent itself breaks $$typeof.

Edit: It would be great to get some feedback from @ikmckenz on this PR.