### PR TITLE
feat: loop playlist when last element is done playing

### DIFF
--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -401,6 +401,8 @@ input ConfigInterfaceInput {
   autostartVideoOnPlaySelected: Boolean
   "If true, next scene in playlist will be played at video end by default"
   continuePlaylistDefault: Boolean
+  "If true, queue wraps to the first scene after the last scene finishes by default"
+  loopPlaylistDefault: Boolean
 
   "If true, studio overlays will be shown as text instead of logo images"
   showStudioAsText: Boolean
@@ -478,6 +480,8 @@ type ConfigInterfaceResult {
   autostartVideoOnPlaySelected: Boolean
   "If true, next scene in playlist will be played at video end by default"
   continuePlaylistDefault: Boolean
+  "If true, queue wraps to the first scene after the last scene finishes by default"
+  loopPlaylistDefault: Boolean
 
   "If true, studio overlays will be shown as text instead of logo images"
   showStudioAsText: Boolean

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -491,6 +491,7 @@ func (r *mutationResolver) ConfigureInterface(ctx context.Context, input ConfigI
 	r.setConfigBool(config.ShowStudioAsText, input.ShowStudioAsText)
 	r.setConfigBool(config.AutostartVideoOnPlaySelected, input.AutostartVideoOnPlaySelected)
 	r.setConfigBool(config.ContinuePlaylistDefault, input.ContinuePlaylistDefault)
+	r.setConfigBool(config.LoopPlaylistDefault, input.LoopPlaylistDefault)
 
 	r.setConfigString(config.Language, input.Language)
 

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -154,6 +154,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 	autostartVideo := config.GetAutostartVideo()
 	autostartVideoOnPlaySelected := config.GetAutostartVideoOnPlaySelected()
 	continuePlaylistDefault := config.GetContinuePlaylistDefault()
+	loopPlaylistDefault := config.GetLoopPlaylistDefault()
 	showStudioAsText := config.GetShowStudioAsText()
 	css := config.GetCSS()
 	cssEnabled := config.GetCSSEnabled()
@@ -183,6 +184,7 @@ func makeConfigInterfaceResult() *ConfigInterfaceResult {
 		ShowStudioAsText:             &showStudioAsText,
 		AutostartVideoOnPlaySelected: &autostartVideoOnPlaySelected,
 		ContinuePlaylistDefault:      &continuePlaylistDefault,
+		LoopPlaylistDefault:          &loopPlaylistDefault,
 		CSS:                          &css,
 		CSSEnabled:                   &cssEnabled,
 		Javascript:                   &javascript,

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -209,6 +209,7 @@ const (
 	AutostartVideoOnPlaySelected        = "autostart_video_on_play_selected"
 	autostartVideoOnPlaySelectedDefault = true
 	ContinuePlaylistDefault             = "continue_playlist_default"
+	LoopPlaylistDefault                 = "loop_playlist_default"
 	ShowStudioAsText                    = "show_studio_as_text"
 	CSSEnabled                          = "cssenabled"
 	JavascriptEnabled                   = "javascriptenabled"
@@ -1324,6 +1325,10 @@ func (i *Config) GetAutostartVideoOnPlaySelected() bool {
 
 func (i *Config) GetContinuePlaylistDefault() bool {
 	return i.getBool(ContinuePlaylistDefault)
+}
+
+func (i *Config) GetLoopPlaylistDefault() bool {
+	return i.getBool(LoopPlaylistDefault)
 }
 
 func (i *Config) GetShowStudioAsText() bool {

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -121,6 +121,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.SetInterface(DisableDropdownCreateMovie, i.GetDisableDropdownCreate().Movie)
 				i.SetInterface(AutostartVideoOnPlaySelected, i.GetAutostartVideoOnPlaySelected())
 				i.SetInterface(ContinuePlaylistDefault, i.GetContinuePlaylistDefault())
+				i.SetInterface(LoopPlaylistDefault, i.GetLoopPlaylistDefault())
 				i.SetInterface(PythonPath, i.GetPythonPath())
 				t.Logf("Worker %v iteration %v took %v", wk, l, time.Since(start))
 			}

--- a/ui/v2.5/graphql/data/config.graphql
+++ b/ui/v2.5/graphql/data/config.graphql
@@ -90,6 +90,7 @@ fragment ConfigInterfaceData on ConfigInterfaceResult {
   autostartVideo
   autostartVideoOnPlaySelected
   continuePlaylistDefault
+  loopPlaylistDefault
   showStudioAsText
   css
   cssEnabled

--- a/ui/v2.5/src/components/Scenes/SceneDetails/QueueViewer.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/QueueViewer.tsx
@@ -19,8 +19,10 @@ export interface IPlaylistViewer {
   currentID?: string;
   start?: number;
   continue?: boolean;
+  loop?: boolean;
   hasMoreScenes: boolean;
   setContinue: (v: boolean) => void;
+  setLoop: (v: boolean) => void;
   onSceneClicked: (id: string) => void;
   onNext: () => void;
   onPrevious: () => void;
@@ -34,8 +36,10 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
   currentID,
   start = 0,
   continue: continuePlaylist = false,
+  loop: loopPlaylist = false,
   hasMoreScenes,
   setContinue,
+  setLoop,
   onNext,
   onPrevious,
   onRandom,
@@ -125,6 +129,14 @@ export const QueueViewer: React.FC<IPlaylistViewer> = ({
             label={intl.formatMessage({ id: "actions.continue" })}
             onChange={() => {
               setContinue(!continuePlaylist);
+            }}
+          />
+          <Form.Check
+            id="loop-checkbox"
+            checked={loopPlaylist}
+            label={intl.formatMessage({ id: "actions.loop" })}
+            onChange={() => {
+              setLoop(!loopPlaylist);
             }}
           />
         </div>

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -154,6 +154,8 @@ interface IProps {
   collapsed: boolean;
   setCollapsed: (state: boolean) => void;
   setContinuePlaylist: (value: boolean) => void;
+  loopPlaylist: boolean;
+  setLoopPlaylist: (value: boolean) => void;
 }
 
 interface ISceneParams {
@@ -183,6 +185,8 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
     collapsed,
     setCollapsed,
     setContinuePlaylist,
+    loopPlaylist,
+    setLoopPlaylist,
   } = props;
 
   const Toast = useToast();
@@ -598,6 +602,8 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
               currentID={scene.id}
               continue={continuePlaylist}
               setContinue={setContinuePlaylist}
+              loop={loopPlaylist}
+              setLoop={setLoopPlaylist}
               onSceneClicked={onQueueSceneClicked}
               onNext={onQueueNext}
               onPrevious={onQueuePrevious}
@@ -672,9 +678,8 @@ const ScenePage: React.FC<IProps> = PatchComponent("ScenePage", (props) => {
       {maybeRenderMergeDialog()}
       {maybeRenderDeleteDialog()}
       <div
-        className={`scene-tabs order-xl-first order-last ${
-          collapsed ? "collapsed" : ""
-        }`}
+        className={`scene-tabs order-xl-first order-last ${collapsed ? "collapsed" : ""
+          }`}
       >
         <div>
           <div className="scene-header-container">
@@ -785,10 +790,19 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
     }
   }, [configuration?.interface.continuePlaylistDefault, queryParams]);
 
+  const queryLoop = useMemo(() => {
+    const loop = queryParams.get("loop");
+    if (loop) {
+      return loop === "true";
+    }
+    return !!configuration?.interface.loopPlaylistDefault;
+  }, [configuration?.interface.loopPlaylistDefault, queryParams]);
+
   const [queueScenes, setQueueScenes] = useState<QueuedScene[]>([]);
 
   const [collapsed, setCollapsed] = useState(false);
   const [continuePlaylist, setContinuePlaylist] = useState(queryContinue);
+  const [loopPlaylist, setLoopPlaylist] = useState(queryLoop);
   const [hideScrubber, setHideScrubber] = useState(
     !(configuration?.interface.showScrubber ?? true)
   );
@@ -904,11 +918,12 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
       newPage,
       autoPlay,
       continue: continuePlaylist,
+      loop: loopPlaylist,
     });
     history.replace(sceneLink);
   }
 
-  async function queueNext(autoPlay: boolean) {
+  async function queueNext(autoPlay: boolean, allowLoop = false) {
     if (currentQueueIndex === -1) return;
 
     if (currentQueueIndex < queueScenes.length - 1) {
@@ -922,6 +937,8 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
           const newPage = (sceneQueue.query?.currentPage ?? 0) + 1;
           loadScene(loadedScenes[0].id, autoPlay, newPage);
         }
+      } else if (allowLoop && loopPlaylist && queueScenes.length > 0) {
+        loadScene(queueScenes[0].id, autoPlay);
       }
     }
   }
@@ -972,7 +989,7 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
   function onComplete() {
     // load the next scene if we're continuing
     if (continuePlaylist) {
-      queueNext(true);
+      queueNext(true, true);
     }
   }
 
@@ -1029,6 +1046,8 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
         collapsed={collapsed}
         setCollapsed={setCollapsed}
         setContinuePlaylist={setContinuePlaylist}
+        loopPlaylist={loopPlaylist}
+        setLoopPlaylist={setLoopPlaylist}
       />
       <div className={`scene-player-container ${collapsed ? "expanded" : ""}`}>
         <ScenePlayer

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -467,6 +467,14 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             onChange={(v) => saveInterface({ continuePlaylistDefault: v })}
           />
 
+          <BooleanSetting
+            id="loop-playlist-default"
+            headingID="config.ui.scene_player.options.loop_playlist_default.heading"
+            subHeadingID="config.ui.scene_player.options.loop_playlist_default.description"
+            checked={iface.loopPlaylistDefault ?? undefined}
+            onChange={(v) => saveInterface({ loopPlaylistDefault: v })}
+          />
+
           <ModalSetting<number>
             id="max-loop-duration"
             headingID="config.ui.max_loop_duration.heading"
@@ -807,26 +815,26 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
           </SelectSetting>
           {(ui.ratingSystemOptions?.type ?? defaultRatingSystemType) ===
             RatingSystemType.Stars && (
-            <SelectSetting
-              id="rating_system_star_precision"
-              headingID="config.ui.editing.rating_system.star_precision.label"
-              value={
-                ui.ratingSystemOptions?.starPrecision ??
-                defaultRatingStarPrecision
-              }
-              onChange={(v) =>
-                saveRatingSystemStarPrecision(v as RatingStarPrecision)
-              }
-            >
-              {Array.from(ratingStarPrecisionIntlMap.entries()).map((v) => (
-                <option key={v[0]} value={v[0]}>
-                  {intl.formatMessage({
-                    id: v[1],
-                  })}
-                </option>
-              ))}
-            </SelectSetting>
-          )}
+              <SelectSetting
+                id="rating_system_star_precision"
+                headingID="config.ui.editing.rating_system.star_precision.label"
+                value={
+                  ui.ratingSystemOptions?.starPrecision ??
+                  defaultRatingStarPrecision
+                }
+                onChange={(v) =>
+                  saveRatingSystemStarPrecision(v as RatingStarPrecision)
+                }
+              >
+                {Array.from(ratingStarPrecisionIntlMap.entries()).map((v) => (
+                  <option key={v[0]} value={v[0]}>
+                    {intl.formatMessage({
+                      id: v[1],
+                    })}
+                  </option>
+                ))}
+              </SelectSetting>
+            )}
         </SettingSection>
 
         <SettingSection headingID="config.ui.custom_css.heading">

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -71,6 +71,7 @@
     "hide_configuration": "Hide Configuration",
     "identify": "Identify",
     "ignore": "Ignore",
+    "loop": "Loop",
     "import": "Import…",
     "import_from_file": "Import from file",
     "load": "Load",
@@ -841,6 +842,10 @@
           "continue_playlist_default": {
             "description": "Play next scene in queue when video finishes.",
             "heading": "Continue playlist by default"
+          },
+          "loop_playlist_default": {
+            "description": "When the last scene in the queue finishes, continue from the first scene.",
+            "heading": "Loop playlist by default"
           },
           "disable_mobile_media_auto_rotate": "Disable auto-rotate of fullscreen media on mobile",
           "enable_chromecast": "Enable Chromecast",

--- a/ui/v2.5/src/models/sceneQueue.ts
+++ b/ui/v2.5/src/models/sceneQueue.ts
@@ -12,6 +12,7 @@ export interface IPlaySceneOptions {
   newPage?: number;
   autoPlay?: boolean;
   continue?: boolean;
+  loop?: boolean;
   start?: number;
 }
 
@@ -116,6 +117,9 @@ export class SceneQueue {
     }
     if (options.continue !== undefined) {
       params.push("continue=" + options.continue);
+    }
+    if (options.loop !== undefined) {
+      params.push("loop=" + options.loop);
     }
     if (options.start !== undefined) {
       params.push("t=" + options.start);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
Adds checkbox to the queue and starts the playlist again after its done playing



## Related Issue
This would close https://github.com/stashapp/stash/issues/2913



## Testing
I manually tested the behavior with and without the flag set to true



## Screenshots
<!-- For visual changes, please add before and after screenshots. -->
Interface Settings before the change:
<img width="748" height="177" alt="Screenshot 2026-06-14 113005" src="https://github.com/user-attachments/assets/30343bf4-a207-462d-ae1d-d89fd1285a9b" />

Interface Settings after the change:
<img width="735" height="244" alt="Screenshot 2026-06-14 113301" src="https://github.com/user-attachments/assets/a83735e2-0eeb-4fd3-b3b5-83f8df0393d3" />

Queue Settings before the change:
<img width="111" height="61" alt="Screenshot 2026-06-14 113020" src="https://github.com/user-attachments/assets/5a06a656-63a0-4e1e-8c07-1e081e3782b5" />

Queue Settings after the change:
<img width="98" height="63" alt="Screenshot 2026-06-14 112805" src="https://github.com/user-attachments/assets/f2150626-8232-48fa-8093-6e89d74008b7" />

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).
  - I'm not sure if there is corresponding documentation. I modelled the setting after the "continue" setting, so I added code and text for the setting everywhere I found the continue setting as well, to make sure I didn't miss anything. If I still missed a spot, just let me know and I'll fix that.

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
I used copilot to figure out what needs to be added and where, then I added the code in the same schema that the "continue" setting uses.

I also used copilot to quickly skim if I needed to set up docker to test my changes or if I could do it without.

The code itself and the text for english and german are from me, but as I stated, I oriented myself on the "continue" setting, to keep things consistent.


## Additional Context
<!-- Add any other context about the pull request here. -->

I didn't add any other translations than english and german, because thats the only languages I speak. I can try to create translations for other languages using AI if necessary, but I'd rather avoid that unless its needed.