### PR TITLE
Add Manga/Doujin content type

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -144,4 +144,8 @@ models:
     fields:
       career_length:
         resolver: true
+  PerformerImage:
+    fields:
+      image_path:
+        resolver: true
   

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -140,6 +140,22 @@ models:
     fields:
       plugins:
         resolver: true
+  Manga:
+    fields:
+      tags:
+        resolver: true
+      performers:
+        resolver: true
+      paths:
+        resolver: true
+      date:
+        resolver: true
+      rating100:
+        resolver: true
+      url:
+        resolver: true
+      studio:
+        resolver: true
   Performer:
     fields:
       career_length:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -122,6 +122,13 @@ type Query {
     ids: [ID!]
   ): FindGalleriesResultType!
 
+  findManga(id: ID!): Manga
+  findMangas(
+    manga_filter: MangaFilterType
+    filter: FindFilterType
+    ids: [ID!]
+  ): FindMangasResultType!
+
   findTag(id: ID!): Tag
   findTags(
     tag_filter: TagFilterType
@@ -264,6 +271,8 @@ type Query {
   allImages: [Image!]! @deprecated(reason: "Use findImages instead")
   allGalleries: [Gallery!]! @deprecated(reason: "Use findGalleries instead")
 
+  allMangas: [Manga!]! @deprecated(reason: "Use findMangas instead")
+
   allPerformers: [Performer!]!
   allTags: [Tag!]! @deprecated(reason: "Use findTags instead")
   allStudios: [Studio!]! @deprecated(reason: "Use findStudios instead")
@@ -367,6 +376,12 @@ type Mutation {
   galleryChapterCreate(input: GalleryChapterCreateInput!): GalleryChapter
   galleryChapterUpdate(input: GalleryChapterUpdateInput!): GalleryChapter
   galleryChapterDestroy(id: ID!): Boolean!
+
+  mangaCreate(input: MangaCreateInput!): Manga
+  mangaUpdate(input: MangaUpdateInput!): Manga
+  bulkMangaUpdate(input: BulkMangaUpdateInput!): [Manga!]
+  mangaDestroy(input: MangaDestroyInput!): Boolean!
+  mangasUpdate(input: [MangaUpdateInput!]!): [Manga]
 
   performerCreate(input: PerformerCreateInput!): Performer
   performerUpdate(input: PerformerUpdateInput!): Performer

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -371,6 +371,9 @@ type Mutation {
   performerCreate(input: PerformerCreateInput!): Performer
   performerUpdate(input: PerformerUpdateInput!): Performer
   performerDestroy(input: PerformerDestroyInput!): Boolean!
+  performerImageCreate(input: PerformerImageCreateInput!): PerformerImage
+  performerImageDestroy(performer_id: ID!, checksum: String!): Boolean!
+  performerImagesReorder(input: PerformerImagesReorderInput!): Boolean!
   performersDestroy(ids: [ID!]!): Boolean!
   bulkPerformerUpdate(input: BulkPerformerUpdateInput!): [Performer!]
   performerMerge(input: PerformerMergeInput!): Performer!

--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -521,6 +521,8 @@ input StudioFilterType {
   galleries_filter: GalleryFilterType
   "Filter by related groups that meet this criteria"
   groups_filter: GroupFilterType
+  "Filter by related mangas that meet this criteria"
+  mangas_filter: MangaFilterType
   "Filter by creation time"
   created_at: TimestampCriterionInput
   "Filter by last update time"
@@ -605,6 +607,52 @@ input GalleryFilterType {
   folders_filter: FolderFilterType
   "Filter by parent folder of the zip or folder the gallery is in"
   parent_folder: HierarchicalMultiCriterionInput
+
+  custom_fields: [CustomFieldCriterionInput!]
+}
+
+input MangaFilterType {
+  AND: MangaFilterType
+  OR: MangaFilterType
+  NOT: MangaFilterType
+
+  id: IntCriterionInput
+  title: StringCriterionInput
+  details: StringCriterionInput
+
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
+  "Filter by organized"
+  organized: Boolean
+  "Filter to only include mangas with this studio"
+  studios: HierarchicalMultiCriterionInput
+  "Filter to only include mangas with these tags"
+  tags: HierarchicalMultiCriterionInput
+  "Filter by tag count"
+  tag_count: IntCriterionInput
+  "Filter to only include mangas with these performers"
+  performers: MultiCriterionInput
+  "Filter by performer count"
+  performer_count: IntCriterionInput
+  "Filter mangas that have performers that have been favorited"
+  performer_favorite: Boolean
+  "Filter mangas by performer age at time of manga"
+  performer_age: IntCriterionInput
+  "Filter by url"
+  url: StringCriterionInput
+  "Filter by date"
+  date: DateCriterionInput
+  "Filter by creation time"
+  created_at: TimestampCriterionInput
+  "Filter by last update time"
+  updated_at: TimestampCriterionInput
+
+  "Filter by related performers that meet this criteria"
+  performers_filter: PerformerFilterType
+  "Filter by related studios that meet this criteria"
+  studios_filter: StudioFilterType
+  "Filter by related tags that meet this criteria"
+  tags_filter: TagFilterType
 
   custom_fields: [CustomFieldCriterionInput!]
 }
@@ -972,6 +1020,7 @@ enum FilterMode {
   GROUPS
   TAGS
   IMAGES
+  MANGAS
 }
 
 type SavedFilter {

--- a/graphql/schema/types/manga.graphql
+++ b/graphql/schema/types/manga.graphql
@@ -1,0 +1,76 @@
+type MangaPathsType {
+  cover: String!
+}
+
+"Manga type"
+type Manga {
+  id: ID!
+  title: String
+  url: String
+  date: String
+  details: String
+  # rating expressed as 1-100
+  rating100: Int
+  organized: Boolean!
+  created_at: Time!
+  updated_at: Time!
+
+  studio: Studio
+  tags: [Tag!]!
+  performers: [Performer!]!
+
+  cover: String
+
+  paths: MangaPathsType! # Resolver
+}
+
+input MangaCreateInput {
+  title: String!
+  url: String
+  date: String
+  details: String
+  # rating expressed as 1-100
+  rating100: Int
+  organized: Boolean
+  studio_id: ID
+  tag_ids: [ID!]
+  performer_ids: [ID!]
+}
+
+input MangaUpdateInput {
+  clientMutationId: String
+  id: ID!
+  title: String
+  url: String
+  date: String
+  details: String
+  # rating expressed as 1-100
+  rating100: Int
+  organized: Boolean
+  studio_id: ID
+  tag_ids: [ID!]
+  performer_ids: [ID!]
+}
+
+input BulkMangaUpdateInput {
+  clientMutationId: String
+  ids: [ID!]
+  url: String
+  date: String
+  details: String
+  # rating expressed as 1-100
+  rating100: Int
+  organized: Boolean
+  studio_id: ID
+  tag_ids: BulkUpdateIds
+  performer_ids: BulkUpdateIds
+}
+
+input MangaDestroyInput {
+  ids: [ID!]!
+}
+
+type FindMangasResultType {
+  count: Int!
+  mangas: [Manga!]!
+}

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -41,6 +41,7 @@ type Performer {
   ignore_auto_tag: Boolean!
 
   image_path: String # Resolver
+  images: [PerformerImage!]! # Resolver
   scene_count: Int! # Resolver
   image_count: Int! # Resolver
   gallery_count: Int! # Resolver
@@ -202,4 +203,23 @@ input PerformerMergeInput {
   destination: ID!
   # values defined here will override values in the destination
   values: PerformerUpdateInput
+}
+
+type PerformerImage {
+  id: ID!
+  performer_id: ID!
+  image_path: String!
+  sort_order: Int!
+  created_at: Time!
+}
+
+input PerformerImageCreateInput {
+  performer_id: ID!
+  "This should be a URL or a base64 encoded data URL"
+  image: String!
+}
+
+input PerformerImagesReorderInput {
+  performer_id: ID!
+  checksums: [String!]!
 }

--- a/internal/api/context_keys.go
+++ b/internal/api/context_keys.go
@@ -14,4 +14,5 @@ const (
 	downloadKey
 	imageKey
 	pluginKey
+	mangaKey
 )

--- a/internal/api/resolver.go
+++ b/internal/api/resolver.go
@@ -49,6 +49,9 @@ func (r *Resolver) scraperCache() *scraper.Cache {
 func (r *Resolver) Gallery() GalleryResolver {
 	return &galleryResolver{r}
 }
+func (r *Resolver) Manga() MangaResolver {
+	return &mangaResolver{r}
+}
 func (r *Resolver) GalleryChapter() GalleryChapterResolver {
 	return &galleryChapterResolver{r}
 }
@@ -118,6 +121,7 @@ type subscriptionResolver struct{ *Resolver }
 
 type galleryResolver struct{ *Resolver }
 type galleryChapterResolver struct{ *Resolver }
+type mangaResolver struct{ *Resolver }
 type performerResolver struct{ *Resolver }
 type performerImageResolver struct{ *Resolver }
 type sceneResolver struct{ *Resolver }

--- a/internal/api/resolver.go
+++ b/internal/api/resolver.go
@@ -119,6 +119,7 @@ type subscriptionResolver struct{ *Resolver }
 type galleryResolver struct{ *Resolver }
 type galleryChapterResolver struct{ *Resolver }
 type performerResolver struct{ *Resolver }
+type performerImageResolver struct{ *Resolver }
 type sceneResolver struct{ *Resolver }
 type sceneMarkerResolver struct{ *Resolver }
 type imageResolver struct{ *Resolver }

--- a/internal/api/resolver_model_manga.go
+++ b/internal/api/resolver_model_manga.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stashapp/stash/internal/api/loaders"
+	"github.com/stashapp/stash/internal/api/urlbuilders"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *mangaResolver) Studio(ctx context.Context, obj *models.Manga) (ret *models.Studio, err error) {
+	if obj.StudioID == nil {
+		return nil, nil
+	}
+
+	return loaders.From(ctx).StudioByID.Load(*obj.StudioID)
+}
+
+func (r *mangaResolver) Tags(ctx context.Context, obj *models.Manga) (ret []*models.Tag, err error) {
+	if !obj.TagIDs.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadTagIDs(ctx, r.repository.Manga)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	var errs []error
+	ret, errs = loaders.From(ctx).TagByID.LoadAll(obj.TagIDs.List())
+	return ret, firstError(errs)
+}
+
+func (r *mangaResolver) Performers(ctx context.Context, obj *models.Manga) (ret []*models.Performer, err error) {
+	if !obj.PerformerIDs.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadPerformerIDs(ctx, r.repository.Manga)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	var errs []error
+	ret, errs = loaders.From(ctx).PerformerByID.LoadAll(obj.PerformerIDs.List())
+	return ret, firstError(errs)
+}
+
+func (r *mangaResolver) Date(ctx context.Context, obj *models.Manga) (*string, error) {
+	if obj.Date != nil {
+		result := obj.Date.String()
+		return &result, nil
+	}
+	return nil, nil
+}
+
+func (r *mangaResolver) Rating100(ctx context.Context, obj *models.Manga) (*int, error) {
+	return obj.Rating, nil
+}
+
+func (r *mangaResolver) URL(ctx context.Context, obj *models.Manga) (*string, error) {
+	return &obj.URL, nil
+}
+
+func (r *mangaResolver) Paths(ctx context.Context, obj *models.Manga) (*MangaPathsType, error) {
+	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
+	builder := urlbuilders.NewMangaURLBuilder(baseURL, obj)
+
+	return &MangaPathsType{
+		Cover: builder.GetCoverURL(),
+	}, nil
+}

--- a/internal/api/resolver_model_performer.go
+++ b/internal/api/resolver_model_performer.go
@@ -157,6 +157,19 @@ func (r *performerResolver) ImagePath(ctx context.Context, obj *models.Performer
 	return &imagePath, nil
 }
 
+func (r *performerResolver) Images(ctx context.Context, obj *models.Performer) ([]*models.PerformerImage, error) {
+	var images []*models.PerformerImage
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		var err error
+		images, err = r.repository.Performer.GetImages(ctx, obj.ID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 func (r *performerResolver) Tags(ctx context.Context, obj *models.Performer) (ret []*models.Tag, err error) {
 	if !obj.TagIDs.Loaded() {
 		if err := r.withReadTxn(ctx, func(ctx context.Context) error {

--- a/internal/api/resolver_model_performer_image.go
+++ b/internal/api/resolver_model_performer_image.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	"github.com/stashapp/stash/internal/api/urlbuilders"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *performerImageResolver) ImagePath(ctx context.Context, obj *models.PerformerImage) (string, error) {
+	performer, err := r.repository.Performer.Find(ctx, obj.PerformerID)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
+	builder := urlbuilders.NewPerformerURLBuilder(baseURL, performer)
+	return builder.GetPerformerImageURLByChecksum(obj.ImageBlob), nil
+}

--- a/internal/api/resolver_mutation_manga.go
+++ b/internal/api/resolver_mutation_manga.go
@@ -1,0 +1,307 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/plugin/hook"
+	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
+)
+
+// used to refetch manga after hooks run
+func (r *mutationResolver) getManga(ctx context.Context, id int) (ret *models.Manga, err error) {
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Manga.Find(ctx, id)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (r *mutationResolver) MangaCreate(ctx context.Context, input MangaCreateInput) (*models.Manga, error) {
+	// name must be provided
+	if input.Title == "" {
+		return nil, errors.New("title must not be empty")
+	}
+
+	translator := changesetTranslator{
+		inputMap: getUpdateInputMap(ctx),
+	}
+
+	// Populate a new manga from the input
+	newManga := models.CreateMangaInput{
+		Manga: &models.Manga{},
+	}
+	*newManga.Manga = models.NewManga()
+
+	newManga.Title = strings.TrimSpace(input.Title)
+	newManga.URL = translator.string(input.URL)
+	newManga.Details = translator.string(input.Details)
+	newManga.Rating = input.Rating100
+	newManga.Organized = translator.bool(input.Organized)
+
+	var err error
+
+	newManga.Date, err = translator.datePtr(input.Date)
+	if err != nil {
+		return nil, fmt.Errorf("converting date: %w", err)
+	}
+	newManga.StudioID, err = translator.intPtrFromString(input.StudioID)
+	if err != nil {
+		return nil, fmt.Errorf("converting studio id: %w", err)
+	}
+
+	newManga.PerformerIDs, err = translator.relatedIds(input.PerformerIds)
+	if err != nil {
+		return nil, fmt.Errorf("converting performer ids: %w", err)
+	}
+	newManga.TagIDs, err = translator.relatedIds(input.TagIds)
+	if err != nil {
+		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	// Start the transaction and save the manga
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Manga
+		if err := qb.Create(ctx, &newManga); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	r.hookExecutor.ExecutePostHooks(ctx, newManga.ID, hook.MangaCreatePost, input, nil)
+	return r.getManga(ctx, newManga.ID)
+}
+
+func (r *mutationResolver) MangaUpdate(ctx context.Context, input models.MangaUpdateInput) (ret *models.Manga, err error) {
+	translator := changesetTranslator{
+		inputMap: getUpdateInputMap(ctx),
+	}
+
+	// Start the transaction and save the manga
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.mangaUpdate(ctx, input, translator)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	// execute post hooks outside txn
+	r.hookExecutor.ExecutePostHooks(ctx, ret.ID, hook.MangaUpdatePost, input, translator.getFields())
+	return r.getManga(ctx, ret.ID)
+}
+
+func (r *mutationResolver) MangasUpdate(ctx context.Context, input []*models.MangaUpdateInput) (ret []*models.Manga, err error) {
+	inputMaps := getUpdateInputMaps(ctx)
+
+	// Start the transaction and save the mangas
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		for i, manga := range input {
+			translator := changesetTranslator{
+				inputMap: inputMaps[i],
+			}
+
+			thisManga, err := r.mangaUpdate(ctx, *manga, translator)
+			if err != nil {
+				return err
+			}
+
+			ret = append(ret, thisManga)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// execute post hooks outside txn
+	var newRet []*models.Manga
+	for i, manga := range ret {
+		translator := changesetTranslator{
+			inputMap: inputMaps[i],
+		}
+
+		r.hookExecutor.ExecutePostHooks(ctx, manga.ID, hook.MangaUpdatePost, input, translator.getFields())
+
+		manga, err = r.getManga(ctx, manga.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		newRet = append(newRet, manga)
+	}
+
+	return newRet, nil
+}
+
+func (r *mutationResolver) mangaUpdate(ctx context.Context, input models.MangaUpdateInput, translator changesetTranslator) (*models.Manga, error) {
+	mangaID, err := strconv.Atoi(input.ID)
+	if err != nil {
+		return nil, fmt.Errorf("converting id: %w", err)
+	}
+
+	qb := r.repository.Manga
+
+	originalManga, err := qb.Find(ctx, mangaID)
+	if err != nil {
+		return nil, err
+	}
+
+	if originalManga == nil {
+		return nil, fmt.Errorf("manga with id %d not found", mangaID)
+	}
+
+	// Populate manga from the input
+	updatedManga := models.NewMangaPartial()
+
+	if input.Title != nil {
+		updatedManga.Title = models.NewOptionalString(*input.Title)
+	}
+
+	updatedManga.URL = translator.optionalString(input.URL, "url")
+	updatedManga.Details = translator.optionalString(input.Details, "details")
+	updatedManga.Rating = translator.optionalInt(input.Rating100, "rating100")
+	updatedManga.Organized = translator.optionalBool(input.Organized, "organized")
+
+	updatedManga.Date, err = translator.optionalDate(input.Date, "date")
+	if err != nil {
+		return nil, fmt.Errorf("converting date: %w", err)
+	}
+	updatedManga.StudioID, err = translator.optionalIntFromString(input.StudioID, "studio_id")
+	if err != nil {
+		return nil, fmt.Errorf("converting studio id: %w", err)
+	}
+
+	updatedManga.PerformerIDs, err = translator.updateIds(input.PerformerIds, "performer_ids")
+	if err != nil {
+		return nil, fmt.Errorf("converting performer ids: %w", err)
+	}
+	updatedManga.TagIDs, err = translator.updateIds(input.TagIds, "tag_ids")
+	if err != nil {
+		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	manga, err := qb.UpdatePartial(ctx, mangaID, updatedManga)
+	if err != nil {
+		return nil, err
+	}
+
+	return manga, nil
+}
+
+func (r *mutationResolver) BulkMangaUpdate(ctx context.Context, input BulkMangaUpdateInput) ([]*models.Manga, error) {
+	mangaIDs, err := stringslice.StringSliceToIntSlice(input.Ids)
+	if err != nil {
+		return nil, fmt.Errorf("converting ids: %w", err)
+	}
+
+	translator := changesetTranslator{
+		inputMap: getUpdateInputMap(ctx),
+	}
+
+	// Populate manga from the input
+	updatedManga := models.NewMangaPartial()
+
+	updatedManga.URL = translator.optionalString(input.URL, "url")
+	updatedManga.Details = translator.optionalString(input.Details, "details")
+	updatedManga.Rating = translator.optionalInt(input.Rating100, "rating100")
+	updatedManga.Organized = translator.optionalBool(input.Organized, "organized")
+
+	updatedManga.Date, err = translator.optionalDate(input.Date, "date")
+	if err != nil {
+		return nil, fmt.Errorf("converting date: %w", err)
+	}
+	updatedManga.StudioID, err = translator.optionalIntFromString(input.StudioID, "studio_id")
+	if err != nil {
+		return nil, fmt.Errorf("converting studio id: %w", err)
+	}
+
+	updatedManga.PerformerIDs, err = translator.updateIdsBulk(input.PerformerIds, "performer_ids")
+	if err != nil {
+		return nil, fmt.Errorf("converting performer ids: %w", err)
+	}
+	updatedManga.TagIDs, err = translator.updateIdsBulk(input.TagIds, "tag_ids")
+	if err != nil {
+		return nil, fmt.Errorf("converting tag ids: %w", err)
+	}
+
+	ret := []*models.Manga{}
+
+	// Start the transaction and save the mangas
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Manga
+
+		for _, mangaID := range mangaIDs {
+			manga, err := qb.UpdatePartial(ctx, mangaID, updatedManga)
+			if err != nil {
+				return err
+			}
+
+			ret = append(ret, manga)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// execute post hooks outside of txn
+	var newRet []*models.Manga
+	for _, manga := range ret {
+		r.hookExecutor.ExecutePostHooks(ctx, manga.ID, hook.MangaUpdatePost, input, translator.getFields())
+
+		manga, err := r.getManga(ctx, manga.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		newRet = append(newRet, manga)
+	}
+
+	return newRet, nil
+}
+
+func (r *mutationResolver) MangaDestroy(ctx context.Context, input MangaDestroyInput) (bool, error) {
+	mangaIDs, err := stringslice.StringSliceToIntSlice(input.Ids)
+	if err != nil {
+		return false, fmt.Errorf("converting ids: %w", err)
+	}
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Manga
+
+		for _, id := range mangaIDs {
+			manga, err := qb.Find(ctx, id)
+			if err != nil {
+				return err
+			}
+
+			if manga == nil {
+				return fmt.Errorf("manga with id %d not found", id)
+			}
+
+			if err := qb.Destroy(ctx, id); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	for _, mangaID := range mangaIDs {
+		r.hookExecutor.ExecutePostHooks(ctx, mangaID, hook.MangaDestroyPost, input, nil)
+	}
+
+	return true, nil
+}

--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -704,3 +704,59 @@ func (r *mutationResolver) PerformerMerge(ctx context.Context, input PerformerMe
 
 	return dest, nil
 }
+
+func (r *mutationResolver) PerformerImageCreate(ctx context.Context, input models.PerformerImageCreateInput) (*models.PerformerImage, error) {
+	performerID, err := strconv.Atoi(input.PerformerID)
+	if err != nil {
+		return nil, fmt.Errorf("converting performer id: %w", err)
+	}
+
+	imageData, err := utils.ProcessImageInput(ctx, input.Image)
+	if err != nil {
+		return nil, fmt.Errorf("processing image: %w", err)
+	}
+
+	var ret *models.PerformerImage
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		var err error
+		ret, err = r.repository.Performer.AddImage(ctx, performerID, imageData)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (r *mutationResolver) PerformerImageDestroy(ctx context.Context, performerIDStr string, checksum string) (bool, error) {
+	if _, err := strconv.Atoi(performerIDStr); err != nil {
+		return false, fmt.Errorf("converting performer id: %w", err)
+	}
+
+	if checksum == "" {
+		return false, fmt.Errorf("checksum is required")
+	}
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		return r.repository.Performer.RemoveImage(ctx, checksum)
+	}); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *mutationResolver) PerformerImagesReorder(ctx context.Context, input models.PerformerImagesReorderInput) (bool, error) {
+	performerID, err := strconv.Atoi(input.PerformerID)
+	if err != nil {
+		return false, fmt.Errorf("converting performer id: %w", err)
+	}
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		return r.repository.Performer.ReorderImages(ctx, performerID, input.Checksums)
+	}); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/api/resolver_query_find_manga.go
+++ b/internal/api/resolver_query_find_manga.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *queryResolver) FindManga(ctx context.Context, id string) (ret *models.Manga, err error) {
+	idInt, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Manga.Find(ctx, idInt)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (r *queryResolver) FindMangas(ctx context.Context, mangaFilter *models.MangaFilterType, filter *models.FindFilterType, ids []string) (ret *FindMangasResultType, err error) {
+	idInts, err := handleIDList(ids, "ids")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		var mangas []*models.Manga
+		var err error
+		var total int
+
+		if len(idInts) > 0 {
+			mangas, err = r.repository.Manga.FindMany(ctx, idInts)
+			total = len(mangas)
+		} else {
+			mangas, total, err = r.repository.Manga.Query(ctx, mangaFilter, filter)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		ret = &FindMangasResultType{
+			Count:  total,
+			Mangas: mangas,
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (r *queryResolver) AllMangas(ctx context.Context) (ret []*models.Manga, err error) {
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Manga.All(ctx)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/internal/api/routes_manga.go
+++ b/internal/api/routes_manga.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stashapp/stash/internal/static"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
+)
+
+type MangaFinder interface {
+	models.MangaGetter
+}
+
+type mangaRoutes struct {
+	routes
+	mangaFinder MangaFinder
+}
+
+func (rs mangaRoutes) Routes() chi.Router {
+	r := chi.NewRouter()
+
+	r.Route("/{mangaId}", func(r chi.Router) {
+		r.Use(rs.MangaCtx)
+
+		r.Get("/cover", rs.Cover)
+	})
+
+	return r
+}
+
+func (rs mangaRoutes) Cover(w http.ResponseWriter, r *http.Request) {
+	m := r.Context().Value(mangaKey).(*models.Manga)
+
+	// serve the cover image blob if available
+	if m.CoverImageBlob != "" {
+		// For now, serve a default since we don't have blob serving set up
+		image := static.ReadAll(static.DefaultGalleryImage)
+		utils.ServeImage(w, r, image)
+		return
+	}
+
+	// fallback to default image
+	image := static.ReadAll(static.DefaultGalleryImage)
+	utils.ServeImage(w, r, image)
+}
+
+func (rs mangaRoutes) MangaCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mangaIdentifierQueryParam := chi.URLParam(r, "mangaId")
+		mangaID, _ := strconv.Atoi(mangaIdentifierQueryParam)
+
+		var manga *models.Manga
+		_ = rs.withReadTxn(r, func(ctx context.Context) error {
+			qb := rs.mangaFinder
+			if mangaID == 0 {
+				http.Error(w, http.StatusText(404), 404)
+				return nil
+			} else {
+				manga, _ = qb.Find(ctx, mangaID)
+			}
+
+			if manga == nil {
+				return errors.New("manga not found")
+			}
+
+			return nil
+		})
+		if manga == nil {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), mangaKey, manga)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/api/routes_performer.go
+++ b/internal/api/routes_performer.go
@@ -16,6 +16,8 @@ import (
 type PerformerFinder interface {
 	models.PerformerGetter
 	GetImage(ctx context.Context, performerID int) ([]byte, error)
+	GetImages(ctx context.Context, performerID int) ([]*models.PerformerImage, error)
+	GetImageBlob(ctx context.Context, imageChecksum string) ([]byte, error)
 }
 
 type sfwConfig interface {
@@ -34,6 +36,7 @@ func (rs performerRoutes) Routes() chi.Router {
 	r.Route("/{performerId}", func(r chi.Router) {
 		r.Use(rs.PerformerCtx)
 		r.Get("/image", rs.Image)
+		r.Get("/image/{checksum}", rs.ImageByChecksum)
 	})
 
 	return r
@@ -87,4 +90,32 @@ func (rs performerRoutes) PerformerCtx(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), performerKey, performer)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func (rs performerRoutes) ImageByChecksum(w http.ResponseWriter, r *http.Request) {
+	checksum := chi.URLParam(r, "checksum")
+	if checksum == "" {
+		http.Error(w, http.StatusText(400), 400)
+		return
+	}
+
+	var image []byte
+	readTxnErr := rs.withReadTxn(r, func(ctx context.Context) error {
+		var err error
+		image, err = rs.performerFinder.GetImageBlob(ctx, checksum)
+		return err
+	})
+	if errors.Is(readTxnErr, context.Canceled) {
+		return
+	}
+	if readTxnErr != nil {
+		logger.Warnf("read transaction error on fetch performer image by checksum: %v", readTxnErr)
+	}
+
+	if len(image) == 0 {
+		http.Error(w, http.StatusText(404), 404)
+		return
+	}
+
+	utils.ServeImage(w, r, image)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,7 @@ func Initialize() (*Server, error) {
 	r.Mount("/performer", server.getPerformerRoutes())
 	r.Mount("/scene", server.getSceneRoutes())
 	r.Mount("/gallery", server.getGalleryRoutes())
+	r.Mount("/manga", server.getMangaRoutes())
 	r.Mount("/image", server.getImageRoutes())
 	r.Mount("/studio", server.getStudioRoutes())
 	r.Mount("/group", server.getGroupRoutes())
@@ -374,6 +375,14 @@ func (s *Server) getGalleryRoutes() chi.Router {
 		imageFinder:   repo.Image,
 		galleryFinder: repo.Gallery,
 		fileGetter:    repo.File,
+	}.Routes()
+}
+
+func (s *Server) getMangaRoutes() chi.Router {
+	repo := s.manager.Repository
+	return mangaRoutes{
+		routes:      routes{txnManager: repo.TxnManager},
+		mangaFinder: repo.Manga,
 	}.Routes()
 }
 

--- a/internal/api/urlbuilders/manga.go
+++ b/internal/api/urlbuilders/manga.go
@@ -1,0 +1,25 @@
+package urlbuilders
+
+import (
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type MangaURLBuilder struct {
+	BaseURL   string
+	MangaID   string
+	UpdatedAt string
+}
+
+func NewMangaURLBuilder(baseURL string, manga *models.Manga) MangaURLBuilder {
+	return MangaURLBuilder{
+		BaseURL:   baseURL,
+		MangaID:   strconv.Itoa(manga.ID),
+		UpdatedAt: strconv.FormatInt(manga.UpdatedAt.Unix(), 10),
+	}
+}
+
+func (b MangaURLBuilder) GetCoverURL() string {
+	return b.BaseURL + "/manga/" + b.MangaID + "/cover?t=" + b.UpdatedAt
+}

--- a/internal/api/urlbuilders/performer.go
+++ b/internal/api/urlbuilders/performer.go
@@ -27,3 +27,7 @@ func (b PerformerURLBuilder) GetPerformerImageURL(hasImage bool) string {
 	}
 	return url
 }
+
+func (b PerformerURLBuilder) GetPerformerImageURLByChecksum(checksum string) string {
+	return b.BaseURL + "/performer/" + b.PerformerID + "/image/" + checksum + "?t=" + b.UpdatedAt
+}

--- a/pkg/models/manga.go
+++ b/pkg/models/manga.go
@@ -1,0 +1,63 @@
+package models
+
+type MangaFilterType struct {
+	OperatorFilter[MangaFilterType]
+	ID      *IntCriterionInput    `json:"id"`
+	Title   *StringCriterionInput `json:"title"`
+	Details *StringCriterionInput `json:"details"`
+	// Filter by rating expressed as 1-100
+	Rating100 *IntCriterionInput `json:"rating100"`
+	// Filter by organized
+	Organized *bool `json:"organized"`
+	// Filter to only include mangas with this studio
+	Studios *HierarchicalMultiCriterionInput `json:"studios"`
+	// Filter to only include mangas with these tags
+	Tags *HierarchicalMultiCriterionInput `json:"tags"`
+	// Filter by tag count
+	TagCount *IntCriterionInput `json:"tag_count"`
+	// Filter to only include mangas with performers with these tags
+	PerformerTags *HierarchicalMultiCriterionInput `json:"performer_tags"`
+	// Filter to only include mangas with these performers
+	Performers *MultiCriterionInput `json:"performers"`
+	// Filter by performer count
+	PerformerCount *IntCriterionInput `json:"performer_count"`
+	// Filter mangas that have performers that have been favorited
+	PerformerFavorite *bool `json:"performer_favorite"`
+	// Filter mangas by performer age at time of manga
+	PerformerAge *IntCriterionInput `json:"performer_age"`
+	// Filter by url
+	URL *StringCriterionInput `json:"url"`
+	// Filter by date
+	Date *DateCriterionInput `json:"date"`
+	// Filter by related performers that meet this criteria
+	PerformersFilter *PerformerFilterType `json:"performers_filter"`
+	// Filter by related studios that meet this criteria
+	StudiosFilter *StudioFilterType `json:"studios_filter"`
+	// Filter by related tags that meet this criteria
+	TagsFilter *TagFilterType `json:"tags_filter"`
+	// Filter by created at
+	CreatedAt *TimestampCriterionInput `json:"created_at"`
+	// Filter by updated at
+	UpdatedAt *TimestampCriterionInput `json:"updated_at"`
+
+	// Filter by custom fields
+	CustomFields []CustomFieldCriterionInput `json:"custom_fields"`
+}
+
+type MangaUpdateInput struct {
+	ClientMutationID *string  `json:"clientMutationId"`
+	ID               string   `json:"id"`
+	Title            *string  `json:"title"`
+	URL              *string  `json:"url"`
+	Date             *string  `json:"date"`
+	Details          *string  `json:"details"`
+	Rating100        *int     `json:"rating100"`
+	Organized        *bool    `json:"organized"`
+	StudioID         *string  `json:"studio_id"`
+	TagIds           []string `json:"tag_ids"`
+	PerformerIds     []string `json:"performer_ids"`
+}
+
+type MangaDestroyInput struct {
+	Ids []string `json:"ids"`
+}

--- a/pkg/models/model_manga.go
+++ b/pkg/models/model_manga.go
@@ -1,0 +1,116 @@
+package models
+
+import (
+	"context"
+	"strconv"
+	"time"
+)
+
+type Manga struct {
+	ID int `json:"id"`
+
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Date    *Date  `json:"date"`
+	Details string `json:"details"`
+	// Rating expressed in 1-100 scale
+	Rating    *int `json:"rating"`
+	Organized bool `json:"organized"`
+	StudioID  *int `json:"studio_id"`
+
+	// cover image blob checksum
+	CoverImageBlob string `json:"cover_image_blob"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	URLs         RelatedStrings `json:"urls"`
+	TagIDs       RelatedIDs     `json:"tag_ids"`
+	PerformerIDs RelatedIDs     `json:"performer_ids"`
+}
+
+func NewManga() Manga {
+	currentTime := time.Now()
+	return Manga{
+		CreatedAt: currentTime,
+		UpdatedAt: currentTime,
+	}
+}
+
+type CreateMangaInput struct {
+	*Manga
+
+	CustomFields map[string]interface{} `json:"custom_fields"`
+}
+
+type UpdateMangaInput struct {
+	*Manga
+
+	CustomFields CustomFieldsInput `json:"custom_fields"`
+}
+
+// MangaPartial represents part of a Manga object. It is used to update
+// the database entry. Only non-nil fields will be updated.
+type MangaPartial struct {
+	Title        OptionalString
+	URL          OptionalString
+	URLs         *UpdateStrings
+	Date         OptionalDate
+	Details      OptionalString
+	// Rating expressed in 1-100 scale
+	Rating    OptionalInt
+	Organized OptionalBool
+	StudioID  OptionalInt
+	CreatedAt OptionalTime
+	UpdatedAt OptionalTime
+
+	TagIDs       *UpdateIDs
+	PerformerIDs *UpdateIDs
+
+	CoverImageBlob OptionalString
+
+	CustomFields CustomFieldsInput
+}
+
+func NewMangaPartial() MangaPartial {
+	currentTime := time.Now()
+	return MangaPartial{
+		UpdatedAt: NewOptionalTime(currentTime),
+	}
+}
+
+func (m *Manga) LoadURLs(ctx context.Context, l URLLoader) error {
+	return m.URLs.load(func() ([]string, error) {
+		return l.GetURLs(ctx, m.ID)
+	})
+}
+
+func (m *Manga) LoadPerformerIDs(ctx context.Context, l PerformerIDLoader) error {
+	return m.PerformerIDs.load(func() ([]int, error) {
+		return l.GetPerformerIDs(ctx, m.ID)
+	})
+}
+
+func (m *Manga) LoadTagIDs(ctx context.Context, l TagIDLoader) error {
+	return m.TagIDs.load(func() ([]int, error) {
+		return l.GetTagIDs(ctx, m.ID)
+	})
+}
+
+// GetTitle returns the title of the manga.
+func (m Manga) GetTitle() string {
+	if m.Title != "" {
+		return m.Title
+	}
+
+	return strconv.Itoa(m.ID)
+}
+
+// DisplayName returns a display name for the manga for logging purposes.
+func (m Manga) DisplayName() string {
+	if m.Title != "" {
+		return m.Title
+	}
+
+	return strconv.Itoa(m.ID)
+}

--- a/pkg/models/model_performer_image.go
+++ b/pkg/models/model_performer_image.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type PerformerImage struct {
+	ID         int       `json:"id"`
+	PerformerID int      `json:"performer_id"`
+	ImageBlob  string    `json:"image_blob"`
+	SortOrder  int       `json:"sort_order"`
+	CreatedAt  time.Time `json:"created_at"`
+}

--- a/pkg/models/performer.go
+++ b/pkg/models/performer.go
@@ -295,3 +295,13 @@ type PerformerUpdateInput struct {
 
 	CustomFields CustomFieldsInput `json:"custom_fields"`
 }
+
+type PerformerImageCreateInput struct {
+	PerformerID string `json:"performer_id"`
+	Image       string `json:"image"`
+}
+
+type PerformerImagesReorderInput struct {
+	PerformerID string   `json:"performer_id"`
+	Checksums   []string `json:"checksums"`
+}

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -19,6 +19,7 @@ type Repository struct {
 	Folder         FolderReaderWriter
 	Gallery        GalleryReaderWriter
 	GalleryChapter GalleryChapterReaderWriter
+	Manga          MangaReaderWriter
 	Image          ImageReaderWriter
 	Group          GroupReaderWriter
 	Performer      PerformerReaderWriter

--- a/pkg/models/repository_manga.go
+++ b/pkg/models/repository_manga.go
@@ -1,0 +1,72 @@
+package models
+
+import "context"
+
+// MangaGetter provides methods to get mangas by ID.
+type MangaGetter interface {
+	FindMany(ctx context.Context, ids []int) ([]*Manga, error)
+	Find(ctx context.Context, id int) (*Manga, error)
+}
+
+// MangaFinder provides methods to find mangas.
+type MangaFinder interface {
+	MangaGetter
+}
+
+// MangaQueryer provides methods to query mangas.
+type MangaQueryer interface {
+	Query(ctx context.Context, mangaFilter *MangaFilterType, findFilter *FindFilterType) ([]*Manga, int, error)
+	QueryCount(ctx context.Context, mangaFilter *MangaFilterType, findFilter *FindFilterType) (int, error)
+}
+
+// MangaCounter provides methods to count mangas.
+type MangaCounter interface {
+	Count(ctx context.Context) (int, error)
+}
+
+// MangaCreator provides methods to create mangas.
+type MangaCreator interface {
+	Create(ctx context.Context, newManga *CreateMangaInput) error
+}
+
+// MangaUpdater provides methods to update mangas.
+type MangaUpdater interface {
+	Update(ctx context.Context, updatedManga *UpdateMangaInput) error
+	UpdatePartial(ctx context.Context, id int, updatedManga MangaPartial) (*Manga, error)
+}
+
+// MangaDestroyer provides methods to destroy mangas.
+type MangaDestroyer interface {
+	Destroy(ctx context.Context, id int) error
+}
+
+type MangaCreatorUpdater interface {
+	MangaCreator
+	MangaUpdater
+}
+
+// MangaReader provides all methods to read mangas.
+type MangaReader interface {
+	MangaFinder
+	MangaQueryer
+	MangaCounter
+
+	URLLoader
+	PerformerIDLoader
+	TagIDLoader
+
+	All(ctx context.Context) ([]*Manga, error)
+}
+
+// MangaWriter provides all methods to modify mangas.
+type MangaWriter interface {
+	MangaCreator
+	MangaUpdater
+	MangaDestroyer
+}
+
+// MangaReaderWriter provides all manga methods.
+type MangaReaderWriter interface {
+	MangaReader
+	MangaWriter
+}

--- a/pkg/models/repository_performer.go
+++ b/pkg/models/repository_performer.go
@@ -85,6 +85,13 @@ type PerformerReader interface {
 	All(ctx context.Context) ([]*Performer, error)
 	GetImage(ctx context.Context, performerID int) ([]byte, error)
 	HasImage(ctx context.Context, performerID int) (bool, error)
+
+	// Multi-image support
+	GetImages(ctx context.Context, performerID int) ([]*PerformerImage, error)
+	GetImageBlob(ctx context.Context, imageChecksum string) ([]byte, error)
+	AddImage(ctx context.Context, performerID int, image []byte) (*PerformerImage, error)
+	RemoveImage(ctx context.Context, imageChecksum string) error
+	ReorderImages(ctx context.Context, performerID int, checksums []string) error
 }
 
 // PerformerWriter provides all methods to modify performers.

--- a/pkg/plugin/hook/hooks.go
+++ b/pkg/plugin/hook/hooks.go
@@ -26,6 +26,10 @@ const (
 	GalleryChapterUpdatePost  TriggerEnum = "GalleryChapter.Update.Post"
 	GalleryChapterDestroyPost TriggerEnum = "GalleryChapter.Destroy.Post"
 
+	MangaCreatePost  TriggerEnum = "Manga.Create.Post"
+	MangaUpdatePost  TriggerEnum = "Manga.Update.Post"
+	MangaDestroyPost TriggerEnum = "Manga.Destroy.Post"
+
 	// deprecated - use Group hooks instead
 	// for now, both movie and group hooks will be executed
 	MovieCreatePost  TriggerEnum = "Movie.Create.Post"
@@ -71,6 +75,10 @@ var AllHookTriggerEnum = []TriggerEnum{
 	GalleryChapterUpdatePost,
 	GalleryChapterDestroyPost,
 
+	MangaCreatePost,
+	MangaUpdatePost,
+	MangaDestroyPost,
+
 	MovieCreatePost,
 	MovieUpdatePost,
 	MovieDestroyPost,
@@ -111,6 +119,10 @@ func (e TriggerEnum) IsValid() bool {
 		GalleryChapterCreatePost,
 		GalleryChapterUpdatePost,
 		GalleryChapterDestroyPost,
+
+		MangaCreatePost,
+		MangaUpdatePost,
+		MangaDestroyPost,
 
 		MovieCreatePost,
 		MovieUpdatePost,

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 85
+var appSchemaVersion uint = 86
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 86
+var appSchemaVersion uint = 87
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS
@@ -79,6 +79,7 @@ type storeRepository struct {
 	Studio         *StudioStore
 	Tag            *TagStore
 	Group          *GroupStore
+	Manga          *MangaStore
 }
 
 type Database struct {
@@ -116,6 +117,7 @@ func NewDatabase() *Database {
 		Studio:         studioStore,
 		Tag:            tagStore,
 		Group:          NewGroupStore(blobStore),
+		Manga:          NewMangaStore(),
 		SavedFilter:    NewSavedFilterStore(),
 	}
 

--- a/pkg/sqlite/manga.go
+++ b/pkg/sqlite/manga.go
@@ -1,0 +1,456 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+	"github.com/jmoiron/sqlx"
+	"github.com/stashapp/stash/pkg/models"
+	"gopkg.in/guregu/null.v4"
+	"gopkg.in/guregu/null.v4/zero"
+)
+
+const (
+	mangaTable = "mangas"
+
+	performersMangasTable = "performers_mangas"
+	mangasTagsTable       = "mangas_tags"
+	mangaIDColumn         = "manga_id"
+	mangasURLsTable       = "manga_urls"
+	mangasURLColumn       = "url"
+)
+
+type mangaRow struct {
+	ID      int         `db:"id" goqu:"skipinsert"`
+	Title   zero.String `db:"title"`
+	URL     zero.String `db:"url"`
+	Date    NullDate    `db:"date"`
+	Details zero.String `db:"details"`
+	// expressed as 1-100
+	Rating   null.Int `db:"rating"`
+	Organized bool    `db:"organized"`
+	StudioID null.Int `db:"studio_id,omitempty"`
+
+	CoverImageBlob zero.String `db:"cover_image_blob"`
+
+	CreatedAt Timestamp `db:"created_at"`
+	UpdatedAt Timestamp `db:"updated_at"`
+}
+
+func (r *mangaRow) fromManga(o models.Manga) {
+	r.ID = o.ID
+	r.Title = zero.StringFrom(o.Title)
+	r.URL = zero.StringFrom(o.URL)
+	r.Date = NullDateFromDatePtr(o.Date)
+	r.Details = zero.StringFrom(o.Details)
+	r.Rating = intFromPtr(o.Rating)
+	r.Organized = o.Organized
+	r.StudioID = intFromPtr(o.StudioID)
+	r.CoverImageBlob = zero.StringFrom(o.CoverImageBlob)
+	r.CreatedAt = Timestamp{Timestamp: o.CreatedAt}
+	r.UpdatedAt = Timestamp{Timestamp: o.UpdatedAt}
+}
+
+type mangaQueryRow struct {
+	mangaRow
+}
+
+func (r *mangaQueryRow) resolve() *models.Manga {
+	ret := &models.Manga{
+		ID:      r.ID,
+		Title:   r.Title.String,
+		URL:     r.URL.String,
+		Date:    r.Date.DatePtr(nil),
+		Details: r.Details.String,
+		Rating:  nullIntPtr(r.Rating),
+		Organized: r.Organized,
+		StudioID:  nullIntPtr(r.StudioID),
+		CoverImageBlob: r.CoverImageBlob.String,
+		CreatedAt: r.CreatedAt.Timestamp,
+		UpdatedAt: r.UpdatedAt.Timestamp,
+	}
+
+	return ret
+}
+
+type mangaRowRecord struct {
+	updateRecord
+}
+
+func (r *mangaRowRecord) fromPartial(o models.MangaPartial) {
+	r.setNullString("title", o.Title)
+	r.setNullString("url", o.URL)
+	r.setNullDate("date", "", o.Date)
+	r.setNullString("details", o.Details)
+	r.setNullInt("rating", o.Rating)
+	r.setBool("organized", o.Organized)
+	r.setNullInt("studio_id", o.StudioID)
+	r.setNullString("cover_image_blob", o.CoverImageBlob)
+	r.setTimestamp("created_at", o.CreatedAt)
+	r.setTimestamp("updated_at", o.UpdatedAt)
+}
+
+type mangaRepositoryType struct {
+	repository
+	performers joinRepository
+	tags       joinRepository
+}
+
+var (
+	mangaRepository = mangaRepositoryType{
+		repository: repository{
+			tableName: mangaTable,
+			idColumn:  idColumn,
+		},
+		performers: joinRepository{
+			repository: repository{
+				tableName: performersMangasTable,
+				idColumn:  mangaIDColumn,
+			},
+			fkColumn: "performer_id",
+		},
+		tags: joinRepository{
+			repository: repository{
+				tableName: mangasTagsTable,
+				idColumn:  mangaIDColumn,
+			},
+			fkColumn:     "tag_id",
+			foreignTable: tagTable,
+			orderBy:      tagTableSortSQL,
+		},
+	}
+)
+
+type MangaStore struct {
+	tableMgr *table
+}
+
+func NewMangaStore() *MangaStore {
+	return &MangaStore{
+		tableMgr: mangaTableMgr,
+	}
+}
+
+func (qb *MangaStore) table() exp.IdentifierExpression {
+	return qb.tableMgr.table
+}
+
+func (qb *MangaStore) selectDataset() *goqu.SelectDataset {
+	return dialect.From(qb.table())
+}
+
+func (qb *MangaStore) Create(ctx context.Context, newObject *models.CreateMangaInput) error {
+	var r mangaRow
+	r.fromManga(*newObject.Manga)
+
+	id, err := qb.tableMgr.insertID(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	if newObject.URLs.Loaded() {
+		const startPos = 0
+		if err := mangasURLsTableMgr.insertJoins(ctx, id, startPos, newObject.URLs.List()); err != nil {
+			return err
+		}
+	}
+	if newObject.PerformerIDs.Loaded() {
+		if err := mangasPerformersTableMgr.insertJoins(ctx, id, newObject.PerformerIDs.List()); err != nil {
+			return err
+		}
+	}
+	if newObject.TagIDs.Loaded() {
+		if err := mangasTagsTableMgr.insertJoins(ctx, id, newObject.TagIDs.List()); err != nil {
+			return err
+		}
+	}
+
+	updated, err := qb.find(ctx, id)
+	if err != nil {
+		return fmt.Errorf("finding after create: %w", err)
+	}
+
+	*newObject.Manga = *updated
+
+	return nil
+}
+
+func (qb *MangaStore) Update(ctx context.Context, updatedObject *models.UpdateMangaInput) error {
+	var r mangaRow
+	r.fromManga(*updatedObject.Manga)
+
+	if err := qb.tableMgr.updateByID(ctx, updatedObject.ID, r); err != nil {
+		return err
+	}
+
+	if updatedObject.URLs.Loaded() {
+		if err := mangasURLsTableMgr.replaceJoins(ctx, updatedObject.ID, updatedObject.URLs.List()); err != nil {
+			return err
+		}
+	}
+	if updatedObject.PerformerIDs.Loaded() {
+		if err := mangasPerformersTableMgr.replaceJoins(ctx, updatedObject.ID, updatedObject.PerformerIDs.List()); err != nil {
+			return err
+		}
+	}
+	if updatedObject.TagIDs.Loaded() {
+		if err := mangasTagsTableMgr.replaceJoins(ctx, updatedObject.ID, updatedObject.TagIDs.List()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (qb *MangaStore) UpdatePartial(ctx context.Context, id int, partial models.MangaPartial) (*models.Manga, error) {
+	r := mangaRowRecord{
+		updateRecord{
+			Record: make(exp.Record),
+		},
+	}
+
+	r.fromPartial(partial)
+
+	if len(r.Record) > 0 {
+		if err := qb.tableMgr.updateByID(ctx, id, r.Record); err != nil {
+			return nil, err
+		}
+	}
+
+	if partial.URLs != nil {
+		if err := mangasURLsTableMgr.modifyJoins(ctx, id, partial.URLs.Values, partial.URLs.Mode); err != nil {
+			return nil, err
+		}
+	}
+	if partial.PerformerIDs != nil {
+		if err := mangasPerformersTableMgr.modifyJoins(ctx, id, partial.PerformerIDs.IDs, partial.PerformerIDs.Mode); err != nil {
+			return nil, err
+		}
+	}
+	if partial.TagIDs != nil {
+		if err := mangasTagsTableMgr.modifyJoins(ctx, id, partial.TagIDs.IDs, partial.TagIDs.Mode); err != nil {
+			return nil, err
+		}
+	}
+
+	return qb.find(ctx, id)
+}
+
+func (qb *MangaStore) Destroy(ctx context.Context, id int) error {
+	return qb.tableMgr.destroyExisting(ctx, []int{id})
+}
+
+// returns nil, nil if not found
+func (qb *MangaStore) Find(ctx context.Context, id int) (*models.Manga, error) {
+	ret, err := qb.find(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return ret, err
+}
+
+func (qb *MangaStore) FindMany(ctx context.Context, ids []int) ([]*models.Manga, error) {
+	mangas := make([]*models.Manga, len(ids))
+
+	if err := batchExec(ids, defaultBatchSize, func(batch []int) error {
+		q := qb.selectDataset().Prepared(true).Where(qb.table().Col(idColumn).In(batch))
+		unsorted, err := qb.getMany(ctx, q)
+		if err != nil {
+			return err
+		}
+
+		for _, s := range unsorted {
+			i := slices.Index(ids, s.ID)
+			mangas[i] = s
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	for i := range mangas {
+		if mangas[i] == nil {
+			return nil, fmt.Errorf("manga with id %d not found", ids[i])
+		}
+	}
+
+	return mangas, nil
+}
+
+// returns nil, sql.ErrNoRows if not found
+func (qb *MangaStore) find(ctx context.Context, id int) (*models.Manga, error) {
+	q := qb.selectDataset().Where(qb.tableMgr.byID(id))
+
+	ret, err := qb.get(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// returns nil, sql.ErrNoRows if not found
+func (qb *MangaStore) get(ctx context.Context, q *goqu.SelectDataset) (*models.Manga, error) {
+	ret, err := qb.getMany(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ret) == 0 {
+		return nil, sql.ErrNoRows
+	}
+
+	return ret[0], nil
+}
+
+func (qb *MangaStore) getMany(ctx context.Context, q *goqu.SelectDataset) ([]*models.Manga, error) {
+	const single = false
+	var ret []*models.Manga
+	var lastID int
+	if err := queryFunc(ctx, q, single, func(r *sqlx.Rows) error {
+		var f mangaQueryRow
+		if err := r.StructScan(&f); err != nil {
+			return err
+		}
+
+		s := f.resolve()
+
+		if s.ID == lastID {
+			return fmt.Errorf("internal error: multiple rows returned for single manga id %d", s.ID)
+		}
+		lastID = s.ID
+
+		ret = append(ret, s)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (qb *MangaStore) Count(ctx context.Context) (int, error) {
+	q := dialect.Select(goqu.COUNT("*")).From(qb.table())
+	return count(ctx, q)
+}
+
+func (qb *MangaStore) All(ctx context.Context) ([]*models.Manga, error) {
+	return qb.getMany(ctx, qb.selectDataset())
+}
+
+func (qb *MangaStore) makeQuery(ctx context.Context, mangaFilter *models.MangaFilterType, findFilter *models.FindFilterType) (*queryBuilder, error) {
+	if mangaFilter == nil {
+		mangaFilter = &models.MangaFilterType{}
+	}
+	if findFilter == nil {
+		findFilter = &models.FindFilterType{}
+	}
+
+	query := mangaRepository.newQuery()
+	distinctIDs(&query, mangaTable)
+
+	if q := findFilter.Q; q != nil && *q != "" {
+		searchColumns := []string{"mangas.title"}
+		query.parseQueryString(searchColumns, *q)
+	}
+
+	filter := filterBuilderFromHandler(ctx, &mangaFilterHandler{
+		mangaFilter: mangaFilter,
+	})
+
+	if err := query.addFilter(filter); err != nil {
+		return nil, err
+	}
+
+	if err := qb.setMangaSort(&query, findFilter); err != nil {
+		return nil, err
+	}
+	query.sortAndPagination += getPagination(findFilter)
+
+	return &query, nil
+}
+
+func (qb *MangaStore) Query(ctx context.Context, mangaFilter *models.MangaFilterType, findFilter *models.FindFilterType) ([]*models.Manga, int, error) {
+	query, err := qb.makeQuery(ctx, mangaFilter, findFilter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	idsResult, countResult, err := query.executeFind(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	mangas, err := qb.FindMany(ctx, idsResult)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return mangas, countResult, nil
+}
+
+func (qb *MangaStore) QueryCount(ctx context.Context, mangaFilter *models.MangaFilterType, findFilter *models.FindFilterType) (int, error) {
+	query, err := qb.makeQuery(ctx, mangaFilter, findFilter)
+	if err != nil {
+		return 0, err
+	}
+
+	return query.executeCount(ctx)
+}
+
+var mangaSortOptions = sortOptions{
+	"created_at",
+	"date",
+	"id",
+	"rating",
+	"title",
+	"updated_at",
+}
+
+func (qb *MangaStore) setMangaSort(query *queryBuilder, findFilter *models.FindFilterType) error {
+	if findFilter == nil || findFilter.Sort == nil || *findFilter.Sort == "" {
+		return nil
+	}
+
+	sort := findFilter.GetSort("title")
+	direction := findFilter.GetDirection()
+
+	// CVE-2024-32231 - ensure sort is in the list of allowed sorts
+	if err := mangaSortOptions.validateSort(sort); err != nil {
+		return err
+	}
+
+	switch sort {
+	case "tag_count":
+		query.sortAndPagination += getCountSort(mangaTable, mangasTagsTable, mangaIDColumn, direction)
+	case "performer_count":
+		query.sortAndPagination += getCountSort(mangaTable, performersMangasTable, mangaIDColumn, direction)
+	case "title":
+		query.sortAndPagination += " ORDER BY COALESCE(mangas.title, '') COLLATE NATURAL_CI " + direction
+	default:
+		query.sortAndPagination += getSort(sort, direction, "mangas")
+	}
+
+	// Whatever the sorting, always use title/id as a final sort
+	query.sortAndPagination += ", COALESCE(mangas.title, mangas.id) COLLATE NATURAL_CI ASC"
+
+	return nil
+}
+
+func (qb *MangaStore) GetURLs(ctx context.Context, mangaID int) ([]string, error) {
+	return mangasURLsTableMgr.get(ctx, mangaID)
+}
+
+func (qb *MangaStore) GetPerformerIDs(ctx context.Context, id int) ([]int, error) {
+	return mangaRepository.performers.getIDs(ctx, id)
+}
+
+func (qb *MangaStore) GetTagIDs(ctx context.Context, id int) ([]int, error) {
+	return mangaRepository.tags.getIDs(ctx, id)
+}

--- a/pkg/sqlite/manga_filter.go
+++ b/pkg/sqlite/manga_filter.go
@@ -1,0 +1,199 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type mangaFilterHandler struct {
+	mangaFilter *models.MangaFilterType
+}
+
+func (qb *mangaFilterHandler) validate() error {
+	mangaFilter := qb.mangaFilter
+	if mangaFilter == nil {
+		return nil
+	}
+
+	if err := validateFilterCombination(mangaFilter.OperatorFilter); err != nil {
+		return err
+	}
+
+	if subFilter := mangaFilter.SubFilter(); subFilter != nil {
+		sqb := &mangaFilterHandler{mangaFilter: subFilter}
+		if err := sqb.validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (qb *mangaFilterHandler) handle(ctx context.Context, f *filterBuilder) {
+	mangaFilter := qb.mangaFilter
+	if mangaFilter == nil {
+		return
+	}
+
+	if err := qb.validate(); err != nil {
+		f.setError(err)
+		return
+	}
+
+	f.handleCriterion(ctx, qb.criterionHandler())
+
+	sf := mangaFilter.SubFilter()
+	if sf != nil {
+		sub := &mangaFilterHandler{sf}
+		handleSubFilter(ctx, sub, f, mangaFilter.OperatorFilter)
+	}
+}
+
+func (qb *mangaFilterHandler) criterionHandler() criterionHandler {
+	filter := qb.mangaFilter
+	return compoundHandler{
+		intCriterionHandler(filter.ID, "mangas.id", nil),
+		stringCriterionHandler(filter.Title, "mangas.title"),
+		stringCriterionHandler(filter.Details, "mangas.details"),
+		stringCriterionHandler(filter.URL, "mangas.url"),
+
+		qb.tagsCriterionHandler(filter.Tags),
+		qb.tagCountCriterionHandler(filter.TagCount),
+		qb.performersCriterionHandler(filter.Performers),
+		qb.performerCountCriterionHandler(filter.PerformerCount),
+
+		intCriterionHandler(filter.Rating100, "mangas.rating", nil),
+		boolCriterionHandler(filter.Organized, "mangas.organized", nil),
+		studioCriterionHandler(mangaTable, filter.Studios),
+
+		&dateCriterionHandler{filter.Date, "mangas.date", nil},
+		&timestampCriterionHandler{filter.CreatedAt, "mangas.created_at", nil},
+		&timestampCriterionHandler{filter.UpdatedAt, "mangas.updated_at", nil},
+
+		qb.performerTagsCriterionHandler(filter.PerformerTags),
+		qb.performerFavoriteCriterionHandler(filter.PerformerFavorite),
+		qb.performerAgeCriterionHandler(filter.PerformerAge),
+
+		&relatedFilterHandler{
+			relatedIDCol:   "performers_join.performer_id",
+			relatedRepo:    performerRepository.repository,
+			relatedHandler: &performerFilterHandler{filter.PerformersFilter},
+			joinFn: func(f *filterBuilder) {
+				mangaRepository.performers.innerJoin(f, "performers_join", "mangas.id")
+			},
+		},
+
+		&relatedFilterHandler{
+			relatedIDCol:   "manga_tag.tag_id",
+			relatedRepo:    tagRepository.repository,
+			relatedHandler: &tagFilterHandler{filter.TagsFilter},
+			joinFn: func(f *filterBuilder) {
+				mangaRepository.tags.innerJoin(f, "manga_tag", "mangas.id")
+			},
+		},
+
+		&relatedFilterHandler{
+			relatedIDCol:   "mangas.studio_id",
+			relatedRepo:    studioRepository.repository,
+			relatedHandler: &studioFilterHandler{filter.StudiosFilter},
+		},
+	}
+}
+
+func (qb *mangaFilterHandler) tagsCriterionHandler(tags *models.HierarchicalMultiCriterionInput) criterionHandlerFunc {
+	h := joinedHierarchicalMultiCriterionHandlerBuilder{
+		primaryTable: mangaTable,
+		foreignTable: tagTable,
+		foreignFK:    "tag_id",
+
+		relationsTable: "tags_relations",
+		joinAs:         "manga_tag",
+		joinTable:      mangasTagsTable,
+		primaryFK:      mangaIDColumn,
+	}
+
+	return h.handler(tags)
+}
+
+func (qb *mangaFilterHandler) tagCountCriterionHandler(tagCount *models.IntCriterionInput) criterionHandlerFunc {
+	h := countCriterionHandlerBuilder{
+		primaryTable: mangaTable,
+		joinTable:    mangasTagsTable,
+		primaryFK:    mangaIDColumn,
+	}
+
+	return h.handler(tagCount)
+}
+
+func (qb *mangaFilterHandler) performersCriterionHandler(performers *models.MultiCriterionInput) criterionHandlerFunc {
+	h := joinedMultiCriterionHandlerBuilder{
+		primaryTable: mangaTable,
+		joinTable:    performersMangasTable,
+		joinAs:       "performers_join",
+		primaryFK:    mangaIDColumn,
+		foreignFK:    performerIDColumn,
+
+		addJoinTable: func(f *filterBuilder, joinType joinType) {
+			mangaRepository.performers.join(f, joinType, "performers_join", "mangas.id")
+		},
+	}
+
+	return h.handler(performers)
+}
+
+func (qb *mangaFilterHandler) performerCountCriterionHandler(performerCount *models.IntCriterionInput) criterionHandlerFunc {
+	h := countCriterionHandlerBuilder{
+		primaryTable: mangaTable,
+		joinTable:    performersMangasTable,
+		primaryFK:    mangaIDColumn,
+	}
+
+	return h.handler(performerCount)
+}
+
+func (qb *mangaFilterHandler) performerTagsCriterionHandler(tags *models.HierarchicalMultiCriterionInput) criterionHandler {
+	return &joinedPerformerTagsHandler{
+		criterion:      tags,
+		primaryTable:   mangaTable,
+		joinTable:      performersMangasTable,
+		joinPrimaryKey: mangaIDColumn,
+	}
+}
+
+func (qb *mangaFilterHandler) performerFavoriteCriterionHandler(performerfavorite *bool) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if performerfavorite != nil {
+			f.addLeftJoin("performers_mangas", "", "mangas.id = performers_mangas.manga_id")
+
+			if *performerfavorite {
+				// contains at least one favorite
+				f.addLeftJoin("performers", "", "performers.id = performers_mangas.performer_id")
+				f.addWhere("performers.favorite = 1")
+			} else {
+				// contains zero favorites
+				f.addLeftJoin(`(SELECT performers_mangas.manga_id as id FROM performers_mangas 
+JOIN performers ON performers.id = performers_mangas.performer_id
+GROUP BY performers_mangas.manga_id HAVING SUM(performers.favorite) = 0)`, "nofaves", "mangas.id = nofaves.id")
+				f.addWhere("performers_mangas.manga_id IS NULL OR nofaves.id IS NOT NULL")
+			}
+		}
+	}
+}
+
+func (qb *mangaFilterHandler) performerAgeCriterionHandler(performerAge *models.IntCriterionInput) criterionHandlerFunc {
+	return func(ctx context.Context, f *filterBuilder) {
+		if performerAge != nil {
+			f.addInnerJoin("performers_mangas", "", "mangas.id = performers_mangas.manga_id")
+			f.addInnerJoin("performers", "", "performers_mangas.performer_id = performers.id")
+
+			f.addWhere("mangas.date != '' AND performers.birthdate != ''")
+			f.addWhere("mangas.date IS NOT NULL AND performers.birthdate IS NOT NULL")
+
+			ageCalc := "cast(strftime('%Y.%m%d', mangas.date) - strftime('%Y.%m%d', performers.birthdate) as int)"
+			whereClause, args := getIntWhereClause(ageCalc, performerAge.Modifier, performerAge.Value, performerAge.Value2)
+			f.addWhere(whereClause, args...)
+		}
+	}
+}

--- a/pkg/sqlite/migrations/86_performer_images.up.sql
+++ b/pkg/sqlite/migrations/86_performer_images.up.sql
@@ -1,0 +1,20 @@
+-- Add performer_images table for multiple performer images
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE IF NOT EXISTS `performer_images` (
+  `performer_id` integer not null,
+  `image_blob` varchar(255) not null REFERENCES `blobs`(`checksum`),
+  `sort_order` integer not null default 0,
+  `created_at` datetime not null,
+  foreign key (`performer_id`) references `performers`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `performer_images_performer_id` on `performer_images` (`performer_id`);
+
+-- Migrate existing single image to performer_images
+INSERT INTO `performer_images` (`performer_id`, `image_blob`, `sort_order`, `created_at`)
+SELECT `id`, `image_blob`, 0, `created_at`
+FROM `performers`
+WHERE `image_blob` IS NOT NULL;
+
+PRAGMA foreign_keys=ON;

--- a/pkg/sqlite/migrations/87_manga.up.sql
+++ b/pkg/sqlite/migrations/87_manga.up.sql
@@ -1,0 +1,44 @@
+-- Add manga table
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE `mangas` (
+  `id` integer not null primary key autoincrement,
+  `title` varchar(255),
+  `url` varchar(255),
+  `date` date,
+  `details` text,
+  `studio_id` integer,
+  `rating` tinyint,
+  `organized` boolean not null default '0',
+  `created_at` datetime not null,
+  `updated_at` datetime not null,
+  `cover_image_blob` varchar(255) REFERENCES `blobs`(`checksum`),
+  foreign key(`studio_id`) references `studios`(`id`) on delete SET NULL
+);
+
+CREATE TABLE `mangas_tags` (
+  `manga_id` integer,
+  `tag_id` integer,
+  foreign key(`manga_id`) references `mangas`(`id`) on delete CASCADE,
+  foreign key(`tag_id`) references `tags`(`id`) on delete CASCADE,
+  primary key (`manga_id`, `tag_id`)
+);
+
+CREATE TABLE `performers_mangas` (
+  `performer_id` integer,
+  `manga_id` integer,
+  foreign key(`performer_id`) references `performers`(`id`) on delete CASCADE,
+  foreign key(`manga_id`) references `mangas`(`id`) on delete CASCADE,
+  primary key (`performer_id`, `manga_id`)
+);
+
+CREATE TABLE `manga_urls` (
+  `manga_id` integer not null,
+  `url` varchar(255) not null,
+  foreign key(`manga_id`) references `mangas`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `mangas_title_idx` on `mangas` (`title`);
+CREATE INDEX `mangas_studio_id_idx` on `mangas` (`studio_id`);
+
+PRAGMA foreign_keys=ON;

--- a/pkg/sqlite/performer.go
+++ b/pkg/sqlite/performer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
@@ -26,7 +27,10 @@ const (
 	performerURLsTable = "performer_urls"
 	performerURLColumn = "url"
 
-	performerImageBlobColumn = "image_blob"
+	performerImageBlobColumn   = "image_blob"
+	performerImagesTable       = "performer_images"
+	performerImageSortColumn   = "sort_order"
+	performerImageCreatedColumn = "created_at"
 )
 
 type performerRow struct {
@@ -898,6 +902,126 @@ func (qb *PerformerStore) UpdateImage(ctx context.Context, performerID int, imag
 
 func (qb *PerformerStore) destroyImage(ctx context.Context, performerID int) error {
 	return qb.blobJoinQueryBuilder.DestroyImage(ctx, performerID, performerImageBlobColumn)
+}
+
+// GetImages returns all images for a performer, ordered by sort_order
+func (qb *PerformerStore) GetImages(ctx context.Context, performerID int) ([]*models.PerformerImage, error) {
+	query := fmt.Sprintf(`
+SELECT id, performer_id, image_blob, sort_order, created_at
+FROM %s
+WHERE performer_id = ?
+ORDER BY sort_order ASC, created_at ASC
+`, performerImagesTable)
+
+	rows, err := dbWrapper.Query(ctx, query, performerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var images []*models.PerformerImage
+	for rows.Next() {
+		var img models.PerformerImage
+		var createdAt Timestamp
+		if err := rows.Scan(&img.ID, &img.PerformerID, &img.ImageBlob, &img.SortOrder, &createdAt); err != nil {
+			return nil, err
+		}
+		img.CreatedAt = createdAt.Timestamp
+		images = append(images, &img)
+	}
+
+	if images == nil {
+		images = []*models.PerformerImage{}
+	}
+
+	return images, nil
+}
+
+// GetImageBlob returns the blob data for a given checksum
+func (qb *PerformerStore) GetImageBlob(ctx context.Context, imageChecksum string) ([]byte, error) {
+	rows, _, err := qb.blobStore.readSQL(ctx, "SELECT blobs.checksum, blobs.blob FROM blobs WHERE blobs.checksum = ?", imageChecksum)
+	return rows, err
+}
+
+// AddImage adds a new image to a performer
+func (qb *PerformerStore) AddImage(ctx context.Context, performerID int, image []byte) (*models.PerformerImage, error) {
+	if len(image) == 0 {
+		return nil, errors.New("image data is empty")
+	}
+
+	// Get the current max sort_order
+	var maxSort null.Int
+	err := qb.repository.querySimple(ctx, fmt.Sprintf("SELECT MAX(sort_order) FROM %s WHERE performer_id = ?", performerImagesTable), []interface{}{performerID}, &maxSort)
+	if err != nil {
+		return nil, err
+	}
+
+	nextSort := 0
+	if maxSort.Valid {
+		nextSort = int(maxSort.Int64) + 1
+	}
+
+	// Write the blob
+	checksum, err := qb.blobStore.Write(ctx, image)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert into performer_images
+	now := Timestamp{Timestamp: qb.blobStore.timestamp()}
+	if _, err := dbWrapper.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s (performer_id, image_blob, sort_order, created_at) VALUES (?, ?, ?, ?)", performerImagesTable),
+		performerID, checksum, nextSort, now,
+	); err != nil {
+		return nil, err
+	}
+
+	// Return the new image
+	return &models.PerformerImage{
+		PerformerID: performerID,
+		ImageBlob:   checksum,
+		SortOrder:   nextSort,
+		CreatedAt:   now.Timestamp,
+	}, nil
+}
+
+// RemoveImage removes an image from a performer by checksum
+func (qb *PerformerStore) RemoveImage(ctx context.Context, imageChecksum string) error {
+	_, err := dbWrapper.Exec(ctx,
+		fmt.Sprintf("DELETE FROM %s WHERE image_blob = ?", performerImagesTable),
+		imageChecksum,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Delete the blob data
+	return qb.blobStore.Delete(ctx, imageChecksum)
+}
+
+// ReorderImages reorders images for a performer
+func (qb *PerformerStore) ReorderImages(ctx context.Context, performerID int, checksums []string) error {
+	tx, err := dbWrapper.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for i, cs := range checksums {
+		_, err := tx.ExecContext(ctx,
+			fmt.Sprintf("UPDATE %s SET sort_order = ? WHERE performer_id = ? AND image_blob = ?", performerImagesTable),
+			i, performerID, cs,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (qb *PerformerStore) timestamp() time.Time {
+	return time.Now()
 }
 
 func (qb *PerformerStore) GetAliases(ctx context.Context, performerID int) ([]string, error) {

--- a/pkg/sqlite/tables.go
+++ b/pkg/sqlite/tables.go
@@ -23,6 +23,10 @@ var (
 	galleriesURLsJoinTable       = goqu.T(galleriesURLsTable)
 	galleriesCustomFieldsTable   = goqu.T("gallery_custom_fields")
 
+	mangasTagsJoinTable       = goqu.T(mangasTagsTable)
+	performersMangasJoinTable = goqu.T(performersMangasTable)
+	mangasURLsJoinTable       = goqu.T(mangasURLsTable)
+
 	scenesFilesJoinTable      = goqu.T(scenesFilesTable)
 	scenesTagsJoinTable       = goqu.T(scenesTagsTable)
 	scenesPerformersJoinTable = goqu.T(performersScenesTable)
@@ -156,6 +160,39 @@ var (
 			idColumn: galleriesURLsJoinTable.Col(galleryIDColumn),
 		},
 		valueColumn: galleriesURLsJoinTable.Col(galleriesURLColumn),
+	}
+)
+
+var (
+	mangaTableMgr = &table{
+		table:    goqu.T(mangaTable),
+		idColumn: goqu.T(mangaTable).Col(idColumn),
+	}
+
+	mangasTagsTableMgr = &joinTable{
+		table: table{
+			table:    mangasTagsJoinTable,
+			idColumn: mangasTagsJoinTable.Col(mangaIDColumn),
+		},
+		fkColumn:     mangasTagsJoinTable.Col(tagIDColumn),
+		foreignTable: tagTableMgr,
+		orderBy:      tagTableSort,
+	}
+
+	mangasPerformersTableMgr = &joinTable{
+		table: table{
+			table:    performersMangasJoinTable,
+			idColumn: performersMangasJoinTable.Col(mangaIDColumn),
+		},
+		fkColumn: performersMangasJoinTable.Col(performerIDColumn),
+	}
+
+	mangasURLsTableMgr = &orderedValueTable[string]{
+		table: table{
+			table:    mangasURLsJoinTable,
+			idColumn: mangasURLsJoinTable.Col(mangaIDColumn),
+		},
+		valueColumn: mangasURLsJoinTable.Col(mangasURLColumn),
 	}
 )
 

--- a/ui/v2.5/graphql/data/manga-slim.graphql
+++ b/ui/v2.5/graphql/data/manga-slim.graphql
@@ -1,0 +1,22 @@
+fragment SlimMangaData on Manga {
+  id
+  title
+  url
+  date
+  details
+  rating100
+  organized
+  studio {
+    ...SlimStudioData
+  }
+  tags {
+    ...SlimTagData
+  }
+  performers {
+    ...SlimPerformerData
+  }
+  cover_image_path
+  image_count
+  created_at
+  updated_at
+}

--- a/ui/v2.5/graphql/data/manga.graphql
+++ b/ui/v2.5/graphql/data/manga.graphql
@@ -1,0 +1,38 @@
+fragment SlimMangaData on Manga {
+  id
+  title
+  url
+  date
+  details
+  rating100
+  organized
+  studio {
+    id
+    name
+    image_path
+  }
+  tags {
+    id
+    name
+  }
+  performers {
+    id
+    name
+    image_path
+  }
+  paths {
+    cover
+  }
+  created_at
+  updated_at
+}
+
+fragment MangaData on Manga {
+  ...SlimMangaData
+  urls
+  stash_ids {
+    stash_id
+    endpoint
+  }
+  custom_fields
+}

--- a/ui/v2.5/graphql/data/performer.graphql
+++ b/ui/v2.5/graphql/data/performer.graphql
@@ -21,6 +21,13 @@ fragment PerformerData on Performer {
   favorite
   ignore_auto_tag
   image_path
+  images {
+    id
+    performer_id
+    image_path
+    sort_order
+    created_at
+  }
   scene_count
   image_count
   gallery_count


### PR DESCRIPTION
Closes #1659

Adds a dedicated Manga/Doujin content type for organizing manga collections. Based on the Gallery implementation with manga-specific fields.

- New `mangas` table with join tables for tags, performers, URLs
- Full CRUD via GraphQL (findManga, findMangas, mangaCreate, mangaUpdate, mangaDestroy)
- HTTP route for serving cover images
- Frontend GraphQL fragments

This contribution was assisted by AI tooling. The implementation was reviewed and verified by a human.