### PR TITLE
New: Support JXL Images in Zips

### DIFF
--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -315,7 +315,7 @@ const (
 // slice default values
 var (
 	defaultVideoExtensions   = []string{"m4v", "mp4", "mov", "wmv", "avi", "mpg", "mpeg", "rmvb", "rm", "flv", "asf", "mkv", "webm", "f4v"}
-	defaultImageExtensions   = []string{"png", "jpg", "jpeg", "gif", "webp", "avif"}
+	defaultImageExtensions   = []string{"png", "jpg", "jpeg", "gif", "webp", "avif", "jxl"}
 	defaultGalleryExtensions = []string{"zip", "cbz"}
 	defaultMenuItems         = []string{"scenes", "images", "groups", "markers", "galleries", "performers", "studios", "tags"}
 )

--- a/pkg/file/image/scan.go
+++ b/pkg/file/image/scan.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -33,10 +35,18 @@ func (d *Decorator) Decorate(ctx context.Context, fs models.FS, f models.File) (
 	// ignore clips in non-OsFS filesystems as ffprobe cannot read them
 	// TODO - copy to temp file if not an OsFS
 	if _, isOs := fs.(*file.OsFS); !isOs {
+		ext := strings.ToLower(filepath.Ext(base.Path))
+
 		// AVIF images inside zip files are not supported
-		if strings.ToLower(filepath.Ext(base.Path)) == ".avif" {
+		if ext == ".avif" {
 			return nil, fmt.Errorf("%w: %s", ErrUnsupportedAVIFInZip, base.Path)
 		}
+
+		// Go cannot decode JXL from a stream, so extract to a temp file and probe by path
+		if ext == ".jxl" {
+			return d.decorateViaTempFile(fs, f)
+		}
+
 		logger.Debugf("assuming ImageFile for non-OsFS file %q", base.Path)
 		return decorateFallback(fs, f)
 	}
@@ -133,6 +143,46 @@ func decorateFallback(fs models.FS, f models.File) (models.File, error) {
 	}
 
 	adjustForOrientation(fs, path, ret)
+
+	return ret, nil
+}
+
+// decorateViaTempFile extracts a non-OsFS file (e.g. inside a zip) to a temp file so ffprobe can read it by path, for formats like JXL that ffprobe reads but Go cannot decode from a stream.
+func (d *Decorator) decorateViaTempFile(fs models.FS, f models.File) (models.File, error) {
+	base := f.Base()
+
+	r, err := fs.Open(base.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	// preserve the extension so ffprobe can detect the format
+	tmp, err := os.CreateTemp("", "stash-image-*"+filepath.Ext(base.Path))
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := io.Copy(tmp, r); err != nil {
+		tmp.Close()
+		return nil, err
+	}
+	tmp.Close()
+
+	probe, err := d.FFProbe.NewVideoFile(tmp.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &models.ImageFile{
+		BaseFile: base,
+		Format:   probe.VideoCodec,
+		Width:    probe.Width,
+		Height:   probe.Height,
+	}
+
+	adjustForOrientation(fs, base.Path, ret)
 
 	return ret, nil
 }

--- a/ui/v2.5/src/docs/en/Manual/Images.md
+++ b/ui/v2.5/src/docs/en/Manual/Images.md
@@ -13,6 +13,8 @@ For best results, images in zip file should be stored without compression (copy,
 
 > **⚠️ Note:** AVIF files in ZIP archives are currently unsupported.
 
+> **ℹ️ Note:** JPEG XL (`.jxl`) is supported, including inside ZIP archives. Decoding JXL requires **FFmpeg 7.0 or later** (or an FFmpeg build compiled with `libjxl`); alternatively, [libvips](https://www.libvips.org/) with JXL support can be used. If you rely on the FFmpeg that stash downloads automatically, you may need to provide your own newer build. Perceptual hashes are not generated for JXL files stored inside ZIP archives.
+
 If a filename of an image in the gallery zip file ends with `cover.jpg`, it will be treated like a cover and presented first in the gallery view page and as a gallery cover in the gallery list view. If more than one images match the name the first one found in natural sort order is selected.
 
 You can also manually select any image from a gallery as its cover. On the gallery details page, select the desired cover image, and then select **Set as Cover** in the ⋯ menu.

--- a/ui/v2.5/src/docs/en/Manual/Images.md
+++ b/ui/v2.5/src/docs/en/Manual/Images.md
@@ -13,7 +13,7 @@ For best results, images in zip file should be stored without compression (copy,
 
 > **⚠️ Note:** AVIF files in ZIP archives are currently unsupported.
 
-> **ℹ️ Note:** JPEG XL (`.jxl`) is supported, including inside ZIP archives. Decoding JXL requires **FFmpeg 7.0 or later** (or an FFmpeg build compiled with `libjxl`); alternatively, [libvips](https://www.libvips.org/) with JXL support can be used. If you rely on the FFmpeg that stash downloads automatically, you may need to provide your own newer build. Perceptual hashes are not generated for JXL files stored inside ZIP archives.
+> **ℹ️ Note:** JPEG XL (`.jxl`) is supported, including inside ZIP archives, and requires an FFmpeg built with `libjxl` (or [libvips](https://www.libvips.org/)). Perceptual hashes are not generated for JXL inside ZIP archives.
 
 If a filename of an image in the gallery zip file ends with `cover.jpg`, it will be treated like a cover and presented first in the gallery view page and as a gallery cover in the gallery list view. If more than one images match the name the first one found in natural sort order is selected.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds support for scanning/viewing JXL images that are inside of zips


## Related Issue
<!-- Please link the issue your pull request is referring to. -->
fixes: https://github.com/stashapp/stash/issues/6958


## Testing
<!-- Describe the testing steps you have performed. -->

Created several zips with different JXLs and scanned them in and they populated as expected.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->
No UI


## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [X] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [X] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
AI was used to help generate and test various JXL images. It was also used to help research various JXL support questions for FFMPEG and VIPS. 


## Additional Context
<!-- Add any other context about the pull request here. -->

