### PR TITLE
fix: normalize macOS NFD filenames to NFC when scanning

### DIFF
--- a/internal/manager/manager_tasks.go
+++ b/internal/manager/manager_tasks.go
@@ -145,7 +145,8 @@ func (s *Manager) Scan(ctx context.Context, input ScanMetadataInput) (int, error
 		ZipFileExtensions:     cfg.GetGalleryExtensions(),
 		// ScanFilters is set in ScanJob.Execute
 		// HandlerRequiredFilters is set in ScanJob.Execute
-		RootPaths: cfg.GetStashPaths().Paths(),
+		// #4425 - isRootPath compares these against the NFC paths stored during scanning
+		RootPaths: fsutil.NormalizePaths(cfg.GetStashPaths().Paths()),
 		Rescan:    input.Rescan,
 	}
 

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -207,13 +207,21 @@ func (j *ScanJob) queueFileFunc(ctx context.Context, f models.FS, zipFile *file.
 			return err
 		}
 
+		// #4425 - store the NFC-normalized path so search matches user input.
+		// Filtering and filesystem access above use the original path; zip
+		// entries are matched byte-exact so are left unnormalized.
+		storedPath := path
+		if zipFile == nil {
+			storedPath = fsutil.NormalizePath(path)
+		}
+
 		ff := file.ScannedFile{
 			BaseFile: &models.BaseFile{
 				DirEntry: models.DirEntry{
 					ModTime: file.ModTime(info),
 				},
-				Path:     path,
-				Basename: filepath.Base(path),
+				Path:     storedPath,
+				Basename: filepath.Base(storedPath),
 				Size:     size,
 			},
 			FS:   f,

--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 )
@@ -159,8 +160,10 @@ func (s *Scanner) detectFolderMove(ctx context.Context, file ScannedFile) (*mode
 
 				// parent folder must be missing
 				_, err = file.FS.Lstat(pf.Path)
-				if err == nil {
-					// parent folder exists, not a candidate
+				if err == nil && fsutil.NormalizePath(pf.Path) != file.Path {
+					// #4425 - the normalization guard above lets a folder differing
+					// only by NFC/NFD be treated as a move (updated in place) instead
+					// of a duplicate
 					detector.reject(parentFolderID)
 					continue
 				}

--- a/pkg/file/folder_rename_detect.go
+++ b/pkg/file/folder_rename_detect.go
@@ -161,9 +161,12 @@ func (s *Scanner) detectFolderMove(ctx context.Context, file ScannedFile) (*mode
 				// parent folder must be missing
 				_, err = file.FS.Lstat(pf.Path)
 				if err == nil && fsutil.NormalizePath(pf.Path) != file.Path {
-					// #4425 - the normalization guard above lets a folder differing
-					// only by NFC/NFD be treated as a move (updated in place) instead
-					// of a duplicate
+					// parent folder exists, not a candidate
+					// #4425 - Lstat succeeds via a pre-normalization NFD path too,
+					// since macOS is normalization-insensitive; exclude that case,
+					// since it's the same folder as the one being scanned rather
+					// than a separate one that's still present, so its path should
+					// be updated in place instead of creating a duplicate
 					detector.reject(parentFolderID)
 					continue
 				}

--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/txn"
@@ -609,6 +610,11 @@ func (s *Scanner) handleRename(ctx context.Context, f models.File, fp []models.F
 		info, err := fs.Lstat(other.Base().Path)
 		switch {
 		case err != nil:
+			missing = append(missing, other)
+		case other.Base().Path != f.Base().Path && fsutil.NormalizePath(other.Base().Path) == fsutil.NormalizePath(f.Base().Path):
+			// #4425 - same file under a different normalization (e.g. NFD stored
+			// before NFC was introduced); treat as a move so the path is updated
+			// in place instead of creating a duplicate
 			missing = append(missing, other)
 		case strings.EqualFold(f.Base().Path, other.Base().Path):
 			// #1426 - if file exists but is a case-insensitive match for the

--- a/pkg/fsutil/dir.go
+++ b/pkg/fsutil/dir.go
@@ -23,6 +23,10 @@ func DirExists(path string) (bool, error) {
 
 // IsPathInDir returns true if pathToCheck is within dir.
 func IsPathInDir(dir, pathToCheck string) bool {
+	// #4425 - normalize so NFC/NFD differences don't break containment checks
+	dir = NormalizePath(dir)
+	pathToCheck = NormalizePath(pathToCheck)
+
 	rel, err := filepath.Rel(dir, pathToCheck)
 
 	if err == nil {

--- a/pkg/fsutil/dir_test.go
+++ b/pkg/fsutil/dir_test.go
@@ -3,10 +3,27 @@ package fsutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestIsPathInDirNormalization verifies that containment holds when the dir and
+// the path use different Unicode normalization forms, as happens on macOS where
+// the filesystem may report NFD while the configured/stored path is NFC.
+func TestIsPathInDirNormalization(t *testing.T) {
+	dirNFC := filepath.Join("/library", gaNFC)
+	fileNFD := filepath.Join("/library", gaNFD, "video.mp4")
+
+	// Only macOS treats NFC and NFD as equivalent; elsewhere they differ
+	// byte-wise and the path is considered outside the dir.
+	want := runtime.GOOS == "darwin"
+	assert.Equal(t, want, IsPathInDir(dirNFC, fileNFD))
+
+	// An exact (same-form) match must always hold.
+	assert.True(t, IsPathInDir(filepath.Join("/library", gaNFC), filepath.Join("/library", gaNFC, "video.mp4")))
+}
 
 func TestIsPathInDir(t *testing.T) {
 	type test struct {

--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // CopyFile copies the contents of the file at srcpath to a regular file at dstpath.
@@ -180,4 +182,27 @@ func GetExeName(base string) string {
 		return base + ".exe"
 	}
 	return base
+}
+
+// NormalizePath returns path normalized to Unicode NFC (composed) form on macOS,
+// where the filesystem reports filenames in NFD (decomposed) form. It is a no-op
+// on other platforms.
+//
+// Only macOS is normalization-insensitive, so an NFD file on disk is still found
+// via its NFC path; normalizing on a normalization-sensitive filesystem (e.g.
+// Linux) would prevent NFD-named files from being found.
+func NormalizePath(path string) string {
+	if runtime.GOOS == "darwin" {
+		return norm.NFC.String(path)
+	}
+	return path
+}
+
+// NormalizePaths returns a new slice with NormalizePath applied to each path.
+func NormalizePaths(paths []string) []string {
+	ret := make([]string, len(paths))
+	for i, p := range paths {
+		ret[i] = NormalizePath(p)
+	}
+	return ret
 }

--- a/pkg/fsutil/file.go
+++ b/pkg/fsutil/file.go
@@ -10,8 +10,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"golang.org/x/text/unicode/norm"
 )
 
 // CopyFile copies the contents of the file at srcpath to a regular file at dstpath.
@@ -182,20 +180,6 @@ func GetExeName(base string) string {
 		return base + ".exe"
 	}
 	return base
-}
-
-// NormalizePath returns path normalized to Unicode NFC (composed) form on macOS,
-// where the filesystem reports filenames in NFD (decomposed) form. It is a no-op
-// on other platforms.
-//
-// Only macOS is normalization-insensitive, so an NFD file on disk is still found
-// via its NFC path; normalizing on a normalization-sensitive filesystem (e.g.
-// Linux) would prevent NFD-named files from being found.
-func NormalizePath(path string) string {
-	if runtime.GOOS == "darwin" {
-		return norm.NFC.String(path)
-	}
-	return path
 }
 
 // NormalizePaths returns a new slice with NormalizePath applied to each path.

--- a/pkg/fsutil/file_darwin.go
+++ b/pkg/fsutil/file_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+// +build darwin
+
+package fsutil
+
+import "golang.org/x/text/unicode/norm"
+
+// NormalizePath returns path normalized to Unicode NFC (composed) form.
+//
+// macOS filesystems report filenames in NFD (decomposed) form but are
+// normalization-insensitive, so an NFD file on disk is still found via its
+// NFC path.
+func NormalizePath(path string) string {
+	return norm.NFC.String(path)
+}

--- a/pkg/fsutil/file_nondarwin.go
+++ b/pkg/fsutil/file_nondarwin.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+// +build !darwin
+
+package fsutil
+
+// NormalizePath returns path unchanged.
+//
+// Only macOS is normalization-insensitive; normalizing on a
+// normalization-sensitive filesystem (e.g. Linux) would prevent files with
+// NFD names on disk from being found.
+func NormalizePath(path string) string {
+	return path
+}

--- a/pkg/fsutil/file_test.go
+++ b/pkg/fsutil/file_test.go
@@ -1,6 +1,59 @@
 package fsutil
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
+
+// Unicode forms of the Japanese character "が" used to exercise NFC/NFD handling.
+const (
+	gaNFC = "が"  // composed: が
+	gaNFD = "が" // decomposed: か + combining dakuten
+)
+
+func TestNormalizePath(t *testing.T) {
+	// NFD input is normalized to NFC on macOS, left unchanged elsewhere.
+	wantNFD := gaNFD
+	if runtime.GOOS == "darwin" {
+		wantNFD = gaNFC
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"nfd", gaNFD, wantNFD},
+		{"nfc unchanged", gaNFC, gaNFC},
+		{"ascii unchanged", "/a/b/c.mp4", "/a/b/c.mp4"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizePath(tt.in); got != tt.want {
+				t.Errorf("NormalizePath(%q) = %q, want %q (GOOS=%s)", tt.in, got, tt.want, runtime.GOOS)
+			}
+		})
+	}
+}
+
+func TestNormalizePaths(t *testing.T) {
+	in := []string{gaNFD, "/ascii"}
+	got := NormalizePaths(in)
+
+	// must return a new slice, leaving the input untouched
+	if in[0] != gaNFD {
+		t.Errorf("NormalizePaths mutated its input: %q", in[0])
+	}
+
+	want0 := gaNFD
+	if runtime.GOOS == "darwin" {
+		want0 = gaNFC
+	}
+	if got[0] != want0 || got[1] != "/ascii" {
+		t.Errorf("NormalizePaths() = %q, want [%q /ascii]", got, want0)
+	}
+}
 
 func TestSanitiseBasename(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

On macOS, filenames are reported by the filesystem in NFD (decomposed) form — for example `が` is stored as `か` plus a combining mark. SQLite compares strings byte-wise, so a search for the composed (NFC) form that I actually type never matches the decomposed form that was stored during scanning.

This normalizes scanned paths to NFC before storing them, so stored data matches what users type. A custom collation was suggested in the issue, but collations don't apply to `LIKE` (which the `q` search uses), so normalizing at scan time is the approach taken here.

Details:
- Normalization is applied only on macOS, whose filesystems are normalization-insensitive (the on-disk file is still found via its NFC path). It is a no-op elsewhere, because on a byte-exact filesystem (e.g. Linux) storing NFC would break access to files whose on-disk names are NFD.
- Path containment checks (library membership / generated folder) are made normalization-insensitive.
- File/folder rename detection treats an entry differing only by normalization as the same entry, so rescanning an existing library updates paths in place rather than creating duplicates.
- Entries inside zip files are left byte-exact.

## Related Issue

Fixes #4425 (also the earlier #3727)

## Testing

- [x] Added unit tests for `NormalizePath` and the normalization-insensitive `IsPathInDir`
- [x] Built locally and ran a scan against a file whose on-disk name is NFD; confirmed the stored `basename` is NFC and that a composed-form search returns the file
- [x] Confirmed the on-disk file is still accessible via the normalized path

## Screenshots

N/A (no visual changes)

## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable). — N/A

## AI Usage Disclosure

- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

I used Claude Code (Anthropic) to assist with implementing the change, writing the unit tests, running the manual scan/search verification, and drafting this description. I have reviewed and understand all of the changes, performed the testing described above, and take full responsibility for the code.

## Additional Context

Recreated from #7070, which was closed for not following the PR template; this PR follows the template. It is a small, focused bug fix for an issue I reported, not a large generated feature.
