### PR TITLE
Increase busy timeout to 5s

### DIFF
--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -236,6 +236,7 @@ func (db *Database) Close() error {
 
 func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, error) {
 	// https://github.com/mattn/go-sqlite3
+	// 5s timeout is the default.
 	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL&_busy_timeout=5000"
 	if !disableForeignKeys {
 		url += "&_fk=true"

--- a/pkg/sqlite/database.go
+++ b/pkg/sqlite/database.go
@@ -236,7 +236,7 @@ func (db *Database) Close() error {
 
 func (db *Database) open(disableForeignKeys bool, writable bool) (*sqlx.DB, error) {
 	// https://github.com/mattn/go-sqlite3
-	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL&_busy_timeout=50"
+	url := "file:" + db.dbPath + "?_journal=WAL&_sync=NORMAL&_busy_timeout=5000"
 	if !disableForeignKeys {
 		url += "&_fk=true"
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

PR #3593 set the timeout to 50ms, implying that the default was 0 (i.e. that in case of a lock a query would fail immediately).

As best as I can tell, the default timeout has been five seconds for a very long time, see e.g.:
https://github.com/mattn/go-sqlite3/commit/d754d2db456cb912005948bfa82b7c06f3733274

So this commit just restores the timeout to the default 5s, which should reduce the number of "database locked" errors when there is a slow(ish) write operation running.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #7188 

## Testing
<!-- Describe the testing steps you have performed. -->



## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

n/a

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [n/a] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Codex/ChatGPT to find this code and understand context but the PR was written manually.

## Additional Context
<!-- Add any other context about the pull request here. -->

