### PR TITLE
Run Docker image as configurable non-root user

### DIFF
--- a/docker/ci/x86_64/Dockerfile
+++ b/docker/ci/x86_64/Dockerfile
@@ -13,7 +13,33 @@ FROM --platform=$TARGETPLATFORM alpine:latest AS app
 COPY --from=binary /stash /usr/bin/
 
 RUN apk add --no-cache ca-certificates python3 py3-requests py3-requests-toolbelt py3-lxml py3-pip ffmpeg tzdata vips vips-tools vips-heif \
-    && pip install --break-system-packages mechanicalsoup cloudscraper stashapp-tools
+    su-exec \
+    && pip install --break-system-packages mechanicalsoup cloudscraper stashapp-tools \
+    && mkdir -p /root/.stash /data /metadata /cache /blobs /generated \
+    && { \
+      echo '#!/bin/sh'; \
+      echo 'set -eu'; \
+      echo ': "${PUID:=1000}"'; \
+      echo ': "${PGID:=1000}"'; \
+      echo 'if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ]; then'; \
+      echo '  HOME=/root'; \
+      echo 'fi'; \
+      echo 'export HOME'; \
+      echo 'if [ "$(id -u)" = "0" ]; then'; \
+      echo '  for dir in "$HOME" /data /metadata /cache /blobs /generated; do'; \
+      echo '    if [ -e "$dir" ]; then'; \
+      echo '      chown -R "$PUID:$PGID" "$dir" 2>/dev/null || true'; \
+      echo '    fi'; \
+      echo '  done'; \
+      echo '  exec su-exec "$PUID:$PGID" env HOME="$HOME" "$@"'; \
+      echo 'fi'; \
+      echo 'exec "$@"'; \
+    } > /usr/local/bin/docker-entrypoint.sh \
+    && chmod 755 /usr/local/bin/docker-entrypoint.sh
+
+ENV HOME=/root
+ENV PUID=1000
+ENV PGID=1000
 ENV STASH_CONFIG_FILE=/root/.stash/config.yml
 
 # Basic build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
@@ -25,4 +51,5 @@ LABEL org.opencontainers.image.title="Stash" \
     org.opencontainers.image.licenses="AGPL-3.0"
 
 EXPOSE 9999
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["stash"]

--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -33,6 +33,10 @@ Docker is effectively a cross-platform software package repository. It allows yo
 
 The StashApp docker container ships with everything you need to automatically run stash, including ffmpeg.
 
+The container runs Stash as a non-root user by default. Set the `PUID` and `PGID`
+environment variables in `docker-compose.yml` if files created by Stash should
+match a specific host user and group.
+
 ### docker compose
 Docker Compose lets you specify how and where to run your containers, and to manage their environment. The docker-compose.yml file in this folder gets you a fully working instance of StashApp exactly as you would need it to have a reasonable instance for testing / developing on. If you are deploying a live instance for production, a [reverse proxy](https://docs.stashapp.cc/guides/reverse-proxy/) (such as NGINX or Traefik) is recommended, but not required.
 

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         max-file: "10"
         max-size: "2m"
     environment:
+      - PUID=1000
+      - PGID=1000
       - STASH_STASH=/data/
       - STASH_GENERATED=/generated/
       - STASH_METADATA=/metadata/


### PR DESCRIPTION
## Summary
- add a production Docker entrypoint that chowns mounted app directories and drops to the configured PUID/PGID before running stash
- keep the existing /root/.stash config path for compatibility while making HOME writable for scraper/plugin cache use
- document PUID/PGID in the production Docker README and compose example

Fixes #684

## Verification
- Built the production Dockerfile with a dummy linux/amd64 stash binary from a dist-style context:
  `docker build --platform linux/amd64 -f docker/ci/x86_64/Dockerfile /private/tmp/stash-docker-test -t stash-nonroot-test`
- Ran default UID/GID check:
  `docker run --rm stash-nonroot-test` -> `uid=1000 gid=1000 home=/root config=/root/.stash/config.yml writable=yes`
- Ran custom UID/GID check:
  `docker run --rm -e PUID=1234 -e PGID=1235 stash-nonroot-test` -> `uid=1234 gid=1235 home=/root config=/root/.stash/config.yml writable=yes`