### PR TITLE
Avoid setting WAL mode on read connections

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -236,12 +236,26 @@ func (db *Database) Close() error {
 
 func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, error) {
 	// https://github.com/mattn/go-sqlite3
-	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL&_busy_timeout=50"
+	url := db.connectionURL(disableForeignKeys, writable)
+
+	conn, err := sqlx.Open(sqlite3Driver, url)
+	if err != nil {
+		return nil, fmt.Errorf("db.Open(): %w", err)
+	}
+
+	return conn, nil
+}
+
+func (db *Database) connectionURL(disableForeignKeys bool, writable bool) string {
+	url := "file:" + db.dbPath + "?_sync=NORMAL&_busy_timeout=50"
 	if !disableForeignKeys {
 		url += "&_fk=true"
 	}
 
 	if writable {
+		// journal_mode is a database-wide setting. Do not set it while opening
+		// read-only connections: doing so can contend with an active writer.
+		url += "&_journal=WAL"
 		url += "&_txlock=immediate"
 	} else {
 		url += "&mode=ro"
@@ -253,12 +267,7 @@ func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, erro
 		url += "&_cache_size=" + cacheSize
 	}
 
-	conn, err := sqlx.Open(sqlite3Driver, url)
-	if err != nil {
-		return nil, fmt.Errorf("db.Open(): %w", err)
-	}
-
-	return conn, nil
+	return url
 }
 
 func (db *Database) initialise() error {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
I have found that I often get an error message on the scenes page saying that there is a database lock. Codex has discovered that even read-only connections set WAL mode, which is a database-wide setting that is not read-only and can trigger this situation.

Hence, this PR only sets WAL mode on read-write connections.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->



## Testing
`go test ./pkg/sqlite`



## Screenshots
n/a


## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [n/a] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [X] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I have used ChatGPT (formerly known as Codex) to figure out what might be causing frequent database locks, and it has identified this specific code and it wrote the CL for me.

The AI policy says that comments must not be written by AI although the comment in this CL seems pretty clear as it is and I don't see the value in rewriting it. But let me know if this is an issue.

## Additional Context
<!-- Add any other context about the pull request here. -->

