### PR TITLE
Only mark builds from the upstream repo as official

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
 
     - name: Start build container
       env:
-        official-build: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'release' && github.ref != 'refs/tags/latest_develop') }}
+        official-build: ${{ github.repository == 'stashapp/stash' && ((github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'release' && github.ref != 'refs/tags/latest_develop')) }}
       run: |
         mkdir -p .go-cache
         docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated --mount type=bind,source="$(pwd)/.go-cache",target=/root/.cache/go-build,consistency=delegated --env OFFICIAL_BUILD=${{ env.official-build }} -w /stash $COMPILER_IMAGE tail -f /dev/null


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The build matrix passes `OFFICIAL_BUILD=true` for pushes to `develop` and for release events, which drives the "Official Build" / "Unofficial Build" label in **Settings > About**. Forks fire these same triggers, so binaries built from a fork's `develop` or releases are incorrectly labelled "Official Build".

This gates the `official-build` expression on the repository so only the upstream repository produces official builds:

```yaml
official-build: ${{ github.repository == 'stashapp/stash' && ( ...existing condition... ) }}
```

Official builds from `stashapp/stash` are unaffected; fork builds now correctly report "Unofficial Build". The "Official Build" label becomes trustworthy, and it's easier to triage bug reports by telling from the version string whether a build is official or modified.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7065

## Testing
<!-- Describe the testing steps you have performed. -->

Evaluated the GitHub Actions expression for the relevant trigger/repository combinations:

- `stashapp/stash`, push to `develop` → `true` (unchanged)
- `stashapp/stash`, release (not `latest_develop`) → `true` (unchanged)
- fork, push to `develop` → `false` (was incorrectly `true`)
- fork, release → `false` (was incorrectly `true`)
- pull request (any repo) → `false` (unchanged)

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A — CI workflow change only.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Claude Code was used to help draft and test this change.

## Additional Context
<!-- Add any other context about the pull request here. -->

This is a one-line change to the `official-build` expression in `.github/workflows/build.yml`.
