### PR TITLE
Auto-save confirmed scene edit fields (opt-in)

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -28,6 +28,7 @@ import { addUpdateStashID, getStashIDs } from "src/utils/stashIds";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { useConfigurationContext } from "src/hooks/Config";
+import { IUIConfig } from "src/core/config";
 import { IGroupEntry, SceneGroupTable } from "./SceneGroupTable";
 import {
   faSearch,
@@ -212,8 +213,36 @@ export const SceneEditPanel: React.FC<IProps> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
-    useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+  const {
+    tags,
+    onSetTags,
+    updateTagsStateFromScraper,
+    resetTagsState,
+    tagsControl,
+  } = useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+
+  // auto-save applies only to fields whose value comes from an explicit
+  // selection, and never while creating a new scene
+  const autoSaveEnabled =
+    !isNew &&
+    ((stashConfig?.ui as IUIConfig)?.autoSaveConfirmedFields ?? false);
+
+  // set after a selection to submit once formik state has caught up
+  const [autoSaveRequested, setAutoSaveRequested] = useState(false);
+
+  function requestAutoSave() {
+    if (autoSaveEnabled) {
+      setAutoSaveRequested(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!autoSaveRequested) return;
+    setAutoSaveRequested(false);
+    if (formik.dirty) {
+      formik.submitForm();
+    }
+  }, [autoSaveRequested, formik.dirty, formik.submitForm]);
 
   const coverImagePreview = useMemo(() => {
     const sceneImage = scene.paths?.screenshot;
@@ -245,6 +274,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "gallery_ids",
       items.map((i) => i.id)
     );
+    requestAutoSave();
   }
 
   function onSetPerformers(items: Performer[]) {
@@ -253,11 +283,13 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "performer_ids",
       items.map((item) => item.id)
     );
+    requestAutoSave();
   }
 
   function onSetStudio(item: Studio | null) {
     setStudio(item);
     formik.setFieldValue("studio_id", item ? item.id : null);
+    requestAutoSave();
   }
 
   useEffect(() => {
@@ -614,6 +646,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "stash_ids",
       addUpdateStashID(formik.values.stash_ids, item)
     );
+    requestAutoSave();
   }
 
   const image = useMemo(() => {
@@ -737,6 +770,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     }));
 
     formik.setFieldValue("groups", newGroups);
+    requestAutoSave();
   }
 
   function renderGroupsField() {
@@ -750,7 +784,14 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   function renderTagsField() {
     const title = intl.formatMessage({ id: "tags" });
-    return renderField("tag_ids", title, tagsControl(), fullWidthProps);
+    const control = tagsControl({
+      onSelect: (items) => {
+        onSetTags(items);
+        requestAutoSave();
+      },
+    });
+
+    return renderField("tag_ids", title, control, fullWidthProps);
   }
 
   function renderDetailsField() {

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -711,6 +711,13 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
         </SettingSection>
 
         <SettingSection headingID="config.ui.editing.heading">
+          <BooleanSetting
+            id="auto-save-confirmed-fields"
+            headingID="config.ui.editing.auto_save_confirmed_fields.heading"
+            subHeadingID="config.ui.editing.auto_save_confirmed_fields.description"
+            checked={ui.autoSaveConfirmedFields ?? false}
+            onChange={(v) => saveUI({ autoSaveConfirmedFields: v })}
+          />
           <div className="setting-group">
             <div className="setting">
               <div>

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -55,6 +55,10 @@ export interface IUIConfig {
 
   abbreviateCounters?: boolean;
 
+  // if true, selecting a value in a confirmed selector (tags, performers,
+  // studio, galleries, groups, stash IDs) saves the edit form immediately
+  autoSaveConfirmedFields?: boolean;
+
   ratingSystemOptions?: RatingSystemOptions;
 
   // if true a background image will be display on header

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -732,6 +732,10 @@
         }
       },
       "editing": {
+        "auto_save_confirmed_fields": {
+          "description": "Immediately save the edit form when a tag, performer, studio, gallery, group, or stash-box ID is selected, without needing to press Save.",
+          "heading": "Auto-save on selection"
+        },
         "disable_dropdown_create": {
           "description": "Remove the ability to create new objects from the dropdown selectors.",
           "heading": "Disable dropdown create"


### PR DESCRIPTION
## Summary
- Adds an opt-in "Auto-save on selection" setting (Settings → Interface → Editing, off by default) that submits the scene edit form immediately after a tag, performer, studio, gallery, group, or stash-box ID is confirmed — skipping the extra manual Save click described in the issue.
- Only fires for fields whose value comes from an explicit user selection. Free-text fields, values applied from a scrape result, and new-scene creation are unaffected.
- No backend/GraphQL changes — the toggle is a client-side `IUIConfig` field.

Closes #4353

## AI disclosure
Implemented with AI assistance (Claude Code), per the repo's AI usage policy.

## Test plan
- [x] `make validate-ui` passes (biome + tsc clean for changed files)
- [x] With the setting off (default): selecting a tag/performer/studio/gallery/group/stash-box ID behaves exactly as before (Save button required)
- [x] With the setting on: selecting a tag/performer/studio/gallery/group, or linking a stash-box ID, saves immediately without pressing Save
- [x] With the setting on: running a scraper and applying results does not auto-save
- [x] With the setting on, on a new (unsaved) scene: selections do not auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)