### PR TITLE
RatingBanner: expose rating value + system as DOM attributes for theming

### DIFF
--- a/ui/v2.5/src/components/Shared/RatingBanner.tsx
+++ b/ui/v2.5/src/components/Shared/RatingBanner.tsx
@@ -32,6 +32,9 @@ export const RatingBanner: React.FC<IProps> = ({ rating }) => {
           ? `rating-banner rating-${convertedRating}`
           : `rating-banner rating-100-${Math.trunc(rating / 5)}`
       }
+      data-rating100={rating}
+      data-rating-system={ratingSystemOptions.type}
+      style={{ "--rating-100": rating } as React.CSSProperties}
     >
       <FormattedMessage id="rating" />: {convertedRating}
     </div>


### PR DESCRIPTION
## Description of the Change

Adds three additive hooks to the `.rating-banner` element in `RatingBanner.tsx` so CSS themes can style ratings directly:

- `data-rating100`: the raw 0-100 integer value (full precision)
- `data-rating-system`: the active rating system (`stars` / `decimal`)
- `--rating-100`: the value as a CSS custom property, for `calc()`-based styling

```diff
     <div
       className={
         isLegacy
           ? `rating-banner rating-${convertedRating}`
           : `rating-banner rating-100-${Math.trunc(rating / 5)}`
       }
+      data-rating100={rating}
+      data-rating-system={ratingSystemOptions.type}
+      style={{ "--rating-100": rating } as React.CSSProperties}
     >
```

Purely additive. The existing `rating-banner`, `rating-100-N`, and `rating-N` class names are untouched, so the current `index.scss` color map and any existing theme styling keep working verbatim. No API/schema change, and no new data fetched, since both `rating` and `ratingSystemOptions.type` are already in the component.

## Reasoning / Motivation

CSS themes currently can't style ratings without reaching into internals. The DOM exposes the value only as a lossy `rating-100-${Math.trunc(rating / 5)}` class (bucketed 0-20, so the real value isn't recoverable), and the active rating system isn't in the DOM at all, since it lives only in React state (`useConfigurationContext`). In half/quarter/tenth star precision the class is the same `rating-100-N` that decimal mode emits, so the element is ambiguous.

As a result, a theme has to make its own `configuration { ui }` GraphQL query just to learn the rating system, cache it, and mirror it onto a `<body>` class. That is a whole side-channel to recover something Stash already knows at render time. These attributes let themes style ratings in pure CSS (for example `[data-rating-system="stars"] .rating-banner { ... }`, or `calc(var(--rating-100) ... )`) and drop that side-channel entirely.

For context, I maintain Refract, a CSS theme for Stash, where this exact workaround (config query + cached body class + classname parsing) is what prompted the proposal. Happy for it to be useful to any theme, not just that one.

This keeps the change to the card badge (`RatingBanner`). The editable `RatingNumber` / `RatingStars` controls could get the same treatment for consistency if that is wanted; happy to extend it, or to adjust any of the naming below.

Open to your preferences: attribute names (`data-rating100` mirrors the GraphQL field, but `data-rating` is also fine), whether the `--rating-100` CSS var is wanted or you would rather keep it to just the two data-attrs, and whether `data-rating-system` should also reflect `starPrecision`. Glad to reshape to match your conventions.

## Screenshots (if appropriate)

No visual change, since these are non-rendering attributes.
