### PR TITLE
feat: support TZ environment variable for timezone configuration

### DIFF
--- a/cmd/stash/main.go
+++ b/cmd/stash/main.go
@@ -11,6 +11,9 @@ import (
 	"runtime/pprof"
 	"syscall"
 
+	// fallback timezone database for systems without tzdata installed
+	_ "time/tzdata"
+
 	"github.com/spf13/pflag"
 
 	"github.com/stashapp/stash/internal/api"

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -22,8 +22,10 @@ services:
       - STASH_CACHE=/cache/
       ## Adjust below to change default port (9999)
       - STASH_PORT=9999
+      ## Set your timezone, e.g. America/New_York or Europe/Berlin
+      ## see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      - TZ=Etc/UTC
     volumes:
-      - /etc/localtime:/etc/localtime:ro
       ## Adjust below paths (the left part) to your liking.
       ## E.g. you can change ./config:/root/.stash to ./stash:/root/.stash
       ## The left part is the path on your host, the right part is the path in the stash container.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description

go lang already supports `TZ` as mentioned in their [time package docs](https://pkg.go.dev/time#Location):

> ... On Unix systems, Local consults the TZ environment variable to find the time zone to use. No TZ means use the system default /etc/localtime. TZ="" means use UTC. TZ="foo" means use file foo in the system timezone directory.

this adds `time/tzdata` package as a fallback timezone database. it's very well explained in [their docs](https://pkg.go.dev/time/tzdata):

> Package tzdata provides an embedded copy of the timezone database. If this package is imported anywhere in the program, then if the time package cannot find tzdata files on the system, it will use this embedded information.
> 
> Importing this package will increase the size of a program by about 450 KB.

this is a backup in case tzdata doesnt exist (stashapp already adds tzdata in the `docker/ci/x86_64/Dockerfile`. but its better to have this fallback).
also adjusted the example `docker-compose.yaml`


## Related Issue
Closes #1238 


## Testing
Testing files:
  ```go
  //go:build withtz
  package main

  import (
        "fmt"
        "time"
        _ "time/tzdata"
  )

  func main() {
        fmt.Println("local time:", time.Now().Format("2006-01-02 15:04:05 MST -0700"))
  }
```
  ```go
  //go:build !withtz
  package main

  import (
        "fmt"
        "time"
  )

  func main() {
        fmt.Println("local time:", time.Now().Format("2006-01-02 15:04:05 MST -0700"))
  }
```
Test run (pure alpine):
```
docker run --rm -v /tmp/tztest:/t:ro -e TZ=America/New_York alpine:latest sh -c 'echo "tzdata installed: $(test -d /usr/share/zoneinfo && echo yes || echo no)"; echo -n "WITHOUT embed: "; /t/tz_without; echo -n "WITH embed:    "; /t/tz_with'
```
Results:
```
tzdata installed: no
WITHOUT embed: local time: 2026-06-13 00:45:20 UTC +0000
WITH embed:    local time: 2026-06-12 20:45:20 EDT -0400
```
Test run (alpine with tzdata installed):
```
docker run --rm -v /tmp/tztest:/t:ro -e TZ=America/New_York alpine:latest sh -c 'apk add -q tzdata && echo -n "WITHOUT embed + system tzdata: " && /t/tz_without'
```
Results:
```
WITHOUT embed + system tzdata: local time: 2026-06-12 20:45:33 EDT -0400
```


## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

I did use claude code to generate the tests
