### PR TITLE
Fix A/V desync after seeking when video is stream-copied

### DIFF
--- a/pkg/ffmpeg/options.go
+++ b/pkg/ffmpeg/options.go
@@ -37,6 +37,11 @@ func (a Args) Seek(seconds float64) Args {
 	return append(a, "-ss", fmt.Sprint(seconds))
 }
 
+// NoAccurateSeek adds the -noaccurate_seek flag and returns the result.
+func (a Args) NoAccurateSeek() Args {
+	return append(a, "-noaccurate_seek")
+}
+
 // Duration sets the duration (-t) to the given seconds and returns the result.
 func (a Args) Duration(seconds float64) Args {
 	return append(a, "-t", fmt.Sprint(seconds))

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -202,6 +202,13 @@ func (o TranscodeOptions) makeStreamArgs(sm *StreamManager) Args {
 	args = append(args, extraInputArgs...)
 
 	if o.StartTime != 0 {
+		if codec == VideoCodecCopy {
+			// Stream-copied video can only start at the keyframe preceding the
+			// seek point, while re-encoded audio would be trimmed exactly to it,
+			// leaving the output desynced by up to a GOP. Disable accurate seek
+			// so that both streams start at the keyframe.
+			args = args.NoAccurateSeek()
+		}
 		args = args.Seek(o.StartTime)
 	}
 

--- a/pkg/ffmpeg/stream_transcode.go
+++ b/pkg/ffmpeg/stream_transcode.go
@@ -203,10 +203,7 @@ func (o TranscodeOptions) makeStreamArgs(sm *StreamManager) Args {
 
 	if o.StartTime != 0 {
 		if codec == VideoCodecCopy {
-			// Stream-copied video can only start at the keyframe preceding the
-			// seek point, while re-encoded audio would be trimmed exactly to it,
-			// leaving the output desynced by up to a GOP. Disable accurate seek
-			// so that both streams start at the keyframe.
+			// #7103 - keep audio aligned with copied video, which can only start at a keyframe
 			args = args.NoAccurateSeek()
 		}
 		args = args.Seek(o.StartTime)


### PR DESCRIPTION
## Description
When a live transcode stream-copies the video while re-encoding the audio, ffmpeg's accurate seek trims the decoded audio exactly to the -ss position, but the copied video can only start at the preceding keyframe, leaving the audio ahead of the video by up to a GOP for the rest of playback.

This PR adds -noaccurate_seek to the live transcode args only when the selected video codec is VideoCodecCopy and a start time is set, so both streams start together at the preceding keyframe. Re-encoded streams keep ffmpeg's default accurate seek, and non-seek playback is untouched. The same arg builder serves the MP4, WebM and MKV endpoints, so all copy-capable paths are covered.

## Related Issue
Closes #7103.

## Testing
Built and tested inside the stashapp/stash:v0.31.1 Docker image against the repro file from #7103.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

Not a visual change.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I have used Claude Code with the Fable 5 model to assist me in finding the bug and reasoning about it.

## Additional Context
With this change, the scrubber can land up to one GOP before the requested position. This is the same keyframe-aligned seeking many video players perform by default.
