### PR TITLE
Fix: Lightbox Back Button Behavior

### DIFF
--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -446,6 +446,13 @@ export const LightboxComponent: React.FC<IProps> = ({
     inScrollGroup.current = false;
   }, SCROLL_ZOOM_TIMEOUT);
 
+  useEffect(() => {
+    return () => {
+      disableInstantTransition.cancel();
+      debouncedScrollReset.cancel();
+    };
+  }, [disableInstantTransition, debouncedScrollReset]);
+
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
       if (e.repeat && (e.key === "ArrowRight" || e.key === "ArrowLeft"))

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -53,6 +53,7 @@ import { useDebounce } from "../debounce";
 import { isVideo } from "src/utils/visualFile";
 import { imageTitle } from "src/core/files";
 import { galleryTitle } from "src/core/galleries";
+import type { LightboxHideReason } from "./context";
 
 const CLASSNAME = "Lightbox";
 const CLASSNAME_HEADER = `${CLASSNAME}-header`;
@@ -98,7 +99,7 @@ interface IProps {
   totalCount?: number;
   pageCallback?: (props: { direction?: number; page?: number }) => void;
   chapters?: IChapter[];
-  hide: () => void;
+  hide: (reason?: LightboxHideReason) => void;
   onDeleteImage?: (id: string) => void;
 }
 
@@ -333,12 +334,26 @@ export const LightboxComponent: React.FC<IProps> = ({
   };
 
   useEffect(() => {
-    if (isVisible) {
-      if (index === null) setIndex(initialIndex);
-      document.body.style.overflow = "hidden";
-      Mousetrap.pause();
-    }
+    if (isVisible && index === null) setIndex(initialIndex);
   }, [initialIndex, isVisible, index]);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    document.body.style.overflow = "hidden";
+    Mousetrap.pause();
+    return () => {
+      const fullscreenElement = document.fullscreenElement;
+      if (
+        fullscreenElement &&
+        containerRef.current?.contains(fullscreenElement)
+      ) {
+        document.exitFullscreen();
+      }
+      document.body.style.overflow = "auto";
+      Mousetrap.unpause();
+    };
+  }, [isVisible]);
 
   const toggleSlideshow = useCallback(() => {
     if (slideshowInterval) {
@@ -355,13 +370,12 @@ export const LightboxComponent: React.FC<IProps> = ({
     }
   });
 
-  const close = useCallback(() => {
-    if (isFullscreen) document.exitFullscreen();
-
-    hide();
-    document.body.style.overflow = "auto";
-    Mousetrap.unpause();
-  }, [isFullscreen, hide]);
+  const close = useCallback(
+    (reason: LightboxHideReason = "dismiss") => {
+      hide(reason);
+    },
+    [hide]
+  );
 
   const handleClose = (e: React.MouseEvent<HTMLDivElement>) => {
     const { className } = e.target as Element;
@@ -993,7 +1007,8 @@ export const LightboxComponent: React.FC<IProps> = ({
                   <Link
                     className="image-link"
                     to={`/images/${currentImage.id}`}
-                    onClick={() => close()}
+                    replace
+                    onClick={() => close("navigate")}
                   >
                     {title ?? ""}
                   </Link>
@@ -1011,7 +1026,8 @@ export const LightboxComponent: React.FC<IProps> = ({
                   <Link
                     className="image-gallery-link"
                     to={`/galleries/${currentImage.galleries[0].id}`}
-                    onClick={() => close()}
+                    replace
+                    onClick={() => close("navigate")}
                   >
                     <Icon icon={faImages} />
                     {galleryTitle(currentImage.galleries[0])}

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -70,6 +70,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
 
   const activeHistoryID = useRef<number>();
   const nextHistoryID = useRef(0);
+  const isDismissingRef = useRef(false);
   const isVisibleRef = useRef(lightboxState.isVisible);
   const onCloseRef = useRef<(() => void) | undefined>();
 
@@ -87,6 +88,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
     const id = nextHistoryID.current + 1;
     nextHistoryID.current = id;
     activeHistoryID.current = id;
+    isDismissingRef.current = false;
 
     history.pushState(
       {
@@ -110,11 +112,13 @@ export const LightboxProvider: React.FC = ({ children }) => {
     delete (currentState as ILightboxHistoryState)[LIGHTBOX_HISTORY_KEY];
     history.replaceState(currentState, "", window.location.href);
     activeHistoryID.current = undefined;
+    isDismissingRef.current = false;
   }, [isCurrentLightboxHistoryEntry]);
 
   const closeLightbox = useCallback(() => {
     if (!isVisibleRef.current) return;
 
+    isDismissingRef.current = false;
     isVisibleRef.current = false;
     setLightboxState((currentState: IState) =>
       currentState.isVisible
@@ -134,6 +138,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
         pushLightboxHistory();
         isVisibleRef.current = true;
       } else if (state.isVisible === false) {
+        isDismissingRef.current = false;
         isVisibleRef.current = false;
       }
 
@@ -154,6 +159,9 @@ export const LightboxProvider: React.FC = ({ children }) => {
       }
 
       if (isCurrentLightboxHistoryEntry()) {
+        if (isDismissingRef.current) return;
+
+        isDismissingRef.current = true;
         history.back();
         return;
       }
@@ -171,6 +179,7 @@ export const LightboxProvider: React.FC = ({ children }) => {
         historyID === activeHistoryID.current
       ) {
         if (!isVisibleRef.current) {
+          isDismissingRef.current = false;
           isVisibleRef.current = true;
           setLightboxState((currentState: IState) => ({
             ...currentState,

--- a/ui/v2.5/src/hooks/Lightbox/context.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/context.tsx
@@ -1,8 +1,17 @@
-import React, { Suspense, useCallback, useState } from "react";
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { lazyComponent } from "src/utils/lazyComponent";
 import { ILightboxImage, IChapter } from "./types";
 
 const LightboxComponent = lazyComponent(() => import("./Lightbox"));
+const LIGHTBOX_HISTORY_KEY = "stashLightbox";
+
+export type LightboxHideReason = "dismiss" | "navigate";
 
 export interface IState {
   images: ILightboxImage[];
@@ -25,6 +34,19 @@ interface IContext {
   setLightboxState: (state: Partial<IState>) => void;
 }
 
+interface ILightboxHistoryState {
+  [LIGHTBOX_HISTORY_KEY]?: {
+    id?: number;
+  };
+}
+
+const getLightboxHistoryID = (state: unknown) => {
+  if (!state || typeof state !== "object") return;
+
+  const lightboxState = (state as ILightboxHistoryState)[LIGHTBOX_HISTORY_KEY];
+  return typeof lightboxState?.id === "number" ? lightboxState.id : undefined;
+};
+
 export const LightboxContext = React.createContext<IContext | null>(null);
 
 export function useLightboxContext() {
@@ -46,26 +68,126 @@ export const LightboxProvider: React.FC = ({ children }) => {
     slideshowEnabled: false,
   });
 
-  const setPartialState = useCallback((state: Partial<IState>) => {
-    setLightboxState((currentState: IState) => ({
-      ...currentState,
-      ...state,
-    }));
+  const activeHistoryID = useRef<number>();
+  const nextHistoryID = useRef(0);
+  const isVisibleRef = useRef(lightboxState.isVisible);
+  const onCloseRef = useRef<(() => void) | undefined>();
+
+  isVisibleRef.current = lightboxState.isVisible;
+  onCloseRef.current = lightboxState.onClose;
+
+  const isCurrentLightboxHistoryEntry = useCallback(() => {
+    return (
+      activeHistoryID.current !== undefined &&
+      getLightboxHistoryID(history.state) === activeHistoryID.current
+    );
   }, []);
 
-  const onHide = () => {
-    // slideshowAutostart is a per-open instruction (set when opening a gallery's
-    // lightbox from the galleries page). Clear it on close so it doesn't leak
-    // into the next lightbox opened from another entry point.
-    setLightboxState({
-      ...lightboxState,
-      isVisible: false,
-      slideshowAutostart: false,
-    });
-    if (lightboxState.onClose) {
-      lightboxState.onClose();
-    }
-  };
+  const pushLightboxHistory = useCallback(() => {
+    const id = nextHistoryID.current + 1;
+    nextHistoryID.current = id;
+    activeHistoryID.current = id;
+
+    history.pushState(
+      {
+        ...(typeof history.state === "object" && history.state !== null
+          ? history.state
+          : {}),
+        [LIGHTBOX_HISTORY_KEY]: { id },
+      },
+      "",
+      window.location.href
+    );
+  }, []);
+
+  const clearCurrentLightboxHistory = useCallback(() => {
+    if (!isCurrentLightboxHistoryEntry()) return;
+
+    const currentState =
+      typeof history.state === "object" && history.state !== null
+        ? { ...history.state }
+        : {};
+    delete (currentState as ILightboxHistoryState)[LIGHTBOX_HISTORY_KEY];
+    history.replaceState(currentState, "", window.location.href);
+    activeHistoryID.current = undefined;
+  }, [isCurrentLightboxHistoryEntry]);
+
+  const closeLightbox = useCallback(() => {
+    if (!isVisibleRef.current) return;
+
+    isVisibleRef.current = false;
+    setLightboxState((currentState: IState) =>
+      currentState.isVisible
+        ? {
+            ...currentState,
+            isVisible: false,
+            slideshowAutostart: false,
+          }
+        : currentState
+    );
+    onCloseRef.current?.();
+  }, []);
+
+  const setPartialState = useCallback(
+    (state: Partial<IState>) => {
+      if (state.isVisible === true && !isVisibleRef.current) {
+        pushLightboxHistory();
+        isVisibleRef.current = true;
+      } else if (state.isVisible === false) {
+        isVisibleRef.current = false;
+      }
+
+      setLightboxState((currentState: IState) => ({
+        ...currentState,
+        ...state,
+      }));
+    },
+    [pushLightboxHistory]
+  );
+
+  const onHide = useCallback(
+    (reason: LightboxHideReason = "dismiss") => {
+      if (reason === "navigate") {
+        clearCurrentLightboxHistory();
+        closeLightbox();
+        return;
+      }
+
+      if (isCurrentLightboxHistoryEntry()) {
+        history.back();
+        return;
+      }
+
+      closeLightbox();
+    },
+    [clearCurrentLightboxHistory, closeLightbox, isCurrentLightboxHistoryEntry]
+  );
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      const historyID = getLightboxHistoryID(event.state);
+      if (
+        activeHistoryID.current !== undefined &&
+        historyID === activeHistoryID.current
+      ) {
+        if (!isVisibleRef.current) {
+          isVisibleRef.current = true;
+          setLightboxState((currentState: IState) => ({
+            ...currentState,
+            isVisible: true,
+          }));
+        }
+        return;
+      }
+
+      closeLightbox();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [closeLightbox]);
 
   const onDeleteImage = useCallback((id: string) => {
     setLightboxState((s) => ({


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds history-aware dismissal for the image lightbox so the browser Back button closes the overlay while keeping the user on the current page.

This change:
- Pushes a marked lightbox history entry when the lightbox opens.
- Closes the lightbox on Back by responding to `popstate`.
- Allows Forward to re-enter the lightbox history entry instead of becoming inert.
- Guards against repeated dismiss actions while a history-backed close is pending.
- Separates dismiss closes from in-lightbox navigation closes.
- Moves lightbox teardown cleanup into lifecycle cleanup so scroll lock, Mousetrap pause state, fullscreen, and debounced callbacks are handled consistently on every close path.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #1940

## Testing
<!-- Describe the testing steps you have performed. -->

- Ran `pnpm.cmd --dir ui\v2.5 check`
- Ran `pnpm.cmd --dir ui\v2.5 lint`
- Ran `pnpm.cmd --dir ui\v2.5 format-check src/hooks/Lightbox/context.tsx src/hooks/Lightbox/Lightbox.tsx`
- Ran `git diff --check`

Manual testing performed:
- Opened a gallery image in the lightbox and confirmed browser Back closes the overlay while remaining on the gallery page.
- Repeated open/Back and open/close flows to confirm the page does not navigate away unexpectedly.
- Confirmed `X`, Escape, and backdrop click follow the same dismiss behavior.
- Confirmed browser Forward after Back re-enters the lightbox entry.
- Confirmed image and gallery footer links navigate away without leaving the overlay open or adding a duplicate same-page history step.
- Confirmed repeated image navigation followed by closing the lightbox does not trigger debounced state updates after unmount.


## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Codex to assist with the investigation, help drafting the implementation, and to help catch some edge cases.  Manually reviewed and tested everything.

## Additional Context
<!-- Add any other context about the pull request here. -->

This avoids using `history.back()` as a generic close mechanism for all lightbox exits. Dismissal, browser history state, in-lightbox navigation, and component teardown are handled separately so repeated closes and footer-link navigation do not corrupt the browser stack.

The debounce cleanup issue was noticed during my testing (hold down an arrow key in lightbox for a bit and then close lightbox) and was adjacent so I just added 7 lines to fix it.