### PR TITLE
Fix: API Context Key Constants

### DIFF
--- a/internal/api/context_keys.go
+++ b/internal/api/context_keys.go
@@ -5,7 +5,7 @@ package api
 type key int
 
 const (
-	galleryKey key = 0
+	galleryKey key = iota
 	performerKey
 	sceneKey
 	studioKey


### PR DESCRIPTION
## Summary

Fixes API route context key constants so each key has a unique value.

The previous constant block assigned `galleryKey key = 0` and omitted expressions for the remaining constants. In Go, omitted constant expressions repeat the previous expression, so all of these context keys resolved to `0`.

Using `iota` gives each route context key a distinct value and prevents context value collisions between unrelated route middleware.

While I am not aware of this causing any issues in live, I found and fixed this while making a secondary file playback feature and I do not believe there is any legitimate reason to leave it as is.

## Testing

- `gofmt -w internal/api/context_keys.go`
- `go test ./internal/api/...`
- `go test ./internal/...`
- `golangci-lint run`
- Performed a search through the uses of the keys and did not find any hardcoded numeric values so it shouldn't break anything.
