### PR TITLE
Improve tagger preview image formatting

### DIFF
--- a/ui/v2.5/graphql/data/scrapers.graphql
+++ b/ui/v2.5/graphql/data/scrapers.graphql
@@ -175,6 +175,7 @@ fragment ScrapedSceneData on ScrapedScene {
   code
   details
   director
+  duration
   urls
   date
   production_date

--- a/ui/v2.5/src/components/Scenes/SceneCard.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneCard.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Button, ButtonGroup, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
@@ -55,6 +61,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(
     volume,
   }) => {
     const videoEl = useRef<HTMLVideoElement>(null);
+    const [isPlaying, setIsPlaying] = useState(false);
 
     useEffect(() => {
       const observer = new IntersectionObserver((entries) => {
@@ -79,7 +86,7 @@ export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(
     return (
       <div className={cx("scene-card-preview", { portrait: isPortrait })}>
         <img
-          className="scene-card-preview-image"
+          className={cx("scene-card-preview-image", { "d-none": isPlaying })}
           loading="lazy"
           src={image}
           alt=""
@@ -93,6 +100,11 @@ export const ScenePreview: React.FC<IScenePreviewProps> = React.memo(
           preload="none"
           ref={videoEl}
           src={video}
+          onLoadStart={() => setIsPlaying(false)}
+          onPlaying={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onEnded={() => setIsPlaying(false)}
+          onError={() => setIsPlaying(false)}
         />
         <PreviewScrubber
           vttPath={vttPath}

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -19,6 +19,7 @@ import { Icon } from "src/components/Shared/Icon";
 import { SuccessIcon } from "src/components/Shared/SuccessIcon";
 import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { TagSelect } from "src/components/Shared/Select";
+import TextUtils from "src/utils/text";
 import { TruncatedText } from "src/components/Shared/TruncatedText";
 import { OperationButton } from "src/components/Shared/OperationButton";
 import * as FormUtils from "src/utils/form";
@@ -553,11 +554,22 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
             }
             setExclude={(v) => setExcludedField(fields.cover_image, v)}
           >
-            <img
-              src={scene.image}
-              alt=""
-              className="align-self-center scene-image"
-            />
+            <div className="scene-image-overlay-container">
+              <img
+                src={scene.image}
+                alt=""
+                className="align-self-center scene-image"
+              />
+              {scene.duration ? (
+                <div className="scene-specs-overlay">
+                  <span className="overlay-duration">
+                    {TextUtils.secondsToTimestamp(scene.duration)}
+                  </span>
+                </div>
+              ) : (
+                ""
+              )}
+            </div>
           </OptionalField>
         </div>
       );

--- a/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
+++ b/ui/v2.5/src/components/Tagger/scenes/StashSearchResult.tsx
@@ -560,14 +560,12 @@ const StashSearchResult: React.FC<IStashSearchResultProps> = ({
                 alt=""
                 className="align-self-center scene-image"
               />
-              {scene.duration ? (
+              {scene.duration && (
                 <div className="scene-specs-overlay">
                   <span className="overlay-duration">
                     {TextUtils.secondsToTimestamp(scene.duration)}
                   </span>
                 </div>
-              ) : (
-                ""
               )}
             </div>
           </OptionalField>

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -18,10 +18,16 @@
   .scene-card-preview {
     border-radius: 3px;
     color: $text-color;
-    height: 100px;
+    height: 10rem;
     margin-bottom: 0;
     overflow: hidden;
-    width: auto;
+    width: 14rem;
+
+    &-image,
+    &-video {
+      object-fit: contain;
+      object-position: center;
+    }
   }
 
   .sprite-button {
@@ -205,15 +211,18 @@
 }
 
 .scene-image {
-  max-height: 10rem;
-  max-width: 14rem;
-  min-width: 168px;
+  max-height: 100%;
+  max-width: 100%;
   object-fit: contain;
 }
 
 .scene-image-overlay-container {
-  display: inline-flex;
+  align-items: center;
+  display: flex;
+  height: 10rem;
+  justify-content: center;
   position: relative;
+  width: 14rem;
 
   .scene-specs-overlay {
     bottom: 0.3rem;

--- a/ui/v2.5/src/components/Tagger/styles.scss
+++ b/ui/v2.5/src/components/Tagger/styles.scss
@@ -211,6 +211,16 @@
   object-fit: contain;
 }
 
+.scene-image-overlay-container {
+  display: inline-flex;
+  position: relative;
+
+  .scene-specs-overlay {
+    bottom: 0.3rem;
+    right: 0.4rem;
+  }
+}
+
 .scene-metadata {
   margin-left: 1rem;
 }
@@ -485,8 +495,8 @@ li:not(.active) {
     display: none;
   }
 
-  .scene-image {
-    padding-left: 1rem;
+  .scene-image-overlay-container {
+    margin-left: 1rem;
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
The primary change here is to render portrait cover images as portrait in tagger. Because Stash already renders the scraped image in portrait, this change makes it easier/possible to tell whether the image is the same or not.

Also makes minor formatting changes to improve how this looks particularly with the duration overlay:
- Standardizes preview image/video container dimensions (`14rem` x `10rem`) with a subtle dark background.
- Formats and aligns the overlay duration badge cleanly on top of both preview cards and scraped scene images.

Includes the changes from #7193; I will rebase once that PR lands.

## Related Issue
Fixes #7202

## Testing
Manually checked how vertical and horizontal cover images look in tagger.

## Screenshots

After:
<img width="320" height="438" alt="Screenshot 2026-09-02 174933" src="https://github.com/user-attachments/assets/595dd21c-625d-4216-b5b0-9c8bffa41d51" />

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

I used AI tools (Codex aka ChatGPT and Antigravity) to draft and refine the CSS formatting changes.

## Additional Context
<!-- Add any other context about the pull request here. -->
