### PR TITLE
Fix: Set Html Lang Attribute From Language Preference

### DIFF
--- a/ui/v2.5/src/App.tsx
+++ b/ui/v2.5/src/App.tsx
@@ -312,6 +312,7 @@ export const App: React.FC = () => {
 
   const title = config.data?.configuration.ui.title || "Stash";
   const titleProps = makeTitleProps(title);
+  const htmlAttributes = { lang: language };
 
   if (!messages) {
     return null;
@@ -324,6 +325,7 @@ export const App: React.FC = () => {
         messages={messages}
         formats={intlFormats}
       >
+        <Helmet htmlAttributes={htmlAttributes} />
         <MainContainer>{content}</MainContainer>
       </IntlProvider>
     );
@@ -370,7 +372,10 @@ export const App: React.FC = () => {
                   <LightboxProvider>
                     <ManualProvider>
                       <InteractiveProvider>
-                        <Helmet {...titleProps} />
+                        <Helmet
+                          {...titleProps}
+                          htmlAttributes={htmlAttributes}
+                        />
                         {maybeRenderNavbar()}
                         <MainContainer>{renderContent()}</MainContainer>
                       </InteractiveProvider>


### PR DESCRIPTION
## Description
- Set the root document language from the configured interface language by passing `htmlAttributes={{ lang: language }}` through React Helmet.
- Applied the same HTML `lang` attribute during loading/error rendering so the document language remains consistent outside the main app view.
- Updated the main app Helmet instance to include the computed HTML attributes alongside the existing title props.



## Related Issue
Fixes #7092



## Testing
Tested [here](https://github.com/stashapp/stash/issues/7092#issuecomment-4936414958) and works.




## Checklist
- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
Fix found with Codex.