### PR TITLE
fix(ci): increase test timeout to prevent flaky pkg/sqlite failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         name: generated
 
     - name: Test Backend
-      run: make it
+      run: go test -timeout 30m -tags "sqlite_stat4 sqlite_math_functions integration" ./...
 
   # Job 3: Cross-compile for all platforms
   # Each platform gets its own runner and Docker container (ghcr.io/stashapp/compiler:13).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,9 @@ jobs:
         name: generated
 
     - name: Test Backend
-      run: go test -timeout 30m -tags "sqlite_stat4 sqlite_math_functions integration" ./...
+      run: make it
+      env:
+        GOTESTFLAGS: -timeout 30m
 
   # Job 3: Cross-compile for all platforms
   # Each platform gets its own runner and Docker container (ghcr.io/stashapp/compiler:13).

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ test:
 .PHONY: it
 it:
 	$(eval GO_BUILD_TAGS += integration)
-	go test -tags "$(GO_BUILD_TAGS)" ./...
+	go test $(GOTESTFLAGS) -tags "$(GO_BUILD_TAGS)" ./...
 
 # generates test mocks
 .PHONY: generate-test-mocks


### PR DESCRIPTION
## Description
CI intermittently fails with a hard test timeout on `pkg/sqlite`. I encountered this bug while I was working on my own branch. It happened because of slow runners. Go's default timeout for tests is 10 minutes and my run failed at 11th minute, even though it has no bugs or any other issue. I am adding timeout flag to solve this issue. It doesn't touch `make it` command.

Proof for failed run can be found [here](https://github.com/slick-daddy/stash/actions/runs/29625640460/job/88029616607?pr=27).

Especially see:
> *** Test killed with quit: ran too long (11m0s). (**Fails at 11th minute.**)
> FAIL	github.com/stashapp/stash/pkg/sqlite	660.039s
> ?   	github.com/stashapp/stash/pkg/sqlite/blob	[no test files]
> ?   	github.com/stashapp/stash/pkg/sqlite/migrations	[no test files]
> ?   	github.com/stashapp/stash/pkg/stashbox	[no test files]
> ?   	github.com/stashapp/stash/pkg/stashbox/graphql	[no test files]
> ok  	github.com/stashapp/stash/pkg/studio	0.006s
> ok  	github.com/stashapp/stash/pkg/tag	0.008s
> ?   	github.com/stashapp/stash/pkg/txn	[no test files]
> ok  	github.com/stashapp/stash/pkg/utils	0.010s
> ?   	github.com/stashapp/stash/ui	[no test files]
> FAIL
> make: *** [Makefile:334: it] Error 1
> Error: Process completed with exit code 2.

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
No AI used.