### PR TITLE
Fix: Avoid Buffering Video Image Clips For Thumbnails

### DIFF
--- a/pkg/image/thumbnail.go
+++ b/pkg/image/thumbnail.go
@@ -66,6 +66,11 @@ func NewThumbnailEncoder(ffmpegEncoder *ffmpeg.FFMpeg, ffProbe *ffmpeg.FFProbe, 
 // It returns nil and an error if an error occurs reading, decoding or encoding
 // the image, or if the image is not suitable for thumbnails.
 func (e *ThumbnailEncoder) GetThumbnail(f models.File, maxSize int) ([]byte, error) {
+	// Video-backed image clips can be large, so avoid buffering the whole file.
+	if _, ok := f.(*models.VideoFile); ok {
+		return e.ffmpegImageThumbnailPath(f.Base().Path, maxSize)
+	}
+
 	reader, err := f.Open(&file.OsFS{})
 	if err != nil {
 		return nil, err
@@ -106,11 +111,6 @@ func (e *ThumbnailEncoder) GetThumbnail(f models.File, maxSize int) ([]byte, err
 			}
 			return e.ffmpegImageThumbnailPath(f.Base().Path, maxSize)
 		}
-	}
-
-	// Videofiles can only be thumbnailed with ffmpeg
-	if _, ok := f.(*models.VideoFile); ok {
-		return e.ffmpegImageThumbnail(buf, maxSize)
 	}
 
 	// vips has issues loading files from stdin on Windows


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Avoid buffering entire video-backed image clips when generating image thumbnails.

When video files are scanned as image clips, image thumbnail generation previously read the full file into memory before detecting that the file was a video. This changes video-backed image clips to use ffmpeg from the file path directly, avoiding large temporary Go heap allocations.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6536

## Testing
<!-- Describe the testing steps you have performed. -->

- Reproduced the memory spike with video-backed image clip thumbnail generation using a couple 1+gb mp4s and multiple generates in a session while sampling the memory from the Windows Stash process.
- Before fix:
  - Peak: `9194.8 MB` working set / `9225.2 MB` private
  - Settled: `7567.7 MB` working set / `7594.6 MB` private
- After fix:
  - Peak: `118.3 MB` working set / `109.1 MB` private
  - Settled: `109.5 MB` working set / `99.7 MB` private
- `go test ./pkg/image`
- `mingw32-make.exe lint`


## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to assist in investigating the issue, suggesting possible fixes, and then review my changes.

## Additional Context
<!-- Add any other context about the pull request here. -->

