### PR TITLE
New: Add data-action Attributes to Interactive Controls for Theme/Plugin Targeting

### DIFF
--- a/ui/v2.5/src/components/MainNavbar.tsx
+++ b/ui/v2.5/src/components/MainNavbar.tsx
@@ -397,7 +397,7 @@ export const MainNavbar: React.FC = () => {
           {!!newPath && (
             <div className="mr-2">
               <Link to={newPath}>
-                <Button variant="primary">
+                <Button variant="primary" data-action="new">
                   <FormattedMessage id="new" defaultMessage="New" />
                 </Button>
               </Link>

--- a/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/SceneDuplicateChecker.tsx
@@ -938,12 +938,14 @@ export const SceneDuplicateChecker: React.FC = () => {
                         <Button
                           className="edit-button"
                           variant="danger"
+                          data-action="delete"
                           onClick={() => handleDeleteScene(scene)}
                         >
                           <FormattedMessage id="actions.delete" />
                         </Button>
                         <Button
                           className="edit-button"
+                          data-action="merge"
                           onClick={() => onMergeClicked(group, scene)}
                         >
                           <FormattedMessage id="actions.merge" />

--- a/ui/v2.5/src/components/Scenes/SceneDetails/OCounterButton.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/OCounterButton.tsx
@@ -81,7 +81,7 @@ export const OCounterButton: React.FC<IOCounterButtonProps> = (
   };
 
   return (
-    <ButtonGroup className="o-counter">
+    <ButtonGroup className="o-counter" data-action="o-counter">
       {renderButton()}
       {maybeRenderDropdown()}
     </ButtonGroup>

--- a/ui/v2.5/src/components/Shared/CountButton.tsx
+++ b/ui/v2.5/src/components/Shared/CountButton.tsx
@@ -14,6 +14,7 @@ interface ICountButtonProps {
   onValueClicked?: () => void;
   title?: string;
   countTitle?: string;
+  dataAction?: string;
 }
 
 export const CountButton: React.FC<ICountButtonProps> = ({
@@ -23,10 +24,12 @@ export const CountButton: React.FC<ICountButtonProps> = ({
   onValueClicked,
   title,
   countTitle,
+  dataAction,
 }) => {
   return (
     <ButtonGroup
       className={cx("count-button", { "increment-only": !onValueClicked })}
+      data-action={dataAction}
     >
       <Button
         className="minimal count-icon"
@@ -76,6 +79,7 @@ export const OCounterButton: React.FC<CountButtonPropsNoIcon> = (props) => {
       icon={icon}
       title={intl.formatMessage({ id: messageID })}
       countTitle={intl.formatMessage({ id: "actions.view_history" })}
+      dataAction="o-counter"
     />
   );
 };


### PR DESCRIPTION
## Description of the Change

Adds stable `data-action` attributes to a few interactive controls so CSS themes and plugins can target them without matching on localized text or Bootstrap variant classes:

- the o-counter button group (`OCounterButton` in scene details, and the shared `CountButton` used elsewhere): `data-action="o-counter"`
- the `SceneDuplicateChecker` per-row action buttons: `data-action="merge"` and `data-action="delete"`
- the navbar create button (`MainNavbar`): `data-action="new"`

```diff
// Shared/CountButton.tsx (the OCounterButton wrapper; ViewCountButton left untouched)
     <ButtonGroup
       className={cx("count-button", { "increment-only": !onValueClicked })}
+      data-action={dataAction}
     >

// Scenes/SceneDetails/OCounterButton.tsx
-    <ButtonGroup className="o-counter">
+    <ButtonGroup className="o-counter" data-action="o-counter">

// SceneDuplicateChecker/SceneDuplicateChecker.tsx
     <Button className="edit-button" variant="danger" data-action="delete" ... >
     <Button className="edit-button" data-action="merge" ... >

// MainNavbar.tsx
-    <Button variant="primary">
+    <Button variant="primary" data-action="new">
```

Additive only. Existing classes, titles, icons, and behavior are unchanged. The shared `CountButton` gains an optional `dataAction` prop that only `OCounterButton` sets, so `ViewCountButton` (play count) is deliberately not tagged. No API/schema change.

## Reasoning / Motivation

Themes and plugins that want to target these controls currently have to match on localized strings or non-semantic Bootstrap classes. The o-counter button is identified only by its `title` (the `o_count` message); the duplicate-checker Merge/Delete buttons share `className="edit-button"` and differ only by their `FormattedMessage` text; and the navbar create button is just a `variant="primary"` Button with a localized `New` label, so themes resort to brittle selectors like `button.btn-primary:not(.btn-sm)`. None of them has a stable, locale-independent hook today.

That has two problems. First, any theme styling or behavior keyed off these controls silently breaks for non-English users (and, for the New button, breaks whenever a button variant or utility class changes). Second, and more seriously, the duplicate-checker case is destructive: a theme or plugin that matches the Merge/Delete buttons by text can fire the wrong action (merge a scene the user meant to delete, or the reverse) in any locale where the labels differ. A stable `data-action` makes the intent unambiguous regardless of language.

For context, I maintain Refract, a CSS theme for Stash, where these exact problems (matching `button[title="O Count"]`, telling the two duplicate-checker buttons apart, and finding the New button without a stable hook) are what prompted the proposal. It is meant to help any theme or plugin, not just that one.

Open to your preferences on the attribute values (`o-counter` / `merge` / `delete` / `new`), and happy to extend the same pattern to other controls if that is wanted.

## Screenshots (if appropriate)

No visual change, since these are non-rendering attributes.
