### PR TITLE
Drop Stash to non privileged user in Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,5 @@ stash
 dist
 
 docker
+! docker/build/x86_64/alpine-entrypoint.sh
+! docker/build/x86_64/ubuntu-entrypoint.sh

--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -37,8 +37,9 @@ RUN make flags-release flags-pie stash
 
 # Final Runnable Image
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates vips-tools ffmpeg
+RUN apk add --no-cache ca-certificates vips-tools ffmpeg su-exec
 COPY --from=backend /stash/stash /usr/bin/
-ENV STASH_CONFIG_FILE=/root/.stash/config.yml
+ENV STASH_CONFIG_FILE=/home/stash/.stash/config.yml
 EXPOSE 9999
-ENTRYPOINT ["stash"]
+COPY ./docker/build/x86_64/alpine-entrypoint.sh /usr/local/bin/set-user-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/set-user-entrypoint.sh", "stash"]

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -44,7 +44,9 @@ RUN apt update && apt upgrade -y && apt install -y \
     # intel dependencies
     intel-media-va-driver-non-free vainfo \
     # python tools
-    python3 python3-pip && \
+    python3 python3-pip \
+    # allow to run as non-root user
+    gosu && \
   # cleanup
   apt autoremove -y && apt clean && \
   rm -rf /var/lib/apt/lists/*
@@ -53,13 +55,14 @@ COPY --from=backend --chmod=555 /stash/stash /usr/bin/
 # NVENC Patch
 RUN mkdir -p /usr/local/bin /patched-lib
 ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh /usr/local/bin/patch.sh
-ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh /usr/local/bin/nvidia-patch-entrypoint.sh
 
 ENV LANG=C.UTF-8
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=video,utility
-ENV STASH_CONFIG_FILE=/root/.stash/config.yml
+ENV STASH_CONFIG_FILE=/home/stash/.stash/config.yml
 EXPOSE 9999
-ENTRYPOINT ["docker-entrypoint.sh", "stash"]
+COPY ./docker/build/x86_64/ubuntu-entrypoint.sh /usr/local/bin/set-user-entrypoint.sh
+ENTRYPOINT ["nvidia-patch-entrypoint.sh", "/usr/local/bin/set-user-entrypoint.sh", "stash"]
 
 # vim: ft=dockerfile

--- a/docker/build/x86_64/alpine-entrypoint.sh
+++ b/docker/build/x86_64/alpine-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+USER_ID=${LOCAL_UID:-1000}
+
+USER_NAME="$(getent passwd | awk -F: '$3 == '${USER_ID}' { print $1 }')"
+
+if [ "$USER_NAME" == "" ]; then
+  USER_NAME=stash
+
+  if [ -d "/home/${USER_NAME}" ]; then
+    ARGS='-H'
+  fi
+
+  adduser -D -s /bin/sh -u ${USER_ID} ${ARGS} "$USER_NAME"
+  export HOME="/home/${USER_NAME}"
+
+  chown ${USER_NAME} $HOME
+fi
+
+su-exec ${USER_NAME} "$@"

--- a/docker/build/x86_64/ubuntu-entrypoint.sh
+++ b/docker/build/x86_64/ubuntu-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+USER_ID=${LOCAL_UID:-1000}
+
+USER_NAME="$(getent passwd | awk -F: '$3 == '${USER_ID}' { print $1 }')"
+
+if [ "$USER_NAME" == "" ]; then
+  USER_NAME=stash
+
+  if [ ! -d "/home/{USER_NAME}" ]; then
+    ARGS='-m'
+  fi
+
+  useradd --shell /bin/bash -u "$USER_ID" $ARGS "$USER_NAME"
+  export HOME="/home/${USER_NAME}"
+
+  chown "$USER_NAME" $HOME
+fi
+
+gosu "$USER_NAME" "$@"

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -25,13 +25,15 @@ services:
       ## Set your timezone, e.g. America/New_York or Europe/Berlin
       ## see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       - TZ=Etc/UTC
+      ## Set this to your local user id to ensure that files created by stash are owned by your user.
+      - LOCAL_UID=1000
     volumes:
       ## Adjust below paths (the left part) to your liking.
-      ## E.g. you can change ./config:/root/.stash to ./stash:/root/.stash
+      ## E.g. you can change ./config:/home/stash/.stash to ./stash:/home/stash/.stash
       ## The left part is the path on your host, the right part is the path in the stash container.
 
       ## Keep configs, scrapers, and plugins here.
-      - ./config:/root/.stash
+      - ./config:/home/stash/.stash
       ## Point this at your collection.
       ## The left side is where your collection is on your host, the right side is where it will be in stash.
       - ./data:/data


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
Add option to run Stash as a non-root user from Docker containers perspective and generated files to be owned by the specified user.

## Related Issue
#684 

## Testing
<!-- Describe the testing steps you have performed. -->
1. Build the docker container with `make docker-build `
  - There was an issue with the `pnpm` configuration/version (unrelated) so I temporarily bypassed it by adding `RUN corepack enable` to the build front end stage of the Docker build
2. Switched to the `docker/production` directory
3. Executed  `mkdir blobs cache config data generated metadata` (see explanation in additional context)
4. Temporarily mapped the data volume in the docker compose yml to my home directory
5. Temporarily updated the image in docker compose yml to `docker.io/stash/build:latest`
6. Executed `docker compose up`
7. logged in with the browser on local port 9999
8. Configured the application
9. Scanned for my movies directory -> ok, movies loaded
10. Verified files are not owned by root and that they are owned by me from my perspective.
11. Verified files are owned by stash from the containers perspective
<img width="674" height="444" alt="Screenshot from 2026-08-11 20-13-46" src="https://github.com/user-attachments/assets/79fd06bf-2f10-4b2a-b4fa-6f02352a4f05" />


I also executed `make docker-cuda-build` to build and test the Cuda build then followed the exact same steps.
its worth mentioning that the build failed for the `pnpm` version mismatch so I temporarily fixed the same way I fixed it in the non Cuda test. Also the image `golang:1.25.9-bullseye ` does not exist at the time of making this PR so I updated the cuda build to use `golang:1.25.9-trixie` as the backend base.
<img width="674" height="444" alt="Screenshot from 2026-08-11 20-37-07" src="https://github.com/user-attachments/assets/ffc909b2-852e-4778-95bb-811ff4b78445" />


Ahhh. Yes, from the Cuda containers perspective ubuntu owns the files generated by stash instead of stash. This is because my host user is user 1000 and the base ubuntu container already has user 1000 and is named ubuntu it skipped creating the stash user with ID 1000 because the ubuntu user already exists and has user id 1000. This is expected behavior. I'll change the user id in the compose yml to user id 1005 and upload one more screen shot. You will see now from the container perspective the stash files are owned by stash and from my perspective the files are owned by undefined user 1005 because my local system doesn't have a user 1005.
<img width="672" height="379" alt="Screenshot from 2026-08-11 20-53-12" src="https://github.com/user-attachments/assets/51c4e1fe-fd5d-4703-b6ba-b921d4191e21" />

<details>
  <summary>See diff used for testing</summary>

This is how I tested the changes. I didn't want to include these changes in the PR as they are unrelated to the issue.

```diff
diff --git a/docker/build/x86_64/Dockerfile b/docker/build/x86_64/Dockerfile
index 124ea8d0..bb9dcf30 100644
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -11,6 +11,7 @@ COPY ./graphql /stash/graphql/
 COPY ./ui /stash/ui/
 # pnpm install with npm
 RUN npm install -g pnpm
+RUN corepack enable
 RUN make pre-ui
 RUN make generate-ui
 ARG GITHASH
diff --git a/docker/build/x86_64/Dockerfile-CUDA b/docker/build/x86_64/Dockerfile-CUDA
index 98b66b66..6a8bcdf6 100644
--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -12,6 +12,7 @@ COPY ./graphql /stash/graphql/
 COPY ./ui /stash/ui/
 # pnpm install with npm
 RUN npm install -g pnpm
+RUN corepack enable
 RUN make pre-ui
 RUN make generate-ui
 ARG GITHASH
@@ -19,7 +20,7 @@ ARG STASH_VERSION
 RUN BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S") make ui-only
 
 # Build Backend
-FROM golang:1.25.9-bullseye AS backend
+FROM golang:1.25.9-trixie AS backend
 RUN apt update && apt install -y build-essential golang
 WORKDIR /stash
 COPY ./go* ./*.go Makefile gqlgen.yml .gqlgenc.yml /stash/
diff --git a/docker/production/docker-compose.yml b/docker/production/docker-compose.yml
index 4efcd94c..21f291bf 100644
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -2,7 +2,7 @@
 # APPDESCRIPTION=An organizer for your porn, written in Go
 services:
   stash:
-    image: stashapp/stash:latest
+    image: docker.io/stash/cuda-build:latest
     container_name: stash
     restart: unless-stopped
     ## the container's port must be the same with the STASH_PORT in the environment section
@@ -26,7 +26,7 @@ services:
       ## see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       - TZ=Etc/UTC
       ## Set this to your local user id to ensure that files created by stash are owned by your user.
-      - LOCAL_UID=1000
+      - LOCAL_UID=1005
     volumes:
       ## Adjust below paths (the left part) to your liking.
       ## E.g. you can change ./config:/home/stash/.stash to ./stash:/home/stash/.stash
@@ -36,7 +36,7 @@ services:
       - ./config:/home/stash/.stash
       ## Point this at your collection.
       ## The left side is where your collection is on your host, the right side is where it will be in stash.
-      - ./data:/data
+      - $HOME:/data
       ## This is where your stash's metadata lives
       - ./metadata:/metadata
       ## Any other cache content.
```
</details>

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

## Additional Context
<!-- Add any other context about the pull request here. -->

It is worth mentioning that when we mount a local directory as a volume, if it doesn't exist before docker creates the container docker (using it's own permission, generally root) will create the directory. This is also expected docker behavior. So the directories need to exist before docker starts the container otherwise root will own the directories then stash will fail to put files in the directories as stash is now running as non root and can not manipulate files in directories owned by root.

I understand there are concerns about not be able to run as root breaking things. These changes to the docker builds do allow running stash as root as well.

<img width="673" height="447" alt="Screenshot from 2026-08-11 21-51-27" src="https://github.com/user-attachments/assets/c1ddc4cf-e697-4ac0-b39e-d4d7fdeb9997" />

Although if your worried about breaking current installs/setups/workflows then I can update this PR to run the container as root by default. But I think that leaves security vulnerabilities on the table as does anything running with unnecessary elevated privileges.

Yes I am bounty hunting, but I am human. No AI was used to make this PR.
