### PR TITLE
Open gallery slideshow from the galleries page

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCard.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { MouseEvent, useMemo, useState } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { GridCard } from "../Shared/GridCard/GridCard";
 import { HoverPopover } from "../Shared/HoverPopover";
@@ -10,22 +10,27 @@ import { PerformerPopoverButton } from "../Shared/PerformerPopoverButton";
 import { PopoverCountButton } from "../Shared/PopoverCountButton";
 import NavUtils from "src/utils/navigation";
 import { RatingBanner } from "../Shared/RatingBanner";
-import { faBox, faPlayCircle, faTag } from "@fortawesome/free-solid-svg-icons";
+import {
+  faBox,
+  faPlayCircle,
+  faSearch,
+  faTag,
+} from "@fortawesome/free-solid-svg-icons";
 import { galleryTitle } from "src/core/galleries";
 import { StudioOverlay } from "../Shared/GridCard/StudioOverlay";
 import { GalleryPreviewScrubber } from "./GalleryPreviewScrubber";
 import cx from "classnames";
-import { useHistory } from "react-router-dom";
 import { PatchComponent } from "src/patch";
 
 interface IGalleryPreviewProps {
   gallery: GQL.SlimGalleryDataFragment;
   onScrubberClick?: (index: number) => void;
+  onPreview?: (ev: MouseEvent) => void;
   disabled?: boolean;
 }
 
 export const GalleryPreview: React.FC<IGalleryPreviewProps> = React.memo(
-  ({ gallery, onScrubberClick, disabled }) => {
+  ({ gallery, onScrubberClick, onPreview, disabled }) => {
     const [imgSrc, setImgSrc] = useState<string | undefined>(
       gallery.paths.cover ?? undefined
     );
@@ -50,6 +55,13 @@ export const GalleryPreview: React.FC<IGalleryPreviewProps> = React.memo(
             disabled={disabled}
           />
         )}
+        {onPreview && gallery.image_count > 0 ? (
+          <div className="preview-button">
+            <Button onClick={onPreview}>
+              <Icon icon={faSearch} />
+            </Button>
+          </div>
+        ) : undefined}
       </div>
     );
   }
@@ -62,6 +74,7 @@ interface IGalleryCardProps {
   selected?: boolean | undefined;
   zoomIndex?: number;
   onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
+  onPreview?: (index: number, ev?: MouseEvent) => void;
 }
 
 const GalleryCardPopovers = React.memo(
@@ -208,20 +221,14 @@ const GalleryCardOverlays = React.memo(
 
 const GalleryCardImage = React.memo(
   PatchComponent("GalleryCard.Image", (props: IGalleryCardProps) => {
-    const history = useHistory();
-
-    const onScrubberClick = useCallback(
-      (i: number) => {
-        history.push(`/galleries/${props.gallery.id}/images/${i}`);
-      },
-      [props.gallery.id, history]
-    );
+    const onPreview = props.selecting ? undefined : props.onPreview;
 
     return (
       <>
         <GalleryPreview
           gallery={props.gallery}
-          onScrubberClick={onScrubberClick}
+          onScrubberClick={onPreview ? (i) => onPreview(i) : undefined}
+          onPreview={onPreview ? (ev) => onPreview(0, ev) : undefined}
           disabled={props.selecting}
         />
         <RatingBanner rating={props.gallery.rating100} />

--- a/ui/v2.5/src/components/Galleries/GalleryCardGrid.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryCardGrid.tsx
@@ -12,13 +12,18 @@ interface IGalleryCardGrid {
   selectedIds: Set<string>;
   zoomIndex: number;
   onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
+  onPreview?: (
+    gallery: GQL.SlimGalleryDataFragment,
+    index: number,
+    ev?: React.MouseEvent
+  ) => void;
 }
 
 const zoomWidths = [280, 340, 480, 640];
 
 export const GalleryCardGrid: React.FC<IGalleryCardGrid> = PatchComponent(
   "GalleryCardGrid",
-  ({ galleries, selectedIds, zoomIndex, onSelectChange }) => {
+  ({ galleries, selectedIds, zoomIndex, onSelectChange, onPreview }) => {
     const [componentRef, { width: containerWidth }] = useContainerDimensions();
     const cardWidth = useCardWidth(containerWidth, zoomIndex, zoomWidths);
 
@@ -34,6 +39,11 @@ export const GalleryCardGrid: React.FC<IGalleryCardGrid> = PatchComponent(
             selected={selectedIds.has(gallery.id)}
             onSelectedChanged={(selected: boolean, shiftKey: boolean) =>
               onSelectChange(gallery.id, selected, shiftKey)
+            }
+            onPreview={
+              selectedIds.size < 1 && onPreview
+                ? (index, ev) => onPreview(gallery, index, ev)
+                : undefined
             }
           />
         ))}

--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -5,6 +5,8 @@ import { useHistory } from "react-router-dom";
 import Mousetrap from "mousetrap";
 import * as GQL from "src/core/generated-graphql";
 import { useFilteredItemList } from "../List/ItemList";
+import { useGalleriesLightbox } from "src/hooks/Lightbox/hooks";
+import { useConfigurationContext } from "src/hooks/Config";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { DisplayMode } from "src/models/list-filter/types";
 import { queryFindGalleries, useFindGalleries } from "src/core/StashService";
@@ -62,6 +64,22 @@ const GalleryList: React.FC<{
 }> = PatchComponent(
   "GalleryList",
   ({ galleries, filter, selectedIds, onSelectChange }) => {
+    const { configuration } = useConfigurationContext();
+    const showLightbox = useGalleriesLightbox();
+
+    const onPreview = useCallback(
+      (
+        gallery: GQL.SlimGalleryDataFragment,
+        index: number,
+        ev?: React.MouseEvent
+      ) => {
+        const autostart = configuration?.ui.autostartGallerySlideshow ?? false;
+        showLightbox(gallery, index, true, autostart);
+        ev?.preventDefault();
+      },
+      [showLightbox, configuration?.ui.autostartGallerySlideshow]
+    );
+
     if (galleries.length === 0) {
       return null;
     }
@@ -73,6 +91,7 @@ const GalleryList: React.FC<{
           selectedIds={selectedIds}
           zoomIndex={filter.zoomIndex}
           onSelectChange={onSelectChange}
+          onPreview={onPreview}
         />
       );
     }

--- a/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryWallCard.tsx
@@ -5,7 +5,8 @@ import { Link } from "react-router-dom";
 import * as GQL from "src/core/generated-graphql";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import TextUtils from "src/utils/text";
-import { useGalleryLightbox } from "src/hooks/Lightbox/hooks";
+import { useGalleriesLightbox } from "src/hooks/Lightbox/hooks";
+import { useConfigurationContext } from "src/hooks/Config";
 import { galleryTitle } from "src/core/galleries";
 import { RatingSystem } from "../Shared/Rating/RatingSystem";
 import { GalleryPreviewScrubber } from "./GalleryPreviewScrubber";
@@ -42,7 +43,10 @@ const GalleryWallCard: React.FC<IProps> = ({
     React.useState<Orientation>("landscape");
   const [imageOrientation, setImageOrientation] =
     React.useState<Orientation>("landscape");
-  const showLightbox = useGalleryLightbox(gallery.id, gallery.chapters);
+  const { configuration } = useConfigurationContext();
+  const showLightbox = useGalleriesLightbox();
+  const autostartSlideshow =
+    configuration?.ui.autostartGallerySlideshow ?? false;
 
   const { dragProps } = useDragMoveSelect({
     selecting: selecting || false,
@@ -87,7 +91,7 @@ const GalleryWallCard: React.FC<IProps> = ({
       return;
     }
 
-    showLightbox(0);
+    showLightbox(gallery, 0, true, autostartSlideshow);
   }
 
   const imgClassname =
@@ -155,7 +159,7 @@ const GalleryWallCard: React.FC<IProps> = ({
           defaultPath={cover ?? ""}
           imageCount={gallery.image_count}
           onClick={(i) => {
-            showLightbox(i);
+            showLightbox(gallery, i, true, autostartSlideshow);
           }}
           onPathChanged={setImgSrc}
         />

--- a/ui/v2.5/src/components/Galleries/styles.scss
+++ b/ui/v2.5/src/components/Galleries/styles.scss
@@ -110,6 +110,13 @@
     top: 0;
   }
 
+  // the cover is a plain block (not flex like the image card), so the
+  // absolutely-positioned preview button needs an explicit offset to overlay
+  // the cover rather than falling to its static position below it.
+  .preview-button {
+    top: 0;
+  }
+
   &-image {
     object-fit: contain;
   }

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -560,6 +560,14 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             onChange={(v) => saveLightboxSettings({ slideshowDelay: v })}
           />
 
+          <BooleanSetting
+            id="autostart-gallery-slideshow"
+            headingID="config.ui.autostart_gallery_slideshow.heading"
+            subHeadingID="config.ui.autostart_gallery_slideshow.description"
+            checked={ui.autostartGallerySlideshow ?? undefined}
+            onChange={(v) => saveUI({ autostartGallerySlideshow: v })}
+          />
+
           <SelectSetting
             id="lightbox_display_mode"
             headingID="dialogs.lightbox.display_mode.label"

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -73,6 +73,9 @@ export interface IUIConfig {
   // if true the chromecast option will enabled
   enableChromecast?: boolean;
 
+  // if true the slideshow autostarts when opening a gallery's lightbox from the galleries page
+  autostartGallerySlideshow?: boolean;
+
   // if true the fullscreen mobile media auto-rotate option will be disabled
   disableMobileMediaAutoRotateEnabled?: boolean;
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -91,6 +91,7 @@ interface IProps {
   initialIndex?: number;
   showNavigation: boolean;
   slideshowEnabled?: boolean;
+  slideshowAutostart?: boolean;
   page?: number;
   pages?: number;
   pageSize?: number;
@@ -107,6 +108,7 @@ export const LightboxComponent: React.FC<IProps> = ({
   initialIndex = 0,
   showNavigation,
   slideshowEnabled = false,
+  slideshowAutostart = false,
   page,
   pages,
   pageSize = 40,
@@ -237,12 +239,16 @@ export const LightboxComponent: React.FC<IProps> = ({
     setLightboxSettings({ displayMode: v });
   }
 
-  // slideshowInterval is used for controlling the logic
-  // displaySlideshowInterval is for display purposes only
-  // keeping them separate and independent allows us to handle the logic however we want
-  // while still displaying something that makes sense to the user
+  // `slideshowInterval` controls the slideshow logic, while
+  // `displayedSlideshowInterval` is for display purposes only. Keeping the two
+  // separate lets us handle the logic however we want while still showing the
+  // user something that makes sense.
+  //
+  // Autostart the slideshow on open when requested (e.g. opening a gallery's
+  // lightbox from the galleries page). The component mounts fresh on each open,
+  // so initialising the interval here starts playback immediately.
   const [slideshowInterval, setSlideshowInterval] = useState<number | null>(
-    null
+    slideshowEnabled && slideshowAutostart ? slideshowDelay : null
   );
 
   const [displayedSlideshowInterval, setDisplayedSlideshowInterval] =

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -16,6 +16,7 @@ export interface IState {
   pages?: number;
   pageSize?: number;
   slideshowEnabled: boolean;
+  slideshowAutostart?: boolean;
   onClose?: () => void;
 }
 interface IContext {
@@ -52,7 +53,14 @@ export const LightboxProvider: React.FC = ({ children }) => {
   }, []);
 
   const onHide = () => {
-    setLightboxState({ ...lightboxState, isVisible: false });
+    // slideshowAutostart is a per-open instruction (set when opening a gallery's
+    // lightbox from the galleries page). Clear it on close so it doesn't leak
+    // into the next lightbox opened from another entry point.
+    setLightboxState({
+      ...lightboxState,
+      isVisible: false,
+      slideshowAutostart: false,
+    });
     if (lightboxState.onClose) {
       lightboxState.onClose();
     }

--- a/ui/v2.5/src/hooks/Lightbox/hooks.ts
+++ b/ui/v2.5/src/hooks/Lightbox/hooks.ts
@@ -61,7 +61,7 @@ export const useGalleriesLightbox = () => {
   const { setLightboxState } = useLightboxContext();
 
   const pageSize = 40;
-  const [fetchImages] = GQL.useFindImagesLazyQuery();
+  const [fetchImages, { data }] = GQL.useFindImagesLazyQuery();
 
   // details of the gallery currently shown in the lightbox, used for paging
   const active = useRef<{
@@ -72,6 +72,19 @@ export const useGalleriesLightbox = () => {
     page: number;
     pages: number;
   }>();
+
+  // Keep the lightbox images in sync with the live query result. The lazy query
+  // stays subscribed after execution, so its data updates whenever the Apollo
+  // cache changes (e.g. rating an image from inside the lightbox evicts and
+  // refetches findImages). Push those updates into the lightbox state so edits
+  // are reflected immediately, mirroring useLightbox above. Without this the
+  // images are a one-shot snapshot taken at fetch time and never refresh.
+  useEffect(() => {
+    if (!active.current) return;
+    const images = data?.findImages?.images;
+    if (!images) return;
+    setLightboxState({ images });
+  }, [data, setLightboxState]);
 
   function loadPage(page: number) {
     const current = active.current;

--- a/ui/v2.5/src/hooks/Lightbox/hooks.ts
+++ b/ui/v2.5/src/hooks/Lightbox/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import * as GQL from "src/core/generated-graphql";
 import { IState, useLightboxContext } from "./context";
 import { IChapter } from "./types";
@@ -48,108 +48,132 @@ export const useLightbox = (
   return show;
 };
 
-export const useGalleryLightbox = (id: string, chapters: IChapter[] = []) => {
+// Drives the lightbox for a gallery chosen at call time. A single lazy query is
+// used and variables are passed to the execute function, so it can be
+// instantiated once per list (rather than once per card) and the gallery to
+// open is supplied to show() rather than baked into the hook.
+interface ILightboxGallery {
+  id: string;
+  chapters?: IChapter[];
+}
+
+export const useGalleriesLightbox = () => {
   const { setLightboxState } = useLightboxContext();
 
   const pageSize = 40;
-  const [page, setPage] = useState(1);
+  const [fetchImages] = GQL.useFindImagesLazyQuery();
 
-  const currentFilter = useMemo(() => {
-    return {
-      page,
-      per_page: pageSize,
-      sort: "path",
-    };
-  }, [page]);
+  // details of the gallery currently shown in the lightbox, used for paging
+  const active = useRef<{
+    id: string;
+    chapters: IChapter[];
+    slideshowEnabled: boolean;
+    slideshowAutostart: boolean;
+    page: number;
+    pages: number;
+  }>();
 
-  const [fetchGallery, { data }] = GQL.useFindImagesLazyQuery({
-    variables: {
-      filter: currentFilter,
-      image_filter: {
-        galleries: {
-          modifier: GQL.CriterionModifier.Includes,
-          value: [id],
+  function loadPage(page: number) {
+    const current = active.current;
+    if (!current) return;
+
+    fetchImages({
+      variables: {
+        filter: { page, per_page: pageSize, sort: "path" },
+        image_filter: {
+          galleries: {
+            modifier: GQL.CriterionModifier.Includes,
+            value: [current.id],
+          },
         },
       },
-    },
-  });
+    }).then((result) => {
+      // ignore if a different gallery was opened in the meantime
+      if (active.current !== current) return;
 
-  const pages = useMemo(() => {
-    const totalCount = data?.findImages.count ?? 0;
-    return Math.ceil(totalCount / pageSize);
-  }, [data?.findImages.count]);
+      const totalCount = result.data?.findImages.count ?? 0;
+      const pages = Math.ceil(totalCount / pageSize);
+      current.page = page;
+      current.pages = pages;
 
-  const handleLightBoxPage = useCallback(
-    (props: { direction?: number; page?: number }) => {
-      const { direction, page: newPage } = props;
+      setLightboxState({
+        isLoading: false,
+        isVisible: true,
+        images: result.data?.findImages?.images ?? [],
+        pageCallback: pages > 1 ? handleLightBoxPage : undefined,
+        page,
+        pages,
+        pageSize,
+        chapters: current.chapters,
+        slideshowEnabled: current.slideshowEnabled,
+        slideshowAutostart: current.slideshowAutostart,
+      });
+    });
+  }
 
-      if (direction !== undefined) {
-        if (direction < 0) {
-          if (page === 1) {
-            setPage(pages);
-          } else {
-            setPage(page + direction);
-          }
-        } else if (direction > 0) {
-          if (page === pages) {
-            // return to the first page
-            setPage(1);
-          } else {
-            setPage(page + direction);
-          }
-        }
-      } else if (newPage !== undefined) {
-        setPage(newPage);
+  function handleLightBoxPage(props: { direction?: number; page?: number }) {
+    const current = active.current;
+    if (!current) return;
+
+    const { direction, page: newPage } = props;
+    let target = current.page;
+
+    if (direction !== undefined) {
+      if (direction < 0) {
+        target = current.page === 1 ? current.pages : current.page + direction;
+      } else if (direction > 0) {
+        target = current.page === current.pages ? 1 : current.page + direction;
       }
-    },
-    [page, pages]
-  );
-
-  useEffect(() => {
-    if (data)
-      setLightboxState({
-        isLoading: false,
-        isVisible: true,
-        images: data.findImages?.images ?? [],
-        pageCallback: pages > 1 ? handleLightBoxPage : undefined,
-        page,
-        pages,
-      });
-  }, [setLightboxState, data, handleLightBoxPage, page, pages]);
-
-  const show = (index: number = 0) => {
-    if (index > pageSize) {
-      setPage(Math.floor(index / pageSize) + 1);
-      index = index % pageSize;
-    } else {
-      setPage(1);
+    } else if (newPage !== undefined) {
+      target = newPage;
     }
-    if (data)
-      setLightboxState({
-        isLoading: false,
-        isVisible: true,
-        initialIndex: index,
-        images: data.findImages?.images ?? [],
-        pageCallback: pages > 1 ? handleLightBoxPage : undefined,
-        page,
-        pages,
-        pageSize,
-        chapters: chapters,
-      });
-    else {
-      setLightboxState({
-        images: [],
-        isLoading: true,
-        isVisible: true,
-        initialIndex: index,
-        pageCallback: undefined,
-        page: undefined,
-        pageSize,
-        chapters: chapters,
-      });
-      fetchGallery();
-    }
-  };
+
+    loadPage(target);
+  }
+
+  function show(
+    gallery: ILightboxGallery,
+    index: number = 0,
+    slideshowEnabled: boolean = false,
+    slideshowAutostart: boolean = false
+  ) {
+    const chapters = gallery.chapters ?? [];
+    const startPage = Math.floor(index / pageSize) + 1;
+    const initialIndex = index % pageSize;
+
+    active.current = {
+      id: gallery.id,
+      chapters,
+      slideshowEnabled,
+      slideshowAutostart,
+      page: startPage,
+      pages: 1,
+    };
+
+    setLightboxState({
+      images: [],
+      isLoading: true,
+      isVisible: true,
+      initialIndex,
+      showNavigation: false,
+      pageCallback: undefined,
+      page: undefined,
+      pageSize,
+      chapters,
+      slideshowEnabled,
+      slideshowAutostart,
+    });
+
+    loadPage(startPage);
+  }
 
   return show;
+};
+
+// Bound to a single gallery, for callers that always open the same one (the
+// gallery detail page, wall cards, and the plugin API). Thin wrapper over
+// useGalleriesLightbox so the paging/fetch logic lives in one place.
+export const useGalleryLightbox = (id: string, chapters: IChapter[] = []) => {
+  const show = useGalleriesLightbox();
+  return (index: number = 0) => show({ id, chapters }, index);
 };

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -658,6 +658,10 @@
         "description": "Abbreviate counters in cards and details view pages, for example \"1831\" will get formated to \"1.8K\".",
         "heading": "Abbreviate counters"
       },
+      "autostart_gallery_slideshow": {
+        "description": "Automatically start the slideshow when opening a gallery's lightbox from the galleries page.",
+        "heading": "Auto-start gallery slideshow"
+      },
       "basic_settings": "Basic Settings",
       "custom_css": {
         "description": "Page must be reloaded for changes to take effect. There is no guarantee of compatibility between custom CSS and future releases of Stash.",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Starting a gallery slideshow currently takes several steps (open the gallery → switch to Wall view → open a picture → press Play). This PR lets you open a gallery's slideshow in the lightbox directly from the **galleries page**:

- On the **grid**, hovering a gallery cover shows a **magnifying-glass** button that opens that gallery's images in the lightbox, mirroring the existing image-card interaction.
- A new **"Auto-start gallery slideshow"** interface setting (Settings → Interface → Image Lightbox) controls whether the slideshow begins playing automatically when opened from either the grid or wall galleries-page entry points.
- The cover's hover-scrubber opens the lightbox at the scrubbed image, on both the grid and Wall view.
- Clicking the cover or title still navigates to the gallery page.

Key design choices:

- **Auto-start is scoped to the galleries-page entry points** — the grid card (magnifying glass or scrubber) and Wall-view covers/scrubbers. Opening the lightbox from *within* a gallery (clicking an individual image) or via a detail-page chapter marker is arguably a different user intent — you want to view *that* image, not start a slideshow — so it never auto-starts there. Auto-start is a per-open instruction that is cleared when the lightbox closes, so it can't leak into a lightbox subsequently opened from another entry point.
- **The setting is a backend interface setting**, implemented as the gallery analogue of the scene player's `autostartVideo` ("auto-start playback") preference: a typed `ConfigInterfaceResult` boolean (`autostartGallerySlideshow`), wired through the config getter and the configure/query resolvers, defaulting to `false`. It lives alongside `autostartVideo` and the lightbox `slideshowDelay` rather than in the front-end-only UI config.
- **The hover-scrubber opens the lightbox at the scrubbed image, consistently on the grid and in Wall view.** Previously the grid card's scrubber navigated to the single-image viewer page (`/galleries/{id}/images/{i}`) while the Wall-view scrubber opened the lightbox. It now opens the lightbox at the scrubbed index in both, so scrubbing-then-clicking behaves the same everywhere. (This intentionally replaces the grid card's prior navigate-to-viewer behavior in favor of consistency.)
- **Reuse the image-card UI for the trigger.** The magnifying-glass button reuses the image card's existing `.preview-button` markup/styling; the only gallery-specific CSS is a one-line `top: 0` (the gallery cover is a block container rather than a flex one).
- **A single list-level lightbox controller (new code).** `useGalleriesLightbox` drives the lightbox for the whole list rather than a hook per card.
  - Versus a per-card hook: one lazy query for the list instead of one per gallery; the gallery is chosen at `show()` time rather than baked into the hook; query variables are passed to the lazy-query *execute* function, which avoids the `useLazyQuery` "pass variables to execute" deprecation warning; and the lightbox opens only in response to an explicit `show()`, rather than from a "data is present → open" effect that races across instances on the shared lightbox state.
  - The existing `useGalleryLightbox` (plugin API; also used by the gallery detail page) now delegates to it, so the gallery paging/fetch logic lives in one place.
  - As a drive-by, routing every gallery entry point through this one controller also fixes **path-dependent** behavior of the lightbox's thumbnail-navigation strip (`showNavigation`). It defaults to *shown* in the shared lightbox state; only the image list and the gallery viewer ever explicitly set it to hidden, while the gallery detail page's chapter markers and the Wall-view covers never set it at all — so whether the strip appeared depended on which lightbox you had opened previously in the session (e.g. on a fresh page load a Wall-view or chapter open would show it, but once you'd opened the in-gallery image viewer, which sets it hidden, it would stay hidden). The controller sets `showNavigation: false`, so the strip is consistently hidden regardless of path.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #1579

## Testing
<!-- Describe the testing steps you have performed. -->

- Galleries grid: hovering a cover shows the magnifying glass; clicking opens the lightbox at image 1 without navigating away.
- Wall view: clicking a cover (or scrubbing to an index) opens the lightbox; the slideshow auto-starts when the setting is on and stays paused when off.
- Setting off → lightbox opens paused; setting on → slideshow auto-advances.
- Opening the lightbox from the images list / within a gallery does **not** auto-start, even after a galleries-page auto-start open (verified the per-open flag is cleared on close).
- Cover/title click still routes to the gallery page.
- Hover-scrubber click (grid and Wall view): scrubbing to a position and clicking opens the lightbox at that image — it stays on `/galleries` (no longer navigates to the single-image viewer) and opens a different image than the magnifying glass at index 0, confirming the scrubbed index is honored.
- Multi-page galleries (>40 images) page correctly in the lightbox — via the new grid entry point and the existing detail-page chapters / Wall cards that now share the same controller.
- Selecting mode hides the magnifying glass (drag/box-select unaffected).
- `make validate` passes (Go build/vet/gofmt, tsc, biome, stylelint).

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

**Before:** hovering a gallery cover on the galleries only shows the select box; there is no way to open the gallery's slideshow from the grid.

<img width="317" height="364" alt="before" src="https://github.com/user-attachments/assets/5fadb305-b7d0-403d-84c7-c3000639c0d4" />

**After:** hovering a gallery cover also shows a magnifying-glass button; clicking it opens the gallery's images in the lightbox (auto-starting the slideshow when the new setting is enabled).

<img width="317" height="364" alt="after" src="https://github.com/user-attachments/assets/9ad23796-6868-448b-9abd-48513d21ba41" />

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Claude Code (Anthropic) to assist with this PR. It helped explore the existing image-card/lightbox implementations, propose and implement the approach (the config setting and resolvers, the gallery-card magnifying glass, and the list-level lightbox controller). I directed the design decisions, reviewed all changes, and manually verified the behavior against a running instance (including the auto-start scoping, scrubber/title behavior, multi-page paging, and selection mode).

## Additional Context
<!-- Add any other context about the pull request here. -->

The new setting (`autostartGallerySlideshow`) requires regenerating the GraphQL bindings (`make generate`); no generated files are committed, consistent with the repo's setup. The setting defaults to `false`, so existing behavior is unchanged unless a user opts in.
