### PR TITLE
Improve scene marker generation error logging

### DIFF
--- a/internal/manager/task_generate_markers.go
+++ b/internal/manager/task_generate_markers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
@@ -37,105 +38,119 @@ func (t *GenerateMarkersTask) GetDescription() string {
 
 func (t *GenerateMarkersTask) Start(ctx context.Context) {
 	if t.Scene != nil {
-		t.generateSceneMarkers(ctx)
+		t.generateSceneMarkers(ctx, t.Scene)
 	}
 
 	if t.Marker != nil {
-		var scene *models.Scene
-		r := t.repository
-		if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
-			var err error
-			scene, err = r.Scene.Find(ctx, t.Marker.SceneID)
-			if err != nil {
-				return err
-			}
-			if scene == nil {
-				return fmt.Errorf("scene with id %d not found", t.Marker.SceneID)
-			}
-
-			return scene.LoadPrimaryFile(ctx, r.File)
-		}); err != nil {
-			logger.Errorf("error finding scene for marker generation: %v", err)
-			return
-		}
-
-		videoFile := scene.Files.Primary()
-
-		if videoFile == nil {
-			// nothing to do
-			return
-		}
-
-		t.generateMarker(videoFile, scene, t.Marker)
+		t.generateSpecificMarker(ctx, t.Marker)
 	}
 }
 
-func (t *GenerateMarkersTask) generateSceneMarkers(ctx context.Context) {
+func (t *GenerateMarkersTask) generateSpecificMarker(ctx context.Context, marker *models.SceneMarker) {
+	var scene *models.Scene
+	r := t.repository
+	if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
+		var err error
+		scene, err = r.Scene.Find(ctx, marker.SceneID)
+		if err != nil {
+			return err
+		}
+		if scene == nil {
+			return fmt.Errorf("scene with id %d not found", marker.SceneID)
+		}
+
+		return scene.LoadPrimaryFile(ctx, r.File)
+	}); err != nil {
+		logger.Errorf("error finding scene for marker generation: %v", err)
+		return
+	}
+
+	videoFile := scene.Files.Primary()
+
+	if videoFile == nil {
+		// nothing to do
+		return
+	}
+
+	if err := t.generateMarker(videoFile, scene, marker); err != nil {
+		logger.Errorf("[generator] error generating marker files for scene (%d) marker (%d) at %s: %v", scene.ID, marker.ID, formatSeconds(float64(marker.Seconds)), err)
+		logErrorOutput(err)
+	}
+}
+
+func formatSeconds(seconds float64) string {
+	d := time.Duration(float64(time.Second) * seconds)
+	return d.String()
+}
+
+func (t *GenerateMarkersTask) generateSceneMarkers(ctx context.Context, scene *models.Scene) {
 	var sceneMarkers []*models.SceneMarker
 	r := t.repository
 	if err := r.WithReadTxn(ctx, func(ctx context.Context) error {
 		var err error
-		sceneMarkers, err = r.SceneMarker.FindBySceneID(ctx, t.Scene.ID)
+		sceneMarkers, err = r.SceneMarker.FindBySceneID(ctx, scene.ID)
 		return err
 	}); err != nil {
 		logger.Errorf("error getting scene markers: %s", err.Error())
 		return
 	}
 
-	videoFile := t.Scene.Files.Primary()
+	videoFile := scene.Files.Primary()
 
 	if len(sceneMarkers) == 0 || videoFile == nil {
 		return
 	}
 
-	sceneHash := t.Scene.GetHash(t.fileNamingAlgorithm)
+	sceneHash := scene.GetHash(t.fileNamingAlgorithm)
 
 	// Make the folder for the scenes markers
 	markersFolder := filepath.Join(instance.Paths.Generated.Markers, sceneHash)
 	if err := fsutil.EnsureDir(markersFolder); err != nil {
-		logger.Warnf("could not create the markers folder (%v): %v", markersFolder, err)
+		logger.Errorf("could not create the markers folder (%v): %v", markersFolder, err)
+		return
 	}
 
 	for i, sceneMarker := range sceneMarkers {
 		index := i + 1
 		logger.Progressf("[generator] <%s> scene marker %d of %d", sceneHash, index, len(sceneMarkers))
 
-		t.generateMarker(videoFile, t.Scene, sceneMarker)
+		if err := t.generateMarker(videoFile, scene, sceneMarker); err != nil {
+			logger.Errorf("[generator] error generating marker files for scene (%d) marker (%d) at %s: %v", scene.ID, sceneMarker.ID, formatSeconds(float64(sceneMarker.Seconds)), err)
+			logErrorOutput(err)
+		}
 	}
 }
 
-func (t *GenerateMarkersTask) generateMarker(videoFile *models.VideoFile, scene *models.Scene, sceneMarker *models.SceneMarker) {
+func (t *GenerateMarkersTask) generateMarker(videoFile *models.VideoFile, scene *models.Scene, sceneMarker *models.SceneMarker) error {
 	sceneHash := scene.GetHash(t.fileNamingAlgorithm)
 	seconds := float64(sceneMarker.Seconds)
 
 	// check if marker past duration
 	if seconds > float64(videoFile.Duration) {
-		logger.Warnf("[generator] scene marker at %.2f seconds exceeds video duration of %.2f seconds, skipping", seconds, float64(videoFile.Duration))
-		return
+		return fmt.Errorf("scene marker at %s exceeds scene's video duration of %s", formatSeconds(seconds), formatSeconds(videoFile.Duration))
 	}
 
 	g := t.generator
 
 	if t.VideoPreview {
 		if err := g.MarkerPreviewVideo(context.TODO(), videoFile.Path, sceneHash, seconds, sceneMarker.EndSeconds, instance.Config.GetPreviewAudio()); err != nil {
-			logger.Errorf("[generator] failed to generate marker video: %v", err)
-			logErrorOutput(err)
+			return fmt.Errorf("failed to generate marker video : %w", err)
 		}
 	}
 
 	if t.ImagePreview {
 		if err := g.SceneMarkerWebp(context.TODO(), videoFile.Path, sceneHash, seconds); err != nil {
-			logger.Errorf("[generator] failed to generate marker image: %v", err)
-			logErrorOutput(err)
+			return fmt.Errorf("failed to generate marker image: %w", err)
 		}
 	}
 
 	if t.Screenshot {
 		if err := g.SceneMarkerScreenshot(context.TODO(), videoFile.Path, sceneHash, seconds, videoFile.Width); err != nil {
-			logger.Errorf("[generator] failed to generate marker screenshot: %v", err)
-			logErrorOutput(err)
+			return fmt.Errorf("failed to generate marker screenshot: %w", err)
 		}
 	}
+
+	return nil
 }
 
 func (t *GenerateMarkersTask) markersNeeded(ctx context.Context) int {

--- a/internal/manager/task_generate_markers.go
+++ b/internal/manager/task_generate_markers.go
@@ -74,7 +74,6 @@ func (t *GenerateMarkersTask) generateSpecificMarker(ctx context.Context, marker
 
 	if err := t.generateMarker(videoFile, scene, marker); err != nil {
 		logger.Errorf("[generator] error generating marker files for scene (%d) marker (%d) at %s: %v", scene.ID, marker.ID, formatSeconds(float64(marker.Seconds)), err)
-		logErrorOutput(err)
 	}
 }
 
@@ -116,7 +115,6 @@ func (t *GenerateMarkersTask) generateSceneMarkers(ctx context.Context, scene *m
 
 		if err := t.generateMarker(videoFile, scene, sceneMarker); err != nil {
 			logger.Errorf("[generator] error generating marker files for scene (%d) marker (%d) at %s: %v", scene.ID, sceneMarker.ID, formatSeconds(float64(sceneMarker.Seconds)), err)
-			logErrorOutput(err)
 		}
 	}
 }
@@ -134,19 +132,22 @@ func (t *GenerateMarkersTask) generateMarker(videoFile *models.VideoFile, scene 
 
 	if t.VideoPreview {
 		if err := g.MarkerPreviewVideo(context.TODO(), videoFile.Path, sceneHash, seconds, sceneMarker.EndSeconds, instance.Config.GetPreviewAudio()); err != nil {
-			return fmt.Errorf("failed to generate marker video : %w", err)
+			logger.Errorf("[generator] failed to generate marker video for scene (%d) marker (%d) at %s: %v", scene.ID, sceneMarker.ID, formatSeconds(float64(sceneMarker.Seconds)), err)
+			logErrorOutput(err)
 		}
 	}
 
 	if t.ImagePreview {
 		if err := g.SceneMarkerWebp(context.TODO(), videoFile.Path, sceneHash, seconds); err != nil {
-			return fmt.Errorf("failed to generate marker image: %w", err)
+			logger.Errorf("[generator] failed to generate marker image for scene (%d) marker (%d) at %s: %v", scene.ID, sceneMarker.ID, formatSeconds(float64(sceneMarker.Seconds)), err)
+			logErrorOutput(err)
 		}
 	}
 
 	if t.Screenshot {
 		if err := g.SceneMarkerScreenshot(context.TODO(), videoFile.Path, sceneHash, seconds, videoFile.Width); err != nil {
-			return fmt.Errorf("failed to generate marker screenshot: %w", err)
+			logger.Errorf("[generator] failed to generate marker screenshot for scene (%d) marker (%d) at %s: %v", scene.ID, sceneMarker.ID, formatSeconds(float64(sceneMarker.Seconds)), err)
+			logErrorOutput(err)
 		}
 	}
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1076,7 +1076,7 @@
       "marker_screenshots": "Marker screenshots",
       "marker_screenshots_tooltip": "Marker static JPG images",
       "markers": "Marker previews",
-      "markers_tooltip": "20 second videos which begin at the given timecode.",
+      "markers_tooltip": "Video previews which begin at the given timecode.",
       "override_preview_generation_options": "Override preview generation options",
       "override_preview_generation_options_desc": "Override preview generation options for this operation. Defaults are set in System -> Preview Generation.",
       "overwrite": "Overwrite existing files",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Improves the logging when a marker generation task fails. Now includes the scene and marker ids, and the marker timestamp formatted as a duration (`xhymz.zs`). Examples:

```
ERRO[2026-06-15 10:09:11] [generator] error generating marker files for scene (85) marker (42) at 11m0s: scene marker at 11m0s exceeds scene's video duration of 10m34.6s
ERRO[2026-06-15 10:09:25] [generator] error generating marker files for scene (85) marker (43) at 27s: failed to generate marker video : error starting command
```

Includes some minor refactoring.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Reported in the [Discourse](https://discourse.stashapp.cc/t/preview-generation-of-markers/9274).


## Testing

Created marker exceeding scene duration and ran marker generation. Temporarily moved `ffmpeg` and ran generation.

