### PR TITLE
Fix: Size Summary Should Represent All Files

### DIFF
--- a/pkg/sqlite/image.go
+++ b/pkg/sqlite/image.go
@@ -950,6 +950,11 @@ func (qb *ImageStore) queryGroupedFields(ctx context.Context, options models.Ima
 		aggregateQuery.addColumn("SUM(temp.size) as size")
 	}
 
+	// #5503 - select the file id so equal-sized/megapixel files aren't collapsed by DISTINCT
+	if options.Megapixels || options.TotalSize {
+		query.addColumn(imagesFilesTable + ".file_id")
+	}
+
 	const includeSortPagination = false
 	aggregateQuery.from = fmt.Sprintf("(%s) as temp", query.toSQL(includeSortPagination))
 

--- a/pkg/sqlite/image_test.go
+++ b/pkg/sqlite/image_test.go
@@ -1630,6 +1630,67 @@ func queryImagesWithCount(ctx context.Context, sqb models.ImageReader, imageFilt
 	return images, result.Count, nil
 }
 
+// #5503 - total size/megapixels must include secondary files of equal size/dimensions
+func TestImageQueryTotalSizeMultipleFiles(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		iqb := db.Image
+		fqb := db.File
+
+		const fileSize = int64(1234)
+		const fileWidth = 1000
+		const fileHeight = 1000
+
+		makeFile := func(basename string) models.FileID {
+			f := &models.ImageFile{
+				BaseFile: &models.BaseFile{
+					Path:           getFilePath(folderIdxWithImageFiles, basename),
+					Basename:       basename,
+					ParentFolderID: folderIDs[folderIdxWithImageFiles],
+					Size:           fileSize,
+				},
+				Width:  fileWidth,
+				Height: fileHeight,
+			}
+			if err := fqb.Create(ctx, f); err != nil {
+				t.Fatalf("creating file: %v", err)
+			}
+			return f.ID
+		}
+
+		f1 := makeFile("multifile-image-1.jpg")
+		f2 := makeFile("multifile-image-2.jpg")
+
+		image := &models.Image{Title: "multifile image"}
+		if err := iqb.Create(ctx, &models.CreateImageInput{
+			Image:   image,
+			FileIDs: []models.FileID{f1, f2},
+		}); err != nil {
+			t.Fatalf("creating image: %v", err)
+		}
+
+		result, err := iqb.Query(ctx, models.ImageQueryOptions{
+			QueryOptions: models.QueryOptions{Count: true},
+			ImageFilter: &models.ImageFilterType{
+				ID: &models.IntCriterionInput{
+					Modifier: models.CriterionModifierEquals,
+					Value:    image.ID,
+				},
+			},
+			Megapixels: true,
+			TotalSize:  true,
+		})
+		if err != nil {
+			t.Fatalf("querying image: %v", err)
+		}
+
+		assert.Equal(t, 1, result.Count)
+		assert.Equal(t, float64(fileSize*2), result.TotalSize)
+		assert.Equal(t, float64(fileWidth*fileHeight*2)/1000000, result.Megapixels)
+
+		return nil
+	})
+}
+
 func imageQueryQ(ctx context.Context, t *testing.T, sqb models.ImageReader, q string, expectedImageIdx int) {
 	filter := models.FindFilterType{
 		Q: &q,

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -1121,6 +1121,11 @@ func (qb *SceneStore) queryGroupedFields(ctx context.Context, options models.Sce
 		aggregateQuery.addColumn("SUM(temp.size) as size")
 	}
 
+	// #5503 - select the file id so equal-sized/duration files aren't collapsed by DISTINCT
+	if options.TotalDuration || options.TotalSize {
+		query.addColumn(scenesFilesTable + ".file_id")
+	}
+
 	const includeSortPagination = false
 	aggregateQuery.from = fmt.Sprintf("(%s) as temp", query.toSQL(includeSortPagination))
 

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -2094,6 +2094,62 @@ func sceneQueryQ(ctx context.Context, t *testing.T, sqb models.SceneReader, q st
 	assert.Len(t, scenes, totalScenes)
 }
 
+// #5503 - total size/duration must include secondary files of equal size/duration
+func TestSceneQueryTotalSizeMultipleFiles(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		sqb := db.Scene
+		fqb := db.File
+
+		const fileSize = int64(1234)
+		const fileDuration = float64(100)
+
+		makeFile := func(basename string) models.FileID {
+			f := &models.VideoFile{
+				BaseFile: &models.BaseFile{
+					Path:           getFilePath(folderIdxWithSceneFiles, basename),
+					Basename:       basename,
+					ParentFolderID: folderIDs[folderIdxWithSceneFiles],
+					Size:           fileSize,
+				},
+				Duration: fileDuration,
+			}
+			if err := fqb.Create(ctx, f); err != nil {
+				t.Fatalf("creating file: %v", err)
+			}
+			return f.ID
+		}
+
+		f1 := makeFile("multifile-scene-1.mp4")
+		f2 := makeFile("multifile-scene-2.mp4")
+
+		scene := &models.Scene{Title: "multifile scene"}
+		if err := sqb.Create(ctx, scene, []models.FileID{f1, f2}); err != nil {
+			t.Fatalf("creating scene: %v", err)
+		}
+
+		result, err := sqb.Query(ctx, models.SceneQueryOptions{
+			QueryOptions: models.QueryOptions{Count: true},
+			SceneFilter: &models.SceneFilterType{
+				ID: &models.IntCriterionInput{
+					Modifier: models.CriterionModifierEquals,
+					Value:    scene.ID,
+				},
+			},
+			TotalDuration: true,
+			TotalSize:     true,
+		})
+		if err != nil {
+			t.Fatalf("querying scene: %v", err)
+		}
+
+		assert.Equal(t, 1, result.Count)
+		assert.Equal(t, float64(fileSize*2), result.TotalSize)
+		assert.Equal(t, fileDuration*2, result.TotalDuration)
+
+		return nil
+	})
+}
+
 func TestSceneQuery(t *testing.T) {
 	var (
 		endpoint = sceneStashID(sceneIdxWithGallery).Endpoint


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Previously the size check on scenes or images (The top of the screen that shows how many items and total size) was not respecting objects that had > 1 file associated with that object. This was because `DISTINCT` applies to the entire row so files that had identical sizes/duration were collapsed to one size (4gb down to 2gb). I added the file ID to the distinct selection so files with equal values stay separate rows and are summed appropriately. This was an issue for scenes and images so I just fixed both.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

fixes: https://github.com/stashapp/stash/issues/5503

## Testing
<!-- Describe the testing steps you have performed. -->

Setup various scenes and images that have secondary files and verified the proper size was shown.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

Nothing to show

## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

No AI

## Additional Context
<!-- Add any other context about the pull request here. -->

