### PR TITLE
Fix: Preserve Whitespace In Duplicate Checker Paths

### DIFF
--- a/ui/v2.5/src/components/SceneDuplicateChecker/styles.scss
+++ b/ui/v2.5/src/components/SceneDuplicateChecker/styles.scss
@@ -1,6 +1,7 @@
 #scene-duplicate-checker {
   .scene-path {
     font-size: 0.88em;
+    white-space: pre-wrap;
   }
 
   .filter-container {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Preserves repeated whitespace in Scene Duplicate Checker file paths by rendering path text with `white-space: pre-wrap`.

This fixes cases where paths containing multiple consecutive spaces were visually collapsed to a single space, making the displayed path unreliable for copy/paste cleanup.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #3379 

## Testing
<!-- Describe the testing steps you have performed. -->

- `git diff --check`
- `pnpm.cmd --dir ui/v2.5 lint:css`
- Manually checked the before/after of the scene path in dupe checker with multiple spaces to confirm the fix

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

With the fix:
<img width="1547" height="534" alt="image" src="https://github.com/user-attachments/assets/66e9a44d-4d60-4e3a-b37a-def09ac2bd02" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to assist in investigating the issue, manually made the change, and then had codex do a review.
## Additional Context
<!-- Add any other context about the pull request here. -->

The underlying path value was already rendered from `file.path`. The issue was browser whitespace collapsing in normal text layout.

Edit: Not sure how to trigger a rerun if I even can, but I am pretty confident the failed check is unrelated to my change and just Git having a network hiccup.