### PR TITLE
chore: bunch of security fixes

### DIFF
--- a/pkg/scraper/url.go
+++ b/pkg/scraper/url.go
@@ -27,6 +27,8 @@ import (
 
 const scrapeDefaultSleep = time.Second * 2
 
+var proxyAuthRE = regexp.MustCompile(`^(https?:\/\/)(([\P{Cc}]+):([\P{Cc}]+)@)?(([a-zA-Z0-9][a-zA-Z0-9.-]*)(:[0-9]{1,5})?)`)
+
 func loadURL(ctx context.Context, loadURL string, client *http.Client, def Definition, globalConfig GlobalConfig) (io.Reader, error) {
 	driverOptions := def.DriverOptions
 	if driverOptions != nil {
@@ -376,8 +378,7 @@ func proxyUsesAuth(proxyUrl string) bool {
 	if proxyUrl == "" {
 		return false
 	}
-	reg := regexp.MustCompile(`^(https?:\/\/)(([\P{Cc}]+):([\P{Cc}]+)@)?(([a-zA-Z0-9][a-zA-Z0-9.-]*)(:[0-9]{1,5})?)`)
-	matches := reg.FindAllStringSubmatch(proxyUrl, -1)
+	matches := proxyAuthRE.FindAllStringSubmatch(proxyUrl, -1)
 	if matches != nil {
 		split := matches[0]
 		return len(split) == 0 || (len(split) > 5 && split[3] != "")
@@ -390,8 +391,7 @@ func splitProxyAuth(proxyUrl string) (string, string, string) {
 	if proxyUrl == "" {
 		return "", "", ""
 	}
-	reg := regexp.MustCompile(`^(https?:\/\/)(([\P{Cc}]+):([\P{Cc}]+)@)?(([a-zA-Z0-9][a-zA-Z0-9.-]*)(:[0-9]{1,5})?)`)
-	matches := reg.FindAllStringSubmatch(proxyUrl, -1)
+	matches := proxyAuthRE.FindAllStringSubmatch(proxyUrl, -1)
 
 	if matches != nil && len(matches[0]) > 5 {
 		split := matches[0]

--- a/pkg/scraper/xpath.go
+++ b/pkg/scraper/xpath.go
@@ -276,6 +276,11 @@ func (s *xpathScraper) getXPathQuery(doc *html.Node, url string) *xpathQuery {
 	}
 }
 
+var (
+	multiSpaceRE = regexp.MustCompile("  +")
+	newlineRE    = regexp.MustCompile("\n")
+)
+
 type xpathQuery struct {
 	doc       *html.Node
 	scraper   *xpathScraper
@@ -325,12 +330,10 @@ func (q *xpathQuery) nodeText(n *html.Node) string {
 	ret = strings.TrimSpace(ret)
 
 	// remove multiple whitespace
-	re := regexp.MustCompile("  +")
-	ret = re.ReplaceAllString(ret, " ")
+	ret = multiSpaceRE.ReplaceAllString(ret, " ")
 
 	// TODO - make this optional
-	re = regexp.MustCompile("\n")
-	ret = re.ReplaceAllString(ret, "")
+	ret = newlineRE.ReplaceAllString(ret, "")
 
 	return ret
 }

--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -1087,15 +1087,17 @@ func (h *stashIDCriterionHandler) handle(ctx context.Context, f *filterBuilder) 
 	}
 
 	joinClause := fmt.Sprintf("%s.%s = %s", t, stashIDRepo.idColumn, h.parentIDCol)
+	var args []interface{}
 	if h.c.Endpoint != nil && *h.c.Endpoint != "" {
-		joinClause += fmt.Sprintf(" AND %s.endpoint = '%s'", t, *h.c.Endpoint)
+		joinClause += fmt.Sprintf(" AND %s.endpoint = ?", t)
+		args = append(args, *h.c.Endpoint)
 	}
 
 	joinType := joinTypeInner
 	if h.c.Modifier == models.CriterionModifierIsNull || h.c.Modifier == models.CriterionModifierNotMatchesRegex {
 		joinType = joinTypeLeft
 	}
-	f.addJoin(joinType, stashIDRepo.tableName, h.stashIDTableAs, joinClause)
+	f.addJoin(joinType, stashIDRepo.tableName, h.stashIDTableAs, joinClause, args...)
 
 	v := ""
 	if h.c.StashID != nil {
@@ -1127,8 +1129,10 @@ func (h *stashIDsCriterionHandler) handle(ctx context.Context, f *filterBuilder)
 	}
 
 	joinClause := fmt.Sprintf("%s.%s = %s", t, stashIDRepo.idColumn, h.parentIDCol)
+	var args []interface{}
 	if h.c.Endpoint != nil && *h.c.Endpoint != "" {
-		joinClause += fmt.Sprintf(" AND %s.endpoint = '%s'", t, *h.c.Endpoint)
+		joinClause += fmt.Sprintf(" AND %s.endpoint = ?", t)
+		args = append(args, *h.c.Endpoint)
 	}
 
 	joinType := joinTypeInner
@@ -1136,7 +1140,7 @@ func (h *stashIDsCriterionHandler) handle(ctx context.Context, f *filterBuilder)
 		joinType = joinTypeLeft
 	}
 
-	f.addJoin(joinType, stashIDRepo.tableName, h.stashIDTableAs, joinClause)
+	f.addJoin(joinType, stashIDRepo.tableName, h.stashIDTableAs, joinClause, args...)
 
 	switch h.c.Modifier {
 	case models.CriterionModifierIsNull:

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -17,6 +17,8 @@ const imageGetTimeout = time.Second * 60
 
 const base64RE = `^data:.+\/(.+);base64,(.*)$`
 
+var base64Regex = regexp.MustCompile(base64RE)
+
 // ProcessImageInput transforms an image string either from a base64 encoded
 // string, or from a URL, and returns the image as a byte slice
 func ProcessImageInput(ctx context.Context, imageInput string) ([]byte, error) {
@@ -24,8 +26,7 @@ func ProcessImageInput(ctx context.Context, imageInput string) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	regex := regexp.MustCompile(base64RE)
-	if regex.MatchString(imageInput) {
+	if base64Regex.MatchString(imageInput) {
 		d, err := ProcessBase64Image(imageInput)
 		return d, err
 	}
@@ -84,11 +85,10 @@ func ProcessBase64Image(imageString string) ([]byte, error) {
 		return nil, fmt.Errorf("empty image string")
 	}
 
-	regex := regexp.MustCompile(base64RE)
-	matches := regex.FindStringSubmatch(imageString)
+	matches := base64Regex.FindStringSubmatch(imageString)
 	var encodedString string
 	if len(matches) > 2 {
-		encodedString = regex.FindStringSubmatch(imageString)[2]
+		encodedString = matches[2]
 	} else {
 		encodedString = imageString
 	}


### PR DESCRIPTION
- SQL injection fix: Parameterize stash-box endpoint values in stashIDCriterionHandler and stashIDsCriterionHandler to prevent SQL injection via crafted endpoint strings.
- Regex hoisting: Move regexp.MustCompile calls to package level in xpath.go, url.go, and image.go to avoid recompilation on every call.