### PR TITLE
New: Show Remote Duration in Tagger

### DIFF
--- a/ui/v2.5/graphql/data/scrapers.graphql
+++ b/ui/v2.5/graphql/data/scrapers.graphql
@@ -175,6 +175,7 @@ fragment ScrapedSceneData on ScrapedScene {
   code
   details
   director
+  duration
   urls
   date
   production_date

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -19,6 +19,7 @@ import { Icon } from "src/components/Shared/Icon";
 import { SuccessIcon } from "src/components/Shared/SuccessIcon";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { TagSelect } from "src/components/Shared/Select";
+import TextUtils from "src/utils/text";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { OperationButton } from "src/components/Shared/OperationButton";
 import * as FormUtils from "src/utils/form";
@@ -553,11 +554,22 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             }
             setExclude={(v) => setExcludedField(fields.cover_image, v)}
           >
-            <img
-              src={scene.image}
-              alt=""
-              className="align-self-center scene-image"
-            />
+            <div className="scene-image-overlay-container">
+              <img
+                src={scene.image}
+                alt=""
+                className="align-self-center scene-image"
+              />
+              {scene.duration ? (
+                <div className="scene-specs-overlay">
+                  <span className="overlay-duration">
+                    {TextUtils.secondsToTimestamp(scene.duration)}
+                  </span>
+                </div>
+              ) : (
+                ""
+              )}
+            </div>
           </OptionalField>
         </div>
       );

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -560,14 +560,12 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
                 alt=""
                 className="align-self-center scene-image"
               />
-              {scene.duration ? (
+              {scene.duration && (
                 <div className="scene-specs-overlay">
                   <span className="overlay-duration">
                     {TextUtils.secondsToTimestamp(scene.duration)}
                   </span>
                 </div>
-              ) : (
-                ""
               )}
             </div>
           </OptionalField>

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -211,6 +211,16 @@
   object-fit: contain;
 }
 
+.scene-image-overlay-container {
+  display: inline-flex;
+  position: relative;
+
+  .scene-specs-overlay {
+    bottom: 0.3rem;
+    right: 0.4rem;
+  }
+}
+
 .scene-metadata {
   margin-left: 1rem;
 }
@@ -485,8 +495,8 @@ li:not(.active) {
     display: none;
   }
 
-  .scene-image {
-    padding-left: 1rem;
+  .scene-image-overlay-container {
+    margin-left: 1rem;
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
In scene tagger, if the stash box provided a duration, shows it on top of the scene image similar to how the local scene duration is displayed.

This is especially useful if the remote has a duration but no fingerprints (this can frequently happen with TPDB). Even when there are fingerprints, it can be useful to easily see exactly how the local duration differs from the remote duration.


## Related Issue

Fixes #7201 (this was also a secondary request in #4482)


## Testing
Manually scraped scenes with and without duration



## Screenshots
Before:
<img width="597" height="432" alt="image" src="https://github.com/user-attachments/assets/423e2ca2-f756-4e83-9c59-d4434d9effc3" />


After: 
<img width="592" height="440" alt="Screenshot 2026-08-31 142252" src="https://github.com/user-attachments/assets/e1805cec-55b0-49f0-8bdd-3381303359dc" />



## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [n/a] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used Codex/ChatGPT to write some of this code, especially the CSS. I did read and understand every line of the PR, though.


## Additional Context
<!-- Add any other context about the pull request here. -->

