### PR TITLE
Fix studios with no parent disappearing under Parents Excludes filter

### DIFF
--- a/pkg/sqlite/criterion_handlers.go
+++ b/pkg/sqlite/criterion_handlers.go
@@ -558,7 +558,14 @@ func (m *multiCriterionHandlerBuilder) handler(criterion *models.MultiCriterionI
 				args = append(args, tagID)
 			}
 
-			if m.addJoinsFunc != nil {
+			// EXCLUDES is evaluated using a self-contained NOT IN/NOT EXISTS
+			// clause that never references the joined table, so the join must
+			// be skipped here. Adding it anyway turns it into an inner join
+			// that silently drops any row whose foreign key is NULL, before
+			// the EXCLUDES clause even runs - excluding rows that should be
+			// included (e.g. a studio with no parent, when excluding by
+			// parent studio).
+			if m.addJoinsFunc != nil && criterion.Modifier != models.CriterionModifierExcludes {
 				m.addJoinsFunc(f, joinTypeInner)
 			}
 

--- a/pkg/sqlite/studio_test.go
+++ b/pkg/sqlite/studio_test.go
@@ -858,6 +858,43 @@ func TestStudioQueryParent(t *testing.T) {
 	})
 }
 
+// TestStudioQueryParentExcludesNilParent ensures that excluding by parent
+// studio does not also exclude studios that have no parent at all. The
+// Parents Excludes filter was previously implemented with an inner join
+// against the parent studio, which silently dropped every studio with a
+// NULL parent_id before the exclusion clause was even evaluated.
+func TestStudioQueryParentExcludesNilParent(t *testing.T) {
+	withTxn(func(ctx context.Context) error {
+		sqb := db.Studio
+
+		studioCriterion := models.MultiCriterionInput{
+			Value: []string{
+				strconv.Itoa(studioIDs[studioIdxWithParentStudio]),
+			},
+			Modifier: models.CriterionModifierExcludes,
+		}
+
+		studioFilter := models.StudioFilterType{
+			Parents: &studioCriterion,
+		}
+
+		studios, _, err := sqb.Query(ctx, &studioFilter, nil)
+		if err != nil {
+			t.Errorf("Error querying studio: %s", err.Error())
+		}
+
+		// studioIdxWithScene has no parent studio, so it must not be
+		// excluded by a Parents Excludes filter on an unrelated parent.
+		var ids []int
+		for _, s := range studios {
+			ids = append(ids, s.ID)
+		}
+		assert.Contains(t, ids, studioIDs[studioIdxWithScene])
+
+		return nil
+	})
+}
+
 func TestStudioDestroyParent(t *testing.T) {
 	const parentName = "parent"
 	const childName = "child"


### PR DESCRIPTION
## Description

`multiCriterionHandlerBuilder.handler` in `pkg/sqlite/criterion_handlers.go` unconditionally inner-joins the foreign/parent table before applying the criterion, regardless of the modifier. For `EXCLUDES`, the actual filtering is done by a self-contained `NOT IN`/`NOT EXISTS` subquery (see `getMultiCriterionClause`) that never references the joined alias at all — so the join is both unnecessary and harmful.

Concretely, for the Studios `Parents` filter, the join is:

```go
addJoinsFunc := func(f *filterBuilder, joinType joinType) {
    f.addJoin(joinType, "studios", "parent_studio", "parent_studio.id = studios.parent_id")
}
```

which is added as an `INNER JOIN` even when `Modifier == EXCLUDES`. Since `studios.parent_id` is nullable, any studio with no parent at all has no row to join against, so it's silently dropped from the result set *before* the `WHERE`/`NOT EXISTS` clause is ever evaluated — independent of which studios were actually in the exclusion list.

Reproduced against a real library: applying any "Parent Studio Excludes [...]" filter on the Studios page made every top-level (parentless) studio vanish from the results, even ones that clearly shouldn't match any parent-based exclusion.

## Fix

Skip `addJoinsFunc` when `criterion.Modifier == models.CriterionModifierExcludes`, since none of the code paths in `getMultiCriterionClause` for that modifier reference the joined table. `INCLUDES`/`INCLUDES_ALL` are unaffected and still get the join they need.

## Related Issue

N/A - no existing issue found for this (searched open/closed issues and PRs for "parent"/"exclude" first).

## Testing

- `go test -tags="integration sqlite_stat4 sqlite_math_functions" ./pkg/sqlite/... -count=1` - full package passes
- `gofmt -l pkg/sqlite/criterion_handlers.go pkg/sqlite/studio_test.go` - clean
- `go vet ./pkg/sqlite/...` - clean
- Added `TestStudioQueryParentExcludesNilParent`, which fails on unfixed code (confirmed by reverting the fix locally and re-running: the studio with no parent is missing from results) and passes with the fix.
- Manually verified against my own `stash-go.sqlite`: the raw SQL Stash generates for this filter (with vs. without the erroneous inner join) reproduces exactly this symptom on real data.

## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable) - not applicable, no user-facing behavior/docs change beyond the bug fix itself.

## AI Usage Disclosure

- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

This PR was investigated and written by Claude Code (Anthropic), working with me interactively. I reported the symptom (a specific studio missing from filtered results), Claude traced it through my local `stash-go.sqlite` database and the Go source to the root cause described above, wrote the fix and regression test, ran the test suite, and verified the test fails without the fix. I reviewed the diff and reasoning before approving submission.