### PR TITLE
Fix: Handling UTF-8 BOM in Funscript Parsing

### DIFF
--- a/internal/manager/generator_interactive_heatmap_speed.go
+++ b/internal/manager/generator_interactive_heatmap_speed.go
@@ -48,6 +48,12 @@ type Action struct {
 	Speed float64
 }
 
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+func unmarshalFunscriptData(data []byte, funscript *Script) error {
+	return json.Unmarshal(bytes.TrimPrefix(data, utf8BOM), funscript)
+}
+
 type GradientTable []struct {
 	Col    colorful.Color
 	Pos    float64
@@ -96,7 +102,7 @@ func (g *InteractiveHeatmapSpeedGenerator) LoadFunscriptData(path string, sceneD
 	}
 
 	var funscript Script
-	err = json.Unmarshal(data, &funscript)
+	err = unmarshalFunscriptData(data, &funscript)
 	if err != nil {
 		return Script{}, err
 	}
@@ -370,7 +376,7 @@ func LoadFunscriptData(path string) (Script, error) {
 	}
 
 	var funscript Script
-	err = json.Unmarshal(data, &funscript)
+	err = unmarshalFunscriptData(data, &funscript)
 	if err != nil {
 		return Script{}, err
 	}

--- a/internal/manager/generator_interactive_heatmap_speed_test.go
+++ b/internal/manager/generator_interactive_heatmap_speed_test.go
@@ -1,0 +1,53 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFunscriptDataHandlesUTF8BOM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.funscript")
+	data := append([]byte{0xEF, 0xBB, 0xBF}, []byte(`{"actions":[{"at":100,"pos":40},{"at":50,"pos":20}]}`)...)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		load func() (Script, error)
+	}{
+		{
+			name: "load funscript data",
+			load: func() (Script, error) {
+				return LoadFunscriptData(path)
+			},
+		},
+		{
+			name: "heatmap generator load funscript data",
+			load: func() (Script, error) {
+				return NewInteractiveHeatmapSpeedGenerator(false).LoadFunscriptData(path, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			funscript, err := tt.load()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(funscript.Actions) != 2 {
+				t.Fatalf("expected 2 actions, got %d", len(funscript.Actions))
+			}
+
+			if funscript.Actions[0].At != 50 || funscript.Actions[0].Pos != 20 {
+				t.Errorf("expected first action to be sorted to at=50 pos=20, got at=%v pos=%d", funscript.Actions[0].At, funscript.Actions[0].Pos)
+			}
+			if funscript.Actions[1].At != 100 || funscript.Actions[1].Pos != 40 {
+				t.Errorf("expected second action to be sorted to at=100 pos=40, got at=%v pos=%d", funscript.Actions[1].At, funscript.Actions[1].Pos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes funscript parsing when a `.funscript` file is encoded as UTF-8 with BOM.

Go's JSON decoder rejects a leading BOM before the opening `{`, causing heatmap generation to fail with:

`invalid character 'ï' looking for beginning of value`

This trims a leading UTF-8 BOM at the funscript JSON unmarshalling boundary and applies the same behavior to both heatmap generation and funscript CSV conversion.

## Changes

- Added shared funscript unmarshalling helper that trims a UTF-8 BOM before `json.Unmarshal`
- Updated both funscript load paths to use the helper
- Added coverage for BOM-prefixed funscript files

## Testing

- `mingw32-make fmt`
- `go test ./internal/manager`
- `golangci-lint run`
- Tested on both working UTF8 and previously erroring UTF8BOM funscripts to confirm that heatmap generation still works as expected.

## Notes

As with my last PR, I used Codex to help investigate, review my code/check for go specific issues, and also write the test file.