### PR TITLE
Restore scroll position when navigating back to a list

### DIFF
--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -29,6 +29,7 @@ import { MainNavbar } from "./components/MainNavbar";
 import { PageNotFound } from "./components/PageNotFound";
 import * as GQL from "./core/generated-graphql";
 import { makeTitleProps } from "./hooks/title";
+import { useScrollRestoration } from "./hooks/scrollRestoration";
 import { LoadingIndicator } from "./components/Shared/LoadingIndicator";
 
 import {
@@ -205,6 +206,8 @@ export const App: React.FC = () => {
   const location = useLocation();
   const history = useHistory();
   const setupMatch = useRouteMatch(["/setup", "/migrate", "/welcome"]);
+
+  useScrollRestoration();
 
   // dispatch event when location changes
   useEffect(() => {

--- a/ui/v2.5/src/components/List/PagedList.tsx
+++ b/ui/v2.5/src/components/List/PagedList.tsx
@@ -5,6 +5,7 @@ import { Pagination, PaginationIndex } from "./Pagination";
 import { LoadingIndicator } from "../Shared/LoadingIndicator";
 import { ErrorMessage } from "../Shared/ErrorMessage";
 import { FormattedMessage } from "react-intl";
+import { useContentLoading } from "src/hooks/scrollRestoration";
 
 export const LoadedContent: React.FC<
   PropsWithChildren<{
@@ -51,6 +52,10 @@ export const PagedList: React.FC<
   children,
 }) => {
   const pages = Math.ceil(totalCount / filter.itemsPerPage);
+
+  // let an in-progress scroll restoration wait for the list rather than for a
+  // fixed amount of time
+  useContentLoading(result.loading);
 
   const pagination = useMemo(() => {
     return (

--- a/ui/v2.5/src/components/List/util.ts
+++ b/ui/v2.5/src/components/List/util.ts
@@ -8,6 +8,7 @@ import { IHasID } from "src/utils/data";
 import { useConfigurationContext } from "src/hooks/Config";
 import { View } from "./views";
 import { usePrevious } from "src/hooks/state";
+import { isRestoringScroll } from "src/hooks/scrollRestoration";
 import * as GQL from "src/core/generated-graphql";
 import { DisplayMode } from "src/models/list-filter/types";
 import { Criterion } from "src/models/list-filter/criteria/criterion";
@@ -604,6 +605,12 @@ export function useScrollToTopOnPageChange(
   // only scroll to top if the page has changed and is not loading
   useEffect(() => {
     if (loading || currentPage === prevPage || prevPage === undefined) {
+      return;
+    }
+
+    // don't interfere with the scroll position being restored when navigating
+    // back to a list that was showing a different page
+    if (isRestoringScroll()) {
       return;
     }
 

--- a/ui/v2.5/src/hooks/scrollRestoration.ts
+++ b/ui/v2.5/src/hooks/scrollRestoration.ts
@@ -1,0 +1,202 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
+// the initial history entry has no key
+const initialKey = "@@initial";
+
+// scroll positions for each history entry, keyed by location key. Kept in
+// session storage so that the positions survive a page reload - the history
+// entries do.
+const storageKey = "stash-scroll-positions";
+
+function loadPositions() {
+  try {
+    const stored = sessionStorage.getItem(storageKey);
+    if (stored) return new Map<string, number>(JSON.parse(stored));
+  } catch {
+    // ignore - unparseable or unavailable storage
+  }
+  return new Map<string, number>();
+}
+
+const positions = loadPositions();
+
+// the number of history entries to remember positions for
+const maxPositions = 50;
+
+function setPosition(key: string, position: number) {
+  positions.set(key, position);
+
+  while (positions.size > maxPositions) {
+    positions.delete(positions.keys().next().value!);
+  }
+}
+
+// positions are updated as the user scrolls, so they are only written out when
+// navigating or leaving the page
+function savePositions() {
+  try {
+    sessionStorage.setItem(storageKey, JSON.stringify([...positions]));
+  } catch {
+    // ignore - storage may be unavailable or full
+  }
+}
+
+// how long to keep trying to restore the scroll position while the page
+// content is still loading in
+const restoreTimeout = 3000;
+
+// how long to keep the restored position applied - the list components scroll
+// the page around as their contents settle
+const settleTime = 750;
+
+let restoreCount = 0;
+
+// true while a scroll position is being restored. Automatic scrolling (such as
+// scrolling to the top of a list when its page changes) should be suppressed
+// while this is the case.
+export function isRestoringScroll() {
+  return restoreCount > 0;
+}
+
+// Scrolls to the given position, keeping it applied while the page settles.
+//
+// The position can't be applied while the document is still too short - which
+// is the case while the page content is being fetched and rendered - and once
+// it can be applied, the content rendering in may scroll it away again. Keep
+// it applied until the page has settled, the user scrolls themselves, or we
+// give up.
+//
+// Returns a function to abort the restoration.
+export function scrollToWhenReady(target: number) {
+  const start = Date.now();
+  let reached: number | undefined;
+  let frame = 0;
+  let stopped = false;
+
+  restoreCount++;
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    restoreCount--;
+    cancelAnimationFrame(frame);
+    window.removeEventListener("wheel", stop);
+    window.removeEventListener("touchstart", stop);
+    window.removeEventListener("keydown", stop);
+  }
+
+  function attempt() {
+    const now = Date.now();
+
+    if (Math.abs(window.scrollY - target) > 1) {
+      window.scrollTo(0, target);
+    }
+
+    if (Math.abs(window.scrollY - target) <= 1) {
+      // applied - keep it that way until the page has settled
+      if (reached === undefined) reached = now;
+      if (now - reached > settleTime) {
+        stop();
+        return;
+      }
+    } else if (now - start > restoreTimeout) {
+      // the page never got tall enough - give up
+      stop();
+      return;
+    }
+
+    frame = requestAnimationFrame(attempt);
+  }
+
+  // abandon the restoration if the user scrolls in the meantime
+  window.addEventListener("wheel", stop, { passive: true });
+  window.addEventListener("touchstart", stop, { passive: true });
+  window.addEventListener("keydown", stop);
+
+  attempt();
+
+  return stop;
+}
+
+// Restores the scroll position when navigating back or forward.
+//
+// The browser's native restoration doesn't work for the list views: at the
+// point the history entry is popped, the page content hasn't been fetched and
+// rendered yet, so the document is too short and the position is clamped to
+// the top. Instead we record the position for each history entry ourselves and
+// re-apply it once the page is able to scroll there.
+export function useScrollRestoration() {
+  const location = useLocation();
+  const history = useHistory();
+
+  const key = location.key ?? initialKey;
+  const keyRef = useRef(key);
+  const abortRestore = useRef<() => void>();
+
+  // take over scroll restoration from the browser
+  useEffect(() => {
+    if (!("scrollRestoration" in window.history)) return;
+
+    const original = window.history.scrollRestoration;
+    window.history.scrollRestoration = "manual";
+    return () => {
+      window.history.scrollRestoration = original;
+    };
+  }, []);
+
+  // record the scroll position of the current history entry
+  useEffect(() => {
+    function onScroll() {
+      // ignore the scroll events generated while restoring - they would
+      // overwrite the position being restored to
+      if (isRestoringScroll()) return;
+
+      setPosition(keyRef.current, window.scrollY);
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("pagehide", savePositions);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("pagehide", savePositions);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => abortRestore.current?.();
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only running when the history entry changes
+  useLayoutEffect(() => {
+    const prevKey = keyRef.current;
+    keyRef.current = key;
+
+    if (history.action === "REPLACE") {
+      // the same history entry under a new key - the lists replace the URL to
+      // keep it in sync with their filter, and do so while the position is
+      // still being restored. Carry the position over and leave the
+      // restoration running.
+      const position = positions.get(prevKey);
+      if (position !== undefined) {
+        setPosition(key, position);
+      }
+      savePositions();
+      return;
+    }
+
+    abortRestore.current?.();
+    savePositions();
+
+    if (history.action !== "POP") {
+      // new entry - it starts wherever the browser leaves us
+      setPosition(key, window.scrollY);
+      return;
+    }
+
+    const target = positions.get(key) ?? 0;
+    if (target === 0 && window.scrollY === 0) return;
+
+    abortRestore.current = scrollToWhenReady(target);
+  }, [key]);
+}

--- a/ui/v2.5/src/hooks/scrollRestoration.ts
+++ b/ui/v2.5/src/hooks/scrollRestoration.ts
@@ -42,13 +42,43 @@ function savePositions() {
   }
 }
 
-// how long to keep trying to restore the scroll position while the page
-// content is still loading in
-const restoreTimeout = 3000;
+let pendingLoads = 0;
 
-// how long to keep the restored position applied - the list components scroll
-// the page around as their contents settle
-const settleTime = 750;
+// Registers that a component is waiting on the content it is going to render.
+// A scroll restoration in progress waits for the content rather than for a
+// fixed amount of time - a slow query would otherwise run out the clock and
+// leave the page at the top, which is the very thing being fixed here.
+export function useContentLoading(loading: boolean) {
+  useEffect(() => {
+    if (!loading) return;
+
+    pendingLoads++;
+    return () => {
+      pendingLoads--;
+    };
+  }, [loading]);
+}
+
+// true while a component is waiting on its content
+function isContentLoading() {
+  return pendingLoads > 0;
+}
+
+// how long to keep trying once nothing is loading any more. This only applies
+// to pages that don't report their loading state - for those that do, the
+// restoration waits for the content however long it takes.
+const idleTimeout = 3000;
+
+// an absolute cap on a restoration, in case a page never finishes loading
+const maxRestoreTime = 30000;
+
+// how long to keep the restored position applied after the content has loaded
+// - the list components scroll the page around as their contents settle
+const settleTime = 250;
+
+// how often to re-check the deadlines. The restoration itself is driven by the
+// document resizing, so this doesn't need to be frequent.
+const tickInterval = 100;
 
 let restoreCount = 0;
 
@@ -64,57 +94,95 @@ export function isRestoringScroll() {
 // The position can't be applied while the document is still too short - which
 // is the case while the page content is being fetched and rendered - and once
 // it can be applied, the content rendering in may scroll it away again. Keep
-// it applied until the page has settled, the user scrolls themselves, or we
-// give up.
+// it applied until the content has loaded and the page has settled, the user
+// interacts, or we give up.
+//
+// Re-applying is driven by the document changing height, so the position is
+// restored as soon as the page is able to scroll there.
 //
 // Returns a function to abort the restoration.
 export function scrollToWhenReady(target: number) {
   const start = Date.now();
-  let reached: number | undefined;
-  let frame = 0;
+  // the last time content was seen loading - the give-up clock runs from here
+  let idleSince = start;
+  let settledSince: number | undefined;
   let stopped = false;
 
   restoreCount++;
+
+  const observer = new ResizeObserver(() => tick());
+  const timer = window.setInterval(() => tick(), tickInterval);
 
   function stop() {
     if (stopped) return;
     stopped = true;
     restoreCount--;
-    cancelAnimationFrame(frame);
+    observer.disconnect();
+    window.clearInterval(timer);
     window.removeEventListener("wheel", stop);
     window.removeEventListener("touchstart", stop);
+    window.removeEventListener("pointerdown", stop);
     window.removeEventListener("keydown", stop);
   }
 
-  function attempt() {
-    const now = Date.now();
-
+  // Applies the position, returning whether the page was able to scroll there.
+  function apply() {
     if (Math.abs(window.scrollY - target) > 1) {
       window.scrollTo(0, target);
     }
 
-    if (Math.abs(window.scrollY - target) <= 1) {
-      // applied - keep it that way until the page has settled
-      if (reached === undefined) reached = now;
-      if (now - reached > settleTime) {
-        stop();
-        return;
-      }
-    } else if (now - start > restoreTimeout) {
-      // the page never got tall enough - give up
+    return Math.abs(window.scrollY - target) <= 1;
+  }
+
+  function tick() {
+    if (stopped) return;
+
+    const now = Date.now();
+    const loading = isContentLoading();
+    if (loading) idleSince = now;
+
+    const applied = apply();
+
+    if (applied && !loading) {
+      // applied and the content is in - keep the position applied until the
+      // page has settled
+      if (settledSince === undefined) settledSince = now;
+      if (now - settledSince > settleTime) stop();
+      return;
+    }
+
+    settledSince = undefined;
+
+    if (!loading && now - idleSince > idleTimeout) {
+      // nothing is loading and the page never got tall enough - give up
       stop();
       return;
     }
 
-    frame = requestAnimationFrame(attempt);
+    if (now - start > maxRestoreTime) {
+      // the content never arrived - give up rather than suppress the automatic
+      // scrolling indefinitely
+      stop();
+    }
   }
 
-  // abandon the restoration if the user scrolls in the meantime
+  // abandon the restoration if the user interacts in the meantime
   window.addEventListener("wheel", stop, { passive: true });
   window.addEventListener("touchstart", stop, { passive: true });
+  window.addEventListener("pointerdown", stop, { passive: true });
   window.addEventListener("keydown", stop);
 
-  attempt();
+  // apply synchronously so that a position that is already reachable - the
+  // content was cached, say - is restored before the page is painted
+  tick();
+  if (stopped) return stop;
+
+  // re-apply whenever the document grows, so that the position is restored as
+  // soon as the content makes the page tall enough. Both elements are observed
+  // because custom CSS may pin the height of either one; if neither reports,
+  // the interval still drives the restoration.
+  observer.observe(document.documentElement);
+  observer.observe(document.body);
 
   return stop;
 }


### PR DESCRIPTION

## Description
React Router v5 has no scroll restoration, so the app relied on the browser's native restoration. That doesn't work for the list views: at the point the history entry is popped, the list content hasn't been fetched and rendered yet, so the document is one viewport tall and the position is clamped to the top. Nothing scrolls back once the content arrives, leaving the user at the top of the list.

Record the scroll position for each history entry and re-apply it on POP until the page is able to scroll there, holding it briefly while the list settles. Positions are kept in session storage so they survive a page reload.

Coming back to a list that was showing a page other than the first re-parses the filter from the query string, which looks like a page change to useScrollToTopOnPageChange and scrolled over the restored position, so that hook now defers to an in-progress restoration.

## Related Issue
Closes https://github.com/stashapp/stash/issues/7142


## Testing
manual testing in my own browser



## Screenshots
-



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
- Claude Opus 5


## Additional Context
<!-- Add any other context about the pull request here. -->

