### PR TITLE
Add text filter to sort by select

### DIFF
--- a/ui/v2.5/src/components/List/FilteredListToolbar.tsx
+++ b/ui/v2.5/src/components/List/FilteredListToolbar.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { QueryResult } from "@apollo/client";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { PageSizeSelector, SearchTermInput, SortBySelect } from "./ListFilter";
+import { PageSizeSelector, SearchTermInput } from "./ListFilter";
+import { SortBySelect } from "./SortBySelect";
 import { ListViewButtonGroup } from "./ListViewOptions";
 import {
   IListFilterOperation,

--- a/ui/v2.5/src/components/List/ListFilter.tsx
+++ b/ui/v2.5/src/components/List/ListFilter.tsx
@@ -6,34 +6,16 @@ import React, {
   useState,
 } from "react";
 import Mousetrap from "mousetrap";
-import { SortDirectionEnum } from "src/core/generated-graphql";
-import {
-  Button,
-  ButtonGroup,
-  Dropdown,
-  Form,
-  OverlayTrigger,
-  Tooltip,
-  InputGroup,
-  Popover,
-  Overlay,
-} from "react-bootstrap";
+import { Button, Form, InputGroup, Popover, Overlay } from "react-bootstrap";
 
 import { Icon } from "../Shared/Icon";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import useFocus from "src/utils/focus";
 import { useIntl } from "react-intl";
-import {
-  faCaretDown,
-  faCaretUp,
-  faCheck,
-  faRandom,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { useDebounce } from "src/hooks/debounce";
 import { ClearableInput } from "../Shared/ClearableInput";
 import { useStopWheelScroll } from "src/utils/form";
-import { ISortByOption } from "src/models/list-filter/filter-options";
-import { useConfigurationContext } from "src/hooks/Config";
 
 export function useDebouncedSearchInput(
   filter: ListFilterModel,
@@ -225,104 +207,5 @@ export const PageSizeSelector: React.FC<{
         </Popover>
       </Overlay>
     </div>
-  );
-};
-
-export const SortBySelect: React.FC<{
-  className?: string;
-  sortBy: string | undefined;
-  sortDirection: SortDirectionEnum;
-  options: ISortByOption[];
-  onChangeSortBy: (eventKey: string | null) => void;
-  onChangeSortDirection: () => void;
-  onReshuffleRandomSort: () => void;
-}> = ({
-  className,
-  sortBy,
-  sortDirection,
-  options,
-  onChangeSortBy,
-  onChangeSortDirection,
-  onReshuffleRandomSort,
-}) => {
-  const intl = useIntl();
-  const { configuration } = useConfigurationContext();
-  const { sfwContentMode } = configuration.interface;
-
-  const currentSortBy = options.find((o) => o.value === sortBy);
-  const currentSortByMessageID = currentSortBy
-    ? !sfwContentMode
-      ? currentSortBy.messageID
-      : (currentSortBy.sfwMessageID ?? currentSortBy.messageID)
-    : "";
-
-  function renderSortByOptions() {
-    return options
-      .map((o) => {
-        const messageID = !sfwContentMode
-          ? o.messageID
-          : (o.sfwMessageID ?? o.messageID);
-        return {
-          message: intl.formatMessage({ id: messageID }),
-          value: o.value,
-        };
-      })
-      .sort((a, b) => a.message.localeCompare(b.message))
-      .map((option) => (
-        <Dropdown.Item
-          onSelect={onChangeSortBy}
-          key={option.value}
-          className="bg-secondary text-white"
-          eventKey={option.value}
-          data-value={option.value}
-        >
-          {option.message}
-        </Dropdown.Item>
-      ));
-  }
-
-  return (
-    <Dropdown as={ButtonGroup} className={`${className ?? ""} sort-by-select`}>
-      <InputGroup.Prepend>
-        <Dropdown.Toggle variant="secondary">
-          {currentSortBy
-            ? intl.formatMessage({ id: currentSortByMessageID })
-            : ""}
-        </Dropdown.Toggle>
-      </InputGroup.Prepend>
-      <Dropdown.Menu className="bg-secondary text-white">
-        {renderSortByOptions()}
-      </Dropdown.Menu>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id="sort-direction-tooltip">
-            {sortDirection === SortDirectionEnum.Asc
-              ? intl.formatMessage({ id: "ascending" })
-              : intl.formatMessage({ id: "descending" })}
-          </Tooltip>
-        }
-      >
-        <Button variant="secondary" onClick={onChangeSortDirection}>
-          <Icon
-            icon={
-              sortDirection === SortDirectionEnum.Asc ? faCaretUp : faCaretDown
-            }
-          />
-        </Button>
-      </OverlayTrigger>
-      {sortBy === "random" && (
-        <OverlayTrigger
-          overlay={
-            <Tooltip id="sort-reshuffle-tooltip">
-              {intl.formatMessage({ id: "actions.reshuffle" })}
-            </Tooltip>
-          }
-        >
-          <Button variant="secondary" onClick={onReshuffleRandomSort}>
-            <Icon icon={faRandom} />
-          </Button>
-        </OverlayTrigger>
-      )}
-    </Dropdown>
   );
 };

--- a/ui/v2.5/src/components/List/SortBySelect.tsx
+++ b/ui/v2.5/src/components/List/SortBySelect.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { SortDirectionEnum } from "src/core/generated-graphql";
 import {
   Button,
@@ -18,6 +18,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { ISortByOption } from "src/models/list-filter/filter-options";
 import { useConfigurationContext } from "src/hooks/Config";
+import ClearableInput from "../Shared/ClearableInput";
+import useFocus from "src/utils/focus";
+import ScreenUtils from "src/utils/screen";
 
 export const SortBySelect: React.FC<{
   className?: string;
@@ -40,6 +43,12 @@ export const SortBySelect: React.FC<{
   const { configuration } = useConfigurationContext();
   const { sfwContentMode } = configuration.interface;
 
+  const [filter, setFilter] = React.useState("");
+
+  const focusOnOpen = !ScreenUtils.isTouch();
+  const focusRef = useFocus();
+  const [, setFocus] = focusRef;
+
   const currentSortBy = options.find((o) => o.value === sortBy);
   const currentSortByMessageID = currentSortBy
     ? !sfwContentMode
@@ -47,7 +56,7 @@ export const SortBySelect: React.FC<{
       : (currentSortBy.sfwMessageID ?? currentSortBy.messageID)
     : "";
 
-  function renderSortByOptions() {
+  const sortedOptions = useMemo(() => {
     return options
       .map((o) => {
         const messageID = !sfwContentMode
@@ -58,22 +67,39 @@ export const SortBySelect: React.FC<{
           value: o.value,
         };
       })
-      .sort((a, b) => a.message.localeCompare(b.message))
-      .map((option) => (
-        <Dropdown.Item
-          onSelect={onChangeSortBy}
-          key={option.value}
-          className="bg-secondary text-white"
-          eventKey={option.value}
-          data-value={option.value}
-        >
-          {option.message}
-        </Dropdown.Item>
-      ));
-  }
+      .sort((a, b) => a.message.localeCompare(b.message));
+  }, [intl, options, sfwContentMode]);
+
+  const filteredOptions = useMemo(() => {
+    if (!filter) return sortedOptions;
+
+    return sortedOptions.filter((o) =>
+      o.message.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [sortedOptions, filter]);
+
+  const dropdownItems = useMemo(() => {
+    return filteredOptions.map((option) => (
+      <Dropdown.Item
+        onSelect={onChangeSortBy}
+        key={option.value}
+        className="bg-secondary text-white"
+        eventKey={option.value}
+        data-value={option.value}
+      >
+        {option.message}
+      </Dropdown.Item>
+    ));
+  }, [filteredOptions, onChangeSortBy]);
 
   return (
-    <Dropdown as={ButtonGroup} className={`${className ?? ""} sort-by-select`}>
+    <Dropdown
+      as={ButtonGroup}
+      className={`${className ?? ""} sort-by-select`}
+      onToggle={(v) => {
+        if (focusOnOpen && v) setTimeout(() => setFocus(true), 0);
+      }}
+    >
       <InputGroup.Prepend>
         <Dropdown.Toggle variant="secondary">
           {currentSortBy
@@ -82,7 +108,16 @@ export const SortBySelect: React.FC<{
         </Dropdown.Toggle>
       </InputGroup.Prepend>
       <Dropdown.Menu className="bg-secondary text-white">
-        {renderSortByOptions()}
+        <div className="sort-by-filter-container">
+          <ClearableInput
+            placeholder={`${intl.formatMessage({ id: "filter" })}...`}
+            value={filter}
+            setValue={setFilter}
+            focus={focusRef}
+          />
+        </div>
+
+        {dropdownItems}
       </Dropdown.Menu>
       <OverlayTrigger
         overlay={

--- a/ui/v2.5/src/components/List/SortBySelect.tsx
+++ b/ui/v2.5/src/components/List/SortBySelect.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { SortDirectionEnum } from "src/core/generated-graphql";
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  OverlayTrigger,
+  Tooltip,
+  InputGroup,
+} from "react-bootstrap";
+
+import { Icon } from "../Shared/Icon";
+import { useIntl } from "react-intl";
+import {
+  faCaretDown,
+  faCaretUp,
+  faRandom,
+} from "@fortawesome/free-solid-svg-icons";
+import { ISortByOption } from "src/models/list-filter/filter-options";
+import { useConfigurationContext } from "src/hooks/Config";
+
+export const SortBySelect: React.FC<{
+  className?: string;
+  sortBy: string | undefined;
+  sortDirection: SortDirectionEnum;
+  options: ISortByOption[];
+  onChangeSortBy: (eventKey: string | null) => void;
+  onChangeSortDirection: () => void;
+  onReshuffleRandomSort: () => void;
+}> = ({
+  className,
+  sortBy,
+  sortDirection,
+  options,
+  onChangeSortBy,
+  onChangeSortDirection,
+  onReshuffleRandomSort,
+}) => {
+  const intl = useIntl();
+  const { configuration } = useConfigurationContext();
+  const { sfwContentMode } = configuration.interface;
+
+  const currentSortBy = options.find((o) => o.value === sortBy);
+  const currentSortByMessageID = currentSortBy
+    ? !sfwContentMode
+      ? currentSortBy.messageID
+      : (currentSortBy.sfwMessageID ?? currentSortBy.messageID)
+    : "";
+
+  function renderSortByOptions() {
+    return options
+      .map((o) => {
+        const messageID = !sfwContentMode
+          ? o.messageID
+          : (o.sfwMessageID ?? o.messageID);
+        return {
+          message: intl.formatMessage({ id: messageID }),
+          value: o.value,
+        };
+      })
+      .sort((a, b) => a.message.localeCompare(b.message))
+      .map((option) => (
+        <Dropdown.Item
+          onSelect={onChangeSortBy}
+          key={option.value}
+          className="bg-secondary text-white"
+          eventKey={option.value}
+          data-value={option.value}
+        >
+          {option.message}
+        </Dropdown.Item>
+      ));
+  }
+
+  return (
+    <Dropdown as={ButtonGroup} className={`${className ?? ""} sort-by-select`}>
+      <InputGroup.Prepend>
+        <Dropdown.Toggle variant="secondary">
+          {currentSortBy
+            ? intl.formatMessage({ id: currentSortByMessageID })
+            : ""}
+        </Dropdown.Toggle>
+      </InputGroup.Prepend>
+      <Dropdown.Menu className="bg-secondary text-white">
+        {renderSortByOptions()}
+      </Dropdown.Menu>
+      <OverlayTrigger
+        overlay={
+          <Tooltip id="sort-direction-tooltip">
+            {sortDirection === SortDirectionEnum.Asc
+              ? intl.formatMessage({ id: "ascending" })
+              : intl.formatMessage({ id: "descending" })}
+          </Tooltip>
+        }
+      >
+        <Button variant="secondary" onClick={onChangeSortDirection}>
+          <Icon
+            icon={
+              sortDirection === SortDirectionEnum.Asc ? faCaretUp : faCaretDown
+            }
+          />
+        </Button>
+      </OverlayTrigger>
+      {sortBy === "random" && (
+        <OverlayTrigger
+          overlay={
+            <Tooltip id="sort-reshuffle-tooltip">
+              {intl.formatMessage({ id: "actions.reshuffle" })}
+            </Tooltip>
+          }
+        >
+          <Button variant="secondary" onClick={onReshuffleRandomSort}>
+            <Icon icon={faRandom} />
+          </Button>
+        </OverlayTrigger>
+      )}
+    </Dropdown>
+  );
+};

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1241,5 +1241,5 @@ ul.selectable-list {
       background-color: unset;
       border: unset;
     }
-  }  
+  }
 }

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1214,3 +1214,32 @@ ul.selectable-list {
     top: 0;
   }
 }
+
+.sort-by-select .dropdown-menu {
+  min-width: 250px;
+  padding-top: 0;
+
+  .sort-by-filter-container {
+    background-color: $secondary;
+    border-bottom: solid 1px $textfield-bg;
+    display: flex;
+    padding: 5px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
+    .clearable-input-group {
+      flex-grow: 1;
+    }
+
+    .clearable-text-field {
+      background-color: $textfield-bg;
+      width: 100%;
+    }
+
+    .clearable-text-field-clear {
+      background-color: unset;
+      border: unset;
+    }
+  }  
+}


### PR DESCRIPTION
## Description

There is a growing number of sort by options, and the list is becoming very long. This PR adds a text filter to the sort by select dropdown. Incidentally moves the sort by selector into its own file. Text field is focused when sort by dropdown is opened on non-touch devices.

Currently, the filter does _not_ clear after selecting or closing the dropdown. I can change this here or in a follow up PR based on user testing.

## Testing

- opened sort by select dropdown and ensured that entering text into the field filters the available options.
- selected items, and closed dropdown without selecting to test filter text persistence between opening

## Screenshots

Before:
<img width="346" height="521" alt="image" src="https://github.com/user-attachments/assets/e45c3a2b-2c44-464a-86fb-ff54f25887fb" />
After:
<img width="378" height="520" alt="image" src="https://github.com/user-attachments/assets/620ed249-3f9d-4a1d-aaa8-2504dc27c152" />

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

## Additional Context
I have a follow up branch to pin options to the top of the list.

