### PR TITLE
Support pinning sort by options to top of list

### DIFF
--- a/ui/v2.5/src/components/List/FilteredListToolbar.tsx
+++ b/ui/v2.5/src/components/List/FilteredListToolbar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { QueryResult } from "@apollo/client";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
@@ -19,6 +19,9 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { faSquareCheck } from "@fortawesome/free-regular-svg-icons";
 import { useIntl } from "react-intl";
 import cx from "classnames";
+import { useConfigurationContext } from "src/hooks/Config";
+import { useConfigureUI } from "src/core/StashService";
+import { useToast } from "src/hooks/Toast";
 
 const SelectionSection: React.FC<{
   filter: ListFilterModel;
@@ -99,6 +102,62 @@ export const FilteredListToolbar: React.FC<IFilteredListToolbar> = ({
   filterable = true,
   sortable = true,
 }) => {
+  const { configuration } = useConfigurationContext();
+  const { pinnedSortBy = {} } = configuration.ui;
+
+  const Toast = useToast();
+
+  const [saveUI] = useConfigureUI();
+
+  const pinnedOptions = useMemo(
+    () => (view ? (pinnedSortBy[view] ?? []) : []),
+    [view, pinnedSortBy]
+  );
+
+  const updatePinnedSortBy = useCallback(
+    async (value: string[]) => {
+      if (!view) {
+        return;
+      }
+
+      try {
+        await saveUI({
+          variables: {
+            input: {
+              ...configuration?.ui,
+              pinnedSortBy: {
+                ...configuration?.ui.pinnedSortBy,
+                [view]: value,
+              },
+            },
+          },
+        });
+      } catch (e) {
+        Toast.error(e);
+      }
+    },
+    [view, saveUI, configuration.ui, Toast]
+  );
+
+  const togglePinSortBy = useCallback(
+    (sortBy: string) => {
+      if (!view) {
+        return;
+      }
+
+      let newPinned: string[];
+
+      if (pinnedOptions.includes(sortBy)) {
+        newPinned = pinnedOptions.filter((s) => s !== sortBy);
+      } else {
+        newPinned = [...pinnedOptions, sortBy];
+      }
+
+      updatePinnedSortBy(newPinned);
+    },
+    [view, pinnedOptions, updatePinnedSortBy]
+  );
+
   const filterOptions = filter.options;
   // Something in the popper layout for groups.sub-groups tab to double calculates the offset
   // causing the dropdown to be misaligned. Portal to document.body to fix this.
@@ -161,6 +220,8 @@ export const FilteredListToolbar: React.FC<IFilteredListToolbar> = ({
               sortBy={filter.sortBy}
               sortDirection={filter.sortDirection}
               options={filterOptions.sortByOptions}
+              pinnedOptions={pinnedOptions}
+              togglePinSortBy={togglePinSortBy}
               onChangeSortBy={(e) =>
                 setFilter(filter.setSortBy(e ?? undefined))
               }

--- a/ui/v2.5/src/components/List/SortBySelect.tsx
+++ b/ui/v2.5/src/components/List/SortBySelect.tsx
@@ -15,6 +15,7 @@ import {
   faCaretDown,
   faCaretUp,
   faRandom,
+  faThumbtack,
 } from "@fortawesome/free-solid-svg-icons";
 import { ISortByOption } from "src/models/list-filter/filter-options";
 import { useConfigurationContext } from "src/hooks/Config";
@@ -22,11 +23,18 @@ import ClearableInput from "../Shared/ClearableInput";
 import useFocus from "src/utils/focus";
 import ScreenUtils from "src/utils/screen";
 
+interface IMessageValue {
+  value: string;
+  message: string;
+}
+
 export const SortBySelect: React.FC<{
   className?: string;
   sortBy: string | undefined;
   sortDirection: SortDirectionEnum;
   options: ISortByOption[];
+  pinnedOptions?: string[];
+  togglePinSortBy?: (sortBy: string) => void;
   onChangeSortBy: (eventKey: string | null) => void;
   onChangeSortDirection: () => void;
   onReshuffleRandomSort: () => void;
@@ -35,6 +43,8 @@ export const SortBySelect: React.FC<{
   sortBy,
   sortDirection,
   options,
+  pinnedOptions = [],
+  togglePinSortBy,
   onChangeSortBy,
   onChangeSortDirection,
   onReshuffleRandomSort,
@@ -56,7 +66,7 @@ export const SortBySelect: React.FC<{
       : (currentSortBy.sfwMessageID ?? currentSortBy.messageID)
     : "";
 
-  const sortedOptions = useMemo(() => {
+  const sortedOptions: IMessageValue[] = useMemo(() => {
     return options
       .map((o) => {
         const messageID = !sfwContentMode
@@ -78,19 +88,57 @@ export const SortBySelect: React.FC<{
     );
   }, [sortedOptions, filter]);
 
+  const filteredPinnedOptions = useMemo(() => {
+    return filteredOptions.filter((o) => pinnedOptions.includes(o.value));
+  }, [filteredOptions, pinnedOptions]);
+
+  const unpinnedOptions = useMemo(() => {
+    return filteredOptions.filter((o) => !pinnedOptions.includes(o.value));
+  }, [filteredOptions, pinnedOptions]);
+
   const dropdownItems = useMemo(() => {
-    return filteredOptions.map((option) => (
-      <Dropdown.Item
-        onSelect={onChangeSortBy}
-        key={option.value}
-        className="bg-secondary text-white"
-        eventKey={option.value}
-        data-value={option.value}
-      >
-        {option.message}
-      </Dropdown.Item>
-    ));
-  }, [filteredOptions, onChangeSortBy]);
+    function togglePin(
+      e: React.MouseEvent<HTMLElement>,
+      option: IMessageValue
+    ) {
+      e.stopPropagation();
+      e.preventDefault();
+      togglePinSortBy?.(option.value);
+    }
+
+    function renderOptionMessage(option: IMessageValue, isPin: boolean) {
+      return (
+        <Dropdown.Item
+          onSelect={onChangeSortBy}
+          key={option.value}
+          className="bg-secondary text-white sort-by-option"
+          eventKey={option.value}
+          data-value={option.value}
+        >
+          {option.message}
+          {togglePinSortBy && (
+            <Button
+              className="pin-sort-by-button"
+              variant="minimal"
+              onClick={(e) => togglePin(e, option)}
+            >
+              <Icon icon={faThumbtack} className={isPin ? "" : "tilted"} />
+            </Button>
+          )}
+        </Dropdown.Item>
+      );
+    }
+
+    return (
+      <>
+        {filteredPinnedOptions.map((option) =>
+          renderOptionMessage(option, true)
+        )}
+        {filteredPinnedOptions.length > 0 && <Dropdown.Divider />}
+        {unpinnedOptions.map((option) => renderOptionMessage(option, false))}
+      </>
+    );
+  }, [filteredPinnedOptions, unpinnedOptions, onChangeSortBy, togglePinSortBy]);
 
   return (
     <Dropdown

--- a/ui/v2.5/src/components/List/styles.scss
+++ b/ui/v2.5/src/components/List/styles.scss
@@ -1219,6 +1219,11 @@ ul.selectable-list {
   min-width: 250px;
   padding-top: 0;
 
+  .dropdown-divider {
+    border-top-color: $textfield-bg;
+    margin: 0.25rem 0;
+  }
+
   .sort-by-filter-container {
     background-color: $secondary;
     border-bottom: solid 1px $textfield-bg;
@@ -1240,6 +1245,35 @@ ul.selectable-list {
     .clearable-text-field-clear {
       background-color: unset;
       border: unset;
+    }
+  }
+
+  .sort-by-option {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding-right: 0;
+
+    .pin-sort-by-button {
+      border: 0;
+      color: $text-color;
+      font-size: 0.8rem;
+      margin-left: 0.5rem;
+      padding-bottom: 0;
+      padding-top: 0;
+      visibility: hidden;
+
+      @media (pointer: coarse) {
+        visibility: visible;
+      }
+
+      &:hover svg {
+        transform: rotate(0);
+      }
+    }
+
+    &:hover .pin-sort-by-button {
+      visibility: visible;
     }
   }
 }

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -103,6 +103,7 @@ export interface IUIConfig {
 
   pinnedFilters?: Record<string, string[]>;
   tableColumns?: Record<string, string[]>;
+  pinnedSortBy?: Record<string, string[]>;
 
   advancedMode?: boolean;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
Follow up to #7078. Allows pinning sort by options to the top of the list. Pinned items are saved per view, so this means that pinned sort options for the main scenes page will be separate to those in studio -> scenes view, for example. Pragmatically, we could probably save them per list type, but saving per view adds a little more flexibility at the expense of having to manually pin items in multiple views.

Adds a pin button to the right of the sort option. On non-touch devices, the pin button is hidden until the item is moused over. Like the filter pin buttons, the pin rotated diagonally for unpinned items, and faces down for pinned items - it also faces down when the button is moused over. On touch devices, the pin buttons are all visible.

There is a subtle divider between pinned and unpinned items.

Pinned items are saved in the UI config.

Text filter is applied to both pinned and unpinned items.

## Testing

- pinned and unpinned sort options
- checked presentation on desktop and emulated phone environments

## Screenshots

<img width="377" height="518" alt="image" src="https://github.com/user-attachments/assets/ed410f25-3794-4931-bed4-15f67e0450f1" />

Here the first six items shown are pinned, with the `Path` option moused over showing the pin button.

<img width="368" height="519" alt="image" src="https://github.com/user-attachments/assets/1dbbd4fb-c7c6-4402-998a-c11b6c87fcf9" />

On touch devices, all pin buttons are shown, and you can see the pinned and unpinned button icons.

