### PR TITLE
docker: run production image as non-root with configurable PUID/PGID

### DIFF
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -37,8 +37,11 @@ RUN make flags-release flags-pie stash
 
 # Final Runnable Image
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates vips-tools ffmpeg
+RUN apk add --no-cache ca-certificates vips-tools ffmpeg su-exec
 COPY --from=backend /stash/stash /usr/bin/
-ENV STASH_CONFIG_FILE=/root/.stash/config.yml
+COPY ./docker/build/x86_64/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENV STASH_CONFIG_FILE=/config/config.yml
 EXPOSE 9999
-ENTRYPOINT ["stash"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["stash"]

--- a/docker/build/x86_64/docker-entrypoint.sh
+++ b/docker/build/x86_64/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+# If the container is started as a non-root user, honor that directly.
+if [ "$(id -u)" -ne 0 ]; then
+  exec "$@"
+fi
+
+: "${PUID:=1000}"
+: "${PGID:=1000}"
+: "${UMASK:=002}"
+: "${STASH_USER:=stash}"
+: "${STASH_GROUP:=stash}"
+: "${STASH_CONFIG_FILE:=/config/config.yml}"
+
+export HOME=/config
+export STASH_CONFIG_FILE
+
+umask "${UMASK}" 2>/dev/null || true
+
+mkdir -p /config /cache /metadata /generated /blobs
+
+existing_group="$(awk -F: -v gid="${PGID}" '$3 == gid { print $1; exit }' /etc/group)"
+if [ -n "${existing_group}" ]; then
+  STASH_GROUP="${existing_group}"
+elif ! grep -q "^${STASH_GROUP}:" /etc/group; then
+  addgroup -g "${PGID}" -S "${STASH_GROUP}"
+fi
+
+existing_user="$(awk -F: -v uid="${PUID}" '$3 == uid { print $1; exit }' /etc/passwd)"
+if [ -n "${existing_user}" ]; then
+  STASH_USER="${existing_user}"
+elif ! id -u "${STASH_USER}" >/dev/null 2>&1; then
+  adduser -u "${PUID}" -S -D -h /config -G "${STASH_GROUP}" "${STASH_USER}"
+fi
+
+addgroup "${STASH_USER}" "${STASH_GROUP}" >/dev/null 2>&1 || true
+
+chown -R "${PUID}:${PGID}" /config /cache /metadata /generated /blobs
+
+exec su-exec "${PUID}:${PGID}" "$@"

--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -24,6 +24,8 @@ Once you have that file where you want it, modify the settings as you please, an
 docker compose up -d
 ```
 
+By default, the production image now starts `stash` as a non-root user using `PUID` and `PGID` from `docker-compose.yml` (both default to `1000`). Adjust these values to match the UID/GID that should own created files on your host.
+
 Installing StashApp this way will by default bind stash to port 9999. This is available in your web browser locally at http://localhost:9999 or on your network as http://YOUR-LOCAL-IP:9999
 
 Good luck and have fun!

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         max-file: "10"
         max-size: "2m"
     environment:
+      - PUID=1000
+      - PGID=1000
       - STASH_STASH=/data/
       - STASH_GENERATED=/generated/
       - STASH_METADATA=/metadata/
@@ -25,11 +27,11 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       ## Adjust below paths (the left part) to your liking.
-      ## E.g. you can change ./config:/root/.stash to ./stash:/root/.stash
+      ## E.g. you can change ./config:/config to ./stash:/config
       ## The left part is the path on your host, the right part is the path in the stash container.
 
       ## Keep configs, scrapers, and plugins here.
-      - ./config:/root/.stash
+      - ./config:/config
       ## Point this at your collection.
       ## The left side is where your collection is on your host, the right side is where it will be in stash.
       - ./data:/data


### PR DESCRIPTION
## Summary
- run the production container with a non-root user by default
- add `PUID`/`PGID` support in the image entrypoint so host file ownership is controllable
- move the default config location from `/root/.stash` to `/config` for non-root compatibility
- update production compose + docs to reflect the new defaults

Fixes #684.

## Validation
- `sh -n docker/build/x86_64/docker-entrypoint.sh`
- `docker compose -f docker/production/docker-compose.yml config`

## Notes
- explicit runtime `--user` overrides remain supported (entrypoint bypasses user creation when already non-root)
