### PR TITLE
Fix: Clean Folder Galleries Marked With .nogallery

### DIFF
--- a/internal/manager/task_clean.go
+++ b/internal/manager/task_clean.go
@@ -2,8 +2,10 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -32,6 +34,12 @@ type cleanJob struct {
 	scanSubs     *subscriptionManager
 }
 
+// galleryCleanCandidate avoids retaining full gallery models for large libraries.
+type galleryCleanCandidate struct {
+	id   int
+	path string
+}
+
 func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	logger.Infof("Starting cleaning of tracked files")
 	start := time.Now()
@@ -51,7 +59,7 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) error {
 		return nil
 	}
 
-	j.cleanEmptyGalleries(ctx)
+	j.cleanGalleries(ctx)
 
 	j.scanSubs.notify()
 	elapsed := time.Since(start)
@@ -59,46 +67,10 @@ func (j *cleanJob) Execute(ctx context.Context, progress *job.Progress) error {
 	return nil
 }
 
-func (j *cleanJob) cleanEmptyGalleries(ctx context.Context) {
-	const batchSize = 1000
-	var toClean []int
-	findFilter := models.BatchFindFilter(batchSize)
-	r := j.repository
-	if err := r.WithTxn(ctx, func(ctx context.Context) error {
-		found := true
-		for found {
-			emptyGalleries, _, err := r.Gallery.Query(ctx, &models.GalleryFilterType{
-				ImageCount: &models.IntCriterionInput{
-					Value:    0,
-					Modifier: models.CriterionModifierEquals,
-				},
-			}, findFilter)
-
-			if err != nil {
-				return err
-			}
-
-			found = len(emptyGalleries) > 0
-
-			for _, g := range emptyGalleries {
-				if g.Path == "" {
-					continue
-				}
-
-				if len(j.input.Paths) > 0 && !fsutil.IsPathInDirs(j.input.Paths, g.Path) {
-					continue
-				}
-
-				logger.Infof("Gallery has 0 images. Marking to clean: %s", g.DisplayName())
-				toClean = append(toClean, g.ID)
-			}
-
-			*findFilter.Page++
-		}
-
-		return nil
-	}); err != nil {
-		logger.Errorf("Error finding empty galleries: %v", err)
+func (j *cleanJob) cleanGalleries(ctx context.Context) {
+	toClean, err := j.findGalleriesToClean(ctx)
+	if err != nil {
+		logger.Errorf("Error finding galleries to clean: %v", err)
 		return
 	}
 
@@ -107,6 +79,115 @@ func (j *cleanJob) cleanEmptyGalleries(ctx context.Context) {
 			j.deleteGallery(ctx, id)
 		}
 	}
+}
+
+func isNoGalleryFolder(path string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(path, ".forcegallery")); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	if _, err := os.Stat(filepath.Join(path, ".nogallery")); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (j *cleanJob) findGalleriesToClean(ctx context.Context) ([]int, error) {
+	const batchSize = 1000
+	var toClean []int
+	var folderGalleries []galleryCleanCandidate
+	toCleanSet := make(map[int]struct{})
+	r := j.repository
+
+	inCleanPaths := func(g *models.Gallery) bool {
+		return g.Path != "" && (len(j.input.Paths) == 0 || fsutil.IsPathInDirs(j.input.Paths, g.Path))
+	}
+
+	markForClean := func(id int, displayName, reason string) {
+		if _, exists := toCleanSet[id]; exists {
+			return
+		}
+
+		logger.Infof("%s. Marking to clean: %s", reason, displayName)
+		toCleanSet[id] = struct{}{}
+		toClean = append(toClean, id)
+	}
+
+	queryInBatches := func(ctx context.Context, galleryFilter *models.GalleryFilterType, visit func(*models.Gallery)) error {
+		findFilter := models.BatchFindFilter(batchSize)
+		found := true
+		for found {
+			galleries, _, err := r.Gallery.Query(ctx, galleryFilter, findFilter)
+			if err != nil {
+				return err
+			}
+
+			found = len(galleries) > 0
+			for _, g := range galleries {
+				visit(g)
+			}
+
+			*findFilter.Page++
+		}
+
+		return nil
+	}
+
+	err := r.WithTxn(ctx, func(ctx context.Context) error {
+		emptyGalleryFilter := &models.GalleryFilterType{
+			ImageCount: &models.IntCriterionInput{
+				Value:    0,
+				Modifier: models.CriterionModifierEquals,
+			},
+		}
+		if err := queryInBatches(ctx, emptyGalleryFilter, func(g *models.Gallery) {
+			if inCleanPaths(g) {
+				markForClean(g.ID, g.DisplayName(), "Gallery has 0 images")
+			}
+		}); err != nil {
+			return err
+		}
+
+		folderGalleryFilter := &models.GalleryFilterType{
+			FoldersFilter: &models.FolderFilterType{
+				Path: &models.StringCriterionInput{
+					Modifier: models.CriterionModifierNotNull,
+				},
+			},
+		}
+		return queryInBatches(ctx, folderGalleryFilter, func(g *models.Gallery) {
+			if inCleanPaths(g) {
+				folderGalleries = append(folderGalleries, galleryCleanCandidate{
+					id:   g.ID,
+					path: g.Path,
+				})
+			}
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Gallery folders may be on slow network filesystems, so check them after
+	// releasing the database transaction.
+	for _, g := range folderGalleries {
+		isNoGallery, err := isNoGalleryFolder(g.path)
+		if err != nil {
+			logger.Errorf("Error checking gallery marker files in %q: %v", g.path, err)
+			continue
+		}
+
+		if isNoGallery {
+			markForClean(g.id, g.path, "Gallery folder contains .nogallery")
+		}
+	}
+
+	return toClean, nil
 }
 
 func (j *cleanJob) deleteGallery(ctx context.Context, id int) {

--- a/internal/manager/task_clean_test.go
+++ b/internal/manager/task_clean_test.go
@@ -1,0 +1,108 @@
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stashapp/stash/pkg/models"
+	"github.com/stashapp/stash/pkg/models/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindGalleriesToCleanIncludesNoGalleryFolders(t *testing.T) {
+	cleanPath := t.TempDir()
+	outsideCleanPath := t.TempDir()
+
+	createGalleryFolder := func(root, name string, markers ...string) string {
+		t.Helper()
+
+		path := filepath.Join(root, name)
+		require.NoError(t, os.MkdirAll(path, 0755))
+		for _, marker := range markers {
+			require.NoError(t, os.WriteFile(filepath.Join(path, marker), nil, 0644))
+		}
+
+		return path
+	}
+
+	// Empty path-backed galleries retain the existing clean behaviour.
+	emptyGallery := &models.Gallery{ID: 1, Path: createGalleryFolder(cleanPath, "empty")}
+
+	// A gallery matching both clean rules must only be returned once.
+	emptyNoGalleryFolderID := models.FolderID(2)
+	emptyNoGallery := &models.Gallery{
+		ID:       2,
+		Path:     createGalleryFolder(cleanPath, "empty-nogallery", ".nogallery"),
+		FolderID: &emptyNoGalleryFolderID,
+	}
+
+	// A populated folder gallery is cleaned when its folder opts out.
+	noGalleryFolderID := models.FolderID(3)
+	noGallery := &models.Gallery{
+		ID:       3,
+		Path:     createGalleryFolder(cleanPath, "nogallery", ".nogallery"),
+		FolderID: &noGalleryFolderID,
+	}
+
+	// An ordinary folder gallery has no reason to be cleaned.
+	regularFolderID := models.FolderID(4)
+	regular := &models.Gallery{
+		ID:       4,
+		Path:     createGalleryFolder(cleanPath, "regular"),
+		FolderID: &regularFolderID,
+	}
+
+	// Selective clean must not touch galleries outside the requested paths.
+	outsideFolderID := models.FolderID(5)
+	outside := &models.Gallery{
+		ID:       5,
+		Path:     createGalleryFolder(outsideCleanPath, "nogallery", ".nogallery"),
+		FolderID: &outsideFolderID,
+	}
+
+	// Match Scan semantics: .forcegallery wins when both markers exist.
+	forcedFolderID := models.FolderID(7)
+	forced := &models.Gallery{
+		ID:       7,
+		Path:     createGalleryFolder(cleanPath, "forced", ".nogallery", ".forcegallery"),
+		FolderID: &forcedFolderID,
+	}
+
+	db := mocks.NewDatabase()
+	emptyGalleryFilter := mock.MatchedBy(func(filter *models.GalleryFilterType) bool {
+		return filter != nil && filter.ImageCount != nil &&
+			filter.ImageCount.Value == 0 &&
+			filter.ImageCount.Modifier == models.CriterionModifierEquals
+	})
+	// Only folder galleries need marker checks; filter out user and file galleries in SQL.
+	folderGalleryFilter := mock.MatchedBy(func(filter *models.GalleryFilterType) bool {
+		return filter != nil && filter.FoldersFilter != nil &&
+			filter.FoldersFilter.Path != nil &&
+			filter.FoldersFilter.Path.Modifier == models.CriterionModifierNotNull
+	})
+
+	db.Gallery.On("Query", mock.Anything, emptyGalleryFilter, mock.Anything).
+		Return([]*models.Gallery{emptyGallery, emptyNoGallery}, 2, nil).Once()
+	db.Gallery.On("Query", mock.Anything, emptyGalleryFilter, mock.Anything).
+		Return([]*models.Gallery{}, 0, nil).Once()
+	db.Gallery.On("Query", mock.Anything, folderGalleryFilter, mock.Anything).
+		Return([]*models.Gallery{emptyNoGallery, noGallery, regular, outside, forced}, 5, nil).Once()
+	db.Gallery.On("Query", mock.Anything, folderGalleryFilter, mock.Anything).
+		Return([]*models.Gallery{}, 0, nil).Once()
+
+	j := cleanJob{
+		repository: db.Repository(),
+		input: CleanMetadataInput{
+			Paths: []string{cleanPath},
+		},
+	}
+
+	got, err := j.findGalleriesToClean(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []int{emptyGallery.ID, emptyNoGallery.ID, noGallery.ID}, got)
+	db.Gallery.AssertExpectations(t)
+}


### PR DESCRIPTION
## Description

This fixes folder-based galleries remaining in the database after a `.nogallery` marker is added to their directory.

Previously, `Clean` only removed galleries whose underlying file or folder was missing and path-backed galleries with no images. It did not reevaluate the gallery creation markers used by `Scan`, so adding `.nogallery` after a folder gallery had already been created had no effect.

The change extends gallery cleanup to inspect existing folder-backed galleries and remove those whose directories contain `.nogallery`.

Key points:
- `Scan` relationship with images, galleries and `.nogallery .forcegallery` files was considered as intended behaviour role model and not questioned
  - `.nogallery` is applied only to galleries created from folders
  - only the gallery db record is affected. Images, files, and directories are untouched
  - `.forcegallery` has precedence when both markers exist
- no existing behavior is broken
  - dry-run is preserved
  - cleanup of empty path-backed galleries is preserved
  - selective Clean paths are respected

## Related Issue

Fixes #7179

## Testing

### Automated testing

The following checks pass in the project's official compiler container:

- `make generate`
- `make validate-ui`
- `make it` (`go test -tags "sqlite_stat4 sqlite_math_functions integration" ./...`)
- `golangci-lint run` with the CI version (`v2.11.4`)
- `make ui`
- `go test -race ./internal/manager`
- `git diff --check`
- `gofmt -l internal/manager/task_clean.go internal/manager/task_clean_test.go` produces no output

The production UI build emits the repository's existing Sass deprecation warnings but completes successfully.

### Manual testing

On a local build from 68f30978666bb815c10e68077f1de259f90c3225 commit:
1. Added new library directory with photos enabled (test)
2. Created two folders inside test1 and test2 and put image files in them
3. Made sure `Create galleries from folders containing images` option is on
4. Selective scanned the test directory
5. Made sure both new galleries have been created
6. Added .nogalleries file to the test2 dir
7. Selective cleaned the test directory
8. Made sure test1 gallery stayed and test2 gallery is gone
9. Made sure the images from test2 gallery are still accessible in `Images` (questionable, but consistent with `Scan`)

## Screenshots

N/A. This is a backend-only change with no visual changes.

## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

No documentation changes are required because the existing Configuration documentation already describes `.nogallery` as preventing a directory from becoming a gallery. This change makes Clean enforce that existing documented behavior.

## AI Usage Disclosure

- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.

Codex (gpt-5.6-sol at high/ultra effort) was used to investigate the existing Scan and Clean behavior, assist with the implementation and regression tests, review the resulting diff, run automated validation, and prepare working notes for the issue and pull request.

Before submitting this pull request, i personally reviewed the implementation and reiterated on it several times. Stuff like keeping FS calls out of db transaction and minimizing memory impact of storing folder galleries comes from these reiterations.

The text for this PR as well as the corresponding issue was originally written by AI, then reviewed and modified/rewritten by me where i deem necessary. 

## Additional Context

FS checks are intentionally performed after the database transaction has been released. Gallery directories may be located on slow or temporarily unavailable network filesystems, and holding a database transaction during `os.Stat` calls would unnecessarily increase transaction duration.

While collecting folder galleries inside the transaction, the implementation retains only each gallery's ID and path instead of the full gallery model - to keep the memory footprint low on high galleries DBs.

Errors encountered while checking marker files are logged and cause the affected gallery to be conservatively skipped rather than deleted.