### PR TITLE
Fix: Case Insensitive Scan File Lookup

### DIFF
--- a/pkg/file/scan.go
+++ b/pkg/file/scan.go
@@ -371,7 +371,7 @@ func (s *Scanner) ScanFile(ctx context.Context, f ScannedFile) (*ScanFileResult,
 		// #1426 / #6326 - if file is in a case-insensitive filesystem, then try
 		// case insensitive search
 		// assume case sensitive if in zip
-		if ff == nil && f.ZipFileID != nil {
+		if ff == nil && f.ZipFileID == nil {
 			caseSensitive, _ := f.FS.IsPathCaseSensitive(f.Path)
 
 			if !caseSensitive {

--- a/pkg/file/scan_test.go
+++ b/pkg/file/scan_test.go
@@ -1,0 +1,142 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type scanTestFS struct {
+	caseSensitive bool
+}
+
+func (f scanTestFS) Stat(name string) (fs.FileInfo, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (f scanTestFS) Lstat(name string) (fs.FileInfo, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (f scanTestFS) Open(name string) (fs.ReadDirFile, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (f scanTestFS) OpenZip(name string, size int64) (models.ZipFS, error) {
+	return nil, errors.New("zip files not supported")
+}
+
+func (f scanTestFS) IsPathCaseSensitive(path string) (bool, error) {
+	return f.caseSensitive, nil
+}
+
+type scanTestFileInfo struct {
+	name    string
+	size    int64
+	modTime time.Time
+}
+
+func (i scanTestFileInfo) Name() string       { return i.name }
+func (i scanTestFileInfo) Size() int64        { return i.size }
+func (i scanTestFileInfo) Mode() fs.FileMode  { return 0644 }
+func (i scanTestFileInfo) ModTime() time.Time { return i.modTime }
+func (i scanTestFileInfo) IsDir() bool        { return false }
+func (i scanTestFileInfo) Sys() interface{}   { return nil }
+
+type scanTestFingerprintCalculator struct {
+	fingerprints []models.Fingerprint
+}
+
+func (c scanTestFingerprintCalculator) CalculateFingerprints(f *models.BaseFile, o Opener, useExisting bool) ([]models.Fingerprint, error) {
+	return c.fingerprints, nil
+}
+
+func TestScannerScanFileMatchesCaseOnlyRenameOnCaseInsensitiveFilesystem(t *testing.T) {
+	ctx := context.Background()
+	db := mocks.NewDatabase()
+
+	oldModTime := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	newModTime := oldModTime.Add(time.Hour)
+
+	existing := &models.VideoFile{
+		BaseFile: &models.BaseFile{
+			ID:             1,
+			Path:           `C:\stash\ALLCAPS.mp4`,
+			Basename:       "ALLCAPS.mp4",
+			ParentFolderID: 2,
+			Size:           100,
+			DirEntry: models.DirEntry{
+				ModTime: oldModTime,
+			},
+			Fingerprints: []models.Fingerprint{
+				{Type: models.FingerprintTypeOshash, Fingerprint: "old-oshash"},
+				{Type: models.FingerprintTypeMD5, Fingerprint: "old-md5"},
+				{Type: models.FingerprintTypePhash, Fingerprint: int64(1234)},
+			},
+		},
+		Format:     "mp4",
+		VideoCodec: "h264",
+		AudioCodec: "aac",
+	}
+
+	newFingerprints := []models.Fingerprint{
+		{Type: models.FingerprintTypeOshash, Fingerprint: "new-oshash"},
+		{Type: models.FingerprintTypeMD5, Fingerprint: "new-md5"},
+	}
+
+	scanner := Scanner{
+		FS: scanTestFS{caseSensitive: false},
+		Repository: Repository{
+			TxnManager: db,
+			File:       db.File,
+			Folder:     db.Folder,
+		},
+		FingerprintCalculator: scanTestFingerprintCalculator{fingerprints: newFingerprints},
+	}
+
+	scanned := ScannedFile{
+		BaseFile: &models.BaseFile{
+			Path:     `C:\stash\Allcaps.mp4`,
+			Basename: "Allcaps.mp4",
+			Size:     90,
+			DirEntry: models.DirEntry{
+				ModTime: newModTime,
+			},
+		},
+		FS: scanTestFS{caseSensitive: false},
+		Info: scanTestFileInfo{
+			name:    "Allcaps.mp4",
+			size:    90,
+			modTime: newModTime,
+		},
+	}
+
+	db.File.On("FindByPath", mock.Anything, scanned.Path, true).Return(nil, nil).Once()
+	db.File.On("FindByPath", mock.Anything, scanned.Path, false).Return(existing, nil).Once()
+	db.File.On("Update", mock.Anything, mock.MatchedBy(func(f models.File) bool {
+		base := f.Base()
+		return base.ID == existing.ID &&
+			base.Basename == scanned.Basename &&
+			base.Size == scanned.Size &&
+			base.Fingerprints.Get(models.FingerprintTypeOshash) == "new-oshash" &&
+			base.Fingerprints.Get(models.FingerprintTypeMD5) == "new-md5" &&
+			base.Fingerprints.Get(models.FingerprintTypePhash) == nil
+	})).Return(nil).Once()
+
+	result, err := scanner.ScanFile(ctx, scanned)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.New)
+	assert.True(t, result.Updated)
+	assert.Equal(t, existing.ID, result.File.Base().ID)
+
+	db.File.AssertExpectations(t)
+}

--- a/pkg/sqlite/file.go
+++ b/pkg/sqlite/file.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
@@ -624,7 +623,7 @@ func (qb *FileStore) find(ctx context.Context, id models.FileID) (models.File, e
 	return ret, nil
 }
 
-// FindByPath returns the first file that matches the given path. Wildcard characters are supported.
+// FindByPath returns the first file that matches the given path. The * wildcard is supported.
 func (qb *FileStore) FindByPath(ctx context.Context, p string, caseSensitive bool) (models.File, error) {
 
 	ret, err := qb.FindAllByPath(ctx, p, caseSensitive)
@@ -641,28 +640,29 @@ func (qb *FileStore) FindByPath(ctx context.Context, p string, caseSensitive boo
 }
 
 // FindAllByPath returns all the files that match the given path.
-// Wildcard characters are supported.
+// The * wildcard is supported.
 func (qb *FileStore) FindAllByPath(ctx context.Context, p string, caseSensitive bool) ([]models.File, error) {
 	// separate basename from path
 	basename := filepath.Base(p)
 	dirName := filepath.Dir(p)
 
-	// replace wildcards
-	basename = strings.ReplaceAll(basename, "*", "%")
-	dirName = strings.ReplaceAll(dirName, "*", "%")
-
 	table := qb.table()
 	folderTable := folderTableMgr.table
 
-	// like uses case-insensitive matching. Only use like if wildcards are used
 	q := qb.selectDataset().Prepared(true)
 
-	if strings.Contains(basename, "%") || strings.Contains(dirName, "%") || !caseSensitive {
+	switch {
+	case pathHasWildcard(basename) || pathHasWildcard(dirName):
 		q = q.Where(
-			folderTable.Col("path").Like(dirName),
-			table.Col("basename").Like(basename),
+			pathLike(folderTable.Col("path"), dirName),
+			pathLike(table.Col("basename"), basename),
 		)
-	} else {
+	case !caseSensitive:
+		q = q.Where(
+			pathEqNoCase(folderTable.Col("path"), dirName),
+			pathEqNoCase(table.Col("basename"), basename),
+		)
+	default:
 		q = q.Where(
 			folderTable.Col("path").Eq(dirName),
 			table.Col("basename").Eq(basename),

--- a/pkg/sqlite/file_test.go
+++ b/pkg/sqlite/file_test.go
@@ -562,6 +562,55 @@ func Test_FileStore_FindByPath(t *testing.T) {
 	}
 }
 
+func TestFileStore_FindByPathCaseInsensitiveTreatsLikeWildcardsLiterally(t *testing.T) {
+	qb := db.File
+
+	runWithRollbackTxn(t, "literal wildcards", func(t *testing.T, ctx context.Context) {
+		now := time.Now()
+		makeTestFile := func(basename string) models.File {
+			return &models.BaseFile{
+				Path:           getFilePath(folderIdxWithFiles, basename),
+				ParentFolderID: folderIDs[folderIdxWithFiles],
+				Basename:       basename,
+				Size:           1,
+				DirEntry: models.DirEntry{
+					ModTime: now,
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+		}
+
+		ambiguous := makeTestFile("scan_lookup_AB1.mp4")
+		if !assert.NoError(t, qb.Create(ctx, ambiguous)) {
+			return
+		}
+
+		got, err := qb.FindByPath(ctx, getFilePath(folderIdxWithFiles, "scan_lookup_A_1.mp4"), false)
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+
+		got, err = qb.FindByPath(ctx, getFilePath(folderIdxWithFiles, "scan_lookup_A%1.mp4"), false)
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+
+		literalUnderscore := makeTestFile("scan_lookup_A_1.mp4")
+		if !assert.NoError(t, qb.Create(ctx, literalUnderscore)) {
+			return
+		}
+
+		got, err = qb.FindByPath(ctx, getFilePath(folderIdxWithFiles, "SCAN_LOOKUP_a_1.MP4"), false)
+		assert.NoError(t, err)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, literalUnderscore.Base().ID, got.Base().ID)
+		}
+
+		wildcardMatches, err := qb.FindAllByPath(ctx, getFilePath(folderIdxWithFiles, "scan_lookup_A*1.mp4"), true)
+		assert.NoError(t, err)
+		assert.Len(t, wildcardMatches, 2)
+	})
+}
+
 func TestFileStore_FindByFingerprint(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/sqlite/folder.go
+++ b/pkg/sqlite/folder.go
@@ -296,12 +296,11 @@ func (qb *FolderStore) FindMany(ctx context.Context, ids []models.FolderID) ([]*
 }
 
 func (qb *FolderStore) FindByPath(ctx context.Context, p string, caseSensitive bool) (*models.Folder, error) {
-	// use like for case insensitive search
-	var criterion exp.BooleanExpression
+	var criterion exp.Expression
 	if caseSensitive {
 		criterion = qb.table().Col("path").Eq(p)
 	} else {
-		criterion = qb.table().Col("path").ILike(p)
+		criterion = pathEqNoCase(qb.table().Col("path"), p)
 	}
 
 	q := qb.selectDataset().Prepared(true).Where(criterion)

--- a/pkg/sqlite/folder_test.go
+++ b/pkg/sqlite/folder_test.go
@@ -238,6 +238,48 @@ func Test_FolderStore_FindByPath(t *testing.T) {
 	}
 }
 
+func TestFolderStore_FindByPathCaseInsensitiveTreatsLikeWildcardsLiterally(t *testing.T) {
+	qb := db.Folder
+
+	runWithRollbackTxn(t, "literal wildcards", func(t *testing.T, ctx context.Context) {
+		now := time.Now()
+		makeTestFolder := func(path string) *models.Folder {
+			return &models.Folder{
+				Path: path,
+				DirEntry: models.DirEntry{
+					ModTime: now,
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+		}
+
+		ambiguous := makeTestFolder("folder_lookup_AB1")
+		if !assert.NoError(t, qb.Create(ctx, ambiguous)) {
+			return
+		}
+
+		got, err := qb.FindByPath(ctx, "folder_lookup_A_1", false)
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+
+		got, err = qb.FindByPath(ctx, "folder_lookup_A%1", false)
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+
+		literalUnderscore := makeTestFolder("folder_lookup_A_1")
+		if !assert.NoError(t, qb.Create(ctx, literalUnderscore)) {
+			return
+		}
+
+		got, err = qb.FindByPath(ctx, "FOLDER_LOOKUP_a_1", false)
+		assert.NoError(t, err)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, literalUnderscore.ID, got.ID)
+		}
+	})
+}
+
 func Test_FolderStore_GetManyParentFolderIDs(t *testing.T) {
 	var empty []models.FolderID
 	emptyResult := [][]models.FolderID{empty}

--- a/pkg/sqlite/path_match.go
+++ b/pkg/sqlite/path_match.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"strings"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+)
+
+func pathHasWildcard(path string) bool {
+	return strings.Contains(path, "*")
+}
+
+func pathToLikePattern(path string) string {
+	var b strings.Builder
+	b.Grow(len(path))
+
+	for _, r := range path {
+		switch r {
+		case '\\', '%', '_':
+			b.WriteRune('\\')
+		case '*':
+			b.WriteRune('%')
+			continue
+		}
+
+		b.WriteRune(r)
+	}
+
+	return b.String()
+}
+
+func pathLike(col exp.IdentifierExpression, pattern string) exp.Expression {
+	return goqu.L(`? LIKE ? ESCAPE '\'`, col, pathToLikePattern(pattern))
+}
+
+func pathEqNoCase(col exp.IdentifierExpression, value string) exp.Expression {
+	return goqu.L("? = ? COLLATE NOCASE", col, value)
+}

--- a/pkg/sqlite/scene.go
+++ b/pkg/sqlite/scene.go
@@ -721,20 +721,25 @@ func (qb *SceneStore) FindByPath(ctx context.Context, p string) ([]*models.Scene
 	basename := filepath.Base(p)
 	dir := filepath.Dir(p)
 
-	// replace wildcards
-	basename = strings.ReplaceAll(basename, "*", "%")
-	dir = strings.ReplaceAll(dir, "*", "%")
-
 	sq := dialect.From(scenesFilesJoinTable).InnerJoin(
 		filesTable,
 		goqu.On(filesTable.Col(idColumn).Eq(scenesFilesJoinTable.Col(fileIDColumn))),
 	).InnerJoin(
 		foldersTable,
 		goqu.On(foldersTable.Col(idColumn).Eq(filesTable.Col("parent_folder_id"))),
-	).Select(scenesFilesJoinTable.Col(sceneIDColumn)).Where(
-		foldersTable.Col("path").Like(dir),
-		filesTable.Col("basename").Like(basename),
-	)
+	).Select(scenesFilesJoinTable.Col(sceneIDColumn))
+
+	if pathHasWildcard(basename) || pathHasWildcard(dir) {
+		sq = sq.Where(
+			pathLike(foldersTable.Col("path"), dir),
+			pathLike(filesTable.Col("basename"), basename),
+		)
+	} else {
+		sq = sq.Where(
+			pathEqNoCase(foldersTable.Col("path"), dir),
+			pathEqNoCase(filesTable.Col("basename"), basename),
+		)
+	}
 
 	ret, err := qb.findBySubquery(ctx, sq)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1735,6 +1736,12 @@ func Test_sceneQueryBuilder_FindByPath(t *testing.T) {
 		{
 			"valid",
 			getPath(sceneIdxWithSpacedName),
+			[]*models.Scene{makeSceneWithID(sceneIdxWithSpacedName)},
+			false,
+		},
+		{
+			"case insensitive",
+			strings.ToUpper(getPath(sceneIdxWithSpacedName)),
 			[]*models.Scene{makeSceneWithID(sceneIdxWithSpacedName)},
 			false,
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes case-insensitive scan path matching for files whose path casing changes on case-insensitive filesystems.

Previously, the scan path lookup only attempted a case-insensitive fallback for files inside zip archives due to a likely typo. That meant normal filesystem files could be treated as new files after a case-only path change, such as when a re-encode tool rewrites `ALLCAPS.mp4` as `Allcaps.mp4`. The scanner would create a second file row instead of updating the existing one, which could leave stale duplicate/phash state behind.

This PR updates the scan lookup so normal filesystem files can use the case-insensitive fallback, while zip file contents continue to be treated as case-sensitive.

While testing that path, this also fixes SQLite path lookup behavior where exact case-insensitive matches used `LIKE`. That caused SQLite wildcard characters in literal paths, such as `_` and `%`, to match unrelated files. For example, `a_1.mp4` could match `ab1.mp4`. Exact case-insensitive path lookups now use `COLLATE NOCASE`, and only explicit `*` wildcards use `LIKE` with escaped LIKE wildcard characters.  Pulled them out into a helper file `path_match.go` for consistent behavior with using like vs case insensitive eq.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6326

## Testing
<!-- Describe the testing steps you have performed. -->

- Added a scanner regression test for a case-only filename change on a case-insensitive filesystem.
- Added SQLite integration tests to verify literal `_` and `%` characters do not behave as LIKE wildcards during exact path lookup.
- Added coverage to confirm explicit `*` wildcard path searches still work.
- Added scene path coverage to confirm exact scene path lookup remains case-insensitive.
- `go test ./pkg/file -run TestScannerScanFileMatchesCaseOnlyRenameOnCaseInsensitiveFilesystem -count=1`
- `go test -tags "integration sqlite_math_functions" ./pkg/sqlite`
- `golangci-lint run`
- `git diff --check`
- Manually performed scans testing including:
  - SQL Wildcards
  - Case differences.
  - Galleries still scan and link properly with wildcards
  - Caption sidecars 

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to help investigate, write the test files, assist in refactoring into helpers, and review the changes.

## Additional Context
<!-- Add any other context about the pull request here. -->

This preserves the original intent from #6326: case-only path changes on case-insensitive filesystems should update the existing file row instead of creating a duplicate. Zip file paths remain case-sensitive because archive entries may contain distinct files whose names differ only by case.

Additionally, having LIKE escaping characters may be desired in other areas where `_` is treated unintentionally as a wildcard (i.e. scene search with `_`).  That would expand these changes significantly into other areas and the main examples I found were more fuzzy searches anyways so I didn't mess with it.  Similar cause as #6791 