### PR TITLE
Fix: Respect wall preview type in scene walls

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
@@ -32,6 +32,7 @@ function wallItemTitle(sceneMarker: GQL.SceneMarkerDataFragment) {
 interface IMarkerPhoto {
   marker: GQL.SceneMarkerDataFragment;
   link: string;
+  mediaType: "image" | "video";
   onError?: (photo: PhotoProps<IMarkerPhoto>) => void;
 }
 
@@ -85,7 +86,7 @@ export const MarkerWallItem: React.FC<
     }
   }
 
-  const video = props.photo.src.includes("stream");
+  const video = props.photo.mediaType === "video";
   const ImagePreview = video ? "video" : "img";
 
   const { marker } = props.photo;
@@ -166,15 +167,55 @@ interface IMarkerWallProps {
 // HACK: typescript doesn't allow Gallery to accept a parameter for some reason
 const MarkerGallery = Gallery as unknown as GalleryI<IMarkerPhoto>;
 
-function getFirstValidSrc(srcSet: string[], invalidSrcSet: string[]) {
-  if (!srcSet.length) {
-    return "";
+interface IPreviewSource {
+  src?: string | null;
+  mediaType: "image" | "video";
+}
+
+interface ISelectedPreviewSource {
+  src: string;
+  mediaType: "image" | "video";
+}
+
+function getFirstValidPreviewSource(
+  srcSet: readonly IPreviewSource[],
+  invalidSrcSet: string[]
+): ISelectedPreviewSource {
+  const validSrcSet = srcSet.filter((s) => s.src);
+
+  if (!validSrcSet.length) {
+    return { src: "", mediaType: "image" };
   }
 
-  return (
-    srcSet.find((src) => !invalidSrcSet.includes(src)) ??
-    ([...srcSet].pop() as string)
-  );
+  const selected =
+    validSrcSet.find(({ src }) => !invalidSrcSet.includes(src!)) ??
+    ([...validSrcSet].pop() as IPreviewSource);
+
+  return {
+    src: selected.src!,
+    mediaType: selected.mediaType,
+  };
+}
+
+function getMarkerPreviewSources(
+  marker: GQL.SceneMarkerDataFragment,
+  previewType?: string | null
+) {
+  if (previewType === "image") {
+    return [{ src: marker.screenshot, mediaType: "image" }] as const;
+  }
+
+  if (previewType === "animation") {
+    return [
+      { src: marker.preview, mediaType: "image" },
+      { src: marker.screenshot, mediaType: "image" },
+    ] as const;
+  }
+
+  return [
+    { src: marker.stream, mediaType: "video" },
+    { src: marker.screenshot, mediaType: "image" },
+  ] as const;
 }
 
 interface IFile {
@@ -210,6 +251,8 @@ const MarkerWall: React.FC<IMarkerWallProps> = ({
   selecting,
 }) => {
   const history = useHistory();
+  const { configuration } = useConfigurationContext();
+  const previewType = configuration?.interface.wallPlayback;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -242,8 +285,8 @@ const MarkerWall: React.FC<IMarkerWallProps> = ({
 
       return {
         marker: m,
-        src: getFirstValidSrc(
-          [m.stream, m.preview, m.screenshot],
+        ...getFirstValidPreviewSource(
+          getMarkerPreviewSources(m, previewType),
           erroredImgs[m.id] || []
         ),
         link: NavUtils.makeSceneMarkerUrl(m),
@@ -256,7 +299,7 @@ const MarkerWall: React.FC<IMarkerWallProps> = ({
         onError: (photo: PhotoProps<IMarkerPhoto>) => handleError(m.id, photo),
       };
     });
-  }, [markers, erroredImgs, handleError]);
+  }, [markers, previewType, erroredImgs, handleError]);
 
   const onClick = useCallback(
     (_event, { index }) => {

--- a/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerWallPanel.tsx
@@ -15,6 +15,10 @@ import { useDragMoveSelect } from "../Shared/GridCard/dragMoveSelect";
 import cx from "classnames";
 import NavUtils from "src/utils/navigation";
 import { markerTitle } from "src/core/markers";
+import {
+  getFirstValidPreviewSource,
+  PreviewMediaType,
+} from "src/utils/wallPreview";
 
 function wallItemTitle(sceneMarker: GQL.SceneMarkerDataFragment) {
   const newTitle = markerTitle(sceneMarker);
@@ -32,7 +36,7 @@ function wallItemTitle(sceneMarker: GQL.SceneMarkerDataFragment) {
 interface IMarkerPhoto {
   marker: GQL.SceneMarkerDataFragment;
   link: string;
-  mediaType: "image" | "video";
+  mediaType: PreviewMediaType;
   onError?: (photo: PhotoProps<IMarkerPhoto>) => void;
 }
 
@@ -166,36 +170,6 @@ interface IMarkerWallProps {
 
 // HACK: typescript doesn't allow Gallery to accept a parameter for some reason
 const MarkerGallery = Gallery as unknown as GalleryI<IMarkerPhoto>;
-
-interface IPreviewSource {
-  src?: string | null;
-  mediaType: "image" | "video";
-}
-
-interface ISelectedPreviewSource {
-  src: string;
-  mediaType: "image" | "video";
-}
-
-function getFirstValidPreviewSource(
-  srcSet: readonly IPreviewSource[],
-  invalidSrcSet: string[]
-): ISelectedPreviewSource {
-  const validSrcSet = srcSet.filter((s) => s.src);
-
-  if (!validSrcSet.length) {
-    return { src: "", mediaType: "image" };
-  }
-
-  const selected =
-    validSrcSet.find(({ src }) => !invalidSrcSet.includes(src!)) ??
-    ([...validSrcSet].pop() as IPreviewSource);
-
-  return {
-    src: selected.src!,
-    mediaType: selected.mediaType,
-  };
-}
 
 function getMarkerPreviewSources(
   marker: GQL.SceneMarkerDataFragment,

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -26,6 +26,7 @@ import { defaultPreviewVolume } from "src/core/config";
 interface IScenePhoto {
   scene: GQL.SlimSceneDataFragment;
   link: string;
+  mediaType: "image" | "video";
   onError?: (photo: PhotoProps<IScenePhoto>) => void;
 }
 
@@ -82,7 +83,7 @@ export const SceneWallItem: React.FC<
     }
   }
 
-  const video = props.photo.src.includes("preview");
+  const video = props.photo.mediaType === "video";
   const previewProps = {
     loading: "lazy",
     loop: video,
@@ -211,6 +212,57 @@ const breakpointZoomHeights = [
 
 type FailedSrcMap = Record<string, string[]>; // id to list of failed srcs
 
+interface IPreviewSource {
+  src?: string | null;
+  mediaType: "image" | "video";
+}
+
+interface ISelectedPreviewSource {
+  src: string;
+  mediaType: "image" | "video";
+}
+
+function getFirstValidPreviewSource(
+  srcSet: readonly IPreviewSource[],
+  invalidSrcSet: string[]
+): ISelectedPreviewSource {
+  const validSrcSet = srcSet.filter((s) => s.src);
+
+  if (!validSrcSet.length) {
+    return { src: "", mediaType: "image" };
+  }
+
+  const selected =
+    validSrcSet.find(({ src }) => !invalidSrcSet.includes(src!)) ??
+    ([...validSrcSet].pop() as IPreviewSource);
+
+  return {
+    src: selected.src!,
+    mediaType: selected.mediaType,
+  };
+}
+
+function getScenePreviewSources(
+  scene: GQL.SlimSceneDataFragment,
+  previewType?: string | null
+) {
+  if (previewType === "image") {
+    return [{ src: scene.paths.screenshot, mediaType: "image" }] as const;
+  }
+
+  if (previewType === "animation") {
+    return [
+      { src: scene.paths.webp, mediaType: "image" },
+      { src: scene.paths.screenshot, mediaType: "image" },
+    ] as const;
+  }
+
+  return [
+    { src: scene.paths.preview, mediaType: "video" },
+    { src: scene.paths.screenshot, mediaType: "image" },
+  ] as const;
+}
+
 const SceneWall: React.FC<ISceneWallProps> = ({
   scenes,
   sceneQueue,
@@ -220,6 +272,8 @@ const SceneWall: React.FC<ISceneWallProps> = ({
   selecting,
 }) => {
   const history = useHistory();
+  const { configuration } = useConfigurationContext();
+  const previewType = configuration?.interface.wallPlayback;
 
   const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -249,13 +303,15 @@ const SceneWall: React.FC<ISceneWallProps> = ({
   const photos: PhotoProps<IScenePhoto>[] = useMemo(() => {
     return scenes.map((s, index) => {
       const { width, height } = getDimensions(s);
+      const previewSource = getFirstValidPreviewSource(
+        getScenePreviewSources(s, previewType),
+        erroredImgs[s.id] || []
+      );
 
       return {
         scene: s,
-        src:
-          s.paths.preview && !erroredImgs[s.id]?.includes(s.paths.preview)
-            ? s.paths.preview!
-            : s.paths.screenshot!,
+        src: previewSource.src,
+        mediaType: previewSource.mediaType,
         link: sceneQueue
           ? sceneQueue.makeLink(s.id, { sceneIndex: index })
           : `/scenes/${s.id}`,
@@ -268,7 +324,7 @@ const SceneWall: React.FC<ISceneWallProps> = ({
         onError: (photo: PhotoProps<IScenePhoto>) => handleError(s.id, photo),
       };
     });
-  }, [scenes, sceneQueue, erroredImgs, handleError]);
+  }, [scenes, previewType, sceneQueue, erroredImgs, handleError]);
 
   const onClick = useCallback(
     (_event, { index }) => {

--- a/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneWallPanel.tsx
@@ -22,11 +22,15 @@ import { useIntl } from "react-intl";
 import { useDragMoveSelect } from "../Shared/GridCard/dragMoveSelect";
 import cx from "classnames";
 import { defaultPreviewVolume } from "src/core/config";
+import {
+  getFirstValidPreviewSource,
+  PreviewMediaType,
+} from "src/utils/wallPreview";
 
 interface IScenePhoto {
   scene: GQL.SlimSceneDataFragment;
   link: string;
-  mediaType: "image" | "video";
+  mediaType: PreviewMediaType;
   onError?: (photo: PhotoProps<IScenePhoto>) => void;
 }
 
@@ -211,36 +215,6 @@ const breakpointZoomHeights = [
 ];
 
 type FailedSrcMap = Record<string, string[]>; // id to list of failed srcs
-
-interface IPreviewSource {
-  src?: string | null;
-  mediaType: "image" | "video";
-}
-
-interface ISelectedPreviewSource {
-  src: string;
-  mediaType: "image" | "video";
-}
-
-function getFirstValidPreviewSource(
-  srcSet: readonly IPreviewSource[],
-  invalidSrcSet: string[]
-): ISelectedPreviewSource {
-  const validSrcSet = srcSet.filter((s) => s.src);
-
-  if (!validSrcSet.length) {
-    return { src: "", mediaType: "image" };
-  }
-
-  const selected =
-    validSrcSet.find(({ src }) => !invalidSrcSet.includes(src!)) ??
-    ([...validSrcSet].pop() as IPreviewSource);
-
-  return {
-    src: selected.src!,
-    mediaType: selected.mediaType,
-  };
-}
 
 function getScenePreviewSources(
   scene: GQL.SlimSceneDataFragment,

--- a/ui/v2.5/src/utils/wallPreview.ts
+++ b/ui/v2.5/src/utils/wallPreview.ts
@@ -1,0 +1,31 @@
+export type PreviewMediaType = "image" | "video";
+
+export interface PreviewSource {
+  src?: string | null;
+  mediaType: PreviewMediaType;
+}
+
+export interface SelectedPreviewSource {
+  src: string;
+  mediaType: PreviewMediaType;
+}
+
+export function getFirstValidPreviewSource(
+  srcSet: readonly PreviewSource[],
+  invalidSrcSet: string[]
+): SelectedPreviewSource {
+  const validSrcSet = srcSet.filter((s) => s.src);
+
+  if (!validSrcSet.length) {
+    return { src: "", mediaType: "image" };
+  }
+
+  const selected =
+    validSrcSet.find(({ src }) => !invalidSrcSet.includes(src!)) ??
+    ([...validSrcSet].pop() as PreviewSource);
+
+  return {
+    src: selected.src!,
+    mediaType: selected.mediaType,
+  };
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
Fixes the scene and marker wall views so they respect the configured Scene/Marker Wall Preview type.

Previously, the top-level scene wall always preferred scene video previews when available, and the marker wall always preferred marker streams, regardless of the `wallPlayback` interface setting. This meant changing the  `Settings > Interface > Scene Wall > Wall Preview` setting back to Static image could still leave animated/video previews visible.

This updates the wall source selection so:

- Video uses scene previews / marker streams, falling back to screenshots
- Animated image uses scene webp / marker animated previews, falling back to screenshots
- Static image uses screenshots only

The wall items now use an explicit media type instead of inferring video/image from URL substrings.

## Related Issue
Fixes #6836



## Testing
<!-- Describe the testing steps you have performed. -->
- Ran `pnpm.cmd run check`
- Ran `pnpm.cmd run lint:js`
- Ran `pnpm.cmd exec biome format src\components\Scenes\SceneWallPanel.tsx src\components\Scenes\SceneMarkerWallPanel.tsx`
- Ran `git diff --check`


Manual testing:
- Set Scene/Marker Wall Preview type to Video and confirm wall previews play as video.
- Set it to Animated image and confirm wall previews use animated image previews.
- Set it to Static image and confirm scene and marker wall views use screenshots only.
- Scan new video, only generate screenshot, and confirm Video and Animated settings fallback to screenshot
- Scan new video, only generate video preview, and confirm Animated and static image settings fallback to default missing image
- Navigated around the scene/marker walls generally to confirm there weren't any obvious regressions.
- Also confirmed that the Marker Wall in Scene Details that uses `WallItem` still functions


## Screenshots
Not included. This is a behavior fix for preview media selection.



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

I used Codex assistance to help investigate the affected code paths and with the initial draft implementation. I have manually confirmed every change, ran validation locally with a small test library, and take responsibility for the final code.




## Additional Context
<!-- Add any other context about the pull request here. -->
There is already preview-type handling in `components/Wall/WallItem.tsx`, but the top-level scene and marker wall display modes do not use that component. They use the photo-gallery implementations in `SceneWallPanel.tsx` and `SceneMarkerWallPanel.tsx`.

Those panels already consumed related interface settings such as `wallShowTitle` and `soundOnPreview`, but their media source selection still used a fixed priority order. This PR brings their source selection in line with the existing `WallItem` behavior while keeping the current gallery layout.  

One relevant difference from `components/Wall/WallItem.tsx` is the playing video on hover.  This fix is limited to adding preview-type handling for `SceneWallPanel.tsx` and `SceneMarkerWallPanel.tsx` and does not add that feature for static images.   

