### PR TITLE
Install all package requirements when updating a package

### DIFF
--- a/pkg/pkg/manager.go
+++ b/pkg/pkg/manager.go
@@ -151,6 +151,19 @@ func (m *Manager) getStore(remoteURL string) *Store {
 }
 
 func (m *Manager) Install(ctx context.Context, spec models.PackageSpecInput) error {
+	return m.install(ctx, spec, make(map[string]struct{}))
+}
+
+// installs the package identified by spec, then recursively installs
+// or updates any of its requirements that are missing or outdated. installing
+// tracks package IDs currently being installed in this call tree to guard
+// against dependency cycles
+func (m *Manager) install(ctx context.Context, spec models.PackageSpecInput, installing map[string]struct{}) error {
+	if _, inProgress := installing[spec.ID]; inProgress {
+		return nil
+	}
+	installing[spec.ID] = struct{}{}
+
 	remote, err := m.remoteFromURL(spec.SourceURL)
 	if err != nil {
 		return fmt.Errorf("creating remote repository: %w", err)
@@ -196,6 +209,44 @@ func (m *Manager) Install(ctx context.Context, spec models.PackageSpecInput) err
 		return fmt.Errorf("installing package: %w", err)
 	}
 
+	if err := m.installRequirements(ctx, *pkg, spec.SourceURL, store, installing); err != nil {
+		return fmt.Errorf("installing required packages: %w", err)
+	}
+
+	return nil
+}
+
+// installRequirements installs any packages listed in pkg.Requires that are
+// not already present in store, and updates any that are already installed
+// but older than the version available from the source
+//
+// requirements are resolved against the same source as pkg itself.
+func (m *Manager) installRequirements(ctx context.Context, pkg RemotePackage, sourceURL string, store *Store, installing map[string]struct{}) error {
+	for _, reqID := range pkg.Requires {
+		reqSpec := models.PackageSpecInput{ID: reqID, SourceURL: sourceURL}
+
+		local, err := store.getManifest(ctx, reqID)
+		if err == nil {
+			// already installed - only reinstall if the source has a newer version
+			remotePkg, err := m.packageByID(ctx, reqSpec)
+			if err != nil {
+				return fmt.Errorf("getting remote package %s, required by %s: %w", reqID, pkg.ID, err)
+			}
+
+			if remotePkg == nil || !local.Upgradable(remotePkg.PackageVersion) {
+				continue
+			}
+
+			logger.Infof("Updating package %s, required by %s", reqID, pkg.ID)
+		} else {
+			logger.Infof("Installing package %s, required by %s", reqID, pkg.ID)
+		}
+
+		if err := m.install(ctx, reqSpec, installing); err != nil {
+			return fmt.Errorf("installing package %s, required by %s: %w", reqID, pkg.ID, err)
+		}
+	}
+
 	return nil
 }
 
@@ -206,6 +257,7 @@ func (m *Manager) installPackage(pkg RemotePackage, store *Store, zr *zip.Reader
 		Metadata:       pkg.Metadata,
 		PackageVersion: pkg.PackageVersion,
 		RepositoryURL:  pkg.Repository.Path(),
+		Requires:       pkg.Requires,
 	}
 
 	for _, f := range zr.File {


### PR DESCRIPTION
## Description
Resolves and installs package requirements in the backend itself. This is necessary to ensure updating packages get their full set of required packages if they were added in an update. This also makes it safe to naively install packages through the GraphQL API for tools that integrate with Stash such as [stash-scrape-ci-standalone](<https://github.com/feederbox826/stash-scrape-ci-standalone>)

## Related Issue
This resolves #7198 

## Testing
The easiest way to test this is to install a package that has multiple dependencies, for example the Evil Angel scraper mentioned in the original issue and this will pull in both the Altwolia and py_common packages. Immediately uninstall those two packages, then go edit the manifest for Evil Angel to modify its version to make Stash think it's outdated.

At this point we're essentially at the state of users who have updated Evil Angel on v0.31.1, the scraper does not work because the dependencies are missing.

But now you can update the package either through the API or the UI and it should be updated as expected, but it should also reinstall those missing packages you uninstalled earlier. At this point the scraper works, and users will no stop reporting this bug! :)

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).