### PR TITLE
Show a global image position counter in the lightbox

### DIFF
--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -212,6 +212,7 @@ interface IImageListImages {
   selectedIds: Set<string>;
   onChangePage: (page: number) => void;
   pageCount: number;
+  totalCount: number;
   onSelectChange: (id: string, selected: boolean, shiftKey: boolean) => void;
   slideshowRunning: boolean;
   setSlideshowRunning: (running: boolean) => void;
@@ -226,6 +227,7 @@ const ImageList: React.FC<IImageListImages> = PatchComponent(
     selectedIds,
     onChangePage,
     pageCount,
+    totalCount,
     onSelectChange,
     slideshowRunning,
     setSlideshowRunning,
@@ -269,12 +271,14 @@ const ImageList: React.FC<IImageListImages> = PatchComponent(
         page: filter.currentPage,
         pages: pageCount,
         pageSize: filter.itemsPerPage,
+        totalCount,
         slideshowEnabled: slideshowRunning,
         onClose: handleClose,
       };
     }, [
       images,
       pageCount,
+      totalCount,
       filter.currentPage,
       filter.itemsPerPage,
       slideshowRunning,
@@ -769,6 +773,7 @@ export const FilteredImageList = PatchComponent(
             onChangePage={setPage}
             onSelectChange={onSelectChange}
             pageCount={pageCount}
+            totalCount={totalCount}
             selectedIds={selectedIds}
             slideshowRunning={slideshowRunning}
             setSlideshowRunning={setSlideshowRunning}

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -95,6 +95,7 @@ interface IProps {
   page?: number;
   pages?: number;
   pageSize?: number;
+  totalCount?: number;
   pageCallback?: (props: { direction?: number; page?: number }) => void;
   chapters?: IChapter[];
   hide: () => void;
@@ -110,8 +111,8 @@ export const LightboxComponent: React.FC<IProps> = ({
   slideshowEnabled = false,
   slideshowAutostart = false,
   page,
-  pages,
   pageSize = 40,
+  totalCount,
   pageCallback,
   chapters = [],
   hide,
@@ -790,26 +791,20 @@ export const LightboxComponent: React.FC<IProps> = ({
       }
     }
 
-    const pageHeader =
-      page && pages
-        ? intl.formatMessage(
-            { id: "dialogs.lightbox.page_header" },
-            { page, total: pages }
-          )
-        : "";
+    const currentNumber =
+      page !== undefined
+        ? (page - 1) * pageSize + currentIndex + 1
+        : currentIndex + 1;
+    const displayTotal = totalCount ?? images.length;
 
     return (
       <>
         <div className={CLASSNAME_HEADER}>
           <div className={CLASSNAME_LEFT_SPACER}>{renderChapterMenu()}</div>
           <div className={CLASSNAME_INDICATOR}>
-            <span>
-              {chapterHeader()} {pageHeader}
-            </span>
-            {images.length > 1 ? (
-              <b ref={indicatorRef}>{`${currentIndex + 1} / ${
-                images.length
-              }`}</b>
+            <span>{chapterHeader()}</span>
+            {displayTotal > 1 ? (
+              <b ref={indicatorRef}>{`${currentNumber} / ${displayTotal}`}</b>
             ) : undefined}
           </div>
           <div className={CLASSNAME_RIGHT}>

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -15,6 +15,7 @@ export interface IState {
   page?: number;
   pages?: number;
   pageSize?: number;
+  totalCount?: number;
   slideshowEnabled: boolean;
   slideshowAutostart?: boolean;
   onClose?: () => void;

--- a/ui/v2.5/src/hooks/Lightbox/hooks.ts
+++ b/ui/v2.5/src/hooks/Lightbox/hooks.ts
@@ -17,6 +17,7 @@ export const useLightbox = (
       page: state.page,
       pages: state.pages,
       pageSize: state.pageSize,
+      totalCount: state.totalCount,
       slideshowEnabled: state.slideshowEnabled,
       onClose: state.onClose,
     });
@@ -28,6 +29,7 @@ export const useLightbox = (
     state.page,
     state.pages,
     state.pageSize,
+    state.totalCount,
     state.slideshowEnabled,
     state.onClose,
   ]);
@@ -40,10 +42,18 @@ export const useLightbox = (
         page: props.page ?? state.page,
         pages: props.pages ?? state.pages,
         pageSize: props.pageSize ?? state.pageSize,
+        totalCount: props.totalCount ?? state.totalCount,
         chapters: chapters,
       });
     },
-    [setLightboxState, state.page, state.pages, state.pageSize, chapters]
+    [
+      setLightboxState,
+      state.page,
+      state.pages,
+      state.pageSize,
+      state.totalCount,
+      chapters,
+    ]
   );
   return show;
 };
@@ -83,7 +93,9 @@ export const useGalleriesLightbox = () => {
     if (!active.current) return;
     const images = data?.findImages?.images;
     if (!images) return;
-    setLightboxState({ images });
+    // totalCount drives the lightbox position counter; keep it in sync with the
+    // live query so it stays correct after edits that refetch (e.g. deletion).
+    setLightboxState({ images, totalCount: data?.findImages.count });
   }, [data, setLightboxState]);
 
   function loadPage(page: number) {
@@ -117,6 +129,7 @@ export const useGalleriesLightbox = () => {
         page,
         pages,
         pageSize,
+        totalCount,
         chapters: current.chapters,
         slideshowEnabled: current.slideshowEnabled,
         slideshowAutostart: current.slideshowAutostart,

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1039,7 +1039,6 @@
         "original": "Original"
       },
       "options": "Options",
-      "page_header": "Page {page} / {total}",
       "reset_zoom_on_nav": "Reset zoom level when changing image",
       "scale_up": {
         "description": "Scale smaller images up to fill screen.",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The lightbox image indicator is currently per-page: on a paginated gallery it shows a "Page X / Y" header plus a "15 / 40" counter that resets every page. This replaces both with a single global position counter ("55 / 200") spanning the whole gallery.

The total comes from the server-reported image count (`findImages.count`), threaded through the lightbox state as `totalCount`. It is set when a page loads and kept in sync by the live-query effect, so it stays correct after edits that refetch `findImages` (e.g. deleting an image). For non-paginated lightboxes `totalCount` is unset and `images.length` is used, preserving the previous behaviour.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #4315

## Testing
<!-- Describe the testing steps you have performed. -->

- Manually drove the web UI in a real browser (vite dev server against a local backend).
- Paginated gallery of 77 images (two pages of 40):
  - Opening image 1 shows `1 / 77` with no "Page X / Y" header.
  - Opening the last image of page 1 shows the global `40 / 77` (not `40 / 40`).
  - Pressing ArrowRight crosses to page 2 (triggering the page-2 refetch) and the counter continues to `41 / 77` rather than resetting.
- Single-page gallery of 10 images shows `1 / 10`.
- Confirmed the same behaviour on Chromium, Firefox and WebKit.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

Before:
<img width="73" height="43" alt="before" src="https://github.com/user-attachments/assets/bc255b16-610a-4cd0-b6ab-be1967f4ef68" />

After:
<img width="52" height="28" alt="after" src="https://github.com/user-attachments/assets/39d19732-bf3b-412c-9073-53e019c16769" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used [Claude Code](https://claude.ai/code) as a coding assistant for this PR. It helped explore the lightbox's paginated state and implement the approach — threading the server-reported total (`findImages.count`) through the lightbox state as `totalCount` across the gallery and image-list entry points, and replacing the per-page "Page X / Y" header and counter with a single global indicator — and with rebasing the change onto current develop and verifying the behaviour in a browser. I directed the design decisions, reviewed all changes, and manually verified the behaviour on a running instance (the global count across page boundaries, single-page galleries, and that it stays correct after edits that refetch `findImages`).

## Additional Context
<!-- Add any other context about the pull request here. -->

