### PR TITLE
Fix: Detail Page Default Tab Rendering

### DIFF
--- a/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/Group.tsx
@@ -76,7 +76,7 @@ const GroupTabs: React.FC<{
     return "scenes";
   }, [sceneCount, performerCount, groupCount]);
 
-  const { setTabKey } = useTabKey({
+  const { activeTabKey, setTabKey } = useTabKey({
     tabKey,
     validTabs,
     defaultTabKey: populatedDefaultTab,
@@ -88,7 +88,7 @@ const GroupTabs: React.FC<{
       id="group-tabs"
       mountOnEnter
       unmountOnExit
-      activeKey={tabKey}
+      activeKey={activeTabKey}
       onSelect={setTabKey}
     >
       <Tab
@@ -101,7 +101,7 @@ const GroupTabs: React.FC<{
           />
         }
       >
-        <GroupScenesPanel active={tabKey === "scenes"} group={group} />
+        <GroupScenesPanel active={activeTabKey === "scenes"} group={group} />
       </Tab>
       <Tab
         eventKey="performers"
@@ -113,7 +113,10 @@ const GroupTabs: React.FC<{
           />
         }
       >
-        <GroupPerformersPanel active={tabKey === "performers"} group={group} />
+        <GroupPerformersPanel
+          active={activeTabKey === "performers"}
+          group={group}
+        />
       </Tab>
       <Tab
         eventKey="subgroups"
@@ -125,7 +128,10 @@ const GroupTabs: React.FC<{
           />
         }
       >
-        <GroupSubGroupsPanel active={tabKey === "subgroups"} group={group} />
+        <GroupSubGroupsPanel
+          active={activeTabKey === "subgroups"}
+          group={group}
+        />
       </Tab>
     </Tabs>
   );

--- a/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/Performer.tsx
@@ -95,7 +95,7 @@ const PerformerTabs: React.FC<{
     return ret;
   }, [performer]);
 
-  const { setTabKey } = useTabKey({
+  const { activeTabKey, setTabKey } = useTabKey({
     tabKey,
     validTabs,
     defaultTabKey: populatedDefaultTab,
@@ -114,16 +114,12 @@ const PerformerTabs: React.FC<{
     };
   });
 
-  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
-  // when it is subsequently set to a valid value.
-  if (!tabKey) return null;
-
   return (
     <Tabs
       id="performer-tabs"
       mountOnEnter
       unmountOnExit
-      activeKey={tabKey}
+      activeKey={activeTabKey}
       onSelect={setTabKey}
     >
       <Tab
@@ -137,7 +133,7 @@ const PerformerTabs: React.FC<{
         }
       >
         <PerformerScenesPanel
-          active={tabKey === "scenes"}
+          active={activeTabKey === "scenes"}
           performer={performer}
         />
       </Tab>
@@ -153,7 +149,7 @@ const PerformerTabs: React.FC<{
         }
       >
         <PerformerGalleriesPanel
-          active={tabKey === "galleries"}
+          active={activeTabKey === "galleries"}
           performer={performer}
         />
       </Tab>
@@ -169,7 +165,7 @@ const PerformerTabs: React.FC<{
         }
       >
         <PerformerImagesPanel
-          active={tabKey === "images"}
+          active={activeTabKey === "images"}
           performer={performer}
         />
       </Tab>
@@ -185,7 +181,7 @@ const PerformerTabs: React.FC<{
         }
       >
         <PerformerGroupsPanel
-          active={tabKey === "groups"}
+          active={activeTabKey === "groups"}
           performer={performer}
         />
       </Tab>
@@ -201,7 +197,7 @@ const PerformerTabs: React.FC<{
         }
       >
         <PerformerAppearsWithPanel
-          active={tabKey === "appearswith"}
+          active={activeTabKey === "appearswith"}
           performer={performer}
         />
       </Tab>

--- a/ui/v2.5/src/components/Shared/DetailsPage/Tabs.tsx
+++ b/ui/v2.5/src/components/Shared/DetailsPage/Tabs.tsx
@@ -29,24 +29,32 @@ export function useTabKey(props: {
   const { tabKey, validTabs, defaultTabKey, baseURL } = props;
 
   const history = useHistory();
+  const activeTabKey =
+    tabKey && tabKey !== "default" && validTabs.includes(tabKey)
+      ? tabKey
+      : defaultTabKey;
 
   const setTabKey = useCallback(
     (newTabKey: string | null) => {
-      if (!newTabKey) newTabKey = defaultTabKey;
-      if (newTabKey === tabKey) return;
-
-      if (validTabs.includes(newTabKey)) {
-        history.replace(`${baseURL}/${newTabKey}`);
+      if (
+        !newTabKey ||
+        newTabKey === "default" ||
+        !validTabs.includes(newTabKey)
+      ) {
+        newTabKey = defaultTabKey;
       }
+      if (newTabKey === activeTabKey) return;
+
+      history.replace(`${baseURL}/${newTabKey}`);
     },
-    [defaultTabKey, validTabs, tabKey, history, baseURL]
+    [activeTabKey, defaultTabKey, validTabs, history, baseURL]
   );
 
   useEffect(() => {
-    if (!tabKey) {
-      setTabKey(defaultTabKey);
+    if (tabKey !== activeTabKey) {
+      history.replace(`${baseURL}/${activeTabKey}`);
     }
-  }, [setTabKey, defaultTabKey, tabKey]);
+  }, [activeTabKey, baseURL, history, tabKey]);
 
-  return { setTabKey };
+  return { activeTabKey, setTabKey };
 }

--- a/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/Studio.tsx
@@ -124,7 +124,7 @@ const StudioTabs: React.FC<{
     studio,
   ]);
 
-  const { setTabKey } = useTabKey({
+  const { activeTabKey, setTabKey } = useTabKey({
     tabKey,
     validTabs,
     defaultTabKey: populatedDefaultTab,
@@ -149,16 +149,12 @@ const StudioTabs: React.FC<{
     );
   }, [showAllDetails, studio.child_studios.length]);
 
-  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
-  // when it is subsequently set to a valid value.
-  if (!tabKey) return null;
-
   return (
     <Tabs
       id="studio-tabs"
       mountOnEnter
       unmountOnExit
-      activeKey={tabKey}
+      activeKey={activeTabKey}
       onSelect={setTabKey}
     >
       <Tab
@@ -173,7 +169,7 @@ const StudioTabs: React.FC<{
       >
         {contentSwitch}
         <StudioScenesPanel
-          active={tabKey === "scenes"}
+          active={activeTabKey === "scenes"}
           studio={studio}
           showChildStudioContent={showAllDetails}
         />
@@ -190,7 +186,7 @@ const StudioTabs: React.FC<{
       >
         {contentSwitch}
         <StudioGalleriesPanel
-          active={tabKey === "galleries"}
+          active={activeTabKey === "galleries"}
           studio={studio}
           showChildStudioContent={showAllDetails}
         />
@@ -207,7 +203,7 @@ const StudioTabs: React.FC<{
       >
         {contentSwitch}
         <StudioImagesPanel
-          active={tabKey === "images"}
+          active={activeTabKey === "images"}
           studio={studio}
           showChildStudioContent={showAllDetails}
         />
@@ -224,7 +220,7 @@ const StudioTabs: React.FC<{
       >
         {contentSwitch}
         <StudioPerformersPanel
-          active={tabKey === "performers"}
+          active={activeTabKey === "performers"}
           studio={studio}
           showChildStudioContent={showAllDetails}
         />
@@ -241,7 +237,7 @@ const StudioTabs: React.FC<{
       >
         {contentSwitch}
         <StudioGroupsPanel
-          active={tabKey === "groups"}
+          active={activeTabKey === "groups"}
           studio={studio}
           showChildStudioContent={showAllDetails}
         />
@@ -257,7 +253,7 @@ const StudioTabs: React.FC<{
         }
       >
         <StudioChildrenPanel
-          active={tabKey === "childstudios"}
+          active={activeTabKey === "childstudios"}
           studio={studio}
         />
       </Tab>

--- a/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/Tag.tsx
@@ -127,7 +127,7 @@ const TagTabs: React.FC<{
     groupCount,
   ]);
 
-  const { setTabKey } = useTabKey({
+  const { activeTabKey, setTabKey } = useTabKey({
     tabKey,
     validTabs,
     defaultTabKey: populatedDefaultTab,
@@ -152,16 +152,12 @@ const TagTabs: React.FC<{
     );
   }, [showAllDetails, tag.children.length]);
 
-  // #6798 - if Tabs renders while tabKey is undefined, it doesn't render correctly
-  // when it is subsequently set to a valid value.
-  if (!tabKey) return null;
-
   return (
     <Tabs
       id="tag-tabs"
       mountOnEnter
       unmountOnExit
-      activeKey={tabKey}
+      activeKey={activeTabKey}
       onSelect={setTabKey}
     >
       <Tab
@@ -176,7 +172,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagScenesPanel
-          active={tabKey === "scenes"}
+          active={activeTabKey === "scenes"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -193,7 +189,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagImagesPanel
-          active={tabKey === "images"}
+          active={activeTabKey === "images"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -210,7 +206,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagGalleriesPanel
-          active={tabKey === "galleries"}
+          active={activeTabKey === "galleries"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -227,7 +223,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagGroupsPanel
-          active={tabKey === "groups"}
+          active={activeTabKey === "groups"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -244,7 +240,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagMarkersPanel
-          active={tabKey === "markers"}
+          active={activeTabKey === "markers"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -261,7 +257,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagPerformersPanel
-          active={tabKey === "performers"}
+          active={activeTabKey === "performers"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />
@@ -278,7 +274,7 @@ const TagTabs: React.FC<{
       >
         {contentSwitch}
         <TagStudiosPanel
-          active={tabKey === "studios"}
+          active={activeTabKey === "studios"}
           tag={tag}
           showSubTagContent={showAllDetails}
         />


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes detail page tab rendering when the route tab is missing or set to `default`.

The shared detail tab hook now resolves a render-safe `activeTabKey` before rendering `Tabs`, treating missing tab values and the internal `default` sentinel as the populated default tab. Performer, group, studio, and tag detail pages now use that resolved key for tab activation and panel queries.

This removes the per-page workaround that hid tabs until the URL effect ran, and also covers group detail pages and `/default` URLs.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6798
Supercedes #6923 
Also resolves the "Performer galleries not shown if performer has no scenes" bug in the bug tracker project board I believe

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd run check`
- `pnpm.cmd run lint:js`
- `pnpm.cmd exec biome lint src/components/Shared/DetailsPage/Tabs.tsx src/components/Performers/PerformerDetails/Performer.tsx src/components/Groups/GroupDetails/Group.tsx src/components/Studios/StudioDetails/Studio.tsx src/components/Tags/TagDetails/Tag.tsx`
- `pnpm.cmd exec biome format src/components/Shared/DetailsPage/Tabs.tsx src/components/Performers/PerformerDetails/Performer.tsx src/components/Groups/GroupDetails/Group.tsx src/components/Studios/StudioDetails/Studio.tsx src/components/Tags/TagDetails/Tag.tsx`
- `git diff --check`
- Manually confirmed with `/[type]/[id]`, `/[type]/[id]/default`, and `/[type]/[id]/test` for performers, groups, studios, and tags for both when the first tab was populated and when the default tab populated was not the first.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the tab routing issue, draft the shared `activeTabKey` handling, and then manually reviewed and tested the changes.

## Additional Context
<!-- Add any other context about the pull request here. -->

The `default` tab value is accepted by several detail routes but does not correspond to a rendered `Tab`. Resolving it before render prevents React-Bootstrap from receiving an undefined or non-rendered active key, while the URL is still canonicalized afterward with `history.replace`.