### PR TITLE
fix: close Lightbox overlay on browser back button press

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { lazyComponent } from "src/utils/lazyComponent";
 import { ILightboxImage, IChapter } from "./types";
 
@@ -44,19 +44,44 @@ export const LightboxProvider: React.FC = ({ children }) => {
     slideshowEnabled: false,
   });
 
+  // Use ref for onClose to avoid stale closures in callbacks
+  const onCloseRef = useRef<(() => void) | undefined>();
+  onCloseRef.current = lightboxState.onClose;
+
   const setPartialState = useCallback((state: Partial<IState>) => {
-    setLightboxState((currentState: IState) => ({
-      ...currentState,
-      ...state,
-    }));
+    setLightboxState((currentState: IState) => {
+      // Push history entry when lightbox opens so back button closes it
+      // instead of navigating away from the current page
+      if (state.isVisible && !currentState.isVisible) {
+        history.pushState({ lightbox: true }, '');
+      }
+      return { ...currentState, ...state };
+    });
   }, []);
 
-  const onHide = () => {
-    setLightboxState({ ...lightboxState, isVisible: false });
-    if (lightboxState.onClose) {
-      lightboxState.onClose();
-    }
-  };
+  const onHide = useCallback(() => {
+    // User-initiated close (close button, escape, etc.) — navigate back
+    // which will trigger popstate and handle the actual state update
+    history.back();
+  }, []);
+
+  // Close lightbox on browser back/forward navigation
+  useEffect(() => {
+    const handlePopState = () => {
+      setLightboxState((currentState: IState) => {
+        if (currentState.isVisible) {
+          return { ...currentState, isVisible: false };
+        }
+        return currentState;
+      });
+      onCloseRef.current?.();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
 
   return (
     <LightboxContext.Provider

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -74,13 +74,17 @@ export const LightboxProvider: React.FC = ({ children }) => {
   // Close lightbox on browser back/forward navigation
   useEffect(() => {
     const handlePopState = () => {
+      let wasVisible = false;
       setLightboxState((currentState: IState) => {
         if (currentState.isVisible) {
+          wasVisible = true;
           return { ...currentState, isVisible: false };
         }
         return currentState;
       });
-      onCloseRef.current?.();
+      if (wasVisible) {
+        onCloseRef.current?.();
+      }
     };
 
     window.addEventListener("popstate", handlePopState);

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -1,4 +1,10 @@
-import React, { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { lazyComponent } from "src/utils/lazyComponent";
 import { ILightboxImage, IChapter } from "./types";
 
@@ -53,7 +59,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
       // Push history entry when lightbox opens so back button closes it
       // instead of navigating away from the current page
       if (state.isVisible && !currentState.isVisible) {
-        history.pushState({ lightbox: true }, '');
+        history.pushState({ lightbox: true }, "");
       }
       return { ...currentState, ...state };
     });

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -55,14 +55,15 @@ export const LightboxProvider: React.FC = ({ children }) => {
   onCloseRef.current = lightboxState.onClose;
 
   const setPartialState = useCallback((state: Partial<IState>) => {
+    let shouldPushHistory = false;
     setLightboxState((currentState: IState) => {
-      // Push history entry when lightbox opens so back button closes it
-      // instead of navigating away from the current page
-      if (state.isVisible && !currentState.isVisible) {
-        history.pushState({ lightbox: true }, "");
-      }
+      shouldPushHistory = state.isVisible === true && !currentState.isVisible;
       return { ...currentState, ...state };
     });
+    // Push history entry after state update to keep updater pure
+    if (shouldPushHistory) {
+      history.pushState({ lightbox: true }, '');
+    }
   }, []);
 
   const onHide = useCallback(() => {

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -62,7 +62,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
     });
     // Push history entry after state update to keep updater pure
     if (shouldPushHistory) {
-      history.pushState({ lightbox: true }, '');
+      history.pushState({ lightbox: true }, "");
     }
   }, []);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

The Image View overlay (Lightbox) did not close when the browser back button was pressed, causing the overlay to persist over the wrong page or show an empty state.

- Add popstate event listener to close lightbox on browser navigation
- Push history entry when lightbox opens so back closes it without navigating away from the current page
- Use ref for onClose callback to avoid stale closures



## Related Issue
<!-- Please link the issue your pull request is referring to. -->
Fixes #1940



## Testing
<!-- Describe the testing steps you have performed. -->

1. Go to 'Galleries'
2. Click on any gallery
3. Click on any image in the gallery to open it with Image View overlay UI
4. Click the "Back" button in the web browser
5.  Lighbox succesfully closes and, it doesn't stay open.


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
Mimo v2.5 LLM and Coderabbit used to review the code.