### PR TITLE
Add Story content type for text files and audio files

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -122,6 +122,13 @@ type Query {
     ids: [ID!]
   ): FindGalleriesResultType!
 
+  findStory(id: ID!): Story
+  findStories(
+    story_filter: StoryFilterType
+    filter: FindFilterType
+    ids: [ID!]
+  ): FindStoriesResultType!
+
   findTag(id: ID!): Tag
   findTags(
     tag_filter: TagFilterType
@@ -263,6 +270,7 @@ type Query {
     @deprecated(reason: "Use findSceneMarkers instead")
   allImages: [Image!]! @deprecated(reason: "Use findImages instead")
   allGalleries: [Gallery!]! @deprecated(reason: "Use findGalleries instead")
+  allStories: [Story!]! @deprecated(reason: "Use findStories instead")
 
   allPerformers: [Performer!]!
   allTags: [Tag!]! @deprecated(reason: "Use findTags instead")
@@ -367,6 +375,11 @@ type Mutation {
   galleryChapterCreate(input: GalleryChapterCreateInput!): GalleryChapter
   galleryChapterUpdate(input: GalleryChapterUpdateInput!): GalleryChapter
   galleryChapterDestroy(id: ID!): Boolean!
+
+  storyCreate(input: StoryCreateInput!): Story
+  storyUpdate(input: StoryUpdateInput!): Story
+  bulkStoryUpdate(input: BulkStoryUpdateInput!): [Story!]
+  storyDestroy(input: StoryDestroyInput!): Boolean!
 
   performerCreate(input: PerformerCreateInput!): Performer
   performerUpdate(input: PerformerUpdateInput!): Performer

--- a/graphql/schema/types/story.graphql
+++ b/graphql/schema/types/story.graphql
@@ -1,0 +1,79 @@
+type Story {
+  id: ID!
+  title: String
+  author: String
+  url: String
+  date: String
+  language: String
+  tag_line: String
+  details: String
+  rating100: Int
+  created_at: Time!
+  updated_at: Time!
+
+  studio: Studio
+  tags: [Tag!]!
+  performers: [Performer!]!
+
+  front_image_path: String
+  back_image_path: String
+}
+
+input StoryCreateInput {
+  title: String!
+  author: String
+  url: String
+  date: String
+  language: String
+  tag_line: String
+  details: String
+  rating100: Int
+  studio_id: ID
+  tag_ids: [ID!]
+  performer_ids: [ID!]
+  "This should be a URL or a base64 encoded data URL"
+  front_image: String
+  "This should be a URL or a base64 encoded data URL"
+  back_image: String
+}
+
+input StoryUpdateInput {
+  id: ID!
+  title: String
+  author: String
+  url: String
+  date: String
+  language: String
+  tag_line: String
+  details: String
+  rating100: Int
+  studio_id: ID
+  tag_ids: [ID!]
+  performer_ids: [ID!]
+  "This should be a URL or a base64 encoded data URL"
+  front_image: String
+  "This should be a URL or a base64 encoded data URL"
+  back_image: String
+}
+
+input BulkStoryUpdateInput {
+  ids: [ID!]
+  url: String
+  date: String
+  language: String
+  tag_line: String
+  details: String
+  rating100: Int
+  studio_id: ID
+  tag_ids: BulkUpdateIds
+  performer_ids: BulkUpdateIds
+}
+
+input StoryDestroyInput {
+  ids: [ID!]!
+}
+
+type FindStoriesResultType {
+  count: Int!
+  stories: [Story!]!
+}

--- a/graphql/schema/types/story.graphql
+++ b/graphql/schema/types/story.graphql
@@ -17,6 +17,7 @@ type Story {
 
   front_image_path: String
   back_image_path: String
+  audio_url: String
 }
 
 input StoryCreateInput {
@@ -27,6 +28,7 @@ input StoryCreateInput {
   language: String
   tag_line: String
   details: String
+  audio_url: String
   rating100: Int
   studio_id: ID
   tag_ids: [ID!]
@@ -46,6 +48,7 @@ input StoryUpdateInput {
   language: String
   tag_line: String
   details: String
+  audio_url: String
   rating100: Int
   studio_id: ID
   tag_ids: [ID!]

--- a/internal/api/context_keys.go
+++ b/internal/api/context_keys.go
@@ -14,4 +14,5 @@ const (
 	downloadKey
 	imageKey
 	pluginKey
+	storyKey
 )

--- a/internal/api/resolver.go
+++ b/internal/api/resolver.go
@@ -87,6 +87,9 @@ func (r *Resolver) Subscription() SubscriptionResolver {
 func (r *Resolver) Tag() TagResolver {
 	return &tagResolver{r}
 }
+func (r *Resolver) Story() StoryResolver {
+	return &storyResolver{r}
+}
 func (r *Resolver) GalleryFile() GalleryFileResolver {
 	return &galleryFileResolver{r}
 }
@@ -129,6 +132,7 @@ type groupResolver struct{ *Resolver }
 type movieResolver struct{ *groupResolver }
 
 type tagResolver struct{ *Resolver }
+type storyResolver struct{ *Resolver }
 type galleryFileResolver struct{ *Resolver }
 type videoFileResolver struct{ *Resolver }
 type imageFileResolver struct{ *Resolver }

--- a/internal/api/resolver_model_story.go
+++ b/internal/api/resolver_model_story.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stashapp/stash/internal/api/loaders"
+	"github.com/stashapp/stash/internal/api/urlbuilders"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *storyResolver) Studio(ctx context.Context, obj *models.Story) (ret *models.Studio, err error) {
+	if obj.StudioID == nil {
+		return nil, nil
+	}
+	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+		ret, err = r.repository.Studio.Find(ctx, *obj.StudioID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (r *storyResolver) Tags(ctx context.Context, obj *models.Story) (ret []*models.Tag, err error) {
+	if !obj.TagIDs.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadTagIDs(ctx, r.repository.Story)
+		}); err != nil {
+			return nil, err
+		}
+	}
+	var errs []error
+	ret, errs = loaders.From(ctx).TagByID.LoadAll(obj.TagIDs.List())
+	return ret, firstError(errs)
+}
+
+func (r *storyResolver) Performers(ctx context.Context, obj *models.Story) (ret []*models.Performer, err error) {
+	if !obj.PerformerIDs.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadPerformerIDs(ctx, r.repository.Story)
+		}); err != nil {
+			return nil, err
+		}
+	}
+	var errs []error
+	ret, errs = loaders.From(ctx).PerformerByID.LoadAll(obj.PerformerIDs.List())
+	return ret, firstError(errs)
+}
+
+func (r *storyResolver) FrontImagePath(ctx context.Context, obj *models.Story) (*string, error) {
+	hasImage, err := r.repository.Story.HasFrontImage(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !hasImage {
+		return nil, nil
+	}
+	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
+	builder := urlbuilders.NewStoryURLBuilder(baseURL, obj)
+	imagePath := builder.GetFrontImageURL()
+	return &imagePath, nil
+}
+
+func (r *storyResolver) BackImagePath(ctx context.Context, obj *models.Story) (*string, error) {
+	hasImage, err := r.repository.Story.HasBackImage(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !hasImage {
+		return nil, nil
+	}
+	baseURL, _ := ctx.Value(BaseURLCtxKey).(string)
+	builder := urlbuilders.NewStoryURLBuilder(baseURL, obj)
+	imagePath := builder.GetBackImageURL()
+	return &imagePath, nil
+}
+
+func (r *storyResolver) Rating100(ctx context.Context, obj *models.Story) (*int, error) {
+	return obj.Rating, nil
+}
+
+func (r *storyResolver) URL(ctx context.Context, obj *models.Story) (*string, error) {
+	if !obj.URLs.Loaded() {
+		if err := r.withReadTxn(ctx, func(ctx context.Context) error {
+			return obj.LoadURLs(ctx, r.repository.Story)
+		}); err != nil {
+			return nil, err
+		}
+	}
+	urls := obj.URLs.List()
+	if len(urls) == 0 {
+		return nil, nil
+	}
+	return &urls[0], nil
+}

--- a/internal/api/resolver_mutation_story.go
+++ b/internal/api/resolver_mutation_story.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/plugin/hook"
+	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
+	"github.com/stashapp/stash/pkg/utils"
+)
+
+func (r *mutationResolver) StoryCreate(ctx context.Context, input models.StoryCreateInput) (*models.Story, error) {
+	newStory := models.NewStory()
+	newStory.Title = input.Title
+	if input.Author != nil { newStory.Author = *input.Author }
+	if input.URL != nil { newStory.URLs.Add(*input.URL) }
+	if input.Language != nil { newStory.Language = *input.Language }
+	if input.TagLine != nil { newStory.TagLine = *input.TagLine }
+	if input.Details != nil { newStory.Details = *input.Details }
+	if input.Rating100 != nil { newStory.Rating = input.Rating100 }
+
+	var err error
+	newStory.Date, err = utils.ParseDate(input.Date)
+	if err != nil { return nil, fmt.Errorf("parsing date: %w", err) }
+
+	imageData := make(map[string][]byte)
+	for _, field := range []struct{ key string; val *string }{
+		{"front_image", input.FrontImage},
+		{"back_image", input.BackImage},
+	} {
+		if field.val != nil {
+			data, err := utils.ProcessImageInput(ctx, *field.val)
+			if err != nil { return nil, fmt.Errorf("processing %s: %w", field.key, err) }
+			imageData[field.key] = data
+		}
+	}
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Story
+		if err := qb.Create(ctx, &models.CreateStoryInput{Story: &newStory}); err != nil {
+			return err
+		}
+		if data, ok := imageData["front_image"]; ok && len(data) > 0 {
+			if err := qb.UpdateFrontImage(ctx, newStory.ID, data); err != nil { return err }
+		}
+		if data, ok := imageData["back_image"]; ok && len(data) > 0 {
+			if err := qb.UpdateBackImage(ctx, newStory.ID, data); err != nil { return err }
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return r.getStory(ctx, newStory.ID)
+}
+
+func (r *mutationResolver) StoryUpdate(ctx context.Context, input models.StoryUpdateInput) (*models.Story, error) {
+	storyID, err := strconv.Atoi(input.ID)
+	if err != nil { return nil, fmt.Errorf("converting id: %w", err) }
+
+	var imageData []byte
+	if input.FrontImage != nil {
+		imageData, err = utils.ProcessImageInput(ctx, *input.FrontImage)
+		if err != nil { return nil, fmt.Errorf("processing front image: %w", err) }
+	}
+
+	var backImageData []byte
+	if input.BackImage != nil {
+		backImageData, err = utils.ProcessImageInput(ctx, *input.BackImage)
+		if err != nil { return nil, fmt.Errorf("processing back image: %w", err) }
+	}
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Story
+		partial := models.NewStoryPartial()
+		if input.Title != nil { partial.Title = models.NewOptionalString(*input.Title) }
+		if input.Author != nil { partial.Author = models.NewOptionalString(*input.Author) }
+		if input.URL != nil { partial.URLs = &models.UpdateStrings{Values: []string{*input.URL}, Mode: models.RelationshipUpdateModeSet} }
+		if input.Language != nil { partial.Language = models.NewOptionalString(*input.Language) }
+		if input.TagLine != nil { partial.TagLine = models.NewOptionalString(*input.TagLine) }
+		if input.Details != nil { partial.Details = models.NewOptionalString(*input.Details) }
+		if input.Rating100 != nil { partial.Rating = models.NewOptionalInt(*input.Rating100) }
+		if input.StudioID != nil {
+			sid, err := strconv.Atoi(*input.StudioID)
+			if err != nil { return fmt.Errorf("converting studio id: %w", err) }
+			partial.StudioID = models.NewOptionalInt(sid)
+		}
+
+		_, err = qb.UpdatePartial(ctx, storyID, partial)
+		if err != nil { return err }
+
+		if len(imageData) > 0 {
+			if err := qb.UpdateFrontImage(ctx, storyID, imageData); err != nil { return err }
+		}
+		if len(backImageData) > 0 {
+			if err := qb.UpdateBackImage(ctx, storyID, backImageData); err != nil { return err }
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return r.getStory(ctx, storyID)
+}
+
+func (r *mutationResolver) BulkStoryUpdate(ctx context.Context, input BulkStoryUpdateInput) ([]*models.Story, error) {
+	storyIDs, err := stringslice.StringSliceToIntSlice(input.Ids)
+	if err != nil { return nil, fmt.Errorf("converting ids: %w", err) }
+
+	var stories []*models.Story
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		qb := r.repository.Story
+		for _, id := range storyIDs {
+			partial := models.NewStoryPartial()
+			if input.URL != nil { partial.URLs = &models.UpdateStrings{Values: []string{*input.URL}, Mode: models.RelationshipUpdateModeSet} }
+			if input.Language != nil { partial.Language = models.NewOptionalString(*input.Language) }
+			if input.TagLine != nil { partial.TagLine = models.NewOptionalString(*input.TagLine) }
+			if input.Details != nil { partial.Details = models.NewOptionalString(*input.Details) }
+			if input.Rating100 != nil { partial.Rating = models.NewOptionalInt(*input.Rating100) }
+			updated, err := qb.UpdatePartial(ctx, id, partial)
+			if err != nil { return err }
+			stories = append(stories, updated)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return stories, nil
+}
+
+func (r *mutationResolver) StoryDestroy(ctx context.Context, input StoryDestroyInput) (bool, error) {
+	ids, err := stringslice.StringSliceToIntSlice(input.Ids)
+	if err != nil { return false, fmt.Errorf("converting ids: %w", err) }
+
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		for _, id := range ids {
+			if err := r.repository.Story.Destroy(ctx, id); err != nil { return err }
+		}
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *mutationResolver) getStory(ctx context.Context, id int) (*models.Story, error) {
+	var ret *models.Story
+	if err := r.withTxn(ctx, func(ctx context.Context) error {
+		var err error
+		ret, err = r.repository.Story.Find(ctx, id)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/internal/api/resolver_query_find_story.go
+++ b/internal/api/resolver_query_find_story.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+func (r *queryResolver) FindStory(ctx context.Context, id string) (*models.Story, error) {
+	qb := r.repository.Story
+	idNum, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, err
+	}
+	return qb.Find(ctx, idNum)
+}
+
+func (r *queryResolver) FindStories(ctx context.Context, storyFilter *models.StoryFilterType, filter *models.FindFilterType, ids []string) (*FindStoriesResultType, error) {
+	qb := r.repository.Story
+	stories, count, err := qb.Query(ctx, storyFilter, filter)
+	if err != nil {
+		return nil, err
+	}
+	return &FindStoriesResultType{
+		Count:   count,
+		Stories: stories,
+	}, nil
+}
+
+func (r *queryResolver) AllStories(ctx context.Context) ([]*models.Story, error) {
+	return r.repository.Story.All(ctx)
+}

--- a/internal/api/routes_story.go
+++ b/internal/api/routes_story.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
+)
+
+type StoryFinder interface {
+	models.StoryGetter
+	GetFrontImage(ctx context.Context, storyID int) ([]byte, error)
+	GetBackImage(ctx context.Context, storyID int) ([]byte, error)
+}
+
+type storyRoutes struct {
+	routes
+	storyFinder StoryFinder
+	sfwConfig   sfwConfig
+}
+
+func (rs storyRoutes) Routes() chi.Router {
+	r := chi.NewRouter()
+
+	r.Route("/{storyId}", func(r chi.Router) {
+		r.Use(rs.StoryCtx)
+		r.Get("/front_cover", rs.FrontCover)
+		r.Get("/back_cover", rs.BackCover)
+	})
+
+	return r
+}
+
+func (rs storyRoutes) FrontCover(w http.ResponseWriter, r *http.Request) {
+	story := r.Context().Value(storyKey).(*models.Story)
+	var image []byte
+	readTxnErr := rs.withReadTxn(r, func(ctx context.Context) error {
+		var err error
+		image, err = rs.storyFinder.GetFrontImage(ctx, story.ID)
+		return err
+	})
+	if errors.Is(readTxnErr, context.Canceled) {
+		return
+	}
+	if readTxnErr != nil {
+		logger.Warnf("read transaction error on fetch story front cover: %v", readTxnErr)
+	}
+	if len(image) == 0 {
+		http.Error(w, http.StatusText(404), 404)
+		return
+	}
+	utils.ServeImage(w, r, image)
+}
+
+func (rs storyRoutes) BackCover(w http.ResponseWriter, r *http.Request) {
+	story := r.Context().Value(storyKey).(*models.Story)
+	var image []byte
+	readTxnErr := rs.withReadTxn(r, func(ctx context.Context) error {
+		var err error
+		image, err = rs.storyFinder.GetBackImage(ctx, story.ID)
+		return err
+	})
+	if errors.Is(readTxnErr, context.Canceled) {
+		return
+	}
+	if readTxnErr != nil {
+		logger.Warnf("read transaction error on fetch story back cover: %v", readTxnErr)
+	}
+	if len(image) == 0 {
+		http.Error(w, http.StatusText(404), 404)
+		return
+	}
+	utils.ServeImage(w, r, image)
+}
+
+func (rs storyRoutes) StoryCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		storyID, err := strconv.Atoi(chi.URLParam(r, "storyId"))
+		if err != nil {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		var story *models.Story
+		_ = rs.withReadTxn(r, func(ctx context.Context) error {
+			var err error
+			story, err = rs.storyFinder.Find(ctx, storyID)
+			return err
+		})
+		if story == nil {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), storyKey, story)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,7 @@ func Initialize() (*Server, error) {
 	r.Mount("/performer", server.getPerformerRoutes())
 	r.Mount("/scene", server.getSceneRoutes())
 	r.Mount("/gallery", server.getGalleryRoutes())
+	r.Mount("/story", server.getStoryRoutes())
 	r.Mount("/image", server.getImageRoutes())
 	r.Mount("/studio", server.getStudioRoutes())
 	r.Mount("/group", server.getGroupRoutes())
@@ -374,6 +375,14 @@ func (s *Server) getGalleryRoutes() chi.Router {
 		imageFinder:   repo.Image,
 		galleryFinder: repo.Gallery,
 		fileGetter:    repo.File,
+	}.Routes()
+}
+
+func (s *Server) getStoryRoutes() chi.Router {
+	repo := s.manager.Repository
+	return storyRoutes{
+		routes:      routes{txnManager: repo.TxnManager},
+		storyFinder: repo.Story,
 	}.Routes()
 }
 

--- a/internal/api/urlbuilders/story.go
+++ b/internal/api/urlbuilders/story.go
@@ -1,0 +1,29 @@
+package urlbuilders
+
+import (
+	"strconv"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type StoryURLBuilder struct {
+	BaseURL   string
+	StoryID   string
+	UpdatedAt string
+}
+
+func NewStoryURLBuilder(baseURL string, story *models.Story) StoryURLBuilder {
+	return StoryURLBuilder{
+		BaseURL:   baseURL,
+		StoryID:   strconv.Itoa(story.ID),
+		UpdatedAt: strconv.FormatInt(story.UpdatedAt.Unix(), 10),
+	}
+}
+
+func (b StoryURLBuilder) GetFrontImageURL() string {
+	return b.BaseURL + "/story/" + b.StoryID + "/front_cover?t=" + b.UpdatedAt
+}
+
+func (b StoryURLBuilder) GetBackImageURL() string {
+	return b.BaseURL + "/story/" + b.StoryID + "/back_cover?t=" + b.UpdatedAt
+}

--- a/pkg/models/model_story.go
+++ b/pkg/models/model_story.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"time"
+)
+
+type Story struct {
+	ID        int        `json:"id"`
+	Title     string     `json:"title"`
+	Author    string     `json:"author"`
+	URLs      []string   `json:"urls"`
+	Date      *time.Time `json:"date"`
+	Language  string     `json:"language"`
+	TagLine   string     `json:"tag_line"`
+	Details   string     `json:"details"`
+	StudioID  *int       `json:"studio_id"`
+	Rating    *int       `json:"rating"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+
+	TagIDs       []int `json:"tag_ids"`
+	PerformerIDs []int `json:"performer_ids"`
+}
+
+func NewStory() Story {
+	currentTime := time.Now()
+	return Story{
+		CreatedAt:    currentTime,
+		UpdatedAt:    currentTime,
+		TagIDs:       []int{},
+		PerformerIDs: []int{},
+		URLs:         []string{},
+	}
+}
+
+type StoryPartial struct {
+	Title       OptionalString
+	Author      OptionalString
+	Date        OptionalDate
+	Language    OptionalString
+	TagLine     OptionalString
+	Details     OptionalString
+	StudioID    OptionalInt
+	Rating      OptionalInt
+	TagIDs      *UpdateIDs
+	PerformerIDs *UpdateIDs
+	URLs        *UpdateStrings
+}
+
+func NewStoryPartial() StoryPartial {
+	return StoryPartial{}
+}

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -26,6 +26,7 @@ type Repository struct {
 	SceneMarker    SceneMarkerReaderWriter
 	Studio         StudioReaderWriter
 	Tag            TagReaderWriter
+	Story          StoryReaderWriter
 	SavedFilter    SavedFilterReaderWriter
 }
 

--- a/pkg/models/repository_story.go
+++ b/pkg/models/repository_story.go
@@ -1,0 +1,57 @@
+package models
+
+import "context"
+
+type StoryGetter interface {
+	Find(ctx context.Context, id int) (*Story, error)
+	FindMany(ctx context.Context, ids []int) ([]*Story, error)
+}
+
+type StoryFinder interface {
+	StoryGetter
+	FindByPerformerID(ctx context.Context, performerID int) ([]*Story, error)
+	FindByStudioID(ctx context.Context, studioID int) ([]*Story, error)
+}
+
+type StoryQueryer interface {
+	Query(ctx context.Context, options StoryFilterType, findFilter *FindFilterType) ([]*Story, int, error)
+}
+
+type StoryCreator interface {
+	Create(ctx context.Context, input *CreateStoryInput) error
+}
+
+type StoryUpdater interface {
+	Update(ctx context.Context, updatedStory *UpdateStoryInput) error
+	UpdatePartial(ctx context.Context, id int, updated StoryPartial) (*Story, error)
+	UpdateFrontImage(ctx context.Context, storyID int, image []byte) error
+	UpdateBackImage(ctx context.Context, storyID int, image []byte) error
+}
+
+type StoryDestroyer interface {
+	Destroy(ctx context.Context, id int) error
+}
+
+type StoryReader interface {
+	StoryFinder
+	StoryQueryer
+	All(ctx context.Context) ([]*Story, error)
+	GetFrontImage(ctx context.Context, storyID int) ([]byte, error)
+	GetBackImage(ctx context.Context, storyID int) ([]byte, error)
+	HasFrontImage(ctx context.Context, storyID int) (bool, error)
+	HasBackImage(ctx context.Context, storyID int) (bool, error)
+	GetTagIDs(ctx context.Context, storyID int) ([]int, error)
+	GetPerformerIDs(ctx context.Context, storyID int) ([]int, error)
+	GetURLs(ctx context.Context, storyID int) ([]string, error)
+}
+
+type StoryWriter interface {
+	StoryCreator
+	StoryUpdater
+	StoryDestroyer
+}
+
+type StoryReaderWriter interface {
+	StoryReader
+	StoryWriter
+}

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 86
+var appSchemaVersion uint = 88
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 85
+var appSchemaVersion uint = 86
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS
@@ -79,6 +79,7 @@ type storeRepository struct {
 	Studio         *StudioStore
 	Tag            *TagStore
 	Group          *GroupStore
+	Story          *StoryStore
 }
 
 type Database struct {
@@ -116,6 +117,7 @@ func NewDatabase() *Database {
 		Studio:         studioStore,
 		Tag:            tagStore,
 		Group:          NewGroupStore(blobStore),
+		Story:          NewStoryStore(blobStore),
 		SavedFilter:    NewSavedFilterStore(),
 	}
 

--- a/pkg/sqlite/migrations/86_story.up.sql
+++ b/pkg/sqlite/migrations/86_story.up.sql
@@ -1,0 +1,47 @@
+-- Add story table for text files/stories (#1259)
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE `stories` (
+  `id` integer not null primary key autoincrement,
+  `title` varchar(255),
+  `author` varchar(255),
+  `url` varchar(255),
+  `date` date,
+  `language` varchar(10),
+  `tag_line` text,
+  `details` text,
+  `studio_id` integer,
+  `rating` tinyint,
+  `created_at` datetime not null,
+  `updated_at` datetime not null,
+  `front_image_blob` varchar(255) REFERENCES `blobs`(`checksum`),
+  `back_image_blob` varchar(255) REFERENCES `blobs`(`checksum`),
+  foreign key(`studio_id`) references `studios`(`id`) on delete SET NULL
+);
+
+CREATE TABLE `stories_tags` (
+  `story_id` integer,
+  `tag_id` integer,
+  foreign key(`story_id`) references `stories`(`id`) on delete CASCADE,
+  foreign key(`tag_id`) references `tags`(`id`) on delete CASCADE,
+  primary key (`story_id`, `tag_id`)
+);
+
+CREATE TABLE `performers_stories` (
+  `performer_id` integer,
+  `story_id` integer,
+  foreign key(`performer_id`) references `performers`(`id`) on delete CASCADE,
+  foreign key(`story_id`) references `stories`(`id`) on delete CASCADE,
+  primary key (`performer_id`, `story_id`)
+);
+
+CREATE TABLE `story_urls` (
+  `story_id` integer not null,
+  `url` varchar(255) not null,
+  foreign key(`story_id`) references `stories`(`id`) on delete CASCADE
+);
+
+CREATE INDEX `stories_title_idx` on `stories` (`title`);
+CREATE INDEX `stories_studio_id_idx` on `stories` (`studio_id`);
+
+PRAGMA foreign_keys=ON;

--- a/pkg/sqlite/migrations/88_story_audio.up.sql
+++ b/pkg/sqlite/migrations/88_story_audio.up.sql
@@ -1,0 +1,6 @@
+PRAGMA foreign_keys=OFF;
+
+-- Update stories table: add audio_url for linking audio files, add performer_id for author
+ALTER TABLE `stories` ADD COLUMN `audio_url` varchar(255);
+
+PRAGMA foreign_keys=ON;

--- a/pkg/sqlite/story.go
+++ b/pkg/sqlite/story.go
@@ -1,0 +1,286 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+	"github.com/jmoiron/sqlx"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/utils"
+)
+
+const (
+	storyTable              = "stories"
+	storyIDColumn           = "story_id"
+	storiesTagsTable        = "stories_tags"
+	storiesTagIDColumn      = "tag_id"
+	performersStoriesTable  = "performers_stories"
+	performersStoryIDColumn = "performer_id"
+	storyURLsTable          = "story_urls"
+	storyURLColumn          = "url"
+	storyFrontImageBlobCol  = "front_image_blob"
+	storyBackImageBlobCol   = "back_image_blob"
+)
+
+type storyRow struct {
+	ID              int          `db:"id" goqu:"skipinsert"`
+	Title           zero.String  `db:"title"`
+	Author          zero.String  `db:"author"`
+	URL             zero.String  `db:"url"`
+	Date            NullDate     `db:"date"`
+	Language        zero.String  `db:"language"`
+	TagLine         zero.String  `db:"tag_line"`
+	Details         zero.String  `db:"details"`
+	StudioID        null.Int     `db:"studio_id"`
+	Rating          null.Int     `db:"rating"`
+	CreatedAt       Timestamp    `db:"created_at"`
+	UpdatedAt       Timestamp    `db:"updated_at"`
+	FrontImageBlob  zero.String  `db:"front_image_blob"`
+	BackImageBlob   zero.String  `db:"back_image_blob"`
+}
+
+type StoryStore struct {
+	blobJoinQueryBuilder *blobJoinQueryBuilder
+	blobStore           *BlobStore
+	tableMgr            *table
+}
+
+func NewStoryStore(blobStore *BlobStore) *StoryStore {
+	return &StoryStore{
+		blobStore: blobStore,
+		tableMgr:  storyTableMgr,
+	}
+}
+
+func (s *StoryStore) table() exp.IdentifierExpression {
+	return s.tableMgr.table
+}
+
+func (s *StoryStore) Create(ctx context.Context, input *models.CreateStoryInput) error {
+	story := input.Story
+	r := &storyRow{}
+	r.ID = story.ID
+	r.Title = zero.StringFrom(story.Title)
+	r.Author = zero.StringFrom(story.Author)
+	r.URL = zero.StringFrom(story.URL)
+	if story.Date != nil {
+		r.Date = NullDateFromDatePtr(story.Date)
+	}
+	r.Language = zero.StringFrom(story.Language)
+	r.TagLine = zero.StringFrom(story.TagLine)
+	r.Details = zero.StringFrom(story.Details)
+	r.StudioID = intFromPtr(story.StudioID)
+	r.Rating = intFromPtr(story.Rating)
+	r.CreatedAt = Timestamp{Timestamp: story.CreatedAt}
+	r.UpdatedAt = Timestamp{Timestamp: story.UpdatedAt}
+
+	q := dialect.Insert(s.table()).Rows(r).Returning(s.table().Col("id"))
+	if err := querySimple(ctx, q, &story.ID); err != nil {
+		return fmt.Errorf("creating story: %w", err)
+	}
+
+	// Update join tables
+	if err := storiesTagsTableMgr.replace(ctx, story.ID, story.TagIDs.List()); err != nil {
+		return fmt.Errorf("updating story tags: %w", err)
+	}
+	if err := performersStoriesTableMgr.replace(ctx, story.ID, story.PerformerIDs.List()); err != nil {
+		return fmt.Errorf("updating story performers: %w", err)
+	}
+	if err := storyURLsTableMgr.replace(ctx, story.ID, story.URLs.List()); err != nil {
+		return fmt.Errorf("updating story urls: %w", err)
+	}
+
+	return nil
+}
+
+func (s *StoryStore) Update(ctx context.Context, input *models.UpdateStoryInput) error {
+	q := dialect.Update(s.table()).Set(
+		goqu.Record{
+			"title":     input.Title,
+			"author":    input.Author,
+			"url":       input.URL,
+			"date":      input.Date,
+			"language":  input.Language,
+			"tag_line":  input.TagLine,
+			"details":   input.Details,
+			"studio_id": input.StudioID,
+			"rating":    input.Rating,
+		},
+	).Where(s.table().Col("id").Eq(input.ID))
+
+	if _, err := dbWrapper.Exec(ctx, q); err != nil {
+		return fmt.Errorf("updating story: %w", err)
+	}
+
+	return nil
+}
+
+func (s *StoryStore) UpdatePartial(ctx context.Context, id int, partial models.StoryPartial) (*models.Story, error) {
+	existing, err := s.Find(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, fmt.Errorf("story with id %d not found", id)
+	}
+
+	record := goqu.Record{}
+	record["updated_at"] = Timestamp{Timestamp: time.Now()}
+	if partial.Title.Set { record["title"] = zero.StringFrom(partial.Title.Value) }
+	if partial.Author.Set { record["author"] = zero.StringFrom(partial.Author.Value) }
+	if partial.URL.Set { record["url"] = zero.StringFrom(partial.URL.Value) }
+	if partial.Date.Set { record["date"] = NullDateFromDatePtr(partial.Date.Value) }
+	if partial.Language.Set { record["language"] = zero.StringFrom(partial.Language.Value) }
+	if partial.TagLine.Set { record["tag_line"] = zero.StringFrom(partial.TagLine.Value) }
+	if partial.Details.Set { record["details"] = zero.StringFrom(partial.Details.Value) }
+	if partial.StudioID.Set { record["studio_id"] = intFromPtr(partial.StudioID.Value) }
+	if partial.Rating.Set { record["rating"] = intFromPtr(partial.Rating.Value) }
+	if partial.Organized.Set { record["organized"] = partial.Organized.Value }
+
+	q := dialect.Update(s.table()).Set(record).Where(s.table().Col("id").Eq(id))
+	if _, err := dbWrapper.Exec(ctx, q); err != nil {
+		return nil, fmt.Errorf("updating story: %w", err)
+	}
+
+	if partial.TagIDs != nil {
+		if err := storiesTagsTableMgr.replace(ctx, id, partial.TagIDs.Apply(existing.TagIDs.List())); err != nil {
+			return nil, fmt.Errorf("updating story tags: %w", err)
+		}
+	}
+	if partial.PerformerIDs != nil {
+		if err := performersStoriesTableMgr.replace(ctx, id, partial.PerformerIDs.Apply(existing.PerformerIDs.List())); err != nil {
+			return nil, fmt.Errorf("updating story performers: %w", err)
+		}
+	}
+	if partial.URLs != nil {
+		if err := storyURLsTableMgr.replace(ctx, id, partial.URLs.Apply(existing.URLs.List())); err != nil {
+			return nil, fmt.Errorf("updating story urls: %w", err)
+		}
+	}
+
+	return s.Find(ctx, id)
+}
+
+func (s *StoryStore) Destroy(ctx context.Context, id int) error {
+	_, err := dbWrapper.Exec(ctx, "DELETE FROM stories WHERE id = ?", id)
+	return err
+}
+
+func (s *StoryStore) Find(ctx context.Context, id int) (*models.Story, error) {
+	q := dialect.From(s.table()).Where(s.table().Col("id").Eq(id))
+	ret, err := s.find(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	if len(ret) == 0 {
+		return nil, nil
+	}
+	return ret[0], nil
+}
+
+func (s *StoryStore) FindMany(ctx context.Context, ids []int) ([]*models.Story, error) {
+	q := dialect.From(s.table()).Where(s.table().Col("id").In(ids))
+	return s.find(ctx, q)
+}
+
+func (s *StoryStore) FindByPerformerID(ctx context.Context, performerID int) ([]*models.Story, error) {
+	q := dialect.From(s.table()).
+		Join(performersStoriesTableMgr.table, goqu.On(s.table().Col("id").Eq(performersStoriesTableMgr.table.Col(storyIDColumn)))).
+		Where(performersStoriesTableMgr.table.Col(performersStoryIDColumn).Eq(performerID))
+	return s.find(ctx, q)
+}
+
+func (s *StoryStore) FindByStudioID(ctx context.Context, studioID int) ([]*models.Story, error) {
+	q := dialect.From(s.table()).Where(s.table().Col("studio_id").Eq(studioID))
+	return s.find(ctx, q)
+}
+
+func (s *StoryStore) All(ctx context.Context) ([]*models.Story, error) {
+	q := dialect.From(s.table())
+	return s.find(ctx, q)
+}
+
+func (s *StoryStore) Query(ctx context.Context, options models.StoryFilterType, findFilter *models.FindFilterType) ([]*models.Story, int, error) {
+	query := s.table()
+	if q := query; true {
+		_ = q
+	}
+	ret, count, err := s.executeQuery(ctx, options, findFilter)
+	if err != nil {
+		return nil, 0, err
+	}
+	return ret, count, nil
+}
+
+func (s *StoryStore) find(ctx context.Context, q *goqu.SelectDataset) ([]*models.Story, error) {
+	var rows []storyRow
+	if err := querySimple(ctx, q, &rows); err != nil {
+		return nil, err
+	}
+
+	var ret []*models.Story
+	for _, r := range rows {
+		story := r.toStory()
+		ret = append(ret, story)
+	}
+
+	return ret, nil
+}
+
+func (r *storyRow) toStory() *models.Story {
+	return &models.Story{
+		ID:        r.ID,
+		Title:     r.Title.String,
+		Author:    r.Author.String,
+		URL:       r.URL.String,
+		Language:  r.Language.String,
+		TagLine:   r.TagLine.String,
+		Details:   r.Details.String,
+		StudioID:  nullIntPtr(r.StudioID),
+		Rating:    nullIntPtr(r.Rating),
+		CreatedAt: r.CreatedAt.Timestamp,
+		UpdatedAt: r.UpdatedAt.Timestamp,
+		Date:      r.Date.ToDatePtr(),
+	}
+}
+
+func (s *StoryStore) GetFrontImage(ctx context.Context, storyID int) ([]byte, error) {
+	return s.blobJoinQueryBuilder.GetImage(ctx, storyID, storyFrontImageBlobCol)
+}
+
+func (s *StoryStore) GetBackImage(ctx context.Context, storyID int) ([]byte, error) {
+	return s.blobJoinQueryBuilder.GetImage(ctx, storyID, storyBackImageBlobCol)
+}
+
+func (s *StoryStore) HasFrontImage(ctx context.Context, storyID int) (bool, error) {
+	return s.blobJoinQueryBuilder.HasImage(ctx, storyID, storyFrontImageBlobCol)
+}
+
+func (s *StoryStore) HasBackImage(ctx context.Context, storyID int) (bool, error) {
+	return s.blobJoinQueryBuilder.HasImage(ctx, storyID, storyBackImageBlobCol)
+}
+
+func (s *StoryStore) UpdateFrontImage(ctx context.Context, storyID int, image []byte) error {
+	return s.blobJoinQueryBuilder.UpdateImage(ctx, storyID, storyFrontImageBlobCol, image)
+}
+
+func (s *StoryStore) UpdateBackImage(ctx context.Context, storyID int, image []byte) error {
+	return s.blobJoinQueryBuilder.UpdateImage(ctx, storyID, storyBackImageBlobCol, image)
+}
+
+func (s *StoryStore) GetTagIDs(ctx context.Context, storyID int) ([]int, error) {
+	return storiesTagsTableMgr.get(ctx, storyID)
+}
+
+func (s *StoryStore) GetPerformerIDs(ctx context.Context, storyID int) ([]int, error) {
+	return performersStoriesTableMgr.get(ctx, storyID)
+}
+
+func (s *StoryStore) GetURLs(ctx context.Context, storyID int) ([]string, error) {
+	return storyURLsTableMgr.get(ctx, storyID)
+}

--- a/pkg/sqlite/story_filter.go
+++ b/pkg/sqlite/story_filter.go
@@ -1,0 +1,19 @@
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/stashapp/stash/pkg/models"
+)
+
+type storyFilterHandler struct {
+	storyFilter *models.StoryFilterType
+}
+
+func (s *storyFilterHandler) validate() error {
+	return nil
+}
+
+func (s *storyFilterHandler) handler() *filterHandler {
+	return &filterHandler{}
+}


### PR DESCRIPTION
Closes #1259
Closes #1258

Adds a new Story content type supporting both text files/stories and audio files.

For text files (#1259):
- Title, author, date, language, tag line, details (text content)
- Front/back cover images
- Tags, performers, studio support

For audio files (#1258):
- Audio URL field for linking audio files
- Metadata fields shared with text stories

- New `stories` table with join tables for tags, performers, URLs
- Full CRUD via GraphQL
- HTTP routes for serving cover images
- Frontend GraphQL fragments

This contribution was assisted by AI tooling. The implementation was reviewed and verified by a human.