### PR TITLE
Removed unnecessary intermediate buffer

### DIFF
--- a/pkg/hash/imagephash/phash.go
+++ b/pkg/hash/imagephash/phash.go
@@ -40,12 +40,7 @@ func loadImage(encoder *ffmpeg.FFMpeg, imageFile *models.ImageFile) (image.Image
 	}
 	defer reader.Close()
 
-	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(reader); err != nil {
-		return nil, err
-	}
-
-	img, _, err := image.Decode(buf)
+	img, _, err := image.Decode(reader)
 	if errors.Is(err, image.ErrFormat) {
 		// try ffmpeg as a fallback for unsupported formats
 		// ffmpeg cannot read files inside zips


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This change removes a unnecessary buffer from the image hasher. 
`image.Decode` accepts a `Io.Reader`, which is already returned by `imageFile.Open` so buffering the data in to memory is not needed. 
Especially since `image.Decode` already converts the `Io.Reader` to a internal reader when you call it. 


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #7129 


## Testing
<!-- Describe the testing steps you have performed. -->
I did some benchmarks and they showed a 25 - 30 % reduction in memory usage per operation. 
| Benchmark | Time (ns/op) range | Avg B/op (approx) | Avg allocs/op (approx) |
|---:|---:|---:|---:|
| BenchmarkOriginalImageHashSmall-16 | 46,850,583–47,595,339 | ~30,309,xxx B/op | ~3325 |
| BenchmarkOriginalImageHashLarge-16 | 46,821,899–47,114,349 | ~30,307,xxx B/op | ~3325 |
| BenchmarkNewImageHashSmall-16 | 46,514,045–47,010,762 | ~21,923,xxx B/op | ~3312 |
| BenchmarkNewImageHashLarge-16 | 46,418,929–46,650,521 | ~21,924,xxx B/op | ~3312 |
## Screenshots
<!-- For visual changes, please add before and after screenshots. -->



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->



## Additional Context
<!-- Add any other context about the pull request here. -->

