### PR TITLE
Add plugin media-src CSP support

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -611,6 +611,7 @@ func setPageSecurityHeaders(w http.ResponseWriter, r *http.Request, plugins []*p
 		connectSrcSlice = append(connectSrcSlice, ui.CSP.ConnectSrc...)
 		scriptSrcSlice = append(scriptSrcSlice, ui.CSP.ScriptSrc...)
 		styleSrcSlice = append(styleSrcSlice, ui.CSP.StyleSrc...)
+		mediaSrc += " " + strings.Join(ui.CSP.MediaSrc, " ")
 	}
 
 	connectSrc := strings.Join(connectSrcSlice, " ")

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -72,6 +72,7 @@ type PluginCSP struct {
 	ScriptSrc  []string `json:"script-src" yaml:"script-src"`
 	StyleSrc   []string `json:"style-src" yaml:"style-src"`
 	ConnectSrc []string `json:"connect-src" yaml:"connect-src"`
+	MediaSrc   []string `json:"media-src" yaml:"media-src"`
 }
 
 type UIConfig struct {

--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -159,7 +159,7 @@ Mappings that try to go outside of the directory containing the plugin configura
 ignored.
 
 The `csp` field contains overrides to the content security policies. The URLs in `script-src`,
-`style-src` and `connect-src` will be added to the applicable content security policy.
+`style-src`, `connect-src` and `media-src` will be added to the applicable content security policy.
 
 See [External Plugins](/help/ExternalPlugins.md) for details for making plugins with external tasks.
 

--- a/ui/v2.5/src/docs/en/Manual/Plugins.md
+++ b/ui/v2.5/src/docs/en/Manual/Plugins.md
@@ -103,6 +103,9 @@ ui:
     connect-src:
       - http://alloweddomain.com
 
+    media-src:
+      - http://alloweddomain.com
+
 # map of setting names to be displayed in the plugins page in the UI
 settings:
   # internal name


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR adds `media-src` support to the CSP for Plugins (requires changing stash's as well, since the plugins run within stash). 

I am developing a custom plugin for stash that serves as a media browser and downloader with it's own native bridge. Since my UI is rendered inside a stash plugin, I cannot currently stream videos unless I buffer them through `blob:` in my native bridge (horrible for performance).

This change allows non-same-origin videos to be embedded within plugin UI, meaning I won't need to maintain my own fork of the client. My security understanding on this is that it does not meaningfully move the trust boundary in a way that the other existing CSP properties do not.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->
Closes #7197


## Testing
<!-- Describe the testing steps you have performed. -->
Ran the go tests, built a local copy and have successfully used the changes with my own plugin.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->
N/A

## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [X] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [X] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
I used Codex 5.6 Sol to understand the scope of the plugin surface that needed changing for this use case, and generate the patch, which I have reviewed manually.

## Additional Context
<!-- Add any other context about the pull request here. -->
I understand from the contribution agreement that stash core is not intended to facilitate downloading. This is a feature in the plugin API that would make my life easier for my downloader client. If this goes against the goals of the maintainers, feel free to close this without reviewing.
