### PR TITLE
Use file checksum for image URL cache-busting

### DIFF
--- a/internal/api/urlbuilders/image.go
+++ b/internal/api/urlbuilders/image.go
@@ -24,17 +24,30 @@ func NewImageURLBuilder(baseURL string, image *models.Image) ImageURLBuilder {
 	}
 }
 
+// cacheBuster returns the value used to bust client-side caches. The image
+// content is immutable for a given file, so the checksum of the primary file
+// is preferred: this keeps the URL stable across metadata edits (rating,
+// o-counter, tags, etc.) so the browser can reuse its cached copy. When no
+// primary file is present the checksum is empty, in which case we fall back to
+// the updated timestamp.
+func (b ImageURLBuilder) cacheBuster() string {
+	if b.Checksum != "" {
+		return b.Checksum
+	}
+	return b.UpdatedAt
+}
+
 func (b ImageURLBuilder) GetImageURL() string {
-	return b.BaseURL + "/image/" + b.ImageID + "/image?t=" + b.UpdatedAt
+	return b.BaseURL + "/image/" + b.ImageID + "/image?t=" + b.cacheBuster()
 }
 
 func (b ImageURLBuilder) GetThumbnailURL() string {
-	return b.BaseURL + "/image/" + b.ImageID + "/thumbnail?t=" + b.UpdatedAt
+	return b.BaseURL + "/image/" + b.ImageID + "/thumbnail?t=" + b.cacheBuster()
 }
 
 func (b ImageURLBuilder) GetPreviewURL() string {
 	if exists, err := fsutil.FileExists(manager.GetInstance().Paths.Generated.GetClipPreviewPath(b.Checksum, models.DefaultGthumbWidth)); exists && err == nil {
-		return b.BaseURL + "/image/" + b.ImageID + "/preview?" + b.UpdatedAt
+		return b.BaseURL + "/image/" + b.ImageID + "/preview?t=" + b.cacheBuster()
 	} else {
 		return ""
 	}

--- a/internal/api/urlbuilders/image_test.go
+++ b/internal/api/urlbuilders/image_test.go
@@ -1,0 +1,106 @@
+package urlbuilders
+
+import "testing"
+
+func TestImageURLBuilder_cacheBuster(t *testing.T) {
+	tests := []struct {
+		name      string
+		checksum  string
+		updatedAt string
+		want      string
+	}{
+		{
+			name:      "prefers checksum when present",
+			checksum:  "abc123",
+			updatedAt: "1700000000",
+			want:      "abc123",
+		},
+		{
+			name:      "falls back to updatedAt when checksum is empty",
+			checksum:  "",
+			updatedAt: "1700000000",
+			want:      "1700000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := ImageURLBuilder{Checksum: tt.checksum, UpdatedAt: tt.updatedAt}
+			if got := b.cacheBuster(); got != tt.want {
+				t.Errorf("cacheBuster() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImageURLBuilder_GetImageURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		checksum  string
+		updatedAt string
+		want      string
+	}{
+		{
+			name:      "uses checksum so the URL is stable across metadata edits",
+			checksum:  "abc123",
+			updatedAt: "1700000000",
+			want:      "http://localhost:9999/image/42/image?t=abc123",
+		},
+		{
+			name:      "falls back to updatedAt when there is no primary file",
+			checksum:  "",
+			updatedAt: "1700000000",
+			want:      "http://localhost:9999/image/42/image?t=1700000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := ImageURLBuilder{
+				BaseURL:   "http://localhost:9999",
+				ImageID:   "42",
+				Checksum:  tt.checksum,
+				UpdatedAt: tt.updatedAt,
+			}
+			if got := b.GetImageURL(); got != tt.want {
+				t.Errorf("GetImageURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImageURLBuilder_GetThumbnailURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		checksum  string
+		updatedAt string
+		want      string
+	}{
+		{
+			name:      "uses checksum so the URL is stable across metadata edits",
+			checksum:  "abc123",
+			updatedAt: "1700000000",
+			want:      "http://localhost:9999/image/42/thumbnail?t=abc123",
+		},
+		{
+			name:      "falls back to updatedAt when there is no primary file",
+			checksum:  "",
+			updatedAt: "1700000000",
+			want:      "http://localhost:9999/image/42/thumbnail?t=1700000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := ImageURLBuilder{
+				BaseURL:   "http://localhost:9999",
+				ImageID:   "42",
+				Checksum:  tt.checksum,
+				UpdatedAt: tt.updatedAt,
+			}
+			if got := b.GetThumbnailURL(); got != tt.want {
+				t.Errorf("GetThumbnailURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Image URLs (`paths.image`, `paths.thumbnail`, `paths.preview`) append a cache-buster derived from the image's `updated_at`. That value bumps on *any* metadata edit — rating, o-counter, organized, tags — none of which change the image bytes. Because the URL changes, the browser re-downloads the identical image. It's most visible in the gallery lightbox: setting a rating makes the current image visibly reload/flicker (the carousel also uses the path as its React `key`, so the element remounts), but it affects image/thumbnail caching everywhere (grids, detail pages, wall view).

This changes the cache-buster to use the primary file's checksum instead, so the URL is stable across metadata edits and only changes when the file content changes — preserving the original anti-stale intent of the timestamp suffix. When an image has no primary file the checksum is empty, in which case it falls back to `updated_at`.

Scenes and galleries are intentionally left on `updated_at`: their thumbnails can change without the underlying content changing (e.g. reassigning a gallery cover), so a content-based key would be wrong for them. They use separate URL builders, so this change is scoped to images only.

## Related Issue

Discussed and agreed approach in #6975 (@WithoutPants  confirmed checksum-based cache-busting is fine for images, and flagged the scenes/galleries distinction that this PR respects).

## Testing

- Added unit tests for the image URL builder (`internal/api/urlbuilders/image_test.go`) covering: checksum present, empty-checksum fallback to `updated_at`, and the full URL shape for `GetImageURL`/`GetThumbnailURL`.
- Built the full app (UI + backend) and verified against a real library:
  - Image URL is now `/image/1/image?t=<md5 checksum>` instead of a timestamp.
  - Setting a rating bumps `updated_at` but the image/thumbnail URL stays byte-for-byte
    identical, so the browser keeps its cached copy and the image no longer reloads.
  - The image/thumbnail endpoints still serve correctly (the server ignores the `?t=`
    value; it is purely a client cache key).

Note: image thumbnail/preview *regeneration* never bumped `image.updated_at` (the generate tasks only write the file to disk; unlike the scene screenshot/heatmap tasks they don't call `UpdatePartial`), so a force-regenerated preview already served from the client cache before this change. This PR preserves that existing behavior rather
than introducing a regression.

## Screenshots

<!-- N/A — no visual changes; the fix removes an unnecessary network refetch. -->

## Checklist

- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure

- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

I used Claude (Anthropic) as an assistant during this work: to help trace the call paths in the codebase, to draft this description, and to run the verification steps above. I reviewed the change, understand every line, and can explain and defend the design decisions in review. The manual testing described above was performed and confirmed against a real library.

## Additional Context

Possible follow-up (not in this PR): the lightbox carousel keys items by `image.paths.image`. With this fix the path is stable across edits so it no longer churns, but `key={image.id}` would be more semantically correct. Happy to do it here or as a separate change if preferred.
