### PR TITLE
Add scene upload from web UI (#13)

### DIFF
--- a/internal/api/handler_scene_upload.go
+++ b/internal/api/handler_scene_upload.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/stashapp/stash/internal/manager"
+	"github.com/stashapp/stash/pkg/fsutil"
+	"github.com/stashapp/stash/pkg/logger"
+)
+
+func (rs sceneRoutes) Upload(w http.ResponseWriter, r *http.Request) {
+	// Limit upload size to 10GB
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<30)
+
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		logger.Errorf("error parsing upload form: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		logger.Errorf("error getting uploaded file: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	mgr := manager.GetInstance()
+	cfg := mgr.Config
+
+	// Determine destination path
+	var destPath string
+	stashPaths := cfg.GetStashPaths()
+	if len(stashPaths) > 0 {
+		destPath = filepath.Join(stashPaths[0].Path, filepath.Base(header.Filename))
+	} else if genPath := cfg.GetGeneratedPath(); genPath != "" {
+		destPath = filepath.Join(genPath, filepath.Base(header.Filename))
+	} else {
+		http.Error(w, "no stash paths or generated path configured", http.StatusBadRequest)
+		return
+	}
+
+	destPath = resolveUniquePath(destPath)
+
+	// Write the file to disk
+	dst, err := os.Create(destPath)
+	if err != nil {
+		logger.Errorf("error creating file %s: %v", destPath, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	written, err := io.Copy(dst, file)
+	if err != nil {
+		dst.Close()
+		logger.Errorf("error writing file %s: %v", destPath, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	dst.Close()
+
+	logger.Infof("uploaded file %s (%d bytes)", destPath, written)
+
+	// Trigger scan for the uploaded file
+	input := manager.ScanMetadataInput{
+		Paths: []string{destPath},
+	}
+
+	jobID, err := mgr.Scan(r.Context(), input)
+	if err != nil {
+		logger.Errorf("error starting scan for %s: %v", destPath, err)
+		// File was saved; return success with scan=failed so frontend can handle
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"path":    destPath,
+			"size":    written,
+			"scan":    "failed",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": true,
+		"job_id":  jobID,
+		"path":    destPath,
+		"size":    written,
+	})
+}
+
+// resolveUniquePath returns the next available filename by appending
+// a numeric suffix if the file already exists.
+func resolveUniquePath(path string) string {
+	if exists, _ := fsutil.FileExists(path); !exists {
+		return path
+	}
+
+	ext := filepath.Ext(path)
+	base := path[:len(path)-len(ext)]
+
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s_%d%s", base, i, ext)
+		if exists, _ := fsutil.FileExists(candidate); !exists {
+			return candidate
+		}
+	}
+}

--- a/internal/api/handler_scene_upload.go
+++ b/internal/api/handler_scene_upload.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (rs sceneRoutes) Upload(w http.ResponseWriter, r *http.Request) {
-	// Limit upload size to 10GB
+	// Limit upload size based on configuration
 	mgr := manager.GetInstance()
 	// Use configured max upload size, default to 10GB
 	maxUploadSize := mgr.Config.GetMaxUploadSize()

--- a/internal/api/handler_scene_upload.go
+++ b/internal/api/handler_scene_upload.go
@@ -15,7 +15,13 @@ import (
 
 func (rs sceneRoutes) Upload(w http.ResponseWriter, r *http.Request) {
 	// Limit upload size to 10GB
-	r.Body = http.MaxBytesReader(w, r.Body, 10<<30)
+	mgr := manager.GetInstance()
+	// Use configured max upload size, default to 10GB
+	maxUploadSize := mgr.Config.GetMaxUploadSize()
+	if maxUploadSize <= 0 {
+		maxUploadSize = 10 << 30
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		logger.Errorf("error parsing upload form: %v", err)
@@ -31,7 +37,6 @@ func (rs sceneRoutes) Upload(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	mgr := manager.GetInstance()
 	cfg := mgr.Config
 
 	// Determine destination path

--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -55,6 +55,9 @@ type sceneRoutes struct {
 func (rs sceneRoutes) Routes() chi.Router {
 	r := chi.NewRouter()
 
+	// File upload endpoint - must be before /{sceneId} to avoid routing conflicts
+	r.Post("/upload", rs.Upload)
+
 	r.Route("/{sceneId}", func(r chi.Router) {
 		r.Use(rs.SceneCtx)
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneCreate.tsx
@@ -7,6 +7,9 @@ import { mutateCreateScene, useFindScene } from "src/core/StashService";
 import ImageUtils from "src/utils/image";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { useToast } from "src/hooks/Toast";
+import { Button } from "react-bootstrap";
+import { Icon } from "src/components/Shared/Icon";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
 
 const SceneCreate: React.FC = () => {
   const history = useHistory();
@@ -20,6 +23,8 @@ const SceneCreate: React.FC = () => {
   const { data, loading } = useFindScene(query.get("from_scene_id") ?? "new");
   const [loadingCoverImage, setLoadingCoverImage] = useState(false);
   const [coverImage, setCoverImage] = useState<string>();
+  const [uploading, setUploading] = useState(false);
+  const [uploadedFile, setUploadedFile] = useState<{ path: string } | null>(null);
 
   const scene = useMemo(() => {
     if (data?.findScene) {
@@ -57,6 +62,41 @@ const SceneCreate: React.FC = () => {
     return <LoadingIndicator />;
   }
 
+  async function onFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    setUploading(true);
+    const formData = new FormData();
+    formData.append("file", files[0]);
+
+    try {
+      const resp = await fetch("/scene/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const result = await resp.json();
+
+      if (result.success) {
+        setUploadedFile(result);
+        Toast.success(
+          intl.formatMessage(
+            { id: "toast.upload_complete" },
+            { filename: files[0].name }
+          )
+        );
+        // Navigate to scenes list to see the scan result
+        history.push("/scenes");
+      } else {
+        Toast.error(intl.formatMessage({ id: "toast.upload_failed" }));
+      }
+    } catch (err) {
+      Toast.error(intl.formatMessage({ id: "toast.upload_failed" }));
+    } finally {
+      setUploading(false);
+    }
+  }
+
   async function onSave(input: GQL.SceneCreateInput, andNew?: boolean) {
     const fileID = query.get("file_id") ?? undefined;
     const result = await mutateCreateScene({
@@ -85,6 +125,46 @@ const SceneCreate: React.FC = () => {
             values={{ entityType: intl.formatMessage({ id: "scene" }) }}
           />
         </h2>
+
+        {!uploadedFile && (
+          <div className="upload-area mb-4 p-4 text-center border rounded">
+            <h5>
+              <Icon icon={faUpload} className="mr-2" />
+              <FormattedMessage id="actions.upload_file" />
+            </h5>
+            <p className="text-muted">
+              <FormattedMessage id="upload_scene.description" />
+            </p>
+            <Button
+              variant="primary"
+              disabled={uploading}
+              onClick={() => document.getElementById("scene-file-input")?.click()}
+            >
+              {uploading ? (
+                <LoadingIndicator inline small />
+              ) : (
+                <FormattedMessage id="actions.choose_file" />
+              )}
+            </Button>
+            <input
+              id="scene-file-input"
+              type="file"
+              accept="video/*"
+              className="d-none"
+              onChange={onFileUpload}
+            />
+          </div>
+        )}
+
+        {uploadedFile && (
+          <div className="alert alert-success">
+            <FormattedMessage
+              id="upload_scene.success"
+              values={{ path: uploadedFile.path }}
+            />
+          </div>
+        )}
+
         <SceneEditPanel
           scene={scene}
           initialCoverImage={coverImage}

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -159,7 +159,9 @@
     "unset": "Unset",
     "use_default": "Use default",
     "view_history": "View history",
-    "view_random": "View Random"
+    "view_random": "View Random",
+    "upload_file": "Upload a file",
+    "choose_file": "Choose file"
   },
   "actions_name": "Actions",
   "age": "Age",
@@ -1691,7 +1693,9 @@
     "started_auto_tagging": "Started auto tagging",
     "started_generating": "Started generating",
     "started_importing": "Started importing",
-    "updated_entity": "Updated {entity}"
+    "updated_entity": "Updated {entity}",
+    "upload_complete": "Uploaded {filename}",
+    "upload_failed": "File upload failed"
   },
   "total": "Total",
   "true": "True",
@@ -1715,5 +1719,9 @@
   "weight": "Weight",
   "weight_kg": "Weight (kg)",
   "years_old": "years old",
-  "zip_file_count": "Zip File Count"
+  "zip_file_count": "Zip File Count",
+  "upload_scene": {
+    "description": "Upload a video file to add it to your library. The file will be saved to your stash library path and scanned automatically.",
+    "success": "File uploaded to {path}. The scan has started in the background."
+  }
 }

--- a/ui/v2.5/src/locales/en-US.json
+++ b/ui/v2.5/src/locales/en-US.json
@@ -1,31 +1,41 @@
 {
-    "actions": {
-        "anonymise": "Anonymize",
-        "download_anonymised": "Download anonymized",
-        "customise": "Customize",
-        "optimise_database": "Optimize Database"
+  "actions": {
+    "anonymise": "Anonymize",
+    "download_anonymised": "Download anonymized",
+    "customise": "Customize",
+    "optimise_database": "Optimize Database",
+    "upload_file": "Upload a file",
+    "choose_file": "Choose file"
+  },
+  "config": {
+    "tools": {
+      "scene_filename_parser": {
+        "ignore_organized": "Ignore organized scenes"
+      }
     },
-    "config": {
-        "tools": {
-            "scene_filename_parser": {
-                "ignore_organized": "Ignore organized scenes"
-            }
-        },
-        "ui": {
-            "custom_locales": {
-                "heading": "Custom localization",
-                "option_label": "Custom localization enabled"
-            }
-        }
-    },
-    "eye_color": "Eye Color",
-    "favourite": "Favorite",
-    "hair_color": "Hair Color",
-    "organized": "Organized",
-    "performer_favorite": "Performer Favorited",
-    "component_tagger": {
-        "config": {
-            "mark_organized_label": "Mark as Organized on save"
-        }
+    "ui": {
+      "custom_locales": {
+        "heading": "Custom localization",
+        "option_label": "Custom localization enabled"
+      }
     }
+  },
+  "eye_color": "Eye Color",
+  "favourite": "Favorite",
+  "hair_color": "Hair Color",
+  "organized": "Organized",
+  "performer_favorite": "Performer Favorited",
+  "component_tagger": {
+    "config": {
+      "mark_organized_label": "Mark as Organized on save"
+    }
+  },
+  "toast": {
+    "upload_complete": "Uploaded {filename}",
+    "upload_failed": "File upload failed"
+  },
+  "upload_scene": {
+    "description": "Upload a video file to add it to your library.",
+    "success": "File uploaded to {path}."
+  }
 }


### PR DESCRIPTION
## Description
Adds the ability to upload a scene video file directly from the web UI (fixes #13).

### Changes

**Backend:**
- New  endpoint that accepts multipart file uploads
- Uploaded files are saved to the first configured stash library path (or generated path as fallback)
- Automatically triggers a scan job for the uploaded file
- Respects the configured  setting

**Frontend:**
- Updated  page to show a file upload area when creating a new scene
- File picker with accept="video/*" filter
- Loading state during upload
- Auto-redirects to scenes list after successful upload
- Success/error toast notifications

### How to test
1. Go to **Scenes → New Scene** (or navigate to )
2. Click "Choose file" and select a video file
3. Wait for the upload to complete and scan to start
4. The new scene will appear in your scenes list after the scan finishes

### Notes
- This is a minimal implementation that follows the existing patterns in the codebase
- File conflicts are handled by appending a numeric suffix (e.g. )
- The scan runs in the background via the existing scan job infrastructure
- If the scan fails to start (e.g. ffmpeg not configured), the file is still saved
