### PR TITLE
Fix: Sidebar Performer and Studio Select Count Filter Depth

### DIFF
--- a/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/LabeledIdFilter.tsx
@@ -23,6 +23,7 @@ import {
   HierarchicalCountInput,
   ImageFilterType,
   InputMaybe,
+  IntCriterionInput,
   PerformerFilterType,
   SceneFilterType,
   SceneMarkerFilterType,
@@ -520,19 +521,36 @@ export function makeQueryVariables(query: string, extraProps: object) {
 
 interface IFilterType {
   scenes_filter?: InputMaybe<SceneFilterType>;
-  scene_count?: InputMaybe<HierarchicalCountInput>;
+  scene_count?: InputMaybe<CountCriterionInput>;
   performers_filter?: InputMaybe<PerformerFilterType>;
-  performer_count?: InputMaybe<HierarchicalCountInput>;
+  performer_count?: InputMaybe<CountCriterionInput>;
   galleries_filter?: InputMaybe<GalleryFilterType>;
-  gallery_count?: InputMaybe<HierarchicalCountInput>;
+  gallery_count?: InputMaybe<CountCriterionInput>;
   images_filter?: InputMaybe<ImageFilterType>;
-  image_count?: InputMaybe<HierarchicalCountInput>;
+  image_count?: InputMaybe<CountCriterionInput>;
   groups_filter?: InputMaybe<GroupFilterType>;
-  group_count?: InputMaybe<HierarchicalCountInput>;
+  group_count?: InputMaybe<CountCriterionInput>;
   studios_filter?: InputMaybe<StudioFilterType>;
-  studio_count?: InputMaybe<HierarchicalCountInput>;
-  marker_count?: InputMaybe<HierarchicalCountInput>;
+  studio_count?: InputMaybe<CountCriterionInput>;
+  marker_count?: InputMaybe<CountCriterionInput>;
   markers_filter?: InputMaybe<SceneMarkerFilterType>;
+}
+
+type CountCriterionInput = IntCriterionInput | HierarchicalCountInput;
+
+interface ISetObjectFilterOptions {
+  hierarchicalCounts?: boolean;
+}
+
+function makeCountCriterion(
+  options?: ISetObjectFilterOptions
+): CountCriterionInput {
+  const criterion = {
+    modifier: CriterionModifier.GreaterThan,
+    value: 0,
+  };
+
+  return options?.hierarchicalCounts ? { ...criterion, depth: -1 } : criterion;
 }
 
 export function setObjectFilter(
@@ -543,7 +561,8 @@ export function setObjectFilter(
     | PerformerFilterType
     | GalleryFilterType
     | GroupFilterType
-    | StudioFilterType
+    | StudioFilterType,
+  options?: ISetObjectFilterOptions
 ) {
   const empty = Object.keys(relatedFilterOutput).length === 0;
 
@@ -551,11 +570,7 @@ export function setObjectFilter(
     case FilterMode.Scenes:
       // if empty, only get objects with scenes
       if (empty) {
-        out.scene_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.scene_count = makeCountCriterion(options);
         break;
       }
       out.scenes_filter = relatedFilterOutput as SceneFilterType;
@@ -563,11 +578,7 @@ export function setObjectFilter(
     case FilterMode.Performers:
       // if empty, only get objects with performers
       if (empty) {
-        out.performer_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.performer_count = makeCountCriterion(options);
         break;
       }
       out.performers_filter = relatedFilterOutput as PerformerFilterType;
@@ -575,23 +586,15 @@ export function setObjectFilter(
     case FilterMode.Galleries:
       // if empty, only get objects with galleries
       if (empty) {
-        out.gallery_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.gallery_count = makeCountCriterion(options);
         break;
       }
       out.galleries_filter = relatedFilterOutput as GalleryFilterType;
       break;
     case FilterMode.Images:
-      // if empty, only get objects with galleries
+      // if empty, only get objects with images
       if (empty) {
-        out.image_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.image_count = makeCountCriterion(options);
         break;
       }
       out.images_filter = relatedFilterOutput as ImageFilterType;
@@ -599,11 +602,7 @@ export function setObjectFilter(
     case FilterMode.Groups:
       // if empty, only get objects with groups
       if (empty) {
-        out.group_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.group_count = makeCountCriterion(options);
         break;
       }
       out.groups_filter = relatedFilterOutput as GroupFilterType;
@@ -611,11 +610,7 @@ export function setObjectFilter(
     case FilterMode.Studios:
       // if empty, only get objects with studios
       if (empty) {
-        out.studio_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.studio_count = makeCountCriterion(options);
         break;
       }
       out.studios_filter = relatedFilterOutput as StudioFilterType;
@@ -623,11 +618,7 @@ export function setObjectFilter(
     case FilterMode.SceneMarkers:
       // if empty, only get objects with scene markers
       if (empty) {
-        out.marker_count = {
-          modifier: CriterionModifier.GreaterThan,
-          value: 0,
-          depth: -1,
-        };
+        out.marker_count = makeCountCriterion(options);
         break;
       }
       out.markers_filter = relatedFilterOutput as SceneMarkerFilterType;

--- a/ui/v2.5/src/components/List/Filters/TagsFilter.tsx
+++ b/ui/v2.5/src/components/List/Filters/TagsFilter.tsx
@@ -47,7 +47,9 @@ function queryVariables(query: string, f?: ListFilterModel) {
       // TODO - look for same in AND?
     }
 
-    setObjectFilter(tagFilter, f.mode, filterOutput);
+    setObjectFilter(tagFilter, f.mode, filterOutput, {
+      hierarchicalCounts: true,
+    });
   }
 
   return makeQueryVariables(query, { tag_filter: tagFilter });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes performer and studio options failing to load in list sidebars because
their GraphQL count filters included an unsupported `depth` field.

The shared `setObjectFilter` helper now creates plain integer count criteria by
default. Callers can explicitly request hierarchical counts through a named
option, which the tag selector uses to preserve descendant-tag matching.

This prevents `depth` from being sent to `PerformerFilterType` and
`StudioFilterType` count fields while retaining the intended behavior for
`TagFilterType`.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #7105

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd exec biome check src/components/List/Filters/LabeledIdFilter.tsx src/components/List/Filters/TagsFilter.tsx`
- `git diff --check`
- `pnpm.cmd run validate`
- Manually tested each of the pages' sidebars. Confirmed sidebar options now properly populate options for studios/performers and didn't find any regressions.  Also specifically confirmed that parent tags still show in the list.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Codex was used as an assistant to investigate the issue, draft possible solutions, and as an additional reviewer.

## Additional Context
<!-- Add any other context about the pull request here. -->

The regression was introduced by `9cb2ffd56c` / #6929 when hierarchical depth
was added to the shared sidebar count-filter fallback.

Tag count fields accept `HierarchicalCountInput`, while performer and studio
count fields use `IntCriterionInput`. This change keeps those two payload shapes
separate without changing the GraphQL schema.