### PR TITLE
Fix: Gallery Parent Folder Exclusion SQL Error

### DIFF
--- a/pkg/sqlite/gallery_filter.go
+++ b/pkg/sqlite/gallery_filter.go
@@ -332,7 +332,7 @@ func (qb *galleryFilterHandler) parentFolderCriterionHandler(folder *models.Hier
 				return
 			}
 
-			f.addWhere(fmt.Sprintf("files.parent_folder_id NOT IN (SELECT column2 FROM (%s)) OR folders.parent_folder_id IS NULL", valuesClause))
+			f.addWhere(fmt.Sprintf("files.parent_folder_id NOT IN (SELECT column2 FROM (%s)) OR files.parent_folder_id IS NULL", valuesClause))
 			f.addWhere(fmt.Sprintf("gallery_folder.parent_folder_id NOT IN (SELECT column2 FROM (%s)) OR gallery_folder.parent_folder_id IS NULL", valuesClause))
 		}
 	}

--- a/pkg/sqlite/gallery_test.go
+++ b/pkg/sqlite/gallery_test.go
@@ -1586,6 +1586,43 @@ func TestGalleryQueryPath(t *testing.T) {
 	}
 }
 
+func TestGalleryQueryParentFolderExcludes(t *testing.T) {
+	tests := []struct {
+		name      string
+		folderIdx int
+		depth     int
+	}{
+		{
+			name:      "exact folder",
+			folderIdx: folderIdxWithGalleryFiles,
+			depth:     0,
+		},
+		{
+			name:      "parent folder recursively",
+			folderIdx: folderIdxForObjectFiles,
+			depth:     -1,
+		},
+	}
+
+	for _, tt := range tests {
+		runWithRollbackTxn(t, tt.name, func(t *testing.T, ctx context.Context) {
+			galleries, count, err := db.Gallery.Query(ctx, &models.GalleryFilterType{
+				ParentFolder: &models.HierarchicalMultiCriterionInput{
+					Value: []string{
+						strconv.Itoa(int(folderIDs[tt.folderIdx])),
+					},
+					Modifier: models.CriterionModifierExcludes,
+					Depth:    &tt.depth,
+				},
+			}, nil)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+			require.Len(t, galleries, 1)
+			assert.Equal(t, galleryIDs[galleryIdxWithoutFile], galleries[0].ID)
+		})
+	}
+}
+
 func verifyGalleriesPath(ctx context.Context, t *testing.T, pathCriterion models.StringCriterionInput) {
 	galleryFilter := models.GalleryFilterType{
 		Path: &pathCriterion,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes the gallery parent-folder exclusion query using an incorrect table alias.

The ZIP-gallery condition filtered on `files.parent_folder_id`, but its `IS NULL` branch still referenced `folders.parent_folder_id`. The `folders` table is not present under that name in this query, causing SQLite to return `no such column: folders.parent_folder_id`.

The null check now consistently uses `files.parent_folder_id`.

Adds regression coverage for both exact-folder and recursive parent-folder exclusions.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6993 

## Testing
<!-- Describe the testing steps you have performed. -->

- `go test -tags="integration sqlite_stat4 sqlite_math_functions" ./pkg/sqlite -count=1`
- `git diff --check`
- `gofmt -w pkg/sqlite/gallery_filter.go pkg/sqlite/gallery_test.go`

Manual testing:

- Applied an exact parent-folder exclusion to galleries.
- Applied the same exclusion recursively with subfolders included.
- Confirmed ZIP-backed galleries in the excluded folders were removed.
- Confirmed galleries outside the excluded hierarchy remained visible.
- Confirmed the GraphQL request completed without a SQLite error.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used codex as assistant to investigate and write the regression tests.  Implemented and manually tested the fix myself.

## Additional Context
<!-- Add any other context about the pull request here. -->

This change is intentionally limited to the SQL error reported in #6993.

During testing, two adjacent behaviors were identified but are not changed here:

- A multi-file gallery remains visible when at least one associated file is outside the excluded folder hierarchy.
- A configured library nested inside another configured library is treated as an independent folder root for recursive filtering.

They were the result of intentional design choices elsewhere, but I am not sure if this is an intended behavior for this filtering.