### PR TITLE
feat: extract embedded subtitles as VTT captions during scan

### DIFF
--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -362,6 +362,24 @@ func (j *ScanJob) handleFile(ctx context.Context, f file.ScannedFile, progress *
 		}
 	}
 
+	// extract embedded subtitle streams for new or changed video files
+	if r.New || r.FingerprintChanged {
+		if videoFile, ok := r.File.(*models.VideoFile); ok {
+			mgr := GetInstance()
+			if mgr.FFProbe != nil && mgr.FFMpeg != nil {
+				if probed, err := mgr.FFProbe.NewVideoFile(videoFile.Path); err == nil && len(probed.SubtitleStreams) > 0 {
+					txnMgr := j.scanner.Repository.TxnManager
+					fileRepo := j.scanner.Repository.File
+					if txnErr := txn.WithTxn(ctx, txnMgr, func(ctx context.Context) error {
+						return video.ExtractEmbeddedCaptions(ctx, videoFile.Path, probed.SubtitleStreams, mgr.FFMpeg.Path(), videoFile.ID, fileRepo)
+					}); txnErr != nil {
+						logger.Errorf("Error extracting embedded captions for %s: %v", videoFile.Path, txnErr)
+					}
+				}
+			}
+		}
+	}
+
 	// clean captions - scene handler handles this as well, but
 	// unchanged files aren't processed by the scene handler
 	if r.IsUnchanged() {

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -85,9 +85,10 @@ func ResolveFFProbe(path string, fallbackPath string) string {
 
 // VideoFile represents the ffprobe output for a video file.
 type VideoFile struct {
-	JSON        FFProbeJSON
-	AudioStream *FFProbeStream
-	VideoStream *FFProbeStream
+	JSON            FFProbeJSON
+	AudioStream     *FFProbeStream
+	VideoStream     *FFProbeStream
+	SubtitleStreams  []*FFProbeStream
 
 	Path      string
 	Title     string
@@ -343,6 +344,8 @@ func parse(filePath string, probeJSON *FFProbeJSON) (*VideoFile, error) {
 		}
 	}
 
+	result.SubtitleStreams = result.getSubtitleStreams()
+
 	return result, nil
 }
 
@@ -363,6 +366,17 @@ func isRotated(s *FFProbeStream) bool {
 	}
 
 	return false
+}
+
+func (v *VideoFile) getSubtitleStreams() []*FFProbeStream {
+	var result []*FFProbeStream
+	for i := range v.JSON.Streams {
+		s := &v.JSON.Streams[i]
+		if s.CodecType == "subtitle" && s.Disposition.AttachedPic == 0 {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 func (v *VideoFile) getAudioStream() *FFProbeStream {

--- a/pkg/file/video/embedded_caption.go
+++ b/pkg/file/video/embedded_caption.go
@@ -1,0 +1,89 @@
+package video
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	stashExec "github.com/stashapp/stash/pkg/exec"
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+var supportedSubtitleCodecs = map[string]struct{}{
+	"subrip":   {},
+	"srt":      {},
+	"ass":      {},
+	"ssa":      {},
+	"webvtt":   {},
+	"mov_text": {},
+}
+
+// ExtractEmbeddedCaptions extracts embedded subtitle streams from a video file
+// to WebVTT sidecar files and registers them via the provided CaptionUpdater.
+// Streams with unsupported codecs or that already have a registered VTT caption
+// for the same language are silently skipped.
+func ExtractEmbeddedCaptions(ctx context.Context, videoPath string, streams []*ffmpeg.FFProbeStream, ffmpegPath string, fileID models.FileID, w CaptionUpdater) error {
+	captions, err := w.GetCaptions(ctx, fileID)
+	if err != nil {
+		return fmt.Errorf("getting captions for %s: %w", videoPath, err)
+	}
+
+	changed := false
+	for _, s := range streams {
+		if _, ok := supportedSubtitleCodecs[s.CodecName]; !ok {
+			logger.Debugf("[embedded captions] unsupported codec %q in %s, skipping stream %d", s.CodecName, videoPath, s.Index)
+			continue
+		}
+
+		lang := LangUnknown
+		if IsValidLanguage(s.Tags.Language) {
+			lang = s.Tags.Language
+		}
+
+		if IsLangInCaptions(lang, "vtt", captions) {
+			logger.Debugf("[embedded captions] lang=%s vtt already registered for %s", lang, videoPath)
+			continue
+		}
+
+		vttPath := GetCaptionPath(videoPath, lang, "vtt")
+
+		if _, statErr := os.Stat(vttPath); statErr != nil {
+			if err := extractSubtitleStream(ctx, ffmpegPath, videoPath, s.Index, vttPath); err != nil {
+				logger.Warnf("[embedded captions] failed to extract stream %d from %s: %v", s.Index, videoPath, err)
+				continue
+			}
+		}
+
+		captions = append(captions, &models.VideoCaption{
+			LanguageCode: lang,
+			Filename:     filepath.Base(vttPath),
+			CaptionType:  "vtt",
+		})
+		changed = true
+		logger.Infof("[embedded captions] extracted subtitle stream (lang=%s, index=%d) from %s", lang, s.Index, videoPath)
+	}
+
+	if changed {
+		return w.UpdateCaptions(ctx, fileID, captions)
+	}
+	return nil
+}
+
+func extractSubtitleStream(ctx context.Context, ffmpegPath, videoPath string, streamIndex int, outputPath string) error {
+	args := []string{
+		"-v", "quiet",
+		"-i", videoPath,
+		"-map", fmt.Sprintf("0:%d", streamIndex),
+		"-c:s", "webvtt",
+		outputPath,
+	}
+	cmd := stashExec.CommandContext(ctx, ffmpegPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ffmpeg exit: %w — output: %s", err, string(out))
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

When scanning a video file that contains embedded subtitle streams (e.g. SRT, ASS/SSA, or WebVTT tracks embedded in MKV/MP4), the scanner now automatically extracts each supported stream to a WebVTT sidecar file and registers it via the existing `CaptionUpdater` pipeline. This makes embedded subtitles available to the web player without the user needing to manually extract them.

**Changes:**

- `pkg/ffmpeg/ffprobe.go` — added `SubtitleStreams []*FFProbeStream` field to `VideoFile` and `getSubtitleStreams()` method, populated during `parse()`.
- `pkg/file/video/embedded_caption.go` (**new file**) — `ExtractEmbeddedCaptions()` extracts each supported subtitle stream via `ffmpeg -c:s webvtt` and registers it through `CaptionUpdater`. Skips streams with unsupported codecs and languages already registered.
- `internal/manager/task_scan.go` — after new/fingerprint-changed video files are stored, calls `ExtractEmbeddedCaptions` using the manager's `FFProbe`/`FFMpeg` instances.

Supported codecs: `subrip`, `srt`, `ass`, `ssa`, `webvtt`, `mov_text`.

## Related Issue

Fixes #3875

## Testing

Tested manually with an MKV containing embedded SRT (English + French) and an ASS track:
1. Added the file to a stash library and ran a full scan.
2. Confirmed two `.vtt` sidecar files were created next to the video (`video.en.vtt`, `video.fr.vtt`).
3. Confirmed the captions appeared in the scene player caption selector.
4. Re-scanned the file — confirmed extraction was skipped (files already existed, captions already registered).
5. Verified files without subtitle streams are unaffected.

## Screenshots

N/A (backend-only change).

## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure

- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

Claude Code (Anthropic) was used to help generate the Go implementation. I reviewed every line, understand the design, and manually tested the behaviour as described above. All architectural decisions (hooking into `handleFile`, using the existing `CaptionUpdater` interface, codec allowlist) were made by me.

## Additional Context

Previous attempt: #7055 (closed for not following the PR template — this PR follows the template).