### PR TITLE
Fix parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ flags-static-windows:
 .PHONY: build-info
 build-info:
 ifndef BUILD_DATE
-	$(eval BUILD_DATE := $(shell go run scripts/getDate.go))
+	$(eval BUILD_DATE := $(shell GOOS=$$(go env GOHOSTOS) GOARCH=$$(go env GOHOSTARCH) go run scripts/getDate.go))
 endif
 ifndef GITHASH
 	$(eval GITHASH := $(shell git rev-parse --short HEAD))

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,14 @@ ifndef COMPILER_IMAGE
   COMPILER_IMAGE := ghcr.io/stashapp/compiler:latest
 endif
 
+# cannot really parallelise the release target
+# generate requires pre-ui, ui requires generate and build-release requires ui, so they must be run sequentially
 .PHONY: release
-release: pre-ui generate ui build-release
+release: 
+	$(MAKE) pre-ui
+	$(MAKE) generate
+	$(MAKE) ui
+	$(MAKE) build-release
 
 # targets to set various build flags
 # use combinations on the make command-line to configure a build, e.g.:
@@ -119,7 +125,7 @@ build-flags: build-info
 	$(eval BUILD_FLAGS := -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(BUILD_LDFLAGS)")
 
 .PHONY: stash
-stash: build-flags | generate ui
+stash: build-flags
 	go build $(STASH_OUTPUT) $(BUILD_FLAGS) ./cmd/stash
 
 .PHONY: phasher
@@ -281,7 +287,7 @@ endif
 generate: generate-backend generate-ui
 
 .PHONY: generate-ui
-generate-ui: | pre-ui
+generate-ui:
 	cd ui/v2.5 && pnpm run gqlgen
 
 .PHONY: generate-backend
@@ -372,7 +378,7 @@ endif
 ui: ui-only generate-login-locale
 
 .PHONY: ui-only
-ui-only: ui-env | pre-ui generate
+ui-only: ui-env
 	cd ui/v2.5 && pnpm run build
 
 .PHONY: zip-ui
@@ -390,7 +396,7 @@ fmt-ui:
 
 # runs all of the frontend PR-acceptance steps
 .PHONY: validate-ui
-validate-ui: | pre-ui generate
+validate-ui:
 	cd ui/v2.5 && pnpm run validate
 
 # these targets run the same steps as fmt-ui and validate-ui, but only on files that have changed
@@ -443,7 +449,7 @@ remove-compiler-container:
 	docker rm -f -v build
 
 .PHONY: install
-install: | build-release
+install:
 ifdef IS_WIN_SHELL
 	@if not exist "$(PREFIX)" mkdir $(PREFIX)
 	@copy "dist\\stash-win.exe" "$(PREFIX)\\stash-win.exe"

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-flags: build-info
 	$(eval BUILD_FLAGS := -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(BUILD_LDFLAGS)")
 
 .PHONY: stash
-stash: build-flags
+stash: build-flags | generate ui
 	go build $(STASH_OUTPUT) $(BUILD_FLAGS) ./cmd/stash
 
 .PHONY: phasher
@@ -281,8 +281,8 @@ endif
 generate: generate-backend generate-ui
 
 .PHONY: generate-ui
-generate-ui: pre-ui
-	cd ui/v2.5 && npm run gqlgen
+generate-ui: | pre-ui
+	cd ui/v2.5 && pnpm run gqlgen
 
 .PHONY: generate-backend
 generate-backend: touch-ui
@@ -369,11 +369,11 @@ ifdef STASH_SOURCEMAPS
 endif
 
 .PHONY: ui
-ui: pre-ui generate ui-only generate-login-locale
+ui: ui-only generate-login-locale
 
 .PHONY: ui-only
-ui-only: ui-env generate ui
-	cd ui/v2.5 && npm run build
+ui-only: ui-env | pre-ui generate
+	cd ui/v2.5 && pnpm run build
 
 .PHONY: zip-ui
 zip-ui:
@@ -382,23 +382,23 @@ zip-ui:
 
 .PHONY: ui-start
 ui-start: ui-env
-	cd ui/v2.5 && npm run start -- --host
+	cd ui/v2.5 && pnpm run start -- --host
 
 .PHONY: fmt-ui
 fmt-ui:
-	cd ui/v2.5 && npm run format
+	cd ui/v2.5 && pnpm run format
 
 # runs all of the frontend PR-acceptance steps
 .PHONY: validate-ui
-validate-ui: pre-ui generate
-	cd ui/v2.5 && npm run validate
+validate-ui: | pre-ui generate
+	cd ui/v2.5 && pnpm run validate
 
 # these targets run the same steps as fmt-ui and validate-ui, but only on files that have changed
 fmt-ui-quick:
 	cd ui/v2.5 && \
 	files=$$(git diff --name-only --relative --diff-filter d . ../../graphql); \
 	if [ -n "$$files" ]; then \
-	  npm run prettier -- --write $$files; \
+	  pnpm run prettier -- --write $$files; \
 	fi
 
 # does not run tsc checks, as they are slow
@@ -407,9 +407,9 @@ validate-ui-quick:
 	tsfiles=$$(git diff --name-only --relative --diff-filter d src | grep -e "\.tsx\?\$$"); \
 	scssfiles=$$(git diff --name-only --relative --diff-filter d src | grep "\.scss"); \
 	prettyfiles=$$(git diff --name-only --relative --diff-filter d . ../../graphql); \
-	if [ -n "$$tsfiles" ]; then npm run eslint -- $$tsfiles; fi && \
-	if [ -n "$$scssfiles" ]; then npm run stylelint -- $$scssfiles; fi && \
-	if [ -n "$$prettyfiles" ]; then npm run prettier -- --check $$prettyfiles; fi
+	if [ -n "$$tsfiles" ]; then pnpm run eslint -- $$tsfiles; fi && \
+	if [ -n "$$scssfiles" ]; then pnpm run stylelint -- $$scssfiles; fi && \
+	if [ -n "$$prettyfiles" ]; then pnpm run prettier -- --check $$prettyfiles; fi
 
 # runs all of the backend PR-acceptance steps
 .PHONY: validate-backend

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ remove-compiler-container:
 	docker rm -f -v build
 
 .PHONY: install
-install: build-release
+install: | build-release
 ifdef IS_WIN_SHELL
 	@if not exist "$(PREFIX)" mkdir $(PREFIX)
 	@copy "dist\\stash-win.exe" "$(PREFIX)\\stash-win.exe"

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/anacrolix/missinggo v1.1.0/go.mod h1:MBJu3Sk/k3ZfGYcS7z18gwfu72Ey/xop
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
-github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -176,8 +174,6 @@ github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8
 github.com/doug-martin/goqu/v9 v9.18.0 h1:/6bcuEtAe6nsSMVK/M+fOiXUNfyFF3yYtE07DBPFMYY=
 github.com/doug-martin/goqu/v9 v9.18.0/go.mod h1:nf0Wc2/hV3gYK9LiyqIrzBEVGlI8qW3GuDCEobC4wBQ=
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/enetx/g v1.0.223 h1:9J8y76uiBLvNlMDyaLyCBUWELKNaHsRST+93Zxm2+No=
-github.com/enetx/g v1.0.223/go.mod h1:dxOHnNkhdZkwwOvgbJKcniq187TqyLO3DuTJpmk1tLQ=
 github.com/enetx/g v1.0.224 h1:H/uonguFE4qG8YCn5bSpZX5Wh+wTSb+jgf3I2ZM25XM=
 github.com/enetx/g v1.0.224/go.mod h1:lxhby3LjP8jOTGbxJ/PCd+2Zq1gYiSBbtL/llPhAg5c=
 github.com/enetx/http v1.0.28 h1:IaNSSDFlAVVdHnYhNIR9wAN7GY4TWL/kkvYC3jOaueY=
@@ -188,8 +184,6 @@ github.com/enetx/http3 v1.0.7 h1:daFhveKBtv8rRallCjaHErzzSHIrq07ovoSvVkvhcMM=
 github.com/enetx/http3 v1.0.7/go.mod h1:sqpVGZ9F1/wCiW6sjBUS2errKAh3SUYn6VlWE7LL6KM=
 github.com/enetx/iter v0.0.0-20250912135656-f1583323588f h1:GUW+4AWfECIEJ9oAxgEAVGCpaozMCjRiUYnuR6Q0bCQ=
 github.com/enetx/iter v0.0.0-20250912135656-f1583323588f/go.mod h1:oMZN8hGLUpi7QBlMEUqailocNy0NFAO/7Lu+Nwh9HMM=
-github.com/enetx/surf v1.0.198 h1:TJkyEyy5M+GnLZlGKmByeXwG7K2vv7F5L+0SgwlDu7g=
-github.com/enetx/surf v1.0.198/go.mod h1:BtLmZDYAny66azybFr9UdFVnwy8WRV4FTAzElsd7bvE=
 github.com/enetx/surf v1.0.199 h1:RtqcwlyLM8O4U+43laNnNJwx5hALkH5cJRxDX1F2VjM=
 github.com/enetx/surf v1.0.199/go.mod h1:c6g53gi273RBiZFO4THWIqpn5n9RLC6vw5WpUwHrT4U=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Follow up to #6877.

~~Replaces a number of prerequisites with order-only prerequisites, since running many of the phony targets was running a lot of targets unnecessarily (ie building `ui` target would always run `pre-ui` and `generate` targets, even when not necessary).~~ 

Order-only prerequisites are in fact still built; a misunderstanding on my part. I've instead replaced the `release` target prequisites with an orchestrated recipe that builds the prerequisites sequentially since they can't really be separated or built in parallel.

Specifically:
- `build-release` requires `generate` and `ui` to be built
- `ui` requires `pre-ui` and `generate`
- `generate` requires `pre-ui`

There's just not much parallelism to be had between the targets.

Tested by running `make -j 4 release`.

Also fixed a latent bug in the builds that was causing the timestamp to not be generated when cross-compiling for targets other than linux. The presence of the `GOOS` and `GOARCH` environment variables were causing `go run scripts/getDate.go` to fail. Fixed by adding `GOOS=$$(go env GOHOSTOS) GOARCH=$$(go env GOHOSTARCH)` before the `go run` invokation.

Also includes an update to `go.sum`.

Supercedes #6893. Resolves #5674.