### PR TITLE
Fix: Selective Generate Preview Options

### DIFF
--- a/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
+++ b/ui/v2.5/src/components/Settings/Tasks/LibraryTasks.tsx
@@ -311,32 +311,13 @@ export const LibraryTasks: React.FC = () => {
     setDialogOpen({ generate: false });
   }
 
-  // XXbiome-ignore @typescript-eslint/no-unused-vars
   async function runGenerate(paths?: string[]) {
+    const general = configuration?.general;
+
     try {
       await mutateMetadataGenerate({
         ...generateOptions,
         paths,
-      });
-
-      Toast.success(
-        intl.formatMessage(
-          { id: "config.tasks.added_job_to_queue" },
-          { operation_name: intl.formatMessage({ id: "actions.generate" }) }
-        )
-      );
-    } catch (e) {
-      Toast.error(e);
-    }
-  }
-
-  async function onGenerateClicked() {
-    try {
-      // insert preview options here instead of loading them
-      const general = configuration?.general;
-
-      await mutateMetadataGenerate({
-        ...generateOptions,
         previewOptions: {
           ...generateOptions.previewOptions,
           previewSegments:
@@ -356,6 +337,7 @@ export const LibraryTasks: React.FC = () => {
             generateOptions.previewOptions?.previewPreset,
         },
       });
+
       Toast.success(
         intl.formatMessage(
           { id: "config.tasks.added_job_to_queue" },
@@ -503,7 +485,7 @@ export const LibraryTasks: React.FC = () => {
               <Button
                 variant="secondary"
                 type="submit"
-                onClick={() => onGenerateClicked()}
+                onClick={() => runGenerate()}
               >
                 <FormattedMessage id="actions.generate" />
               </Button>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fix Selective generate so it uses the configured preview generation settings when generating video previews.

The full Generate action already merged the generated-content preview settings from `configuration.general` into the metadata generation input before starting the task. Selective generate used a separate path that only sent the saved generate options plus selected paths, which could leave preview options at their default zero values.

This updates Generate and Selective generate to share the same `runGenerate(paths?)` submission path, preserving the configured preview options and adding paths only when Selective generate is used.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7023

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd --dir ui/v2.5 check`
- `git diff --check upstream/develop...HEAD`
- `pnpm.cmd --dir ui/v2.5 lint:js`
- Manually confirmed the issue and that this fix allows selective generate to properly generate previews (and did some normal generate to ensure no regression)

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A - no visual changes.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the Selective generate code path, compare it against the full Generate action, and review my changes. 

## Additional Context
<!-- Add any other context about the pull request here. -->
Selective generate was introduced in #6621. The issue appears to be caused by the new selective path bypassing the preview-settings merge used by the existing full Generate action.
