### PR TITLE
Fix: Nested Library Path Matching For Propagating Library Type Exclusions

### DIFF
--- a/internal/manager/config/stash_config.go
+++ b/internal/manager/config/stash_config.go
@@ -22,21 +22,26 @@ type StashConfig struct {
 type StashConfigs []*StashConfig
 
 func (s StashConfigs) GetStashFromPath(path string) *StashConfig {
-	for _, f := range s {
-		if fsutil.IsPathInDir(f.Path, filepath.Dir(path)) {
-			return f
-		}
-	}
-	return nil
+	return s.GetStashFromDirPath(filepath.Dir(path))
 }
 
 func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
+	var ret *StashConfig
+	longestPath := -1
+
 	for _, f := range s {
-		if fsutil.IsPathInDir(f.Path, dirPath) {
-			return f
+		if f == nil {
+			continue
+		}
+
+		path := filepath.Clean(f.Path)
+		if fsutil.IsPathInDir(path, dirPath) && len(path) > longestPath {
+			ret = f
+			longestPath = len(path)
 		}
 	}
-	return nil
+
+	return ret
 }
 
 func (s StashConfigs) Paths() []string {

--- a/internal/manager/config/stash_config.go
+++ b/internal/manager/config/stash_config.go
@@ -21,10 +21,12 @@ type StashConfig struct {
 
 type StashConfigs []*StashConfig
 
+// GetStashFromPath returns the most specific stash configuration containing path.
 func (s StashConfigs) GetStashFromPath(path string) *StashConfig {
 	return s.GetStashFromDirPath(filepath.Dir(path))
 }
 
+// GetStashFromDirPath returns the most specific stash configuration containing dirPath.
 func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
 	var ret *StashConfig
 	longestPath := -1
@@ -38,6 +40,26 @@ func (s StashConfigs) GetStashFromDirPath(dirPath string) *StashConfig {
 		if fsutil.IsPathInDir(path, dirPath) && len(path) > longestPath {
 			ret = f
 			longestPath = len(path)
+		}
+	}
+
+	return ret
+}
+
+// GetStashRootFromDirPath returns the topmost configured stash path containing dirPath.
+func (s StashConfigs) GetStashRootFromDirPath(dirPath string) string {
+	var ret string
+	shortestPath := -1
+
+	for _, f := range s {
+		if f == nil {
+			continue
+		}
+
+		path := filepath.Clean(f.Path)
+		if fsutil.IsPathInDir(path, dirPath) && (shortestPath == -1 || len(path) < shortestPath) {
+			ret = path
+			shortestPath = len(path)
 		}
 	}
 

--- a/internal/manager/config/stash_config_test.go
+++ b/internal/manager/config/stash_config_test.go
@@ -47,6 +47,36 @@ func TestStashConfigsGetStashFromDirPathReturnsMostSpecificPathRegardlessOfOrder
 	}
 }
 
+func TestStashConfigsGetStashRootFromDirPathReturnsTopmostPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+
+	stashes := StashConfigs{
+		{Path: root},
+		{Path: nested},
+	}
+
+	got := stashes.GetStashRootFromDirPath(filepath.Join(nested, "set"))
+	if got != root {
+		t.Fatalf("expected topmost stash path %q, got %q", root, got)
+	}
+}
+
+func TestStashConfigsGetStashRootFromDirPathReturnsTopmostPathRegardlessOfOrder(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+
+	stashes := StashConfigs{
+		{Path: nested},
+		{Path: root},
+	}
+
+	got := stashes.GetStashRootFromDirPath(filepath.Join(nested, "set"))
+	if got != root {
+		t.Fatalf("expected topmost stash path %q, got %q", root, got)
+	}
+}
+
 func TestStashConfigsGetStashFromPathReturnsMostSpecificPath(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "library")
 	nested := filepath.Join(root, "images")
@@ -77,5 +107,17 @@ func TestStashConfigsGetStashFromDirPathReturnsNilOutsideLibraries(t *testing.T)
 	got := stashes.GetStashFromDirPath(outside)
 	if got != nil {
 		t.Fatalf("expected nil stash config, got %#v", got)
+	}
+}
+
+func TestStashConfigsGetStashRootFromDirPathReturnsEmptyOutsideLibraries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	outside := filepath.Join(t.TempDir(), "outside")
+
+	stashes := StashConfigs{{Path: root}}
+
+	got := stashes.GetStashRootFromDirPath(outside)
+	if got != "" {
+		t.Fatalf("expected empty stash path, got %q", got)
 	}
 }

--- a/internal/manager/config/stash_config_test.go
+++ b/internal/manager/config/stash_config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStashConfigsGetStashFromDirPathReturnsMostSpecificPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+
+	parent := &StashConfig{
+		Path:         root,
+		ExcludeImage: true,
+	}
+	child := &StashConfig{
+		Path:         nested,
+		ExcludeVideo: true,
+	}
+
+	stashes := StashConfigs{parent, child}
+
+	got := stashes.GetStashFromDirPath(filepath.Join(nested, "set"))
+	if got != child {
+		t.Fatalf("expected nested stash config, got %#v", got)
+	}
+}
+
+func TestStashConfigsGetStashFromDirPathReturnsMostSpecificPathRegardlessOfOrder(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+
+	parent := &StashConfig{
+		Path:         root,
+		ExcludeImage: true,
+	}
+	child := &StashConfig{
+		Path:         nested,
+		ExcludeVideo: true,
+	}
+
+	stashes := StashConfigs{child, parent}
+
+	got := stashes.GetStashFromDirPath(filepath.Join(nested, "set"))
+	if got != child {
+		t.Fatalf("expected nested stash config, got %#v", got)
+	}
+}
+
+func TestStashConfigsGetStashFromPathReturnsMostSpecificPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+
+	parent := &StashConfig{
+		Path:         root,
+		ExcludeImage: true,
+	}
+	child := &StashConfig{
+		Path:         nested,
+		ExcludeVideo: true,
+	}
+
+	stashes := StashConfigs{parent, child}
+
+	got := stashes.GetStashFromPath(filepath.Join(nested, "image.jpg"))
+	if got != child {
+		t.Fatalf("expected nested stash config, got %#v", got)
+	}
+}
+
+func TestStashConfigsGetStashFromDirPathReturnsNilOutsideLibraries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	outside := filepath.Join(t.TempDir(), "outside")
+
+	stashes := StashConfigs{{Path: root}}
+
+	got := stashes.GetStashFromDirPath(outside)
+	if got != nil {
+		t.Fatalf("expected nil stash config, got %#v", got)
+	}
+}

--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -185,7 +185,7 @@ func (f *cleanFilter) Accept(ctx context.Context, path string, info fs.FileInfo,
 	}
 
 	// Check .stashignore files, bounded to the library root.
-	if !f.stashIgnoreFilter.Accept(ctx, path, info, stash.Path, zipFilePath) {
+	if !f.stashIgnoreFilter.Accept(ctx, path, info, f.stashPaths.GetStashRootFromDirPath(path), zipFilePath) {
 		logger.Infof("%s is excluded due to .stashignore. Marking to clean: %q", fileOrFolder, path)
 		return false
 	}

--- a/internal/manager/task_scan.go
+++ b/internal/manager/task_scan.go
@@ -592,7 +592,7 @@ func (f *scanFilter) Accept(ctx context.Context, path string, info fs.FileInfo, 
 	}
 
 	// Check .stashignore files, bounded to the library root.
-	if !f.stashIgnoreFilter.Accept(ctx, path, info, s.Path, zipFilePath) {
+	if !f.stashIgnoreFilter.Accept(ctx, path, info, f.stashPaths.GetStashRootFromDirPath(path), zipFilePath) {
 		logger.Debugf("Skipping %s due to .stashignore", path)
 		return false
 	}

--- a/internal/manager/task_stashignore_test.go
+++ b/internal/manager/task_stashignore_test.go
@@ -1,0 +1,66 @@
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stashapp/stash/internal/manager/config"
+	"github.com/stashapp/stash/pkg/file"
+)
+
+func createStashIgnoreTestFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create directory for %s: %v", path, err)
+	}
+
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create file %s: %v", path, err)
+	}
+}
+
+func TestStashIgnoreUsesTopmostLibraryRootWithNestedLibraries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	nested := filepath.Join(root, "images")
+	ignoredFile := filepath.Join(nested, "secret", "image.jpg")
+
+	createStashIgnoreTestFile(t, ignoredFile)
+	if err := os.WriteFile(filepath.Join(root, ".stashignore"), []byte("images/secret/\n"), 0644); err != nil {
+		t.Fatalf("failed to create .stashignore: %v", err)
+	}
+
+	info, err := os.Stat(ignoredFile)
+	if err != nil {
+		t.Fatalf("failed to stat %s: %v", ignoredFile, err)
+	}
+
+	stashPaths := config.StashConfigs{
+		{Path: root, ExcludeImage: true},
+		{Path: nested},
+	}
+
+	scannerFilter := &scanFilter{
+		stashPaths:        stashPaths,
+		generatedPath:     filepath.Join(root, "generated"),
+		stashIgnoreFilter: file.NewStashIgnoreFilter(),
+	}
+
+	if scannerFilter.Accept(context.Background(), ignoredFile, info, "") {
+		t.Fatalf("expected scan filter to reject file due to parent .stashignore")
+	}
+
+	cleanFilter := &cleanFilter{
+		scanFilter: scanFilter{
+			stashPaths:        stashPaths,
+			generatedPath:     filepath.Join(root, "generated"),
+			stashIgnoreFilter: file.NewStashIgnoreFilter(),
+		},
+	}
+
+	if cleanFilter.Accept(context.Background(), ignoredFile, info, "") {
+		t.Fatalf("expected clean filter to reject file due to parent .stashignore")
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes nested library path matching so overlapping library entries consistently use the most specific matching path.

Previously, library path resolution returned the first configured path that contained the scanned file. For nested libraries, this made media-type inclusion/exclusion order-dependent. A child library could inherit the parent library’s video/image settings if the parent appeared first in the config.

This updates `StashConfigs.GetStashFromDirPath` to choose the deepest matching library path, and routes `GetStashFromPath` through the same logic. This keeps scan, clean, and related path classification behavior consistent.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #4956 

## Testing
<!-- Describe the testing steps you have performed. -->

- `golangci-lint run ./internal/manager/config`
- `git diff --check`
- `go test ./internal/... `
- Manually tested this with nested library paths with mixed images/videos in both the parent and child.  Confirmed scan, clean, and generate with the nest library and swapping the video/image exclusions between them as well as swapping the order.
  - Also did a quick smoke test of image clips to make sure they still followed the exclusions

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

I don't believe any doc changes are necessary since this is just aligning it with the expected behavior.  One possible exception would be if a specific direction for .stashignore is chosen.

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate, review my changes, and write the testing.

## Additional Context
<!-- Add any other context about the pull request here. -->

This change also makes the `.stashignore` boundary behavior deterministic for nested library entries, but that behavior may need explicit review/confirmation.

Without this fix, the `.stashignore` boundary already depends on library order because `GetStashFromDirPath` returns the first matching library.

For a nested path such as `/media/images/foo.jpg`:

- Config order `/media`, then `/media/images`: old code picks `/media`, so parent `.stashignore` files cascade, but the parent video/image exclusions incorrectly win.
- Config order `/media/images`, then `/media`: old code picks `/media/images`, so the child exclusions win, but parent `/media/.stashignore` no longer participates.

So this patch does not introduce the possible `.stashignore` discrepancy from nothing. It resolves order-dependent media-type behavior by deterministically choosing the child library config. If parent `.stashignore` files are intended to cascade across nested library entries, then the selected library config probably should not also be used as the `.stashignore` root without a separate explicit decision.