### PR TITLE
Scene edit: fix scroll reset on save, clarify already-selected dropdown items

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -10,6 +10,7 @@ import {
   SplitButton,
 } from "react-bootstrap";
 import Mousetrap from "mousetrap";
+import cx from "classnames";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
 import {
@@ -147,6 +148,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
+  // tracks only the save mutation, so a save doesn't unmount/reset-scroll the
+  // whole form the way a scrape (isLoading) does
+  const [isSaving, setIsSaving] = useState(false);
 
   const schema = yup.object({
     title: yup.string().ensure(),
@@ -231,7 +235,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
   const [autoSaveRequested, setAutoSaveRequested] = useState(false);
 
   function requestAutoSave() {
-    if (autoSaveEnabled) {
+    if (autoSaveEnabled && !isSaving) {
       setAutoSaveRequested(true);
     }
   }
@@ -333,7 +337,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
   }
 
   async function onSave(input: InputValues, andNew?: boolean) {
-    setIsLoading(true);
+    setIsSaving(true);
     try {
       await onSubmit(input, andNew);
       formik.resetForm();
@@ -354,7 +358,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     } catch (e) {
       Toast.error(e);
     }
-    setIsLoading(false);
+    setIsSaving(false);
   }
 
   async function onSaveAndNewClick() {
@@ -842,7 +846,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
                 className="edit-button"
                 variant="primary"
                 disabled={
-                  !isEqual(formik.errors, {}) || customFieldsError !== undefined
+                  isSaving ||
+                  !isEqual(formik.errors, {}) ||
+                  customFieldsError !== undefined
                 }
                 title={intl.formatMessage({ id: "actions.save" })}
                 onClick={() => formik.submitForm()}
@@ -857,18 +863,21 @@ export const SceneEditPanel: React.FC<IProps> = ({
                 variant="primary"
                 disabled={
                   (!isNew && !formik.dirty) ||
+                  isSaving ||
                   !isEqual(formik.errors, {}) ||
                   customFieldsError !== undefined
                 }
                 onClick={() => formik.submitForm()}
               >
                 <FormattedMessage id="actions.save" />
+                {isSaving && <LoadingIndicator inline small message="" />}
               </Button>
             )}
             {onDelete && (
               <Button
                 className="edit-button"
                 variant="danger"
+                disabled={isSaving}
                 onClick={() => onDelete()}
               >
                 <FormattedMessage id="actions.delete" />
@@ -897,7 +906,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
             </div>
           )}
         </Row>
-        <Row className="form-container px-3">
+        <Row className={cx("form-container px-3", { saving: isSaving })}>
           <Col lg={7} xl={12}>
             {renderInputField("title")}
             {renderInputField("code", "text", "scene_code")}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -28,6 +28,7 @@ import { addUpdateStashID, getStashIDs } from "src/utils/stashIds";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { useConfigurationContext } from "src/hooks/Config";
+import { IUIConfig } from "src/core/config";
 import { IGroupEntry, SceneGroupTable } from "./SceneGroupTable";
 import {
   faSearch,
@@ -212,8 +213,36 @@ export const SceneEditPanel: React.FC<IProps> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
-    useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+  const {
+    tags,
+    onSetTags,
+    updateTagsStateFromScraper,
+    resetTagsState,
+    tagsControl,
+  } = useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+
+  // auto-save applies only to fields whose value comes from an explicit
+  // selection, and never while creating a new scene
+  const autoSaveEnabled =
+    !isNew &&
+    ((stashConfig?.ui as IUIConfig)?.autoSaveConfirmedFields ?? false);
+
+  // set after a selection to submit once formik state has caught up
+  const [autoSaveRequested, setAutoSaveRequested] = useState(false);
+
+  function requestAutoSave() {
+    if (autoSaveEnabled) {
+      setAutoSaveRequested(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!autoSaveRequested) return;
+    setAutoSaveRequested(false);
+    if (formik.dirty) {
+      formik.submitForm();
+    }
+  }, [autoSaveRequested, formik.dirty, formik.submitForm]);
 
   const coverImagePreview = useMemo(() => {
     const sceneImage = scene.paths?.screenshot;
@@ -245,6 +274,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "gallery_ids",
       items.map((i) => i.id)
     );
+    requestAutoSave();
   }
 
   function onSetPerformers(items: Performer[]) {
@@ -253,11 +283,13 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "performer_ids",
       items.map((item) => item.id)
     );
+    requestAutoSave();
   }
 
   function onSetStudio(item: Studio | null) {
     setStudio(item);
     formik.setFieldValue("studio_id", item ? item.id : null);
+    requestAutoSave();
   }
 
   useEffect(() => {
@@ -614,6 +646,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "stash_ids",
       addUpdateStashID(formik.values.stash_ids, item)
     );
+    requestAutoSave();
   }
 
   const image = useMemo(() => {
@@ -737,6 +770,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     }));
 
     formik.setFieldValue("groups", newGroups);
+    requestAutoSave();
   }
 
   function renderGroupsField() {
@@ -750,7 +784,14 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   function renderTagsField() {
     const title = intl.formatMessage({ id: "tags" });
-    return renderField("tag_ids", title, tagsControl(), fullWidthProps);
+    const control = tagsControl({
+      onSelect: (items) => {
+        onSetTags(items);
+        requestAutoSave();
+      },
+    });
+
+    return renderField("tag_ids", title, control, fullWidthProps);
   }
 
   function renderDetailsField() {

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -565,6 +565,13 @@ input[type="range"].blue-slider {
     font-size: 0.85em;
   }
 
+  // keep the form mounted while a save is in flight, rather than swapping it
+  // out for a spinner, so scroll position isn't lost
+  .form-container.saving {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
   @include media-breakpoint-up(xl) {
     .custom-fields-input {
       .custom-fields-field {

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -711,6 +711,13 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
         </SettingSection>
 
         <SettingSection headingID="config.ui.editing.heading">
+          <BooleanSetting
+            id="auto-save-confirmed-fields"
+            headingID="config.ui.editing.auto_save_confirmed_fields.heading"
+            subHeadingID="config.ui.editing.auto_save_confirmed_fields.description"
+            checked={ui.autoSaveConfirmedFields ?? false}
+            onChange={(v) => saveUI({ autoSaveConfirmedFields: v })}
+          />
           <div className="setting-group">
             <div className="setting">
               <div>

--- a/ui/v2.5/src/components/Shared/FilterSelect.tsx
+++ b/ui/v2.5/src/components/Shared/FilterSelect.tsx
@@ -28,6 +28,7 @@ interface ISelectProps<T, IsMulti extends boolean>
   showDropdown?: boolean;
   groupHeader?: string;
   noOptionsMessageText?: string | null;
+  isAlreadySelected?: (inputValue: string) => boolean;
 }
 
 interface IFilterSelectProps<T, IsMulti extends boolean>
@@ -64,6 +65,7 @@ const SelectComponent = <T, IsMulti extends boolean>(
     placeholder,
     showDropdown = true,
     noOptionsMessageText: noOptionsMessage = "None",
+    isAlreadySelected,
   } = props;
 
   const styles: StylesConfig<Option<T>, IsMulti> = {
@@ -89,7 +91,10 @@ const SelectComponent = <T, IsMulti extends boolean>(
     value: selectedOptions ?? null,
     className: cx("react-select", props.className),
     classNamePrefix: "react-select",
-    noOptionsMessage: () => noOptionsMessage,
+    noOptionsMessage: ({ inputValue }: { inputValue: string }) =>
+      inputValue && isAlreadySelected?.(inputValue)
+        ? "Already selected"
+        : noOptionsMessage,
     placeholder: isDisabled ? "" : placeholder,
     components: {
       ...components,
@@ -233,6 +238,15 @@ export const FilterSelectComponent = <
         }
       : undefined;
 
+  // an exact match against the *selected* values (rather than the loaded
+  // search results) means the "no options" state is because the item is
+  // already added, not because it doesn't exist
+  const isAlreadySelected =
+    creatable && isValidNewOption
+      ? (inputValue: string) =>
+          !!values?.length && !isValidNewOption(inputValue, values)
+      : undefined;
+
   const debounceDelay = 100;
   const debounceLoadOptions = useDebounce((inputValue, callback) => {
     loadOptions(inputValue).then(callback);
@@ -248,6 +262,7 @@ export const FilterSelectComponent = <
       onCreateOption={onCreate}
       getNewOptionData={getNewOptionData}
       isValidNewOption={validNewOption}
+      isAlreadySelected={isAlreadySelected}
     />
   );
 };

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -55,6 +55,10 @@ export interface IUIConfig {
 
   abbreviateCounters?: boolean;
 
+  // if true, selecting a value in a confirmed selector (tags, performers,
+  // studio, galleries, groups, stash IDs) saves the edit form immediately
+  autoSaveConfirmedFields?: boolean;
+
   ratingSystemOptions?: RatingSystemOptions;
 
   // if true a background image will be display on header

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -732,6 +732,10 @@
         }
       },
       "editing": {
+        "auto_save_confirmed_fields": {
+          "description": "Immediately save the edit form when a tag, performer, studio, gallery, group, or stash-box ID is selected, without needing to press Save.",
+          "heading": "Auto-save on selection"
+        },
         "disable_dropdown_create": {
           "description": "Remove the ability to create new objects from the dropdown selectors.",
           "heading": "Disable dropdown create"


### PR DESCRIPTION
## Summary
- Stop the scene edit form from fully unmounting (and losing scroll position) on every save. It now stays mounted, dims, and disables itself while the save is in flight (small inline spinner on the Save button), instead of swapping to a bare full-panel spinner. Scraping still uses the existing full-panel spinner unchanged.
- When typing a performer/tag/studio name that exactly matches something already selected, the typeahead dropdown now shows "Already selected" instead of the generic "None" (which gave no indication of why no "Create new..." option appeared). Fixed once in the shared `FilterSelect` component, so it applies to Performers, Tags, Studios, and Groups.

**Depends on #7182** — this branch is stacked on top of it (same author), so the diff/commit list here only makes sense once that one is reviewed/merged first. Happy to rebase onto `develop` once #7182 lands.

## AI disclosure
Implemented with AI assistance (Claude Code), per the repo's AI usage policy.

## Test plan
- [ ] `make validate-ui` passes (biome + tsc clean for changed files)
- [ ] Scroll to the Performers field on an existing scene, add/remove a tag: form dims briefly with a spinner on Save, scroll position is preserved, no flash to a blank page
- [ ] Scraping a scene (via "Scrape with...") still shows the existing full-panel loading indicator unchanged
- [ ] Type the exact name of an already-selected performer/tag/studio: dropdown shows "Already selected"
- [ ] Type a genuinely new name: normal "Create <name>" (or "None" if dropdown-create is disabled) behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)