### PR TITLE
Fix: Safari auto-start on transcode-required scenes

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -269,6 +269,9 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
 
     const started = useRef(false);
     const auto = useRef(false);
+    // durable autostart intent: unlike `auto`, this is not consumed by the
+    // one-shot play effect, so it survives source failover (e.g. transcode fallback)
+    const autostartIntent = useRef(false);
     const interactiveReady = useRef(false);
     const minimumPlayPercent = uiConfig?.minimumPlayPercent ?? 0;
     const trackActivity = uiConfig?.trackActivity ?? true;
@@ -714,6 +717,15 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
         buttonEnabled ||
         (interfaceConfig?.autostartVideo ?? false) ||
         _initialTimestamp > 0;
+      autostartIntent.current = auto.current;
+
+      // let the source selector know whether playback is intended, so it doesn't
+      // auto-start during source failover/preload (e.g. transcode fallback in Safari).
+      // uses autostartIntent (not auto) because auto is cleared by the one-shot play
+      // effect before failover occurs; started covers mid-playback source swaps.
+      sourceSelector.setShouldAutoplay(
+        () => autostartIntent.current || started.current
+      );
 
       player.ready(() => {
         player.vttThumbnails().src(scene.paths.vtt ?? null);

--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -110,6 +110,10 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
   // don't auto play next source if user manually selected a source
   private manuallySelected = false;
 
+  // returns whether playback is currently intended (autostart or already playing).
+  // used to avoid auto-starting playback during source resolution/failover.
+  private shouldAutoplay: () => boolean = () => false;
+
   constructor(player: VideoJsPlayer) {
     super(player);
 
@@ -154,7 +158,9 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
         if (currentSrc === null) return;
 
         if (currentSrc.includes(".m3u8") || currentSrc.includes(".mpd")) {
-          player.play();
+          if (this.shouldAutoplay()) {
+            player.play();
+          }
         } else {
           player.error(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
           return;
@@ -202,7 +208,9 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
         player.one("canplay", () => {
           player.currentTime(currentTime);
         });
-        player.play();
+        if (this.shouldAutoplay()) {
+          player.play();
+        }
       } else {
         console.log("No more sources in playlist");
       }
@@ -224,6 +232,10 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
 
     this.sources = sources;
     this.player.src(sources[0]);
+  }
+
+  setShouldAutoplay(fn: () => boolean) {
+    this.shouldAutoplay = fn;
   }
 
   get textTracks(): HTMLTrackElement[] {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

In Safari, opening a scene that requires server-side transcoding started playback automatically even when the **Auto-start video** interface setting was disabled.

The cause is in the scene player's `sourceSelector` plugin. When the original file can't be played directly (e.g. VP9/WebM), Safari fails over from the unsupported direct source to a transcoded HLS/DASH stream. The plugin called `player.play()` unconditionally in two spots during that resolution:

- the `error` handler that advances to the next source after a source fails, and
- the `loadedmetadata` handler that handles Safari's zero-dimension media event for `.m3u8`/`.mpd` sources.

Both bypassed the user's auto-start preference, so the transcode fallback always started playing.

This PR gates those two `play()` calls on whether playback is actually intended. The player component passes a callback into the plugin that reports intent as "auto-start is enabled (a durable flag that survives the source failover) **or** playback is already in progress". As a result:

- Auto-start **off** + transcode-required source → the HLS/DASH stream loads but stays paused.
- Auto-start **on** → fails over and plays, as before.
- A source that fails **mid-playback** → playback continues on the next source, as before.

Direct-play sources and non-Safari browsers are unaffected. The failover mechanics (`player.src()` + `player.load()`) are untouched, so the deceptive-WEBM fix from #3676 does not regress.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6646

## Testing
<!-- Describe the testing steps you have performed. -->

Reproduced with a VP9/WebM clip (transcode-required) and verified against an H.264/MP4 scene (direct play), toggling the **Auto-start video** setting, in both Safari and Chrome:

| Browser | Source | Auto-start OFF | Auto-start ON |
| --- | --- | --- | --- |
| Safari | VP9/WebM (transcode) | Loads paused ✅ | Fails over to HLS and plays ✅ |
| Safari | H.264/MP4 (direct) | Loads paused ✅ | Plays ✅ |
| Chrome | VP9/WebM | Loads paused ✅ | Plays ✅ |
| Chrome | H.264/MP4 | Loads paused ✅ | Plays ✅ |

Frontend checks pass: `pnpm run check` (`tsc --noEmit`) and `make validate-ui-quick` (Biome lint + format on the changed files).

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A — behavioral change only, no visual differences.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable). <!-- Not applicable — this is a behavioral bug fix with no documentation impact. -->

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Claude Code (Anthropic) to help investigate the issue, trace the root cause through the scene player and source-selector plugin, design the approach, draft the code changes, and run the type/lint checks. I reviewed all changes and manually tested the behavior across browsers and auto-start states myself.

## Additional Context
<!-- Add any other context about the pull request here. -->

The intent signal deliberately uses a separate, durable auto-start flag rather than the component's existing one-shot `auto` ref: the one-shot ref is cleared by the play effect immediately after the first `play()` on the (unplayable) direct source, which is *before* the failover happens — so reusing it would suppress the legitimate auto-start of the transcode fallback.

Out of scope: while testing the auto-start-on failover, an unrelated, pre-existing `AbortError` unhandled rejection can appear in the console (the direct source's `play()` promise being aborted by the failover `load()`). It is benign and predates this change; happy to address it separately if desired.
