### PR TITLE
Support explicit non-root Docker users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,4 @@ stash
 dist
 
 docker
+!docker/build/x86_64/cuda-entrypoint.sh

--- a/docker/build/x86_64/Dockerfile-CUDA
+++ b/docker/build/x86_64/Dockerfile-CUDA
@@ -53,7 +53,8 @@ COPY --from=backend --chmod=555 /stash/stash /usr/bin/
 # NVENC Patch
 RUN mkdir -p /usr/local/bin /patched-lib
 ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh /usr/local/bin/patch.sh
-ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ADD --chmod=555 https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh /usr/local/bin/nvidia-patch-entrypoint.sh
+COPY --chmod=555 ./docker/build/x86_64/cuda-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENV LANG=C.UTF-8
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/docker/build/x86_64/cuda-entrypoint.sh
+++ b/docker/build/x86_64/cuda-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  exec /usr/local/bin/nvidia-patch-entrypoint.sh "$@"
+fi
+
+exec "$@"

--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -28,6 +28,28 @@ Installing StashApp this way will by default bind stash to port 9999. This is av
 
 Good luck and have fun!
 
+### Run as a non-root user
+
+The image runs as root by default for compatibility with existing installations. To run Stash without root privileges, set a numeric user and group in `docker-compose.yml`:
+
+```yaml
+services:
+  stash:
+    user: "1000:1000"
+    environment:
+      - HOME=/config
+      - USER=stash
+      - STASH_CONFIG_FILE=/config/config.yml
+    volumes:
+      - ./config:/config
+```
+
+Replace `1000:1000` with the UID and GID that should own files created by Stash. That user must have access to the host directories mounted for config, media, metadata, cache, blobs, and generated content before the container starts. The container does not change ownership of mounted files.
+
+Using `/config` as `HOME` also gives Python scrapers and plugins a writable location for their cache.
+
+The CUDA image skips the optional NVIDIA driver patch when it is launched as a non-root user because patching the mounted driver libraries requires root. Hardware encoding remains subject to the limits of the host driver in that mode.
+
 ### Docker
 Docker is effectively a cross-platform software package repository. It allows you to ship an entire environment in what's referred to as a container. Containers are intended to hold everything that is needed to run an application from one place to another, making it easy for everyone along the way to reproduce the environment.
 

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: stashapp/stash:latest
     container_name: stash
     restart: unless-stopped
+    ## To run as a non-root user, uncomment the next line and replace the IDs with your own.
+    # user: "1000:1000"
     ## the container's port must be the same with the STASH_PORT in the environment section
     ports:
       - "9999:9999"
@@ -25,12 +27,17 @@ services:
       ## Set your timezone, e.g. America/New_York or Europe/Berlin
       ## see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       - TZ=Etc/UTC
+      ## When running as a non-root user, uncomment the next three lines and use /config below.
+      # - HOME=/config
+      # - USER=stash
+      # - STASH_CONFIG_FILE=/config/config.yml
     volumes:
       ## Adjust below paths (the left part) to your liking.
       ## E.g. you can change ./config:/root/.stash to ./stash:/root/.stash
       ## The left part is the path on your host, the right part is the path in the stash container.
 
       ## Keep configs, scrapers, and plugins here.
+      ## When running as a non-root user, change the container path to /config.
       - ./config:/root/.stash
       ## Point this at your collection.
       ## The left side is where your collection is on your host, the right side is where it will be in stash.

--- a/pkg/fsutil/dir.go
+++ b/pkg/fsutil/dir.go
@@ -59,8 +59,12 @@ func GetWorkingDirectory() string {
 	return ret
 }
 
-// GetHomeDirectory returns the path of the user's home directory.  ~ on Unix and C:\Users\UserName on Windows
+// GetHomeDirectory returns the home directory from the environment, falling back to the current user.
 func GetHomeDirectory() string {
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		return homeDir
+	}
+
 	currentUser, err := user.Current()
 	if err != nil {
 		panic(err)

--- a/pkg/fsutil/dir_test.go
+++ b/pkg/fsutil/dir_test.go
@@ -25,6 +25,20 @@ func TestIsPathInDirNormalization(t *testing.T) {
 	assert.True(t, IsPathInDir(filepath.Join("/library", gaNFC), filepath.Join("/library", gaNFC, "video.mp4")))
 }
 
+func TestGetHomeDirectoryFromEnvironment(t *testing.T) {
+	homeDir := t.TempDir()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("USERPROFILE", homeDir)
+	case "plan9":
+		t.Setenv("home", homeDir)
+	default:
+		t.Setenv("HOME", homeDir)
+	}
+
+	assert.Equal(t, homeDir, GetHomeDirectory())
+}
+
 func TestIsPathInDir(t *testing.T) {
 	type test struct {
 		dir         string


### PR DESCRIPTION
I went through the previous attempts and the rootless guide before working on this. I ended up keeping the current image behavior unchanged and relying on Docker's own `user: UID:GID` support instead of adding another PUID/PGID entrypoint.

The main thing in the way was Stash trying to look up the current user. Numeric container users don't always exist in `/etc/passwd`, so Stash now uses `HOME` first and falls back to the previous lookup when needed. The compose example shows the matching home and config settings without changing anything for existing installations.

CUDA actually needed a small exception because its optional NVIDIA patch writes to system directories. It still works exactly as before when running as root, while a non-root container skips the patch and starts Stash normally.

I tested this with UID/GID `12345:23456` and no matching user entry, and success! Stash started in the official image, responded over HTTP, and wrote files with the expected ownership.

The Go tests, configuration tests, Compose validation, shell checks and full backend build also pass. Should be good to go.

Closes #684.

AI Usage Disclosure: I used Codex while researching the previous attempts, tidying/tying up the implementation and running some tests. I reviewed all of its changes and take full responsibility for them.