### PR TITLE
Fix: Signed Caption URLs With Authentication

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -659,7 +659,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
         return languageCode;
       }
 
-      if (scene.captions && scene.captions.length > 0) {
+      if (scene.paths.caption && scene.captions && scene.captions.length > 0) {
         const languageCode = getDefaultLanguageCode();
         let hasDefault = false;
 
@@ -675,9 +675,13 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
           if (setAsDefault) {
             hasDefault = true;
           }
+          const captionURL = new URL(scene.paths.caption, window.location.href);
+          captionURL.searchParams.set("lang", lang);
+          captionURL.searchParams.set("type", caption.caption_type);
+
           sourceSelector.addTextTrack(
             {
-              src: `${scene.paths.caption}?lang=${lang}&type=${caption.caption_type}`,
+              src: captionURL.toString(),
               kind: "captions",
               srclang: lang,
               label: label,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes external caption track URLs when authentication is enabled.

When auth is enabled, `scene.paths.caption` can already include signed URL query parameters. The scene player was appending `?lang=...&type=...` directly, producing URLs with a second `?` and preventing the backend from receiving the caption language/type parameters.

This updates caption track URL construction to use `URL.searchParams`, preserving existing signed URL params while adding `lang` and `type`.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7060

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd --dir ui\v2.5 validate`
- `pnpm.cmd --dir ui\v2.5 exec biome format src/components/ScenePlayer/ScenePlayer.tsx`
- `git diff --check`
- `pnpm.cmd --dir ui\v2.5 build`
- Manually tested to confirm it fixed the caption issue, confirmed in dev tools that the url was properly formed with params while authentication was enabled and disabled.  (Note: Used `ui_location:` in config to run it properly with auth since the normal dev ui doesn't work well with auth)

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the signed caption URL issue, suggest possible fixes and then review my work.  

## Additional Context
<!-- Add any other context about the pull request here. -->

The broken authenticated caption request looked like:

`/scene/1778/caption?cid=...&expires=...&signature=...?lang=en&type=srt`

After this change, caption URLs preserve the signed params and append caption params correctly:

`/scene/1778/caption?cid=...&expires=...&signature=...&lang=en&type=srt`