### PR TITLE
New: Add Stash ID Endpoint Dropdown

### DIFF
--- a/ui/v2.5/src/components/List/Filters/StashIDFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/StashIDFilter.tsx
@@ -4,6 +4,8 @@ import { useIntl } from "react-intl";
 import { IStashIDValue } from "../../../models/list-filter/types";
 import { ModifierCriterion } from "../../../models/list-filter/criteria/criterion";
 import { CriterionModifier } from "src/core/generated-graphql";
+import { useConfigurationContext } from "src/hooks/Config";
+import { stashboxDisplayName } from "src/utils/stashbox";
 
 interface IStashIDFilterProps {
   criterion: ModifierCriterion<IStashIDValue>;
@@ -15,9 +17,12 @@ export const StashIDFilter: React.FC<IStashIDFilterProps> = ({
   onValueChanged,
 }) => {
   const intl = useIntl();
+  const { configuration } = useConfigurationContext();
   const { value } = criterion;
+  const stashBoxes = configuration.general.stashBoxes;
+  const selectedEndpoint = value?.endpoint ?? "";
 
-  function onEndpointChanged(event: React.ChangeEvent<HTMLInputElement>) {
+  function onEndpointChanged(event: React.ChangeEvent<HTMLSelectElement>) {
     onValueChanged({
       endpoint: event.target.value,
       stashID: criterion.value.stashID,
@@ -35,11 +40,25 @@ export const StashIDFilter: React.FC<IStashIDFilterProps> = ({
     <div>
       <Form.Group>
         <Form.Control
+          as="select"
           className="btn-secondary"
           onChange={onEndpointChanged}
-          value={value ? value.endpoint : ""}
-          placeholder={intl.formatMessage({ id: "stash_id_endpoint" })}
-        />
+          value={selectedEndpoint}
+          aria-label={intl.formatMessage({ id: "stash_id_endpoint" })}
+        >
+          <option value="">
+            {intl.formatMessage({ id: "stash_id_endpoint_any" })}
+          </option>
+          {stashBoxes.map((stashBox, index) => (
+            <option value={stashBox.endpoint} key={stashBox.endpoint}>
+              {stashboxDisplayName(stashBox.name, index)}
+            </option>
+          ))}
+          {selectedEndpoint &&
+            !stashBoxes.some(
+              (stashBox) => stashBox.endpoint === selectedEndpoint
+            ) && <option value={selectedEndpoint}>{selectedEndpoint}</option>}
+        </Form.Control>
       </Form.Group>
       {criterion.modifier !== CriterionModifier.IsNull &&
         criterion.modifier !== CriterionModifier.NotNull && (

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1567,6 +1567,7 @@
   "stash_id": "Stash ID",
   "stash_id_count": "Stash ID Count",
   "stash_id_endpoint": "Stash ID Endpoint URL",
+  "stash_id_endpoint_any": "Any endpoint",
   "stash_ids": "Stash IDs",
   "stashbox_search": {
     "header": "Search {entityType} from StashBox",


### PR DESCRIPTION
## Description
This is implemented with the help of Codex, but is tested and reviewed by me.
This change adds a dropdown to the Stash ID filter section, allowing you to choose the endpoint instead of typing the endpoint URL manually. Having to remember the URL for filtering and typing it manually is inconvenient. 


## Related Issue
  Closes #4269

## Testing
  - Built and ran the UI with a local Stash backend.
  - Opened the Stash ID filter in Scenes.
  - Confirmed configured stashbox appeared in the dropdown.
  - Confirmed “Any endpoint” was available.
  - Confirmed that selecting a stashbox populates the filter with the corresponding URL
  - TypeScript checking, linting, formatting checks, and the production UI build passed.
  
## Screenshots
Before:
<img width="400" alt="Screenshot 2026-07-15 20 53 31" src="https://github.com/user-attachments/assets/9417667e-7f1d-450d-9291-522daf7a722f" />

After:
<img width="400" alt="Screenshot 2026-07-15 20 39 08" src="https://github.com/user-attachments/assets/86dfd40a-5409-4c0a-abba-eefd50748101" />
<img width="400" alt="Screenshot 2026-07-15 20 39 00" src="https://github.com/user-attachments/assets/28d8cfea-bbc0-4e42-9289-c87bdf95da3c" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).  No documentation changes were required for this UI-only change.

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
Implemented using Codex, then reviewed, tweaked and tested manually
