### PR TITLE
Fix: Pagination Footer Centering With Sidebar

### DIFF
--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1068,8 +1068,8 @@ ul.selectable-list {
   background-color: transparent;
   bottom: $navbar-height;
   margin: auto;
+  pointer-events: none;
   position: sticky;
-  width: fit-content;
   z-index: 10;
 
   @include media-breakpoint-up(sm) {
@@ -1080,6 +1080,7 @@ ul.selectable-list {
 .pagination-footer {
   margin: auto;
   padding: 0.5rem 1rem 0.75rem;
+  pointer-events: auto;
 
   width: fit-content;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes the sticky pagination footer alignment when a filtered list sidebar is open on very wide screens.

The pagination footer wrapper was using `width: fit-content` to avoid blocking clicks beside the visible pagination controls. However, that made it interact poorly with the existing large-screen sidebar centering rule, which applies a negative sidebar-width margin to align list controls when the sidebar is open.

This changes the footer wrapper back to a full-width sticky layout container, while preserving click-through behavior by disabling pointer events on the wrapper and re-enabling them on the visible footer controls.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7029

## Testing
<!-- Describe the testing steps you have performed. -->

- Tested the scene list at a wide viewport with enough results for pagination.
- Confirmed the bottom sticky pagination remains aligned when the left sidebar is opened.
- Confirmed the visible pagination controls remain clickable.
- Confirmed horizontal space beside the visible footer controls does not block clicks.
- Ran `pnpm.cmd run lint:css` from `ui/v2.5`.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

Before (You can see the very tip of the footer hiding in the bottom left):
<img width="1959" height="1035" alt="image" src="https://github.com/user-attachments/assets/e2abfbbd-11d3-4fdd-8e73-8717689e45a8" />

After:
<img width="1956" height="1034" alt="image" src="https://github.com/user-attachments/assets/8d1dc49a-4c9a-41fd-967f-069d9aef09aa" />

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the CSS interaction and compare possible fixes. The final code change was made and tested locally by me.

## Additional Context
<!-- Add any other context about the pull request here. -->

The relevant behavior comes from the combination of the large-screen sidebar compensation rule and the sticky footer wrapper. Keeping the outer wrapper full-width allows the existing centering behavior to work as intended, while `pointer-events: none` on the wrapper preserves the previous fix that prevented the footer area from blocking clicks outside the visible pagination controls.