### PR TITLE
Fix: Mobile Scene File Info Overflow

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -647,6 +647,7 @@ $sceneTabWidth: 450px;
 @media (min-width: 1200px) {
   .scene-tabs {
     flex: 0 0 $sceneTabWidth;
+    max-height: calc(100vh - 4rem);
     max-width: $sceneTabWidth;
     overflow: auto;
 

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -324,7 +324,6 @@ textarea.scene-description {
 .scene-tabs {
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 4rem);
   overflow-wrap: break-word;
   word-wrap: break-word;
 


### PR DESCRIPTION
## Description

Removes the fixed viewport height from scene tabs on mobile, allowing expanded file details to scroll normally above
the bottom navigation bar. The height limit is kept for desktop layouts where it is still needed.

## Related Issue

Closes #7140

## Testing

Tested on a mobile viewport:

1. Opened a scene and expanded a file entry.
2. Confirmed the primary file selector remains accessible above the bottom bar.
3. Checked that the desktop scene tabs still scroll correctly.

Stylelint and formatting checks passed.

## Screenshots

<img width="474" height="590" alt="image" src="https://github.com/user-attachments/assets/400eed6b-ee82-4f8a-994c-aa691d816c09" /><img width="439" height="646" alt="image" src="https://github.com/user-attachments/assets/fb48a2cf-be83-43f5-8ada-9cb454101c6a" />

## Checklist

- [x] I have read and understood the Contributing document.
- [x] I have read and understood the AI Usage Policy.
- [x] Documentation changes are not applicable.

## AI Usage Disclosure

- [x] I used AI tools to help investigate the cause and review the CSS change. I reviewed and manually tested the
final patch.