### PR TITLE
New: Add Additional Plugin UI Extension Hooks

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryList.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryList.tsx
@@ -496,6 +496,7 @@ export const FilteredGalleryList = PatchComponent(
               />
 
               <FilterTags
+                view={view}
                 criteria={filter.criteria}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/Groups/GroupList.tsx
+++ b/ui/v2.5/src/components/Groups/GroupList.tsx
@@ -406,6 +406,7 @@ export const FilteredGroupList = PatchComponent(
         />
 
         <FilterTags
+          view={view}
           criteria={filter.criteria}
           onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
           onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/Images/ImageList.tsx
+++ b/ui/v2.5/src/components/Images/ImageList.tsx
@@ -744,6 +744,7 @@ export const FilteredImageList = PatchComponent(
         />
 
         <FilterTags
+          view={view}
           criteria={filter.criteria}
           onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
           onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/List/EditFilterDialog.tsx
+++ b/ui/v2.5/src/components/List/EditFilterDialog.tsx
@@ -36,7 +36,11 @@ import {
 import { useFocusOnce } from "src/utils/focus";
 import Mousetrap from "mousetrap";
 import ScreenUtils from "src/utils/screen";
-import { LoadFilterDialog, SaveFilterDialog } from "./SavedFilterList";
+import {
+  LoadFilterDialog,
+  notifySavedFilterLoaded,
+  SaveFilterDialog,
+} from "./SavedFilterList";
 import { SearchTermInput } from "./ListFilter";
 
 interface ICriterionList {
@@ -480,6 +484,11 @@ export const EditFilterDialog: React.FC<IEditFilterProps> = ({
     newFilter.randomSeed = -1;
 
     onApply(newFilter);
+    notifySavedFilterLoaded({
+      filter: newFilter,
+      savedFilter: f,
+      source: "dialog",
+    });
   }
 
   async function onSaveFilter(name: string, id?: string) {

--- a/ui/v2.5/src/components/List/FilterTags.tsx
+++ b/ui/v2.5/src/components/List/FilterTags.tsx
@@ -22,6 +22,8 @@ import { CustomFieldsCriterion } from "src/models/list-filter/criteria/custom-fi
 import { useDebounce } from "src/hooks/debounce";
 import cx from "classnames";
 import { useConfigurationContext } from "src/hooks/Config";
+import { PatchContainerComponent } from "src/patch";
+import { View } from "./views";
 
 type TagItemProps = PropsWithChildren<
   ReplaceProps<"span", BsPrefixProps<"span"> & BadgeProps>
@@ -122,6 +124,7 @@ const MoreFilterTags: React.FC<{
 
 interface IFilterTagsProps {
   searchTerm?: string;
+  view?: View;
   criteria: Criterion[];
   onEditSearchTerm?: () => void;
   onEditCriterion: (c: Criterion) => void;
@@ -131,8 +134,18 @@ interface IFilterTagsProps {
   truncateOnOverflow?: boolean;
 }
 
+interface IFilterTagExtrasProps {
+  searchTerm?: string;
+  view?: View;
+  criteria: Criterion[];
+}
+
+const FilterTagExtras =
+  PatchContainerComponent<IFilterTagExtrasProps>("FilterTags.Extras");
+
 export const FilterTags: React.FC<IFilterTagsProps> = ({
   searchTerm,
+  view,
   criteria,
   onEditCriterion,
   onRemoveCriterion,
@@ -302,10 +315,6 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     );
   }
 
-  if (criteria.length === 0 && !searchTerm) {
-    return null;
-  }
-
   const className = "wrap-tags filter-tags";
 
   const filterTags = criteria.flatMap((c) => getFilterTags(c));
@@ -331,19 +340,30 @@ export const FilterTags: React.FC<IFilterTagsProps> = ({
     cutoff !== undefined ? filterTags.slice(0, cutoff) : filterTags;
   const hiddenCriteria = cutoff !== undefined ? filterTags.slice(cutoff) : [];
 
+  const extras = (
+    <FilterTagExtras searchTerm={searchTerm} view={view} criteria={criteria} />
+  );
+
+  if (filterTags.length === 0) {
+    return extras;
+  }
+
   return (
-    <div className={className} ref={ref}>
-      {visibleCriteria}
-      <MoreFilterTags tags={hiddenCriteria} />
-      {filterTags.length >= 3 && (
-        <Button
-          variant="minimal"
-          className="clear-all-button"
-          onClick={() => onRemoveAll()}
-        >
-          <FormattedMessage id="actions.clear" />
-        </Button>
-      )}
-    </div>
+    <>
+      <div className={className} ref={ref}>
+        {visibleCriteria}
+        <MoreFilterTags tags={hiddenCriteria} />
+        {filterTags.length >= 3 && (
+          <Button
+            variant="minimal"
+            className="clear-all-button"
+            onClick={() => onRemoveAll()}
+          >
+            <FormattedMessage id="actions.clear" />
+          </Button>
+        )}
+      </div>
+      {extras}
+    </>
   );
 };

--- a/ui/v2.5/src/components/List/SavedFilterList.tsx
+++ b/ui/v2.5/src/components/List/SavedFilterList.tsx
@@ -32,6 +32,7 @@ import cx from "classnames";
 import { TruncatedInlineText } from "../Shared/TruncatedText";
 import { OperationButton } from "../Shared/OperationButton";
 import { createPortal } from "react-dom";
+import { PatchFunction } from "src/patch";
 
 const ExistingSavedFilterList: React.FC<{
   name: string;
@@ -247,6 +248,18 @@ interface ISavedFilterListProps {
   menuPortalTarget?: Element | DocumentFragment;
 }
 
+export interface ISavedFilterLoaded {
+  savedFilter: SavedFilterDataFragment;
+  filter: ListFilterModel;
+  source: "dialog" | "sidebar" | "toolbar";
+  view?: View;
+}
+
+export const notifySavedFilterLoaded = PatchFunction(
+  "SavedFilter.Loaded",
+  (event: ISavedFilterLoaded) => event
+);
+
 export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
   filter,
   onSetFilter,
@@ -377,6 +390,12 @@ export const SavedFilterList: React.FC<ISavedFilterListProps> = ({
     newFilter.randomSeed = -1;
 
     onSetFilter(newFilter);
+    notifySavedFilterLoaded({
+      filter: newFilter,
+      savedFilter: f,
+      source: "toolbar",
+      view,
+    });
   }
 
   interface ISavedFilterItem {
@@ -762,6 +781,12 @@ export const SidebarSavedFilterList: React.FC<ISavedFilterListProps> = ({
 
     setCurrentSavedFilter({ id: f.id, set: true });
     onSetFilter(newFilter);
+    notifySavedFilterLoaded({
+      filter: newFilter,
+      savedFilter: f,
+      source: "sidebar",
+      view,
+    });
   }
 
   return (

--- a/ui/v2.5/src/components/Performers/PerformerList.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerList.tsx
@@ -608,6 +608,7 @@ export const FilteredPerformerList = PatchComponent(
               />
 
               <FilterTags
+                view={view}
                 criteria={filter.criteria}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/Scenes/SceneList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneList.tsx
@@ -679,6 +679,7 @@ export const FilteredSceneList = PatchComponent(
                 />
 
                 <FilterTags
+                  view={view}
                   criteria={filter.criteria}
                   onEditCriterion={(c) =>
                     showEditFilter(c.criterionOption.type)

--- a/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneMarkerList.tsx
@@ -417,6 +417,7 @@ export const FilteredSceneMarkerList = PatchComponent(
               />
 
               <FilterTags
+                view={view}
                 criteria={filter.criteria}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/Studios/StudioList.tsx
+++ b/ui/v2.5/src/components/Studios/StudioList.tsx
@@ -417,6 +417,7 @@ export const FilteredStudioList = PatchComponent(
               />
 
               <FilterTags
+                view={view}
                 criteria={filter.criteria}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/components/Tags/TagList.tsx
+++ b/ui/v2.5/src/components/Tags/TagList.tsx
@@ -440,6 +440,7 @@ export const FilteredTagList = PatchComponent(
               />
 
               <FilterTags
+                view={view}
                 criteria={filter.criteria}
                 onEditCriterion={(c) => showEditFilter(c.criterionOption.type)}
                 onRemoveCriterion={removeCriterion}

--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -309,6 +309,7 @@ Returns `void`.
 - `RatingStars`
 - `RatingSystem`
 - `RecommendationRow`
+- `SavedFilter.Loaded`
 - `SceneCard`
 - `SceneCard.Details`
 - `SceneCard.Image`

--- a/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
+++ b/ui/v2.5/src/docs/en/Manual/UIPluginApi.md
@@ -239,6 +239,7 @@ Returns `void`.
 - `FilteredSceneMarkerList`
 - `FilteredStudioList`
 - `FilteredTagList`
+- `FilterTags.Extras`
 - `FolderSelect`
 - `FrontPage`
 - `GalleryCard`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds two UI plugin extension points for integrating plugin-owned filters with Stash's native list filtering UI.

- Adds `SavedFilter.Loaded`, a patchable function called after a saved filter is loaded from the toolbar, filter sidebar, or edit-filter dialog.
- The saved-filter event includes the saved filter, configured `ListFilterModel`, load source, and list view where available.
- Adds `FilterTags.Extras`, a patchable container for rendering plugin-owned filter tags alongside the native filter tags.
- Passes the current list view to `FilterTags` on gallery, group, image, performer, scene, scene marker, studio, and tag lists.
- Documents both new patch points in the UI Plugin API manual.

These hooks allow plugins to associate their own state with native saved filters and represent active plugin filters using the normal list filter tag area without modifying Stash's saved-filter format.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Related to #4510 

## Testing
<!-- Describe the testing steps you have performed. -->

-  `pnpm --dir ui/v2.5 exec biome check <modified files>`

- `pnpm --dir ui/v2.5 run check`

- `git diff --check`.

- Manually tested with multiple plugins I have developed.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate and help draft these hooks. Reviewed and tested it manually.

## Additional Context
<!-- Add any other context about the pull request here. -->

`SavedFilter.Loaded` is intentionally emitted only for explicit saved-filter load actions. Default filters and front-page recommendation filters are separate flows and do not represent loading a native saved filter into the active list.

`FilterTags.Extras` is inert when no plugin patches it, preserving the existing filter-tag rendering behavior.