### PR TITLE
Create gclib-based docker images for python compatiblity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,10 @@ endif
 .PHONY: ui
 ui: pre-ui generate ui-only generate-login-locale
 
+.PHONY: ui-build
+ui-build: ui-env pre-ui generate-ui
+	cd ui/v2.5 && npm run build
+
 .PHONY: ui-only
 ui-only: ui-env generate ui
 	cd ui/v2.5 && npm run build
@@ -423,6 +427,11 @@ validate: validate-ui validate-backend
 .PHONY: docker-build
 docker-build: build-info
 	docker build --build-arg GITHASH=$(GITHASH) --build-arg STASH_VERSION=$(STASH_VERSION) -t stash/build -f docker/build/x86_64/Dockerfile .
+
+# locally builds and tags a 'stash/build-debian' docker image (debian-based, improved non-free repo setup)
+.PHONY: docker-build-debian
+docker-build-debian: build-info
+	docker build --build-arg GITHASH=$(GITHASH) --build-arg STASH_VERSION=$(STASH_VERSION) -t stash/build-debian -f docker/build/x86_64/Dockerfile-debian .
 
 # locally builds and tags a 'stash/cuda-build' docker image
 .PHONY: docker-cuda-build

--- a/docker/build/x86_64/Dockerfile-debian
+++ b/docker/build/x86_64/Dockerfile-debian
@@ -1,0 +1,57 @@
+# This dockerfile should be built with `make docker-build-debian` from the stash root.
+# Debian-based variant with improved non-free repo setup for Intel GPU drivers.
+
+# Build Frontend
+FROM node:24-alpine AS frontend
+RUN apk add --no-cache make git
+## cache node_modules separately
+COPY ./ui/v2.5/package.json ./ui/v2.5/pnpm-lock.yaml /stash/ui/v2.5/
+WORKDIR /stash
+COPY Makefile /stash/
+COPY ./graphql /stash/graphql/
+COPY ./ui /stash/ui/
+# pnpm install with npm
+RUN npm install -g pnpm
+RUN make pre-ui
+RUN make generate-ui
+ARG GITHASH
+ARG STASH_VERSION
+RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui-build
+
+# Build Backend
+FROM golang:1.25.9-bookworm AS backend
+RUN apt-get update && apt-get install -y --no-install-recommends make git build-essential && rm -rf /var/lib/apt/lists/*
+WORKDIR /stash
+COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/
+COPY ./graphql /stash/graphql/
+COPY ./scripts /stash/scripts/
+COPY ./pkg /stash/pkg/
+COPY ./cmd /stash/cmd/
+COPY ./internal /stash/internal/
+# needed for generate-login-locale
+COPY ./ui /stash/ui/
+RUN make generate-backend generate-login-locale
+COPY --from=frontend /stash /stash/
+ARG GITHASH
+ARG STASH_VERSION
+RUN make flags-release flags-pie stash
+
+# Final Runnable Image
+FROM python:3.12-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    ffmpeg \
+    git \
+    libvips-tools \
+    mesa-va-drivers \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable non-free repos for Intel GPU drivers (Gen9+)
+RUN echo "deb http://deb.debian.org/debian bookworm non-free non-free-firmware" > /etc/apt/sources.list.d/non-free.list && \
+    apt-get update && apt-get install -y --no-install-recommends intel-media-va-driver-non-free && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=backend /stash/stash /usr/bin/
+ENV STASH_CONFIG_FILE=/root/.stash/config.yml
+EXPOSE 9999
+ENTRYPOINT ["stash"]

--- a/docker/build/x86_64/README.md
+++ b/docker/build/x86_64/README.md
@@ -1,23 +1,41 @@
 # Introduction
 
-This dockerfile is used to build a stash docker container using the current source code. This is ideal for testing your current branch in docker. Note that it does not include python, so python-based scrapers will not work in this image. The production docker images distributed by the project contain python and the necessary packages.
+This directory contains Dockerfiles for building Stash container images using the current source code. There are three variants:
 
-# Building the docker container
+| Dockerfile | Built-in GPU Support | Use Case |
+|---|---|---|
+| `Dockerfile` | None | Default — alpine-based frontend/backend, alpine final image, no GPU drivers |
+| `Dockerfile-debian` | Intel/AMD | Debian-based final image with VA-API support (mesa-va-drivers + intel-media-va-driver-non-free) |
+| `Dockerfile-CUDA` | NVIDIA | NVIDIA GPU support with CUDA, NVENC patch, and VA-API for Intel GPUs |
+
+# Building the docker containers
 
 From the top-level directory (should contain `tools.go` file):
 
 ```
+# Default variant (alpine-based, no GPU)
 make docker-build
 
+# Debian-based variant with high Python binary compatibility and built-in Intel/AMD drivers
+make docker-build-debian
+
+# NVIDIA CUDA variant
+make docker-cuda-build
 ```
 
-# Running the docker container
+# Running the docker containers
 
 ## Using docker-compose
 
 See the `README.md` file in `docker/production` for instructions on how to get docker-compose if needed.
 
-The `stash/build` container can be run with the `docker-compose.yml` file in `docker/production` by changing the `image` value to be `stash/build`. See the instructions in `docker/production` for how to run docker-compose.
+The `stash/build` container can be run with the `docker-compose.yml` file in `docker/production` by changing the `image` value to the appropriate variant:
+
+- `stash/build` — default variant (alpine-based, no GPU)
+- `stash/build-debian` — Debian-based variant with VA-API GPU support
+- `stash/cuda-build` — NVIDIA GPU variant
+
+See the instructions in `docker/production` for how to run docker-compose.
 
 ## Using `docker run`
 


### PR DESCRIPTION
## Main Issue

This has been an issue I've been dealing with for sometime, but have kind of kicked it down the road until in the last month I decided to take a look at it.

All of this is specifically around docker images (non CUDA ones).

There are a number of community plugins that fail when you attempt to run them, they call `PythonDepManager`. Two things seem to consistently fail across multiple plugins:

1. `git` is not installed in the host container, so you have to manually go into the container and add it via `apk add git`, or add this to the start-up script
2. Once that is installed, when `PythonDepManager` attempts to install packages it fails due to python packages being incompatible with alpine's `musl`, as there isn't always pre-compiled versions of those packages (python's PyTorch is a good example of this, `torch`).

<img width="1442" height="564" alt="Screenshot_20260525_155137" src="https://github.com/user-attachments/assets/be1b8ff8-3eb2-42e7-adea-48b095acecff" />

To attempt to solve this problem this PR moves the base deployed docker image and backend go compilation to debian-based containers, which use `gclib` instead of `msul`.

After building the container with the below when I run the install it via the community plugins it runs without me having to jump into the container and run any manual commands:

<img width="1432" height="334" alt="Screenshot_20260525_154710" src="https://github.com/user-attachments/assets/2bf63196-94a3-49d0-bad2-f1d4f937419e" />

## Additional Drivers

A common request is drivers for Intel/AMD (since there's already a separate CUDA-container). This change also installs the AMD/Old Intel drivers (`mesa-va-drivers`) and installs the latest "non-free" Intel drivers as well for modern Intel GPU compatibility, `intel-media-va-driver-non-free`.

I totally understand if we want those specific installs removed from the base docker image and we can let the individual users auto-run install commands of whatever drivers they need after the container starts.

With this specific change if you map the appropriate `/dev/dri` and/or `/dev/kfd` mounts into the container, `ffmpeg` picks up the changes.

## Additional Notes

This PR just adds in a new debian-based option to avoid breaking any existing images that may have `apk`-based commands that run on container start, etc.

I'd like to also possibly publish the debain-based one, but for right now this acts like the CUDA one where it's an option but isn't published to the docker repository.

## Disclosures

I used local LLMs to assist in this change. I'm semi-unsure if the makefile changes were necessary but I couldn't get the `make docker-build` to work without adding in that additional makefile combination.