### PR TITLE
New: Add delete image shortcut and button to lightbox

### DIFF
--- a/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Form } from "react-bootstrap";
 import { useImagesDestroy } from "src/core/StashService";
 import * as GQL from "src/core/generated-graphql";
@@ -52,6 +52,17 @@ export const DeleteImagesDialog: React.FC<IDeleteImageDialogProps> = (
 
   // Network state
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const onDeleteRef = useRef(onDelete);
+  onDeleteRef.current = onDelete;
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && !isDeleting) onDeleteRef.current();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [isDeleting]);
 
   function getImagesDeleteInput(): GQL.ImagesDestroyInput {
     return {

--- a/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
+++ b/ui/v2.5/src/components/Images/DeleteImagesDialog.tsx
@@ -8,8 +8,13 @@ import { useConfigurationContext } from "src/hooks/Config";
 import { FormattedMessage, useIntl } from "react-intl";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 
+interface IImageForDeletion {
+  id: string;
+  visual_files: { path: string }[];
+}
+
 interface IDeleteImageDialogProps {
-  selected: GQL.SlimImageDataFragment[];
+  selected: IImageForDeletion[];
   onClose: (confirmed: boolean) => void;
 }
 

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -134,6 +134,15 @@
 | `s s` | Save Scene |
 | `d d` | Delete Scene |
 
+## Lightbox shortcuts
+
+| Keyboard sequence | Action |
+|-------------------|--------|
+| `←` | Previous image |
+| `→` | Next image |
+| `Escape` | Close lightbox |
+| `d d` | Delete current image |
+
 ## Groups page shortcuts
 
 | Keyboard sequence | Action |

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -998,7 +998,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                   </Link>
                   {currentImage.id !== undefined && (
                     <Button
-                      className="minimal"
+                      className="minimal delete-button"
                       onClick={() => setIsDeleteDialogOpen(true)}
                       title={intl.formatMessage({ id: "actions.delete" })}
                     >

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -533,12 +533,17 @@ export const LightboxComponent: React.FC<IProps> = ({
   const currentIndex = index === null ? initialIndex : index;
 
   useEffect(() => {
+    // Don't auto-close while images are still loading. Some entry points open
+    // the lightbox with an empty image list and isLoading=true, then populate
+    // it asynchronously. Only an empty list *after* loading means the last
+    // image was deleted.
+    if (isLoading) return;
     if (images.length === 0) {
       close();
     } else if (index !== null && index >= images.length) {
       setIndex(images.length - 1);
     }
-  }, [images.length, index, close]);
+  }, [images.length, index, close, isLoading]);
 
   function gotoPage(imageIndex: number) {
     const indexInPage = (imageIndex - 1) % pageSize;

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -993,9 +993,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                   </Link>
                   {currentImage.id !== undefined && (
                     <Button
-                      variant="danger"
-                      size="sm"
-                      className="delete-button btn-danger-minimal"
+                      className="minimal"
                       onClick={() => setIsDeleteDialogOpen(true)}
                       title={intl.formatMessage({ id: "actions.delete" })}
                     >

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -45,8 +45,10 @@ import {
   faTimes,
   faBars,
   faImages,
+  faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
+import { DeleteImagesDialog } from "src/components/Images/DeleteImagesDialog";
 import { useDebounce } from "../debounce";
 import { isVideo } from "src/utils/visualFile";
 import { imageTitle } from "src/core/files";
@@ -95,6 +97,7 @@ interface IProps {
   pageCallback?: (props: { direction?: number; page?: number }) => void;
   chapters?: IChapter[];
   hide: () => void;
+  onDeleteImage?: (id: string) => void;
 }
 
 export const LightboxComponent: React.FC<IProps> = ({
@@ -110,6 +113,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   pageCallback,
   chapters = [],
   hide,
+  onDeleteImage,
 }) => {
   const [updateImage] = useImageUpdate();
 
@@ -123,6 +127,8 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [showOptions, setShowOptions] = useState(false);
   const [showChapters, setShowChapters] = useState(false);
   const [imagesLoaded, setImagesLoaded] = useState(0);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
 
   const oldImages = useRef<ILightboxImage[]>([]);
@@ -426,8 +432,18 @@ export const LightboxComponent: React.FC<IProps> = ({
       if (e.key === "ArrowLeft") handleLeft();
       else if (e.key === "ArrowRight") handleRight();
       else if (e.key === "Escape") close();
+      else if (
+        e.key === "d" &&
+        images[index ?? initialIndex]?.id !== undefined
+      ) {
+        const now = Date.now();
+        if (now - lastDKeyTime.current < 1000) {
+          setIsDeleteDialogOpen(true);
+        }
+        lastDKeyTime.current = now;
+      }
     },
-    [setInstant, handleLeft, handleRight, close]
+    [setInstant, handleLeft, handleRight, close, images, index, initialIndex]
   );
 
   const [clearCallback, resetCallback] = useInterval(
@@ -515,6 +531,14 @@ export const LightboxComponent: React.FC<IProps> = ({
   };
 
   const currentIndex = index === null ? initialIndex : index;
+
+  useEffect(() => {
+    if (images.length === 0) {
+      close();
+    } else if (index !== null && index >= images.length) {
+      setIndex(images.length - 1);
+    }
+  }, [images.length, index, close]);
 
   function gotoPage(imageIndex: number) {
     const indexInPage = (imageIndex - 1) % pageSize;
@@ -956,13 +980,29 @@ export const LightboxComponent: React.FC<IProps> = ({
           <div className={CLASSNAME_FOOTER_CENTER}>
             {currentImage && (
               <>
-                <Link
-                  className="image-link"
-                  to={`/images/${currentImage.id}`}
-                  onClick={() => close()}
+                <div
+                  className="d-flex align-items-center justify-content-center"
+                  style={{ gap: "0.5rem" }}
                 >
-                  {title ?? ""}
-                </Link>
+                  <Link
+                    className="image-link"
+                    to={`/images/${currentImage.id}`}
+                    onClick={() => close()}
+                  >
+                    {title ?? ""}
+                  </Link>
+                  {currentImage.id !== undefined && (
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      className="delete-button btn-danger-minimal"
+                      onClick={() => setIsDeleteDialogOpen(true)}
+                      title={intl.formatMessage({ id: "actions.delete" })}
+                    >
+                      <Icon icon={faTrash} />
+                    </Button>
+                  )}
+                </div>
                 {currentImage.galleries?.length ? (
                   <Link
                     className="image-gallery-link"
@@ -976,7 +1016,7 @@ export const LightboxComponent: React.FC<IProps> = ({
               </>
             )}
           </div>
-          <div className={CLASSNAME_FOOTER_RIGHT}></div>
+          <div className={CLASSNAME_FOOTER_RIGHT} />
         </div>
       </>
     );
@@ -994,6 +1034,20 @@ export const LightboxComponent: React.FC<IProps> = ({
       onClick={handleClose}
     >
       {renderBody()}
+      {isDeleteDialogOpen && images[currentIndex]?.id !== undefined && (
+        <DeleteImagesDialog
+          selected={[
+            {
+              id: images[currentIndex].id!,
+              visual_files: images[currentIndex].visual_files ?? [],
+            },
+          ]}
+          onClose={(confirmed) => {
+            setIsDeleteDialogOpen(false);
+            if (confirmed) onDeleteImage?.(images[currentIndex].id!);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -58,6 +58,13 @@ export const LightboxProvider: React.FC = ({ children }) => {
     }
   };
 
+  const onDeleteImage = useCallback((id: string) => {
+    setLightboxState((s) => ({
+      ...s,
+      images: s.images.filter((img) => img.id !== id),
+    }));
+  }, []);
+
   return (
     <LightboxContext.Provider
       value={{ lightboxState, setLightboxState: setPartialState }}
@@ -65,7 +72,11 @@ export const LightboxProvider: React.FC = ({ children }) => {
       {children}
       <Suspense fallback={null}>
         {lightboxState.isVisible && (
-          <LightboxComponent {...lightboxState} hide={onHide} />
+          <LightboxComponent
+            {...lightboxState}
+            hide={onHide}
+            onDeleteImage={onDeleteImage}
+          />
         )}
       </Suspense>
     </LightboxContext.Provider>

--- a/ui/v2.5/src/hooks/Lightbox/lightbox.scss
+++ b/ui/v2.5/src/hooks/Lightbox/lightbox.scss
@@ -98,6 +98,11 @@
       width: auto;
     }
 
+    .delete-button,
+    button.delete-button:hover {
+      color: $danger;
+    }
+
     &-left {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds the ability to delete the current image directly from the lightbox viewer without having to close it and return to the grid.

Two interaction paths are supported:

- **`d d` keyboard shortcut** — double-tap `d` within one second to open the delete confirmation dialog. Consistent with the existing `d d` shortcut on the images page (grid and wall views).
- **`Enter` to confirm** — once the delete confirmation dialog is open, pressing `Enter` confirms the deletion. This completes a fully keyboard-driven culling flow: `d d` to open, `Enter` to confirm.
- **Trash icon button** — a delete button is shown next to the image filename in the lightbox footer, using the same `danger` styling as the delete button in the images page toolbar. This goes beyond the scope of the issue, but provides a touch-accessible path for mobile users where keyboard shortcuts are unavailable. A swipe-to-delete gesture would be an alternative mobile interaction (swipe-to-delete is a [frequently requested feature in comparable apps such as Immich](https://github.com/immich-app/immich/discussions/24059) as well), and I am happy to implement that instead if preferred.

Both paths open the existing `DeleteImagesDialog`, which gives the user the option to also delete the underlying file and/or generated supporting files, matching the behaviour of every other delete flow in the application.

After confirming deletion the lightbox automatically advances to the next image, or closes if the deleted image was the last one.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #4512

## Testing
<!-- Describe the testing steps you have performed. -->

Tested manually in Safari, Firefox, and Chrome.

1. Opened a gallery and entered the lightbox.
2. Pressed `d` once — nothing happened.
3. Pressed `d` a second time within one second — the delete confirmation dialog appeared showing the current image filename.
4. Pressed `Enter` — deletion was confirmed, image removed, lightbox advanced to the next image.
5. Triggered the dialog again and clicked **Cancel** — dialog closed, image was still present, lightbox remained open.
6. Repeated until only one image remained and confirmed deletion — the lightbox closed.
7. Clicked the trash icon in the footer next to the filename — the same confirmation dialog appeared.
8. Verified the **Delete file** and **Delete generated supporting files** checkboxes behave as expected and respect the defaults configured in Settings.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

**Before** — no delete action available in the lightbox:
<img width="2560" height="1320" alt="before" src="https://github.com/user-attachments/assets/1e886ccb-eda6-45d5-907f-56947af9f820" />

**After** — trash icon next to filename, `d d` + `Enter` shortcut supported:
<img width="2560" height="1320" alt="after" src="https://github.com/user-attachments/assets/5309fe73-dfca-42aa-bfa3-26562f41030e" />

---

*Screenshot images: Photo by [Oskar Kadaksoo](https://unsplash.com/@oskark) on [Unsplash](https://unsplash.com/photos/V_FR5YYMfVE)*

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used [Claude Code](https://claude.ai/code) as a coding assistant during implementation. The assistant helped explore the codebase, propose an implementation approach, and write the initial code. I reviewed all generated code, manually tested the feature end-to-end, and take full responsibility for the changes. The PR description has been written and reviewed by me.

## Additional Context
<!-- Add any other context about the pull request here. -->

The `d d` sequence is detected via a native `keydown` listener (Mousetrap is paused while the lightbox is open) using a timestamp ref to detect two `d` presses within one second. The `DeleteImagesDialog` component's `selected` prop was narrowed from `GQL.SlimImageDataFragment[]` to a local interface requiring only `id` and `visual_files[].path` — the only fields the dialog actually uses — allowing the lighter `ILightboxImage` type from the lightbox context to satisfy it without casting.