### PR TITLE
Settings: collapsible, filterable, sorted plugin list

### DIFF
--- a/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
@@ -177,18 +177,15 @@ export const SettingsPluginsPanel: React.FC = () => {
       const query = filter.toLowerCase();
       const visiblePlugins = (data?.plugins ?? [])
         .slice()
-        .sort((a, b) => {
-          // keep enabled plugins above disabled ones, then sort by name
-          if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
-          return a.name.localeCompare(b.name);
-        })
+        .sort((a, b) => a.name.localeCompare(b.name))
         .filter((plugin) => plugin.name.toLowerCase().includes(query));
 
       const elements = visiblePlugins.map((plugin) => (
         <SettingGroup
           key={plugin.id}
-          collapsible
-          collapsedDefault
+          // only collapsible if there are hooks or settings to show
+          collapsible={!!(plugin.hooks?.length || plugin.settings?.length)}
+          collapsedDefault={!!(plugin.hooks?.length || plugin.settings?.length)}
           settingProps={{
             heading: `${plugin.name} ${
               plugin.version ? `(${plugin.version})` : undefined

--- a/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsPluginsPanel.tsx
@@ -16,7 +16,6 @@ import { SettingSection } from "./SettingSection";
 import {
   BooleanSetting,
   NumberSetting,
-  Setting,
   SettingGroup,
   StringSetting,
 } from "./Inputs";
@@ -27,6 +26,7 @@ import {
   InstalledPluginPackages,
 } from "./PluginPackageManager";
 import { ExternalLink } from "../Shared/ExternalLink";
+import { ClearableInput } from "../Shared/ClearableInput";
 import { PatchComponent } from "src/patch";
 
 interface IPluginSettingProps {
@@ -114,6 +114,8 @@ export const SettingsPluginsPanel: React.FC = () => {
     string | undefined
   >();
 
+  const [filter, setFilter] = React.useState("");
+
   async function onReloadPlugins() {
     try {
       await mutateReloadPlugins();
@@ -172,9 +174,21 @@ export const SettingsPluginsPanel: React.FC = () => {
     }
 
     function renderPlugins() {
-      const elements = (data?.plugins ?? []).map((plugin) => (
+      const query = filter.toLowerCase();
+      const visiblePlugins = (data?.plugins ?? [])
+        .slice()
+        .sort((a, b) => {
+          // keep enabled plugins above disabled ones, then sort by name
+          if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        })
+        .filter((plugin) => plugin.name.toLowerCase().includes(query));
+
+      const elements = visiblePlugins.map((plugin) => (
         <SettingGroup
           key={plugin.id}
+          collapsible
+          collapsedDefault
           settingProps={{
             heading: `${plugin.name} ${
               plugin.version ? `(${plugin.version})` : undefined
@@ -240,7 +254,7 @@ export const SettingsPluginsPanel: React.FC = () => {
     }
 
     return renderPlugins();
-  }, [data?.plugins, intl, Toast, changedPluginID]);
+  }, [data?.plugins, intl, Toast, changedPluginID, filter]);
 
   if (loading || configLoading) return <LoadingIndicator />;
 
@@ -250,7 +264,12 @@ export const SettingsPluginsPanel: React.FC = () => {
       <AvailablePluginPackages />
 
       <SettingSection headingID="config.categories.plugins">
-        <Setting headingID="actions.reload_plugins">
+        <div className="content d-flex justify-content-between">
+          <ClearableInput
+            placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+            value={filter}
+            setValue={(v) => setFilter(v)}
+          />
           <Button onClick={() => onReloadPlugins()}>
             <span className="fa-icon">
               <Icon icon={faSyncAlt} />
@@ -259,7 +278,7 @@ export const SettingsPluginsPanel: React.FC = () => {
               <FormattedMessage id="actions.reload_plugins" />
             </span>
           </Button>
-        </Setting>
+        </div>
         {pluginElements}
       </SettingSection>
     </>


### PR DESCRIPTION
## Description
Plugin list getting unwieldy so added three small things to the Settings > Plugins page:
- **Collapsible plugin groups** (collapsed by default), reuses `SettingGroup`'s existing `collapsible`/`collapsedDefault` props same as the Tasks plugin list
- **Live name filter**, `ClearableInput` in the toolbar next to Reload, same as Scrapers page
- **Alphabetical sort** by display name, disabled plugins at the bottom

One file changed, no new components/CSS/i18n. Doesn't touch anything #5002 related so can land independantly.

## Related Issue
Refs #5002

## Testing
Manual against a local build (six test plugins, folder order scrambled):
- Renders alphabetically, collapsed by default
- Filter narrows in real time, clear button works
- Expanding a group doesn't affect others
- Disabling a plugin moves it below the enabled ones
- `tsc --noEmit`, `biome lint`, `biome format` all pass

## Screenshots
<img width="1100" height="1112" alt="plugins-04-disabled-sort" src="https://github.com/user-attachments/assets/d8f5bbb0-bcda-4e13-83d3-4fc2caed7164" />



## Checklist
- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
 AI was used only to review and polish the PR description (hence the link hallucinations). I have since rewritten the description by hand.

## Additional Context
`SettingGroup` already supports collapse, this just enables it on the Plugins page and adds filter/sort on top.