### PR TITLE
Fix lightbox jumping to a page's last image when crossing a page boundary

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -144,7 +144,19 @@ export const LightboxComponent: React.FC<IProps> = ({
   const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
 
-  const oldImages = useRef<ILightboxImage[]>([]);
+  // An in-flight page switch's intended landing, set synchronously by the nav
+  // handlers / chapter jump *before* pageCallback. The landing is an explicit
+  // target — "first"/"last"/a chapter index — NOT derived from the page-number
+  // direction (a wrap moves the page number opposite to nav direction, so
+  // deriving from direction breaks first/last wraparound). It is resolved to a
+  // concrete index by the settle effect once the new page has loaded.
+  const pendingTarget = useRef<"first" | "last" | number | null>(null);
+  // The page number at switch start. The settle effect treats the switch as
+  // complete when the page number changes (the parent swaps page + images in one
+  // update) — a reliable trigger, unlike comparing the images array identity,
+  // which also changes on same-page refetch/reopen and could fire the settle
+  // early, consuming the switch before the new page arrived.
+  const switchFromPage = useRef<number | undefined>(page);
 
   const [zoom, setZoom] = useState(1);
 
@@ -266,25 +278,37 @@ export const LightboxComponent: React.FC<IProps> = ({
     useState<string>((slideshowDelay / SECONDS_TO_MS).toString());
 
   useEffect(() => {
-    if (images !== oldImages.current && isSwitchingPage) {
-      // The new page's images have arrived. Resolve the handler's intended
-      // landing: a -1 sentinel (set by a backward cross or a backward wrap)
-      // means the new page's last image; any other value is the handler's own
-      // target — 0 for a forward cross/wrap, indexInPage for a chapter jump —
-      // and is kept as-is. Clear the ref synchronously so the index-range
-      // effect can resume guarding same-page shrinks.
-      if (index === -1) setIndex(images.length - 1);
-      // Pin the baseline to the page we just settled. Without this, on engines
-      // where the parent's new `images` and the handler's local setIndex(-1)
-      // land in *different* commits, this effect can fire on the new images
-      // before the -1 has applied, clear isSwitchingPage early, and then the -1
-      // renders (a stray "0 / N"). Re-pinning makes the guard below false until
-      // the next switch actually swaps the array.
-      oldImages.current = images;
+    const target = pendingTarget.current;
+    if (target !== null) {
+      // A page switch is in flight. It completes when the page NUMBER changes:
+      // the parent updates page + images together, so a changed page number
+      // means the new page's images are present. Resolve the handler's explicit
+      // landing then — "last"/"first"/a chapter index — and only then drop the
+      // switch flags. The target is never derived from the page-number
+      // direction, so first/last wraparound and chapter jumps land on the right
+      // image regardless of which way the page number moved.
+      if (page !== switchFromPage.current) {
+        setIndex(
+          target === "last"
+            ? images.length - 1
+            : target === "first"
+              ? 0
+              : target
+        );
+        pendingTarget.current = null;
+        switchFromPage.current = page;
+        isSwitchingPageRef.current = false;
+        setIsSwitchingPage(false);
+      }
+      return;
+    }
+    // No switch pending: clear the switching flag once the first page's images
+    // have loaded (the flag starts true on open so the loader shows until then).
+    if (isSwitchingPage && !isLoading && images.length > 0) {
       isSwitchingPageRef.current = false;
       setIsSwitchingPage(false);
     }
-  }, [isSwitchingPage, images, index]);
+  }, [isSwitchingPage, isLoading, images, page]);
 
   const disableInstantTransition = useDebounce(
     () => setInstantTransition(false),
@@ -394,7 +418,7 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const handleLeft = useCallback(
     (isUserAction = true) => {
-      if (isSwitchingPageRef.current || index === -1) return;
+      if (isSwitchingPageRef.current) return;
 
       if (disableAnimation) {
         setInstant();
@@ -405,16 +429,22 @@ export const LightboxComponent: React.FC<IProps> = ({
 
       if (index === 0) {
         // go to previous page, or loop back if no callback is set. Raise the
-        // guard and set the target index *before* pageCallback: an
+        // guard and record the landing intent *before* pageCallback: an
         // already-cached page can swap its images in synchronously, so the
         // guard must be up first or a rapid input (and the index-range effect)
-        // races the swap. -1 is the sentinel the settle effect resolves to the
-        // new page's last image.
+        // races the swap. "last" is resolved by the settle effect to the new
+        // page's last image once the page number changes — no index is pre-set,
+        // so there is no transient sentinel index to leak into render.
         if (pageCallback) {
           isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
-          setIndex(-1);
-          oldImages.current = images;
+          switchFromPage.current = page;
+          pendingTarget.current = "last";
+          // Park the index at a value that is valid on any non-empty page (0)
+          // while the new page loads. The settle effect moves it to the target
+          // once the page arrives; parking it keeps it in range so the
+          // index-range clamp can't fire on a shorter incoming page.
+          setIndex(0);
           pageCallback({ direction: -1 });
         } else setIndex(images.length - 1);
       } else setIndex((index ?? 0) - 1);
@@ -423,7 +453,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, index, disableAnimation, setInstant]
+    [images, pageCallback, index, page, disableAnimation, setInstant]
   );
 
   const handleRight = useCallback(
@@ -438,14 +468,15 @@ export const LightboxComponent: React.FC<IProps> = ({
       setShowChapters(false);
 
       if (index === images.length - 1) {
-        // go to next page, or loop back if no callback is set. Guard and target
-        // index set before pageCallback (see handleLeft): land on the new
+        // go to next page, or loop back if no callback is set. Guard and landing
+        // intent recorded before pageCallback (see handleLeft): land on the new
         // page's first image, even when a cached page swaps in synchronously.
         if (pageCallback) {
           isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
-          setIndex(0);
-          oldImages.current = images;
+          switchFromPage.current = page;
+          pendingTarget.current = "first";
+          setIndex(0); // keep in range while the page loads (see handleLeft)
           pageCallback({ direction: 1 });
         } else setIndex(0);
       } else setIndex((index ?? 0) + 1);
@@ -454,7 +485,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, index, disableAnimation, setInstant]
+    [images, pageCallback, index, page, disableAnimation, setInstant]
   );
 
   const firstScroll = useRef<number | null>(null);
@@ -595,19 +626,20 @@ export const LightboxComponent: React.FC<IProps> = ({
   }, [images.length, index, close, isLoading]);
 
   function gotoPage(imageIndex: number) {
-    // indexInPage is the handler's chosen target; the settle effect keeps it
-    // (only the -1 sentinel is remapped), so a chapter jump lands on the right
-    // image of the new page rather than its first/last.
+    // indexInPage is the chapter's explicit target; the settle effect lands on
+    // it once the new page loads, so a chapter jump lands on the right image of
+    // the new page rather than its first/last.
     const indexInPage = (imageIndex - 1) % pageSize;
     if (pageCallback) {
       const jumppage = Math.floor((imageIndex - 1) / pageSize) + 1;
       if (page !== jumppage) {
-        // Same ordering as the nav handlers: raise the guard and set the
-        // target index before pageCallback so a cached page can't race them.
+        // Same ordering as the nav handlers: raise the guard and record the
+        // landing intent before pageCallback so a cached page can't race them.
         isSwitchingPageRef.current = true;
         setIsSwitchingPage(true);
-        oldImages.current = images;
-        setIndex(indexInPage);
+        switchFromPage.current = page;
+        pendingTarget.current = indexInPage;
+        setIndex(0); // keep in range while the page loads (see handleLeft)
         pageCallback({ page: jumppage });
         setShowChapters(false);
         return;

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -126,20 +126,16 @@ export const LightboxComponent: React.FC<IProps> = ({
   const oldIndex = useRef<number | null>(null);
   const [instantTransition, setInstantTransition] = useState(false);
   const [isSwitchingPage, setIsSwitchingPage] = useState(true);
-  // Mirrors isSwitchingPage synchronously, purely to gate the nav handlers
-  // (handleLeft/handleRight, reached by both arrow keys and clicks on the
-  // chevrons / image edges): they fire on raw keydown/click events that can
-  // arrive faster than React re-renders, so reading the isSwitchingPage state
-  // from their closure is stale; the ref reflects an in-flight page switch
-  // immediately and drops the extra inputs. (Index reconciliation keys off the
-  // `page` prop, not this.)
+  // Synchronous mirror of isSwitchingPage. The nav handlers (handleLeft/
+  // handleRight, reached by the arrow keys, the on-screen chevrons and the
+  // image-edge clicks) fire on raw keydown/click events that can arrive faster
+  // than React re-renders, so the isSwitchingPage *state* they close over is
+  // stale. The ref reflects an in-flight page switch immediately — set true
+  // before pageCallback — so rapid inputs are dropped and, crucially, the
+  // index-range effect won't clamp a stale index while a (possibly
+  // synchronously-cached) page is still swapping in. The landing index stays
+  // under the handlers' control; this ref only gates, it never picks the index.
   const isSwitchingPageRef = useRef(true);
-  // Tracks the last `page` we reconciled the index for. The parent updates the
-  // `page` and `images` props together, so a change here is the reliable,
-  // race-free signal that a new page has arrived (unlike the switch ref, which
-  // a synchronously-cached page can outrun).
-  const prevPageRef = useRef(page);
-  const initialSettleRef = useRef(false);
   const [isFullscreen, setFullscreen] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [showChapters, setShowChapters] = useState(false);
@@ -147,6 +143,8 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
+
+  const oldImages = useRef<ILightboxImage[]>([]);
 
   const [zoom, setZoom] = useState(1);
 
@@ -267,6 +265,27 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [displayedSlideshowInterval, setDisplayedSlideshowInterval] =
     useState<string>((slideshowDelay / SECONDS_TO_MS).toString());
 
+  useEffect(() => {
+    if (images !== oldImages.current && isSwitchingPage) {
+      // The new page's images have arrived. Resolve the handler's intended
+      // landing: a -1 sentinel (set by a backward cross or a backward wrap)
+      // means the new page's last image; any other value is the handler's own
+      // target — 0 for a forward cross/wrap, indexInPage for a chapter jump —
+      // and is kept as-is. Clear the ref synchronously so the index-range
+      // effect can resume guarding same-page shrinks.
+      if (index === -1) setIndex(images.length - 1);
+      // Pin the baseline to the page we just settled. Without this, on engines
+      // where the parent's new `images` and the handler's local setIndex(-1)
+      // land in *different* commits, this effect can fire on the new images
+      // before the -1 has applied, clear isSwitchingPage early, and then the -1
+      // renders (a stray "0 / N"). Re-pinning makes the guard below false until
+      // the next switch actually swaps the array.
+      oldImages.current = images;
+      isSwitchingPageRef.current = false;
+      setIsSwitchingPage(false);
+    }
+  }, [isSwitchingPage, images, index]);
+
   const disableInstantTransition = useDebounce(
     () => setInstantTransition(false),
     400
@@ -385,14 +404,17 @@ export const LightboxComponent: React.FC<IProps> = ({
       setMovingLeft(true);
 
       if (index === 0) {
-        // go to previous page, or loop back if no callback is set. Set the nav
-        // guard before pageCallback so rapid presses during the switch are
-        // dropped even if the page is cached and swaps in synchronously. The
-        // landing index is reconciled by the page-change effect.
+        // go to previous page, or loop back if no callback is set. Raise the
+        // guard and set the target index *before* pageCallback: an
+        // already-cached page can swap its images in synchronously, so the
+        // guard must be up first or a rapid input (and the index-range effect)
+        // races the swap. -1 is the sentinel the settle effect resolves to the
+        // new page's last image.
         if (pageCallback) {
           isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
           setIndex(-1);
+          oldImages.current = images;
           pageCallback({ direction: -1 });
         } else setIndex(images.length - 1);
       } else setIndex((index ?? 0) - 1);
@@ -416,14 +438,14 @@ export const LightboxComponent: React.FC<IProps> = ({
       setShowChapters(false);
 
       if (index === images.length - 1) {
-        // go to next page, or loop back if no callback is set. Set the nav guard
-        // before pageCallback so rapid presses during the switch are dropped even
-        // if the page is cached and swaps in synchronously. The landing index is
-        // reconciled by the page-change effect.
+        // go to next page, or loop back if no callback is set. Guard and target
+        // index set before pageCallback (see handleLeft): land on the new
+        // page's first image, even when a cached page swaps in synchronously.
         if (pageCallback) {
           isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
           setIndex(0);
+          oldImages.current = images;
           pageCallback({ direction: 1 });
         } else setIndex(0);
       } else setIndex((index ?? 0) + 1);
@@ -558,49 +580,37 @@ export const LightboxComponent: React.FC<IProps> = ({
     if (isLoading) return;
     if (images.length === 0) {
       close();
-      return;
-    }
-
-    const prevPage = prevPageRef.current;
-    if (page !== prevPage) {
-      // A page switch delivered a new page. `page` and `images` update together,
-      // so keying off the page change (rather than the switch ref, which a
-      // synchronously-cached page can outrun) reconciles the index race-free.
-      // Land on the new page's first image going forward, its last going back.
-      prevPageRef.current = page;
-      if (prevPage !== undefined && page !== undefined && page < prevPage) {
-        setIndex(images.length - 1);
-      } else {
-        setIndex(0);
-      }
-      isSwitchingPageRef.current = false;
-      setIsSwitchingPage(false);
-      return;
-    }
-
-    // First settle after open: clear the initial switching state once the images
-    // exist (index is left for the initialIndex effect — don't reset it here).
-    if (!initialSettleRef.current) {
-      initialSettleRef.current = true;
-      isSwitchingPageRef.current = false;
-      setIsSwitchingPage(false);
-    }
-
-    // Same page: keep a now-out-of-range index valid, e.g. when the last image
-    // was deleted and findImages refetched a shorter list.
-    if (index !== null && index >= images.length) {
+    } else if (
+      !isSwitchingPageRef.current &&
+      index !== null &&
+      index >= images.length
+    ) {
+      // Same-page shrink only — e.g. the last image was deleted and findImages
+      // refetched a shorter list. While a page switch is in flight the index is
+      // transiently stale against a just-swapped, shorter page; clamping it
+      // here is what made a forward cross land on the page's *last* image. The
+      // settle effect reconciles the switch instead, so skip the clamp then.
       setIndex(images.length - 1);
     }
-  }, [page, images, index, close, isLoading]);
+  }, [images.length, index, close, isLoading]);
 
   function gotoPage(imageIndex: number) {
+    // indexInPage is the handler's chosen target; the settle effect keeps it
+    // (only the -1 sentinel is remapped), so a chapter jump lands on the right
+    // image of the new page rather than its first/last.
     const indexInPage = (imageIndex - 1) % pageSize;
     if (pageCallback) {
       const jumppage = Math.floor((imageIndex - 1) / pageSize) + 1;
       if (page !== jumppage) {
+        // Same ordering as the nav handlers: raise the guard and set the
+        // target index before pageCallback so a cached page can't race them.
         isSwitchingPageRef.current = true;
         setIsSwitchingPage(true);
+        oldImages.current = images;
+        setIndex(indexInPage);
         pageCallback({ page: jumppage });
+        setShowChapters(false);
+        return;
       }
     }
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -140,23 +140,51 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [showOptions, setShowOptions] = useState(false);
   const [showChapters, setShowChapters] = useState(false);
   const [imagesLoaded, setImagesLoaded] = useState(0);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  // The image the delete dialog acts on, captured when the dialog is opened.
+  // Reading images[currentIndex] at confirm time instead would delete whatever
+  // image the index has since moved to (e.g. a page-switch settle landing
+  // while the dialog is open).
+  const [deleteTarget, setDeleteTarget] = useState<ILightboxImage | null>(null);
   const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
 
-  // An in-flight page switch's intended landing, set synchronously by the nav
-  // handlers / chapter jump *before* pageCallback. The landing is an explicit
-  // target — "first"/"last"/a chapter index — NOT derived from the page-number
-  // direction (a wrap moves the page number opposite to nav direction, so
-  // deriving from direction breaks first/last wraparound). It is resolved to a
-  // concrete index by the settle effect once the new page has loaded.
-  const pendingTarget = useRef<"first" | "last" | number | null>(null);
-  // The page number at switch start. The settle effect treats the switch as
-  // complete when the page number changes (the parent swaps page + images in one
-  // update) — a reliable trigger, unlike comparing the images array identity,
-  // which also changes on same-page refetch/reopen and could fire the settle
-  // early, consuming the switch before the new page arrived.
+  // An in-flight page switch's intended landing, set synchronously by
+  // startPageSwitch *before* pageCallback. The landing is an explicit target —
+  // "last" or a concrete index (0 for a forward cross) — NOT derived from the
+  // page-number direction (a wrap moves the page number opposite to nav
+  // direction, so deriving from direction breaks first/last wraparound). It is
+  // resolved by the settle effect once the new page has loaded.
+  const pendingTarget = useRef<"last" | number | null>(null);
+  // The page number and images array at switch start, used by the settle
+  // effect to detect the new page's arrival.
   const switchFromPage = useRef<number | undefined>(page);
+  const switchFromImages = useRef<ILightboxImage[]>(images);
+
+  // The ref and the state must never disagree, so they are only written
+  // through this setter.
+  const setSwitching = useCallback((v: boolean) => {
+    isSwitchingPageRef.current = v;
+    setIsSwitchingPage(v);
+  }, []);
+
+  // Begin a page switch: raise the guard and record the landing intent
+  // *before* pageCallback. An already-cached page can swap its images in
+  // synchronously, so the guard must be up first or a rapid input (and the
+  // index-range effect) races the swap. The index is parked at 0 — valid on
+  // any non-empty page — while the new page loads, so the index-range clamp
+  // can't fire on a shorter incoming page; the settle effect moves it to the
+  // target once the page arrives.
+  const startPageSwitch = useCallback(
+    (target: "last" | number, cbArg: { direction?: number; page?: number }) => {
+      setSwitching(true);
+      switchFromPage.current = page;
+      switchFromImages.current = images;
+      pendingTarget.current = target;
+      setIndex(0);
+      pageCallback?.(cbArg);
+    },
+    [images, page, pageCallback, setSwitching]
+  );
 
   const [zoom, setZoom] = useState(1);
 
@@ -280,35 +308,39 @@ export const LightboxComponent: React.FC<IProps> = ({
   useEffect(() => {
     const target = pendingTarget.current;
     if (target !== null) {
-      // A page switch is in flight. It completes when the page NUMBER changes:
-      // the parent updates page + images together, so a changed page number
-      // means the new page's images are present. Resolve the handler's explicit
-      // landing then — "last"/"first"/a chapter index — and only then drop the
-      // switch flags. The target is never derived from the page-number
-      // direction, so first/last wraparound and chapter jumps land on the right
-      // image regardless of which way the page number moved.
-      if (page !== switchFromPage.current) {
-        setIndex(
+      // A page switch is in flight. It completes when the page number AND the
+      // images array have both changed: the parent delivers them together, and
+      // requiring both means a parent that updates the page a commit ahead of
+      // the images can't settle the switch against the outgoing page's array.
+      // Callers that provide pageCallback without a page prop can never change
+      // the page number, so for them fall back to the images identity alone.
+      const pageChanged = page !== switchFromPage.current;
+      const imagesChanged = images !== switchFromImages.current;
+      const settled =
+        page === undefined ? imagesChanged : pageChanged && imagesChanged;
+      if (settled) {
+        // Resolve the landing, clamped to the arrived page: a chapter's
+        // numeric target can be stale (images deleted since the chapters
+        // loaded), and "last" is -1 on an empty page (which the close effect
+        // then handles).
+        const resolved =
           target === "last"
             ? images.length - 1
-            : target === "first"
-              ? 0
-              : target
-        );
+            : Math.min(target, images.length - 1);
+        setIndex(Math.max(0, resolved));
         pendingTarget.current = null;
         switchFromPage.current = page;
-        isSwitchingPageRef.current = false;
-        setIsSwitchingPage(false);
+        switchFromImages.current = images;
+        setSwitching(false);
       }
       return;
     }
     // No switch pending: clear the switching flag once the first page's images
     // have loaded (the flag starts true on open so the loader shows until then).
     if (isSwitchingPage && !isLoading && images.length > 0) {
-      isSwitchingPageRef.current = false;
-      setIsSwitchingPage(false);
+      setSwitching(false);
     }
-  }, [isSwitchingPage, isLoading, images, page]);
+  }, [isSwitchingPage, isLoading, images, page, setSwitching]);
 
   const disableInstantTransition = useDebounce(
     () => setInstantTransition(false),
@@ -428,24 +460,10 @@ export const LightboxComponent: React.FC<IProps> = ({
       setMovingLeft(true);
 
       if (index === 0) {
-        // go to previous page, or loop back if no callback is set. Raise the
-        // guard and record the landing intent *before* pageCallback: an
-        // already-cached page can swap its images in synchronously, so the
-        // guard must be up first or a rapid input (and the index-range effect)
-        // races the swap. "last" is resolved by the settle effect to the new
-        // page's last image once the page number changes — no index is pre-set,
-        // so there is no transient sentinel index to leak into render.
+        // go to previous page (landing on its last image), or loop back if no
+        // callback is set
         if (pageCallback) {
-          isSwitchingPageRef.current = true;
-          setIsSwitchingPage(true);
-          switchFromPage.current = page;
-          pendingTarget.current = "last";
-          // Park the index at a value that is valid on any non-empty page (0)
-          // while the new page loads. The settle effect moves it to the target
-          // once the page arrives; parking it keeps it in range so the
-          // index-range clamp can't fire on a shorter incoming page.
-          setIndex(0);
-          pageCallback({ direction: -1 });
+          startPageSwitch("last", { direction: -1 });
         } else setIndex(images.length - 1);
       } else setIndex((index ?? 0) - 1);
 
@@ -453,7 +471,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, index, page, disableAnimation, setInstant]
+    [images, pageCallback, index, disableAnimation, setInstant, startPageSwitch]
   );
 
   const handleRight = useCallback(
@@ -468,16 +486,10 @@ export const LightboxComponent: React.FC<IProps> = ({
       setShowChapters(false);
 
       if (index === images.length - 1) {
-        // go to next page, or loop back if no callback is set. Guard and landing
-        // intent recorded before pageCallback (see handleLeft): land on the new
-        // page's first image, even when a cached page swaps in synchronously.
+        // go to next page (landing on its first image), or loop back if no
+        // callback is set
         if (pageCallback) {
-          isSwitchingPageRef.current = true;
-          setIsSwitchingPage(true);
-          switchFromPage.current = page;
-          pendingTarget.current = "first";
-          setIndex(0); // keep in range while the page loads (see handleLeft)
-          pageCallback({ direction: 1 });
+          startPageSwitch(0, { direction: 1 });
         } else setIndex(0);
       } else setIndex((index ?? 0) + 1);
 
@@ -485,7 +497,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, index, page, disableAnimation, setInstant]
+    [images, pageCallback, index, disableAnimation, setInstant, startPageSwitch]
   );
 
   const firstScroll = useRef<number | null>(null);
@@ -503,15 +515,17 @@ export const LightboxComponent: React.FC<IProps> = ({
       if (e.key === "ArrowLeft") handleLeft();
       else if (e.key === "ArrowRight") handleRight();
       else if (e.key === "Escape") close();
-      else if (
-        e.key === "d" &&
-        images[index ?? initialIndex]?.id !== undefined
-      ) {
-        const now = Date.now();
-        if (now - lastDKeyTime.current < 1000) {
-          setIsDeleteDialogOpen(true);
+      else if (e.key === "d") {
+        // Not while a page switch is in flight: the index is parked at 0 then,
+        // so the shortcut would target an image the user isn't viewing.
+        const image = images[index ?? initialIndex];
+        if (!isSwitchingPageRef.current && image?.id !== undefined) {
+          const now = Date.now();
+          if (now - lastDKeyTime.current < 1000) {
+            setDeleteTarget(image);
+          }
+          lastDKeyTime.current = now;
         }
-        lastDKeyTime.current = now;
       }
     },
     [setInstant, handleLeft, handleRight, close, images, index, initialIndex]
@@ -633,14 +647,7 @@ export const LightboxComponent: React.FC<IProps> = ({
     if (pageCallback) {
       const jumppage = Math.floor((imageIndex - 1) / pageSize) + 1;
       if (page !== jumppage) {
-        // Same ordering as the nav handlers: raise the guard and record the
-        // landing intent before pageCallback so a cached page can't race them.
-        isSwitchingPageRef.current = true;
-        setIsSwitchingPage(true);
-        switchFromPage.current = page;
-        pendingTarget.current = indexInPage;
-        setIndex(0); // keep in range while the page loads (see handleLeft)
-        pageCallback({ page: jumppage });
+        startPageSwitch(indexInPage, { page: jumppage });
         setShowChapters(false);
         return;
       }
@@ -1083,7 +1090,7 @@ export const LightboxComponent: React.FC<IProps> = ({
                   {currentImage.id !== undefined && (
                     <Button
                       className="minimal delete-button"
-                      onClick={() => setIsDeleteDialogOpen(true)}
+                      onClick={() => setDeleteTarget(currentImage)}
                       title={intl.formatMessage({ id: "actions.delete" })}
                     >
                       <Icon icon={faTrash} />
@@ -1121,17 +1128,17 @@ export const LightboxComponent: React.FC<IProps> = ({
       onClick={handleClose}
     >
       {renderBody()}
-      {isDeleteDialogOpen && images[currentIndex]?.id !== undefined && (
+      {deleteTarget?.id !== undefined && (
         <DeleteImagesDialog
           selected={[
             {
-              id: images[currentIndex].id!,
-              visual_files: images[currentIndex].visual_files ?? [],
+              id: deleteTarget.id,
+              visual_files: deleteTarget.visual_files ?? [],
             },
           ]}
           onClose={(confirmed) => {
-            setIsDeleteDialogOpen(false);
-            if (confirmed) onDeleteImage?.(images[currentIndex].id!);
+            setDeleteTarget(null);
+            if (confirmed) onDeleteImage?.(deleteTarget.id!);
           }}
         />
       )}

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -126,6 +126,20 @@ export const LightboxComponent: React.FC<IProps> = ({
   const oldIndex = useRef<number | null>(null);
   const [instantTransition, setInstantTransition] = useState(false);
   const [isSwitchingPage, setIsSwitchingPage] = useState(true);
+  // Mirrors isSwitchingPage synchronously, purely to gate the nav handlers
+  // (handleLeft/handleRight, reached by both arrow keys and clicks on the
+  // chevrons / image edges): they fire on raw keydown/click events that can
+  // arrive faster than React re-renders, so reading the isSwitchingPage state
+  // from their closure is stale; the ref reflects an in-flight page switch
+  // immediately and drops the extra inputs. (Index reconciliation keys off the
+  // `page` prop, not this.)
+  const isSwitchingPageRef = useRef(true);
+  // Tracks the last `page` we reconciled the index for. The parent updates the
+  // `page` and `images` props together, so a change here is the reliable,
+  // race-free signal that a new page has arrived (unlike the switch ref, which
+  // a synchronously-cached page can outrun).
+  const prevPageRef = useRef(page);
+  const initialSettleRef = useRef(false);
   const [isFullscreen, setFullscreen] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [showChapters, setShowChapters] = useState(false);
@@ -133,8 +147,6 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
-
-  const oldImages = useRef<ILightboxImage[]>([]);
 
   const [zoom, setZoom] = useState(1);
 
@@ -255,13 +267,6 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [displayedSlideshowInterval, setDisplayedSlideshowInterval] =
     useState<string>((slideshowDelay / SECONDS_TO_MS).toString());
 
-  useEffect(() => {
-    if (images !== oldImages.current && isSwitchingPage) {
-      if (index === -1) setIndex(images.length - 1);
-      setIsSwitchingPage(false);
-    }
-  }, [isSwitchingPage, images, index]);
-
   const disableInstantTransition = useDebounce(
     () => setInstantTransition(false),
     400
@@ -370,7 +375,7 @@ export const LightboxComponent: React.FC<IProps> = ({
 
   const handleLeft = useCallback(
     (isUserAction = true) => {
-      if (isSwitchingPage || index === -1) return;
+      if (isSwitchingPageRef.current || index === -1) return;
 
       if (disableAnimation) {
         setInstant();
@@ -380,12 +385,15 @@ export const LightboxComponent: React.FC<IProps> = ({
       setMovingLeft(true);
 
       if (index === 0) {
-        // go to next page, or loop back if no callback is set
+        // go to previous page, or loop back if no callback is set. Set the nav
+        // guard before pageCallback so rapid presses during the switch are
+        // dropped even if the page is cached and swaps in synchronously. The
+        // landing index is reconciled by the page-change effect.
         if (pageCallback) {
-          pageCallback({ direction: -1 });
-          setIndex(-1);
-          oldImages.current = images;
+          isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
+          setIndex(-1);
+          pageCallback({ direction: -1 });
         } else setIndex(images.length - 1);
       } else setIndex((index ?? 0) - 1);
 
@@ -393,12 +401,12 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, isSwitchingPage, index, disableAnimation, setInstant]
+    [images, pageCallback, index, disableAnimation, setInstant]
   );
 
   const handleRight = useCallback(
     (isUserAction = true) => {
-      if (isSwitchingPage) return;
+      if (isSwitchingPageRef.current) return;
 
       if (disableAnimation) {
         setInstant();
@@ -408,12 +416,15 @@ export const LightboxComponent: React.FC<IProps> = ({
       setShowChapters(false);
 
       if (index === images.length - 1) {
-        // go to preview page, or loop back if no callback is set
+        // go to next page, or loop back if no callback is set. Set the nav guard
+        // before pageCallback so rapid presses during the switch are dropped even
+        // if the page is cached and swaps in synchronously. The landing index is
+        // reconciled by the page-change effect.
         if (pageCallback) {
-          pageCallback({ direction: 1 });
-          oldImages.current = images;
+          isSwitchingPageRef.current = true;
           setIsSwitchingPage(true);
           setIndex(0);
+          pageCallback({ direction: 1 });
         } else setIndex(0);
       } else setIndex((index ?? 0) + 1);
 
@@ -421,7 +432,7 @@ export const LightboxComponent: React.FC<IProps> = ({
         resetIntervalCallback.current();
       }
     },
-    [images, pageCallback, isSwitchingPage, index, disableAnimation, setInstant]
+    [images, pageCallback, index, disableAnimation, setInstant]
   );
 
   const firstScroll = useRef<number | null>(null);
@@ -547,19 +558,49 @@ export const LightboxComponent: React.FC<IProps> = ({
     if (isLoading) return;
     if (images.length === 0) {
       close();
-    } else if (index !== null && index >= images.length) {
+      return;
+    }
+
+    const prevPage = prevPageRef.current;
+    if (page !== prevPage) {
+      // A page switch delivered a new page. `page` and `images` update together,
+      // so keying off the page change (rather than the switch ref, which a
+      // synchronously-cached page can outrun) reconciles the index race-free.
+      // Land on the new page's first image going forward, its last going back.
+      prevPageRef.current = page;
+      if (prevPage !== undefined && page !== undefined && page < prevPage) {
+        setIndex(images.length - 1);
+      } else {
+        setIndex(0);
+      }
+      isSwitchingPageRef.current = false;
+      setIsSwitchingPage(false);
+      return;
+    }
+
+    // First settle after open: clear the initial switching state once the images
+    // exist (index is left for the initialIndex effect — don't reset it here).
+    if (!initialSettleRef.current) {
+      initialSettleRef.current = true;
+      isSwitchingPageRef.current = false;
+      setIsSwitchingPage(false);
+    }
+
+    // Same page: keep a now-out-of-range index valid, e.g. when the last image
+    // was deleted and findImages refetched a shorter list.
+    if (index !== null && index >= images.length) {
       setIndex(images.length - 1);
     }
-  }, [images.length, index, close, isLoading]);
+  }, [page, images, index, close, isLoading]);
 
   function gotoPage(imageIndex: number) {
     const indexInPage = (imageIndex - 1) % pageSize;
     if (pageCallback) {
       const jumppage = Math.floor((imageIndex - 1) / pageSize) + 1;
       if (page !== jumppage) {
-        pageCallback({ page: jumppage });
-        oldImages.current = images;
+        isSwitchingPageRef.current = true;
         setIsSwitchingPage(true);
+        pageCallback({ page: jumppage });
       }
     }
 

--- a/ui/v2.5/src/hooks/Lightbox/hooks.ts
+++ b/ui/v2.5/src/hooks/Lightbox/hooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import * as GQL from "src/core/generated-graphql";
+import { useToast } from "../Toast";
 import { IState, useLightboxContext } from "./context";
 import { IChapter } from "./types";
 
@@ -69,6 +70,7 @@ interface ILightboxGallery {
 
 export const useGalleriesLightbox = () => {
   const { setLightboxState } = useLightboxContext();
+  const Toast = useToast();
 
   const pageSize = 40;
   const [fetchImages, { data }] = GQL.useFindImagesLazyQuery();
@@ -112,29 +114,36 @@ export const useGalleriesLightbox = () => {
           },
         },
       },
-    }).then((result) => {
-      // ignore if a different gallery was opened in the meantime
-      if (active.current !== current) return;
+    })
+      .then((result) => {
+        // ignore if a different gallery was opened in the meantime
+        if (active.current !== current) return;
 
-      const totalCount = result.data?.findImages.count ?? 0;
-      const pages = Math.ceil(totalCount / pageSize);
-      current.page = page;
-      current.pages = pages;
+        const totalCount = result.data?.findImages.count ?? 0;
+        const pages = Math.ceil(totalCount / pageSize);
+        current.page = page;
+        current.pages = pages;
 
-      setLightboxState({
-        isLoading: false,
-        isVisible: true,
-        images: result.data?.findImages?.images ?? [],
-        pageCallback: pages > 1 ? handleLightBoxPage : undefined,
-        page,
-        pages,
-        pageSize,
-        totalCount,
-        chapters: current.chapters,
-        slideshowEnabled: current.slideshowEnabled,
-        slideshowAutostart: current.slideshowAutostart,
+        setLightboxState({
+          isLoading: false,
+          isVisible: true,
+          images: result.data?.findImages?.images ?? [],
+          pageCallback: pages > 1 ? handleLightBoxPage : undefined,
+          page,
+          pages,
+          pageSize,
+          totalCount,
+          chapters: current.chapters,
+          slideshowEnabled: current.slideshowEnabled,
+          slideshowAutostart: current.slideshowAutostart,
+        });
+      })
+      .catch((e) => {
+        // A failed page load leaves the lightbox on its loader: the page and
+        // images props never change, so an in-flight switch cannot settle.
+        // Surface the error so the stall is at least explained.
+        Toast.error(e);
       });
-    });
   }
 
   function handleLightBoxPage(props: { direction?: number; page?: number }) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

In a paginated gallery's lightbox, navigating across a page boundary could land on the **last** image of the new page instead of the first (e.g. on a 77-image gallery the indicator jumps to `37 / 37` / `Page 2 / 2`, the last image of page 2, rather than `1 / 37`, its first). It reproduces when navigating quickly across the boundary — forward, back, then forward again — and once the adjacent page is cached, with both the keyboard and the on-screen arrows.

Two compounding races in `Lightbox.tsx` cause it:

1. `handleLeft`/`handleRight` run on raw keydown/click events, which can arrive faster than React re-renders, so they read a **stale** `isSwitchingPage` (and `index`) from their closure — the page-switch guard didn't actually block the rapid presses/clicks.
2. `pageCallback(...)` was called **before** the handler set its guard and reset the index. When the adjacent page is already cached, it swaps `images` in *synchronously*, producing a render with the old index against the new, shorter page; the index-range effect then clamped that stale index to `images.length - 1` — the last image.

The fix reconciles the index off the **`page` prop** instead of the timing-sensitive switch flag. The parent updates `page` and `images` together, so a `page` change is a race-free signal to land on the new page's first image (forward) or last (backward). The out-of-range clamp now only runs for a genuine same-page shrink (e.g. a deleted image). A synchronous ref still mirrors `isSwitchingPage` solely to drop rapid inputs mid-switch, and it (plus the target index) is now set **before** `pageCallback` so a cached page can't outrun it.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7082 

## Testing
<!-- Describe the testing steps you have performed. -->

Manually, in a real browser, on a gallery of 77 images (two pages of 40):

- Open the lightbox at image 40 (last of page 1), then **forward → back → forward** across the boundary, quickly. Before: jumps to the last image of page 2, image 77 (`37 / 37`). After: lands on the first image, image 41 (`1 / 37`), every time.
- Repeated with the on-screen ‹ › arrows (and image-edge clicks) — same result; the path is shared with the keyboard.
- Checked single forward and backward crossings, multi-press runs, and rapid mashing at a range of speeds — always lands on the page's first/last image, never the far end.
- Verified normal navigation, opening at a specific image, and the slider→close→reopen flow are unchanged.
- Reproduced/verified on Chromium, Firefox and WebKit.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

not applicable

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used [Claude Code](https://claude.ai/code) as a coding assistant for this fix. It helped reproduce the race in a real browser, trace the render-by-render cause (the navigation handlers reading stale state on rapid input, and an already-cached page swapping its images in synchronously before the index reset — after which the index-range guard clamped the stale index onto the shorter page), and implement the page-keyed reconciliation. I directed the investigation and the approach, reviewed all changes, and manually verified the behavior on a running instance — crossing the page boundary forward/back/forward with both the keyboard and the on-screen arrows.

## Additional Context
<!-- Add any other context about the pull request here. -->

Single commit, one file (`ui/v2.5/src/hooks/Lightbox/Lightbox.tsx`); removes the now-unused `oldImages` ref and the old switch-clear effect, folding their job into the page-keyed index reconciliation. No schema or API changes.