### PR TITLE
Add credentials step to initial setup wizard

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,6 +83,8 @@ When building, you can optionally prepend `flags-*` targets to the target list i
 4. In a separate terminal, run `make ui-start` to run the UI in development mode
 5. Open the UI in a browser: `http://localhost:3000/`
 
+> **⚠️ Note:** Running the UI in development mode does not support sending authentication credentials due to issues with cross-origin requests. Ensure credentials are unset on the server when running the UI in development mode.
+
 Changes to the UI code can be seen by reloading the browser page.
 
 Changes to the backend code require a server restart (`CTRL-C` in the server terminal, followed by `make server-start` again) to be seen.

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -13,6 +13,9 @@ input SetupInput {
   storeBlobsInDatabase: Boolean!
   "Empty to indicate default - only applicable if storeBlobsInDatabase is false"
   blobsLocation: String!
+  
+  initialUsername: String
+  initialPassword: String
 }
 
 enum StreamingResolutionEnum {

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -13,7 +13,7 @@ input SetupInput {
   storeBlobsInDatabase: Boolean!
   "Empty to indicate default - only applicable if storeBlobsInDatabase is false"
   blobsLocation: String!
-  
+
   initialUsername: String
   initialPassword: String
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -292,6 +292,11 @@ func (s *Manager) Setup(ctx context.Context, input SetupInput) error {
 
 	cfg.SetInterface(config.Stash, input.Stashes)
 
+	if input.InitialUsername != "" && input.InitialPassword != "" {
+		cfg.SetString(config.Username, input.InitialUsername)
+		cfg.SetPassword(input.InitialPassword)
+	}
+
 	if err := cfg.Write(); err != nil {
 		return fmt.Errorf("error writing configuration file: %v", err)
 	}

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -32,6 +32,10 @@ type SetupInput struct {
 	StoreBlobsInDatabase bool `json:"storeBlobsInDatabase"`
 	// Empty to indicate default
 	BlobsLocation string `json:"blobsLocation"`
+
+	// Initial credentials
+	InitialUsername string `json:"initialUsername"`
+	InitialPassword string `json:"initialPassword"`
 }
 
 type MigrateInput struct {

--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -55,6 +55,7 @@ import { PatchFunction } from "./patch";
 import moment from "moment/min/moment-with-locales";
 import { ErrorMessage } from "./components/Shared/ErrorMessage";
 import cx from "classnames";
+import Welcome from "./components/Setup/Welcome";
 
 const Performers = lazyComponent(
   () => import("./components/Performers/Performers")
@@ -203,7 +204,7 @@ export const App: React.FC = () => {
 
   const location = useLocation();
   const history = useHistory();
-  const setupMatch = useRouteMatch(["/setup", "/migrate"]);
+  const setupMatch = useRouteMatch(["/setup", "/migrate", "/welcome"]);
 
   // dispatch event when location changes
   useEffect(() => {
@@ -270,6 +271,7 @@ export const App: React.FC = () => {
               component={SceneDuplicateChecker}
             />
             <Route path="/setup" component={Setup} />
+            <Route path="/welcome" component={Welcome} />
             <Route path="/migrate" component={Migrate} />
             <PluginRoutes />
             <Route component={PageNotFound} />

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -9,11 +9,7 @@ import {
   InputGroup,
 } from "react-bootstrap";
 import * as GQL from "src/core/generated-graphql";
-import {
-  mutateSetup,
-  useConfigureUI,
-  useSystemStatus,
-} from "src/core/StashService";
+import { mutateSetup, useSystemStatus } from "src/core/StashService";
 import { useHistory } from "react-router-dom";
 import { useConfigurationContext } from "src/hooks/Config";
 import StashConfiguration from "../Settings/StashConfiguration";
@@ -24,9 +20,7 @@ import { FolderSelectDialog } from "../Shared/FolderSelect/FolderSelectDialog";
 import {
   faEllipsisH,
   faExclamationTriangle,
-  faQuestionCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import { releaseNotes } from "src/docs/en/ReleaseNotes";
 import { ExternalLink } from "../Shared/ExternalLink";
 
 interface ISetupContextState {
@@ -53,7 +47,7 @@ const useSetupContext = () => {
   const context = React.useContext(SetupStateContext);
 
   if (context === null) {
-    throw new Error("useSettings must be used within a SettingsContext");
+    throw new Error("useSetupContext must be used within a SetupContext");
   }
 
   return context;
@@ -672,6 +666,110 @@ const StashExclusions: React.FC<{ stash: GQL.StashConfig }> = ({ stash }) => {
   return <span>{`(excludes ${excludes.join(" and ")})`}</span>;
 };
 
+function validateUsername(username: string) {
+  if (username.trim() !== username) {
+    return false;
+  }
+
+  return true;
+}
+
+function validatePassword(username: string, password: string) {
+  if (!username) return true;
+
+  if (!password.length) return false;
+  return true;
+}
+
+const CredentialsStep: React.FC<IWizardStep> = ({ goBack, next }) => {
+  const { setupState } = useSetupContext();
+  const intl = useIntl();
+
+  const [username, setUsername] = useState(setupState.initialUsername || "");
+  const [password, setPassword] = useState(setupState.initialPassword ?? "");
+  const usernameValid = validateUsername(username);
+  const passwordValid = validatePassword(username, password);
+  const valid = usernameValid && passwordValid;
+
+  function onNext() {
+    const input: Partial<GQL.SetupInput> = {
+      initialUsername: username.trim() === "" ? undefined : username,
+      initialPassword: password === "" ? undefined : password,
+    };
+    next(input);
+  }
+
+  return (
+    <>
+      <section>
+        <h2 className="mb-3">
+          <FormattedMessage id="setup.credentials.heading" />
+        </h2>
+        <p>
+          <FormattedMessage id="setup.credentials.description" />
+        </p>
+
+        <Form.Group controlId="username">
+          <Form.Label>
+            <FormattedMessage id="login.username" />:
+          </Form.Label>
+          <Form.Control
+            className="text-input"
+            placeholder={intl.formatMessage({
+              id: "login.username",
+            })}
+            value={username}
+            onChange={(e) => setUsername(e.currentTarget.value)}
+          />
+          <Form.Control.Feedback type="invalid">
+            {!usernameValid
+              ? intl.formatMessage({ id: "setup.credentials.username_invalid" })
+              : null}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group controlId="password">
+          <Form.Label>
+            <FormattedMessage id="login.password" />:
+          </Form.Label>
+          <Form.Group id="password">
+            <Form.Control
+              className="text-input"
+              type="password"
+              placeholder={intl.formatMessage({
+                id: "login.password",
+              })}
+              value={password}
+              onChange={(e) => setPassword(e.currentTarget.value)}
+            />
+            <Form.Control.Feedback type="invalid">
+              {!passwordValid
+                ? intl.formatMessage({
+                    id: "setup.credentials.password_invalid",
+                  })
+                : null}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Form.Group>
+      </section>
+
+      <section className="mt-5">
+        <div className="d-flex justify-content-center">
+          <Button variant="secondary mx-2 p-5" onClick={() => goBack()}>
+            <FormattedMessage id="actions.previous_action" />
+          </Button>
+          <Button
+            variant="primary mx-2 p-5"
+            onClick={() => onNext()}
+            disabled={!valid}
+          >
+            <FormattedMessage id="actions.next_action" />
+          </Button>
+        </div>
+      </section>
+    </>
+  );
+};
+
 const ConfirmStep: React.FC<IWizardStep> = ({ goBack, next }) => {
   const {
     configuration,
@@ -694,6 +792,8 @@ const ConfirmStep: React.FC<IWizardStep> = ({ goBack, next }) => {
     cacheLocation,
     blobsLocation,
     storeBlobsInDatabase,
+    initialUsername,
+    initialPassword,
   } = setupState;
 
   const overrideDatabase = configuration?.general.databasePath;
@@ -787,7 +887,33 @@ const ConfirmStep: React.FC<IWizardStep> = ({ goBack, next }) => {
             </dd>
           </dl>
         )}
+        {initialUsername?.length && initialPassword?.length && (
+          <>
+            <dl>
+              <dt>
+                <FormattedMessage id="login.username" />
+              </dt>
+              <dd>
+                <code>{initialUsername}</code>
+              </dd>
+            </dl>
+            <dl>
+              <dt>
+                <FormattedMessage id="login.password" />
+              </dt>
+              <dd>
+                <code>********</code>
+              </dd>
+            </dl>
+          </>
+        )}
       </section>
+      {initialUsername?.length && initialPassword?.length && (
+        <p className="lead">
+          <Icon icon={faExclamationTriangle} className="text-warning" />
+          <FormattedMessage id="setup.confirm.password_set_warning" />
+        </p>
+      )}
       <section className="mt-5">
         <div className="d-flex justify-content-center">
           <Button variant="secondary mx-2 p-5" onClick={() => goBack()}>
@@ -845,137 +971,21 @@ const ErrorStep: React.FC<{ error: string; goBack: () => void }> = ({
   );
 };
 
-const SuccessStep: React.FC = () => {
-  const intl = useIntl();
-  const history = useHistory();
-
-  const [mutateDownloadFFMpeg] = GQL.useDownloadFfMpegMutation();
-
-  const [downloadFFmpeg, setDownloadFFmpeg] = useState(true);
-
-  const { systemStatus } = useSetupContext();
-  const status = systemStatus?.systemStatus;
-
-  function onFinishClick() {
-    if ((!status?.ffmpegPath || !status?.ffprobePath) && downloadFFmpeg) {
-      mutateDownloadFFMpeg();
-    }
-
-    history.push("/settings?tab=library");
-  }
-
-  return (
-    <>
-      <section>
-        <h2>
-          <FormattedMessage id="setup.success.your_system_has_been_created" />
-        </h2>
-        <p>
-          <FormattedMessage id="setup.success.next_config_step_one" />
-        </p>
-        <p>
-          <FormattedMessage
-            id="setup.success.next_config_step_two"
-            values={{
-              code: (chunks: string) => <code>{chunks}</code>,
-              localized_task: intl.formatMessage({
-                id: "config.categories.tasks",
-              }),
-              localized_scan: intl.formatMessage({ id: "actions.scan" }),
-            }}
-          />
-        </p>
-        {!status?.ffmpegPath || !status?.ffprobePath ? (
-          <>
-            <Alert variant="warning text-center">
-              <FormattedMessage
-                id="setup.success.missing_ffmpeg"
-                values={{
-                  code: (chunks: string) => <code>{chunks}</code>,
-                }}
-              />
-            </Alert>
-            <p>
-              <Form.Check
-                id="download-ffmpeg"
-                checked={downloadFFmpeg}
-                label={intl.formatMessage({
-                  id: "setup.success.download_ffmpeg",
-                })}
-                onChange={() => setDownloadFFmpeg(!downloadFFmpeg)}
-              />
-            </p>
-          </>
-        ) : null}
-      </section>
-      <section>
-        <h3>
-          <FormattedMessage id="setup.success.getting_help" />
-        </h3>
-        <p>
-          <FormattedMessage
-            id="setup.success.in_app_manual_explained"
-            values={{ icon: <Icon icon={faQuestionCircle} /> }}
-          />
-        </p>
-        <p>
-          <FormattedMessage
-            id="setup.success.help_links"
-            values={{ discordLink: DiscordLink, githubLink: GithubLink }}
-          />
-        </p>
-      </section>
-      <section>
-        <h3>
-          <FormattedMessage id="setup.success.support_us" />
-        </h3>
-        <p>
-          <FormattedMessage
-            id="setup.success.open_collective"
-            values={{
-              open_collective_link: (
-                <ExternalLink href="https://opencollective.com/stashapp">
-                  Open Collective
-                </ExternalLink>
-              ),
-            }}
-          />
-        </p>
-        <p>
-          <FormattedMessage id="setup.success.welcome_contrib" />
-        </p>
-      </section>
-      <section>
-        <p className="lead text-center">
-          <FormattedMessage id="setup.success.thanks_for_trying_stash" />
-        </p>
-      </section>
-      <section className="mt-5">
-        <div className="d-flex justify-content-center">
-          <Button variant="success mx-2 p-5" onClick={() => onFinishClick()}>
-            <FormattedMessage id="actions.finish" />
-          </Button>
-        </div>
-      </section>
-    </>
-  );
-};
-
 const FinishStep: React.FC<IWizardStep> = ({ goBack }) => {
   const { setupError } = useSetupContext();
 
-  if (setupError !== undefined) {
-    return <ErrorStep error={setupError} goBack={goBack} />;
+  if (!setupError) {
+    throw new Error(
+      "FinishStep should only be shown when there is a setupError"
+    );
   }
 
-  return <SuccessStep />;
+  return <ErrorStep error={setupError} goBack={goBack} />;
 };
 
 export const Setup: React.FC = () => {
   const intl = useIntl();
   const { configuration } = useConfigurationContext();
-
-  const [saveUI] = useConfigureUI();
 
   const {
     data: systemStatus,
@@ -993,6 +1003,7 @@ export const Setup: React.FC = () => {
   const steps: React.FC<IWizardStep>[] = [
     WelcomeStep,
     SetPathsStep,
+    CredentialsStep,
     ConfirmStep,
     FinishStep,
   ];
@@ -1003,24 +1014,16 @@ export const Setup: React.FC = () => {
       setCreating(true);
       setSetupError(undefined);
       await mutateSetup(setupInput as GQL.SetupInput);
-      // Set lastNoteSeen to hide release notes dialog
-      await saveUI({
-        variables: {
-          input: {
-            ...configuration?.ui,
-            lastNoteSeen: releaseNotes[0].date,
-          },
-        },
-      });
+      history.replace("/welcome");
     } catch (e) {
       if (e instanceof Error && e.message) {
         setSetupError(e.message);
       } else {
         setSetupError(String(e));
       }
+      setStep(step + 1);
     } finally {
       setCreating(false);
-      setStep(step + 1);
     }
   }
 
@@ -1053,8 +1056,8 @@ export const Setup: React.FC = () => {
     systemStatus &&
     systemStatus.systemStatus.status !== GQL.SystemStatusEnum.Setup
   ) {
-    // redirect to main page
-    history.push("/");
+    // redirect to welcome page
+    history.push("/welcome");
     return <LoadingIndicator />;
   }
 

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -20,6 +20,8 @@ import { FolderSelectDialog } from "../Shared/FolderSelect/FolderSelectDialog";
 import {
   faEllipsisH,
   faExclamationTriangle,
+  faEye,
+  faEyeSlash,
 } from "@fortawesome/free-solid-svg-icons";
 import { ExternalLink } from "../Shared/ExternalLink";
 
@@ -681,6 +683,49 @@ function validatePassword(username: string, password: string) {
   return true;
 }
 
+const PasswordField: React.FC<{
+  password: string;
+  setPassword: React.Dispatch<React.SetStateAction<string>>;
+  isInvalid?: boolean;
+}> = ({ password, setPassword, isInvalid }) => {
+  const [showPassword, setShowPassword] = useState(false);
+  const intl = useIntl();
+
+  const type = showPassword ? "text" : "password";
+  const hideShowTextID = showPassword ? "actions.hide" : "actions.show";
+  const icon = showPassword ? faEyeSlash : faEye;
+
+  return (
+    <div className="password-field-group">
+      <Form.Control
+        className="text-input"
+        type={type}
+        placeholder={intl.formatMessage({
+          id: "login.password",
+        })}
+        value={password}
+        onChange={(e) => setPassword(e.currentTarget.value)}
+        isInvalid={isInvalid}
+      />
+      <Button
+        variant="secondary"
+        onClick={() => setShowPassword(!showPassword)}
+        title={intl.formatMessage({ id: hideShowTextID })}
+        className="show-password-button"
+      >
+        <Icon icon={icon} />
+      </Button>
+      <Form.Control.Feedback type="invalid">
+        {isInvalid
+          ? intl.formatMessage({
+              id: "setup.credentials.password_invalid",
+            })
+          : null}
+      </Form.Control.Feedback>
+    </div>
+  );
+};
+
 const CredentialsStep: React.FC<IWizardStep> = ({ goBack, next }) => {
   const { setupState } = useSetupContext();
   const intl = useIntl();
@@ -733,23 +778,11 @@ const CredentialsStep: React.FC<IWizardStep> = ({ goBack, next }) => {
             <FormattedMessage id="login.password" />:
           </Form.Label>
           <Form.Group id="password">
-            <Form.Control
-              className="text-input"
-              type="password"
-              placeholder={intl.formatMessage({
-                id: "login.password",
-              })}
-              value={password}
-              onChange={(e) => setPassword(e.currentTarget.value)}
+            <PasswordField
+              password={password}
+              setPassword={setPassword}
               isInvalid={!passwordValid}
             />
-            <Form.Control.Feedback type="invalid">
-              {!passwordValid
-                ? intl.formatMessage({
-                    id: "setup.credentials.password_invalid",
-                  })
-                : null}
-            </Form.Control.Feedback>
           </Form.Group>
         </Form.Group>
       </section>

--- a/ui/v2.5/src/components/Setup/Setup.tsx
+++ b/ui/v2.5/src/components/Setup/Setup.tsx
@@ -720,6 +720,7 @@ const CredentialsStep: React.FC<IWizardStep> = ({ goBack, next }) => {
             })}
             value={username}
             onChange={(e) => setUsername(e.currentTarget.value)}
+            isInvalid={!usernameValid}
           />
           <Form.Control.Feedback type="invalid">
             {!usernameValid
@@ -740,6 +741,7 @@ const CredentialsStep: React.FC<IWizardStep> = ({ goBack, next }) => {
               })}
               value={password}
               onChange={(e) => setPassword(e.currentTarget.value)}
+              isInvalid={!passwordValid}
             />
             <Form.Control.Feedback type="invalid">
               {!passwordValid

--- a/ui/v2.5/src/components/Setup/Welcome.tsx
+++ b/ui/v2.5/src/components/Setup/Welcome.tsx
@@ -1,0 +1,214 @@
+import React, { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { Alert, Button, Card, Container, Form } from "react-bootstrap";
+import * as GQL from "src/core/generated-graphql";
+import { useConfigureUI, useSystemStatus } from "src/core/StashService";
+import { useHistory } from "react-router-dom";
+import { useConfigurationContext } from "src/hooks/Config";
+import { Icon } from "../Shared/Icon";
+import { LoadingIndicator } from "../Shared/LoadingIndicator";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { releaseNotes } from "src/docs/en/ReleaseNotes";
+import { ExternalLink } from "../Shared/ExternalLink";
+
+const DiscordLink = (
+  <ExternalLink href="https://discord.gg/2TsNFKt">Discord</ExternalLink>
+);
+const GithubLink = (
+  <ExternalLink href="https://github.com/stashapp/stash/issues">
+    <FormattedMessage id="setup.github_repository" />
+  </ExternalLink>
+);
+
+const SuccessStep: React.FC<{
+  configuration: GQL.ConfigDataFragment;
+  systemStatus: GQL.SystemStatusQuery;
+}> = ({ configuration, systemStatus }) => {
+  const intl = useIntl();
+  const history = useHistory();
+
+  const [mutateDownloadFFMpeg] = GQL.useDownloadFfMpegMutation();
+  const [saveUI] = useConfigureUI();
+
+  const [downloadFFmpeg, setDownloadFFmpeg] = useState(true);
+
+  const status = systemStatus?.systemStatus;
+
+  async function markReleaseNotesSeen() {
+    try {
+      // Set lastNoteSeen to hide release notes dialog
+      await saveUI({
+        variables: {
+          input: {
+            ...configuration?.ui,
+            lastNoteSeen: releaseNotes[0].date,
+          },
+        },
+      });
+    } catch (_e) {
+      // ignore
+    }
+  }
+
+  async function onFinishClick() {
+    await markReleaseNotesSeen();
+
+    if ((!status?.ffmpegPath || !status?.ffprobePath) && downloadFFmpeg) {
+      await mutateDownloadFFMpeg();
+    }
+
+    history.replace("/settings?tab=library");
+  }
+
+  return (
+    <>
+      <section>
+        <h2>
+          <FormattedMessage id="setup.success.your_system_has_been_created" />
+        </h2>
+        <p>
+          <FormattedMessage id="setup.success.next_config_step_one" />
+        </p>
+        <p>
+          <FormattedMessage
+            id="setup.success.next_config_step_two"
+            values={{
+              code: (chunks: string) => <code>{chunks}</code>,
+              localized_task: intl.formatMessage({
+                id: "config.categories.tasks",
+              }),
+              localized_scan: intl.formatMessage({ id: "actions.scan" }),
+            }}
+          />
+        </p>
+        {!status?.ffmpegPath || !status?.ffprobePath ? (
+          <>
+            <Alert variant="warning text-center">
+              <FormattedMessage
+                id="setup.success.missing_ffmpeg"
+                values={{
+                  code: (chunks: string) => <code>{chunks}</code>,
+                }}
+              />
+            </Alert>
+            <p>
+              <Form.Check
+                id="download-ffmpeg"
+                checked={downloadFFmpeg}
+                label={intl.formatMessage({
+                  id: "setup.success.download_ffmpeg",
+                })}
+                onChange={() => setDownloadFFmpeg(!downloadFFmpeg)}
+              />
+            </p>
+          </>
+        ) : null}
+      </section>
+      <section>
+        <h3>
+          <FormattedMessage id="setup.success.getting_help" />
+        </h3>
+        <p>
+          <FormattedMessage
+            id="setup.success.in_app_manual_explained"
+            values={{ icon: <Icon icon={faQuestionCircle} /> }}
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="setup.success.help_links"
+            values={{ discordLink: DiscordLink, githubLink: GithubLink }}
+          />
+        </p>
+      </section>
+      <section>
+        <h3>
+          <FormattedMessage id="setup.success.support_us" />
+        </h3>
+        <p>
+          <FormattedMessage
+            id="setup.success.open_collective"
+            values={{
+              open_collective_link: (
+                <ExternalLink href="https://opencollective.com/stashapp">
+                  Open Collective
+                </ExternalLink>
+              ),
+            }}
+          />
+        </p>
+        <p>
+          <FormattedMessage id="setup.success.welcome_contrib" />
+        </p>
+      </section>
+      <section>
+        <p className="lead text-center">
+          <FormattedMessage id="setup.success.thanks_for_trying_stash" />
+        </p>
+      </section>
+      <section className="mt-5">
+        <div className="d-flex justify-content-center">
+          <Button variant="success mx-2 p-5" onClick={() => onFinishClick()}>
+            <FormattedMessage id="actions.finish" />
+          </Button>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export const Welcome: React.FC = () => {
+  const { configuration } = useConfigurationContext();
+
+  const {
+    data: systemStatus,
+    loading: statusLoading,
+    error: statusError,
+  } = useSystemStatus();
+
+  if (statusLoading) {
+    return <LoadingIndicator />;
+  }
+
+  if (statusError) {
+    return (
+      <Container>
+        <Alert variant="danger">
+          <FormattedMessage
+            id="setup.errors.unable_to_retrieve_system_status"
+            values={{ error: statusError.message }}
+          />
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (!configuration || !systemStatus) {
+    return (
+      <Container>
+        <Alert variant="danger">
+          <FormattedMessage
+            id="setup.errors.unable_to_retrieve_configuration"
+            values={{ error: "configuration or systemStatus === undefined" }}
+          />
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="setup-wizard">
+      <h1 className="text-center">
+        <FormattedMessage id="setup.stash_setup_wizard" />
+      </h1>
+      <Card>
+        <SuccessStep
+          systemStatus={systemStatus}
+          configuration={configuration}
+        />
+      </Card>
+    </Container>
+  );
+};
+
+export default Welcome;

--- a/ui/v2.5/src/components/Setup/styles.scss
+++ b/ui/v2.5/src/components/Setup/styles.scss
@@ -35,4 +35,35 @@
   #password {
     max-width: 300px;
   }
+
+  .password-field-group {
+    align-items: stretch;
+    display: flex;
+    flex-wrap: wrap;
+    position: relative;
+
+    .show-password-button {
+      background-color: transparent;
+      border-color: transparent;
+      bottom: 0;
+      color: $muted-gray;
+      font-size: 0.875rem;
+      margin: 0.375rem 0.75rem;
+      padding: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 4;
+
+      &:hover,
+      &:focus,
+      &:active,
+      &:not(:disabled):not(.disabled):active,
+      &:not(:disabled):not(.disabled):active:focus {
+        background-color: transparent;
+        border-color: transparent;
+        box-shadow: none;
+      }
+    }
+  }
 }

--- a/ui/v2.5/src/components/Setup/styles.scss
+++ b/ui/v2.5/src/components/Setup/styles.scss
@@ -30,4 +30,9 @@
     margin-bottom: 1rem;
     margin-top: 0;
   }
+
+  #username,
+  #password {
+    max-width: 300px;
+  }
 }

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1459,6 +1459,12 @@
   "seconds": "Seconds",
   "settings": "Settings",
   "setup": {
+    "credentials": {
+      "description": "Enter the username and password you want to use to login to stash system. These can be left blank if you do not want to enter a username/password to access the system. Credentials are mandatory for systems accessible from public internet.",
+      "heading": "Setup your credentials",
+      "password_invalid": "Password must be non-empty if username is set.",
+      "username_invalid": "Username must not have any leading or trailing whitespace."
+    },
     "confirm": {
       "almost_ready": "We're almost ready to complete the configuration. Please confirm the following settings. You can click back to change anything incorrect. If everything looks good, click Confirm to create your system.",
       "blobs_directory": "Binary data directory",
@@ -1468,6 +1474,7 @@
       "database_file_path": "Database file path",
       "generated_directory": "Generated directory",
       "nearly_there": "Nearly there!",
+      "password_set_warning": "Note: you will be asked to enter your credentials after the system is created.",
       "stash_library_directories": "Stash library directories"
     },
     "creating": {

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1460,7 +1460,7 @@
   "settings": "Settings",
   "setup": {
     "credentials": {
-      "description": "Enter the username and password you want to use to login to stash system. These can be left blank if you do not want to enter a username/password to access the system. Credentials are required if you are accessing the system from the public internet.",
+      "description": "Enter the username and password you want to use to login to Stash system. These can be left blank if you do not want to enter a username/password to access the system. Credentials are required if you are accessing the system from the public internet.",
       "heading": "Setup your credentials",
       "password_invalid": "Password must be non-empty if username is set.",
       "username_invalid": "Username must not have any leading or trailing whitespace."

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1460,7 +1460,7 @@
   "settings": "Settings",
   "setup": {
     "credentials": {
-      "description": "Enter the username and password you want to use to login to stash system. These can be left blank if you do not want to enter a username/password to access the system. Credentials are mandatory for systems accessible from public internet.",
+      "description": "Enter the username and password you want to use to login to stash system. These can be left blank if you do not want to enter a username/password to access the system. Credentials are required if you are accessing the system from the public internet.",
       "heading": "Setup your credentials",
       "password_invalid": "Password must be non-empty if username is set.",
       "username_invalid": "Username must not have any leading or trailing whitespace."


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description

Adds a step to the setup wizard to setup an initial username and password. This closes some janky behaviour for public-facing systems where (presumably) the security tripwire would be fired after setup since there's no way to set the credentials during the setup phase.

Credentials step occurs after the paths step and before the confirmation step. If populated, username and masked password are shown on the confirmation page. It also includes a warning indicating that login will be required after clicking finish if the credentials are set.

Includes incidental separation of the welcome page into a separate file and route entry, since the login redirect would otherwise lose the welcome page.

## Testing

Created a new system a few times, with and without credentials.

## Screenshots

<img width="1690" height="791" alt="image" src="https://github.com/user-attachments/assets/fe397cfd-22f7-4a2b-90df-ca6b8a459a16" />

<img width="1685" height="519" alt="image" src="https://github.com/user-attachments/assets/14289965-8c37-4482-8432-e252c4b4b45b" />