### PR TITLE
Fix: Save & New Relationship Fields Resetting

### DIFF
--- a/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
+++ b/ui/v2.5/src/components/Galleries/GalleryDetails/GalleryEditPanel.tsx
@@ -117,10 +117,8 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, tagsControl } = useTagsEdit(
-    gallery.tags,
-    (ids) => formik.setFieldValue("tag_ids", ids)
-  );
+  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
+    useTagsEdit(gallery.tags, (ids) => formik.setFieldValue("tag_ids", ids));
 
   function onSetScenes(items: Scene[]) {
     setScenes(items);
@@ -199,6 +197,12 @@ export const GalleryEditPanel: React.FC<IProps> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        setScenes(gallery.scenes ?? []);
+        setPerformers(gallery.performers ?? []);
+        setStudio(gallery.studio ?? null);
+        resetTagsState();
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
+++ b/ui/v2.5/src/components/Groups/GroupDetails/GroupEditPanel.tsx
@@ -127,10 +127,8 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, tagsControl } = useTagsEdit(
-    group.tags,
-    (ids) => formik.setFieldValue("tag_ids", ids)
-  );
+  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
+    useTagsEdit(group.tags, (ids) => formik.setFieldValue("tag_ids", ids));
 
   const containingGroupEntries = useMemo(() => {
     return formik.values.containing_groups
@@ -230,6 +228,11 @@ export const GroupEditPanel: React.FC<IGroupEditPanel> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        setStudio(group.studio ?? null);
+        setContainingGroups(group.containing_groups?.map((m) => m.group) ?? []);
+        resetTagsState();
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -178,10 +178,8 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, tagsControl } = useTagsEdit(
-    performer.tags,
-    (ids) => formik.setFieldValue("tag_ids", ids)
-  );
+  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
+    useTagsEdit(performer.tags, (ids) => formik.setFieldValue("tag_ids", ids));
 
   function translateScrapedGender(scrapedGender?: string) {
     if (!scrapedGender) {
@@ -351,6 +349,9 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        resetTagsState();
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -203,10 +203,8 @@ export const SceneEditPanel: React.FC<IProps> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, tagsControl } = useTagsEdit(
-    scene.tags,
-    (ids) => formik.setFieldValue("tag_ids", ids)
-  );
+  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
+    useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
 
   const coverImagePreview = useMemo(() => {
     const sceneImage = scene.paths?.screenshot;
@@ -298,6 +296,20 @@ export const SceneEditPanel: React.FC<IProps> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        setGalleries(
+          scene.galleries?.map((g) => ({
+            id: g.id,
+            title: galleryTitle(g),
+            files: g.files,
+            folder: g.folder,
+          })) ?? []
+        );
+        setPerformers(scene.performers ?? []);
+        setGroups(scene.groups?.map((m) => m.group) ?? []);
+        setStudio(scene.studio ?? null);
+        resetTagsState();
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
+++ b/ui/v2.5/src/components/Studios/StudioDetails/StudioEditPanel.tsx
@@ -106,7 +106,7 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     onSubmit: submit,
   });
 
-  const { tagsControl } = useTagsEdit(studio.tags, (ids) =>
+  const { resetTagsState, tagsControl } = useTagsEdit(studio.tags, (ids) =>
     formik.setFieldValue("tag_ids", ids)
   );
 
@@ -176,6 +176,26 @@ export const StudioEditPanel: React.FC<IStudioEditPanel> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        setParentStudio(
+          studio.parent_studio
+            ? {
+                id: studio.parent_studio.id,
+                name: studio.parent_studio.name,
+                aliases: [],
+              }
+            : null
+        );
+        setChildStudios(
+          (studio.child_studios ?? []).map((childStudio) => ({
+            id: childStudio.id,
+            name: childStudio.name,
+            aliases: [],
+            image_path: childStudio.image_path,
+          }))
+        );
+        resetTagsState();
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
+++ b/ui/v2.5/src/components/Tags/TagDetails/TagEditPanel.tsx
@@ -144,6 +144,10 @@ export const TagEditPanel: React.FC<ITagEditPanel> = ({
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
+      if (andNew) {
+        setParentTags(tag.parents ?? []);
+        setChildTags(tag.children ?? []);
+      }
     } catch (e) {
       Toast.error(e);
     }

--- a/ui/v2.5/src/hooks/tagsEdit.tsx
+++ b/ui/v2.5/src/hooks/tagsEdit.tsx
@@ -25,6 +25,11 @@ export function useTagsEdit(
     setFieldValue(items.map((item) => item.id));
   }
 
+  function resetTagsState() {
+    setTags(srcTags ?? []);
+    setNewTags(undefined);
+  }
+
   useEffect(() => {
     setTags(srcTags ?? []);
   }, [srcTags]);
@@ -150,6 +155,7 @@ export function useTagsEdit(
   return {
     tags,
     onSetTags,
+    resetTagsState,
     tagsControl,
     updateTagsStateFromScraper,
   };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes relationship selectors retaining stale visible values after using **Save & New**.

Formik reset the submitted relationship IDs after creating an entity, but several selectors maintained separate React state containing the selected objects. This caused the old values to remain visible even though the next create mutation contained empty relationship IDs.

This change resets the auxiliary selector state alongside Formik after a successful **Save & New** operation. The reset is limited to the `andNew` path so normal create and edit saves retain their existing behavior.

The affected fields are:

- Groups: studio, tags, containing groups
- Performers: tags
- Studios: parent studio, subsidiary studios, tags
- Galleries: scenes, studio, performers, tags
- Scenes: galleries, studio, performers, groups, tags
- Tags: parent tags, sub-tags

The shared tag editing hook now also provides a reset operation that clears selected tags and scraped missing-tag state.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Fixes #6969 

## Testing
<!-- Describe the testing steps you have performed. -->

- `pnpm.cmd --dir ui/v2.5 check`
- Biome lint on all changed files
- Biome formatting on all changed files
- `git diff --check`

Manual testing:

1. Populated each affected relationship selector.
2. Used **Save & New**.
3. Confirmed that the selectors returned to their initial values.
4. Created a second entity without touching those selectors.
5. Confirmed that the second entity did not receive relationships from the first entity.

Tested the following:

- Group: studio and tags
- Performer: tags
- Studio: parent studio, subsidiary studios, and tags
- Gallery: scenes, studio, performers, and tags
- Scene: galleries, studio, performers, groups, and tags
- Tag: parent tags and sub-tags

Also confirmed that normal **Save** behavior remains unchanged.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Used Codex to investigate the root cause, double check that I found all affected components, and draft the solution.  Manually reviewed and tested everything.

## Additional Context
<!-- Add any other context about the pull request here. -->

