### PR TITLE
Fix: Remove PHash When OSHash Changes

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -843,6 +843,14 @@ func (s *Scanner) removeOutdatedFingerprints(existing models.File, fp models.Fin
 		return
 	}
 
+	b := existing.Base()
+
+	// oshash has changed - drop phash in case file contents are different
+	if b.Fingerprints.For(models.FingerprintTypePhash) != nil {
+		logger.Infof("Removing outdated phash from %s", b.Path)
+		b.Fingerprints = b.Fingerprints.Remove(models.FingerprintTypePhash)
+	}
+
 	md5 := fp.For(models.FingerprintTypeMD5)
 
 	if md5 != nil {
@@ -851,8 +859,7 @@ func (s *Scanner) removeOutdatedFingerprints(existing models.File, fp models.Fin
 	}
 
 	// oshash has changed, MD5 is missing - remove MD5 from the existing fingerprints
-	logger.Infof("Removing outdated checksum from %s", existing.Base().Path)
-	b := existing.Base()
+	logger.Infof("Removing outdated checksum from %s", b.Path)
 	b.Fingerprints = b.Fingerprints.Remove(models.FingerprintTypeMD5)
 }
 


### PR DESCRIPTION
## Description
We've noticed in stash-box that some users are submitting phash fingerprints that have durations belonging to different matches. Exact phash collisions do not typically happen except in extreme cases, and are not expected for normal scenes.

Initially I suspected scripts, but I've had to rule that out. My best guess for how this happens is that after a file has had phash generated, the file is replaced in place (quality upgrade by Whisparr for instance) by a different scene, and the duration of the second scene is being submitted along with the hash.

The nuclear option is to save the duration in sqlite at hash generation time. This would avoid the whole issue. But before I do that, my suggestion is to wipe phashes when the oshash changes. It's suboptimal for the majority of cases, but it's fairly low cost, and if my theory is right it will close the loophole.

## Testing
I've tested replacing a file with a different file, and verified it removes the phash and regenerates it:
```
INFO[2026-06-06 19:45:05] Starting scan of 1 paths with 2 parallel tasks
INFO[2026-06-06 19:45:05] Finished adding files to queue. 286 files queued
INFO[2026-06-06 19:45:05] /<path>/<file>.mp4 has been updated: rescanning
INFO[2026-06-06 19:45:05] Calculating fingerprints for /<path>/<file>.mp4 ...
INFO[2026-06-06 19:45:05] Removing outdated phash from /<path>/<file>.mp4
INFO[2026-06-06 19:45:05] Removing outdated checksum from /<path>/<file>.mp4
INFO[2026-06-06 19:45:06] renaming /<stash>/generated/screenshots/cfff08ce8455342c.mp4 to /<stash>/generated/screenshots/151aac433b8321df.mp4
INFO[2026-06-06 19:45:06] renaming /<stash>/generated/vtt/cfff08ce8455342c_thumbs.vtt to /<stash>/generated/vtt/151aac433b8321df_thumbs.vtt
INFO[2026-06-06 19:45:06] renaming /<stash>/generated/vtt/cfff08ce8455342c_sprite.jpg to /mnt/lager/stashapp/generated/vtt/151aac433b8321df_sprite.jpg
INFO[2026-06-06 19:45:06] [generator] generating phash sprite for /<path>/<file>.mp4
INFO[2026-06-06 19:45:17] Scan finished (11.56100614s)
```

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Drafted with claude.

## Additional Context
<!-- Add any other context about the pull request here. -->

