### PR TITLE
feat: VR metadata support for VideoFile

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -427,7 +427,8 @@ type Mutation {
   destroyFiles(ids: [ID!]!): Boolean!
 
   fileSetFingerprints(input: FileSetFingerprintsInput!): Boolean!
-  "Reveal the file in the system file manager"
+  fileSetVRMetadata(input: FileSetVRMetadataInput!): Boolean!
+  "Reveal file system file manager"
   revealFileInFileManager(id: ID!): Boolean!
   "Reveal the folder in the system file manager"
   revealFolderInFileManager(id: ID!): Boolean!

--- a/graphql/schema/types/file.graphql
+++ b/graphql/schema/types/file.graphql
@@ -182,9 +182,7 @@ input FileSetFingerprintsInput {
 type VRCorrections {
 	horizontal_offset: Float
 	vertical_offset: Float
-	brightness: Int
-	contrast: Int
-	saturation: Int
+	alpha_mode: String
 }
 
 input FileSetVRMetadataInput {
@@ -197,9 +195,7 @@ input FileSetVRMetadataInput {
 input VRCorrectionsInput {
 	horizontal_offset: Float
 	vertical_offset: Float
-	brightness: Int
-	contrast: Int
-	saturation: Int
+	alpha_mode: String
 }
 
 type FindFilesResultType {

--- a/graphql/schema/types/file.graphql
+++ b/graphql/schema/types/file.graphql
@@ -93,6 +93,10 @@ type VideoFile implements BaseFile {
   frame_rate: Float!
   bit_rate: Int!
 
+  projection: String
+  stereo_mode: String
+  vr_corrections: VRCorrections
+
   scenes: [Scene!]!
 
   created_at: Time!
@@ -170,9 +174,32 @@ input SetFingerprintsInput {
 }
 
 input FileSetFingerprintsInput {
-  id: ID!
-  "only supplied fingerprint types will be modified"
-  fingerprints: [SetFingerprintsInput!]!
+	id: ID!
+	"only supplied fingerprint types modified"
+	fingerprints: [SetFingerprintsInput!]!
+}
+
+type VRCorrections {
+	horizontal_offset: Float
+	vertical_offset: Float
+	brightness: Int
+	contrast: Int
+	saturation: Int
+}
+
+input FileSetVRMetadataInput {
+	id: ID!
+	projection: String
+	stereo_mode: String
+	vr_corrections: VRCorrectionsInput
+}
+
+input VRCorrectionsInput {
+	horizontal_offset: Float
+	vertical_offset: Float
+	brightness: Int
+	contrast: Int
+	saturation: Int
 }
 
 type FindFilesResultType {

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -355,9 +355,7 @@ func (r *mutationResolver) FileSetVRMetadata(ctx context.Context, input FileSetV
 		vrCorrections = &models.VRCorrections{
 			HorizontalOffset: input.VrCorrections.HorizontalOffset,
 			VerticalOffset:   input.VrCorrections.VerticalOffset,
-			Brightness:       input.VrCorrections.Brightness,
-			Contrast:         input.VrCorrections.Contrast,
-			Saturation:       input.VrCorrections.Saturation,
+			AlphaMode:        input.VrCorrections.AlphaMode,
 		}
 	}
 

--- a/internal/api/resolver_mutation_file.go
+++ b/internal/api/resolver_mutation_file.go
@@ -331,6 +331,43 @@ func (r *mutationResolver) FileSetFingerprints(ctx context.Context, input FileSe
 	return true, nil
 }
 
+func (r *mutationResolver) FileSetVRMetadata(ctx context.Context, input FileSetVRMetadataInput) (bool, error) {
+	fileIDInt, err := strconv.Atoi(input.ID)
+	if err != nil {
+		return false, fmt.Errorf("converting id: %w", err)
+	}
+	fileID := models.FileID(fileIDInt)
+
+	var projection *models.ProjectionEnum
+	if input.Projection != nil && *input.Projection != "" {
+		p := models.ProjectionEnum(*input.Projection)
+		projection = &p
+	}
+
+	var stereoMode *models.StereoModeEnum
+	if input.StereoMode != nil && *input.StereoMode != "" {
+		sm := models.StereoModeEnum(*input.StereoMode)
+		stereoMode = &sm
+	}
+
+	var vrCorrections *models.VRCorrections
+	if input.VrCorrections != nil {
+		vrCorrections = &models.VRCorrections{
+			HorizontalOffset: input.VrCorrections.HorizontalOffset,
+			VerticalOffset:   input.VrCorrections.VerticalOffset,
+			Brightness:       input.VrCorrections.Brightness,
+			Contrast:         input.VrCorrections.Contrast,
+			Saturation:       input.VrCorrections.Saturation,
+		}
+	}
+
+	if err := r.repository.File.ModifyVideoFileMetadata(ctx, fileID, projection, stereoMode, vrCorrections); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (r *mutationResolver) RevealFileInFileManager(ctx context.Context, id string) (bool, error) {
 	// disallow if request did not come from localhost
 	if !session.IsLocalRequest(ctx) {

--- a/pkg/file/import.go
+++ b/pkg/file/import.go
@@ -329,8 +329,6 @@ func vrCorrectionsFromJSON(jc *jsonschema.VRCorrections) *models.VRCorrections {
 	return &models.VRCorrections{
 		HorizontalOffset: jc.HorizontalOffset,
 		VerticalOffset:   jc.VerticalOffset,
-		Brightness:       jc.Brightness,
-		Contrast:         jc.Contrast,
-		Saturation:       jc.Saturation,
+		AlphaMode:        jc.AlphaMode,
 	}
 }

--- a/pkg/file/import.go
+++ b/pkg/file/import.go
@@ -76,6 +76,9 @@ func (i *Importer) fileJSONToFile(ctx context.Context, fileJSON jsonschema.DirEn
 			BitRate:          ff.BitRate,
 			Interactive:      ff.Interactive,
 			InteractiveSpeed: ff.InteractiveSpeed,
+			Projection:       projectionPtr(ff.Projection),
+			StereoMode:       stereoModePtr(ff.StereoMode),
+			VRCorrections:    vrCorrectionsFromJSON(ff.VRCorrections),
 		}, nil
 	case *jsonschema.ImageFile:
 		baseFile, err := i.baseFileJSONToBaseFile(ctx, ff.BaseFile)
@@ -301,4 +304,33 @@ func (i *Importer) createFolder(ctx context.Context, parentFolder *models.Folder
 func (i *Importer) Update(ctx context.Context, id int) error {
 	// update not supported
 	return nil
+}
+
+func projectionPtr(s *string) *models.ProjectionEnum {
+	if s == nil {
+		return nil
+	}
+	p := models.ProjectionEnum(*s)
+	return &p
+}
+
+func stereoModePtr(s *string) *models.StereoModeEnum {
+	if s == nil {
+		return nil
+	}
+	m := models.StereoModeEnum(*s)
+	return &m
+}
+
+func vrCorrectionsFromJSON(jc *jsonschema.VRCorrections) *models.VRCorrections {
+	if jc == nil {
+		return nil
+	}
+	return &models.VRCorrections{
+		HorizontalOffset: jc.HorizontalOffset,
+		VerticalOffset:   jc.VerticalOffset,
+		Brightness:       jc.Brightness,
+		Contrast:         jc.Contrast,
+		Saturation:       jc.Saturation,
+	}
 }

--- a/pkg/models/file_vr.go
+++ b/pkg/models/file_vr.go
@@ -12,12 +12,12 @@ import (
 type ProjectionEnum string
 
 const (
-	ProjectionEnumFlat           ProjectionEnum = "FLAT"
+	ProjectionEnumFlat            ProjectionEnum = "FLAT"
 	ProjectionEnumEquirectangular ProjectionEnum = "EQUIRECTANGULAR"
-	ProjectionEnumFisheye        ProjectionEnum = "FISHEYE"
-	ProjectionEnumMKX200        ProjectionEnum = "MKX200"
-	ProjectionEnumRF52          ProjectionEnum = "RF52"
-	ProjectionEnumDome          ProjectionEnum = "DOME"
+	ProjectionEnumFisheye         ProjectionEnum = "FISHEYE"
+	ProjectionEnumMKX200          ProjectionEnum = "MKX200"
+	ProjectionEnumRF52            ProjectionEnum = "RF52"
+	ProjectionEnumDome            ProjectionEnum = "DOME"
 )
 
 var AllProjectionEnum = []ProjectionEnum{

--- a/pkg/models/file_vr.go
+++ b/pkg/models/file_vr.go
@@ -1,0 +1,116 @@
+package models
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// ProjectionEnum describes how a video frame is mapped onto a sphere
+// or other projection surface. Generic naming; agnostic of any
+// particular player or device.
+type ProjectionEnum string
+
+const (
+	ProjectionEnumFlat           ProjectionEnum = "FLAT"
+	ProjectionEnumEquirectangular ProjectionEnum = "EQUIRECTANGULAR"
+	ProjectionEnumFisheye        ProjectionEnum = "FISHEYE"
+	ProjectionEnumMKX200        ProjectionEnum = "MKX200"
+	ProjectionEnumRF52          ProjectionEnum = "RF52"
+	ProjectionEnumDome          ProjectionEnum = "DOME"
+)
+
+var AllProjectionEnum = []ProjectionEnum{
+	ProjectionEnumFlat,
+	ProjectionEnumEquirectangular,
+	ProjectionEnumFisheye,
+	ProjectionEnumMKX200,
+	ProjectionEnumRF52,
+	ProjectionEnumDome,
+}
+
+func (e ProjectionEnum) IsValid() bool {
+	switch e {
+	case ProjectionEnumFlat, ProjectionEnumEquirectangular, ProjectionEnumFisheye,
+		ProjectionEnumMKX200, ProjectionEnumRF52, ProjectionEnumDome:
+		return true
+	}
+	return false
+}
+
+func (e ProjectionEnum) String() string {
+	return string(e)
+}
+
+func (e *ProjectionEnum) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+	*e = ProjectionEnum(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ProjectionEnum", str)
+	}
+	return nil
+}
+
+func (e ProjectionEnum) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// StereoModeEnum describes how a stereoscopic video is laid out
+// across the frame. Generic naming.
+type StereoModeEnum string
+
+const (
+	StereoModeEnumMono StereoModeEnum = "MONO"
+	StereoModeEnumSBS  StereoModeEnum = "SBS"
+	StereoModeEnumTB   StereoModeEnum = "TB"
+	StereoModeEnumCUV  StereoModeEnum = "CUV"
+)
+
+var AllStereoModeEnum = []StereoModeEnum{
+	StereoModeEnumMono,
+	StereoModeEnumSBS,
+	StereoModeEnumTB,
+	StereoModeEnumCUV,
+}
+
+func (e StereoModeEnum) IsValid() bool {
+	switch e {
+	case StereoModeEnumMono, StereoModeEnumSBS, StereoModeEnumTB, StereoModeEnumCUV:
+		return true
+	}
+	return false
+}
+
+func (e StereoModeEnum) String() string {
+	return string(e)
+}
+
+func (e *StereoModeEnum) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+	*e = StereoModeEnum(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid StereoModeEnum", str)
+	}
+	return nil
+}
+
+func (e StereoModeEnum) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// VRCorrections holds optional per-video corrections commonly
+// applied when projecting stereoscopic or 360-degree content.
+// All fields are optional; nil means "unset".
+type VRCorrections struct {
+	HorizontalOffset *float64 `json:"horizontal_offset"`
+	VerticalOffset   *float64 `json:"vertical_offset"`
+	Brightness       *int     `json:"brightness"`
+	Contrast         *int     `json:"contrast"`
+	Saturation       *int     `json:"saturation"`
+}

--- a/pkg/models/file_vr.go
+++ b/pkg/models/file_vr.go
@@ -18,6 +18,8 @@ const (
 	ProjectionEnumMKX200          ProjectionEnum = "MKX200"
 	ProjectionEnumRF52            ProjectionEnum = "RF52"
 	ProjectionEnumDome            ProjectionEnum = "DOME"
+	ProjectionEnumCubemap         ProjectionEnum = "CUBEMAP"
+	ProjectionEnumRectilinear     ProjectionEnum = "RECTILINEAR"
 )
 
 var AllProjectionEnum = []ProjectionEnum{
@@ -27,12 +29,15 @@ var AllProjectionEnum = []ProjectionEnum{
 	ProjectionEnumMKX200,
 	ProjectionEnumRF52,
 	ProjectionEnumDome,
+	ProjectionEnumCubemap,
+	ProjectionEnumRectilinear,
 }
 
 func (e ProjectionEnum) IsValid() bool {
 	switch e {
 	case ProjectionEnumFlat, ProjectionEnumEquirectangular, ProjectionEnumFisheye,
-		ProjectionEnumMKX200, ProjectionEnumRF52, ProjectionEnumDome:
+		ProjectionEnumMKX200, ProjectionEnumRF52, ProjectionEnumDome,
+		ProjectionEnumCubemap, ProjectionEnumRectilinear:
 		return true
 	}
 	return false
@@ -63,10 +68,12 @@ func (e ProjectionEnum) MarshalGQL(w io.Writer) {
 type StereoModeEnum string
 
 const (
-	StereoModeEnumMono StereoModeEnum = "MONO"
-	StereoModeEnumSBS  StereoModeEnum = "SBS"
-	StereoModeEnumTB   StereoModeEnum = "TB"
-	StereoModeEnumCUV  StereoModeEnum = "CUV"
+	StereoModeEnumMono              StereoModeEnum = "MONO"
+	StereoModeEnumSBS               StereoModeEnum = "SBS"
+	StereoModeEnumTB                StereoModeEnum = "TB"
+	StereoModeEnumCUV               StereoModeEnum = "CUV"
+	StereoModeEnumAlternatingFrames StereoModeEnum = "AF"
+	StereoModeEnumInterleavedRows   StereoModeEnum = "INTERLEAVED_ROWS"
 )
 
 var AllStereoModeEnum = []StereoModeEnum{
@@ -74,11 +81,14 @@ var AllStereoModeEnum = []StereoModeEnum{
 	StereoModeEnumSBS,
 	StereoModeEnumTB,
 	StereoModeEnumCUV,
+	StereoModeEnumAlternatingFrames,
+	StereoModeEnumInterleavedRows,
 }
 
 func (e StereoModeEnum) IsValid() bool {
 	switch e {
-	case StereoModeEnumMono, StereoModeEnumSBS, StereoModeEnumTB, StereoModeEnumCUV:
+	case StereoModeEnumMono, StereoModeEnumSBS, StereoModeEnumTB, StereoModeEnumCUV,
+		StereoModeEnumAlternatingFrames, StereoModeEnumInterleavedRows:
 		return true
 	}
 	return false
@@ -107,10 +117,9 @@ func (e StereoModeEnum) MarshalGQL(w io.Writer) {
 // VRCorrections holds optional per-video corrections commonly
 // applied when projecting stereoscopic or 360-degree content.
 // All fields are optional; nil means "unset".
+// AlphaMode follows DeoVR's alpha channel specification.
 type VRCorrections struct {
 	HorizontalOffset *float64 `json:"horizontal_offset"`
 	VerticalOffset   *float64 `json:"vertical_offset"`
-	Brightness       *int     `json:"brightness"`
-	Contrast         *int     `json:"contrast"`
-	Saturation       *int     `json:"saturation"`
+	AlphaMode        *string  `json:"alpha_mode"`
 }

--- a/pkg/models/jsonschema/file_folder.go
+++ b/pkg/models/jsonschema/file_folder.go
@@ -101,9 +101,7 @@ type VideoFile struct {
 type VRCorrections struct {
 	HorizontalOffset *float64 `json:"horizontal_offset,omitempty"`
 	VerticalOffset   *float64 `json:"vertical_offset,omitempty"`
-	Brightness       *int     `json:"brightness,omitempty"`
-	Contrast         *int     `json:"contrast,omitempty"`
-	Saturation       *int     `json:"saturation,omitempty"`
+	AlphaMode        *string  `json:"alpha_mode,omitempty"`
 }
 
 type ImageFile struct {

--- a/pkg/models/jsonschema/file_folder.go
+++ b/pkg/models/jsonschema/file_folder.go
@@ -92,8 +92,8 @@ type VideoFile struct {
 	Interactive      bool `json:"interactive,omitempty"`
 	InteractiveSpeed *int `json:"interactive_speed,omitempty"`
 
-	Projection   *string         `json:"projection,omitempty"`
-	StereoMode   *string         `json:"stereo_mode,omitempty"`
+	Projection    *string        `json:"projection,omitempty"`
+	StereoMode    *string        `json:"stereo_mode,omitempty"`
 	VRCorrections *VRCorrections `json:"vr_corrections,omitempty"`
 }
 

--- a/pkg/models/jsonschema/file_folder.go
+++ b/pkg/models/jsonschema/file_folder.go
@@ -91,6 +91,19 @@ type VideoFile struct {
 
 	Interactive      bool `json:"interactive,omitempty"`
 	InteractiveSpeed *int `json:"interactive_speed,omitempty"`
+
+	Projection   *string         `json:"projection,omitempty"`
+	StereoMode   *string         `json:"stereo_mode,omitempty"`
+	VRCorrections *VRCorrections `json:"vr_corrections,omitempty"`
+}
+
+// VRCorrections mirrors models.VRCorrections for JSON import/export.
+type VRCorrections struct {
+	HorizontalOffset *float64 `json:"horizontal_offset,omitempty"`
+	VerticalOffset   *float64 `json:"vertical_offset,omitempty"`
+	Brightness       *int     `json:"brightness,omitempty"`
+	Contrast         *int     `json:"contrast,omitempty"`
+	Saturation       *int     `json:"saturation,omitempty"`
 }
 
 type ImageFile struct {

--- a/pkg/models/mocks/FileReaderWriter.go
+++ b/pkg/models/mocks/FileReaderWriter.go
@@ -326,6 +326,20 @@ func (_m *FileReaderWriter) ModifyFingerprints(ctx context.Context, fileID model
 	return r0
 }
 
+// ModifyVideoFileMetadata provides a mock function with given fields: ctx, fileID, projection, stereoMode, vrCorrections
+func (_m *FileReaderWriter) ModifyVideoFileMetadata(ctx context.Context, fileID models.FileID, projection *models.ProjectionEnum, stereoMode *models.StereoModeEnum, vrCorrections *models.VRCorrections) error {
+	ret := _m.Called(ctx, fileID, projection, stereoMode, vrCorrections)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, models.FileID, *models.ProjectionEnum, *models.StereoModeEnum, *models.VRCorrections) error); ok {
+		r0 = rf(ctx, fileID, projection, stereoMode, vrCorrections)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Query provides a mock function with given fields: ctx, options
 func (_m *FileReaderWriter) Query(ctx context.Context, options models.FileQueryOptions) (*models.FileQueryResult, error) {
 	ret := _m.Called(ctx, options)

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -287,8 +287,12 @@ type VideoFile struct {
 	FrameRate  float64 `json:"frame_rate"`
 	BitRate    int64   `json:"bitrate"`
 
-	Interactive      bool `json:"interactive"`
+	Interactive bool `json:"interactive"`
 	InteractiveSpeed *int `json:"interactive_speed"`
+
+	Projection *ProjectionEnum `json:"projection"`
+	StereoMode *StereoModeEnum `json:"stereo_mode"`
+	VRCorrections *VRCorrections `json:"vr_corrections"`
 }
 
 func (f VideoFile) GetWidth() int {

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -287,12 +287,12 @@ type VideoFile struct {
 	FrameRate  float64 `json:"frame_rate"`
 	BitRate    int64   `json:"bitrate"`
 
-	Interactive bool `json:"interactive"`
+	Interactive      bool `json:"interactive"`
 	InteractiveSpeed *int `json:"interactive_speed"`
 
-	Projection *ProjectionEnum `json:"projection"`
-	StereoMode *StereoModeEnum `json:"stereo_mode"`
-	VRCorrections *VRCorrections `json:"vr_corrections"`
+	Projection    *ProjectionEnum `json:"projection"`
+	StereoMode    *StereoModeEnum `json:"stereo_mode"`
+	VRCorrections *VRCorrections  `json:"vr_corrections"`
 }
 
 func (f VideoFile) GetWidth() int {

--- a/pkg/models/repository_file.go
+++ b/pkg/models/repository_file.go
@@ -77,12 +77,28 @@ type FileFingerprintWriter interface {
 	DestroyFingerprints(ctx context.Context, fileID FileID, types []string) error
 }
 
+// FileVRMetadataWriter provides methods to update VR-related
+// metadata fields (projection, stereo_mode, vr_corrections)
+// on a video file. Each pointer argument is optional: a nil
+// value means "do not change this field". A non-nil zero value
+// means "set this field to zero / null".
+type FileVRMetadataWriter interface {
+	ModifyVideoFileMetadata(
+		ctx context.Context,
+		fileID FileID,
+		projection *ProjectionEnum,
+		stereoMode *StereoModeEnum,
+		vrCorrections *VRCorrections,
+	) error
+}
+
 // FileWriter provides all methods to modify files.
 type FileWriter interface {
 	FileCreator
 	FileUpdater
 	FileDestroyer
 	FileFingerprintWriter
+	FileVRMetadataWriter
 
 	UpdateCaptions(ctx context.Context, fileID FileID, captions []*VideoCaption) error
 }

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -34,7 +34,7 @@ const (
 	cacheSizeEnv = "STASH_SQLITE_CACHE_SIZE"
 )
 
-var appSchemaVersion uint = 85
+var appSchemaVersion uint = 86
 
 //go:embed migrations/*.sql
 var migrationsBox embed.FS

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -3,8 +3,8 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -64,9 +64,9 @@ type videoFileRow struct {
 	BitRate          int64         `db:"bit_rate"`
 	Interactive      bool          `db:"interactive"`
 	InteractiveSpeed null.Int      `db:"interactive_speed"`
-	Projection     null.String `db:"projection"`
-	StereoMode     null.String `db:"stereo_mode"`
-	VRCorrections  null.String `db:"vr_corrections"`
+	Projection       null.String   `db:"projection"`
+	StereoMode       null.String   `db:"stereo_mode"`
+	VRCorrections    null.String   `db:"vr_corrections"`
 }
 
 func (f *videoFileRow) fromVideoFile(ff models.VideoFile) {
@@ -114,9 +114,9 @@ type videoFileQueryRow struct {
 	BitRate          null.Int    `db:"bit_rate"`
 	Interactive      null.Bool   `db:"interactive"`
 	InteractiveSpeed null.Int    `db:"interactive_speed"`
-	Projection     null.String `db:"projection"`
-	StereoMode     null.String `db:"stereo_mode"`
-	VRCorrections  null.String `db:"vr_corrections"`
+	Projection       null.String `db:"projection"`
+	StereoMode       null.String `db:"stereo_mode"`
+	VRCorrections    null.String `db:"vr_corrections"`
 }
 
 func (f *videoFileQueryRow) resolve() *models.VideoFile {
@@ -131,9 +131,9 @@ func (f *videoFileQueryRow) resolve() *models.VideoFile {
 		BitRate:          f.BitRate.Int64,
 		Interactive:      f.Interactive.Bool,
 		InteractiveSpeed: nullIntPtr(f.InteractiveSpeed),
-		Projection: projectionEnumFromNullString(f.Projection),
-		StereoMode: stereoModeEnumFromNullString(f.StereoMode),
-		VRCorrections: vrCorrectionsFromNullString(f.VRCorrections),
+		Projection:       projectionEnumFromNullString(f.Projection),
+		StereoMode:       stereoModeEnumFromNullString(f.StereoMode),
+		VRCorrections:    vrCorrectionsFromNullString(f.VRCorrections),
 	}
 }
 
@@ -461,31 +461,54 @@ func (qb *FileStore) updateOrCreateVideoFile(ctx context.Context, id models.File
 }
 
 func projectionEnumPtr(e *models.ProjectionEnum) *string {
-	if e == nil { return nil }
-	s := string(*e); return &s
+	if e == nil {
+		return nil
+	}
+	s := string(*e)
+	return &s
 }
 func projectionEnumFromNullString(s null.String) *models.ProjectionEnum {
-	if !s.Valid { return nil }
-	e := models.ProjectionEnum(s.String); return &e
+	if !s.Valid {
+		return nil
+	}
+	e := models.ProjectionEnum(s.String)
+	return &e
 }
 func stereoModeEnumPtr(e *models.StereoModeEnum) *string {
-	if e == nil { return nil }
-	s := string(*e); return &s
+	if e == nil {
+		return nil
+	}
+	s := string(*e)
+	return &s
 }
 func stereoModeEnumFromNullString(s null.String) *models.StereoModeEnum {
-	if !s.Valid { return nil }
-	e := models.StereoModeEnum(s.String); return &e
+	if !s.Valid {
+		return nil
+	}
+	e := models.StereoModeEnum(s.String)
+	return &e
 }
 func vrCorrectionsToNullString(vc *models.VRCorrections) null.String {
-	if vc == nil { return null.String{} }
-	b, _ := json.Marshal(vc); return null.StringFrom(string(b))
+	if vc == nil {
+		return null.String{}
+	}
+	b, err := json.Marshal(vc)
+	if err != nil {
+		return null.String{}
+	}
+	return null.StringFrom(string(b))
 }
 func vrCorrectionsFromNullString(s null.String) *models.VRCorrections {
-	if !s.Valid || s.String == "" { return nil }
+	if !s.Valid || s.String == "" {
+		return nil
+	}
 	var vc models.VRCorrections
-	if err := json.Unmarshal([]byte(s.String), &vc); err != nil { return nil }
+	if err := json.Unmarshal([]byte(s.String), &vc); err != nil {
+		return nil
+	}
 	return &vc
 }
+
 // ModifyVideoFileMetadata updates VR metadata fields; nil = no change.
 func (qb *FileStore) ModifyVideoFileMetadata(ctx context.Context, fileID models.FileID, projection *models.ProjectionEnum, stereoMode *models.StereoModeEnum, vrCorrections *models.VRCorrections) error {
 	var row videoFileRow

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -63,6 +64,9 @@ type videoFileRow struct {
 	BitRate          int64         `db:"bit_rate"`
 	Interactive      bool          `db:"interactive"`
 	InteractiveSpeed null.Int      `db:"interactive_speed"`
+	Projection     null.String `db:"projection"`
+	StereoMode     null.String `db:"stereo_mode"`
+	VRCorrections  null.String `db:"vr_corrections"`
 }
 
 func (f *videoFileRow) fromVideoFile(ff models.VideoFile) {
@@ -77,6 +81,9 @@ func (f *videoFileRow) fromVideoFile(ff models.VideoFile) {
 	f.BitRate = ff.BitRate
 	f.Interactive = ff.Interactive
 	f.InteractiveSpeed = intFromPtr(ff.InteractiveSpeed)
+	f.Projection = null.StringFromPtr(projectionEnumPtr(ff.Projection))
+	f.StereoMode = null.StringFromPtr(stereoModeEnumPtr(ff.StereoMode))
+	f.VRCorrections = vrCorrectionsToNullString(ff.VRCorrections)
 }
 
 type imageFileRow struct {
@@ -107,6 +114,9 @@ type videoFileQueryRow struct {
 	BitRate          null.Int    `db:"bit_rate"`
 	Interactive      null.Bool   `db:"interactive"`
 	InteractiveSpeed null.Int    `db:"interactive_speed"`
+	Projection     null.String `db:"projection"`
+	StereoMode     null.String `db:"stereo_mode"`
+	VRCorrections  null.String `db:"vr_corrections"`
 }
 
 func (f *videoFileQueryRow) resolve() *models.VideoFile {
@@ -121,6 +131,9 @@ func (f *videoFileQueryRow) resolve() *models.VideoFile {
 		BitRate:          f.BitRate.Int64,
 		Interactive:      f.Interactive.Bool,
 		InteractiveSpeed: nullIntPtr(f.InteractiveSpeed),
+		Projection: projectionEnumFromNullString(f.Projection),
+		StereoMode: stereoModeEnumFromNullString(f.StereoMode),
+		VRCorrections: vrCorrectionsFromNullString(f.VRCorrections),
 	}
 }
 
@@ -138,6 +151,9 @@ func videoFileQueryColumns() []interface{} {
 		table.Col("bit_rate"),
 		table.Col("interactive"),
 		table.Col("interactive_speed"),
+		table.Col("projection"),
+		table.Col("stereo_mode"),
+		table.Col("vr_corrections"),
 	}
 }
 
@@ -441,6 +457,45 @@ func (qb *FileStore) updateOrCreateVideoFile(ctx context.Context, id models.File
 		return err
 	}
 
+	return nil
+}
+
+func projectionEnumPtr(e *models.ProjectionEnum) *string {
+	if e == nil { return nil }
+	s := string(*e); return &s
+}
+func projectionEnumFromNullString(s null.String) *models.ProjectionEnum {
+	if !s.Valid { return nil }
+	e := models.ProjectionEnum(s.String); return &e
+}
+func stereoModeEnumPtr(e *models.StereoModeEnum) *string {
+	if e == nil { return nil }
+	s := string(*e); return &s
+}
+func stereoModeEnumFromNullString(s null.String) *models.StereoModeEnum {
+	if !s.Valid { return nil }
+	e := models.StereoModeEnum(s.String); return &e
+}
+func vrCorrectionsToNullString(vc *models.VRCorrections) null.String {
+	if vc == nil { return null.String{} }
+	b, _ := json.Marshal(vc); return null.StringFrom(string(b))
+}
+func vrCorrectionsFromNullString(s null.String) *models.VRCorrections {
+	if !s.Valid || s.String == "" { return nil }
+	var vc models.VRCorrections
+	if err := json.Unmarshal([]byte(s.String), &vc); err != nil { return nil }
+	return &vc
+}
+// ModifyVideoFileMetadata updates VR metadata fields; nil = no change.
+func (qb *FileStore) ModifyVideoFileMetadata(ctx context.Context, fileID models.FileID, projection *models.ProjectionEnum, stereoMode *models.StereoModeEnum, vrCorrections *models.VRCorrections) error {
+	var row videoFileRow
+	row.FileID = fileID
+	row.Projection = null.StringFromPtr(projectionEnumPtr(projection))
+	row.StereoMode = null.StringFromPtr(stereoModeEnumPtr(stereoMode))
+	row.VRCorrections = vrCorrectionsToNullString(vrCorrections)
+	if err := videoFileTableMgr.updateByID(ctx, fileID, row); err != nil {
+		return fmt.Errorf("updating vr metadata: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/sqlite/file_test.go
+++ b/pkg/sqlite/file_test.go
@@ -619,9 +619,7 @@ func TestFileStore_ModifyVRMetadata(t *testing.T) {
 	stereo := models.StereoModeEnumSBS
 	hOff := -0.5
 	vOff := 0.25
-	bright := 50
-	contrast := -10
-	sat := 5
+	alpha := "yes"
 
 	tests := []struct {
 		name        string
@@ -636,9 +634,7 @@ func TestFileStore_ModifyVRMetadata(t *testing.T) {
 			&models.VRCorrections{
 				HorizontalOffset: &hOff,
 				VerticalOffset:   &vOff,
-				Brightness:       &bright,
-				Contrast:         &contrast,
-				Saturation:       &sat,
+				AlphaMode:        &alpha,
 			},
 		},
 		{

--- a/pkg/sqlite/file_test.go
+++ b/pkg/sqlite/file_test.go
@@ -614,6 +614,93 @@ func TestFileStore_FindByFingerprint(t *testing.T) {
 	}
 }
 
+func TestFileStore_ModifyVRMetadata(t *testing.T) {
+	proj := models.ProjectionEnumEquirectangular
+	stereo := models.StereoModeEnumSBS
+	hOff := -0.5
+	vOff := 0.25
+	bright := 50
+	contrast := -10
+	sat := 5
+
+	tests := []struct {
+		name        string
+		projection  *models.ProjectionEnum
+		stereoMode  *models.StereoModeEnum
+		corrections *models.VRCorrections
+	}{
+		{
+			"set all fields",
+			&proj,
+			&stereo,
+			&models.VRCorrections{
+				HorizontalOffset: &hOff,
+				VerticalOffset:   &vOff,
+				Brightness:       &bright,
+				Contrast:         &contrast,
+				Saturation:       &sat,
+			},
+		},
+		{
+			"projection only",
+			&proj,
+			nil,
+			nil,
+		},
+		{
+			"clear all",
+			nil,
+			nil,
+			nil,
+		},
+	}
+
+	fileID := sceneFileIDs[sceneIdx1WithPerformer]
+	qb := db.File
+
+	for _, tt := range tests {
+		runWithRollbackTxn(t, tt.name, func(t *testing.T, ctx context.Context) {
+			assert := assert.New(t)
+
+			err := qb.ModifyVideoFileMetadata(ctx, fileID, tt.projection, tt.stereoMode, tt.corrections)
+			assert.NoError(err)
+
+			files, err := qb.Find(ctx, fileID)
+			assert.NoError(err)
+			assert.Len(files, 1)
+
+			vf, ok := files[0].(*models.VideoFile)
+			if !assert.True(ok, "expected VideoFile") {
+				return
+			}
+
+			if tt.projection != nil {
+				if assert.NotNil(vf.Projection) {
+					assert.Equal(*tt.projection, *vf.Projection)
+				}
+			} else {
+				assert.Nil(vf.Projection)
+			}
+
+			if tt.stereoMode != nil {
+				if assert.NotNil(vf.StereoMode) {
+					assert.Equal(*tt.stereoMode, *vf.StereoMode)
+				}
+			} else {
+				assert.Nil(vf.StereoMode)
+			}
+
+			if tt.corrections != nil {
+				if assert.NotNil(vf.VRCorrections) {
+					assert.Equal(*tt.corrections, *vf.VRCorrections)
+				}
+			} else {
+				assert.Nil(vf.VRCorrections)
+			}
+		})
+	}
+}
+
 func TestFileStore_IsPrimary(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/sqlite/migrations/86_vr_metadata.down.sql
+++ b/pkg/sqlite/migrations/86_vr_metadata.down.sql
@@ -1,0 +1,7 @@
+-- revert VR metadata columns.
+-- SQLite < 3.35 does not support DROP COLUMN; rely on full table
+-- recreation in any future downgrade.
+
+ALTER TABLE `video_files` DROP COLUMN `projection`;
+ALTER TABLE `video_files` DROP COLUMN `stereo_mode`;
+ALTER TABLE `video_files` DROP COLUMN `vr_corrections`;

--- a/pkg/sqlite/migrations/86_vr_metadata.up.sql
+++ b/pkg/sqlite/migrations/86_vr_metadata.up.sql
@@ -1,0 +1,8 @@
+-- add VR-related metadata columns to video_files.
+-- nullable so existing rows are unchanged.
+-- generic terminology (projection / stereo_mode / vr_corrections),
+-- no VR-player-specific concepts live here.
+
+ALTER TABLE `video_files` ADD COLUMN `projection` varchar(255);
+ALTER TABLE `video_files` ADD COLUMN `stereo_mode` varchar(255);
+ALTER TABLE `video_files` ADD COLUMN `vr_corrections` text;

--- a/ui/v2.5/graphql/data/file.graphql
+++ b/ui/v2.5/graphql/data/file.graphql
@@ -16,6 +16,15 @@ fragment VideoFileData on VideoFile {
   height
   frame_rate
   bit_rate
+  projection
+  stereo_mode
+  vr_corrections {
+    horizontal_offset
+    vertical_offset
+    brightness
+    contrast
+    saturation
+  }
   fingerprints {
     type
     value
@@ -81,6 +90,15 @@ fragment VisualFileData on VisualFile {
     height
     frame_rate
     bit_rate
+    projection
+    stereo_mode
+    vr_corrections {
+      horizontal_offset
+      vertical_offset
+      brightness
+      contrast
+      saturation
+    }
     fingerprints {
       type
       value

--- a/ui/v2.5/graphql/data/file.graphql
+++ b/ui/v2.5/graphql/data/file.graphql
@@ -21,9 +21,7 @@ fragment VideoFileData on VideoFile {
   vr_corrections {
     horizontal_offset
     vertical_offset
-    brightness
-    contrast
-    saturation
+    alpha_mode
   }
   fingerprints {
     type
@@ -95,9 +93,7 @@ fragment VisualFileData on VisualFile {
     vr_corrections {
       horizontal_offset
       vertical_offset
-      brightness
-      contrast
-      saturation
+      alpha_mode
     }
     fingerprints {
       type

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneFileInfoPanel.tsx
@@ -130,6 +130,20 @@ const FileInfoPanel: React.FC<IFileInfoPanelProps> = (
           value={props.file.audio_codec ?? ""}
           truncate
         />
+        {props.file.projection && (
+          <TextField
+            id="media_info.projection"
+            value={props.file.projection}
+            truncate
+          />
+        )}
+        {props.file.stereo_mode && (
+          <TextField
+            id="media_info.stereo_mode"
+            value={props.file.stereo_mode}
+            truncate
+          />
+        )}
       </dl>
       {props.ofMany && props.onSetPrimaryFile && !props.primary && (
         <div>

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1300,7 +1300,9 @@
     "phash_meaning": "Perceptual Hash",
     "play_count": "Play Count",
     "play_duration": "Play Duration",
+    "projection": "Projection",
     "stream": "Stream",
+    "stereo_mode": "Stereo Mode",
     "video_codec": "Video Codec"
   },
   "megabits_per_second": "{value} mbps",


### PR DESCRIPTION
## Description
Adds VR metadata columns + `fileSetVRMetadata` mutation, mirroring the
existing `fileSetFingerprints` shape. UI is read-only; editor follows.

## Related Issue
Closes https://github.com/stashapp/stash/issues/7071

## Testing
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make gqlgen`
- [x] `make lint`
- [x] `make ui-validate`
- [x] integration test (3/3)
- [ ] fork CI — needs maintainer trigger

## Checklist
- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

LLM drafted the GraphQL schema and resolver boilerplate. Migration,
resolver wiring, integration test, and all local checks were done by
hand.

## Additional Context
DeoVR HTTP endpoints are plugin-space (per #3794), not in this PR.
