### PR TITLE
[Agent] Add IS_NULL and NOT_NULL modifiers to duration filter for groups

### DIFF
--- a/ui/v2.5/src/components/List/Filters/DurationFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/DurationFilter.tsx
@@ -24,6 +24,13 @@ export const DurationFilter: React.FC<IDurationFilterProps> = ({
   }
 
   function renderTop() {
+    if (
+      criterion.modifier === CriterionModifier.IsNull ||
+      criterion.modifier === CriterionModifier.NotNull
+    ) {
+      return;
+    }
+
     let placeholder: string;
     if (
       criterion.modifier === CriterionModifier.GreaterThan ||

--- a/ui/v2.5/src/models/list-filter/criteria/criterion.ts
+++ b/ui/v2.5/src/models/list-filter/criteria/criterion.ts
@@ -785,6 +785,8 @@ export class MandatoryNumberCriterionOption extends ModifierCriterionOption {
         CriterionModifier.NotEquals,
         CriterionModifier.GreaterThan,
         CriterionModifier.LessThan,
+        CriterionModifier.IsNull,
+        CriterionModifier.NotNull,
         CriterionModifier.Between,
         CriterionModifier.NotBetween,
       ],


### PR DESCRIPTION
Closes #6970

## Summary

Adds `IS_NULL` and `NOT_NULL` modifier options to the duration filter, allowing users to filter groups (and other entities) that are missing duration values.

### Changes

**Frontend: `criterion.ts`**
- Added `CriterionModifier.IsNull` and `CriterionModifier.NotNull` to `MandatoryNumberCriterionOption` modifier options
- This affects all number-based filters including duration for groups

**Frontend: `DurationFilter.tsx`**
- Added early return in `renderTop()` when IS_NULL or NOT_NULL is selected, hiding the value input

### Backend
- The SQL layer (`getNumericWhereClause`) already supports these modifiers
- The Go model (`IntCriterionInput.ValidModifier()`) already includes them
- No backend changes needed