### PR TITLE
feat: add rating and sort by rating feature to tags

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -629,6 +629,9 @@ input TagFilterType {
   "Filter by tag description"
   description: StringCriterionInput
 
+  # rating expressed as 1-100
+  rating100: IntCriterionInput
+
   "Filter to only include tags missing this property"
   is_missing: String
 

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -6,6 +6,7 @@ type Tag {
   description: String
   aliases: [String!]!
   ignore_auto_tag: Boolean!
+  rating: Int
   created_at: Time!
   updated_at: Time!
   favorite: Boolean!
@@ -36,6 +37,7 @@ input TagCreateInput {
   aliases: [String!]
   ignore_auto_tag: Boolean
   favorite: Boolean
+  rating: Int
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]
@@ -56,6 +58,7 @@ input TagUpdateInput {
   aliases: [String!]
   ignore_auto_tag: Boolean
   favorite: Boolean
+  rating: Int
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]
@@ -89,6 +92,7 @@ input BulkTagUpdateInput {
   aliases: BulkUpdateStrings
   ignore_auto_tag: Boolean
   favorite: Boolean
+  rating: Int
 
   parent_ids: BulkUpdateIds
   child_ids: BulkUpdateIds

--- a/graphql/schema/types/tag.graphql
+++ b/graphql/schema/types/tag.graphql
@@ -6,7 +6,8 @@ type Tag {
   description: String
   aliases: [String!]!
   ignore_auto_tag: Boolean!
-  rating: Int
+  # rating expressed as 1-100
+  rating100: Int
   created_at: Time!
   updated_at: Time!
   favorite: Boolean!
@@ -37,7 +38,8 @@ input TagCreateInput {
   aliases: [String!]
   ignore_auto_tag: Boolean
   favorite: Boolean
-  rating: Int
+  # rating expressed as 1-100
+  rating100: Int
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]
@@ -58,7 +60,8 @@ input TagUpdateInput {
   aliases: [String!]
   ignore_auto_tag: Boolean
   favorite: Boolean
-  rating: Int
+  # rating expressed as 1-100
+  rating100: Int
   "This should be a URL or a base64 encoded data URL"
   image: String
   stash_ids: [StashIDInput!]
@@ -92,7 +95,8 @@ input BulkTagUpdateInput {
   aliases: BulkUpdateStrings
   ignore_auto_tag: Boolean
   favorite: Boolean
-  rating: Int
+  # rating expressed as 1-100
+  rating100: Int
 
   parent_ids: BulkUpdateIds
   child_ids: BulkUpdateIds

--- a/internal/api/resolver_model_tag.go
+++ b/internal/api/resolver_model_tag.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stashapp/stash/pkg/studio"
 )
 
+func (r *tagResolver) Rating100(ctx context.Context, obj *models.Tag) (*int, error) {
+	return obj.Rating, nil
+}
+
 func (r *tagResolver) Parents(ctx context.Context, obj *models.Tag) (ret []*models.Tag, err error) {
 	if !obj.ParentIDs.Loaded() {
 		if err := r.withReadTxn(ctx, func(ctx context.Context) error {

--- a/internal/api/resolver_mutation_tag.go
+++ b/internal/api/resolver_mutation_tag.go
@@ -41,7 +41,7 @@ func (r *mutationResolver) TagCreate(ctx context.Context, input TagCreateInput) 
 	newTag.Favorite = translator.bool(input.Favorite)
 	newTag.Description = translator.string(input.Description)
 	newTag.IgnoreAutoTag = translator.bool(input.IgnoreAutoTag)
-	newTag.Rating = input.Rating
+	newTag.Rating = input.Rating100
 
 	var stashIDInputs models.StashIDInputs
 	for _, sid := range input.StashIds {
@@ -111,7 +111,7 @@ func tagPartialFromInput(input TagUpdateInput, translator changesetTranslator) (
 	updatedTag.Favorite = translator.optionalBool(input.Favorite, "favorite")
 	updatedTag.IgnoreAutoTag = translator.optionalBool(input.IgnoreAutoTag, "ignore_auto_tag")
 	updatedTag.Description = translator.optionalString(input.Description, "description")
-	updatedTag.Rating100 = translator.optionalInt(input.Rating, "rating")
+	updatedTag.Rating = translator.optionalInt(input.Rating100, "rating100")
 
 	updatedTag.Aliases = translator.updateStrings(input.Aliases, "aliases")
 
@@ -237,7 +237,7 @@ func (r *mutationResolver) BulkTagUpdate(ctx context.Context, input BulkTagUpdat
 	updatedTag.Description = translator.optionalString(input.Description, "description")
 	updatedTag.Favorite = translator.optionalBool(input.Favorite, "favorite")
 	updatedTag.IgnoreAutoTag = translator.optionalBool(input.IgnoreAutoTag, "ignore_auto_tag")
-	updatedTag.Rating100 = translator.optionalInt(input.Rating, "rating")
+	updatedTag.Rating = translator.optionalInt(input.Rating100, "rating100")
 
 	updatedTag.Aliases = translator.updateStringsBulk(input.Aliases, "aliases")
 

--- a/internal/api/resolver_mutation_tag.go
+++ b/internal/api/resolver_mutation_tag.go
@@ -231,7 +231,7 @@ func (r *mutationResolver) BulkTagUpdate(ctx context.Context, input BulkTagUpdat
 		inputMap: getUpdateInputMap(ctx),
 	}
 
-	// Populate scene from the input
+	// Populate tag from the input
 	updatedTag := models.NewTagPartial()
 
 	updatedTag.Description = translator.optionalString(input.Description, "description")

--- a/internal/api/resolver_mutation_tag.go
+++ b/internal/api/resolver_mutation_tag.go
@@ -41,6 +41,7 @@ func (r *mutationResolver) TagCreate(ctx context.Context, input TagCreateInput) 
 	newTag.Favorite = translator.bool(input.Favorite)
 	newTag.Description = translator.string(input.Description)
 	newTag.IgnoreAutoTag = translator.bool(input.IgnoreAutoTag)
+	newTag.Rating = input.Rating
 
 	var stashIDInputs models.StashIDInputs
 	for _, sid := range input.StashIds {
@@ -110,6 +111,7 @@ func tagPartialFromInput(input TagUpdateInput, translator changesetTranslator) (
 	updatedTag.Favorite = translator.optionalBool(input.Favorite, "favorite")
 	updatedTag.IgnoreAutoTag = translator.optionalBool(input.IgnoreAutoTag, "ignore_auto_tag")
 	updatedTag.Description = translator.optionalString(input.Description, "description")
+	updatedTag.Rating100 = translator.optionalInt(input.Rating, "rating")
 
 	updatedTag.Aliases = translator.updateStrings(input.Aliases, "aliases")
 
@@ -235,6 +237,7 @@ func (r *mutationResolver) BulkTagUpdate(ctx context.Context, input BulkTagUpdat
 	updatedTag.Description = translator.optionalString(input.Description, "description")
 	updatedTag.Favorite = translator.optionalBool(input.Favorite, "favorite")
 	updatedTag.IgnoreAutoTag = translator.optionalBool(input.IgnoreAutoTag, "ignore_auto_tag")
+	updatedTag.Rating100 = translator.optionalInt(input.Rating, "rating")
 
 	updatedTag.Aliases = translator.updateStringsBulk(input.Aliases, "aliases")
 

--- a/pkg/models/jsonschema/tag.go
+++ b/pkg/models/jsonschema/tag.go
@@ -15,6 +15,7 @@ type Tag struct {
 	SortName      string                 `json:"sort_name,omitempty"`
 	Description   string                 `json:"description,omitempty"`
 	Favorite      bool                   `json:"favorite,omitempty"`
+	Rating        int                    `json:"rating,omitempty"`
 	Aliases       []string               `json:"aliases,omitempty"`
 	Image         string                 `json:"image,omitempty"`
 	Parents       []string               `json:"parents,omitempty"`

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -72,7 +72,7 @@ type TagPartial struct {
 	Description   OptionalString
 	Favorite      OptionalBool
 	IgnoreAutoTag OptionalBool
-	Rating100     OptionalInt
+	Rating        OptionalInt
 	CreatedAt     OptionalTime
 	UpdatedAt     OptionalTime
 

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -12,6 +12,7 @@ type Tag struct {
 	Favorite      bool      `json:"favorite"`
 	Description   string    `json:"description"`
 	IgnoreAutoTag bool      `json:"ignore_auto_tag"`
+	Rating        *int      `json:"rating"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 
@@ -71,6 +72,7 @@ type TagPartial struct {
 	Description   OptionalString
 	Favorite      OptionalBool
 	IgnoreAutoTag OptionalBool
+	Rating100     OptionalInt
 	CreatedAt     OptionalTime
 	UpdatedAt     OptionalTime
 

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -12,6 +12,8 @@ type TagFilterType struct {
 	Favorite *bool `json:"favorite"`
 	// Filter by tag description
 	Description *StringCriterionInput `json:"description"`
+	// Filter by rating expressed as 1-100
+	Rating100 *IntCriterionInput `json:"rating100"`
 	// Filter to only include tags missing this property
 	IsMissing *string `json:"is_missing"`
 	// Filter by number of scenes with this tag

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 85
+var appSchemaVersion uint = 86
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/migrations/86_tag_rating.up.sql
+++ b/pkg/sqlite/migrations/86_tag_rating.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tags` ADD COLUMN `rating` tinyint;

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1832,6 +1832,7 @@ func createTags(ctx context.Context, tqb models.TagReaderWriter, n int) error {
 		tag := models.Tag{
 			Name:          getTagStringValue(index, name),
 			IgnoreAutoTag: getIgnoreAutoTag(i),
+			Rating:        getIntPtr(getRating(index)),
 		}
 
 		if (index+1)%5 != 0 {

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -858,8 +858,6 @@ func (qb *TagStore) getTagSort(query *queryBuilder, findFilter *models.FindFilte
 	switch sort {
 	case "name":
 		sortQuery += fmt.Sprintf(" ORDER BY COALESCE(tags.sort_name, tags.name) COLLATE NATURAL_CI %s", getSortDirection(direction))
-	case "rating":
-		sortQuery += fmt.Sprintf(" ORDER BY tags.rating %s", getSortDirection(direction))
 	case "scenes_count":
 		sortQuery += getCountSort(tagTable, scenesTagsTable, tagIDColumn, direction)
 	case "scenes_duration":

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -97,7 +97,7 @@ func (r *tagRowRecord) fromPartial(o models.TagPartial) {
 	r.setNullString("description", o.Description)
 	r.setBool("favorite", o.Favorite)
 	r.setBool("ignore_auto_tag", o.IgnoreAutoTag)
-	r.setNullInt("rating", o.Rating100)
+	r.setNullInt("rating", o.Rating)
 	r.setTimestamp("created_at", o.CreatedAt)
 	r.setTimestamp("updated_at", o.UpdatedAt)
 }

--- a/pkg/sqlite/tag.go
+++ b/pkg/sqlite/tag.go
@@ -37,6 +37,7 @@ type tagRow struct {
 	Favorite      bool        `db:"favorite"`
 	Description   zero.String `db:"description"`
 	IgnoreAutoTag bool        `db:"ignore_auto_tag"`
+	Rating        null.Int    `db:"rating"`
 	CreatedAt     Timestamp   `db:"created_at"`
 	UpdatedAt     Timestamp   `db:"updated_at"`
 
@@ -51,6 +52,7 @@ func (r *tagRow) fromTag(o models.Tag) {
 	r.Favorite = o.Favorite
 	r.Description = zero.StringFrom(o.Description)
 	r.IgnoreAutoTag = o.IgnoreAutoTag
+	r.Rating = intFromPtr(o.Rating)
 	r.CreatedAt = Timestamp{Timestamp: o.CreatedAt}
 	r.UpdatedAt = Timestamp{Timestamp: o.UpdatedAt}
 }
@@ -63,6 +65,7 @@ func (r *tagRow) resolve() *models.Tag {
 		Favorite:      r.Favorite,
 		Description:   r.Description.String,
 		IgnoreAutoTag: r.IgnoreAutoTag,
+		Rating:        nullIntPtr(r.Rating),
 		CreatedAt:     r.CreatedAt.Timestamp,
 		UpdatedAt:     r.UpdatedAt.Timestamp,
 	}
@@ -94,6 +97,7 @@ func (r *tagRowRecord) fromPartial(o models.TagPartial) {
 	r.setNullString("description", o.Description)
 	r.setBool("favorite", o.Favorite)
 	r.setBool("ignore_auto_tag", o.IgnoreAutoTag)
+	r.setNullInt("rating", o.Rating100)
 	r.setTimestamp("created_at", o.CreatedAt)
 	r.setTimestamp("updated_at", o.UpdatedAt)
 }
@@ -796,6 +800,7 @@ var tagSortOptions = sortOptions{
 	"id",
 	"images_count",
 	"movies_count",
+	"rating",
 	"studios_count",
 	"name",
 	"performers_count",
@@ -853,6 +858,8 @@ func (qb *TagStore) getTagSort(query *queryBuilder, findFilter *models.FindFilte
 	switch sort {
 	case "name":
 		sortQuery += fmt.Sprintf(" ORDER BY COALESCE(tags.sort_name, tags.name) COLLATE NATURAL_CI %s", getSortDirection(direction))
+	case "rating":
+		sortQuery += fmt.Sprintf(" ORDER BY tags.rating %s", getSortDirection(direction))
 	case "scenes_count":
 		sortQuery += getCountSort(tagTable, scenesTagsTable, tagIDColumn, direction)
 	case "scenes_duration":

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -67,6 +67,7 @@ func (qb *tagFilterHandler) criterionHandler() criterionHandler {
 
 		boolCriterionHandler(tagFilter.Favorite, tagTable+".favorite", nil),
 		stringCriterionHandler(tagFilter.Description, tagTable+".description"),
+		intCriterionHandler(tagFilter.Rating100, tagTable+".rating", nil),
 		boolCriterionHandler(tagFilter.IgnoreAutoTag, tagTable+".ignore_auto_tag", nil),
 
 		qb.isMissingCriterionHandler(tagFilter.IsMissing),

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -249,6 +249,19 @@ func TestTagQuerySort(t *testing.T) {
 		tags = queryTags(ctx, t, sqb, nil, findFilter)
 		assert.Equal(tagIDs[tagIdx1WithGroup], tags[0].ID)
 
+		// sort by rating, descending. NULL ratings sort last, so every
+		// non-null rating must be non-increasing down the result set.
+		sortBy = "rating"
+		tags = queryTags(ctx, t, sqb, nil, findFilter)
+		prev := math.MaxInt64
+		for _, tag := range tags {
+			if tag.Rating == nil {
+				continue
+			}
+			assert.LessOrEqual(*tag.Rating, prev, "tags not sorted by rating descending")
+			prev = *tag.Rating
+		}
+
 		return nil
 	})
 }

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -1902,7 +1902,7 @@ func TestTagUpdateRating100(t *testing.T) {
 		// update rating100
 		rating100 := 75
 		partial := models.TagPartial{
-			Rating100: models.NewOptionalInt(rating100),
+			Rating: models.NewOptionalInt(rating100),
 		}
 		_, err = qb.UpdatePartial(ctx, tag.ID, partial)
 		if err != nil {

--- a/pkg/sqlite/tag_test.go
+++ b/pkg/sqlite/tag_test.go
@@ -1982,6 +1982,87 @@ func TestTagQueryCustomFields(t *testing.T) {
 	})
 }
 
+func TestTagUpdateRating100(t *testing.T) {
+	if err := withTxn(func(ctx context.Context) error {
+		qb := db.Tag
+
+		// create tag to test against
+		const name = "TestTagUpdateRating100"
+		tag := models.CreateTagInput{
+			Tag: &models.Tag{
+				Name: name,
+			},
+		}
+		err := qb.Create(ctx, &tag)
+		if err != nil {
+			return fmt.Errorf("Error creating tag: %s", err.Error())
+		}
+
+		// update rating100
+		rating100 := 75
+		partial := models.TagPartial{
+			Rating100: models.NewOptionalInt(rating100),
+		}
+		_, err = qb.UpdatePartial(ctx, tag.ID, partial)
+		if err != nil {
+			return fmt.Errorf("Error updating tag rating100: %s", err.Error())
+		}
+
+		// ensure rating100 is set
+		storedTag, err := qb.Find(ctx, tag.ID)
+		if err != nil {
+			return fmt.Errorf("Error getting tag: %s", err.Error())
+		}
+		assert.Equal(t, rating100, *storedTag.Rating)
+
+		return nil
+	}); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestTagQueryRating100(t *testing.T) {
+	const rating = 60
+	ratingCriterion := models.IntCriterionInput{
+		Value:    rating,
+		Modifier: models.CriterionModifierEquals,
+	}
+
+	verifyTagsRating100(t, ratingCriterion)
+
+	ratingCriterion.Modifier = models.CriterionModifierNotEquals
+	verifyTagsRating100(t, ratingCriterion)
+
+	ratingCriterion.Modifier = models.CriterionModifierGreaterThan
+	verifyTagsRating100(t, ratingCriterion)
+
+	ratingCriterion.Modifier = models.CriterionModifierLessThan
+	verifyTagsRating100(t, ratingCriterion)
+
+	ratingCriterion.Modifier = models.CriterionModifierIsNull
+	verifyTagsRating100(t, ratingCriterion)
+
+	ratingCriterion.Modifier = models.CriterionModifierNotNull
+	verifyTagsRating100(t, ratingCriterion)
+}
+
+func verifyTagsRating100(t *testing.T, ratingCriterion models.IntCriterionInput) {
+	withTxn(func(ctx context.Context) error {
+		qb := db.Tag
+		tagFilter := models.TagFilterType{
+			Rating100: &ratingCriterion,
+		}
+
+		tags := queryTags(ctx, t, qb, &tagFilter, nil)
+
+		for _, tag := range tags {
+			verifyIntPtr(t, tag.Rating, ratingCriterion)
+		}
+
+		return nil
+	})
+}
+
 // TODO Destroy
 // TODO Find
 // TODO FindBySceneID

--- a/pkg/tag/export.go
+++ b/pkg/tag/export.go
@@ -32,6 +32,10 @@ func ToJSON(ctx context.Context, reader FinderAliasImageGetter, tag *models.Tag)
 		UpdatedAt:     json.JSONTime{Time: tag.UpdatedAt},
 	}
 
+	if tag.Rating != nil {
+		newTagJSON.Rating = *tag.Rating
+	}
+
 	aliases, err := reader.GetAliases(ctx, tag.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting tag aliases: %v", err)

--- a/pkg/tag/import.go
+++ b/pkg/tag/import.go
@@ -48,6 +48,10 @@ func (i *Importer) PreImport(ctx context.Context) error {
 		UpdatedAt:     i.Input.UpdatedAt.GetTime(),
 	}
 
+	if i.Input.Rating != 0 {
+		i.tag.Rating = &i.Input.Rating
+	}
+
 	var err error
 	if len(i.Input.Image) > 0 {
 		i.imageData, err = utils.ProcessBase64Image(i.Input.Image)

--- a/ui/v2.5/graphql/data/tag.graphql
+++ b/ui/v2.5/graphql/data/tag.graphql
@@ -6,6 +6,7 @@ fragment TagData on Tag {
   aliases
   ignore_auto_tag
   favorite
+  rating
   stash_ids {
     endpoint
     stash_id
@@ -43,6 +44,7 @@ fragment SelectTagData on Tag {
   name
   sort_name
   favorite
+  rating
   description
   aliases
   image_path
@@ -69,6 +71,7 @@ fragment TagListData on Tag {
   aliases
   ignore_auto_tag
   favorite
+  rating
   stash_ids {
     endpoint
     stash_id

--- a/ui/v2.5/graphql/data/tag.graphql
+++ b/ui/v2.5/graphql/data/tag.graphql
@@ -6,7 +6,7 @@ fragment TagData on Tag {
   aliases
   ignore_auto_tag
   favorite
-  rating
+  rating100
   stash_ids {
     endpoint
     stash_id
@@ -44,7 +44,7 @@ fragment SelectTagData on Tag {
   name
   sort_name
   favorite
-  rating
+  rating100
   description
   aliases
   image_path
@@ -71,7 +71,7 @@ fragment TagListData on Tag {
   aliases
   ignore_auto_tag
   favorite
-  rating
+  rating100
   stash_ids {
     endpoint
     stash_id

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -122,7 +122,7 @@ const TagCardOverlays: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderRatingBanner() {
-      if (!tag.rating) {
+      if (tag.rating == null) {
         return;
       }
       return <RatingBanner rating={tag.rating} />;

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -12,6 +12,7 @@ import { Icon } from "../Shared/Icon";
 import { faHeart } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import { useTagUpdate } from "src/core/StashService";
+import { RatingBanner } from "../Shared/RatingBanner";
 
 interface IProps {
   tag: GQL.TagDataFragment | GQL.TagListDataFragment;
@@ -120,7 +121,19 @@ const TagCardOverlays: React.FC<IProps> = PatchComponent(
       }
     }
 
-    return <>{renderFavoriteIcon()}</>;
+    function maybeRenderRatingBanner() {
+      if (!tag.rating) {
+        return;
+      }
+      return <RatingBanner rating={tag.rating} />;
+    }
+
+    return (
+      <>
+        {renderFavoriteIcon()}
+        {maybeRenderRatingBanner()}
+      </>
+    );
   }
 );
 

--- a/ui/v2.5/src/components/Tags/TagCard.tsx
+++ b/ui/v2.5/src/components/Tags/TagCard.tsx
@@ -122,10 +122,10 @@ const TagCardOverlays: React.FC<IProps> = PatchComponent(
     }
 
     function maybeRenderRatingBanner() {
-      if (tag.rating == null) {
+      if (tag.rating100 == null) {
         return;
       }
-      return <RatingBanner rating={tag.rating} />;
+      return <RatingBanner rating={tag.rating100} />;
     }
 
     return (

--- a/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { TagLink } from "src/components/Shared/TagLink";
 import { DetailItem } from "src/components/Shared/DetailItem";
 import { StashIDPill } from "src/components/Shared/StashID";
+import { RatingSystem } from "src/components/Shared/Rating/RatingSystem";
 import * as GQL from "src/core/generated-graphql";
+import { useTagUpdate } from "src/core/StashService";
 import { CustomFields } from "src/components/Shared/CustomFields";
 
 interface ITagDetails {
@@ -11,6 +13,19 @@ interface ITagDetails {
 }
 
 export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
+  const [updateTag] = useTagUpdate();
+
+  function setRating(v: number | null) {
+    updateTag({
+      variables: {
+        input: {
+          id: tag.id,
+          rating: v,
+        },
+      },
+    });
+  }
+
   function renderParentsField() {
     if (!tag.parents?.length) {
       return;
@@ -77,6 +92,11 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
         fullWidth={fullWidth}
       />
       <DetailItem
+        id="rating"
+        value={<RatingSystem value={tag.rating} onSetRating={setRating} />}
+        fullWidth={fullWidth}
+      />
+      <DetailItem
         id="parent_tags"
         value={renderParentsField()}
         fullWidth={fullWidth}
@@ -97,6 +117,19 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
 };
 
 export const CompressedTagDetailsPanel: React.FC<ITagDetails> = ({ tag }) => {
+  const [updateTag] = useTagUpdate();
+
+  function setRating(v: number | null) {
+    updateTag({
+      variables: {
+        input: {
+          id: tag.id,
+          rating: v,
+        },
+      },
+    });
+  }
+
   function scrollToTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -111,6 +144,14 @@ export const CompressedTagDetailsPanel: React.FC<ITagDetails> = ({ tag }) => {
           <>
             <span className="detail-divider">/</span>
             <span className="tag-desc">{tag.description}</span>
+          </>
+        ) : (
+          ""
+        )}
+        {tag.rating !== null ? (
+          <>
+            <span className="detail-divider">/</span>
+            <RatingSystem value={tag.rating} onSetRating={setRating} />
           </>
         ) : (
           ""

--- a/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagDetailsPanel.tsx
@@ -20,7 +20,7 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
       variables: {
         input: {
           id: tag.id,
-          rating: v,
+          rating100: v,
         },
       },
     });
@@ -93,7 +93,7 @@ export const TagDetailsPanel: React.FC<ITagDetails> = ({ tag, fullWidth }) => {
       />
       <DetailItem
         id="rating"
-        value={<RatingSystem value={tag.rating} onSetRating={setRating} />}
+        value={<RatingSystem value={tag.rating100} onSetRating={setRating} />}
         fullWidth={fullWidth}
       />
       <DetailItem
@@ -124,7 +124,7 @@ export const CompressedTagDetailsPanel: React.FC<ITagDetails> = ({ tag }) => {
       variables: {
         input: {
           id: tag.id,
-          rating: v,
+          rating100: v,
         },
       },
     });
@@ -148,10 +148,10 @@ export const CompressedTagDetailsPanel: React.FC<ITagDetails> = ({ tag }) => {
         ) : (
           ""
         )}
-        {tag.rating !== null ? (
+        {tag.rating100 !== null ? (
           <>
             <span className="detail-divider">/</span>
-            <RatingSystem value={tag.rating} onSetRating={setRating} />
+            <RatingSystem value={tag.rating100} onSetRating={setRating} />
           </>
         ) : (
           ""

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -63,7 +63,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     sort_name: yup.string().ensure(),
     aliases: yupRequiredStringArray(intl).defined(),
     description: yup.string().ensure(),
-    rating: yup.number().nullable().defined(),
+    rating100: yup.number().nullable().defined(),
     parent_ids: yup.array(yup.string().required()).defined(),
     child_ids: yup.array(yup.string().required()).defined(),
     ignore_auto_tag: yup.boolean().defined(),
@@ -77,7 +77,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     sort_name: tag?.sort_name ?? "",
     aliases: tag?.aliases ?? [],
     description: tag?.description ?? "",
-    rating: tag?.rating ?? null,
+    rating100: tag?.rating100 ?? null,
     parent_ids: (tag?.parents ?? []).map((t) => t.id),
     child_ids: (tag?.children ?? []).map((t) => t.id),
     ignore_auto_tag: tag?.ignore_auto_tag ?? false,
@@ -272,7 +272,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
           {renderInputField("sort_name", "text")}
           {renderStringListField("aliases", "aliases", { orderable: false })}
           {renderInputField("description", "textarea")}
-          {renderRatingField("rating")}
+          {renderRatingField("rating100")}
           {renderParentTagsField()}
           {renderSubTagsField()}
           {renderStashIDsField(

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -63,6 +63,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     sort_name: yup.string().ensure(),
     aliases: yupRequiredStringArray(intl).defined(),
     description: yup.string().ensure(),
+    rating: yup.number().nullable().defined(),
     parent_ids: yup.array(yup.string().required()).defined(),
     child_ids: yup.array(yup.string().required()).defined(),
     ignore_auto_tag: yup.boolean().defined(),
@@ -76,6 +77,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     sort_name: tag?.sort_name ?? "",
     aliases: tag?.aliases ?? [],
     description: tag?.description ?? "",
+    rating: tag?.rating ?? null,
     parent_ids: (tag?.parents ?? []).map((t) => t.id),
     child_ids: (tag?.children ?? []).map((t) => t.id),
     ignore_auto_tag: tag?.ignore_auto_tag ?? false,
@@ -188,6 +190,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
   const {
     renderField,
     renderInputField,
+    renderRatingField,
     renderStringListField,
     renderStashIDsField,
   } = formikUtils(intl, formik);
@@ -269,6 +272,7 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
           {renderInputField("sort_name", "text")}
           {renderStringListField("aliases", "aliases", { orderable: false })}
           {renderInputField("description", "textarea")}
+          {renderRatingField("rating")}
           {renderParentTagsField()}
           {renderSubTagsField()}
           {renderStashIDsField(

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -45,7 +45,9 @@ import { FilterTags } from "../List/FilterTags";
 import { Pagination, PaginationIndex } from "../List/Pagination";
 import { LoadedContent } from "../List/PagedList";
 import { SidebarBooleanFilter } from "../List/Filters/BooleanFilter";
+import { SidebarRatingFilter } from "../List/Filters/RatingFilter";
 import { FavoriteTagCriterionOption } from "src/models/list-filter/criteria/favorite";
+import { RatingCriterionOption } from "src/models/list-filter/criteria/rating";
 import { TagListTable } from "./TagListTable";
 
 const TagList: React.FC<{
@@ -132,6 +134,11 @@ const SidebarContent: React.FC<{
           setFilter={setFilter}
           filterHook={filterHook}
         /> */}
+        <SidebarRatingFilter
+          filter={filter}
+          setFilter={setFilter}
+          option={RatingCriterionOption}
+        />
         <SidebarBooleanFilter
           title={<FormattedMessage id="favourite" />}
           filter={filter}

--- a/ui/v2.5/src/components/Tags/TagListTable.tsx
+++ b/ui/v2.5/src/components/Tags/TagListTable.tsx
@@ -12,6 +12,7 @@ import { useTagUpdate } from "src/core/StashService";
 import { useTableColumns } from "src/hooks/useTableColumns";
 import cx from "classnames";
 import { IColumn, ListTable } from "../List/ListTable";
+import { RatingSystem } from "../Shared/Rating/RatingSystem";
 
 interface ITagListTableProps {
   tags: GQL.TagListDataFragment[];
@@ -35,6 +36,19 @@ export const TagListTable: React.FC<ITagListTableProps> = (
           input: {
             id: tagId,
             favorite: v,
+          },
+        },
+      });
+    }
+  }
+
+  function setRating(v: number | null, tagId: string) {
+    if (tagId) {
+      updateTag({
+        variables: {
+          input: {
+            id: tagId,
+            rating: v,
           },
         },
       });
@@ -76,6 +90,14 @@ export const TagListTable: React.FC<ITagListTableProps> = (
     >
       <Icon icon={faHeart} />
     </Button>
+  );
+
+  const RatingCell = (tag: GQL.TagListDataFragment) => (
+    <RatingSystem
+      value={tag.rating}
+      onSetRating={(value) => setRating(value, tag.id)}
+      clickToRate
+    />
   );
 
   const SceneCountCell = (tag: GQL.TagListDataFragment) => (
@@ -147,6 +169,12 @@ export const TagListTable: React.FC<ITagListTableProps> = (
       label: intl.formatMessage({ id: "favourite" }),
       defaultShow: true,
       render: FavoriteCell,
+    },
+    {
+      value: "rating",
+      label: intl.formatMessage({ id: "rating" }),
+      defaultShow: true,
+      render: RatingCell,
     },
     {
       value: "scene_count",

--- a/ui/v2.5/src/components/Tags/TagListTable.tsx
+++ b/ui/v2.5/src/components/Tags/TagListTable.tsx
@@ -48,7 +48,7 @@ export const TagListTable: React.FC<ITagListTableProps> = (
         variables: {
           input: {
             id: tagId,
-            rating: v,
+            rating100: v,
           },
         },
       });
@@ -94,7 +94,7 @@ export const TagListTable: React.FC<ITagListTableProps> = (
 
   const RatingCell = (tag: GQL.TagListDataFragment) => (
     <RatingSystem
-      value={tag.rating}
+      value={tag.rating100}
       onSetRating={(value) => setRating(value, tag.id)}
       clickToRate
     />

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2121,7 +2121,12 @@ export const useTagUpdate = () =>
       const tag = result.data?.tagUpdate;
       if (!tag) return;
 
-      evictTypeFields(cache, tagMutationImpactedTypeFields);
+      const obj = { __typename: "Tag", id: tag.id };
+      evictTypeFields(
+        cache,
+        tagMutationImpactedTypeFields,
+        cache.identify(obj) // don't evict this tag
+      );
 
       evictQueries(cache, tagMutationImpactedQueries);
     },

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2083,6 +2083,7 @@ const tagMutationImpactedTypeFields = {
 };
 
 const tagMutationImpactedQueries = [
+  GQL.FindTagDocument, // tag details
   GQL.FindGroupsDocument, // filter by tags
   GQL.FindSceneMarkersDocument, // filter by tags
   GQL.FindScenesDocument, // filter by tags
@@ -2120,12 +2121,7 @@ export const useTagUpdate = () =>
       const tag = result.data?.tagUpdate;
       if (!tag) return;
 
-      const obj = { __typename: "Tag", id: tag.id };
-      evictTypeFields(
-        cache,
-        tagMutationImpactedTypeFields,
-        cache.identify(obj) // don't evict this tag
-      );
+      evictTypeFields(cache, tagMutationImpactedTypeFields);
 
       evictQueries(cache, tagMutationImpactedQueries);
     },

--- a/ui/v2.5/src/models/list-filter/tags.ts
+++ b/ui/v2.5/src/models/list-filter/tags.ts
@@ -16,9 +16,16 @@ import {
 import { FavoriteTagCriterionOption } from "./criteria/favorite";
 import { StashIDCriterionOption } from "./criteria/stash-ids";
 import { CustomFieldsCriterionOption } from "./criteria/custom-fields";
+import { RatingCriterionOption } from "./criteria/rating";
 
 const defaultSortBy = "name";
-const sortByOptions = ["name", "random", "scenes_duration", "scenes_size"]
+const sortByOptions = [
+  "name",
+  "rating",
+  "random",
+  "scenes_duration",
+  "scenes_size",
+]
   .map(ListFilterOptions.createSortBy)
   .concat([
     {
@@ -60,6 +67,7 @@ const criterionOptions = [
   FavoriteTagCriterionOption,
   createMandatoryStringCriterionOption("name"),
   createStringCriterionOption("sort_name"),
+  RatingCriterionOption,
   TagIsMissingCriterionOption,
   createStringCriterionOption("aliases"),
   createStringCriterionOption("description"),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
Added full rating support for tags, bringing them in line with other entities like scenes, performers, and studios.


## Changes

### Database

Added a `rating` column (`tinyint`) to the `tags` table via a new migration (`86_tag_rating.up.sql`), bumping the schema version to 86. Ratings are stored on a 0–100 scale, consistent with the rest of the application.

### Backend
- Added a `Rating` field to the `Tag` and `TagPartial` model structs, storing the value on a 0–100 scale
- Exposed the rating on the GraphQL API as `rating100` on the `Tag` type and the `TagCreateInput`, `TagUpdateInput`, and `BulkTagUpdateInput` inputs, matching the naming used by scenes, performers, and studios
- Wired the `rating100` input through the `TagCreate`, `TagUpdate`, and `BulkTagUpdate` mutation resolvers, and added a `Rating100` field resolver that maps the GraphQL `rating100` field to the model's `Rating`
- Added the `rating` column to the sqlite tag row mapping (read, write, and partial update)
- Added `rating100` to the GraphQL `TagFilterType` schema and wired it to the `tags.rating` column in the SQL filter handler in `tag_filter.go`, enabling tags to be queried by rating
- Added `rating` as a tag sort option, sorted via the shared sort handler
- Added tag rating to import/export (`pkg/tag/export.go`, `pkg/tag/import.go`)
- Regenerated GraphQL types via `go generate`
- Added integration tests for updating, querying/filtering, and sorting by rating, and seeded ratings into the tag test fixtures so the filter and sort tests exercise real data

### Frontend
- Added `rating100` to the `TagData`, `SelectTagData`, and `TagListData` GraphQL fragments
- Added an editable rating to the tag detail and edit panels (`TagDetailsPanel`, `TagEditPanel`), including the compressed detail header
- Added a rating banner to `TagCard` and an inline click-to-rate rating column to the tag list table (`TagListTable`)
- Added a rating sidebar filter and a "rating" sort option to the tag list (`TagList.tsx`, `models/list-filter/tags.ts`)
- Added `FindTagDocument` to `tagMutationImpactedQueries` so the tag detail page refetches after a rating change
- Regenerated GraphQL types via `gqlgen`

## Related Issue
Related #6564, closes the longstanding #1400

## Testing
- Add any rating to any tag. It can be done after clicking Edit button on specific tag page as well.
- It gets rating.
- Rated tags can be sorted and filtered.
- Rating column can be seen if switched to list view for tags.


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
SWE 1.6 pro used for draft. Tests are written by AI. Review by me and some fixes found with Claude.

## Additional Context
**`TagPartial` Struct**
`TagPartial` is used by `UpdatePartial` to perform partial updates — only fields explicitly set (via `OptionalInt`) are written to the database. `Rating` is included on `TagPartial`, not just `Tag`, so that rating-only edits (e.g. clicking a star in the list view) persist without requiring the client to resend other tag fields.