### PR TITLE
Delete stale generated files on same-path content change instead of renaming

### DIFF
--- a/pkg/scene/migrate_hash.go
+++ b/pkg/scene/migrate_hash.go
@@ -48,6 +48,55 @@ func MigrateHash(p *paths.Paths, oldHash string, newHash string) {
 	migrateSceneFolder(oldPath, newPath)
 }
 
+// InvalidateGeneratedFiles removes the generated files associated with hash.
+//
+// Used instead of MigrateHash when a file's content changed at the same path,
+// where the old hash's generated files are no longer valid and should be
+// deleted rather than renamed onto the new hash.
+func InvalidateGeneratedFiles(p *paths.Paths, hash string) {
+	removeSceneFolder(filepath.Join(p.Generated.Markers, hash))
+
+	scenePaths := p.Scene
+	removeSceneFile(scenePaths.GetVideoPreviewPath(hash))
+	removeSceneFile(scenePaths.GetWebpPreviewPath(hash))
+	removeSceneFile(scenePaths.GetTranscodePath(hash))
+	removeSceneFile(scenePaths.GetSpriteVttFilePath(hash))
+	removeSceneFile(scenePaths.GetSpriteImageFilePath(hash))
+	removeSceneFile(scenePaths.GetInteractiveHeatmapPath(hash))
+
+	removeSceneFolder(p.SceneMarkers.GetFolderPath(hash))
+}
+
+func removeSceneFile(path string) {
+	exists, err := fsutil.FileExists(path)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Errorf("Error checking existence of %s: %s", path, err.Error())
+		return
+	}
+
+	if exists {
+		logger.Infof("removing outdated generated file %s", path)
+		if err := os.Remove(path); err != nil {
+			logger.Errorf("error removing %s: %s", path, err.Error())
+		}
+	}
+}
+
+func removeSceneFolder(path string) {
+	exists, err := fsutil.DirExists(path)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Errorf("Error checking existence of %s: %s", path, err.Error())
+		return
+	}
+
+	if exists {
+		logger.Infof("removing outdated generated folder %s", path)
+		if err := os.RemoveAll(path); err != nil {
+			logger.Errorf("error removing %s: %s", path, err.Error())
+		}
+	}
+}
+
 func migrateSceneFiles(oldName, newName string) {
 	oldExists, err := fsutil.FileExists(oldName)
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/scene/scan.go
+++ b/pkg/scene/scan.go
@@ -32,6 +32,7 @@ type ScanCreatorUpdater interface {
 	Create(ctx context.Context, newScene *models.Scene, fileIDs []models.FileID) error
 	UpdatePartial(ctx context.Context, id int, updatedScene models.ScenePartial) (*models.Scene, error)
 	AddFileID(ctx context.Context, id int, fileID models.FileID) error
+	UpdateCover(ctx context.Context, sceneID int, cover []byte) error
 }
 
 type ScanGalleryFinderUpdater interface {
@@ -126,12 +127,20 @@ func (h *ScanHandler) Handle(ctx context.Context, f models.File, oldFile models.
 	}
 
 	if oldFile != nil {
-		// migrate hashes from the old file to the new
 		oldHash := GetHash(oldFile, h.FileNamingAlgorithm)
 		newHash := GetHash(f, h.FileNamingAlgorithm)
 
 		if oldHash != "" && newHash != "" && oldHash != newHash {
-			MigrateHash(h.Paths, oldHash, newHash)
+			// content changed at the same path - remove the old hash's
+			// generated files instead of renaming them onto the new hash,
+			// so stale content doesn't pass as valid for the new content
+			InvalidateGeneratedFiles(h.Paths, oldHash)
+
+			for _, s := range existing {
+				if err := h.CreatorUpdater.UpdateCover(ctx, s.ID, nil); err != nil {
+					logger.Errorf("Error clearing outdated cover for %s: %v", s.DisplayName(), err)
+				}
+			}
 		}
 	}
 

--- a/pkg/scene/scan_test.go
+++ b/pkg/scene/scan_test.go
@@ -2,13 +2,17 @@ package scene
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stashapp/stash/pkg/models"
 	"github.com/stashapp/stash/pkg/models/mocks"
+	"github.com/stashapp/stash/pkg/models/paths"
 	"github.com/stashapp/stash/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssociateExisting_UpdatePartialOnContentChange(t *testing.T) {
@@ -111,4 +115,145 @@ func TestAssociateExisting_UpdatePartialOnNewFile(t *testing.T) {
 
 	db.Scene.AssertCalled(t, "AddFileID", mock.Anything, testSceneID, models.FileID(newFileID))
 	db.Scene.AssertCalled(t, "UpdatePartial", mock.Anything, testSceneID, mock.Anything)
+}
+
+func TestInvalidateGeneratedFiles(t *testing.T) {
+	const hash = "abc123"
+
+	tmpDir := t.TempDir()
+	p := paths.NewPaths(tmpDir, filepath.Join(tmpDir, "blobs"))
+
+	seedFile := func(path string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte("stale"), 0644))
+	}
+
+	videoPreview := p.Scene.GetVideoPreviewPath(hash)
+	webpPreview := p.Scene.GetWebpPreviewPath(hash)
+	transcode := p.Scene.GetTranscodePath(hash)
+	spriteVtt := p.Scene.GetSpriteVttFilePath(hash)
+	spriteImage := p.Scene.GetSpriteImageFilePath(hash)
+	heatmap := p.Scene.GetInteractiveHeatmapPath(hash)
+	markersFolder := filepath.Join(p.Generated.Markers, hash)
+
+	seedFile(videoPreview)
+	seedFile(webpPreview)
+	seedFile(transcode)
+	seedFile(spriteVtt)
+	seedFile(spriteImage)
+	seedFile(heatmap)
+	seedFile(filepath.Join(markersFolder, "1.mp4"))
+
+	// no files exist for this hash - should be a no-op
+	assert.NotPanics(t, func() {
+		InvalidateGeneratedFiles(&p, "no-such-hash")
+	})
+
+	InvalidateGeneratedFiles(&p, hash)
+
+	assert.NoFileExists(t, videoPreview)
+	assert.NoFileExists(t, webpPreview)
+	assert.NoFileExists(t, transcode)
+	assert.NoFileExists(t, spriteVtt)
+	assert.NoFileExists(t, spriteImage)
+	assert.NoFileExists(t, heatmap)
+	assert.NoDirExists(t, markersFolder)
+}
+
+func TestHandle_ContentChangedAtSamePath(t *testing.T) {
+	const testSceneID = 1
+	const testFileID = 100
+
+	const oldHash = "oldhash0000000000000000000000000"
+	const newHash = "newhash0000000000000000000000000"
+
+	tests := []struct {
+		name               string
+		newFingerprint     string
+		expectInvalidation bool
+	}{
+		{
+			name:               "clears stale generated files and cover when content changed at the same path",
+			newFingerprint:     newHash,
+			expectInvalidation: true,
+		},
+		{
+			name:               "leaves generated files and cover alone when the hash is unchanged",
+			newFingerprint:     oldHash,
+			expectInvalidation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldFile := &models.VideoFile{
+				BaseFile: &models.BaseFile{
+					ID:   models.FileID(testFileID),
+					Path: "test.mp4",
+					Fingerprints: models.Fingerprints{
+						{Type: models.FingerprintTypeOshash, Fingerprint: oldHash},
+					},
+				},
+			}
+			newFile := &models.VideoFile{
+				BaseFile: &models.BaseFile{
+					ID:   models.FileID(testFileID),
+					Path: "test.mp4",
+					Fingerprints: models.Fingerprints{
+						{Type: models.FingerprintTypeOshash, Fingerprint: tt.newFingerprint},
+					},
+				},
+			}
+
+			scene := &models.Scene{
+				ID:    testSceneID,
+				Files: models.NewRelatedVideoFiles([]*models.VideoFile{oldFile}),
+			}
+
+			tmpDir := t.TempDir()
+			p := paths.NewPaths(tmpDir, filepath.Join(tmpDir, "blobs"))
+
+			staleSprite := p.Scene.GetSpriteImageFilePath(oldHash)
+			require.NoError(t, os.MkdirAll(filepath.Dir(staleSprite), 0755))
+			require.NoError(t, os.WriteFile(staleSprite, []byte("stale"), 0644))
+
+			db := mocks.NewDatabase()
+			db.File.On("GetCaptions", mock.Anything, mock.Anything).Return(nil, nil)
+			db.Scene.On("FindByFileID", mock.Anything, models.FileID(testFileID)).Return([]*models.Scene{scene}, nil)
+			db.Scene.On("GetFiles", mock.Anything, testSceneID).Return([]*models.VideoFile{oldFile}, nil)
+			db.Scene.On("UpdatePartial", mock.Anything, testSceneID, mock.Anything).
+				Return(&models.Scene{ID: testSceneID}, nil)
+			db.Scene.On("UpdateCover", mock.Anything, testSceneID, mock.Anything).Return(nil)
+			db.Gallery.On("FindByPath", mock.Anything, mock.Anything).Return(nil, nil)
+
+			h := &ScanHandler{
+				CreatorUpdater:       db.Scene,
+				GalleryFinderUpdater: db.Gallery,
+				CaptionUpdater:       db.File,
+				ScanGenerator:        noopScanGenerator{},
+				PluginCache:          &plugin.Cache{},
+				FileNamingAlgorithm:  models.HashAlgorithmOshash,
+				Paths:                &p,
+			}
+
+			db.WithTxnCtx(func(ctx context.Context) {
+				err := h.Handle(ctx, newFile, oldFile)
+				assert.NoError(t, err)
+			})
+
+			if tt.expectInvalidation {
+				assert.NoFileExists(t, staleSprite)
+				db.Scene.AssertCalled(t, "UpdateCover", mock.Anything, testSceneID, mock.Anything)
+			} else {
+				assert.FileExists(t, staleSprite)
+				db.Scene.AssertNotCalled(t, "UpdateCover", mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}
+
+type noopScanGenerator struct{}
+
+func (noopScanGenerator) Generate(ctx context.Context, s *models.Scene, f *models.VideoFile) error {
+	return nil
 }

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -205,6 +205,15 @@ type MarkerFragment = Pick<GQL.SceneMarker, "title" | "seconds"> & {
   tags: Array<Pick<GQL.Tag, "name">>;
 };
 
+function getFileFingerprint(
+  fingerprints: Pick<GQL.Fingerprint, "type" | "value">[]
+) {
+  return fingerprints
+    .map((fp) => `${fp.type}:${fp.value}`)
+    .sort()
+    .join(",");
+}
+
 function getMarkerTitle(marker: MarkerFragment) {
   if (marker.title) {
     return marker.title;
@@ -249,6 +258,7 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
     const videoRef = useRef<HTMLDivElement>(null);
     const [_player, setPlayer] = useState<VideoJsPlayer>();
     const sceneId = useRef<string>();
+    const fileFingerprint = useRef<string>();
     const [sceneSaveActivity] = useSceneSaveActivity();
     const [sceneIncrementPlayCount] = useSceneIncrementPlayCount();
     const [updateInterfaceConfig] = useConfigureInterface();
@@ -438,8 +448,9 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
         videoEl.remove();
         setPlayer(undefined);
 
-        // reset sceneId to force reload sources
+        // reset sceneId/fileFingerprint to force reload sources
         sceneId.current = undefined;
+        fileFingerprint.current = undefined;
       };
       // empty deps - only init once
       // showAbLoopControls is necessary to re-init the player when the config changes
@@ -585,10 +596,18 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       const player = getPlayer();
       if (!player) return;
 
-      // don't re-initialise the player unless the scene has changed
-      if (!file || scene.id === sceneId.current) return;
+      // don't re-initialise the player unless the scene or its underlying
+      // file has changed - same scene id but different fingerprints means
+      // the file itself was edited in place (e.g. trimmed) without the
+      // scene id changing, and still needs new sources/duration pushed
+      // into the player
+      if (!file) return;
+      const fingerprint = getFileFingerprint(file.fingerprints);
+      if (scene.id === sceneId.current && fingerprint === fileFingerprint.current)
+        return;
 
       sceneId.current = scene.id;
+      fileFingerprint.current = fingerprint;
 
       setReady(false);
 

--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -603,7 +603,10 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
       // into the player
       if (!file) return;
       const fingerprint = getFileFingerprint(file.fingerprints);
-      if (scene.id === sceneId.current && fingerprint === fileFingerprint.current)
+      if (
+        scene.id === sceneId.current &&
+        fingerprint === fileFingerprint.current
+      )
         return;
 
       sceneId.current = scene.id;


### PR DESCRIPTION
## Description
Deletes generated content when a file is modified (i.e. trimmed) but the file path remains the same. Also modifies the UI scene player to track media fingerprint instead of just scene id when deciding to update the player.

## Related Issue
Fixes #7155

## Testing
- built the executable in wsl and tested the changes I made on windows
- Confirmed that generated content is deleted after file modification and rescan
- Confirmed that after a refetch, the player will pick up changes to rescanned file
- Added tests to `pkg/scene/scan_test.go` covering my changes

## Screenshots
<!-- N/A unless you want to add any. -->

## Checklist
- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below. 
used claude to make the code changes, tested and verified that the changes work

## Additional Context
Note, this does not touch transcodes (I think they should be removed also but want to hear from maintainers)