### PR TITLE
Extract embedded subtitles as captions

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -337,10 +337,13 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 		return err
 	}
 
+	videoFile, _ := r.File.(*models.VideoFile)
+	if videoFile != nil && !r.IsUnchanged() {
+		j.extractEmbeddedCaptions(ctx, videoFile)
+	}
+
 	// if this is a new video file, match it with any unmatched caption files
 	if r.New && len(j.unmatchedCaptionFiles.Get()) > 0 {
-		videoFile, _ := r.File.(*models.VideoFile)
-
 		if videoFile != nil {
 			// try to match any unmatched caption files to this video file
 			for _, captionPath := range j.unmatchedCaptionFiles.Get() {
@@ -365,8 +368,6 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	// clean captions - scene handler handles this as well, but
 	// unchanged files aren't processed by the scene handler
 	if r.IsUnchanged() {
-		videoFile, _ := r.File.(*models.VideoFile)
-
 		if videoFile != nil {
 			txnMgr := j.scanner.Repository.TxnManager
 			fileRepo := j.scanner.Repository.File
@@ -402,6 +403,18 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 	}
 
 	return nil
+}
+
+func (j *ScanJob) extractEmbeddedCaptions(ctx context.Context, videoFile *models.VideoFile) {
+	if err := video.ExtractEmbeddedCaptions(
+		ctx,
+		videoFile,
+		GetInstance().FFMpeg,
+		j.scanner.Repository.TxnManager,
+		j.scanner.Repository.File,
+	); err != nil {
+		logger.Errorf("Error extracting embedded captions: %v", err)
+	}
 }
 
 func (j *ScanJob) scanZipFile(ctx context.Context, f file.ScannedFile, progress *job.Progress) error {

--- a/pkg/file/video/caption_test.go
+++ b/pkg/file/video/caption_test.go
@@ -1,9 +1,15 @@
 package video
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testCase struct {
@@ -50,4 +56,82 @@ func TestGetCaptionsLangFromPath(t *testing.T) {
 	for _, l := range testCases {
 		assert.Equal(t, l.expectedLang, getCaptionsLangFromPath(l.captionPath))
 	}
+}
+
+func TestEmbeddedCaptionCandidates(t *testing.T) {
+	streams := []models.VideoSubtitleStream{
+		{Index: 2, LanguageCode: "ENG"},
+		{Index: 3, LanguageCode: "fr"},
+		{Index: 4, LanguageCode: ""},
+		{Index: 5, LanguageCode: "eng"},
+	}
+	captions := []*models.VideoCaption{
+		{LanguageCode: "fr", CaptionType: embeddedCaptionType},
+	}
+	existingFiles := map[string]bool{
+		"/stash/video.en.vtt": true,
+	}
+
+	candidates := embeddedCaptionCandidates("/stash/video.mkv", streams, captions, func(path string) bool {
+		return existingFiles[path]
+	})
+
+	assert.Len(t, candidates, 2)
+	assert.Equal(t, 2, candidates[0].streamIndex)
+	assert.Equal(t, "/stash/video.en.vtt", candidates[0].captionPath)
+	assert.Equal(t, "video.en.vtt", candidates[0].caption.Filename)
+	assert.Equal(t, "en", candidates[0].caption.LanguageCode)
+	assert.False(t, candidates[0].needsExtraction)
+
+	assert.Equal(t, 4, candidates[1].streamIndex)
+	assert.Equal(t, "/stash/video.vtt", candidates[1].captionPath)
+	assert.Equal(t, "video.vtt", candidates[1].caption.Filename)
+	assert.Equal(t, LangUnknown, candidates[1].caption.LanguageCode)
+	assert.True(t, candidates[1].needsExtraction)
+}
+
+type fakeEmbeddedCaptionEncoder struct {
+	args ffmpeg.Args
+}
+
+func (e *fakeEmbeddedCaptionEncoder) Generate(ctx context.Context, args ffmpeg.Args) error {
+	e.args = args
+	return os.WriteFile(args[len(args)-1], []byte("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nTest\n"), 0600)
+}
+
+func TestExtractEmbeddedCaption(t *testing.T) {
+	dir := t.TempDir()
+	videoPath := filepath.Join(dir, "video.mkv")
+	captionPath := filepath.Join(dir, "video.en.vtt")
+	encoder := &fakeEmbeddedCaptionEncoder{}
+
+	err := extractEmbeddedCaption(context.Background(), encoder, videoPath, 2, captionPath)
+
+	require.NoError(t, err)
+	got, err := os.ReadFile(captionPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "WEBVTT")
+	assert.Equal(t, ffmpeg.Args{
+		"-v", "error",
+		"-y",
+		"-i", videoPath,
+		"-map", "0:2",
+		"-c:s", "webvtt",
+		"-f", "webvtt",
+		captionPath + ".2.tmp",
+	}, encoder.args)
+}
+
+func TestExtractEmbeddedCaptionDoesNotOverwriteExistingCaption(t *testing.T) {
+	dir := t.TempDir()
+	videoPath := filepath.Join(dir, "video.mkv")
+	captionPath := filepath.Join(dir, "video.en.vtt")
+	require.NoError(t, os.WriteFile(captionPath, []byte("existing"), 0600))
+
+	err := extractEmbeddedCaption(context.Background(), &fakeEmbeddedCaptionEncoder{}, videoPath, 2, captionPath)
+
+	require.NoError(t, err)
+	got, err := os.ReadFile(captionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing", string(got))
 }

--- a/pkg/file/video/embedded_caption.go
+++ b/pkg/file/video/embedded_caption.go
@@ -1,0 +1,200 @@
+package video
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/txn"
+	"golang.org/x/text/language"
+)
+
+const embeddedCaptionType = "vtt"
+
+// EmbeddedCaptionEncoder runs ffmpeg commands for embedded caption extraction.
+type EmbeddedCaptionEncoder interface {
+	Generate(ctx context.Context, args ffmpeg.Args) error
+}
+
+type embeddedCaptionCandidate struct {
+	streamIndex     int
+	captionPath     string
+	caption         *models.VideoCaption
+	needsExtraction bool
+}
+
+// ExtractEmbeddedCaptions extracts embedded subtitle streams to VTT sidecar files and registers them as captions.
+func ExtractEmbeddedCaptions(ctx context.Context, f *models.VideoFile, encoder EmbeddedCaptionEncoder, txnMgr models.TxnManager, w CaptionUpdater) error {
+	if f == nil || len(f.SubtitleStreams) == 0 || encoder == nil || w == nil {
+		return nil
+	}
+
+	captions, err := getExistingCaptions(ctx, f.ID, txnMgr, w)
+	if err != nil {
+		return fmt.Errorf("getting captions for file %s: %w", f.Path, err)
+	}
+
+	candidates := embeddedCaptionCandidates(f.Path, f.SubtitleStreams, captions, captionFileExists)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	var added []*models.VideoCaption
+	for _, candidate := range candidates {
+		if candidate.needsExtraction {
+			if err := extractEmbeddedCaption(ctx, encoder, f.Path, candidate.streamIndex, candidate.captionPath); err != nil {
+				logger.Warnf("Error extracting embedded caption stream %d from %s: %v", candidate.streamIndex, f.Path, err)
+				continue
+			}
+		}
+
+		added = append(added, candidate.caption)
+	}
+
+	if len(added) == 0 {
+		return nil
+	}
+
+	return updateEmbeddedCaptions(ctx, f.ID, txnMgr, w, added)
+}
+
+func embeddedCaptionCandidates(videoPath string, streams []models.VideoSubtitleStream, captions []*models.VideoCaption, exists func(string) bool) []embeddedCaptionCandidate {
+	if exists == nil {
+		exists = captionFileExists
+	}
+
+	seen := make(map[string]struct{})
+	for _, caption := range captions {
+		seen[captionKey(caption.LanguageCode, caption.CaptionType)] = struct{}{}
+	}
+
+	var ret []embeddedCaptionCandidate
+	for _, stream := range streams {
+		lang := normalizeCaptionLanguage(stream.LanguageCode)
+		key := captionKey(lang, embeddedCaptionType)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		captionPath := GetCaptionPath(videoPath, lang, embeddedCaptionType)
+		ret = append(ret, embeddedCaptionCandidate{
+			streamIndex: stream.Index,
+			captionPath: captionPath,
+			caption: &models.VideoCaption{
+				LanguageCode: lang,
+				Filename:     filepath.Base(captionPath),
+				CaptionType:  embeddedCaptionType,
+			},
+			needsExtraction: !exists(captionPath),
+		})
+		seen[key] = struct{}{}
+	}
+
+	return ret
+}
+
+func normalizeCaptionLanguage(lang string) string {
+	lang = strings.ToLower(strings.TrimSpace(lang))
+	switch lang {
+	case "", "und", "unknown":
+		return LangUnknown
+	}
+
+	base, err := language.ParseBase(lang)
+	if err != nil {
+		return LangUnknown
+	}
+
+	return base.String()
+}
+
+func captionKey(lang string, captionType string) string {
+	return lang + "." + captionType
+}
+
+func captionFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func extractEmbeddedCaption(ctx context.Context, encoder EmbeddedCaptionEncoder, videoPath string, streamIndex int, captionPath string) error {
+	tmpPath := fmt.Sprintf("%s.%d.tmp", captionPath, streamIndex)
+	defer os.Remove(tmpPath)
+
+	args := ffmpeg.Args{}.
+		LogLevel(ffmpeg.LogLevelError).
+		Overwrite().
+		Input(videoPath)
+	args = append(args,
+		"-map", fmt.Sprintf("0:%d", streamIndex),
+		"-c:s", "webvtt",
+		"-f", "webvtt",
+		tmpPath,
+	)
+
+	if err := encoder.Generate(ctx, args); err != nil {
+		return err
+	}
+
+	if captionFileExists(captionPath) {
+		return nil
+	}
+
+	return os.Rename(tmpPath, captionPath)
+}
+
+func getExistingCaptions(ctx context.Context, fileID models.FileID, txnMgr models.TxnManager, w CaptionUpdater) ([]*models.VideoCaption, error) {
+	var captions []*models.VideoCaption
+	err := withDatabase(ctx, txnMgr, func(ctx context.Context) error {
+		var err error
+		captions, err = w.GetCaptions(ctx, fileID)
+		return err
+	})
+	return captions, err
+}
+
+func updateEmbeddedCaptions(ctx context.Context, fileID models.FileID, txnMgr models.TxnManager, w CaptionUpdater, added []*models.VideoCaption) error {
+	return withTxn(ctx, txnMgr, func(ctx context.Context) error {
+		captions, err := w.GetCaptions(ctx, fileID)
+		if err != nil {
+			return err
+		}
+
+		changed := false
+		for _, caption := range added {
+			if IsLangInCaptions(caption.LanguageCode, caption.CaptionType, captions) {
+				continue
+			}
+
+			captions = append(captions, caption)
+			changed = true
+		}
+
+		if !changed {
+			return nil
+		}
+
+		return w.UpdateCaptions(ctx, fileID, captions)
+	})
+}
+
+func withDatabase(ctx context.Context, txnMgr models.TxnManager, fn txn.TxnFunc) error {
+	if txnMgr == nil {
+		return fn(ctx)
+	}
+
+	return txn.WithDatabase(ctx, txnMgr, fn)
+}
+
+func withTxn(ctx context.Context, txnMgr models.TxnManager, fn txn.TxnFunc) error {
+	if txnMgr == nil {
+		return fn(ctx)
+	}
+
+	return txn.WithTxn(ctx, txnMgr, fn)
+}

--- a/pkg/file/video/scan.go
+++ b/pkg/file/video/scan.go
@@ -44,17 +44,35 @@ func (d *Decorator) Decorate(ctx context.Context, fs models.FS, f models.File) (
 	}
 
 	return &models.VideoFile{
-		BaseFile:    base,
-		Format:      string(container),
-		VideoCodec:  videoFile.VideoCodec,
-		AudioCodec:  videoFile.AudioCodec,
-		Width:       videoFile.Width,
-		Height:      videoFile.Height,
-		Duration:    videoFile.FileDuration,
-		FrameRate:   videoFile.FrameRate,
-		BitRate:     videoFile.Bitrate,
-		Interactive: interactive,
+		BaseFile:        base,
+		Format:          string(container),
+		VideoCodec:      videoFile.VideoCodec,
+		AudioCodec:      videoFile.AudioCodec,
+		Width:           videoFile.Width,
+		Height:          videoFile.Height,
+		Duration:        videoFile.FileDuration,
+		FrameRate:       videoFile.FrameRate,
+		BitRate:         videoFile.Bitrate,
+		Interactive:     interactive,
+		SubtitleStreams: getSubtitleStreams(videoFile.JSON.Streams),
 	}, nil
+}
+
+func getSubtitleStreams(streams []ffmpeg.FFProbeStream) []models.VideoSubtitleStream {
+	var ret []models.VideoSubtitleStream
+	for _, stream := range streams {
+		if stream.CodecType != "subtitle" {
+			continue
+		}
+
+		ret = append(ret, models.VideoSubtitleStream{
+			Index:        stream.Index,
+			CodecName:    stream.CodecName,
+			LanguageCode: stream.Tags.Language,
+		})
+	}
+
+	return ret
 }
 
 func (d *Decorator) IsMissingMetadata(ctx context.Context, fs models.FS, f models.File) bool {

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -289,6 +289,16 @@ type VideoFile struct {
 
 	Interactive      bool `json:"interactive"`
 	InteractiveSpeed *int `json:"interactive_speed"`
+
+	// transient - populated during scan for embedded caption extraction
+	SubtitleStreams []VideoSubtitleStream `json:"-"`
+}
+
+// VideoSubtitleStream contains scan-time metadata for an embedded subtitle stream.
+type VideoSubtitleStream struct {
+	Index        int
+	CodecName    string
+	LanguageCode string
 }
 
 func (f VideoFile) GetWidth() int {


### PR DESCRIPTION
## Summary
- detect embedded subtitle streams from ffprobe while scanning video files
- extract each new supported embedded subtitle stream to a WebVTT sidecar without overwriting existing caption files
- register extracted or already-present VTT files through the existing scene caption path so the current player can display them

Fixes #3875.

## Bounty
- OpenCollective bounty: $50 contribution 745825, assigned in #3875.

## Testing
- `PATH=/tmp/codex-go1.25.0/go/bin:$PATH go test ./pkg/file/video ./pkg/scene ./pkg/models`
- `make touch-ui`
- `PATH=/tmp/codex-go1.25.0/go/bin:$PATH go test ./internal/manager`
- manual ffmpeg smoke test: generated a tiny MKV with an embedded SRT stream and extracted it with `-map 0:1 -c:s webvtt -f webvtt`, producing valid WebVTT output
