### PR TITLE
Fix: Stashignore Tests on Windows

### DIFF
--- a/pkg/file/stashignore_test.go
+++ b/pkg/file/stashignore_test.go
@@ -66,7 +66,7 @@ func walkAndFilter(t *testing.T, root string, filter *StashIgnoreFilter) []strin
 
 		if filter.Accept(ctx, path, info, root, "") {
 			relPath, _ := filepath.Rel(root, path)
-			accepted = append(accepted, relPath)
+			accepted = append(accepted, filepath.ToSlash(relPath))
 		} else if info.IsDir() {
 			// If directory is rejected, skip it.
 			return filepath.SkipDir


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Normalizes relative paths collected by the `.stashignore` test helper with `filepath.ToSlash`.

Noticed the `stashignore_test.go` tests were failing while running pkg\file tests on my windows dev setup. This keeps the assertions platform-neutral on Windows, where `filepath.Rel` returns paths with `\`, while preserving the existing test behavior and matching the production `.stashignore` path normalization before pattern matching.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

N/A - Minor 1 line test fix

## Testing
<!-- Describe the testing steps you have performed. -->

- `gofmt -w pkg\file\stashignore_test.go`
- `golangci-lint run`
- `git diff --check`
- `go test -count=1 ./pkg/file`
- Also compared before/after and made sure all the failures were just the path normalization issue

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Made the change myself, but just had codex do a review to make sure I wasn't missing anything.

## Additional Context
<!-- Add any other context about the pull request here. -->

I assumed it wasn't needed to write a whole issue for this, but if requested, I can write and link one.

Logs of example failure:
```
--- FAIL: TestStashIgnore_DirectoryExclusion (0.02s)
    stashignore_test.go:175: path mismatch at index 2:
        expected: included_dir/video4.mp4
        actual: included_dir\video4.mp4
--- FAIL: TestStashIgnore_NestedStashIgnoreFiles (0.02s)
    stashignore_test.go:257: path mismatch at index 3:
        expected: subdir/.stashignore
        actual: subdir\.stashignore```