### PR TITLE
Fix: Tagger View UI Crash Without Stash-Box Config

### DIFF
--- a/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/performers/PerformerTagger.tsx
@@ -838,13 +838,16 @@ export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
   const selectedEndpoint =
     stashConfig?.general.stashBoxes[selectedEndpointIndex];
 
-  const selectedEndpointInput = useMemo(
-    () => ({
+  const selectedEndpointInput = useMemo(() => {
+    if (!selectedEndpoint) {
+      return;
+    }
+
+    return {
       endpoint: selectedEndpoint.endpoint,
       index: selectedEndpointIndex,
-    }),
-    [selectedEndpoint, selectedEndpointIndex]
-  );
+    };
+  }, [selectedEndpoint, selectedEndpointIndex]);
 
   if (!config) return <LoadingIndicator />;
 
@@ -931,7 +934,7 @@ export const PerformerTagger: React.FC<ITaggerProps> = ({ performers }) => {
     }
   }
 
-  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+  if (selectedEndpointIndex === -1 || !selectedEndpointInput) {
     return (
       <div className="my-4">
         <h3 className="text-center mt-4">

--- a/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/studios/StudioTagger.tsx
@@ -520,13 +520,16 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
   const selectedEndpoint =
     stashConfig?.general.stashBoxes[selectedEndpointIndex];
 
-  const selectedEndpointInput = useMemo(
-    () => ({
+  const selectedEndpointInput = useMemo(() => {
+    if (!selectedEndpoint) {
+      return;
+    }
+
+    return {
       endpoint: selectedEndpoint.endpoint,
       index: selectedEndpointIndex,
-    }),
-    [selectedEndpoint, selectedEndpointIndex]
-  );
+    };
+  }, [selectedEndpoint, selectedEndpointIndex]);
 
   if (!config) return <LoadingIndicator />;
 
@@ -612,7 +615,7 @@ export const StudioTagger: React.FC<ITaggerProps> = ({ studios }) => {
     }
   }
 
-  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+  if (selectedEndpointIndex === -1 || !selectedEndpointInput) {
     return (
       <div className="my-4">
         <h3 className="text-center mt-4">

--- a/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
+++ b/ui/v2.5/src/components/Tagger/tags/TagTagger.tsx
@@ -534,13 +534,16 @@ export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
   const selectedEndpoint =
     stashConfig?.general.stashBoxes[selectedEndpointIndex];
 
-  const selectedEndpointInput = useMemo(
-    () => ({
+  const selectedEndpointInput = useMemo(() => {
+    if (!selectedEndpoint) {
+      return;
+    }
+
+    return {
       endpoint: selectedEndpoint.endpoint,
       index: selectedEndpointIndex,
-    }),
-    [selectedEndpoint, selectedEndpointIndex]
-  );
+    };
+  }, [selectedEndpoint, selectedEndpointIndex]);
 
   if (!config) return <LoadingIndicator />;
 
@@ -619,7 +622,7 @@ export const TagTagger: React.FC<ITaggerProps> = ({ tags }) => {
     }
   }
 
-  if (selectedEndpointIndex === -1 || !selectedEndpoint) {
+  if (selectedEndpointIndex === -1 || !selectedEndpointInput) {
     return (
       <div className="my-4">
         <h3 className="text-center mt-4">

--- a/ui/v2.5/src/docs/en/Manual/Scraping.md
+++ b/ui/v2.5/src/docs/en/Manual/Scraping.md
@@ -91,7 +91,9 @@ Enter the URL in the `edit` tab of an Item. If a scraper is installed that suppo
 
 ## Tagger view
 
-The Tagger view is accessed from the scenes page. It allows the user to run scrapers on all items on the current page. The Tagger presents the user with potential matches for an item from a selected stash-box instance or metadata source if supported. The user needs to select the correct metadata information to save. 
+The Tagger view is available from supported list pages. Scenes can use stash-boxes and compatible metadata scrapers. Performers, studios, and tags use a configured stash-box instance.
+
+The Tagger presents the user with potential matches for an item from a selected stash-box instance or metadata source if supported. The user needs to select the correct metadata information to save.
 
 When used in combination with stash-box, the user can optionally submit scene fingerprints to contribute to a stash-box instance. A scene fingerprint consists of any generated hashes (`phash`, `oshash`, `md5`) and the scene duration. Fingerprint submissions are associated with your stash-box account. Submitting fingerprints assists others in matching their files, because stash-box returns a count of matching user submitted fingerprints with every potential match.
 
@@ -99,8 +101,11 @@ When used in combination with stash-box, the user can optionally submit scene fi
 |---|:---:|:---:|
 | gallery | | |
 | group | | |
+| image | | |
 | performer | ✔️ | |
 | scene | ✔️ | ✔️ |
+| studio | ✔️ | |
+| tag | ✔️ | |
 
 ## Identify task
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes a UI crash when switching Performers, Studios, or Tags lists to Tagger view on instances with no configured stash-box endpoint.

The affected taggers now avoid dereferencing a missing selected endpoint before their existing setup message can render. This preserves endpoint-change state clearing while allowing the user-friendly “configure stash-box” prompt to appear.

Also updates the scraping manual to clarify which list pages support Tagger view and which taggers require a configured stash-box as I noticed the gap while double-checking what was supported.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7037

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd run check`
- `pnpm.cmd run lint:js`
  - Passed with one pre-existing unrelated warning in `PerformerTagger.tsx`.
- `pnpm.cmd exec biome format src/components/Tagger/performers/PerformerTagger.tsx src/components/Tagger/studios/StudioTagger.tsx src/components/Tagger/tags/TagTagger.tsx src/docs/en/Manual/Scraping.md`
- `git diff --check`
- Manual Smoke Testing:
  - With no stash-box configured, switched Performers, Studios, and Tags to Tagger view and confirmed the setup message renders instead of the error boundary.
  - With a stash-box configured, confirmed Performers, Studios, and Tags Tagger views still render normally.
  - Confirmed Scene Tagger still opens.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the crash path, identify the regression point, draft targeted TypeScript/docs changes, and run its own set of tests.  I have manually reviewed every line and performed my own testing.


## Additional Context
<!-- Add any other context about the pull request here. -->

This appears to have been introduced by #6766. That change memoized the selected stash-box endpoint input so tagger state could be cleared when the source changes, but the new memo dereferenced `selectedEndpoint.endpoint` before the existing no-stashbox fallback rendered.
