### PR TITLE
fix: Prevent Lightbox navigation to open unsaved prompt

### DIFF
--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -715,9 +715,8 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
       <Prompt
         when={formik.dirty}
-        message={(location, action) => {
-          console.log(location, action);  
-          return handleUnsavedChanges(intl, "performers", performer.id)(location)}
+        message={(location) =>
+          handleUnsavedChanges(intl, "performers", performer.id)(location)
         }
       />
       {renderButtons("mb-3")}

--- a/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
+++ b/ui/v2.5/src/components/Performers/PerformerDetails/PerformerEditPanel.tsx
@@ -53,6 +53,7 @@ import {
   formatCustomFieldInput,
 } from "src/components/Shared/CustomFields";
 import cloneDeep from "lodash-es/cloneDeep";
+import { handleUnsavedChanges } from "src/utils/navigation";
 
 const isScraper = (
   scraper: GQL.Scraper | GQL.StashBox
@@ -714,7 +715,10 @@ export const PerformerEditPanel: React.FC<IPerformerDetails> = ({
 
       <Prompt
         when={formik.dirty}
-        message={intl.formatMessage({ id: "dialogs.unsaved_changes" })}
+        message={(location, action) => {
+          console.log(location, action);  
+          return handleUnsavedChanges(intl, "performers", performer.id)(location)}
+        }
       />
       {renderButtons("mb-3")}
 

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -469,7 +469,9 @@ export function handleUnsavedChanges(
 ) {
   return (location: { pathname: string }) => {
     // #2291 - don't prompt if we're navigating within the gallery being edited
-    if (id !== undefined && location.pathname === `/${basepath}/${id}`) {
+    // #7154 - don't prompt on lightbox navigation
+    const regex = new RegExp(`^\\/${basepath}\\/${id}(\\/(default|scenes|galleries|images|groups|appearswith|performers|subgroups))?$`)
+    if (id !== undefined && regex.test(location.pathname)) {
       return true;
     }
 

--- a/ui/v2.5/src/utils/navigation.ts
+++ b/ui/v2.5/src/utils/navigation.ts
@@ -470,7 +470,9 @@ export function handleUnsavedChanges(
   return (location: { pathname: string }) => {
     // #2291 - don't prompt if we're navigating within the gallery being edited
     // #7154 - don't prompt on lightbox navigation
-    const regex = new RegExp(`^\\/${basepath}\\/${id}(\\/(default|scenes|galleries|images|groups|appearswith|performers|subgroups))?$`)
+    const regex = new RegExp(
+      `^\\/${basepath}\\/${id}(\\/(default|scenes|galleries|images|groups|appearswith|performers|subgroups))?$`
+    );
     if (id !== undefined && regex.test(location.pathname)) {
       return true;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This PR adds missing unsaved changes guard on the performer edit panel component and updates the existing rule for exclusion.

The new Regex handles both the old case and the new ones:
- `/${basepath}/${id}` (gallery)
- `/${basepath}/${id}/default` (performer/group)
- `/${basepath}/${id}/scenes` (performer/group)
- `/${basepath}/${id}/galleries` (performer)
- `/${basepath}/${id}/images` (performer)
- `/${basepath}/${id}/groups` (performer)
- `/${basepath}/${id}/appearswith` (performer)
- `/${basepath}/${id}/performers` (group)
- `/${basepath}/${id}/subgroups` (group)

Identified from the `validTabs` const found in both edit panel.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #7154

## Testing
<!-- Describe the testing steps you have performed. -->

Testing was made beforehand to properly identify the issue and understand the app components contributing to the bug.
Applied the fix and tried opening the lightbox on all identified bugged page to make sure the lightbox hide action doesn't trigger the unsaved message on the performer and group detail page.
Also ensured the existing rule was still working on galleries.
Checked for other pages but no Lightbox can be natively opened there.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I haven't used any AI tools for this.

## Additional Context
<!-- Add any other context about the pull request here. -->

