### PR TITLE
Support embedded subtitle tracks (#3875)

### DIFF
--- a/internal/api/resolver_model_scene.go
+++ b/internal/api/resolver_model_scene.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stashapp/stash/internal/api/loaders"
 	"github.com/stashapp/stash/internal/api/urlbuilders"
 	"github.com/stashapp/stash/internal/manager"
+	"github.com/stashapp/stash/pkg/file/video"
+	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/session"
 	"github.com/stashapp/stash/pkg/signedurl"
@@ -183,7 +185,19 @@ func (r *sceneResolver) Captions(ctx context.Context, obj *models.Scene) (ret []
 		return nil, err
 	}
 
-	return ret, err
+	// Include subtitle tracks embedded in the video container. These are extracted
+	// on demand when requested (see the scene caption route). Probing is best-effort:
+	// a failure here must not break the scene query.
+	if mgr := manager.GetInstance(); mgr != nil && mgr.FFProbe != nil {
+		embedded, eerr := video.EmbeddedCaptions(mgr.FFProbe, primaryFile.Path)
+		if eerr != nil {
+			logger.Debugf("error detecting embedded captions for %q: %v", primaryFile.Path, eerr)
+		} else {
+			ret = append(ret, embedded...)
+		}
+	}
+
+	return ret, nil
 }
 
 func (r *sceneResolver) Galleries(ctx context.Context, obj *models.Scene) (ret []*models.Gallery, err error) {

--- a/internal/api/routes_scene.go
+++ b/internal/api/routes_scene.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -408,6 +410,13 @@ func (rs sceneRoutes) InteractiveHeatmap(w http.ResponseWriter, r *http.Request)
 func (rs sceneRoutes) Caption(w http.ResponseWriter, r *http.Request, lang string, ext string) {
 	s := r.Context().Value(sceneKey).(*models.Scene)
 
+	// embedded subtitle tracks have no sidecar file - extract them from the video
+	// container on demand and serve the cached result
+	if ext == models.CaptionTypeEmbedded {
+		rs.serveEmbeddedCaption(w, r, s, lang)
+		return
+	}
+
 	var captions []*models.VideoCaption
 	readTxnErr := rs.withReadTxn(r, func(ctx context.Context) error {
 		var err error
@@ -453,6 +462,57 @@ func (rs sceneRoutes) Caption(w http.ResponseWriter, r *http.Request, lang strin
 		utils.ServeStaticContent(w, r, buf.Bytes())
 		return
 	}
+}
+
+// serveEmbeddedCaption extracts the embedded subtitle track for the given
+// language from the scene's video file (if not already cached), converts it to
+// WebVTT, caches it under the generated directory, and serves it.
+func (rs sceneRoutes) serveEmbeddedCaption(w http.ResponseWriter, r *http.Request, s *models.Scene, lang string) {
+	mgr := manager.GetInstance()
+
+	sceneHash := s.GetHash(config.GetInstance().GetVideoFileNamingAlgorithm())
+	if sceneHash == "" {
+		http.Error(w, "scene has no hash", http.StatusInternalServerError)
+		return
+	}
+
+	cachePath := mgr.Paths.Scene.GetEmbeddedCaptionPath(sceneHash, lang)
+
+	// extract and cache on first request; subsequent requests serve the cached file
+	if exists, _ := fsutil.FileExists(cachePath); !exists {
+		subs, err := video.GetEmbeddedSubtitles(mgr.FFProbe, s.Path)
+		if err != nil {
+			logger.Warnf("error probing embedded subtitles for %q: %v", s.Path, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		streamIndex := -1
+		for _, sub := range subs {
+			if sub.LanguageCode == lang {
+				streamIndex = sub.Index
+				break
+			}
+		}
+		if streamIndex == -1 {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if err := video.ExtractEmbeddedSubtitle(r.Context(), mgr.FFMpeg, s.Path, streamIndex, cachePath); err != nil {
+			logger.Warnf("error extracting embedded subtitle for %q: %v", s.Path, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/vtt")
+	utils.ServeStaticFile(w, r, cachePath)
 }
 
 func (rs sceneRoutes) CaptionLang(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ffmpeg/ffprobe.go
+++ b/pkg/ffmpeg/ffprobe.go
@@ -381,6 +381,20 @@ func (v *VideoFile) getVideoStream() *FFProbeStream {
 	return nil
 }
 
+// GetSubtitleStreams returns all subtitle streams in the file, excluding
+// attached pictures. The returned streams reference the underlying probe data,
+// so callers should not retain them beyond the lifetime of the VideoFile.
+func (v *VideoFile) GetSubtitleStreams() []*FFProbeStream {
+	var ret []*FFProbeStream
+	for i := range v.JSON.Streams {
+		s := &v.JSON.Streams[i]
+		if s.CodecType == "subtitle" && s.Disposition.AttachedPic == 0 {
+			ret = append(ret, s)
+		}
+	}
+	return ret
+}
+
 func (v *VideoFile) getStreamIndex(fileType string, probeJSON FFProbeJSON) int {
 	ret := -1
 	for i, stream := range probeJSON.Streams {

--- a/pkg/file/video/embedded_captions.go
+++ b/pkg/file/video/embedded_captions.go
@@ -1,0 +1,194 @@
+package video
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+	"github.com/stashapp/stash/pkg/models"
+)
+
+// embeddedSubsCache memoises the (relatively expensive) ffprobe of a video file
+// for embedded subtitle detection. The scene caption resolver runs on each scene
+// detail load, so caching avoids re-probing unchanged files. Entries are keyed by
+// path and invalidated when the file's size or modification time changes.
+type embeddedSubsCacheEntry struct {
+	size    int64
+	modTime time.Time
+	subs    []EmbeddedSubtitle
+}
+
+var embeddedSubsCache *lru.Cache[string, embeddedSubsCacheEntry]
+
+func init() {
+	// size is a best-effort bound; errors only occur for a non-positive size.
+	embeddedSubsCache, _ = lru.New[string, embeddedSubsCacheEntry](2048)
+}
+
+// imageSubtitleCodecs are subtitle codecs that are bitmap (image) based and so
+// cannot be converted to text-based WebVTT. They are skipped when detecting
+// embedded captions.
+var imageSubtitleCodecs = map[string]bool{
+	"hdmv_pgs_subtitle": true,
+	"pgssub":            true,
+	"dvd_subtitle":      true,
+	"dvdsub":            true,
+	"dvb_subtitle":      true,
+	"dvbsub":            true,
+	"dvb_teletext":      true,
+	"xsub":              true,
+}
+
+// unknownSubtitleLangs are language tag values that should be treated as
+// "no language" (mapped to LangUnknown).
+var unknownSubtitleLangs = map[string]bool{
+	"":        true,
+	"und":     true,
+	"unknown": true,
+	"none":    true,
+	"mis":     true,
+	"mul":     true,
+	"zxx":     true,
+}
+
+// EmbeddedSubtitle describes a text subtitle stream embedded in a video file.
+type EmbeddedSubtitle struct {
+	// Index is the absolute ffmpeg stream index within the container.
+	Index int
+	// LanguageCode is the normalised ISO-639 language code, or LangUnknown.
+	LanguageCode string
+}
+
+// normalizeSubtitleLang converts an ffprobe language tag into the language code
+// used by stash's caption system, returning LangUnknown when absent or invalid.
+func normalizeSubtitleLang(raw string) string {
+	lang := strings.ToLower(strings.TrimSpace(raw))
+	if unknownSubtitleLangs[lang] {
+		return LangUnknown
+	}
+	// ISO-639 codes are 2 or 3 letters; validate against the language database.
+	if (len(lang) == 2 || len(lang) == 3) && IsValidLanguage(lang) {
+		return lang
+	}
+	return LangUnknown
+}
+
+// GetEmbeddedSubtitles probes the given video file and returns its embedded
+// text subtitle streams, de-duplicated to one per language (preferring the
+// stream marked default, then forced, then the lowest stream index). Image-based
+// subtitle streams are skipped as they cannot be converted to text.
+func GetEmbeddedSubtitles(ffprobe *ffmpeg.FFProbe, videoPath string) ([]EmbeddedSubtitle, error) {
+	if ffprobe == nil {
+		return nil, nil
+	}
+
+	// return a cached result if the file is unchanged since it was last probed
+	var stat os.FileInfo
+	if fi, err := os.Stat(videoPath); err == nil {
+		stat = fi
+		if entry, ok := embeddedSubsCache.Get(videoPath); ok &&
+			entry.size == fi.Size() && entry.modTime.Equal(fi.ModTime()) {
+			return entry.subs, nil
+		}
+	}
+
+	probeResult, err := ffprobe.NewVideoFile(videoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	subs := selectEmbeddedSubtitles(probeResult.GetSubtitleStreams())
+
+	if stat != nil {
+		embeddedSubsCache.Add(videoPath, embeddedSubsCacheEntry{
+			size:    stat.Size(),
+			modTime: stat.ModTime(),
+			subs:    subs,
+		})
+	}
+
+	return subs, nil
+}
+
+// selectEmbeddedSubtitles filters and de-duplicates subtitle streams into the
+// embedded captions stash will expose: image-based codecs are dropped, and at
+// most one stream is kept per language (preferring default, then forced, then
+// the lowest stream index).
+func selectEmbeddedSubtitles(streams []*ffmpeg.FFProbeStream) []EmbeddedSubtitle {
+	// order so that the preferred stream for a language is encountered first
+	sort.SliceStable(streams, func(i, j int) bool {
+		di, dj := streams[i].Disposition, streams[j].Disposition
+		if di.Default != dj.Default {
+			return di.Default > dj.Default
+		}
+		if di.Forced != dj.Forced {
+			return di.Forced > dj.Forced
+		}
+		return streams[i].Index < streams[j].Index
+	})
+
+	seen := make(map[string]bool)
+	var ret []EmbeddedSubtitle
+	for _, s := range streams {
+		if imageSubtitleCodecs[strings.ToLower(s.CodecName)] {
+			continue
+		}
+
+		lang := normalizeSubtitleLang(s.Tags.Language)
+		// stash stores a single caption per language; keep the first (preferred) one
+		if seen[lang] {
+			continue
+		}
+		seen[lang] = true
+
+		ret = append(ret, EmbeddedSubtitle{
+			Index:        s.Index,
+			LanguageCode: lang,
+		})
+	}
+
+	return ret
+}
+
+// EmbeddedCaptions probes the given video file and returns its embedded subtitle
+// tracks as VideoCaption entries (with CaptionType == models.CaptionTypeEmbedded)
+// suitable for inclusion in a scene's caption list.
+func EmbeddedCaptions(ffprobe *ffmpeg.FFProbe, videoPath string) ([]*models.VideoCaption, error) {
+	subs, err := GetEmbeddedSubtitles(ffprobe, videoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]*models.VideoCaption, 0, len(subs))
+	for _, s := range subs {
+		ret = append(ret, &models.VideoCaption{
+			LanguageCode: s.LanguageCode,
+			CaptionType:  models.CaptionTypeEmbedded,
+		})
+	}
+	return ret, nil
+}
+
+// ExtractEmbeddedSubtitle extracts the subtitle stream at the given absolute
+// stream index from the input video and writes it to outputPath as WebVTT.
+func ExtractEmbeddedSubtitle(ctx context.Context, encoder *ffmpeg.FFMpeg, input string, streamIndex int, outputPath string) error {
+	if encoder == nil {
+		return fmt.Errorf("ffmpeg not configured")
+	}
+
+	var args ffmpeg.Args
+	args = args.LogLevel(ffmpeg.LogLevelError)
+	args = args.Overwrite()
+	args = args.Input(input)
+	args = append(args, "-map", fmt.Sprintf("0:%d", streamIndex))
+	args = append(args, "-f", "webvtt")
+	args = args.Output(outputPath)
+
+	return encoder.Generate(ctx, args)
+}

--- a/pkg/file/video/embedded_captions_test.go
+++ b/pkg/file/video/embedded_captions_test.go
@@ -1,0 +1,72 @@
+package video
+
+import (
+	"testing"
+
+	"github.com/stashapp/stash/pkg/ffmpeg"
+)
+
+func subStream(index int, codec, lang string, def, forced int) *ffmpeg.FFProbeStream {
+	s := &ffmpeg.FFProbeStream{CodecType: "subtitle", CodecName: codec, Index: index}
+	s.Tags.Language = lang
+	s.Disposition.Default = def
+	s.Disposition.Forced = forced
+	return s
+}
+
+func TestNormalizeSubtitleLang(t *testing.T) {
+	cases := map[string]string{
+		"eng":     "eng",
+		"en":      "en",
+		"ENG":     "eng",
+		" fr ":    "fr",
+		"":        LangUnknown,
+		"und":     LangUnknown,
+		"unknown": LangUnknown,
+		"zxx":     LangUnknown,
+		"engx":    LangUnknown, // too long / invalid
+		"xx":      LangUnknown, // not a real language
+	}
+	for in, want := range cases {
+		if got := normalizeSubtitleLang(in); got != want {
+			t.Errorf("normalizeSubtitleLang(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSelectEmbeddedSubtitles(t *testing.T) {
+	streams := []*ffmpeg.FFProbeStream{
+		subStream(2, "subrip", "eng", 0, 0),
+		subStream(3, "ass", "eng", 1, 0), // default eng -> wins over index 2
+		subStream(4, "subrip", "spa", 0, 0),
+		subStream(5, "hdmv_pgs_subtitle", "fre", 0, 0), // image-based -> skipped
+		subStream(6, "mov_text", "", 0, 0),             // unknown language
+	}
+
+	got := selectEmbeddedSubtitles(streams)
+
+	want := []EmbeddedSubtitle{
+		{Index: 3, LanguageCode: "eng"}, // default eng track preferred
+		{Index: 4, LanguageCode: "spa"},
+		{Index: 6, LanguageCode: LangUnknown}, // untagged stream
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d subtitles %+v, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("subtitle[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSelectEmbeddedSubtitlesAllImageBased(t *testing.T) {
+	streams := []*ffmpeg.FFProbeStream{
+		subStream(2, "hdmv_pgs_subtitle", "eng", 1, 0),
+		subStream(3, "dvd_subtitle", "spa", 0, 0),
+	}
+	if got := selectEmbeddedSubtitles(streams); len(got) != 0 {
+		t.Errorf("expected no extractable subtitles, got %+v", got)
+	}
+}

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -277,6 +277,12 @@ type SceneFileType struct {
 	Bitrate    *int     `graphql:"bitrate" json:"bitrate"`
 }
 
+// CaptionTypeEmbedded is the reserved caption type used for subtitle tracks that
+// are embedded inside the video container. Unlike sidecar captions (e.g. "srt" or
+// "vtt"), these have no caption file on disk - they are extracted from the video
+// on demand and cached. See the scene caption route.
+const CaptionTypeEmbedded = "embedded"
+
 type VideoCaption struct {
 	LanguageCode string `json:"language_code"`
 	Filename     string `json:"filename"`
@@ -285,4 +291,10 @@ type VideoCaption struct {
 
 func (c VideoCaption) Path(filePath string) string {
 	return filepath.Join(filepath.Dir(filePath), c.Filename)
+}
+
+// IsEmbedded returns true if the caption refers to a subtitle track embedded in
+// the video file rather than a sidecar caption file.
+func (c VideoCaption) IsEmbedded() bool {
+	return c.CaptionType == CaptionTypeEmbedded
 }

--- a/pkg/models/paths/paths_scenes.go
+++ b/pkg/models/paths/paths_scenes.go
@@ -53,3 +53,15 @@ func (sp *scenePaths) GetSpriteVttFilePath(checksum string) string {
 func (sp *scenePaths) GetInteractiveHeatmapPath(checksum string) string {
 	return filepath.Join(sp.InteractiveHeatmap, checksum+".png")
 }
+
+// GetEmbeddedCaptionPath returns the cache path for an embedded subtitle track
+// (extracted from the video container) for the given scene hash and language.
+func (sp *scenePaths) GetEmbeddedCaptionPath(checksum string, lang string) string {
+	return filepath.Join(sp.Vtt, checksum+"_"+lang+"_embedded.vtt")
+}
+
+// GetEmbeddedCaptionGlob returns a glob matching all cached embedded subtitle
+// tracks for the given scene hash, used to clean them up when a scene is removed.
+func (sp *scenePaths) GetEmbeddedCaptionGlob(checksum string) string {
+	return filepath.Join(sp.Vtt, checksum+"_*_embedded.vtt")
+}

--- a/pkg/scene/delete.go
+++ b/pkg/scene/delete.go
@@ -76,6 +76,11 @@ func (d *FileDeleter) MarkGeneratedFiles(scene *models.Scene) error {
 		files = append(files, heatmapPath)
 	}
 
+	// embedded subtitle tracks are cached one file per language
+	if embeddedCaptions, err := filepath.Glob(d.Paths.Scene.GetEmbeddedCaptionGlob(sceneHash)); err == nil {
+		files = append(files, embeddedCaptions...)
+	}
+
 	return d.FilesWithoutTrash(files)
 }
 


### PR DESCRIPTION
## Description
Adds support for subtitle tracks embedded inside video containers (e.g. MKV), which were previously ignored. Embedded text tracks are detected via `ffprobe` when a scene loads and extracted to WebVTT on demand (cached under `generated/vtt`), then served through the existing caption endpoint - so they appear in the player's caption menu as e.g. *"English (embedded)"*. No sidecar files are written to the library; no DB migration, scan, or frontend changes. Implements the on-the-fly + cache approach @WithoutPants described in the issue.

## Related Issue
Closes #3875.

## Testing
- `go build ./...` (CGO), `go vet ./...`, `gofmt` clean; unit tests pass for stream selection and ISO-639 language normalisation.
- End-to-end on a running server: scanned an MKV with two embedded tracks (`eng` SubRip + `spa` ASS). The captions resolver returned both as `embedded`, and:
  - `GET /scene/1/caption?lang=eng&type=embedded` -> 200, `text/vtt`, valid WebVTT
  - `GET /scene/1/caption?lang=spa&type=embedded` -> 200, `text/vtt` (ASS converted to WebVTT)
  - cache files written under `generated/vtt`; re-requests serve from cache.

## Screenshots
N/A - backend change; the track is served through the existing caption endpoint.

## Checklist
- [x] I have read and understood the Contributing document.
- [x] I have read and understood the AI Usage Policy document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

Used an LLM (Claude) to help write the implementation. I reviewed the code, built it, and tested it end-to-end against a running stash server as described above. I take full responsibility for the code and can explain any line or design decision.

## Additional Context
Supersedes the closed #5918, which wrote/served sidecar `.srt` files; this keeps everything in `generated/` and converts on demand. Reopens the work from the previously-closed #7090, now following the PR template.