### PR TITLE
Fix: Recreate Zip-based Galleries on Scan When Deleted but File Unchanged.

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -381,9 +381,11 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	// handle rename should have already handled the contents of the zip file
 	// so shouldn't need to scan it again.
 	// Only scan zip contents if the file is new, the fingerprint changed,
-	// or if a force rescan was requested.
+	// if a force rescan was requested, or if the handler was required because
+	// a related object (e.g. a deleted gallery) is missing and needs to be
+	// recreated from the contents.
 
-	if j.scanner.IsZipFile(f.Info.Name()) && (r.New || r.FingerprintChanged || j.scanner.Rescan) {
+	if j.scanner.IsZipFile(f.Info.Name()) && (r.New || r.FingerprintChanged || j.scanner.Rescan || r.HandlerRequired) {
 		ff := r.File
 		f.BaseFile = ff.Base()
 

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -348,6 +348,7 @@ type ScanFileResult struct {
 	Renamed            bool
 	Updated            bool
 	FingerprintChanged bool
+	HandlerRequired    bool
 }
 
 func (r ScanFileResult) IsUnchanged() bool {
@@ -911,7 +912,8 @@ func (s *Scanner) onUnchangedFile(ctx context.Context, f ScannedFile, existing m
 	// if this file is a zip file, then we need to rescan the contents
 	// as well. We do this by indicating that the file is updated.
 	return &ScanFileResult{
-		File:    existing,
-		Updated: true,
+		File:            existing,
+		Updated:         true,
+		HandlerRequired: true,
 	}, nil
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
A regression in #6633 prevented zip-based galleries from being recreated on a normal scan after they'd been deleted as long as the zip file was unchanged. Deleting the gallery removes the records of the images inside the zip but leaves the zip's file record, so on the next scan the file looks unchanged and the contents were never re-read meaning the gallery couldn't be rebuilt. 

## Related Issue
<!-- Please link the issue your pull request is referring to. -->
 fixes: https://github.com/stashapp/stash/issues/6983


## Testing
<!-- Describe the testing steps you have performed. -->
Reproduced the bug on dev env
With fix installed, redid the steps in the bug report linked above
Gallery was recreated as expected with Rescan files disabled.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->
No UI changes


## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [X] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
No AI.


## Additional Context
<!-- Add any other context about the pull request here. -->

