### PR TITLE
Add Rating Keyboard Shortcuts for Images

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -142,6 +142,11 @@
 | `→` | Next image |
 | `Escape` | Close lightbox |
 | `d d` | Delete current image |
+| Ratings ||
+| `r {1-5}` | Set rating (stars) |
+| `r 0` | Unset rating (stars) |
+| `r {0-9} {0-9}` | Set rating (decimal - `00` for `10.0`) |
+| ``r ` `` | Unset rating (decimal) |
 
 ## Groups page shortcuts
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Button,
   Col,
@@ -15,6 +21,7 @@ import Mousetrap from "mousetrap";
 import { Icon } from "src/components/Shared/Icon";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import useInterval from "../Interval";
+import { useRatingKeybinds } from "../keybinds";
 import usePageVisibility from "../PageVisibility";
 import { useToast } from "../Toast";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -146,7 +153,6 @@ export const LightboxComponent: React.FC<IProps> = ({
   // image the index has since moved to (e.g. a page-switch settle landing
   // while the dialog is open).
   const [deleteTarget, setDeleteTarget] = useState<ILightboxImage | null>(null);
-  const lastDKeyTime = useRef<number>(0);
   const [navOffset, setNavOffset] = useState<React.CSSProperties | undefined>();
 
   // An in-flight page switch's intended landing, set synchronously by
@@ -186,6 +192,17 @@ export const LightboxComponent: React.FC<IProps> = ({
     },
     [images, page, pageCallback, setSwitching]
   );
+
+  // The lightbox pauses the global Mousetrap singleton while open, so it owns a
+  // separate (non-paused) instance for its own sequence shortcuts (ratings,
+  // "d d"). The mousetrap-pause plugin tracks `paused` per-instance, so this
+  // instance keeps firing while global shortcuts stay suppressed.
+  const mousetrap = useMemo(() => new Mousetrap(), []);
+  useEffect(() => {
+    return () => {
+      mousetrap.reset();
+    };
+  }, [mousetrap]);
 
   const [zoom, setZoom] = useState(1);
 
@@ -536,20 +553,8 @@ export const LightboxComponent: React.FC<IProps> = ({
       if (e.key === "ArrowLeft") handleLeft();
       else if (e.key === "ArrowRight") handleRight();
       else if (e.key === "Escape") close();
-      else if (e.key === "d") {
-        // Not while a page switch is in flight: the index is parked at 0 then,
-        // so the shortcut would target an image the user isn't viewing.
-        const image = images[index ?? initialIndex];
-        if (!isSwitchingPageRef.current && image?.id !== undefined) {
-          const now = Date.now();
-          if (now - lastDKeyTime.current < 1000) {
-            setDeleteTarget(image);
-          }
-          lastDKeyTime.current = now;
-        }
-      }
     },
-    [setInstant, handleLeft, handleRight, close, images, index, initialIndex]
+    [setInstant, handleLeft, handleRight, close]
   );
 
   const [clearCallback, resetCallback] = useInterval(
@@ -637,6 +642,49 @@ export const LightboxComponent: React.FC<IProps> = ({
   };
 
   const currentIndex = index === null ? initialIndex : index;
+  const currentImageId = images[currentIndex]?.id;
+
+  function setRating(v: number | null) {
+    if (currentImageId) {
+      updateImage({
+        variables: {
+          input: {
+            id: currentImageId,
+            rating100: v,
+          },
+        },
+      });
+    }
+  }
+
+  // Rating shortcuts ("r" then digit(s)) via the lightbox-scoped Mousetrap
+  // instance, reusing the same hook as the scene/image detail pages.
+  useRatingKeybinds(
+    isVisible,
+    config?.ui.ratingSystemOptions?.type,
+    (v) => setRating(Number.isNaN(v) ? null : v),
+    mousetrap
+  );
+
+  // "d d" delete shortcut, using Mousetrap's native sequence binding (matching
+  // the rest of the app) on the lightbox-scoped instance. Rebinding on
+  // currentImageId change resets Mousetrap's own sequence tracking, so a "d"
+  // press on one image can't combine with a second "d" press after
+  // navigating to another.
+  useEffect(() => {
+    if (!isVisible || currentImageId === undefined) return;
+
+    mousetrap.bind("d d", () => {
+      // Not while a page switch is in flight: the index is parked at 0 then,
+      // so the shortcut would target an image the user isn't viewing.
+      if (isSwitchingPageRef.current) return;
+      const image = images[currentIndex];
+      if (image?.id !== undefined) setDeleteTarget(image);
+    });
+    return () => {
+      mousetrap.unbind("d d");
+    };
+  }, [isVisible, currentImageId, images, currentIndex, mousetrap]);
 
   useEffect(() => {
     // Don't auto-close while images are still loading. Some entry points open
@@ -861,19 +909,6 @@ export const LightboxComponent: React.FC<IProps> = ({
 
     const currentImage: ILightboxImage | undefined = images[currentIndex];
     const title = currentImage ? imageTitle(currentImage) : undefined;
-
-    function setRating(v: number | null) {
-      if (currentImage?.id) {
-        updateImage({
-          variables: {
-            input: {
-              id: currentImage.id,
-              rating100: v,
-            },
-          },
-        });
-      }
-    }
 
     async function onIncrementClick() {
       if (currentImage?.id === undefined) return;

--- a/ui/v2.5/src/hooks/keybinds.ts
+++ b/ui/v2.5/src/hooks/keybinds.ts
@@ -2,86 +2,56 @@ import Mousetrap from "mousetrap";
 import { useEffect, useRef } from "react";
 import { RatingSystemType } from "src/utils/rating";
 
+const starRatingShortcuts: { [char: string]: number } = {
+  "0": NaN,
+  "1": 20,
+  "2": 40,
+  "3": 60,
+  "4": 80,
+  "5": 100,
+};
+
+type RatingSequenceMode = "idle" | "star" | "decimal";
+
 export function useRatingKeybinds(
   isVisible: boolean,
   ratingSystem: RatingSystemType | undefined,
   setRating: (v: number) => void,
   mousetrap: Pick<Mousetrap.MousetrapInstance, "bind" | "unbind"> = Mousetrap
 ) {
+  // setRating/ratingSystem are recreated every render by every caller (they
+  // close over the currently displayed entity). Reading them through refs,
+  // updated unconditionally on each render, lets the bind effect below key
+  // only off isVisible/mousetrap while still always acting on the latest
+  // values -- rebinding "r" itself isn't needed to pick up a fresh setRating.
+  const setRatingRef = useRef(setRating);
+  setRatingRef.current = setRating;
+  const ratingSystemRef = useRef(ratingSystem);
+  ratingSystemRef.current = ratingSystem;
+
+  const mode = useRef<RatingSequenceMode>("idle");
   const firstChar = useRef<string | undefined>(undefined);
-  const ratingTimeout = useRef<ReturnType<typeof setTimeout>>();
-
-  // (Re)start the 1s window after each "r"-initiated sequence, cancelling any
-  // pending unbind. Without this, pressing "r" again before the window elapses
-  // leaves the earlier timeout scheduled, which then unbinds the digit keys
-  // mid-sequence and drops the next keypress (e.g. a quick "r 3" then "r 4").
-  function restartRatingTimeout(unbind: () => void) {
-    if (ratingTimeout.current) clearTimeout(ratingTimeout.current);
-    ratingTimeout.current = setTimeout(() => {
-      ratingTimeout.current = undefined;
-      unbind();
-    }, 1000);
-  }
-
-  const starRatingShortcuts: { [char: string]: number } = {
-    "0": NaN,
-    "1": 20,
-    "2": 40,
-    "3": 60,
-    "4": 80,
-    "5": 100,
-  };
-
-  function handleStarRatingKeybinds() {
-    for (const key in starRatingShortcuts) {
-      mousetrap.bind(key, () => setRating(starRatingShortcuts[key]));
-    }
-
-    restartRatingTimeout(() => {
-      for (const key in starRatingShortcuts) {
-        mousetrap.unbind(key);
-      }
-    });
-  }
-
-  function handleDecimalKeybinds() {
-    // start each sequence fresh so a new "r" doesn't combine with a digit left
-    // buffered from a previous, abandoned sequence
-    firstChar.current = undefined;
-
-    mousetrap.bind("`", () => {
-      setRating(NaN);
-    });
-
-    for (let i = 0; i <= 9; ++i) {
-      mousetrap.bind(i.toString(), () => {
-        if (firstChar.current !== undefined) {
-          let combined = parseInt(firstChar.current + i.toString(), 10);
-          if (combined === 0) {
-            combined = 100;
-          }
-
-          setRating(combined);
-          firstChar.current = undefined;
-        } else {
-          firstChar.current = i.toString();
-        }
-      });
-    }
-
-    restartRatingTimeout(() => {
-      firstChar.current = undefined;
-
-      mousetrap.unbind("`");
-      for (let i = 0; i <= 9; ++i) {
-        mousetrap.unbind(i.toString());
-      }
-    });
-  }
+  const sequenceTimeout = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     if (!isVisible) return;
 
+    function endSequence() {
+      mode.current = "idle";
+      firstChar.current = undefined;
+      if (sequenceTimeout.current) {
+        clearTimeout(sequenceTimeout.current);
+        sequenceTimeout.current = undefined;
+      }
+    }
+
+    // "r", the digits and "`" are bound unconditionally for isVisible's
+    // lifetime, and gate their behaviour on `mode` instead of being bound
+    // and unbound per sequence. Callers pass a setRating closure they don't
+    // memoize, so this effect only depends on isVisible/mousetrap -- if it
+    // depended on setRating too, an unrelated re-render could tear down and
+    // rebind this effect mid-sequence, unbinding the digit keys before the
+    // 1s window elapses.
     mousetrap.bind("r", () => {
       // numeric keypresses get caught by jwplayer, so blur the element
       // if the rating sequence is started
@@ -89,15 +59,53 @@ export function useRatingKeybinds(
         document.activeElement.blur();
       }
 
-      if (!ratingSystem || ratingSystem === RatingSystemType.Stars) {
-        return handleStarRatingKeybinds();
-      } else {
-        return handleDecimalKeybinds();
-      }
+      mode.current =
+        !ratingSystemRef.current ||
+        ratingSystemRef.current === RatingSystemType.Stars
+          ? "star"
+          : "decimal";
+      firstChar.current = undefined;
+
+      if (sequenceTimeout.current) clearTimeout(sequenceTimeout.current);
+      sequenceTimeout.current = setTimeout(endSequence, 1000);
     });
+
+    mousetrap.bind("`", () => {
+      if (mode.current !== "decimal") return;
+      setRatingRef.current(NaN);
+      endSequence();
+    });
+
+    for (let i = 0; i <= 9; ++i) {
+      mousetrap.bind(i.toString(), () => {
+        if (mode.current === "star") {
+          const value = starRatingShortcuts[i.toString()];
+          if (value === undefined) return;
+          setRatingRef.current(value);
+          endSequence();
+        } else if (mode.current === "decimal") {
+          if (firstChar.current !== undefined) {
+            let combined = parseInt(firstChar.current + i.toString(), 10);
+            if (combined === 0) {
+              combined = 100;
+            }
+
+            setRatingRef.current(combined);
+            endSequence();
+          } else {
+            firstChar.current = i.toString();
+          }
+        }
+      });
+    }
 
     return () => {
       mousetrap.unbind("r");
+      mousetrap.unbind("`");
+      for (let i = 0; i <= 9; ++i) {
+        mousetrap.unbind(i.toString());
+      }
+      endSequence();
     };
-  });
+  }, [isVisible, mousetrap]);
 }

--- a/ui/v2.5/src/hooks/keybinds.ts
+++ b/ui/v2.5/src/hooks/keybinds.ts
@@ -5,9 +5,23 @@ import { RatingSystemType } from "src/utils/rating";
 export function useRatingKeybinds(
   isVisible: boolean,
   ratingSystem: RatingSystemType | undefined,
-  setRating: (v: number) => void
+  setRating: (v: number) => void,
+  mousetrap: Pick<Mousetrap.MousetrapInstance, "bind" | "unbind"> = Mousetrap
 ) {
   const firstChar = useRef<string | undefined>(undefined);
+  const ratingTimeout = useRef<ReturnType<typeof setTimeout>>();
+
+  // (Re)start the 1s window after each "r"-initiated sequence, cancelling any
+  // pending unbind. Without this, pressing "r" again before the window elapses
+  // leaves the earlier timeout scheduled, which then unbinds the digit keys
+  // mid-sequence and drops the next keypress (e.g. a quick "r 3" then "r 4").
+  function restartRatingTimeout(unbind: () => void) {
+    if (ratingTimeout.current) clearTimeout(ratingTimeout.current);
+    ratingTimeout.current = setTimeout(() => {
+      ratingTimeout.current = undefined;
+      unbind();
+    }, 1000);
+  }
 
   const starRatingShortcuts: { [char: string]: number } = {
     "0": NaN,
@@ -20,23 +34,27 @@ export function useRatingKeybinds(
 
   function handleStarRatingKeybinds() {
     for (const key in starRatingShortcuts) {
-      Mousetrap.bind(key, () => setRating(starRatingShortcuts[key]));
+      mousetrap.bind(key, () => setRating(starRatingShortcuts[key]));
     }
 
-    setTimeout(() => {
+    restartRatingTimeout(() => {
       for (const key in starRatingShortcuts) {
-        Mousetrap.unbind(key);
+        mousetrap.unbind(key);
       }
-    }, 1000);
+    });
   }
 
   function handleDecimalKeybinds() {
-    Mousetrap.bind("`", () => {
+    // start each sequence fresh so a new "r" doesn't combine with a digit left
+    // buffered from a previous, abandoned sequence
+    firstChar.current = undefined;
+
+    mousetrap.bind("`", () => {
       setRating(NaN);
     });
 
     for (let i = 0; i <= 9; ++i) {
-      Mousetrap.bind(i.toString(), () => {
+      mousetrap.bind(i.toString(), () => {
         if (firstChar.current !== undefined) {
           let combined = parseInt(firstChar.current + i.toString(), 10);
           if (combined === 0) {
@@ -51,20 +69,20 @@ export function useRatingKeybinds(
       });
     }
 
-    setTimeout(() => {
+    restartRatingTimeout(() => {
       firstChar.current = undefined;
 
-      Mousetrap.unbind("`");
+      mousetrap.unbind("`");
       for (let i = 0; i <= 9; ++i) {
-        Mousetrap.unbind(i.toString());
+        mousetrap.unbind(i.toString());
       }
-    }, 1000);
+    });
   }
 
   useEffect(() => {
     if (!isVisible) return;
 
-    Mousetrap.bind("r", () => {
+    mousetrap.bind("r", () => {
       // numeric keypresses get caught by jwplayer, so blur the element
       // if the rating sequence is started
       if (document.activeElement instanceof HTMLElement) {
@@ -79,7 +97,7 @@ export function useRatingKeybinds(
     });
 
     return () => {
-      Mousetrap.unbind("r");
+      mousetrap.unbind("r");
     };
   });
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This implements the rating keyboard shortcuts (`r` then a digit) for images in the lightbox, honoring whichever rating system is configured and matching the scene and image detail pages:

- **Stars** — `r 1`–`r 5` set the rating, `r 0` clears it.
- **Decimal** — `r {0-9}{0-9}` sets the rating (`r 0 0` for `10.0`), `` r ` `` clears it.

Key design choices:

- **Reuse `useRatingKeybinds` via a lightbox-scoped Mousetrap instance.** The lightbox calls `Mousetrap.pause()` while open to suppress global shortcuts behind the overlay, which is why the existing Mousetrap-based hook never fired there. Rather than re-implement the rating logic by hand, the lightbox now owns its own `new Mousetrap()` — the `mousetrap-pause` plugin tracks the paused flag per instance, so a separate instance keeps firing while the global singleton stays paused. The hook gains an optional Mousetrap-instance parameter that defaults to the global singleton, so the scene and image detail pages are unchanged, and the lightbox reuses the hook verbatim instead of duplicating its logic.
- **Move the lightbox's `d d` delete onto the same shared mechanism.** The delete shortcut now uses the standard `Mousetrap.bind("d d", …)` sequence used everywhere else in the app, on the lightbox's own instance, replacing the bespoke timestamp-based double-tap detector that only existed because the global Mousetrap was paused. I added that detector in #7022; folding its removal in here keeps both lightbox sequence shortcuts on the shared mechanism rather than bespoke code, and only the activation glue stays per-consumer (the global hook binds digit keys dynamically through Mousetrap; the lightbox feeds the same hook through its scoped instance).
- **Fix a pre-existing unbind-timer bug in `useRatingKeybinds` that the reuse surfaced.** Every `r` press scheduled its own independent timer to unbind the digit keys after one second but never cancelled the previous one, so a quick second sequence (for example `r 3` then `r 4`) whose digit landed after the first timer fired had its keys unbound mid-sequence and the keypress dropped — the rating did not always update. The timer is now cancelled and rescheduled per sequence, and the decimal entry buffer is reset at the start of each sequence. This fix also benefits the scene and image detail pages, which share the hook.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #5616.

## Testing
<!-- Describe the testing steps you have performed. -->

Verified against a local instance with both rating systems, plus an automated Playwright suite run in my fork (driving a real browser against a dev build of this branch):

- Lightbox, Stars: `r 3` sets three stars and persists across closing and reopening the image; `r 0` clears it.
- Lightbox, Decimal: `r 3 5` sets 3.5 and persists; `` r ` `` clears it.
- Rapid sequence regression: `r 3` immediately followed by `r 4` ends on four stars (this deterministically failed before the timer fix, with the `4` dropped, and passes after it).
- Existing lightbox shortcuts unchanged: arrow-key navigation, `Escape` to close, `d d` to open the delete dialog, and global shortcuts (such as `g s`) staying inert while the lightbox is open.
- Off the lightbox: global navigation shortcuts still route, and the rating shortcuts (including the rapid-sequence case) still work on the scene and image detail pages, confirming the shared-hook change is backward compatible.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

No new UI.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Claude Code (Anthropic) to assist with this PR. It helped explore the lightbox and `useRatingKeybinds` implementations, propose and implement the approach (the scoped Mousetrap instance, the hook parameter, the `d d` dedup, and the unbind-timer fix), and author the Playwright end-to-end tests used to verify it. I directed the design decisions, reviewed all changes, and validated the behavior manually and through the automated tests before submitting.

## Additional Context
<!-- Add any other context about the pull request here. -->

This is a front-end-only change with no schema or generated-binding changes. The keyboard shortcuts are also documented in the keyboard shortcuts manual (`KeyboardShortcuts.md`).