### PR TITLE
Fix: json.Number Custom Field Filters

### DIFF
--- a/internal/api/json.go
+++ b/internal/api/json.go
@@ -3,8 +3,6 @@ package api
 import (
 	"encoding/json"
 	"strings"
-
-	"github.com/stashapp/stash/pkg/models"
 )
 
 // jsonNumberToNumber converts a JSON number to either a float64 or int64.
@@ -15,15 +13,6 @@ func jsonNumberToNumber(n json.Number) interface{} {
 	}
 	ret, _ := n.Int64()
 	return ret
-}
-
-// anyJSONNumberToNumber converts a JSON number using jsonNumberToNumber, otherwise it returns the existing value
-func anyJSONNumberToNumber(v any) any {
-	if n, ok := v.(json.Number); ok {
-		return jsonNumberToNumber(n)
-	}
-
-	return v
 }
 
 // ConvertMapJSONNumbers converts all JSON numbers in a map to either float64 or int64.
@@ -41,24 +30,6 @@ func convertMapJSONNumbers(m map[string]interface{}) (ret map[string]interface{}
 		} else {
 			ret[k] = v
 		}
-	}
-
-	return ret
-}
-
-func convertCustomFieldCriterionValues(c models.CustomFieldCriterionInput) models.CustomFieldCriterionInput {
-	nv := make([]any, len(c.Value))
-	for i, v := range c.Value {
-		nv[i] = anyJSONNumberToNumber(v)
-	}
-	c.Value = nv
-	return c
-}
-
-func convertCustomFieldCriterionInputJSONNumbers(c []models.CustomFieldCriterionInput) []models.CustomFieldCriterionInput {
-	ret := make([]models.CustomFieldCriterionInput, len(c))
-	for i, v := range c {
-		ret[i] = convertCustomFieldCriterionValues(v)
 	}
 
 	return ret

--- a/internal/api/resolver_query_find_performer.go
+++ b/internal/api/resolver_query_find_performer.go
@@ -31,11 +31,6 @@ func (r *queryResolver) FindPerformers(ctx context.Context, performerFilter *mod
 		}
 	}
 
-	// #5682 - convert JSON numbers to float64 or int64
-	if performerFilter != nil {
-		performerFilter.CustomFields = convertCustomFieldCriterionInputJSONNumbers(performerFilter.CustomFields)
-	}
-
 	if err := r.withReadTxn(ctx, func(ctx context.Context) error {
 		var performers []*models.Performer
 		var err error

--- a/pkg/sqlite/custom_fields.go
+++ b/pkg/sqlite/custom_fields.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -101,6 +102,17 @@ func (s *customFieldsStore) validateCustomFieldName(fieldName string) error {
 
 func getSQLValueFromCustomFieldInput(input interface{}) (interface{}, error) {
 	switch v := input.(type) {
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return i, nil
+		}
+
+		f, err := v.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("invalid custom field number %q: %w", v, err)
+		}
+
+		return f, nil
 	case []interface{}, map[string]interface{}:
 		// TODO - in future it would be nice to convert to a JSON string
 		// however, we would need some way to differentiate between a JSON string and a regular string

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -5,6 +5,7 @@ package sqlite_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -5327,6 +5328,85 @@ func TestSceneQueryCustomFields(t *testing.T) {
 				},
 			},
 			nil,
+			[]int{sceneIdxWithPerformer},
+			false,
+		},
+		{
+			"json number greater than",
+			&models.SceneFilterType{
+				CustomFields: []models.CustomFieldCriterionInput{
+					{
+						Field:    "real",
+						Modifier: models.CriterionModifierGreaterThan,
+						Value:    []any{json.Number("0.15")},
+					},
+				},
+			},
+			[]int{sceneIdxWithPerformer},
+			[]int{sceneIdxWithGallery},
+			false,
+		},
+		{
+			"json number equals",
+			&models.SceneFilterType{
+				CustomFields: []models.CustomFieldCriterionInput{
+					{
+						Field:    "real",
+						Modifier: models.CriterionModifierEquals,
+						Value:    []any{json.Number("0.2")},
+					},
+				},
+			},
+			[]int{sceneIdxWithPerformer},
+			[]int{sceneIdxWithGallery},
+			false,
+		},
+		{
+			"json number between",
+			&models.SceneFilterType{
+				CustomFields: []models.CustomFieldCriterionInput{
+					{
+						Field:    "real",
+						Modifier: models.CriterionModifierBetween,
+						Value:    []any{json.Number("0.15"), json.Number("0.25")},
+					},
+				},
+			},
+			[]int{sceneIdxWithPerformer},
+			[]int{sceneIdxWithGallery},
+			false,
+		},
+		{
+			"nested performer json number greater than",
+			&models.SceneFilterType{
+				PerformersFilter: &models.PerformerFilterType{
+					CustomFields: []models.CustomFieldCriterionInput{
+						{
+							Field:    "real",
+							Modifier: models.CriterionModifierGreaterThan,
+							Value:    []any{json.Number("0.15")},
+						},
+					},
+				},
+			},
+			[]int{sceneIdxWithTwoPerformers},
+			[]int{sceneIdxWithPerformer},
+			false,
+		},
+		{
+			"nested performer json number less than",
+			&models.SceneFilterType{
+				PerformersFilter: &models.PerformerFilterType{
+					CustomFields: []models.CustomFieldCriterionInput{
+						{
+							Field:    "real",
+							Modifier: models.CriterionModifierLessThan,
+							Value:    []any{json.Number("0.15")},
+						},
+					},
+				},
+			},
+			[]int{sceneIdxWithTwoPerformers},
 			[]int{sceneIdxWithPerformer},
 			false,
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixes numeric custom-field filters when GraphQL `Any` values arrive as `json.Number`.

The previous fix (#5685) for performer filters normalized `json.Number` in the top-level `findPerformers` resolver, but similar filters for scenes, images, galleries, studios, tags, groups, etc still had the issue as well as nested filters such as `scene_filter.performers_filter.custom_fields` that bypass that resolver. This change moves the conversion into the shared SQLite custom-field value conversion path so direct and nested custom-field filters bind numeric operands as numbers instead of text.

Adds regression coverage for direct scene custom-field filtering and the nested performer-filter bypass path.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7031

## Testing
<!-- Describe the testing steps you have performed. -->
- `go test -tags integration ./pkg/sqlite -run "TestSceneQueryCustomFields/(json_number_greater_than|json_number_equals|json_number_between|nested_performer_json_number_greater_than|nested_performer_json_number_less_than)" -count=1`
- `go test -tags integration ./pkg/sqlite -run "TestSceneQueryCustomFields|Test(Performer|Gallery|Image|Group|Studio|Tag)QueryCustomFields" -count=1`
- `go test -tags "integration sqlite_stat4 sqlite_math_functions" ./pkg/sqlite -count=1`
- `git diff --check`
- `mingw32-make lint`
- Manually testing with custom fields and filters following the general steps in the reported issue to confirm that it resolves the filtering. 


## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A - backend filtering fix.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the filter paths, identify the nested-filter bypass, draft the shared SQLite conversion fix, and write targeted regression tests. I reviewed the changes, test results, and manually tested myself.

## Additional Context
<!-- Add any other context about the pull request here. -->

The fix is intentionally centralized in the SQLite custom-field conversion path rather than adding resolver-level conversions for each entity. This covers top-level custom-field filters and nested related filters that do not pass through the top-level entity resolvers.