### PR TITLE
Make the update-check repository configurable at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
         official-build: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'release' && github.ref != 'refs/tags/latest_develop') }}
       run: |
         mkdir -p .go-cache
-        docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated --mount type=bind,source="$(pwd)/.go-cache",target=/root/.cache/go-build,consistency=delegated --env OFFICIAL_BUILD=${{ env.official-build }} -w /stash $COMPILER_IMAGE tail -f /dev/null
+        docker run -d --name build --mount type=bind,source="$(pwd)",target=/stash,consistency=delegated --mount type=bind,source="$(pwd)/.go-cache",target=/root/.cache/go-build,consistency=delegated --env OFFICIAL_BUILD=${{ env.official-build }} --env UPDATE_REPO=${{ github.repository }} -w /stash $COMPILER_IMAGE tail -f /dev/null
 
     - name: Build (${{ matrix.platform }})
       run: docker exec -t build /bin/bash -c "make ${{ matrix.make-target }}"

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ build-flags: build-info
 	$(eval BUILD_LDFLAGS += -X 'github.com/stashapp/stash/internal/build.githash=$(GITHASH)')
 	$(eval BUILD_LDFLAGS += -X 'github.com/stashapp/stash/internal/build.version=$(STASH_VERSION)')
 	$(eval BUILD_LDFLAGS += -X 'github.com/stashapp/stash/internal/build.officialBuild=$(OFFICIAL_BUILD)')
+ifdef UPDATE_REPO
+	$(eval BUILD_LDFLAGS += -X 'github.com/stashapp/stash/internal/build.updateRepo=$(UPDATE_REPO)')
+endif
 	$(eval BUILD_FLAGS := -v -tags "$(GO_BUILD_TAGS)" $(GO_BUILD_FLAGS) -ldflags "$(BUILD_LDFLAGS)")
 
 .PHONY: stash

--- a/internal/api/check_version.go
+++ b/internal/api/check_version.go
@@ -20,11 +20,20 @@ import (
 )
 
 // we use the github REST V3 API as no login is required
-const apiReleases string = "https://api.github.com/repos/stashapp/stash/releases"
-const apiTags string = "https://api.github.com/repos/stashapp/stash/tags"
+const apiRepoBase string = "https://api.github.com/repos/"
 const apiAcceptHeader string = "application/vnd.github.v3+json"
 const developmentTag string = "latest_develop"
 const defaultSHLength int = 8 // default length of SHA short hash returned by <git rev-parse --short HEAD>
+
+// apiReleasesURL and apiTagsURL build the GitHub API endpoints for the
+// repository configured via build.UpdateRepo (defaults to stashapp/stash).
+func apiReleasesURL() string {
+	return apiRepoBase + build.UpdateRepo() + "/releases"
+}
+
+func apiTagsURL() string {
+	return apiRepoBase + build.UpdateRepo() + "/tags"
+}
 
 var stashReleases = func() map[string]string {
 	return map[string]string{
@@ -190,7 +199,7 @@ func GetLatestRelease(ctx context.Context) (*LatestRelease, error) {
 	platform := fmt.Sprintf("%s/%s", runtime.GOOS, arch)
 	wantedRelease := getWantedRelease(platform)
 
-	url := apiReleases
+	url := apiReleasesURL()
 	if build.IsDevelop() {
 		// get the release tagged with the development tag
 		url += "/tags/" + developmentTag
@@ -258,7 +267,7 @@ func getReleaseHash(ctx context.Context, tagName string) (string, error) {
 
 	// Limit to 5 pages, ie 500 tags - should be plenty
 	for page := 1; page <= 5; {
-		url := fmt.Sprintf("%s?per_page=%d&page=%d", apiTags, perPage, page)
+		url := fmt.Sprintf("%s?per_page=%d&page=%d", apiTagsURL(), perPage, page)
 		tags := []githubTagResponse{}
 		err := makeGithubRequest(ctx, url, &tags)
 		if err != nil {

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -10,8 +10,23 @@ var buildstamp string
 var githash string
 var officialBuild string
 
+// updateRepo is the GitHub "owner/repo" that the built-in update check queries.
+// It can be overridden at build time via -ldflags, allowing forks to point the
+// update check at their own releases. It defaults to the upstream repository.
+var updateRepo string
+
+const defaultUpdateRepo = "stashapp/stash"
+
 func Version() (string, string, string) {
 	return version, githash, buildstamp
+}
+
+// UpdateRepo returns the GitHub "owner/repo" used by the update check.
+func UpdateRepo() string {
+	if updateRepo == "" {
+		return defaultUpdateRepo
+	}
+	return updateRepo
 }
 
 func VersionString() string {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The built-in update check (`internal/api/check_version.go`) hardcodes the `stashapp/stash` GitHub repository for its releases/tags API calls. Forks that publish their own releases either get no useful update information or are told to "update" to an unrelated upstream build (an accidental cross-grade).

This makes the update-check repository overridable at build time, defaulting to `stashapp/stash` so official builds are unchanged:

- Adds a `build.updateRepo` variable (settable via `-ldflags`) exposed through a `build.UpdateRepo()` accessor that defaults to `stashapp/stash`.
- Builds the update-check URLs from `build.UpdateRepo()` instead of hardcoded constants.
- Lets the `Makefile` inject it from an optional `UPDATE_REPO` variable (unset = default).
- Wires `UPDATE_REPO=${{ github.repository }}` through the build workflow, so a build's update check targets the repository that produced it. For `stashapp/stash` this resolves to the default (no-op); forks that build via this workflow automatically point their update check at their own releases without editing anything.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7066

## Testing
<!-- Describe the testing steps you have performed. -->

- `make generate` + `go build ./...` and `go test ./internal/build/... ./internal/api/...` pass.
- Verified `build.UpdateRepo()` returns the default `stashapp/stash` when `updateRepo` is unset, and the injected value when built with `UPDATE_REPO` set, and that `apiReleasesURL()` / `apiTagsURL()` compose the expected `https://api.github.com/repos/<repo>/...` endpoints.
- The workflow change is a single `--env UPDATE_REPO=${{ github.repository }}` added next to the existing `--env OFFICIAL_BUILD=...`; gated by the Makefile's `ifdef UPDATE_REPO`, so upstream builds are unaffected.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A — no UI changes.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Claude Code was used to draft the implementation.

## Additional Context
<!-- Add any other context about the pull request here. -->

The default is preserved whenever `UPDATE_REPO` is unset, so this is purely additive for this project — official builds keep checking `stashapp/stash`. Companion to #7065 (#7075); the two touch different lines of `build.yml` and do not conflict.
