### PR TITLE
feat: Support default quality and media type in scene player

### DIFF
--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -270,6 +270,8 @@ type SceneStreamEndpoint {
   url: String!
   mime_type: String
   label: String
+  stream_type: String
+  resolution: String
 }
 
 input AssignSceneFileInput {

--- a/internal/manager/scene.go
+++ b/internal/manager/scene.go
@@ -11,15 +11,18 @@ import (
 )
 
 type SceneStreamEndpoint struct {
-	URL      string  `json:"url"`
-	MimeType *string `json:"mime_type"`
-	Label    *string `json:"label"`
+	URL        string  `json:"url"`
+	MimeType   *string `json:"mime_type"`
+	Label      *string `json:"label"`
+	StreamType *string `json:"stream_type"`
+	Resolution *string `json:"resolution"`
 }
 
 type endpointType struct {
-	label     string
-	mimeType  string
-	extension string
+	label      string
+	mimeType   string
+	extension  string
+	streamType string
 }
 
 var (
@@ -27,32 +30,38 @@ var (
 		label:     "Direct stream",
 		mimeType:  ffmpeg.MimeMp4Video,
 		extension: "",
+		streamType: "direct",
 	}
 	mp4EndpointType = endpointType{
 		label:     "MP4",
 		mimeType:  ffmpeg.MimeMp4Video,
 		extension: ".mp4",
+		streamType: "mp4",
 	}
 	mkvEndpointType = endpointType{
 		label: "MKV",
 		// use mp4 mimetype to trick the client, since many clients won't try mkv
 		mimeType:  ffmpeg.MimeMp4Video,
 		extension: ".mkv",
+		streamType: "mkv",
 	}
 	webmEndpointType = endpointType{
 		label:     "WEBM",
 		mimeType:  ffmpeg.MimeWebmVideo,
 		extension: ".webm",
+		streamType: "webm",
 	}
 	hlsEndpointType = endpointType{
 		label:     "HLS",
 		mimeType:  ffmpeg.MimeHLS,
 		extension: ".m3u8",
+		streamType: "hls",
 	}
 	dashEndpointType = endpointType{
 		label:     "DASH",
 		mimeType:  ffmpeg.MimeDASH,
 		extension: ".mpd",
+		streamType: "dash",
 	}
 )
 
@@ -117,8 +126,10 @@ func GetSceneStreamPaths(scene *models.Scene, directStreamURL *url.URL, maxStrea
 		url.Path += t.extension
 
 		label := t.label
+		resolutionStr := "ORIGINAL"
 
 		if resolution != "" {
+			resolutionStr = string(resolution)
 			v := url.Query()
 			v.Set("resolution", resolution.String())
 			url.RawQuery = v.Encode()
@@ -138,9 +149,11 @@ func GetSceneStreamPaths(scene *models.Scene, directStreamURL *url.URL, maxStrea
 		}
 
 		return &SceneStreamEndpoint{
-			URL:      url.String(),
-			MimeType: &t.mimeType,
-			Label:    &label,
+			URL:        url.String(),
+			MimeType:   &t.mimeType,
+			Label:      &label,
+			StreamType: &t.streamType,
+			Resolution: &resolutionStr,
 		}
 	}
 

--- a/ui/v2.5/graphql/data/scene.graphql
+++ b/ui/v2.5/graphql/data/scene.graphql
@@ -78,6 +78,8 @@ fragment SceneData on Scene {
     url
     mime_type
     label
+    stream_type
+    resolution
   }
 
   custom_fields

--- a/ui/v2.5/graphql/queries/scene.graphql
+++ b/ui/v2.5/graphql/queries/scene.graphql
@@ -94,6 +94,8 @@ query SceneStreams($id: ID!) {
       url
       mime_type
       label
+      stream_type
+      resolution
     }
   }
 }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -639,10 +639,14 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
               src: stream.url,
               type: stream.mime_type ?? undefined,
               label: stream.label ?? undefined,
+              streamType: stream.stream_type ?? undefined,
+              resolution: stream.resolution ?? undefined,
               offset: !isDirect(src),
               duration,
             };
-          })
+          }),
+          uiConfig?.defaultStreamType,
+          uiConfig?.defaultStreamingResolution
       );
 
       function getDefaultLanguageCode() {
@@ -733,6 +737,8 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       interfaceConfig?.autostartVideo,
       uiConfig?.alwaysStartFromBeginning,
       uiConfig?.disableMobileMediaAutoRotateEnabled,
+      uiConfig?.defaultStreamType,
+      uiConfig?.defaultStreamingResolution,
       _initialTimestamp,
     ]);
 

--- a/ui/v2.5/src/components/ScenePlayer/live.ts
+++ b/ui/v2.5/src/components/ScenePlayer/live.ts
@@ -76,7 +76,10 @@ function offsetMiddleware(player: VideoJsPlayer) {
       tech.trigger("timeupdate");
       tech.trigger("pause");
       tech.trigger("seeking");
-      tech.play();
+      tech.play().catch(() => {
+        // auto-play failed due to browser restrictions
+        seeking = 0;
+      });
     },
     loadDelay,
     { leading: true }

--- a/ui/v2.5/src/components/ScenePlayer/source-selector.ts
+++ b/ui/v2.5/src/components/ScenePlayer/source-selector.ts
@@ -3,6 +3,23 @@ import videojs, { VideoJsPlayer } from "video.js";
 export interface ISource extends videojs.Tech.SourceObject {
   label?: string;
   errored?: boolean;
+  streamType?: string;
+  resolution?: string;
+}
+
+function preferredSourceIndex(
+  sources: ISource[],
+  preferredType: string | undefined,
+  preferredResolution: string | undefined
+): number {
+  let matchedType = -1;
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i];
+    const matchType = preferredType ? source.streamType === preferredType : true;
+    if (matchType && source.resolution === preferredResolution) return i;
+    if (matchType && source.resolution === "ORIGINAL" && matchedType === -1) matchedType = i;
+  }
+  return matchedType === -1 ? 0 : matchedType;
 }
 
 class SourceMenuItem extends videojs.getComponent("MenuItem") {
@@ -46,11 +63,11 @@ class SourceMenuButton extends videojs.getComponent("MenuButton") {
     });
   }
 
-  public setSources(sources: ISource[]) {
+  public setSources(sources: ISource[], selectedIndex: number) {
     this.selectedSource = null;
 
     this.items = sources.map((source, i) => {
-      if (i === 0) {
+      if (i === selectedIndex) {
         this.selectedSource = source;
       }
 
@@ -176,8 +193,10 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
       const currentSource = player.currentSource() as ISource;
       console.log(`Source '${currentSource.label}' is unsupported`);
 
-      // mark current source as errored
-      currentSource.errored = true;
+      // mark current source as errored in this.sources (currentSource() returns a copy)
+      if (this.selectedIndex >= 0 && this.selectedIndex < this.sources.length) {
+        this.sources[this.selectedIndex].errored = true;
+      }
       this.menu.markSourceErrored(currentSource);
 
       // don't auto play next source if user manually selected a source
@@ -187,12 +206,10 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
 
       // TODO - make auto play next source configurable
       // try the next source in the list
-      if (
-        this.selectedIndex !== -1 &&
-        this.selectedIndex + 1 < this.sources.length
-      ) {
-        this.selectedIndex += 1;
-        const newSource = this.sources[this.selectedIndex];
+      const nextIndex = (this.selectedIndex + 1) % this.sources.length;
+      if (this.selectedIndex !== -1 && !this.sources[nextIndex].errored) {
+        this.selectedIndex = nextIndex;
+        const newSource = this.sources[nextIndex];
         console.log(`Trying next source in playlist: '${newSource.label}'`);
         this.menu.setSelectedSource(newSource);
 
@@ -209,21 +226,28 @@ class SourceSelectorPlugin extends videojs.getPlugin("plugin") {
     });
   }
 
-  setSources(sources: ISource[]) {
+  setSources(
+    sources: ISource[],
+    preferredType: string | undefined,
+    preferredResolution: string | undefined
+  ) {
     const cleanupTracks = this.cleanupTextTracks.splice(0);
     for (const track of cleanupTracks) {
       this.player.removeRemoteTextTrack(track);
     }
 
-    this.menu.setSources(sources);
+    const selectedIndex = preferredSourceIndex(sources, preferredType, preferredResolution);
+    if (selectedIndex === this.selectedIndex) return;
+
+    this.menu.setSources(sources, selectedIndex);
     if (sources.length !== 0) {
-      this.selectedIndex = 0;
+      this.selectedIndex = selectedIndex;
     } else {
       this.selectedIndex = -1;
     }
 
     this.sources = sources;
-    this.player.src(sources[0]);
+    this.player.src(sources[selectedIndex]);
   }
 
   get textTracks(): HTMLTrackElement[] {

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -490,6 +490,43 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
             checked={ui.showAbLoopControls ?? undefined}
             onChange={(v) => saveUI({ showAbLoopControls: v })}
           />
+          <SelectSetting
+            id="default-stream-type"
+            headingID="config.ui.scene_player.options.default_stream_type.heading"
+            subHeadingID="config.ui.scene_player.options.default_stream_type.description"
+            value={ui.defaultStreamType ?? ""}
+            onChange={(v) => saveUI({ defaultStreamType: v })}
+          >
+            <option value="">
+              {intl.formatMessage({
+                id: "config.ui.scene_player.options.default_stream_type.no_preference",
+              })}
+            </option>
+            <option value="direct">Direct stream</option>
+            <option value="mkv">MKV</option>
+            <option value="mp4">MP4</option>
+            <option value="webm">WEBM</option>
+            <option value="hls">HLS</option>
+            <option value="dash">DASH</option>
+          </SelectSetting>
+          <SelectSetting
+            id="default-streaming-resolution"
+            headingID="config.ui.scene_player.options.default_streaming_resolution.heading"
+            subHeadingID="config.ui.scene_player.options.default_streaming_resolution.description"
+            value={ui.defaultStreamingResolution ?? ""}
+            onChange={(v) => saveUI({ defaultStreamingResolution: v })}
+          >
+            <option value="ORIGINAL">
+              {intl.formatMessage({
+                id: "config.ui.scene_player.options.default_streaming_resolution.original",
+              })}
+            </option>
+            <option value="FOUR_K">4K (2160p)</option>
+            <option value="FULL_HD">Full HD (1080p)</option>
+            <option value="STANDARD_HD">HD (720p)</option>
+            <option value="STANDARD">Standard (480p)</option>
+            <option value="LOW">Low (240p)</option>
+          </SelectSetting>
         </SettingSection>
         <SettingSection headingID="config.ui.tag_panel.heading">
           <BooleanSetting

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -88,6 +88,10 @@ export interface IUIConfig {
 
   showAbLoopControls?: boolean;
 
+  // resolution and stream type automatically selected when streaming a scene.
+  defaultStreamingResolution?: string;
+  defaultStreamType?: string;
+
   // maximum number of items to shown in the dropdown list - defaults to 200
   // upper limit of 1000
   maxOptionsShown?: number;

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -851,6 +851,16 @@
           "vr_tag": {
             "description": "The VR button will only be displayed for scenes with this tag.",
             "heading": "VR tag"
+          },
+          "default_streaming_resolution": {
+            "heading": "Default streaming resolution",
+            "description": "Resolution automatically selected when streaming a scene.",
+            "original": "Original"
+          },
+          "default_stream_type": {
+            "heading": "Default stream type",
+            "description": "Media type automatically selected when streaming a scene.",
+            "no_preference": "No preference"
           }
         }
       },


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

If Direct stream or MKV is selected, since they do not support any resolution, the resolution will have no effect.
If No preference is selected as a stream type, the last stream type that has an available resolution will be selected.
Otherwise, the stream type with it's specific resolution will be selected. For example, MP4 Full HD (1080p).

In this PR, I'm adding (what I think is) a easy way to select a default source in the ScenePlayer.
I've split it in two, with the possibility to choose a preferred: Stream Type and Resolution.
This allows with only a few options to select one of the 26 possible options.

Here's the full table of what source is selected based on the Stream type on top and Resolution on the left.
|| Direct Stream | MKV | MP4 | WEBM | HLS | DASH |
|---|---|---|---|---|---|---|
| Original | Direct Stream | MKV | MP4 | WEBM | HLS | DASH |
| 4k (2160p) | Direct Stream | MKV | MP4 4k (2160p) | WEBM 4k (2160p) | HLS 4k (2160p) | DASH 4k (2160p) |
| full hd (1080p) | Direct Stream | MKV | MP4 full hd (1080p) | WEBM full hd (1080p) | HLS full hd (1080p) | DASH full hd (1080p) |
| hd (720p) | Direct Stream | MKV | MP4 hd (720p) | WEBM hd (720p) | HLS hd (720p) | DASH hd (720p) |
| standard (480p) | Direct Stream | MKV | MP4 standard (480p) | WEBM standard (480p) | HLS standard (480p) | DASH standard (480p) |
| low (240p) | Direct Stream | MKV | MP4 low (240p) | WEBM low (240p) | HLS low (240p) | DASH low (240p) |

However, since some source are not always present like MKV or on Safari browser, I've added a "No preference" Stream Type to fallback on the first Stream Type with the selected Resolution.

*P.S.*
I did think about making the Stream Type an Ordered List of Preference.
However, this complicated the logic a lot. And (In my opinion), It didn't solve much more than what the "No preference" already does.
But since I'm not at all an expect on every exception that can occur, let me know if you think it would be worth the complexity.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->
Resolves https://github.com/stashapp/stash/issues/2523
Resolves https://github.com/stashapp/stash/issues/4175

## Testing
<!-- Describe the testing steps you have performed. -->
I've checked that the table I've given on top was correct by testing a few options like:
- Direct stream and MKV with Original, 1080p which always selected Direct stream / MKV.
- MP4 / WEBM with Original that selected MP4 / WEBM
- and a few option with the Resolution and Stream Type
- MKV on a MP4 scene (so the MKV option isn't available)

I did not test on Safari browser since I do not own one.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->
<img width="1354" height="1765" alt="image" src="https://github.com/user-attachments/assets/5a9d2fe8-2fbb-427f-aa88-1def88c852e8" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
I have used Claude inside VSCode to make a draft/PoC so I was faster for me to set it up.
Afterward, I just did everything manually and changed every line of code (except some of en-GB.json)

## Additional Context
<!-- Add any other context about the pull request here. -->
Since the Resoltuion (such as Standard, Full HD, ...) aren't translated in the source selector inside the ScenePlayer, I didn't translate them, but would you prefer to have a translation for them in the settings ?

If any test needs to be added, let me know I'll check how to add them
And Thank You for taking the time to read this 😄 
