### PR TITLE
Use LEFT JOIN when filtering for NULL phash

### DIFF
--- a/pkg/sqlite/scene_filter.go
+++ b/pkg/sqlite/scene_filter.go
@@ -110,7 +110,10 @@ func (qb *sceneFilterHandler) criterionHandler() criterionHandler {
 
 		&phashDistanceCriterionHandler{
 			joinFn: func(f *filterBuilder) {
-				const joinType = joinTypeInner
+				joinType := joinTypeInner
+				if sceneFilter.PhashDistance.Modifier == models.CriterionModifierIsNull {
+					joinType = joinTypeLeft
+				}
 				qb.addSceneFilesTable(f, joinType)
 				f.addJoin(joinType, fingerprintTable, "fingerprints_phash", "scenes_files.file_id = fingerprints_phash.file_id AND fingerprints_phash.type = 'phash'")
 			},

--- a/pkg/sqlite/scene_test.go
+++ b/pkg/sqlite/scene_test.go
@@ -3424,23 +3424,71 @@ func TestSceneQueryIsMissingRating(t *testing.T) {
 }
 
 func TestSceneQueryIsMissingPhash(t *testing.T) {
-	withTxn(func(ctx context.Context) error {
-		sqb := db.Scene
-		isMissing := "phash"
-		sceneFilter := models.SceneFilterType{
-			IsMissing: &isMissing,
-		}
+	isMissing := "phash"
 
-		scenes := queryScene(ctx, t, sqb, &sceneFilter, nil)
+	tests := []struct {
+		name        string
+		filter      models.SceneFilterType
+		includeIdxs []int
+		excludeIdxs []int
+		wantErr     bool
+	}{
+		{
+			"is missing phash",
+			models.SceneFilterType{
+				IsMissing: &isMissing,
+			},
+			[]int{sceneIdxMissingPhash},
+			[]int{sceneIdxWithGroup},
+			false,
+		},
+		{
+			"phash null",
+			models.SceneFilterType{
+				Phash: &models.StringCriterionInput{
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+			[]int{sceneIdxMissingPhash},
+			[]int{sceneIdxWithGroup},
+			false,
+		},
+		{
+			"phash distance null",
+			models.SceneFilterType{
+				PhashDistance: &models.PhashDistanceCriterionInput{
+					Modifier: models.CriterionModifierIsNull,
+				},
+			},
+			[]int{sceneIdxMissingPhash},
+			[]int{sceneIdxWithGroup},
+			false,
+		},
+	}
 
-		if !assert.Len(t, scenes, 1) {
-			return nil
-		}
+	for _, tt := range tests {
+		runWithRollbackTxn(t, tt.name, func(t *testing.T, ctx context.Context) {
+			assert := assert.New(t)
 
-		assert.Equal(t, sceneIDs[sceneIdxMissingPhash], scenes[0].ID)
+			results, err := db.Scene.Query(ctx, models.SceneQueryOptions{
+				SceneFilter: &tt.filter,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SceneStore.Query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
-		return nil
-	})
+			include := indexesToIDs(sceneIDs, tt.includeIdxs)
+			exclude := indexesToIDs(sceneIDs, tt.excludeIdxs)
+
+			for _, i := range include {
+				assert.Contains(results.IDs, i)
+			}
+			for _, e := range exclude {
+				assert.NotContains(results.IDs, e)
+			}
+		})
+	}
 }
 
 func TestSceneQueryPerformers(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixes filtering scenes where phash is null.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->
Closes #7120 


## Testing
<!-- Describe the testing steps you have performed. -->
Applied fix, verified filtering worked as expected.


## Screenshots
<!-- For visual changes, please add before and after screenshots. -->



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->



## Additional Context
<!-- Add any other context about the pull request here. -->

