### PR TITLE
Add touch gestures to the image lightbox

### DIFF
--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -143,6 +143,20 @@
 | `Escape` | Close lightbox |
 | `d d` | Delete current image |
 
+### Touch gestures
+
+On touch devices the lightbox also supports gestures:
+
+| Gesture | Action |
+|---------|--------|
+| Swipe left / right | Next / previous image |
+| Swipe up | Delete current image (opens the confirmation dialog) |
+| Swipe down | Close the lightbox |
+| Double-tap | Toggle zoom (fit ↔ zoomed in) |
+| Pinch | Zoom in / out |
+
+While zoomed in, dragging pans the image (stopping at its edges) instead of switching, deleting or closing.
+
 ## Groups page shortcuts
 
 | Keyboard sequence | Action |

--- a/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
+++ b/ui/v2.5/src/docs/en/Manual/KeyboardShortcuts.md
@@ -143,19 +143,17 @@
 | `Escape` | Close lightbox |
 | `d d` | Delete current image |
 
-### Touch gestures
-
-On touch devices the lightbox also supports gestures:
+## Lightbox touch gestures
 
 | Gesture | Action |
-|---------|--------|
-| Swipe left / right | Next / previous image |
-| Swipe up | Delete current image (opens the confirmation dialog) |
-| Swipe down | Close the lightbox |
-| Double-tap | Toggle zoom (fit ↔ zoomed in) |
-| Pinch | Zoom in / out |
-
-While zoomed in, dragging pans the image (stopping at its edges) instead of switching, deleting or closing.
+|-------------------|--------|
+| `Swipe left` | Next image |
+| `Swipe right` | Previous image |
+| `Swipe up` | Delete current image |
+| `Swipe down` | Close the lightbox |
+| `Double-tap` | Toggle zoom |
+| `Pinch` | Zoom in/out |
+| `Drag (while zoomed in)` | Pan image |
 
 ## Groups page shortcuts
 

--- a/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/Lightbox.tsx
@@ -18,7 +18,7 @@ import useInterval from "../Interval";
 import usePageVisibility from "../PageVisibility";
 import { useToast } from "../Toast";
 import { FormattedMessage, useIntl } from "react-intl";
-import { LightboxImage } from "./LightboxImage";
+import { LightboxImage, maxZoomForPixels } from "./LightboxImage";
 import { useConfigurationContext } from "../Config";
 import { Link } from "react-router-dom";
 import { OCounterButton } from "src/components/Scenes/SceneDetails/OCounterButton";
@@ -139,8 +139,17 @@ export const LightboxComponent: React.FC<IProps> = ({
   const [zoom, setZoom] = useState(1);
 
   function updateZoom(v: number) {
+    // Per-image cap (large images on phones get a smaller ceiling - see
+    // maxZoomForPixels) so a runaway scroll/keyboard zoom can't grow the image
+    // into a giant composited layer that crashes the tab. Uses the current
+    // image's natural dimensions, same source the carousel passes to each tile.
+    const ci = index === null ? initialIndex : index;
+    const vf = images[ci]?.visual_files?.[0];
+    const maxZoom = maxZoomForPixels((vf?.width ?? 0) * (vf?.height ?? 0));
     if (v < MIN_ZOOM) {
       setZoom(MIN_ZOOM);
+    } else if (v > maxZoom) {
+      setZoom(maxZoom);
     } else if (Math.abs(v - 1) < ZOOM_NONE_EPSILON) {
       // "snap to 1" effect: if new zoom is close to 1, set to 1
       setZoom(1);
@@ -926,6 +935,14 @@ export const LightboxComponent: React.FC<IProps> = ({
                     debouncedScrollReset={debouncedScrollReset}
                     onLeft={handleLeft}
                     onRight={handleRight}
+                    onSwipeDelete={
+                      currentImage?.id !== undefined
+                        ? () => setIsDeleteDialogOpen(true)
+                        : undefined
+                    }
+                    onSwipeClose={close}
+                    onResetPosition={() => setResetPosition((r) => !r)}
+                    navigationEnabled={!!allowNavigation}
                     isVideo={isVideo(image.visual_files?.[0] ?? {})}
                   />
                 ) : undefined}

--- a/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
+++ b/ui/v2.5/src/hooks/Lightbox/LightboxImage.tsx
@@ -1,5 +1,15 @@
-import React, { useEffect, useRef, useState, useCallback } from "react";
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import { flushSync } from "react-dom";
+import useResizeObserver from "@react-hook/resize-observer";
 import * as GQL from "src/core/generated-graphql";
+import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
+import { useDebounce } from "src/hooks/debounce";
 
 const ZOOM_STEP = 1.1;
 const ZOOM_FACTOR = 700;
@@ -8,6 +18,65 @@ const SCROLL_GROUP_EXIT_THRESHOLD = 4;
 const SCROLL_INFINITE_THRESHOLD = 10;
 const SCROLL_PAN_STEP = 75;
 const SCROLL_PAN_FACTOR = 2;
+// Zoom clamp. The upper cap is image-size-aware (see maxZoomForPixels): only a
+// *large* image's composited layer can exhaust GPU memory at high zoom and crash
+// the tab on phones, so large images get the smaller device-tied cap while small
+// images (cheap to raster at any scale) reach the full ceiling on every device.
+// (PINCH_MIN must match Lightbox.tsx's updateZoom MIN_ZOOM, and both clamp to the
+// same maxZoomForPixels, so the pinch focal-pan uses the same effective scale
+// change the zoom is actually clamped to, or the pan diverges off-screen.)
+const PINCH_MIN_ZOOM = 0.1;
+
+function computeDeviceMaxZoom(): number {
+  // Chrome/Android expose approximate RAM; scale the ceiling with it.
+  const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+  if (typeof mem === "number" && mem > 0) {
+    if (mem >= 8) return 10;
+    if (mem >= 4) return 6;
+    return 4;
+  }
+  // Safari/iOS has no deviceMemory. Phones have far less GPU headroom than
+  // tablets, so use the smaller screen side (CSS px) as a phone-vs-tablet proxy:
+  // phones are < ~430, the smallest iPads ~744.
+  const minSide =
+    typeof window !== "undefined" && window.screen
+      ? Math.min(window.screen.width, window.screen.height)
+      : 0;
+  return minSide > 0 && minSide < 600 ? 5 : 10;
+}
+
+export const DEVICE_MAX_ZOOM = computeDeviceMaxZoom();
+
+// Touch gesture tuning (#2538). A single-finger swipe commits once it travels
+// far enough OR fast enough; the axis (horizontal/vertical/pan) is locked once
+// movement passes the lock threshold so a gesture can't change its mind midway.
+const SWIPE_COMMIT_DISTANCE = 60; // px of travel that commits a nav/delete swipe
+const SWIPE_VELOCITY = 0.3; // px/ms; a quick flick commits below the distance
+const AXIS_LOCK_THRESHOLD = 10; // px of travel before the axis is decided
+const TAP_MAX_MOVE = 10; // px; movement below this is a tap, not a swipe
+const DOUBLE_TAP_MS = 300; // max gap between taps to count as a double-tap
+const DOUBLE_TAP_SLOP = 30; // px; max distance between the two taps
+const PANNABLE_EPSILON = 1; // px tolerance when testing if the image overflows
+// Above this natural resolution, the first zoom-in forces an expensive full-res
+// raster (a multi-second stall on huge images). On a double-tap (which jumps
+// straight to the target zoom, with no in-between feedback) we cover that stall
+// with a busy spinner; a pinch needs no spinner because the live finger-tracking
+// is its own feedback. Cheaper images never trigger it either way. This is also
+// the threshold for the conservative zoom cap below - only images this big risk
+// an OOM.
+const LARGE_IMAGE_PIXELS = 30_000_000; // ~30 MP
+const ZOOM_SPINNER_MIN_MS = 400; // min spinner time when we decode-to-ready
+
+// Hard ceiling on zoom for any image on any device.
+export const MAX_ZOOM = 10;
+
+// Per-image upper zoom cap. A large image (> LARGE_IMAGE_PIXELS) gets the
+// smaller device-tied cap because its composited layer can exhaust GPU memory at
+// high zoom; a small image is cheap to raster at any scale, so it reaches the
+// full ceiling everywhere. `pixels` is the image's natural width * height.
+export function maxZoomForPixels(pixels: number): number {
+  return pixels > LARGE_IMAGE_PIXELS ? DEVICE_MAX_ZOOM : MAX_ZOOM;
+}
 const CLASSNAME = "Lightbox";
 const CLASSNAME_CAROUSEL = `${CLASSNAME}-carousel`;
 const CLASSNAME_IMAGE = `${CLASSNAME_CAROUSEL}-image`;
@@ -50,6 +119,50 @@ function calculateDefaultZoom(
   return newZoom;
 }
 
+interface IDimension {
+  width: number;
+  height: number;
+}
+
+// Track the container's size live via ResizeObserver. The box dimensions feed
+// fit-zoom, centering, the pannable/axis decisions and the pan-edge bounds, so
+// they must follow window resizes and phone orientation changes - measuring once
+// at mount leaves a zoomed image mis-centered after a rotate. Returns a stable
+// ref to attach to the element (also fixes the prior createRef()-per-render).
+function useContainerDimensions<T extends HTMLElement = HTMLDivElement>(): [
+  React.MutableRefObject<T | null>,
+  IDimension,
+] {
+  const ref = useRef<T | null>(null);
+  const [dimension, setDimension] = useState<IDimension>({
+    width: 0,
+    height: 0,
+  });
+
+  // Measure synchronously on mount (before paint) so the fit-zoom is known for
+  // the first render. Otherwise the box stays 0 until the debounced observer
+  // fires, and a large image renders at full natural size for ~120ms first
+  // (an expensive raster) before fit-scaling down.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    if (r.width && r.height) setDimension({ width: r.width, height: r.height });
+  }, []);
+
+  // Debounced so an *animated* rotate - which fires a burst of intermediate
+  // sizes - re-lays-out only once it settles. Used for subsequent resizes /
+  // rotation only; the initial size comes from the layout effect above.
+  const onResize = useDebounce((entry: ResizeObserverEntry) => {
+    const { inlineSize: width, blockSize: height } = entry.contentBoxSize[0];
+    setDimension({ width, height });
+  }, 120);
+
+  useResizeObserver(ref, onResize);
+
+  return [ref, dimension];
+}
+
 interface IProps {
   src: string;
   width: number;
@@ -71,6 +184,14 @@ interface IProps {
   debouncedScrollReset: () => void;
   onLeft: () => void;
   onRight: () => void;
+  // swipe-up-to-delete; opens the confirmation dialog (never bypassed)
+  onSwipeDelete?: () => void;
+  // swipe-down-to-close; dismisses the lightbox
+  onSwipeClose?: () => void;
+  // ask the parent to re-center the image (toggles its resetPosition)
+  onResetPosition?: () => void;
+  // whether horizontal swipes should navigate (false for single-image galleries)
+  navigationEnabled: boolean;
   isVideo: boolean;
 }
 
@@ -92,6 +213,10 @@ export const LightboxImage: React.FC<IProps> = ({
   debouncedScrollReset,
   onLeft,
   onRight,
+  onSwipeDelete,
+  onSwipeClose,
+  onResetPosition,
+  navigationEnabled,
   isVideo,
 }) => {
   const [defaultZoom, setDefaultZoom] = useState(1);
@@ -100,27 +225,78 @@ export const LightboxImage: React.FC<IProps> = ({
   const [positionY, setPositionY] = useState(0);
   const [imageWidth, setImageWidth] = useState(width);
   const [imageHeight, setImageHeight] = useState(height);
-  const [boxWidth, setBoxWidth] = useState(0);
-  const [boxHeight, setBoxHeight] = useState(0);
+  // live container size (follows window resize / orientation change)
+  const [container, { width: boxWidth, height: boxHeight }] =
+    useContainerDimensions<HTMLDivElement>();
   const dimensionsProvided = width > 0 && height > 0;
 
   const mouseDownEvent = useRef<MouseEvent>();
   const resetPositionRef = useRef(resetPosition);
 
-  const container = React.createRef<HTMLDivElement>();
   const startPoints = useRef<number[]>([0, 0]);
   const pointerCache = useRef<React.PointerEvent[]>([]);
-  const prevDiff = useRef<number | undefined>();
+  // Snapshot taken once at the start of a pinch. Pinch zoom/pan is computed
+  // absolutely from this each frame (no per-frame accumulation or DOM reads),
+  // which is what keeps it stable - see onPointerMove.
+  const pinch = useRef<{
+    dist: number;
+    zoom: number;
+    posX: number;
+    posY: number;
+    c0x: number;
+    c0y: number;
+    fx: number;
+    fy: number;
+  } | null>(null);
+
+  // single-finger touch gesture state (#2538)
+  const touchStart = useRef<{ x: number; y: number; t: number } | null>(null);
+  const gestureAxis = useRef<"none" | "horizontal" | "vertical" | "pan">(
+    "none"
+  );
+  const lastTap = useRef<{ x: number; y: number; t: number } | null>(null);
+  // timestamp of the last touchend, used to suppress the "ghost" mouse click
+  // iOS synthesizes after a tap (which would otherwise trigger half-screen nav)
+  const lastTouchEnd = useRef(0);
+
+  // Busy spinner for the first (expensive) zoom-in of a large image. `zoomedOnce`
+  // gates it to once per image (the raster is cached afterwards).
+  const [zoomBusy, setZoomBusy] = useState(false);
+  // True while a 2-finger pinch is active. The busy spinner is unmounted during
+  // a pinch: its always-running rotate animation (needed so it can appear while
+  // the main thread is blocked - see runZoomIn) otherwise competes with the
+  // pinch's own heavy compositing on a huge image and makes it janky. We never
+  // show a spinner for pinch anyway, so dropping it here is free.
+  const [pinching, setPinching] = useState(false);
+  const zoomedOnce = useRef(false);
+  const zoomSpinnerShownAt = useRef(0);
+  const isLargeImage = imageWidth * imageHeight > LARGE_IMAGE_PIXELS;
+  // Per-image zoom ceiling (large images get the conservative device cap).
+  const maxZoom = maxZoomForPixels(imageWidth * imageHeight);
+
+  // Show the busy spinner now (flushSync so it paints before the blocking work).
+  function showZoomBusy() {
+    zoomSpinnerShownAt.current = performance.now();
+    flushSync(() => setZoomBusy(true));
+  }
+
+  // Clear it, but not before it's been visible at least `minMs` (so it always
+  // registers even when the decode finishes quickly).
+  function clearZoomBusy(minMs = ZOOM_SPINNER_MIN_MS) {
+    const wait = minMs - (performance.now() - zoomSpinnerShownAt.current);
+    if (wait > 0) window.setTimeout(() => setZoomBusy(false), wait);
+    else setZoomBusy(false);
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: explicitly want to reset the zoom state whenever the image src changes
+  useEffect(() => {
+    zoomedOnce.current = false;
+    setZoomBusy(false);
+  }, [src]);
 
   const scrollAttempts = useRef(0);
 
   useEffect(() => {
-    const box = container.current;
-    if (box) {
-      setBoxWidth(box.offsetWidth);
-      setBoxHeight(box.offsetHeight);
-    }
-
     function toggleVideoPlay() {
       if (container.current) {
         const openVideo = container.current.getElementsByTagName("video");
@@ -188,6 +364,36 @@ export const LightboxImage: React.FC<IProps> = ({
     [imageHeight, boxHeight]
   );
 
+  // Horizontal pan bounds - mirror of minMaxY (the transform scales about the
+  // wrapper centre and the image lays out flex-start when it overflows, so X is
+  // symmetric to Y). [minX, maxX] is the range of positionX that keeps the
+  // scaled image covering the viewport, i.e. you can't pan past an edge.
+  const minMaxX = useCallback(
+    (appliedZoom: number) => {
+      let minX: number, maxX: number;
+      const inBounds = appliedZoom * imageWidth <= boxWidth;
+
+      if (!inBounds) {
+        if (imageWidth > boxWidth) {
+          minX =
+            (appliedZoom * imageWidth - imageWidth) / 2 -
+            appliedZoom * imageWidth +
+            boxWidth;
+          maxX = (appliedZoom * imageWidth - imageWidth) / 2;
+        } else {
+          minX = (boxWidth - appliedZoom * imageWidth) / 2;
+          maxX = (appliedZoom * imageWidth - boxWidth) / 2;
+        }
+      } else {
+        minX = Math.min((boxWidth - imageWidth) / 2, 0);
+        maxX = minX;
+      }
+
+      return [minX, maxX];
+    },
+    [imageWidth, boxWidth]
+  );
+
   const calculateInitialPosition = useCallback(
     (appliedZoom: number) => {
       // Center image from container's center
@@ -219,42 +425,83 @@ export const LightboxImage: React.FC<IProps> = ({
     ]
   );
 
+  // identity of the currently-positioned view; a change means a genuinely new
+  // image/display option (reset to initial), as opposed to a pure box resize.
+  const viewKey = useRef<string>("");
+  // last observed box size, to tell a resize from an unrelated re-run.
+  const prevBox = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
+
   useEffect(() => {
     // don't set anything until we have the dimensions
     if (!imageWidth || !imageHeight || !boxWidth || !boxHeight) {
       return;
     }
 
-    if (!scaleUp && imageWidth < boxWidth && imageHeight < boxHeight) {
-      setDefaultZoom(1);
-      setPositionX(0);
-      setPositionY(0);
-      return;
-    }
+    const smallUnscaled =
+      !scaleUp && imageWidth < boxWidth && imageHeight < boxHeight;
+    // the fit baseline for the *current* box
+    const newZoom = smallUnscaled
+      ? 1
+      : calculateDefaultZoom(
+          imageWidth,
+          imageHeight,
+          boxWidth,
+          boxHeight,
+          displayMode,
+          scaleUp
+        );
 
-    // set initial zoom level based on options
-    const newZoom = calculateDefaultZoom(
-      imageWidth,
-      imageHeight,
-      boxWidth,
-      boxHeight,
-      displayMode,
-      scaleUp
-    );
+    const key = `${src}|${displayMode}|${scaleUp}|${alignBottom}`;
+    const oldBoxW = prevBox.current.w;
+    const oldBoxH = prevBox.current.h;
+    const boxResized = boxWidth !== oldBoxW || boxHeight !== oldBoxH;
+    prevBox.current = { w: boxWidth, h: boxHeight };
 
-    setDefaultZoom(newZoom);
+    // refit to the box and reset to the initial centered position
+    const resetToInitial = () => {
+      setDefaultZoom(newZoom);
+      if (smallUnscaled) {
+        setPositionX(0);
+        setPositionY(0);
+      } else {
+        const [nx, ny] = calculateInitialPosition(newZoom * 1);
+        setPositionX(nx);
+        setPositionY(ny);
+      }
+      scrollAttempts.current = alignBottom
+        ? scrollAttemptsBeforeChange
+        : -scrollAttemptsBeforeChange;
+    };
 
-    const [newPositionX, newPositionY] = calculateInitialPosition(newZoom * 1);
-
-    setPositionX(newPositionX);
-    setPositionY(newPositionY);
-
-    if (alignBottom) {
-      scrollAttempts.current = scrollAttemptsBeforeChange;
+    if (key !== viewKey.current) {
+      // genuinely new image / display option
+      viewKey.current = key;
+      resetToInitial();
+    } else if (boxResized) {
+      if (Math.abs(zoom - 1) < 0.05) {
+        // viewing at fit: refit + recentre for the new orientation
+        resetToInitial();
+      } else {
+        // zoomed in: preserve the absolute scale (keep defaultZoom, so the image
+        // stays the same size and still overflows = pannable) and the focal
+        // point. `position` is a screen-space translation, so shifting it by half
+        // the box-size change keeps the content under the viewport centre fixed
+        // (scale/layout-independent); then clamp into the new bounds.
+        const applied = defaultZoom * zoom;
+        const dx = (boxWidth - oldBoxW) / 2;
+        const dy = (boxHeight - oldBoxH) / 2;
+        const [minX, maxX] = minMaxX(applied);
+        const [minY, maxY] = minMaxY(applied);
+        setPositionX((px) => Math.min(Math.max(px + dx, minX), maxX));
+        setPositionY((py) => Math.min(Math.max(py + dy, minY), maxY));
+      }
     } else {
-      scrollAttempts.current = -scrollAttemptsBeforeChange;
+      // unrelated re-run (e.g. a zoom change): keep the fit baseline in sync
+      // without touching position, so the pinch/zoom path is untouched
+      setDefaultZoom(newZoom);
     }
   }, [
+    src,
     imageWidth,
     imageHeight,
     boxWidth,
@@ -262,7 +509,11 @@ export const LightboxImage: React.FC<IProps> = ({
     displayMode,
     scaleUp,
     alignBottom,
+    zoom,
+    defaultZoom,
     calculateInitialPosition,
+    minMaxX,
+    minMaxY,
     scrollAttemptsBeforeChange,
   ]);
 
@@ -429,8 +680,12 @@ export const LightboxImage: React.FC<IProps> = ({
     const posY = ev.pageY - startPoints.current[1];
     startPoints.current = [ev.pageX, ev.pageY];
 
-    setPositionX(positionX + posX);
-    setPositionY(positionY + posY);
+    // clamp to the image bounds so a drag stops at the edge (matches touch pan)
+    const appliedZoom = defaultZoom * zoom;
+    const [minX, maxX] = minMaxX(appliedZoom);
+    const [minY, maxY] = minMaxY(appliedZoom);
+    setPositionX(Math.min(Math.max(positionX + posX, minX), maxX));
+    setPositionY(Math.min(Math.max(positionY + posY, minY), maxY));
   }
 
   function onImageMouseDown(ev: React.MouseEvent) {
@@ -442,6 +697,12 @@ export const LightboxImage: React.FC<IProps> = ({
 
   function onImageMouseUp(ev: React.MouseEvent) {
     if (ev.button !== 0) return;
+
+    // ignore the synthesized click that follows a touch tap (iOS doesn't always
+    // honour touchstart-preventDefault here) so touch taps don't navigate -
+    // on touch, zoom is via double-tap and navigation via swipe. Real mouse
+    // clicks have no preceding touchend and pass through.
+    if (ev.timeStamp - lastTouchEnd.current < 700) return;
 
     if (
       !mouseDownEvent.current ||
@@ -468,23 +729,192 @@ export const LightboxImage: React.FC<IProps> = ({
 
   function onTouchStart(ev: React.TouchEvent) {
     ev.preventDefault();
-    if (ev.touches.length === 1) {
-      startPoints.current = [ev.touches[0].pageX, ev.touches[0].pageY];
-      setMoving(true);
+
+    // a second finger means a pinch, which is driven by the pointer handlers;
+    // abandon any single-finger gesture so the two don't fight
+    if (ev.touches.length !== 1 || pointerCache.current.length >= 2) {
+      touchStart.current = null;
+      gestureAxis.current = "none";
+      setMoving(false);
+      return;
     }
+
+    const t = ev.touches[0];
+    touchStart.current = { x: t.pageX, y: t.pageY, t: ev.timeStamp };
+    startPoints.current = [t.pageX, t.pageY];
+    gestureAxis.current = "none";
+    setMoving(true);
   }
 
   function onTouchMove(ev: React.TouchEvent) {
-    if (!moving) return;
+    if (!moving || !touchStart.current) return;
+    // pinch in progress - let the pointer handlers own it
+    if (ev.touches.length !== 1 || pointerCache.current.length >= 2) return;
 
-    if (ev.touches.length === 1) {
-      const posX = ev.touches[0].pageX - startPoints.current[0];
-      const posY = ev.touches[0].pageY - startPoints.current[1];
-      startPoints.current = [ev.touches[0].pageX, ev.touches[0].pageY];
+    const t = ev.touches[0];
 
-      setPositionX(positionX + posX);
-      setPositionY(positionY + posY);
+    // Decide the gesture axis once, when movement first passes the lock
+    // threshold. A drag pans only when the image actually overflows that axis;
+    // otherwise it's a swipe candidate (navigate / delete), committed on release.
+    if (gestureAxis.current === "none") {
+      const dx = t.pageX - touchStart.current.x;
+      const dy = t.pageY - touchStart.current.y;
+      if (Math.hypot(dx, dy) < AXIS_LOCK_THRESHOLD) return;
+
+      const appliedZoom = defaultZoom * zoom;
+      if (Math.abs(dx) > Math.abs(dy)) {
+        const horizPannable =
+          imageWidth * appliedZoom > boxWidth + PANNABLE_EPSILON;
+        gestureAxis.current = horizPannable ? "pan" : "horizontal";
+      } else {
+        const vertPannable =
+          imageHeight * appliedZoom > boxHeight + PANNABLE_EPSILON;
+        gestureAxis.current = vertPannable ? "pan" : "vertical";
+      }
     }
+
+    if (gestureAxis.current === "pan") {
+      const posX = t.pageX - startPoints.current[0];
+      const posY = t.pageY - startPoints.current[1];
+      startPoints.current = [t.pageX, t.pageY];
+
+      // clamp to the image bounds so a drag stops at the edge instead of
+      // flinging the image off the viewport
+      const appliedZoom = defaultZoom * zoom;
+      const [minX, maxX] = minMaxX(appliedZoom);
+      const [minY, maxY] = minMaxY(appliedZoom);
+      setPositionX(Math.min(Math.max(positionX + posX, minX), maxX));
+      setPositionY(Math.min(Math.max(positionY + posY, minY), maxY));
+    }
+  }
+
+  function onTouchEnd(ev: React.TouchEvent) {
+    setMoving(false);
+    lastTouchEnd.current = ev.timeStamp;
+
+    const start = touchStart.current;
+    const axis = gestureAxis.current;
+    touchStart.current = null;
+    gestureAxis.current = "none";
+
+    // pinch end, or a gesture we never started tracking
+    if (!start || pointerCache.current.length >= 2) return;
+    // a pan already applied its movement during touchmove
+    if (axis === "pan") return;
+
+    const t = ev.changedTouches[0];
+    if (!t) return;
+
+    const dx = t.pageX - start.x;
+    const dy = t.pageY - start.y;
+    const dt = Math.max(1, ev.timeStamp - start.t);
+
+    // little movement: it's a tap (single-tap is a no-op, double-tap zooms).
+    // Pass client coords - the double-tap focal zoom anchors on them and matches
+    // them against the container's getBoundingClientRect (also client-space).
+    if (Math.hypot(dx, dy) < TAP_MAX_MOVE) {
+      handleTap(t.clientX, t.clientY, ev.timeStamp);
+      return;
+    }
+
+    // committed once it travels far enough or is flicked fast enough
+    const committed = (d: number) =>
+      Math.abs(d) > SWIPE_COMMIT_DISTANCE || Math.abs(d) / dt > SWIPE_VELOCITY;
+
+    if (axis === "horizontal" && navigationEnabled) {
+      if (committed(dx)) {
+        if (dx > 0) onLeft();
+        else onRight();
+      }
+    } else if (axis === "vertical" && committed(dy)) {
+      // swipe up opens the delete confirmation dialog; swipe down closes the
+      // lightbox. Both only fire when the
+      // image isn't vertically pannable - i.e. at fit zoom - since a zoomed-in
+      // vertical drag locks to "pan" instead.
+      if (dy < 0) {
+        onSwipeDelete?.();
+      } else {
+        onSwipeClose?.();
+      }
+    }
+  }
+
+  function handleTap(x: number, y: number, time: number) {
+    const prev = lastTap.current;
+    if (
+      prev &&
+      time - prev.t < DOUBLE_TAP_MS &&
+      Math.hypot(x - prev.x, y - prev.y) < DOUBLE_TAP_SLOP
+    ) {
+      lastTap.current = null;
+      toggleDoubleTapZoom(x, y);
+      return;
+    }
+    lastTap.current = { x, y, t: time };
+    // A single tap on touch is intentionally a no-op: navigation is via swipe
+    // and zoom via double-tap. Acting on the first tap here would make a
+    // double-tap impossible (or require a 300ms tap-delay hack). Desktop
+    // left/right-half click navigation (onImageMouseUp) is unaffected.
+  }
+
+  function toggleDoubleTapZoom(tapX: number, tapY: number) {
+    if (Math.abs(zoom - 1) >= 0.05) {
+      // already zoomed: reset to fit and re-centre
+      setZoom(1);
+      onResetPosition?.();
+      return;
+    }
+
+    // At fit: zoom toward the tapped point to 1:1 native (à la PhotoSwipe).
+    // defaultZoom is the fit scale, so 1/defaultZoom is exactly 100% native;
+    // clamp to the pinch ceiling, and to a sensible minimum so the gesture
+    // always does something on images that already fit.
+    const target = Math.min(Math.max(1 / (defaultZoom || 1), 2), maxZoom);
+    const box = container.current?.getBoundingClientRect();
+    runZoomIn(() => {
+      if (box) {
+        // anchor the zoom on the tap point (same focal math as pinch)
+        const r = target / zoom;
+        const c0x =
+          box.left + (imageWidth > box.width ? imageWidth : box.width) / 2;
+        const c0y =
+          box.top + (imageHeight > box.height ? imageHeight : box.height) / 2;
+        setPositionX((tapX - c0x) * (1 - r) + r * positionX);
+        setPositionY((tapY - c0y) * (1 - r) + r * positionY);
+      }
+      setZoom(target);
+    });
+  }
+
+  // Apply an expensive zoom-in. The first zoom of a large image triggers a
+  // multi-second full-res re-raster on the main thread (on iOS Safari it jumps
+  // straight to sharp afterwards, with no feedback meanwhile). We cover that
+  // stall with a busy spinner that lives on its own compositor layer (see the
+  // overlay JSX): its opacity + rotate animation are composited independently of
+  // the main thread, so it keeps spinning while the main thread is blocked.
+  //
+  // We deliberately do NOT pre-decode the bitmap: img.decode() forces the whole
+  // full-res image (~width*height*4 bytes, hundreds of MB) into RAM regardless
+  // of how far you zoom, which is redundant with the raster the transform
+  // triggers anyway and just raises peak memory. Letting the browser raster
+  // on-demand keeps the footprint lower on every device.
+  function runZoomIn(apply: () => void) {
+    if (!isLargeImage || zoomedOnce.current) {
+      apply();
+      return;
+    }
+    zoomedOnce.current = true;
+    // Reveal the spinner, yield a real frame (rAF then setTimeout(0) - that
+    // hands the opacity change to the compositor before apply() blocks;
+    // double-rAF is unreliable on iOS), then apply the zoom and clear once the
+    // heavy paint lands.
+    showZoomBusy();
+    requestAnimationFrame(() =>
+      window.setTimeout(() => {
+        apply();
+        requestAnimationFrame(() => clearZoomBusy());
+      }, 0)
+    );
   }
 
   function onPointerDown(ev: React.PointerEvent) {
@@ -494,7 +924,10 @@ export const LightboxImage: React.FC<IProps> = ({
     );
 
     pointerCache.current.push(ev);
-    prevDiff.current = undefined;
+    // (re)start the pinch snapshot; it's captured on the first 2-pointer move
+    pinch.current = null;
+    // unmount the busy spinner while pinching (see `pinching`)
+    if (pointerCache.current.length >= 2) setPinching(true);
   }
 
   function onPointerUp(ev: React.PointerEvent) {
@@ -504,8 +937,19 @@ export const LightboxImage: React.FC<IProps> = ({
         break;
       }
     }
+    if (pointerCache.current.length < 2) {
+      pinch.current = null;
+      // pinch over: remount the spinner so its animation is warm for a later tap
+      setPinching(false);
+    }
   }
 
+  // Pinch-to-zoom, computed ABSOLUTELY from a snapshot taken at the start of the
+  // gesture (à la timmywil/panzoom) rather than accumulated per frame. Each move
+  // derives the target zoom and pan purely from the snapshot + the live finger
+  // distance/midpoint, so there's no frame-to-frame drift, no exponential
+  // divergence, and no per-frame getBoundingClientRect (all of which made the
+  // incremental version fling the image off-screen / crash the tab).
   function onPointerMove(ev: React.PointerEvent) {
     // find the event in the cache
     const cachedIndex = pointerCache.current.findIndex(
@@ -515,27 +959,59 @@ export const LightboxImage: React.FC<IProps> = ({
       pointerCache.current[cachedIndex] = ev;
     }
 
-    // compare the difference between the two pointers
-    if (pointerCache.current.length === 2) {
-      const ev1 = pointerCache.current[0];
-      const ev2 = pointerCache.current[1];
-      const diffX = Math.abs(ev1.clientX - ev2.clientX);
-      const diffY = Math.abs(ev1.clientY - ev2.clientY);
-      const diff = Math.sqrt(diffX ** 2 + diffY ** 2);
+    if (pointerCache.current.length !== 2) return;
 
-      if (prevDiff.current !== undefined) {
-        const diffDiff = diff - prevDiff.current;
-        const factor = (Math.abs(diffDiff) / 20) * 0.1 + 1;
+    const ev1 = pointerCache.current[0];
+    const ev2 = pointerCache.current[1];
+    const dist = Math.hypot(
+      ev1.clientX - ev2.clientX,
+      ev1.clientY - ev2.clientY
+    );
+    const midX = (ev1.clientX + ev2.clientX) / 2;
+    const midY = (ev1.clientY + ev2.clientY) / 2;
 
-        if (diffDiff > 0) {
-          setZoom(zoom * factor);
-        } else if (diffDiff < 0) {
-          setZoom((zoom * 1) / factor);
-        }
-      }
-
-      prevDiff.current = diff;
+    if (!pinch.current) {
+      // Snapshot once: the finger distance, the current zoom/pan, the focal
+      // (the initial midpoint we anchor on), and the wrapper's untransformed
+      // centre. The image lays out at natural size, so it aligns flex-start
+      // when it overflows the box (the usual case) and is margin:auto-centred
+      // only when smaller.
+      const box = container.current?.getBoundingClientRect();
+      pinch.current = {
+        dist: dist || 1,
+        zoom,
+        posX: positionX,
+        posY: positionY,
+        fx: midX,
+        fy: midY,
+        c0x: box
+          ? box.left + (imageWidth > box.width ? imageWidth : box.width) / 2
+          : midX,
+        c0y: box
+          ? box.top + (imageHeight > box.height ? imageHeight : box.height) / 2
+          : midY,
+      };
+      return;
     }
+
+    const p = pinch.current;
+    // zoom scales with the finger-spread ratio (natural pinch feel), clamped
+    const toZoom = Math.min(
+      Math.max((p.zoom * dist) / p.dist, PINCH_MIN_ZOOM),
+      maxZoom
+    );
+    // keep the focal content point fixed: with scale about the wrapper centre,
+    // pan' = (focal - centre)(1 - r) + r * panAtStart, where r = scale ratio
+    // from the start of the gesture. Bounded because toZoom is clamped.
+    const r = toZoom / p.zoom;
+    setPositionX((p.fx - p.c0x) * (1 - r) + r * p.posX);
+    setPositionY((p.fy - p.c0y) * (1 - r) + r * p.posY);
+    setZoom(toZoom);
+
+    // mark the first zoom done so a later double-tap on this image skips the
+    // spinner (the pinch has already decoded it). No spinner for pinch itself -
+    // the live gesture is its own feedback.
+    if (isLargeImage && !zoomedOnce.current) zoomedOnce.current = true;
   }
 
   const ImageView = isVideo ? "video" : "img";
@@ -573,10 +1049,37 @@ export const LightboxImage: React.FC<IProps> = ({
             onMouseMove={onImageMouseOver}
             onTouchStart={onTouchStart}
             onTouchMove={onTouchMove}
+            onTouchEnd={onTouchEnd}
+            onTouchCancel={onTouchEnd}
             onPointerDown={onPointerDown}
             onPointerUp={onPointerUp}
             onPointerMove={onPointerMove}
           />
+        </div>
+      ) : undefined}
+      {current && !pinching ? (
+        // Busy indicator for the first zoom-in of a large image (fixed-centred
+        // over the viewport; non-interactive so it never blocks the gesture).
+        // Mounted (with its rotate animation already running) and toggled via
+        // `opacity` so it sits on its own compositor layer (translateZ(0)) - the
+        // animation must be live on the compositor *before* the zoom blocks the
+        // main thread, or it never paints during the stall (a freshly-mounted
+        // one doesn't commit in time). It's unmounted during a pinch only, where
+        // that perpetual animation would otherwise fight the pinch's compositing.
+        <div
+          aria-hidden={!zoomBusy}
+          style={{
+            position: "fixed",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%) translateZ(0)",
+            zIndex: 10,
+            pointerEvents: "none",
+            opacity: zoomBusy ? 1 : 0,
+            transition: "opacity 80ms linear",
+          }}
+        >
+          <LoadingIndicator inline message="" />
         </div>
       ) : undefined}
     </div>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This adds mobile/touch gesture support to the image lightbox. On a phone or tablet you can now swipe between images, swipe to delete or close, and double-tap or pinch to zoom — previously the lightbox was only usable on touch through the on-screen buttons.

| Gesture | Action |
|---------|--------|
| Swipe left / right | Next / previous image |
| Swipe up | Delete the current image (opens the existing confirmation dialog) |
| Swipe down | Close the lightbox |
| Double-tap | Toggle zoom (fit ↔ zoomed in, toward the tapped point) |
| Pinch | Zoom in / out around the pinch point |

While zoomed in, a drag pans the image (clamped to its edges) instead of navigating, deleting or closing.

The lightbox also now responds to device rotation and window resizing, re-fitting the image to the new viewport (and keeping a zoomed-in image centered on the same point) instead of staying laid out for the previous orientation.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #2538

## Testing
<!-- Describe the testing steps you have performed. -->

Desktop behaviour is unchanged: all the gesture handling is touch-gated, so mouse/keyboard navigation, scroll-zoom, the nav buttons and the delete/O/rating controls behave exactly as before.

Tested on real devices (iPhone and iPad) as well as across Playwright touch-emulation profiles — Pixel 5 (Chromium), iPhone and iPad (WebKit):

- swipe left/right navigates; swipe up opens the delete dialog (confirmed and cancelled); swipe down closes
- double-tap zooms toward the tapped point and back to fit; pinch zooms around the pinch point
- while zoomed, a drag pans and stops at the image edges instead of navigating
- a two-finger gesture doesn't trigger a single-finger swipe
- rotating the device re-fits at fit zoom and preserves the scale/focal point while zoomed in

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

No new UI.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used [Claude Code](https://claude.ai/code) as a coding assistant for this PR. It helped explore the hand-rolled lightbox, draft and implement the approach (the axis-locked single-finger gesture state machine, the swipe/double-tap/pinch handling, the image- and device-aware zoom cap, the compositor-layer busy spinner, and the `ResizeObserver`-driven fit/centering/pan bounds), and author the Playwright end-to-end tests used to verify it. I directed the design decisions, reviewed all changes, and validated the behavior on real devices (iPhone and iPad) as well as through browser touch emulation and the automated tests before submitting.

## Additional Context
<!-- Add any other context about the pull request here. -->

Key design choices:

- **Single-finger, axis-locked state machine.** Once a drag passes a small threshold the axis (horizontal-navigate / vertical / pan) is locked for the rest of the gesture, so it can't change its mind halfway. Whether a drag pans or swipes is decided from the image-vs-viewport geometry: it only pans on an axis where the (zoomed) image actually overflows the viewport, otherwise the drag is a swipe candidate that commits on release by distance *or* flick velocity. A gesture bails as soon as a second finger goes down.
- **Delete never bypasses confirmation.** Swipe-up reuses the existing `DeleteImagesDialog`; it only ever opens the dialog, exactly like the delete button, and is disabled when the current image has no id.
- **Swipe-down to close** is the near-universal photo-viewer dismiss gesture (iOS Photos, Google Photos, PhotoSwipe's `closeOnVerticalDrag`). Vertical gestures only fire at fit zoom; once zoomed in, a vertical drag pans instead.
- **Pinch is computed absolutely from a snapshot taken at gesture start**, and anchored on the pinch focal point, rather than accumulated per frame. Per-frame accumulation (and per-frame `getBoundingClientRect`) drifted and could wedge the view; the absolute form (`pan' = (focal − centre)(1 − r) + r·startPan`) stays stable for the whole pinch.
- **Ghost-click guard.** iOS fires a synthetic `click` shortly after a tap; a short timestamp guard suppresses it so a tap doesn't also trigger the desktop half-screen click-to-navigate. Real mouse clicks on desktop are unaffected — taps zoom, clicks still advance.
- **Pan is clamped to the image edges** for both touch drags and mouse drags, so a pan stops at the edge instead of flinging the image off-screen. (The horizontal clamp mirrors the pre-existing vertical one.)
- **Image- and device-aware zoom cap** — the least obvious part, worth a look. A composited image layer at high zoom can exhaust GPU memory and crash the tab on a phone, but the risk is bound by the image's *source* resolution, not the zoom multiplier, so a small image is cheap to raster at any scale. Only large images (above ~30 MP) get a conservative, device-tied cap (derived from `navigator.deviceMemory` where available, else a phone-vs-tablet screen-size proxy on Safari); every other image keeps the full zoom ceiling on every device. The cap feeds the pinch and double-tap clamps as well as the existing scroll/keyboard zoom.
- **Busy spinner for the first large-image zoom.** The first zoom-in of a large image forces an expensive full-resolution raster that briefly blocks the main thread (a double-tap jumps straight to the target zoom, so unlike a pinch there's no live feedback to cover it). A small spinner on its own compositor layer keeps animating through that block; it's unmounted during an active pinch so its animation can't jank the live tracking.
- **Live container size via `ResizeObserver`.** Fit-zoom, centering, the axis decision and the pan bounds all depend on the viewport box, so they now follow window resizes and device rotation (previously measured once at mount, which left a zoomed image mis-centered after a rotate). On rotate at fit it re-fits; while zoomed it preserves the current scale and focal point and re-clamps. This also removed a `createRef()`-per-render.

Related PR: #6197 also targets #2538, but is narrower. The issue itself asks for swipe left/right navigation and double-tap-to-zoom; #6197 implements the swipe navigation and makes panning stop at the image edge (reworking the pan-position model so 0 means centered, with a non-zero position being an offset), while this PR implements both of the issue's asks and adds further gestures beyond it — pinch zoom, and swipe up/down to delete/close — plus the supporting zoom cap and rotation handling. The two touch the same `Lightbox.tsx`/`LightboxImage.tsx` and overlap on swipe navigation and the pan-edge behaviour (and take different approaches to the pan-position model).

Known device limitation: rotating a *very* large image (tested with a ~140 MP photo) on a memory-constrained iPhone can briefly stutter or freeze the tab. This is an iOS Safari decoded-image/canvas memory ceiling, not this code — it reproduces with the resize handling disabled, because the rotate itself forces the browser to re-raster the full-resolution bitmap. The real fix is serving a downscaled image to the lightbox, a separate Stash-wide change that's out of scope here. Normal-sized images are unaffected.