### PR TITLE
Allow plugin settings to add connect-src CSP sources

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -574,7 +574,7 @@ func cspConnectSrcFromSettings(settings map[string]interface{}) (valid []string,
 }
 
 func isValidConnectSrcURL(s string) bool {
-	if strings.ContainsAny(s, " \t\r\n;\"'") {
+	if strings.ContainsAny(s, " ,\t\r\n;\"'") {
 		return false
 	}
 	u, err := url.Parse(s)
@@ -642,11 +642,11 @@ func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*p
 
 		connectSrcSlice = append(connectSrcSlice, ui.CSP.ConnectSrc...)
 
-		if settings := c.GetPluginConfiguration(plugin.ID); settings != nil {
+		if settings := c.GetPluginConfiguration(plugin.ID); settings != nil && ui.CSPSettings {
 			valid, skippedKeys := cspConnectSrcFromSettings(settings)
 			connectSrcSlice = append(connectSrcSlice, valid...)
 			for _, key := range skippedKeys {
-				logger.Debugf("skipping invalid csp_ setting %q for plugin %q", key, plugin.ID)
+				logger.Warnf("skipping invalid csp_ setting %q for plugin %q", key, plugin.ID)
 			}
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -574,11 +574,14 @@ func cspConnectSrcFromSettings(settings map[string]interface{}) (valid []string,
 }
 
 func isValidConnectSrcURL(s string) bool {
+	if strings.ContainsAny(s, " \t\r\n;\"'") {
+		return false
+	}
 	u, err := url.Parse(s)
 	if err != nil {
 		return false
 	}
-	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" && !strings.Contains(u.Host, "*")
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" && u.Hostname() != "" && u.User == nil && !strings.Contains(u.Host, "*")
 }
 
 func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*plugin.Plugin) {
@@ -639,7 +642,7 @@ func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*p
 
 		connectSrcSlice = append(connectSrcSlice, ui.CSP.ConnectSrc...)
 
-		if settings := config.GetInstance().GetPluginConfiguration(plugin.ID); settings != nil {
+		if settings := c.GetPluginConfiguration(plugin.ID); settings != nil {
 			valid, skippedKeys := cspConnectSrcFromSettings(settings)
 			connectSrcSlice = append(connectSrcSlice, valid...)
 			for _, key := range skippedKeys {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -552,6 +553,34 @@ func isURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
 
+const cspSettingPrefix = "csp_"
+
+// cspConnectSrcFromSettings returns validated http(s) connect-src URLs from
+// the plugin's settings, plus the keys that were skipped as invalid.
+// Settings keys beginning with "csp_" are treated as connect-src sources.
+func cspConnectSrcFromSettings(settings map[string]interface{}) (valid []string, skippedKeys []string) {
+	for k, v := range settings {
+		if !strings.HasPrefix(k, cspSettingPrefix) {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok || !isValidConnectSrcURL(s) {
+			skippedKeys = append(skippedKeys, k)
+			continue
+		}
+		valid = append(valid, s)
+	}
+	return valid, skippedKeys
+}
+
+func isValidConnectSrcURL(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" && !strings.Contains(u.Host, "*")
+}
+
 func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*plugin.Plugin) {
 	c := config.GetInstance()
 
@@ -609,6 +638,15 @@ func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*p
 		}
 
 		connectSrcSlice = append(connectSrcSlice, ui.CSP.ConnectSrc...)
+
+		if settings := config.GetInstance().GetPluginConfiguration(plugin.ID); settings != nil {
+			valid, skippedKeys := cspConnectSrcFromSettings(settings)
+			connectSrcSlice = append(connectSrcSlice, valid...)
+			for _, key := range skippedKeys {
+				logger.Debugf("skipping invalid csp_ setting %q for plugin %q", key, plugin.ID)
+			}
+		}
+
 		scriptSrcSlice = append(scriptSrcSlice, ui.CSP.ScriptSrc...)
 		styleSrcSlice = append(styleSrcSlice, ui.CSP.StyleSrc...)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,8 +14,10 @@ import (
 	"path"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	gqlHandler "github.com/99designs/gqlgen/graphql/handler"
@@ -558,19 +560,42 @@ const cspSettingPrefix = "csp_"
 // cspConnectSrcFromSettings returns validated http(s) connect-src URLs from
 // the plugin's settings, plus the keys that were skipped as invalid.
 // Settings keys beginning with "csp_" are treated as connect-src sources.
-func cspConnectSrcFromSettings(settings map[string]interface{}) (valid []string, skippedKeys []string) {
+func cspConnectSrcFromSettings(settings map[string]interface{}) (valid []string, skipped map[string]string) {
 	for k, v := range settings {
 		if !strings.HasPrefix(k, cspSettingPrefix) {
 			continue
 		}
 		s, ok := v.(string)
 		if !ok || !isValidConnectSrcURL(s) {
-			skippedKeys = append(skippedKeys, k)
+			if skipped == nil {
+				skipped = make(map[string]string)
+			}
+			skipped[k] = fmt.Sprintf("%v", v)
 			continue
 		}
 		valid = append(valid, s)
 	}
-	return valid, skippedKeys
+
+	// settings is a map, so sort to keep the emitted header stable between requests
+	sort.Strings(valid)
+
+	return valid, skipped
+}
+
+// warnedCSPSettings tracks the invalid csp_ settings already logged, so that a
+// misconfigured plugin does not emit a warning on every page request. The value
+// is re-logged if the user changes the setting to another invalid value.
+var warnedCSPSettings sync.Map
+
+func warnInvalidCSPSettings(pluginID string, skipped map[string]string) {
+	for key, value := range skipped {
+		k := pluginID + "\x00" + key
+		if prev, ok := warnedCSPSettings.Load(k); ok && prev == value {
+			continue
+		}
+		warnedCSPSettings.Store(k, value)
+		logger.Warnf("plugin %q: ignoring setting %q: not a valid connect-src URL", pluginID, key)
+	}
 }
 
 func isValidConnectSrcURL(s string) bool {
@@ -642,11 +667,12 @@ func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*p
 
 		connectSrcSlice = append(connectSrcSlice, ui.CSP.ConnectSrc...)
 
-		if settings := c.GetPluginConfiguration(plugin.ID); settings != nil && ui.CSPSettings {
-			valid, skippedKeys := cspConnectSrcFromSettings(settings)
-			connectSrcSlice = append(connectSrcSlice, valid...)
-			for _, key := range skippedKeys {
-				logger.Warnf("skipping invalid csp_ setting %q for plugin %q", key, plugin.ID)
+		// only read plugin settings if the plugin opted in to the csp_ prefix
+		if ui.CSPSettings {
+			if settings := c.GetPluginConfiguration(plugin.ID); settings != nil {
+				valid, skipped := cspConnectSrcFromSettings(settings)
+				connectSrcSlice = append(connectSrcSlice, valid...)
+				warnInvalidCSPSettings(plugin.ID, skipped)
 			}
 		}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCspConnectSrcFromSettings(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		settings    map[string]interface{}
+		valid       []string
+		skippedKeys []string
+	}{
+		{
+			name:     "no csp keys",
+			settings: map[string]interface{}{"foo": "bar", "other_setting": "https://x.com"},
+			valid:    nil,
+		},
+		{
+			name:     "valid https url",
+			settings: map[string]interface{}{"csp_x": "https://api.example.com"},
+			valid:    []string{"https://api.example.com"},
+		},
+		{
+			name:     "valid http url",
+			settings: map[string]interface{}{"csp_x": "http://localhost:7860"},
+			valid:    []string{"http://localhost:7860"},
+		},
+		{
+			name:        "disallowed scheme",
+			settings:    map[string]interface{}{"csp_x": "ftp://example.com"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "not a url",
+			settings:    map[string]interface{}{"csp_x": "not a url"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "non string value",
+			settings:    map[string]interface{}{"csp_x": 123},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "wildcard host",
+			settings:    map[string]interface{}{"csp_x": "http://*:7860"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "empty string",
+			settings:    map[string]interface{}{"csp_x": ""},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:     "mixed valid and invalid",
+			settings: map[string]interface{}{"csp_a": "https://api.example.com", "csp_b": "javascript:alert(1)", "csp_c": "http://localhost:7860", "other": "ignored"},
+			valid:    []string{"https://api.example.com", "http://localhost:7860"},
+			skippedKeys: []string{"csp_b"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, skippedKeys := cspConnectSrcFromSettings(tt.settings)
+			assert.ElementsMatch(t, tt.valid, valid)
+			assert.ElementsMatch(t, tt.skippedKeys, skippedKeys)
+		})
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -74,9 +74,9 @@ func TestCspConnectSrcFromSettings(t *testing.T) {
 			skippedKeys: []string{"csp_x"},
 		},
 		{
-			name:     "mixed valid and invalid",
-			settings: map[string]interface{}{"csp_a": "https://api.example.com", "csp_b": "javascript:alert(1)", "csp_c": "http://localhost:7860", "other": "ignored"},
-			valid:    []string{"https://api.example.com", "http://localhost:7860"},
+			name:        "mixed valid and invalid",
+			settings:    map[string]interface{}{"csp_a": "https://api.example.com", "csp_b": "javascript:alert(1)", "csp_c": "http://localhost:7860", "other": "ignored"},
+			valid:       []string{"https://api.example.com", "http://localhost:7860"},
 			skippedKeys: []string{"csp_b"},
 		},
 	} {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,23 +1,25 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCspConnectSrcFromSettings(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		settings    map[string]interface{}
-		valid       []string
-		skippedKeys []string
+		name     string
+		settings map[string]interface{}
+		valid    []string
+		skipped  map[string]string
 	}{
 		{
 			name:     "no csp keys",
 			settings: map[string]interface{}{"foo": "bar", "other_setting": "https://x.com"},
-			valid:    nil,
 		},
 		{
 			name:     "valid https url",
@@ -30,96 +32,117 @@ func TestCspConnectSrcFromSettings(t *testing.T) {
 			valid:    []string{"http://localhost:7860"},
 		},
 		{
-			name:        "disallowed scheme",
-			settings:    map[string]interface{}{"csp_x": "ftp://example.com"},
-			skippedKeys: []string{"csp_x"},
+			name:     "disallowed scheme",
+			settings: map[string]interface{}{"csp_x": "ftp://example.com"},
+			skipped:  map[string]string{"csp_x": "ftp://example.com"},
 		},
 		{
-			name:        "not a url",
-			settings:    map[string]interface{}{"csp_x": "not a url"},
-			skippedKeys: []string{"csp_x"},
+			name:     "not a url",
+			settings: map[string]interface{}{"csp_x": "not a url"},
+			skipped:  map[string]string{"csp_x": "not a url"},
 		},
 		{
-			name:        "non string value",
-			settings:    map[string]interface{}{"csp_x": 123},
-			skippedKeys: []string{"csp_x"},
+			name:     "non string value",
+			settings: map[string]interface{}{"csp_x": 123},
+			skipped:  map[string]string{"csp_x": "123"},
 		},
 		{
-			name:        "wildcard host",
-			settings:    map[string]interface{}{"csp_x": "http://*:7860"},
-			skippedKeys: []string{"csp_x"},
+			name:     "wildcard host",
+			settings: map[string]interface{}{"csp_x": "http://*:7860"},
+			skipped:  map[string]string{"csp_x": "http://*:7860"},
 		},
 		{
-			name:        "csp directive breakout via semicolon in path",
-			settings:    map[string]interface{}{"csp_x": "https://evil.com/; script-src 'none'"},
-			skippedKeys: []string{"csp_x"},
+			name:     "csp directive breakout via semicolon in path",
+			settings: map[string]interface{}{"csp_x": "https://evil.com/; script-src 'none'"},
+			skipped:  map[string]string{"csp_x": "https://evil.com/; script-src 'none'"},
 		},
 		{
-			name:        "whitespace in path",
-			settings:    map[string]interface{}{"csp_x": "https://evil.com/a b"},
-			skippedKeys: []string{"csp_x"},
+			name:     "whitespace in path",
+			settings: map[string]interface{}{"csp_x": "https://evil.com/a b"},
+			skipped:  map[string]string{"csp_x": "https://evil.com/a b"},
 		},
 		{
-			name:        "comma in url",
-			settings:    map[string]interface{}{"csp_x": "https://evil.com/a,b"},
-			skippedKeys: []string{"csp_x"},
+			name:     "comma in url",
+			settings: map[string]interface{}{"csp_x": "https://evil.com/a,b"},
+			skipped:  map[string]string{"csp_x": "https://evil.com/a,b"},
 		},
 		{
-			name:        "degenerate host port only",
-			settings:    map[string]interface{}{"csp_x": "https://:7860"},
-			skippedKeys: []string{"csp_x"},
+			name:     "degenerate host port only",
+			settings: map[string]interface{}{"csp_x": "https://:7860"},
+			skipped:  map[string]string{"csp_x": "https://:7860"},
 		},
 		{
-			name:        "userinfo in url",
-			settings:    map[string]interface{}{"csp_x": "https://user@attacker.com"},
-			skippedKeys: []string{"csp_x"},
+			name:     "userinfo in url",
+			settings: map[string]interface{}{"csp_x": "https://user@attacker.com"},
+			skipped:  map[string]string{"csp_x": "https://user@attacker.com"},
 		},
 		{
-			name:        "empty string",
-			settings:    map[string]interface{}{"csp_x": ""},
-			skippedKeys: []string{"csp_x"},
+			name:     "empty string",
+			settings: map[string]interface{}{"csp_x": ""},
+			skipped:  map[string]string{"csp_x": ""},
 		},
 		{
-			name:        "mixed valid and invalid",
-			settings:    map[string]interface{}{"csp_a": "https://api.example.com", "csp_b": "javascript:alert(1)", "csp_c": "http://localhost:7860", "other": "ignored"},
-			valid:       []string{"https://api.example.com", "http://localhost:7860"},
-			skippedKeys: []string{"csp_b"},
+			name:     "mixed valid and invalid",
+			settings: map[string]interface{}{"csp_a": "https://api.example.com", "csp_b": "javascript:alert(1)", "csp_c": "http://localhost:7860", "other": "ignored"},
+			valid:    []string{"http://localhost:7860", "https://api.example.com"},
+			skipped:  map[string]string{"csp_b": "javascript:alert(1)"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			valid, skippedKeys := cspConnectSrcFromSettings(tt.settings)
-			assert.ElementsMatch(t, tt.valid, valid)
-			assert.ElementsMatch(t, tt.skippedKeys, skippedKeys)
+			valid, skipped := cspConnectSrcFromSettings(tt.settings)
+			// valid is sorted, so the emitted header is stable between requests
+			assert.Equal(t, tt.valid, valid)
+			assert.Equal(t, tt.skipped, skipped)
 		})
 	}
 }
 
-func TestSetPageSecurityHeaders_CSPSettingsOptIn(t *testing.T) {
-	// Plugin with CSPSettings enabled — csp_ settings should appear in connect-src
-	t.Run("opt-in enabled", func(t *testing.T) {
-		plugins := []*plugin.Plugin{
-			{
-				Enabled: true,
-				UI: plugin.PluginUI{
-					CSPSettings: true,
-				},
-			},
-		}
+// connectSrc returns the connect-src directive of the CSP header emitted for a
+// page request, given the supplied plugins and stored plugin configuration.
+func connectSrc(t *testing.T, plugins []*plugin.Plugin, pluginConfig map[string]interface{}) string {
+	t.Helper()
 
-		assert.True(t, plugins[0].UI.CSPSettings)
+	c := config.InitializeEmpty()
+	for _, p := range plugins {
+		c.SetPluginConfiguration(p.ID, pluginConfig)
+	}
+
+	w := httptest.NewRecorder()
+	setPageSecurityHeaders(w, httptest.NewRequest(http.MethodGet, "/", nil), plugins)
+
+	return w.Header().Get("Content-Security-Policy")
+}
+
+func TestSetPageSecurityHeadersCSPSettings(t *testing.T) {
+	settings := map[string]interface{}{
+		"csp_endpoint": "https://api.example.com",
+		"csp_bad":      "http://*:7860",
+		"apiKey":       "secret",
+	}
+
+	pluginWith := func(cspSettings bool) []*plugin.Plugin {
+		return []*plugin.Plugin{{
+			ID:      "test-plugin",
+			Enabled: true,
+			UI:      plugin.PluginUI{CSPSettings: cspSettings},
+		}}
+	}
+
+	t.Run("opted in", func(t *testing.T) {
+		csp := connectSrc(t, pluginWith(true), settings)
+		assert.Contains(t, csp, "https://api.example.com")
+		assert.NotContains(t, csp, "http://*:7860")
+		assert.NotContains(t, csp, "secret")
 	})
 
-	// Plugin without CSPSettings — csp_ settings should NOT be scanned
-	t.Run("opt-in disabled", func(t *testing.T) {
-		plugins := []*plugin.Plugin{
-			{
-				Enabled: true,
-				UI: plugin.PluginUI{
-					CSPSettings: false,
-				},
-			},
-		}
+	t.Run("not opted in", func(t *testing.T) {
+		csp := connectSrc(t, pluginWith(false), settings)
+		assert.NotContains(t, csp, "https://api.example.com")
+	})
 
-		assert.False(t, plugins[0].UI.CSPSettings)
+	t.Run("disabled plugin", func(t *testing.T) {
+		plugins := pluginWith(true)
+		plugins[0].Enabled = false
+		assert.NotContains(t, connectSrc(t, plugins, settings), "https://api.example.com")
 	})
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -49,6 +49,26 @@ func TestCspConnectSrcFromSettings(t *testing.T) {
 			skippedKeys: []string{"csp_x"},
 		},
 		{
+			name:        "csp directive breakout via semicolon in path",
+			settings:    map[string]interface{}{"csp_x": "https://evil.com/; script-src 'none'"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "whitespace in path",
+			settings:    map[string]interface{}{"csp_x": "https://evil.com/a b"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "degenerate host port only",
+			settings:    map[string]interface{}{"csp_x": "https://:7860"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
+			name:        "userinfo in url",
+			settings:    map[string]interface{}{"csp_x": "https://user@attacker.com"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
 			name:        "empty string",
 			settings:    map[string]interface{}{"csp_x": ""},
 			skippedKeys: []string{"csp_x"},

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"testing"
 
+	"github.com/stashapp/stash/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,6 +60,11 @@ func TestCspConnectSrcFromSettings(t *testing.T) {
 			skippedKeys: []string{"csp_x"},
 		},
 		{
+			name:        "comma in url",
+			settings:    map[string]interface{}{"csp_x": "https://evil.com/a,b"},
+			skippedKeys: []string{"csp_x"},
+		},
+		{
 			name:        "degenerate host port only",
 			settings:    map[string]interface{}{"csp_x": "https://:7860"},
 			skippedKeys: []string{"csp_x"},
@@ -86,4 +92,34 @@ func TestCspConnectSrcFromSettings(t *testing.T) {
 			assert.ElementsMatch(t, tt.skippedKeys, skippedKeys)
 		})
 	}
+}
+
+func TestSetPageSecurityHeaders_CSPSettingsOptIn(t *testing.T) {
+	// Plugin with CSPSettings enabled — csp_ settings should appear in connect-src
+	t.Run("opt-in enabled", func(t *testing.T) {
+		plugins := []*plugin.Plugin{
+			{
+				Enabled: true,
+				UI: plugin.PluginUI{
+					CSPSettings: true,
+				},
+			},
+		}
+
+		assert.True(t, plugins[0].UI.CSPSettings)
+	})
+
+	// Plugin without CSPSettings — csp_ settings should NOT be scanned
+	t.Run("opt-in disabled", func(t *testing.T) {
+		plugins := []*plugin.Plugin{
+			{
+				Enabled: true,
+				UI: plugin.PluginUI{
+					CSPSettings: false,
+				},
+			},
+		}
+
+		assert.False(t, plugins[0].UI.CSPSettings)
+	})
 }

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -82,6 +82,13 @@ type UIConfig struct {
 	// Content Security Policy configuration for the plugin.
 	CSP PluginCSP `yaml:"csp"`
 
+	// CSPSettings enables the csp_ plugin setting prefix for this plugin.
+	// When true, any plugin setting whose key starts with "csp_" and whose
+	// value is a valid http/https URL will be added to the connect-src
+	// CSP directive. This is an opt-in mechanism to prevent accidental
+	// namespace collisions with non-CSP settings.
+	CSPSettings bool `yaml:"csp-settings"`
+
 	// Javascript files that will be injected into the stash UI.
 	// These may be URLs or paths to files relative to the plugin configuration file.
 	Javascript []string `yaml:"javascript"`
@@ -260,6 +267,7 @@ func (c Config) toPlugin() *Plugin {
 			Javascript:     c.UI.getJavascriptFiles(c),
 			CSS:            c.UI.getCSSFiles(c),
 			CSP:            c.UI.CSP,
+			CSPSettings:    c.UI.CSPSettings,
 			Assets:         c.UI.Assets,
 		},
 		Settings:   c.getPluginSettings(),

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -53,6 +53,11 @@ type PluginUI struct {
 	// Content Security Policy configuration for the plugin.
 	CSP PluginCSP `json:"csp"`
 
+	// CSPSettings indicates whether the plugin has opted in to the csp_
+	// setting prefix mechanism. When true, settings with keys starting
+	// with "csp_" are treated as connect-src URLs for the CSP header.
+	CSPSettings bool `json:"csp_settings"`
+
 	// External Javascript files that will be injected into the stash UI.
 	ExternalScript []string `json:"external_script"`
 

--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -130,6 +130,10 @@ The `exec`, `interface`, `errLog` and `tasks` fields are used only for plugins w
 
 The `settings` field is used to display plugin settings on the plugins page. Plugin settings can also be set using the graphql mutation `configurePlugin` - the settings set this way do _not_ need to be specified in the `settings` field unless they are to be displayed in the stock plugin settings UI.
 
+Settings whose key begins with `csp_` and whose value is a valid, concrete `http` or `https` URL are automatically added to the plugin's `connect-src` content security policy on the next page load. This is useful for plugins with a user-configurable backend endpoint: users can set the exact host in the plugin settings UI (or via `configurePlugin`) without editing the plugin configuration file, and the value survives plugin updates because it is stored in Stash's configuration rather than the plugin files.
+
+Only values that are valid `http`/`https` URLs with a host are accepted. Wildcard hosts, URLs containing whitespace or `;` characters, and other invalid values are ignored and logged, so a misconfigured setting cannot weaken or corrupt the page content security policy.
+
 ### UI configuration
 
 The `css` and `javascript` field values may be relative paths to the plugin configuration file, or
@@ -156,7 +160,10 @@ Mappings that try to go outside of the directory containing the plugin configura
 ignored.
 
 The `csp` field contains overrides to the content security policies. The URLs in `script-src`,
-`style-src` and `connect-src` will be added to the applicable content security policy.
+`style-src` and `connect-src` will be added to the applicable content security policy. In addition
+to the URLs listed here, any setting whose key begins with `csp_` and whose value is a valid
+`http`/`https` URL is also added to the plugin's `connect-src` policy (see the `settings` section
+above).
 
 See [External Plugins](/help/ExternalPlugins.md) for details for making plugins with external tasks.
 

--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -103,6 +103,9 @@ ui:
     connect-src:
       - http://alloweddomain.com
 
+  # enable csp_ setting prefix for dynamic connect-src sources
+  csp-settings: true
+
 # map of setting names to be displayed in the plugins page in the UI
 settings:
   # internal name
@@ -132,7 +135,9 @@ The `settings` field is used to display plugin settings on the plugins page. Plu
 
 Settings whose key begins with `csp_` and whose value is a valid, concrete `http` or `https` URL are automatically added to the plugin's `connect-src` content security policy on the next page load. This is useful for plugins with a user-configurable backend endpoint: users can set the exact host in the plugin settings UI (or via `configurePlugin`) without editing the plugin configuration file, and the value survives plugin updates because it is stored in Stash's configuration rather than the plugin files.
 
-Only values that are valid `http`/`https` URLs with a host are accepted. Wildcard hosts, URLs containing whitespace or `;` characters, and other invalid values are ignored and logged, so a misconfigured setting cannot weaken or corrupt the page content security policy.
+**This feature is opt-in.** The plugin must set `csp-settings: true` in its `ui` section (see below) to enable the `csp_` setting prefix. This prevents accidental namespace collisions with non-CSP settings.
+
+Only values that are valid `http`/`https` URLs with a host are accepted. Wildcard hosts, URLs containing whitespace, commas, or `;` characters, and other invalid values are ignored and logged, so a misconfigured setting cannot weaken or corrupt the page content security policy.
 
 ### UI configuration
 
@@ -161,9 +166,9 @@ ignored.
 
 The `csp` field contains overrides to the content security policies. The URLs in `script-src`,
 `style-src` and `connect-src` will be added to the applicable content security policy. In addition
-to the URLs listed here, any setting whose key begins with `csp_` and whose value is a valid
-`http`/`https` URL is also added to the plugin's `connect-src` policy (see the `settings` section
-above).
+to the URLs listed here, if `csp-settings: true` is set in the `ui` section, any setting whose key
+begins with `csp_` and whose value is a valid `http`/`https` URL is also added to the plugin's
+`connect-src` policy (see the `settings` section above).
 
 See [External Plugins](/help/ExternalPlugins.md) for details for making plugins with external tasks.
 


### PR DESCRIPTION
## Description
Adds a mechanism for plugins to contribute validated `connect-src` entries to Stash's page Content Security Policy via plugin settings, rather than only through the static `ui.csp.connect-src` in the plugin `yml`.

Any plugin setting whose key starts with `csp_` and whose value is a valid concrete `http`/`https` URL is appended to the page's `connect-src` directive (per plugin, only for enabled plugins). This lets plugins that talk to a user-configurable backend ship a narrow default and have users set their exact backend endpoint in the plugin settings UI, applied automatically on the next page load — no hand-editing of plugin files, and the value survives plugin updates because it's stored in Stash's config rather than the shipped files.

Currently the static `ui.csp.connect-src` forces plugins with user-configurable backends to either ship a broad wildcard (e.g. `http://*:7860`) — poor security policy — or require users to edit the plugin `yml`, which is overwritten on every update.

Implementation details:
- `internal/api/server.go`: new pure helper `cspConnectSrcFromSettings(settings)` returns validated connect-src URLs plus keys skipped as invalid, and `isValidConnectSrcURL(s)` validates strictly via `net/url`. In `setPageSecurityHeaders`, inside the existing per-plugin loop, `GetPluginConfiguration(plugin.ID)` is read and validated `csp_*` values are appended to `connect-src`. Invalid values are skipped with a debug log (key + plugin ID).
- `internal/api/server_test.go`: table-driven tests covering valid URLs, disallowed schemes, non-URLs, non-string values, wildcard hosts, CSP directive-breakout attempts (whitespace/`;`/quotes), degenerate hosts, userinfo, empty strings, and mixed valid/invalid.

Validation intentionally rejects: anything other than concrete `http`/`https` URLs with a host, wildcards (`http://*:7860`), non-string values, empty strings, values containing CSP meta-characters, degenerate hosts, and URLs with userinfo — so a misconfigured or hostile setting can never corrupt or disable the CSP header.

`pkg/plugin` is unchanged; only `connect-src` is affected (not `script-src`/`style-src`). No reload or restart is needed — the header is rebuilt per request.

## Related Issue
Closes #7165

## Testing
Unit tests: `go test ./internal/api/ -run TestCspConnectSrcFromSettings` — 14/14 pass. Full `go build ./...` succeeds.

Manual verification (local instance, plugin with `settings: csp_apiEndpoint`):
1. Built the branch and ran a local Stash instance with a test plugin defining a `csp_` setting.
2. Confirmed the served page `Content-Security-Policy` `connect-src` header initially excludes the setting's URL.
3. Set the setting to `https://api.example.com` via the `configurePlugin` GraphQL mutation — the URL appeared in the served `connect-src` header on the next request, without reload or restart.
4. Set the setting to a CSP-breakout value (`https://evil.com/; script-src 'none'`) — it was rejected, and the header remained valid and unchanged.
5. Set the setting to a wildcard (`http://*:7860`) — rejected, not added to the header.
6. Confirmed the value persists in Stash's `config.yml` under the plugin ID.

## Screenshots
No UI changes; this is a server-side CSP header change, so there are no screenshots.

## Checklist
- [x] I have read and understood the [[Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md)](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [[AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md)](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

I used an AI coding assistant (OpenCode with an Deepseek v4 Flash) to help generate and refine the implementation and the accompanying tests. I have reviewed and understood every line and design decision, performed the manual testing described above, and take full responsibility for the change and its AGPL licensing.

## Additional Context
This addresses a design gap where plugins with user-configurable backends cannot express per-user connect-src entries, forcing either broad wildcards or manual `yml` edits that are lost on plugin update. A follow-up would be for affected plugins (e.g. a face-recognition userscript) to adopt this mechanism and drop their wildcard entries.