### PR TITLE
New: Make StudioPage, TagPage, GroupPage Patchable

### DIFF
--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -44,6 +44,7 @@ import { GroupSubGroupsPanel } from "./GroupSubGroupsPanel";
 import { GroupPerformersPanel } from "./GroupPerformersPanel";
 import { Icon } from "src/components/Shared/Icon";
 import { goBackOrReplace } from "src/utils/history";
+import { PatchComponent } from "src/patch";
 
 const validTabs = ["default", "scenes", "performers", "subgroups"] as const;
 type TabKey = (typeof validTabs)[number];
@@ -140,327 +141,330 @@ interface IGroupParams {
   tab?: string;
 }
 
-const GroupPage: React.FC<IProps> = ({ group, tabKey }) => {
-  const intl = useIntl();
-  const history = useHistory();
-  const Toast = useToast();
+const GroupPage: React.FC<IProps> = PatchComponent(
+  "GroupPage",
+  ({ group, tabKey }) => {
+    const intl = useIntl();
+    const history = useHistory();
+    const Toast = useToast();
 
-  // Configuration settings
-  const { configuration } = useConfigurationContext();
-  const uiConfig = configuration?.ui;
-  const enableBackgroundImage = uiConfig?.enableMovieBackgroundImage ?? false;
-  const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
-  const showAllDetails = uiConfig?.showAllDetails ?? true;
-  const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+    // Configuration settings
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui;
+    const enableBackgroundImage = uiConfig?.enableMovieBackgroundImage ?? false;
+    const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
+    const showAllDetails = uiConfig?.showAllDetails ?? true;
+    const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
 
-  const [focusedOnFront, setFocusedOnFront] = useState<boolean>(true);
+    const [focusedOnFront, setFocusedOnFront] = useState<boolean>(true);
 
-  const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const loadStickyHeader = useLoadStickyHeader();
+    const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
+    const loadStickyHeader = useLoadStickyHeader();
 
-  // Editing state
-  const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+    // Editing state
+    const [isEditing, setIsEditing] = useState<boolean>(false);
+    const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
-  // Editing group state
-  const [frontImage, setFrontImage] = useState<string | null>();
-  const [backImage, setBackImage] = useState<string | null>();
-  const [encodingImage, setEncodingImage] = useState<boolean>(false);
+    // Editing group state
+    const [frontImage, setFrontImage] = useState<string | null>();
+    const [backImage, setBackImage] = useState<string | null>();
+    const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const aliases = useMemo(
-    () => (group.aliases ? [group.aliases] : []),
-    [group.aliases]
-  );
-
-  const isDefaultImage =
-    group.front_image_path && group.front_image_path.includes("default=true");
-
-  const lightboxImages = useMemo(() => {
-    const covers = [];
-
-    if (group.front_image_path && !isDefaultImage) {
-      covers.push({
-        paths: {
-          thumbnail: group.front_image_path,
-          image: group.front_image_path,
-        },
-      });
-    }
-
-    if (group.back_image_path) {
-      covers.push({
-        paths: {
-          thumbnail: group.back_image_path,
-          image: group.back_image_path,
-        },
-      });
-    }
-    return covers;
-  }, [group.front_image_path, group.back_image_path, isDefaultImage]);
-
-  const activeFrontImage = useMemo(() => {
-    let existingImage = group.front_image_path;
-    if (isEditing) {
-      if (frontImage === null && existingImage) {
-        const imageURL = new URL(existingImage);
-        imageURL.searchParams.set("default", "true");
-        return imageURL.toString();
-      } else if (frontImage) {
-        return frontImage;
-      }
-    }
-
-    return existingImage;
-  }, [isEditing, group.front_image_path, frontImage]);
-
-  const activeBackImage = useMemo(() => {
-    let existingImage = group.back_image_path;
-    if (isEditing) {
-      if (backImage === null) {
-        return undefined;
-      } else if (backImage) {
-        return backImage;
-      }
-    }
-
-    return existingImage;
-  }, [isEditing, group.back_image_path, backImage]);
-
-  const [updateGroup, { loading: updating }] = useGroupUpdate();
-  const [deleteGroup, { loading: deleting }] = useGroupDestroy({
-    id: group.id,
-  });
-
-  // set up hotkeys
-  useEffect(() => {
-    Mousetrap.bind("e", () => toggleEditing());
-    Mousetrap.bind("d d", () => {
-      setIsDeleteAlertOpen(true);
-    });
-    Mousetrap.bind(",", () => setCollapsed(!collapsed));
-
-    return () => {
-      Mousetrap.unbind("e");
-      Mousetrap.unbind("d d");
-    };
-  });
-
-  useRatingKeybinds(
-    true,
-    configuration?.ui.ratingSystemOptions?.type,
-    setRating
-  );
-
-  async function onSave(input: GQL.GroupCreateInput) {
-    await updateGroup({
-      variables: {
-        input: {
-          id: group.id,
-          ...input,
-        },
-      },
-    });
-    toggleEditing(false);
-    Toast.success(
-      intl.formatMessage(
-        { id: "toast.updated_entity" },
-        { entity: intl.formatMessage({ id: "group" }).toLocaleLowerCase() }
-      )
+    const aliases = useMemo(
+      () => (group.aliases ? [group.aliases] : []),
+      [group.aliases]
     );
-  }
 
-  async function onDelete() {
-    try {
-      await deleteGroup();
-    } catch (e) {
-      Toast.error(e);
-      return;
-    }
+    const isDefaultImage =
+      group.front_image_path && group.front_image_path.includes("default=true");
 
-    goBackOrReplace(history, "/groups");
-  }
+    const lightboxImages = useMemo(() => {
+      const covers = [];
 
-  function toggleEditing(value?: boolean) {
-    if (value !== undefined) {
-      setIsEditing(value);
-    } else {
-      setIsEditing((e) => !e);
-    }
-    setFrontImage(undefined);
-    setBackImage(undefined);
-  }
+      if (group.front_image_path && !isDefaultImage) {
+        covers.push({
+          paths: {
+            thumbnail: group.front_image_path,
+            image: group.front_image_path,
+          },
+        });
+      }
 
-  function renderDeleteAlert() {
-    return (
-      <ModalComponent
-        show={isDeleteAlertOpen}
-        icon={faTrashAlt}
-        accept={{
-          text: intl.formatMessage({ id: "actions.delete" }),
-          variant: "danger",
-          onClick: onDelete,
-        }}
-        cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
-      >
-        <p>
-          <FormattedMessage
-            id="dialogs.delete_confirm"
-            values={{
-              entityName:
-                group.name ??
-                intl.formatMessage({ id: "group" }).toLocaleLowerCase(),
-            }}
-          />
-        </p>
-      </ModalComponent>
+      if (group.back_image_path) {
+        covers.push({
+          paths: {
+            thumbnail: group.back_image_path,
+            image: group.back_image_path,
+          },
+        });
+      }
+      return covers;
+    }, [group.front_image_path, group.back_image_path, isDefaultImage]);
+
+    const activeFrontImage = useMemo(() => {
+      let existingImage = group.front_image_path;
+      if (isEditing) {
+        if (frontImage === null && existingImage) {
+          const imageURL = new URL(existingImage);
+          imageURL.searchParams.set("default", "true");
+          return imageURL.toString();
+        } else if (frontImage) {
+          return frontImage;
+        }
+      }
+
+      return existingImage;
+    }, [isEditing, group.front_image_path, frontImage]);
+
+    const activeBackImage = useMemo(() => {
+      let existingImage = group.back_image_path;
+      if (isEditing) {
+        if (backImage === null) {
+          return undefined;
+        } else if (backImage) {
+          return backImage;
+        }
+      }
+
+      return existingImage;
+    }, [isEditing, group.back_image_path, backImage]);
+
+    const [updateGroup, { loading: updating }] = useGroupUpdate();
+    const [deleteGroup, { loading: deleting }] = useGroupDestroy({
+      id: group.id,
+    });
+
+    // set up hotkeys
+    useEffect(() => {
+      Mousetrap.bind("e", () => toggleEditing());
+      Mousetrap.bind("d d", () => {
+        setIsDeleteAlertOpen(true);
+      });
+      Mousetrap.bind(",", () => setCollapsed(!collapsed));
+
+      return () => {
+        Mousetrap.unbind("e");
+        Mousetrap.unbind("d d");
+      };
+    });
+
+    useRatingKeybinds(
+      true,
+      configuration?.ui.ratingSystemOptions?.type,
+      setRating
     );
-  }
 
-  function setRating(v: number | null) {
-    if (group.id) {
-      updateGroup({
+    async function onSave(input: GQL.GroupCreateInput) {
+      await updateGroup({
         variables: {
           input: {
             id: group.id,
-            rating100: v,
+            ...input,
           },
         },
       });
+      toggleEditing(false);
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.updated_entity" },
+          { entity: intl.formatMessage({ id: "group" }).toLocaleLowerCase() }
+        )
+      );
     }
-  }
 
-  if (updating || deleting) return <LoadingIndicator />;
+    async function onDelete() {
+      try {
+        await deleteGroup();
+      } catch (e) {
+        Toast.error(e);
+        return;
+      }
 
-  const headerClassName = cx("detail-header", {
-    edit: isEditing,
-    collapsed,
-    "full-width": !collapsed && !compactExpandedDetails,
-  });
+      goBackOrReplace(history, "/groups");
+    }
 
-  return (
-    <div id="group-page" className="row">
-      <Helmet>
-        <title>{group?.name}</title>
-      </Helmet>
+    function toggleEditing(value?: boolean) {
+      if (value !== undefined) {
+        setIsEditing(value);
+      } else {
+        setIsEditing((e) => !e);
+      }
+      setFrontImage(undefined);
+      setBackImage(undefined);
+    }
 
-      <div className={headerClassName}>
-        <BackgroundImage
-          imagePath={group.front_image_path ?? undefined}
-          show={enableBackgroundImage && !isEditing}
-        />
-        <div className="detail-container">
-          <HeaderImage encodingImage={encodingImage}>
-            <div className="group-images">
-              {!!activeFrontImage && (
-                <LightboxLink images={lightboxImages}>
-                  <DetailImage
-                    className={`front-cover ${
-                      focusedOnFront ? "active" : "inactive"
-                    }`}
-                    alt="Front Cover"
-                    src={activeFrontImage}
-                  />
-                </LightboxLink>
-              )}
-              {!!activeBackImage && (
-                <LightboxLink
-                  images={lightboxImages}
-                  index={lightboxImages.length - 1}
-                >
-                  <DetailImage
-                    className={`back-cover ${
-                      !focusedOnFront ? "active" : "inactive"
-                    }`}
-                    alt="Back Cover"
-                    src={activeBackImage}
-                  />
-                </LightboxLink>
-              )}
-              {!!(activeFrontImage && activeBackImage) && (
-                <Button
-                  className="flip"
-                  onClick={() => setFocusedOnFront(!focusedOnFront)}
-                >
-                  <Icon icon={faRefresh} />
-                </Button>
-              )}
-            </div>
-          </HeaderImage>
-          <div className="row">
-            <div className="group-head col">
-              <DetailTitle name={group.name} classNamePrefix="group">
+    function renderDeleteAlert() {
+      return (
+        <ModalComponent
+          show={isDeleteAlertOpen}
+          icon={faTrashAlt}
+          accept={{
+            text: intl.formatMessage({ id: "actions.delete" }),
+            variant: "danger",
+            onClick: onDelete,
+          }}
+          cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
+        >
+          <p>
+            <FormattedMessage
+              id="dialogs.delete_confirm"
+              values={{
+                entityName:
+                  group.name ??
+                  intl.formatMessage({ id: "group" }).toLocaleLowerCase(),
+              }}
+            />
+          </p>
+        </ModalComponent>
+      );
+    }
+
+    function setRating(v: number | null) {
+      if (group.id) {
+        updateGroup({
+          variables: {
+            input: {
+              id: group.id,
+              rating100: v,
+            },
+          },
+        });
+      }
+    }
+
+    if (updating || deleting) return <LoadingIndicator />;
+
+    const headerClassName = cx("detail-header", {
+      edit: isEditing,
+      collapsed,
+      "full-width": !collapsed && !compactExpandedDetails,
+    });
+
+    return (
+      <div id="group-page" className="row">
+        <Helmet>
+          <title>{group?.name}</title>
+        </Helmet>
+
+        <div className={headerClassName}>
+          <BackgroundImage
+            imagePath={group.front_image_path ?? undefined}
+            show={enableBackgroundImage && !isEditing}
+          />
+          <div className="detail-container">
+            <HeaderImage encodingImage={encodingImage}>
+              <div className="group-images">
+                {!!activeFrontImage && (
+                  <LightboxLink images={lightboxImages}>
+                    <DetailImage
+                      className={`front-cover ${
+                        focusedOnFront ? "active" : "inactive"
+                      }`}
+                      alt="Front Cover"
+                      src={activeFrontImage}
+                    />
+                  </LightboxLink>
+                )}
+                {!!activeBackImage && (
+                  <LightboxLink
+                    images={lightboxImages}
+                    index={lightboxImages.length - 1}
+                  >
+                    <DetailImage
+                      className={`back-cover ${
+                        !focusedOnFront ? "active" : "inactive"
+                      }`}
+                      alt="Back Cover"
+                      src={activeBackImage}
+                    />
+                  </LightboxLink>
+                )}
+                {!!(activeFrontImage && activeBackImage) && (
+                  <Button
+                    className="flip"
+                    onClick={() => setFocusedOnFront(!focusedOnFront)}
+                  >
+                    <Icon icon={faRefresh} />
+                  </Button>
+                )}
+              </div>
+            </HeaderImage>
+            <div className="row">
+              <div className="group-head col">
+                <DetailTitle name={group.name} classNamePrefix="group">
+                  {!isEditing && (
+                    <ExpandCollapseButton
+                      collapsed={collapsed}
+                      setCollapsed={(v) => setCollapsed(v)}
+                    />
+                  )}
+                  <span className="name-icons">
+                    <ExternalLinkButtons urls={group.urls ?? undefined} />
+                  </span>
+                </DetailTitle>
+
+                <AliasList aliases={aliases} />
+                <RatingSystem
+                  value={group.rating100}
+                  onSetRating={(value) => setRating(value)}
+                  clickToRate
+                  withoutContext
+                />
                 {!isEditing && (
-                  <ExpandCollapseButton
+                  <GroupDetailsPanel
+                    group={group}
                     collapsed={collapsed}
-                    setCollapsed={(v) => setCollapsed(v)}
+                    fullWidth={!collapsed && !compactExpandedDetails}
                   />
                 )}
-                <span className="name-icons">
-                  <ExternalLinkButtons urls={group.urls ?? undefined} />
-                </span>
-              </DetailTitle>
+                {isEditing ? (
+                  <GroupEditPanel
+                    group={group}
+                    onSubmit={onSave}
+                    onCancel={() => toggleEditing()}
+                    onDelete={onDelete}
+                    setFrontImage={setFrontImage}
+                    setBackImage={setBackImage}
+                    setEncodingImage={setEncodingImage}
+                  />
+                ) : (
+                  <DetailsEditNavbar
+                    objectName={group.name}
+                    isNew={false}
+                    isEditing={isEditing}
+                    onToggleEdit={() => toggleEditing()}
+                    onSave={() => {}}
+                    onImageChange={() => {}}
+                    onDelete={onDelete}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
 
-              <AliasList aliases={aliases} />
-              <RatingSystem
-                value={group.rating100}
-                onSetRating={(value) => setRating(value)}
-                clickToRate
-                withoutContext
-              />
+        {!isEditing && loadStickyHeader && (
+          <CompressedGroupDetailsPanel group={group} />
+        )}
+
+        <div className="detail-body">
+          <div className="group-body">
+            <div className="group-tabs">
               {!isEditing && (
-                <GroupDetailsPanel
+                <GroupTabs
                   group={group}
-                  collapsed={collapsed}
-                  fullWidth={!collapsed && !compactExpandedDetails}
-                />
-              )}
-              {isEditing ? (
-                <GroupEditPanel
-                  group={group}
-                  onSubmit={onSave}
-                  onCancel={() => toggleEditing()}
-                  onDelete={onDelete}
-                  setFrontImage={setFrontImage}
-                  setBackImage={setBackImage}
-                  setEncodingImage={setEncodingImage}
-                />
-              ) : (
-                <DetailsEditNavbar
-                  objectName={group.name}
-                  isNew={false}
-                  isEditing={isEditing}
-                  onToggleEdit={() => toggleEditing()}
-                  onSave={() => {}}
-                  onImageChange={() => {}}
-                  onDelete={onDelete}
+                  tabKey={tabKey}
+                  abbreviateCounter={abbreviateCounter}
                 />
               )}
             </div>
           </div>
         </div>
+        {renderDeleteAlert()}
       </div>
-
-      {!isEditing && loadStickyHeader && (
-        <CompressedGroupDetailsPanel group={group} />
-      )}
-
-      <div className="detail-body">
-        <div className="group-body">
-          <div className="group-tabs">
-            {!isEditing && (
-              <GroupTabs
-                group={group}
-                tabKey={tabKey}
-                abbreviateCounter={abbreviateCounter}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-      {renderDeleteAlert()}
-    </div>
-  );
-};
+    );
+  }
+);
 
 const GroupLoader: React.FC<RouteComponentProps<IGroupParams>> = ({
   location,

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -48,6 +48,7 @@ import { ExternalLinkButtons } from "src/components/Shared/ExternalLinksButton";
 import { AliasList } from "src/components/Shared/DetailsPage/AliasList";
 import { HeaderImage } from "src/components/Shared/DetailsPage/HeaderImage";
 import { goBackOrReplace } from "src/utils/history";
+import { PatchComponent } from "src/patch";
 import { OCounterButton } from "src/components/Shared/CountButton";
 import { OrganizedButton } from "src/components/Scenes/SceneDetails/OrganizedButton";
 
@@ -264,316 +265,320 @@ const StudioTabs: React.FC<{
   );
 };
 
-const StudioPage: React.FC<IProps> = ({ studio, tabKey }) => {
-  const history = useHistory();
-  const Toast = useToast();
-  const intl = useIntl();
+const StudioPage: React.FC<IProps> = PatchComponent(
+  "StudioPage",
+  ({ studio, tabKey }) => {
+    const history = useHistory();
+    const Toast = useToast();
+    const intl = useIntl();
 
-  // Configuration settings
-  const { configuration } = useConfigurationContext();
-  const uiConfig = configuration?.ui;
-  const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
-  const enableBackgroundImage = uiConfig?.enableStudioBackgroundImage ?? false;
-  const showAllDetails = uiConfig?.showAllDetails ?? true;
-  const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
+    // Configuration settings
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui;
+    const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+    const enableBackgroundImage =
+      uiConfig?.enableStudioBackgroundImage ?? false;
+    const showAllDetails = uiConfig?.showAllDetails ?? true;
+    const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
-  const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const loadStickyHeader = useLoadStickyHeader();
+    const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
+    const loadStickyHeader = useLoadStickyHeader();
 
-  // Editing state
-  const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+    // Editing state
+    const [isEditing, setIsEditing] = useState<boolean>(false);
+    const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
 
-  // Editing studio state
-  const [image, setImage] = useState<string | null>();
-  const [encodingImage, setEncodingImage] = useState<boolean>(false);
+    // Editing studio state
+    const [image, setImage] = useState<string | null>();
+    const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const [updateStudio] = useStudioUpdate();
-  const [deleteStudio] = useStudioDestroy({ id: studio.id });
+    const [updateStudio] = useStudioUpdate();
+    const [deleteStudio] = useStudioDestroy({ id: studio.id });
 
-  const showAllCounts = uiConfig?.showChildStudioContent;
+    const showAllCounts = uiConfig?.showChildStudioContent;
 
-  const studioImage = useMemo(() => {
-    const existingPath = studio.image_path;
-    if (isEditing) {
-      if (image === null && existingPath) {
-        const studioImageURL = new URL(existingPath);
-        studioImageURL.searchParams.set("default", "true");
-        return studioImageURL.toString();
-      } else if (image) {
-        return image;
+    const studioImage = useMemo(() => {
+      const existingPath = studio.image_path;
+      if (isEditing) {
+        if (image === null && existingPath) {
+          const studioImageURL = new URL(existingPath);
+          studioImageURL.searchParams.set("default", "true");
+          return studioImageURL.toString();
+        } else if (image) {
+          return image;
+        }
+      }
+
+      return existingPath;
+    }, [isEditing, image, studio.image_path]);
+
+    function setFavorite(v: boolean) {
+      if (studio.id) {
+        updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              favorite: v,
+            },
+          },
+        });
       }
     }
 
-    return existingPath;
-  }, [isEditing, image, studio.image_path]);
+    const [organizedLoading, setOrganizedLoading] = useState(false);
 
-  function setFavorite(v: boolean) {
-    if (studio.id) {
-      updateStudio({
-        variables: {
-          input: {
-            id: studio.id,
-            favorite: v,
+    async function onOrganizedClick() {
+      if (!studio.id) return;
+
+      setOrganizedLoading(true);
+      try {
+        await updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              organized: !studio.organized,
+            },
           },
-        },
-      });
+        });
+      } catch (e) {
+        Toast.error(e);
+      } finally {
+        setOrganizedLoading(false);
+      }
     }
-  }
 
-  const [organizedLoading, setOrganizedLoading] = useState(false);
+    // set up hotkeys
+    useEffect(() => {
+      Mousetrap.bind("e", () => toggleEditing());
+      Mousetrap.bind("d d", () => {
+        setIsDeleteAlertOpen(true);
+      });
+      Mousetrap.bind(",", () => setCollapsed(!collapsed));
+      Mousetrap.bind("f", () => setFavorite(!studio.favorite));
 
-  async function onOrganizedClick() {
-    if (!studio.id) return;
+      return () => {
+        Mousetrap.unbind("e");
+        Mousetrap.unbind("d d");
+        Mousetrap.unbind(",");
+        Mousetrap.unbind("f");
+      };
+    });
 
-    setOrganizedLoading(true);
-    try {
+    useRatingKeybinds(
+      true,
+      configuration?.ui.ratingSystemOptions?.type,
+      setRating
+    );
+
+    async function onSave(input: GQL.StudioCreateInput) {
       await updateStudio({
         variables: {
           input: {
             id: studio.id,
-            organized: !studio.organized,
+            ...input,
           },
         },
       });
-    } catch (e) {
-      Toast.error(e);
-    } finally {
-      setOrganizedLoading(false);
+      toggleEditing(false);
+      Toast.success(
+        intl.formatMessage(
+          { id: "toast.updated_entity" },
+          { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
+        )
+      );
     }
-  }
 
-  // set up hotkeys
-  useEffect(() => {
-    Mousetrap.bind("e", () => toggleEditing());
-    Mousetrap.bind("d d", () => {
-      setIsDeleteAlertOpen(true);
+    async function onAutoTag() {
+      if (!studio.id) return;
+      try {
+        await mutateMetadataAutoTag({ studios: [studio.id] });
+        Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
+      } catch (e) {
+        Toast.error(e);
+      }
+    }
+
+    async function onDelete() {
+      try {
+        await deleteStudio();
+      } catch (e) {
+        Toast.error(e);
+        return;
+      }
+
+      goBackOrReplace(history, "/studios");
+    }
+
+    function renderDeleteAlert() {
+      return (
+        <ModalComponent
+          show={isDeleteAlertOpen}
+          icon={faTrashAlt}
+          accept={{
+            text: intl.formatMessage({ id: "actions.delete" }),
+            variant: "danger",
+            onClick: onDelete,
+          }}
+          cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
+        >
+          <p>
+            <FormattedMessage
+              id="dialogs.delete_confirm"
+              values={{
+                entityName:
+                  studio.name ??
+                  intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
+              }}
+            />
+          </p>
+        </ModalComponent>
+      );
+    }
+
+    function toggleEditing(value?: boolean) {
+      if (value !== undefined) {
+        setIsEditing(value);
+      } else {
+        setIsEditing((e) => !e);
+      }
+      setImage(undefined);
+    }
+
+    function setRating(v: number | null) {
+      if (studio.id) {
+        updateStudio({
+          variables: {
+            input: {
+              id: studio.id,
+              rating100: v,
+            },
+          },
+        });
+      }
+    }
+
+    const headerClassName = cx("detail-header", {
+      edit: isEditing,
+      collapsed,
+      "full-width": !collapsed && !compactExpandedDetails,
     });
-    Mousetrap.bind(",", () => setCollapsed(!collapsed));
-    Mousetrap.bind("f", () => setFavorite(!studio.favorite));
 
-    return () => {
-      Mousetrap.unbind("e");
-      Mousetrap.unbind("d d");
-      Mousetrap.unbind(",");
-      Mousetrap.unbind("f");
-    };
-  });
-
-  useRatingKeybinds(
-    true,
-    configuration?.ui.ratingSystemOptions?.type,
-    setRating
-  );
-
-  async function onSave(input: GQL.StudioCreateInput) {
-    await updateStudio({
-      variables: {
-        input: {
-          id: studio.id,
-          ...input,
-        },
-      },
-    });
-    toggleEditing(false);
-    Toast.success(
-      intl.formatMessage(
-        { id: "toast.updated_entity" },
-        { entity: intl.formatMessage({ id: "studio" }).toLocaleLowerCase() }
-      )
-    );
-  }
-
-  async function onAutoTag() {
-    if (!studio.id) return;
-    try {
-      await mutateMetadataAutoTag({ studios: [studio.id] });
-      Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
-    } catch (e) {
-      Toast.error(e);
-    }
-  }
-
-  async function onDelete() {
-    try {
-      await deleteStudio();
-    } catch (e) {
-      Toast.error(e);
-      return;
-    }
-
-    goBackOrReplace(history, "/studios");
-  }
-
-  function renderDeleteAlert() {
     return (
-      <ModalComponent
-        show={isDeleteAlertOpen}
-        icon={faTrashAlt}
-        accept={{
-          text: intl.formatMessage({ id: "actions.delete" }),
-          variant: "danger",
-          onClick: onDelete,
-        }}
-        cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
-      >
-        <p>
-          <FormattedMessage
-            id="dialogs.delete_confirm"
-            values={{
-              entityName:
-                studio.name ??
-                intl.formatMessage({ id: "studio" }).toLocaleLowerCase(),
-            }}
+      <div id="studio-page" className="row">
+        <Helmet>
+          <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
+        </Helmet>
+
+        <div className={headerClassName}>
+          <BackgroundImage
+            imagePath={studio.image_path ?? undefined}
+            show={enableBackgroundImage && !isEditing}
           />
-        </p>
-      </ModalComponent>
-    );
-  }
-
-  function toggleEditing(value?: boolean) {
-    if (value !== undefined) {
-      setIsEditing(value);
-    } else {
-      setIsEditing((e) => !e);
-    }
-    setImage(undefined);
-  }
-
-  function setRating(v: number | null) {
-    if (studio.id) {
-      updateStudio({
-        variables: {
-          input: {
-            id: studio.id,
-            rating100: v,
-          },
-        },
-      });
-    }
-  }
-
-  const headerClassName = cx("detail-header", {
-    edit: isEditing,
-    collapsed,
-    "full-width": !collapsed && !compactExpandedDetails,
-  });
-
-  return (
-    <div id="studio-page" className="row">
-      <Helmet>
-        <title>{studio.name ?? intl.formatMessage({ id: "studio" })}</title>
-      </Helmet>
-
-      <div className={headerClassName}>
-        <BackgroundImage
-          imagePath={studio.image_path ?? undefined}
-          show={enableBackgroundImage && !isEditing}
-        />
-        <div className="detail-container">
-          <HeaderImage encodingImage={encodingImage}>
-            {studioImage && (
-              <DetailImage
-                className="logo"
-                alt={studio.name}
-                src={studioImage}
-              />
-            )}
-          </HeaderImage>
-          <div className="row">
-            <div className="studio-head col">
-              <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
-                {!isEditing && (
-                  <ExpandCollapseButton
-                    collapsed={collapsed}
-                    setCollapsed={(v) => setCollapsed(v)}
-                  />
-                )}
-                <span className="name-icons">
-                  <FavoriteIcon
-                    favorite={studio.favorite}
-                    onToggleFavorite={(v) => setFavorite(v)}
-                  />
-                  <OrganizedButton
-                    loading={organizedLoading}
-                    organized={studio.organized}
-                    onClick={onOrganizedClick}
-                  />
-                  <ExternalLinkButtons urls={studio.urls} />
-                </span>
-              </DetailTitle>
-
-              <AliasList aliases={studio.aliases} />
-              <div className="quality-group">
-                <RatingSystem
-                  value={studio.rating100}
-                  onSetRating={(value) => setRating(value)}
-                  clickToRate
-                  withoutContext
-                />
-                {!!studio.o_counter && (
-                  <OCounterButton value={studio.o_counter} />
-                )}
-              </div>
-              {!isEditing && (
-                <StudioDetailsPanel
-                  studio={studio}
-                  collapsed={collapsed}
-                  fullWidth={!collapsed && !compactExpandedDetails}
+          <div className="detail-container">
+            <HeaderImage encodingImage={encodingImage}>
+              {studioImage && (
+                <DetailImage
+                  className="logo"
+                  alt={studio.name}
+                  src={studioImage}
                 />
               )}
-              {isEditing ? (
-                <StudioEditPanel
+            </HeaderImage>
+            <div className="row">
+              <div className="studio-head col">
+                <DetailTitle name={studio.name ?? ""} classNamePrefix="studio">
+                  {!isEditing && (
+                    <ExpandCollapseButton
+                      collapsed={collapsed}
+                      setCollapsed={(v) => setCollapsed(v)}
+                    />
+                  )}
+                  <span className="name-icons">
+                    <FavoriteIcon
+                      favorite={studio.favorite}
+                      onToggleFavorite={(v) => setFavorite(v)}
+                    />
+                    <OrganizedButton
+                      loading={organizedLoading}
+                      organized={studio.organized}
+                      onClick={onOrganizedClick}
+                    />
+                    <ExternalLinkButtons urls={studio.urls} />
+                  </span>
+                </DetailTitle>
+
+                <AliasList aliases={studio.aliases} />
+                <div className="quality-group">
+                  <RatingSystem
+                    value={studio.rating100}
+                    onSetRating={(value) => setRating(value)}
+                    clickToRate
+                    withoutContext
+                  />
+                  {!!studio.o_counter && (
+                    <OCounterButton value={studio.o_counter} />
+                  )}
+                </div>
+                {!isEditing && (
+                  <StudioDetailsPanel
+                    studio={studio}
+                    collapsed={collapsed}
+                    fullWidth={!collapsed && !compactExpandedDetails}
+                  />
+                )}
+                {isEditing ? (
+                  <StudioEditPanel
+                    studio={studio}
+                    onSubmit={onSave}
+                    onCancel={() => toggleEditing()}
+                    onDelete={onDelete}
+                    setImage={setImage}
+                    setEncodingImage={setEncodingImage}
+                  />
+                ) : (
+                  <DetailsEditNavbar
+                    objectName={
+                      studio.name ?? intl.formatMessage({ id: "studio" })
+                    }
+                    isNew={false}
+                    isEditing={isEditing}
+                    onToggleEdit={() => toggleEditing()}
+                    onSave={() => {}}
+                    onImageChange={() => {}}
+                    onClearImage={() => {}}
+                    onAutoTag={onAutoTag}
+                    autoTagDisabled={studio.ignore_auto_tag}
+                    onDelete={onDelete}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {!isEditing && loadStickyHeader && (
+          <CompressedStudioDetailsPanel studio={studio} />
+        )}
+
+        <div className="detail-body">
+          <div className="studio-body">
+            <div className="studio-tabs">
+              {!isEditing && (
+                <StudioTabs
                   studio={studio}
-                  onSubmit={onSave}
-                  onCancel={() => toggleEditing()}
-                  onDelete={onDelete}
-                  setImage={setImage}
-                  setEncodingImage={setEncodingImage}
-                />
-              ) : (
-                <DetailsEditNavbar
-                  objectName={
-                    studio.name ?? intl.formatMessage({ id: "studio" })
-                  }
-                  isNew={false}
-                  isEditing={isEditing}
-                  onToggleEdit={() => toggleEditing()}
-                  onSave={() => {}}
-                  onImageChange={() => {}}
-                  onClearImage={() => {}}
-                  onAutoTag={onAutoTag}
-                  autoTagDisabled={studio.ignore_auto_tag}
-                  onDelete={onDelete}
+                  tabKey={tabKey}
+                  abbreviateCounter={abbreviateCounter}
+                  showAllCounts={showAllCounts}
                 />
               )}
             </div>
           </div>
         </div>
+        {renderDeleteAlert()}
       </div>
-
-      {!isEditing && loadStickyHeader && (
-        <CompressedStudioDetailsPanel studio={studio} />
-      )}
-
-      <div className="detail-body">
-        <div className="studio-body">
-          <div className="studio-tabs">
-            {!isEditing && (
-              <StudioTabs
-                studio={studio}
-                tabKey={tabKey}
-                abbreviateCounter={abbreviateCounter}
-                showAllCounts={showAllCounts}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-      {renderDeleteAlert()}
-    </div>
-  );
-};
+    );
+  }
+);
 
 const StudioLoader: React.FC<RouteComponentProps<IStudioParams>> = ({
   location,

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -45,6 +45,7 @@ import { FavoriteIcon } from "src/components/Shared/FavoriteIcon";
 import { AliasList } from "src/components/Shared/DetailsPage/AliasList";
 import { HeaderImage } from "src/components/Shared/DetailsPage/HeaderImage";
 import { goBackOrReplace } from "src/utils/history";
+import { PatchComponent } from "src/patch";
 
 interface IProps {
   tag: GQL.TagDataFragment;
@@ -286,305 +287,308 @@ const TagTabs: React.FC<{
   );
 };
 
-const TagPage: React.FC<IProps> = ({ tag, tabKey }) => {
-  const history = useHistory();
-  const Toast = useToast();
-  const intl = useIntl();
+const TagPage: React.FC<IProps> = PatchComponent(
+  "TagPage",
+  ({ tag, tabKey }) => {
+    const history = useHistory();
+    const Toast = useToast();
+    const intl = useIntl();
 
-  // Configuration settings
-  const { configuration } = useConfigurationContext();
-  const uiConfig = configuration?.ui;
-  const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
-  const enableBackgroundImage = uiConfig?.enableTagBackgroundImage ?? false;
-  const showAllDetails = uiConfig?.showAllDetails ?? true;
-  const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
+    // Configuration settings
+    const { configuration } = useConfigurationContext();
+    const uiConfig = configuration?.ui;
+    const abbreviateCounter = uiConfig?.abbreviateCounters ?? false;
+    const enableBackgroundImage = uiConfig?.enableTagBackgroundImage ?? false;
+    const showAllDetails = uiConfig?.showAllDetails ?? true;
+    const compactExpandedDetails = uiConfig?.compactExpandedDetails ?? false;
 
-  const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
-  const loadStickyHeader = useLoadStickyHeader();
+    const [collapsed, setCollapsed] = useState<boolean>(!showAllDetails);
+    const loadStickyHeader = useLoadStickyHeader();
 
-  // Editing state
-  const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
-  const [isMerging, setIsMerging] = useState<boolean>(false);
+    // Editing state
+    const [isEditing, setIsEditing] = useState<boolean>(false);
+    const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState<boolean>(false);
+    const [isMerging, setIsMerging] = useState<boolean>(false);
 
-  // Editing tag state
-  const [image, setImage] = useState<string | null>();
-  const [encodingImage, setEncodingImage] = useState<boolean>(false);
+    // Editing tag state
+    const [image, setImage] = useState<string | null>();
+    const [encodingImage, setEncodingImage] = useState<boolean>(false);
 
-  const [updateTag] = useTagUpdate();
-  const [deleteTag] = useTagDestroy({ id: tag.id });
+    const [updateTag] = useTagUpdate();
+    const [deleteTag] = useTagDestroy({ id: tag.id });
 
-  const showAllCounts = uiConfig?.showChildTagContent;
+    const showAllCounts = uiConfig?.showChildTagContent;
 
-  const tagImage = useMemo(() => {
-    let existingImage = tag.image_path;
-    if (isEditing) {
-      if (image === null && existingImage) {
-        const tagImageURL = new URL(existingImage);
-        tagImageURL.searchParams.set("default", "true");
-        return tagImageURL.toString();
-      } else if (image) {
-        return image;
-      }
-    }
-
-    return existingImage;
-  }, [isEditing, tag.image_path, image]);
-
-  function setFavorite(v: boolean) {
-    if (tag.id) {
-      updateTag({
-        variables: {
-          input: {
-            id: tag.id,
-            favorite: v,
-          },
-        },
-      });
-    }
-  }
-
-  // set up hotkeys
-  useEffect(() => {
-    Mousetrap.bind("e", () => toggleEditing());
-    Mousetrap.bind("d d", () => {
-      setIsDeleteAlertOpen(true);
-    });
-    Mousetrap.bind(",", () => setCollapsed(!collapsed));
-    Mousetrap.bind("f", () => setFavorite(!tag.favorite));
-
-    return () => {
+    const tagImage = useMemo(() => {
+      let existingImage = tag.image_path;
       if (isEditing) {
-        Mousetrap.unbind("s s");
+        if (image === null && existingImage) {
+          const tagImageURL = new URL(existingImage);
+          tagImageURL.searchParams.set("default", "true");
+          return tagImageURL.toString();
+        } else if (image) {
+          return image;
+        }
       }
 
-      Mousetrap.unbind("e");
-      Mousetrap.unbind("d d");
-      Mousetrap.unbind(",");
-      Mousetrap.unbind("f");
-    };
-  });
+      return existingImage;
+    }, [isEditing, tag.image_path, image]);
 
-  async function onSave(input: GQL.TagCreateInput) {
-    const oldRelations = {
-      parents: tag.parents ?? [],
-      children: tag.children ?? [],
-    };
-    const result = await updateTag({
-      variables: {
-        input: {
-          id: tag.id,
-          ...input,
-        },
-      },
-    });
-    if (result.data?.tagUpdate) {
-      toggleEditing(false);
-      const updated = result.data.tagUpdate;
-      tagRelationHook(updated, oldRelations, {
-        parents: updated.parents,
-        children: updated.children,
+    function setFavorite(v: boolean) {
+      if (tag.id) {
+        updateTag({
+          variables: {
+            input: {
+              id: tag.id,
+              favorite: v,
+            },
+          },
+        });
+      }
+    }
+
+    // set up hotkeys
+    useEffect(() => {
+      Mousetrap.bind("e", () => toggleEditing());
+      Mousetrap.bind("d d", () => {
+        setIsDeleteAlertOpen(true);
       });
-      Toast.success(
-        intl.formatMessage(
-          { id: "toast.updated_entity" },
-          { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
-        )
-      );
-    }
-  }
+      Mousetrap.bind(",", () => setCollapsed(!collapsed));
+      Mousetrap.bind("f", () => setFavorite(!tag.favorite));
 
-  async function onAutoTag() {
-    if (!tag.id) return;
-    try {
-      await mutateMetadataAutoTag({ tags: [tag.id] });
-      Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
-    } catch (e) {
-      Toast.error(e);
-    }
-  }
+      return () => {
+        if (isEditing) {
+          Mousetrap.unbind("s s");
+        }
 
-  async function onDelete() {
-    try {
+        Mousetrap.unbind("e");
+        Mousetrap.unbind("d d");
+        Mousetrap.unbind(",");
+        Mousetrap.unbind("f");
+      };
+    });
+
+    async function onSave(input: GQL.TagCreateInput) {
       const oldRelations = {
         parents: tag.parents ?? [],
         children: tag.children ?? [],
       };
-      await deleteTag();
-      tagRelationHook(tag as GQL.TagDataFragment, oldRelations, {
-        parents: [],
-        children: [],
+      const result = await updateTag({
+        variables: {
+          input: {
+            id: tag.id,
+            ...input,
+          },
+        },
       });
-    } catch (e) {
-      Toast.error(e);
-      return;
+      if (result.data?.tagUpdate) {
+        toggleEditing(false);
+        const updated = result.data.tagUpdate;
+        tagRelationHook(updated, oldRelations, {
+          parents: updated.parents,
+          children: updated.children,
+        });
+        Toast.success(
+          intl.formatMessage(
+            { id: "toast.updated_entity" },
+            { entity: intl.formatMessage({ id: "tag" }).toLocaleLowerCase() }
+          )
+        );
+      }
     }
 
-    goBackOrReplace(history, "/tags");
-  }
-
-  function renderDeleteAlert() {
-    return (
-      <ModalComponent
-        show={isDeleteAlertOpen}
-        icon={faTrashAlt}
-        accept={{
-          text: intl.formatMessage({ id: "actions.delete" }),
-          variant: "danger",
-          onClick: onDelete,
-        }}
-        cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
-      >
-        <p>
-          <FormattedMessage
-            id="dialogs.delete_confirm"
-            values={{
-              entityName:
-                tag.name ??
-                intl.formatMessage({ id: "tag" }).toLocaleLowerCase(),
-            }}
-          />
-        </p>
-      </ModalComponent>
-    );
-  }
-
-  function toggleEditing(value?: boolean) {
-    if (value !== undefined) {
-      setIsEditing(value);
-    } else {
-      setIsEditing((e) => !e);
+    async function onAutoTag() {
+      if (!tag.id) return;
+      try {
+        await mutateMetadataAutoTag({ tags: [tag.id] });
+        Toast.success(intl.formatMessage({ id: "toast.started_auto_tagging" }));
+      } catch (e) {
+        Toast.error(e);
+      }
     }
-    setImage(undefined);
-  }
 
-  function renderMergeButton() {
-    return (
-      <Button variant="secondary" onClick={() => setIsMerging(true)}>
-        <FormattedMessage id="actions.merge" />
-        ...
-      </Button>
-    );
-  }
+    async function onDelete() {
+      try {
+        const oldRelations = {
+          parents: tag.parents ?? [],
+          children: tag.children ?? [],
+        };
+        await deleteTag();
+        tagRelationHook(tag as GQL.TagDataFragment, oldRelations, {
+          parents: [],
+          children: [],
+        });
+      } catch (e) {
+        Toast.error(e);
+        return;
+      }
 
-  function renderMergeDialog() {
-    if (!tag.id) return;
-    return (
-      <TagMergeModal
-        show={isMerging}
-        onClose={(mergedId) => {
-          setIsMerging(false);
-          if (mergedId !== undefined && mergedId !== tag.id) {
-            // By default, the merge destination is the current tag, but
-            // the user can change it, in which case we need to redirect.
-            history.replace(`/tags/${mergedId}`);
-          }
-        }}
-        tags={[tag]}
-      />
-    );
-  }
+      goBackOrReplace(history, "/tags");
+    }
 
-  const headerClassName = cx("detail-header", {
-    edit: isEditing,
-    collapsed,
-    "full-width": !collapsed && !compactExpandedDetails,
-  });
+    function renderDeleteAlert() {
+      return (
+        <ModalComponent
+          show={isDeleteAlertOpen}
+          icon={faTrashAlt}
+          accept={{
+            text: intl.formatMessage({ id: "actions.delete" }),
+            variant: "danger",
+            onClick: onDelete,
+          }}
+          cancel={{ onClick: () => setIsDeleteAlertOpen(false) }}
+        >
+          <p>
+            <FormattedMessage
+              id="dialogs.delete_confirm"
+              values={{
+                entityName:
+                  tag.name ??
+                  intl.formatMessage({ id: "tag" }).toLocaleLowerCase(),
+              }}
+            />
+          </p>
+        </ModalComponent>
+      );
+    }
 
-  return (
-    <div id="tag-page" className="row">
-      <Helmet>
-        <title>{tag.name}</title>
-      </Helmet>
+    function toggleEditing(value?: boolean) {
+      if (value !== undefined) {
+        setIsEditing(value);
+      } else {
+        setIsEditing((e) => !e);
+      }
+      setImage(undefined);
+    }
 
-      <div className={headerClassName}>
-        <BackgroundImage
-          imagePath={tag.image_path ?? undefined}
-          show={enableBackgroundImage && !isEditing}
+    function renderMergeButton() {
+      return (
+        <Button variant="secondary" onClick={() => setIsMerging(true)}>
+          <FormattedMessage id="actions.merge" />
+          ...
+        </Button>
+      );
+    }
+
+    function renderMergeDialog() {
+      if (!tag.id) return;
+      return (
+        <TagMergeModal
+          show={isMerging}
+          onClose={(mergedId) => {
+            setIsMerging(false);
+            if (mergedId !== undefined && mergedId !== tag.id) {
+              // By default, the merge destination is the current tag, but
+              // the user can change it, in which case we need to redirect.
+              history.replace(`/tags/${mergedId}`);
+            }
+          }}
+          tags={[tag]}
         />
-        <div className="detail-container">
-          <HeaderImage encodingImage={encodingImage}>
-            {tagImage && (
-              <DetailImage className="logo" alt={tag.name} src={tagImage} />
-            )}
-          </HeaderImage>
-          <div className="row">
-            <div className="tag-head col">
-              <DetailTitle name={tag.name} classNamePrefix="tag">
+      );
+    }
+
+    const headerClassName = cx("detail-header", {
+      edit: isEditing,
+      collapsed,
+      "full-width": !collapsed && !compactExpandedDetails,
+    });
+
+    return (
+      <div id="tag-page" className="row">
+        <Helmet>
+          <title>{tag.name}</title>
+        </Helmet>
+
+        <div className={headerClassName}>
+          <BackgroundImage
+            imagePath={tag.image_path ?? undefined}
+            show={enableBackgroundImage && !isEditing}
+          />
+          <div className="detail-container">
+            <HeaderImage encodingImage={encodingImage}>
+              {tagImage && (
+                <DetailImage className="logo" alt={tag.name} src={tagImage} />
+              )}
+            </HeaderImage>
+            <div className="row">
+              <div className="tag-head col">
+                <DetailTitle name={tag.name} classNamePrefix="tag">
+                  {!isEditing && (
+                    <ExpandCollapseButton
+                      collapsed={collapsed}
+                      setCollapsed={(v) => setCollapsed(v)}
+                    />
+                  )}
+                  <span className="name-icons">
+                    <FavoriteIcon
+                      favorite={tag.favorite}
+                      onToggleFavorite={(v) => setFavorite(v)}
+                    />
+                  </span>
+                </DetailTitle>
+
+                <AliasList aliases={tag.aliases} />
                 {!isEditing && (
-                  <ExpandCollapseButton
-                    collapsed={collapsed}
-                    setCollapsed={(v) => setCollapsed(v)}
+                  <TagDetailsPanel
+                    tag={tag}
+                    fullWidth={!collapsed && !compactExpandedDetails}
                   />
                 )}
-                <span className="name-icons">
-                  <FavoriteIcon
-                    favorite={tag.favorite}
-                    onToggleFavorite={(v) => setFavorite(v)}
+                {isEditing ? (
+                  <TagEditPanel
+                    tag={tag}
+                    onSubmit={onSave}
+                    onCancel={() => toggleEditing()}
+                    onDelete={onDelete}
+                    setImage={setImage}
+                    setEncodingImage={setEncodingImage}
                   />
-                </span>
-              </DetailTitle>
+                ) : (
+                  <DetailsEditNavbar
+                    objectName={tag.name}
+                    isNew={false}
+                    isEditing={isEditing}
+                    onToggleEdit={() => toggleEditing()}
+                    onSave={() => {}}
+                    onImageChange={() => {}}
+                    onClearImage={() => {}}
+                    onAutoTag={onAutoTag}
+                    autoTagDisabled={tag.ignore_auto_tag}
+                    onDelete={onDelete}
+                    classNames="mb-2"
+                    customButtons={renderMergeButton()}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
 
-              <AliasList aliases={tag.aliases} />
+        {!isEditing && loadStickyHeader && (
+          <CompressedTagDetailsPanel tag={tag} />
+        )}
+
+        <div className="detail-body">
+          <div className="tag-body">
+            <div className="tag-tabs">
               {!isEditing && (
-                <TagDetailsPanel
+                <TagTabs
+                  tabKey={tabKey}
                   tag={tag}
-                  fullWidth={!collapsed && !compactExpandedDetails}
-                />
-              )}
-              {isEditing ? (
-                <TagEditPanel
-                  tag={tag}
-                  onSubmit={onSave}
-                  onCancel={() => toggleEditing()}
-                  onDelete={onDelete}
-                  setImage={setImage}
-                  setEncodingImage={setEncodingImage}
-                />
-              ) : (
-                <DetailsEditNavbar
-                  objectName={tag.name}
-                  isNew={false}
-                  isEditing={isEditing}
-                  onToggleEdit={() => toggleEditing()}
-                  onSave={() => {}}
-                  onImageChange={() => {}}
-                  onClearImage={() => {}}
-                  onAutoTag={onAutoTag}
-                  autoTagDisabled={tag.ignore_auto_tag}
-                  onDelete={onDelete}
-                  classNames="mb-2"
-                  customButtons={renderMergeButton()}
+                  abbreviateCounter={abbreviateCounter}
+                  showAllCounts={showAllCounts}
                 />
               )}
             </div>
           </div>
         </div>
+        {renderDeleteAlert()}
+        {renderMergeDialog()}
       </div>
-
-      {!isEditing && loadStickyHeader && (
-        <CompressedTagDetailsPanel tag={tag} />
-      )}
-
-      <div className="detail-body">
-        <div className="tag-body">
-          <div className="tag-tabs">
-            {!isEditing && (
-              <TagTabs
-                tabKey={tabKey}
-                tag={tag}
-                abbreviateCounter={abbreviateCounter}
-                showAllCounts={showAllCounts}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-      {renderDeleteAlert()}
-      {renderMergeDialog()}
-    </div>
-  );
-};
+    );
+  }
+);
 
 const TagLoader: React.FC<RouteComponentProps<ITagParams>> = ({
   location,

--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -257,6 +257,7 @@ Returns `void`.
 - `GroupCardGrid`
 - `GroupIDSelect`
 - `GroupList`
+- `GroupPage`
 - `GroupRecommendationRow`
 - `GroupSelect`
 - `GroupSelect.sort`
@@ -343,6 +344,7 @@ Returns `void`.
 - `StudioDetailsPanel`
 - `StudioIDSelect`
 - `StudioList`
+- `StudioPage`
 - `StudioRecommendationRow`
 - `StudioSelect`
 - `StudioSelect.sort`
@@ -358,6 +360,7 @@ Returns `void`.
 - `TagIDSelect`
 - `TagLink`
 - `TagList`
+- `TagPage`
 - `TagRecommendationRow`
 - `TagSelect`
 - `TagSelect.sort`

--- a/ui/v2.5/src/pluginApi.d.ts
+++ b/ui/v2.5/src/pluginApi.d.ts
@@ -693,6 +693,7 @@ declare namespace PluginApi {
     GroupCardGrid: React.FC<any>;
     GroupIDSelect: React.FC<any>;
     GroupList: React.FC<any>;
+    GroupPage: React.FC<any>;
     GroupRecommendationRow: React.FC<any>;
     GroupSelect: React.FC<any>;
     GroupSubGroupsPanel: React.FC<any>;
@@ -769,6 +770,7 @@ declare namespace PluginApi {
     StudioDetailsPanel: React.FC<any>;
     StudioIDSelect: React.FC<any>;
     StudioList: React.FC<any>;
+    StudioPage: React.FC<any>;
     StudioRecommendationRow: React.FC<any>;
     StudioSelect: React.FC<any>;
     SweatDrops: React.FC<any>;
@@ -782,6 +784,7 @@ declare namespace PluginApi {
     TagCardGrid: React.FC<any>;
     TagLink: React.FC<any>;
     TagList: React.FC<any>;
+    TagPage: React.FC<any>;
     TagRecommendationRow: React.FC<any>;
     TagSelect: React.FC<any>;
     TruncatedText: React.FC<any>;


### PR DESCRIPTION
## Summary

Wraps the three remaining detail-page components — `StudioPage`, `TagPage`, `GroupPage` — in `PatchComponent`, so plugins can use `PluginApi.patch.{before,instead,after}` on them. This matches the pattern already used for `PerformerPage` (#5703) and `ScenePage`.

Fixes #6846. Also addresses the corresponding ask in the umbrella #4510. cc @ezgoing269 @DogmaDragon

## Changes

- `Studio.tsx`, `Tag.tsx`, `Group.tsx`: wrap each page component in `PatchComponent("<Name>", ...)`
- `pluginApi.d.ts`: add `StudioPage`, `TagPage`, `GroupPage` to the components type list
- `UIPluginApi.md`: add the three new entries to the patchable components list

The large diff size is from re-indenting the function bodies one level deeper (same as PR #5703 did for `PerformerPage`); the semantic change per file is ~5 lines. `PatchComponent` is a transparent Proxy when no patches are registered, so core behavior is unchanged.
