### PR TITLE
Add warning for scraper URL conflicts

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -149,6 +149,9 @@ type Query {
   "List available scrapers"
   listScrapers(types: [ScrapeContentType!]!): [Scraper!]!
 
+  "List installed scrapers with overlapping URL patterns"
+  scraperURLConflicts: [ScraperURLConflict!]!
+
   "Scrape for a single scene"
   scrapeSingleScene(
     source: ScraperSourceInput!

--- a/graphql/schema/types/scraper.graphql
+++ b/graphql/schema/types/scraper.graphql
@@ -51,6 +51,32 @@ type Scraper {
   group: ScraperSpec
 }
 
+"An installed package that may provide a scraper involved in a ScraperURLConflict"
+type ScraperURLConflictPackage {
+  package: Package!
+  "IDs of other scrapers installed as part of the same package, which would also be affected by uninstalling it"
+  sibling_scraper_ids: [String!]!
+}
+
+"""
+Describes two installed scrapers whose URL patterns for the same content type
+overlap, such that Stash cannot deterministically choose between them when
+scraping by URL.
+"""
+type ScraperURLConflict {
+  type: ScrapeContentType!
+  scraper_id: ID!
+  pattern: String!
+  """
+  The installed package believed to provide this scraper, if one could be
+  found with a matching id. Null if no such package was found.
+  """
+  scraper_package: ScraperURLConflictPackage
+  other_scraper_id: ID!
+  other_pattern: String!
+  other_scraper_package: ScraperURLConflictPackage
+}
+
 type ScrapedStudio {
   "Set if studio matched"
   stored_id: ID

--- a/internal/api/resolver.go
+++ b/internal/api/resolver.go
@@ -111,6 +111,9 @@ func (r *Resolver) Plugin() PluginResolver {
 func (r *Resolver) ConfigResult() ConfigResultResolver {
 	return &configResultResolver{r}
 }
+func (r *Resolver) ScraperURLConflict() ScraperURLConflictResolver {
+	return &scraperURLConflictResolver{r}
+}
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
@@ -137,6 +140,7 @@ type folderResolver struct{ *Resolver }
 type savedFilterResolver struct{ *Resolver }
 type pluginResolver struct{ *Resolver }
 type configResultResolver struct{ *Resolver }
+type scraperURLConflictResolver struct{ *Resolver }
 
 func (r *Resolver) withTxn(ctx context.Context, fn func(ctx context.Context) error) error {
 	return r.repository.WithTxn(ctx, fn)

--- a/internal/api/resolver_model_scraper_url_conflict.go
+++ b/internal/api/resolver_model_scraper_url_conflict.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/stashapp/stash/pkg/scraper"
+)
+
+func (r *scraperURLConflictResolver) ScraperPackage(ctx context.Context, obj *scraper.ScraperURLConflict) (*ScraperURLConflictPackage, error) {
+	return findInstalledScraperPackage(ctx, obj.ScraperID)
+}
+
+func (r *scraperURLConflictResolver) OtherScraperPackage(ctx context.Context, obj *scraper.ScraperURLConflict) (*ScraperURLConflictPackage, error) {
+	return findInstalledScraperPackage(ctx, obj.OtherScraperID)
+}
+
+// ASSUMPTION: the scraper name is the same as the package name
+// if this assumption is not true, we safely return nil and leave it up to the user
+func findInstalledScraperPackage(ctx context.Context, scraperID string) (*ScraperURLConflictPackage, error) {
+	pm, err := getPackageManager(PackageTypeScraper)
+	if err != nil {
+		return nil, err
+	}
+
+	installed, err := pm.ListInstalled(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for spec, manifest := range installed {
+		if spec.ID != scraperID {
+			continue
+		}
+
+		var siblings []string
+		for _, f := range manifest.Files {
+			if filepath.Ext(f) != ".yml" {
+				continue
+			}
+
+			id := strings.TrimSuffix(filepath.Base(f), ".yml")
+			if id != scraperID {
+				siblings = append(siblings, id)
+			}
+		}
+
+		return &ScraperURLConflictPackage{
+			Package:           manifestToPackage(manifest),
+			SiblingScraperIds: siblings,
+		}, nil
+	}
+
+	return nil, nil
+}

--- a/internal/api/resolver_query_scraper.go
+++ b/internal/api/resolver_query_scraper.go
@@ -23,6 +23,17 @@ func (r *queryResolver) ListScrapers(ctx context.Context, types []scraper.Scrape
 	return r.scraperCache().ListScrapers(types), nil
 }
 
+func (r *queryResolver) ScraperURLConflicts(ctx context.Context) ([]*scraper.ScraperURLConflict, error) {
+	conflicts := r.scraperCache().FindURLConflicts()
+
+	ret := make([]*scraper.ScraperURLConflict, len(conflicts))
+	for i := range conflicts {
+		ret[i] = &conflicts[i]
+	}
+
+	return ret, nil
+}
+
 func (r *queryResolver) ScrapePerformerURL(ctx context.Context, url string) (*models.ScrapedPerformer, error) {
 	content, err := r.scraperCache().ScrapeURL(ctx, url, scraper.ScrapeContentTypePerformer)
 	if err != nil {

--- a/pkg/scraper/conflicts.go
+++ b/pkg/scraper/conflicts.go
@@ -1,0 +1,101 @@
+package scraper
+
+import "strings"
+
+// ScraperURLConflict describes two installed scrapers whose URL patterns for the
+// same content type overlap, such that Cache.ScrapeURL cannot deterministically
+// choose between them
+type ScraperURLConflict struct {
+	Type ScrapeContentType `json:"type"`
+
+	ScraperID string `json:"scraperID"`
+	Pattern   string `json:"pattern"`
+
+	OtherScraperID string `json:"otherScraperID"`
+	OtherPattern   string `json:"otherPattern"`
+}
+
+// urlsForType returns the URL patterns declared by spec for the given content
+// type. Movie and Group are treated as the same bucket, since they are
+// matched identically by Definition.matchesURL
+func urlsForType(spec Scraper, ty ScrapeContentType) []string {
+	var s *ScraperSpec
+
+	switch ty {
+	case ScrapeContentTypeScene:
+		s = spec.Scene
+	case ScrapeContentTypePerformer:
+		s = spec.Performer
+	case ScrapeContentTypeGallery:
+		s = spec.Gallery
+	case ScrapeContentTypeImage:
+		s = spec.Image
+	case ScrapeContentTypeGroup, ScrapeContentTypeMovie:
+		s = spec.Group
+	}
+
+	if s == nil {
+		return nil
+	}
+
+	return s.Urls
+}
+
+// FindURLConflicts finds pairs of installed scrapers whose URL patterns for
+// the same content type overlap in a way that makes ScrapeURL's dispatch
+// ambiguous: one pattern is equal to, or a substring of, another pattern
+// belonging to a different scraper
+//
+// Each conflicting pattern pair is reported once
+func (c Cache) FindURLConflicts() []ScraperURLConflict {
+	var ret []ScraperURLConflict
+
+	tys := make([]ScrapeContentType, 0, len(AllScrapeContentType))
+	for _, ty := range AllScrapeContentType {
+		if ty != ScrapeContentTypeMovie {
+			tys = append(tys, ty)
+		}
+	}
+
+	type patternSource struct {
+		scraperID string
+		pattern   string
+	}
+
+	for _, ty := range tys {
+		var patterns []patternSource
+		for _, s := range c.scrapers {
+			spec := s.spec()
+			for _, u := range urlsForType(spec, ty) {
+				patterns = append(patterns, patternSource{scraperID: spec.ID, pattern: u})
+			}
+		}
+
+		for i, a := range patterns {
+			for j, b := range patterns {
+				if i == j || a.scraperID == b.scraperID {
+					continue
+				}
+
+				if !strings.Contains(a.pattern, b.pattern) {
+					continue
+				}
+
+				// deliberately compare 'greater than' to guarantee a total ordering
+				if a.pattern == b.pattern && a.scraperID > b.scraperID {
+					continue
+				}
+
+				ret = append(ret, ScraperURLConflict{
+					Type:           ty,
+					ScraperID:      a.scraperID,
+					Pattern:        a.pattern,
+					OtherScraperID: b.scraperID,
+					OtherPattern:   b.pattern,
+				})
+			}
+		}
+	}
+
+	return ret
+}

--- a/pkg/scraper/conflicts_test.go
+++ b/pkg/scraper/conflicts_test.go
@@ -1,0 +1,123 @@
+package scraper
+
+import (
+	"sort"
+	"testing"
+)
+
+func makeTestScraper(id string, sceneURLs []string, performerURLs []string) scraper {
+	def := Definition{
+		ID:   id,
+		Name: id,
+	}
+
+	for _, u := range sceneURLs {
+		def.SceneByURL = append(def.SceneByURL, &ByURLDefinition{URL: []string{u}})
+	}
+	for _, u := range performerURLs {
+		def.PerformerByURL = append(def.PerformerByURL, &ByURLDefinition{URL: []string{u}})
+	}
+
+	return scraperFromDefinition(def, nil)
+}
+
+func sortConflicts(c []ScraperURLConflict) {
+	sort.Slice(c, func(i, j int) bool {
+		if c[i].ScraperID != c[j].ScraperID {
+			return c[i].ScraperID < c[j].ScraperID
+		}
+		if c[i].Pattern != c[j].Pattern {
+			return c[i].Pattern < c[j].Pattern
+		}
+		return c[i].OtherScraperID < c[j].OtherScraperID
+	})
+}
+
+func TestCache_FindURLConflicts_Subsumption(t *testing.T) {
+	c := Cache{
+		scrapers: map[string]scraper{
+			"a": makeTestScraper("a", []string{"example.com"}, nil),
+			"b": makeTestScraper("b", []string{"example.com/scene"}, nil),
+		},
+	}
+
+	got := c.FindURLConflicts()
+	sortConflicts(got)
+
+	// the longer, more specific pattern ("example.com/scene") contains the
+	// shorter, broader one ("example.com"), so it is reported as the primary
+	// side of the pair: consumers should treat the pair as unordered
+	want := []ScraperURLConflict{
+		{
+			Type:           ScrapeContentTypeScene,
+			ScraperID:      "b",
+			Pattern:        "example.com/scene",
+			OtherScraperID: "a",
+			OtherPattern:   "example.com",
+		},
+	}
+
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("FindURLConflicts() = %+v, want %+v", got, want)
+	}
+}
+
+func TestCache_FindURLConflicts_DisjointPatternsNoConflict(t *testing.T) {
+	c := Cache{
+		scrapers: map[string]scraper{
+			"a": makeTestScraper("a", []string{"example.com/scenes/"}, nil),
+			"b": makeTestScraper("b", []string{"example.com/movies/"}, nil),
+		},
+	}
+
+	got := c.FindURLConflicts()
+	if len(got) != 0 {
+		t.Errorf("FindURLConflicts() = %+v, want no conflicts for disjoint patterns on the same domain", got)
+	}
+}
+
+func TestCache_FindURLConflicts_EqualPatternsReportedOnce(t *testing.T) {
+	c := Cache{
+		scrapers: map[string]scraper{
+			"a": makeTestScraper("a", []string{"example.com"}, nil),
+			"b": makeTestScraper("b", []string{"example.com"}, nil),
+		},
+	}
+
+	got := c.FindURLConflicts()
+	if len(got) != 1 {
+		t.Fatalf("FindURLConflicts() returned %d conflicts for identical patterns, want exactly 1", len(got))
+	}
+	if got[0].ScraperID != "a" || got[0].OtherScraperID != "b" {
+		t.Errorf("FindURLConflicts() = %+v, want scraperID a, otherScraperID b (canonical ordering)", got[0])
+	}
+}
+
+func TestCache_FindURLConflicts_SameScraperNoSelfConflict(t *testing.T) {
+	c := Cache{
+		scrapers: map[string]scraper{
+			"a": makeTestScraper("a", []string{"example.com", "example.com/scene"}, nil),
+		},
+	}
+
+	got := c.FindURLConflicts()
+	if len(got) != 0 {
+		t.Errorf("FindURLConflicts() = %+v, want no conflicts within a single scraper's own patterns", got)
+	}
+}
+
+func TestCache_FindURLConflicts_ScopedPerContentType(t *testing.T) {
+	// a scene scraper and a performer scraper on the same domain is not a
+	// conflict, since ScrapeURL dispatches independently per content type
+	c := Cache{
+		scrapers: map[string]scraper{
+			"a": makeTestScraper("a", []string{"example.com"}, nil),
+			"b": makeTestScraper("b", nil, []string{"example.com"}),
+		},
+	}
+
+	got := c.FindURLConflicts()
+	if len(got) != 0 {
+		t.Errorf("FindURLConflicts() = %+v, want no conflicts across different content types", got)
+	}
+}

--- a/ui/v2.5/graphql/queries/scrapers/scrapers.graphql
+++ b/ui/v2.5/graphql/queries/scrapers/scrapers.graphql
@@ -53,6 +53,28 @@ query ListGroupScrapers {
   }
 }
 
+query ScraperURLConflicts {
+  scraperURLConflicts {
+    type
+    scraper_id
+    pattern
+    scraper_package {
+      package {
+        ...PackageData
+      }
+      sibling_scraper_ids
+    }
+    other_scraper_id
+    other_pattern
+    other_scraper_package {
+      package {
+        ...PackageData
+      }
+      sibling_scraper_ids
+    }
+  }
+}
+
 query ScrapeSingleStudio(
   $source: ScraperSourceInput!
   $input: ScrapeSingleStudioInput!

--- a/ui/v2.5/src/components/Settings/ScraperURLConflicts.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperURLConflicts.tsx
@@ -1,0 +1,281 @@
+import React, { useMemo, useState } from "react";
+import { Badge, Button } from "react-bootstrap";
+import { FormattedMessage, useIntl } from "react-intl";
+import * as GQL from "src/core/generated-graphql";
+import {
+  evictQueries,
+  getClient,
+  mutateUninstallScraperPackages,
+  scraperMutationImpactedQueries,
+} from "src/core/StashService";
+import { useMonitorJob } from "src/utils/job";
+import { Icon } from "../Shared/Icon";
+import { WarningHoverPopover } from "../Shared/HoverPopover";
+import { AlertModal } from "../Shared/Alert";
+import { ModalComponent } from "../Shared/Modal";
+import {
+  faExclamationTriangle,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
+
+type Conflict = GQL.ScraperUrlConflictsQuery["scraperURLConflicts"][number];
+type ConflictPackage = NonNullable<Conflict["scraper_package"]>;
+
+// a conflict as seen from the perspective of one particular scraper/pattern -
+// "mine" is the side matching the scraper/url being rendered, "other" is the
+// side it conflicts with
+export interface ILocalConflict {
+  mineID: string;
+  minePattern: string;
+  minePackage?: ConflictPackage | null;
+  otherID: string;
+  otherPattern: string;
+  otherPackage?: ConflictPackage | null;
+}
+
+export function findConflict(
+  conflicts: Conflict[] | undefined,
+  scraperID: string,
+  url: string
+): ILocalConflict | undefined {
+  const c = conflicts?.find(
+    (conflict) =>
+      (conflict.scraper_id === scraperID && conflict.pattern === url) ||
+      (conflict.other_scraper_id === scraperID &&
+        conflict.other_pattern === url)
+  );
+
+  if (!c) return undefined;
+
+  if (c.scraper_id === scraperID) {
+    return {
+      mineID: c.scraper_id,
+      minePattern: c.pattern,
+      minePackage: c.scraper_package,
+      otherID: c.other_scraper_id,
+      otherPattern: c.other_pattern,
+      otherPackage: c.other_scraper_package,
+    };
+  }
+
+  return {
+    mineID: c.other_scraper_id,
+    minePattern: c.other_pattern,
+    minePackage: c.other_scraper_package,
+    otherID: c.scraper_id,
+    otherPattern: c.pattern,
+    otherPackage: c.scraper_package,
+  };
+}
+
+function packageIsOlder(
+  a?: ConflictPackage | null,
+  b?: ConflictPackage | null
+) {
+  if (!a?.package.date || !b?.package.date) return false;
+  return new Date(a.package.date) < new Date(b.package.date);
+}
+
+const ConflictSide: React.FC<{
+  name: string;
+  pattern: string;
+  pkg?: ConflictPackage | null;
+  recommended: boolean;
+  onUninstall: () => void;
+}> = ({ name, pattern, pkg, recommended, onUninstall }) => {
+  const intl = useIntl();
+
+  return (
+    <div className="scraper-conflict-side">
+      <div className="scraper-conflict-side-heading">
+        <strong>{name}</strong>
+        {recommended && (
+          <Badge variant="warning">
+            <FormattedMessage id="config.scraping.url_conflict.older" />
+          </Badge>
+        )}
+      </div>
+      <div>
+        <code>{pattern}</code>
+      </div>
+      {pkg ? (
+        <>
+          <div className="text-muted">
+            {pkg.package.version ?? pkg.package.package_id}
+            {pkg.package.date && (
+              <>
+                {" "}
+                (
+                {intl.formatDate(new Date(pkg.package.date), {
+                  timeZone: "utc",
+                })}
+                )
+              </>
+            )}
+          </div>
+          <Button
+            size="sm"
+            variant={recommended ? "danger" : "secondary"}
+            onClick={onUninstall}
+          >
+            <Icon icon={faTrash} />
+            <FormattedMessage
+              id="config.scraping.url_conflict.uninstall"
+              values={{ name }}
+            />
+          </Button>
+        </>
+      ) : (
+        <div className="text-muted">
+          <FormattedMessage id="config.scraping.url_conflict.no_package" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ScraperConflictModal: React.FC<{
+  conflict: ILocalConflict;
+  mineName: string;
+  otherName: string;
+  onHide: () => void;
+}> = ({ conflict, mineName, otherName, onHide }) => {
+  const intl = useIntl();
+  const [uninstallTarget, setUninstallTarget] = useState<{
+    name: string;
+    pkg: ConflictPackage;
+  }>();
+  const [jobID, setJobID] = useState<string>();
+  const { job } = useMonitorJob(jobID, () => {
+    const ac = getClient();
+    evictQueries(ac.cache, scraperMutationImpactedQueries);
+    onHide();
+  });
+
+  const mineIsOlder = packageIsOlder(
+    conflict.minePackage,
+    conflict.otherPackage
+  );
+  const otherIsOlder = packageIsOlder(
+    conflict.otherPackage,
+    conflict.minePackage
+  );
+
+  async function confirmUninstall() {
+    if (!uninstallTarget) return;
+
+    const { package_id, sourceURL } = uninstallTarget.pkg.package;
+    const r = await mutateUninstallScraperPackages([
+      { id: package_id, sourceURL },
+    ]);
+    setJobID(r.data?.uninstallPackages);
+    setUninstallTarget(undefined);
+  }
+
+  return (
+    <>
+      <ModalComponent
+        show
+        icon={faExclamationTriangle}
+        header={intl.formatMessage({
+          id: "config.scraping.url_conflict.heading",
+        })}
+        onHide={onHide}
+        accept={{ onClick: onHide, variant: "secondary" }}
+        disabled={!!job}
+        modalProps={{ size: "lg" }}
+      >
+        <p>
+          <FormattedMessage id="config.scraping.url_conflict.description" />
+        </p>
+        <div className="scraper-conflict-sides">
+          <ConflictSide
+            name={mineName}
+            pattern={conflict.minePattern}
+            pkg={conflict.minePackage}
+            recommended={mineIsOlder}
+            onUninstall={() =>
+              conflict.minePackage &&
+              setUninstallTarget({
+                name: mineName,
+                pkg: conflict.minePackage,
+              })
+            }
+          />
+          <ConflictSide
+            name={otherName}
+            pattern={conflict.otherPattern}
+            pkg={conflict.otherPackage}
+            recommended={otherIsOlder}
+            onUninstall={() =>
+              conflict.otherPackage &&
+              setUninstallTarget({
+                name: otherName,
+                pkg: conflict.otherPackage,
+              })
+            }
+          />
+        </div>
+      </ModalComponent>
+
+      <AlertModal
+        show={!!uninstallTarget}
+        text={
+          <FormattedMessage
+            id="config.scraping.url_conflict.confirm_uninstall"
+            values={{
+              name: uninstallTarget?.name,
+              siblings: uninstallTarget?.pkg.sibling_scraper_ids.join(", "),
+              hasSiblings:
+                (uninstallTarget?.pkg.sibling_scraper_ids.length ?? 0) > 0
+                  ? 1
+                  : 0,
+            }}
+          />
+        }
+        onConfirm={confirmUninstall}
+        onCancel={() => setUninstallTarget(undefined)}
+      />
+    </>
+  );
+};
+
+export const ConflictBadge: React.FC<{
+  conflict: ILocalConflict;
+  mineName: string;
+  otherName: string;
+}> = ({ conflict, mineName, otherName }) => {
+  const intl = useIntl();
+  const [showModal, setShowModal] = useState(false);
+
+  const tooltip = useMemo(
+    () =>
+      intl.formatMessage(
+        { id: "config.scraping.url_conflict.tooltip" },
+        { name: otherName }
+      ),
+    [intl, otherName]
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        className="scraper-url-conflict-badge"
+        onClick={() => setShowModal(true)}
+      >
+        <WarningHoverPopover content={tooltip} placement="top">
+          <span />
+        </WarningHoverPopover>
+      </button>
+      {showModal && (
+        <ScraperConflictModal
+          conflict={conflict}
+          mineName={mineName}
+          otherName={otherName}
+          onHide={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsScrapingPanel.tsx
@@ -8,7 +8,10 @@ import {
   useListSceneScrapers,
   useListGalleryScrapers,
   useListImageScrapers,
+  useScraperURLConflicts,
 } from "src/core/StashService";
+import * as GQL from "src/core/generated-graphql";
+import { ConflictBadge, findConflict } from "./ScraperURLConflicts";
 import { useToast } from "src/hooks/Toast";
 import TextUtils from "src/utils/text";
 import { CollapseButton } from "../Shared/CollapseButton";
@@ -106,11 +109,22 @@ const ScrapeTypeList: React.FC<{
   );
 };
 
+type ScraperURLConflict =
+  GQL.ScraperUrlConflictsQuery["scraperURLConflicts"][number];
+
 interface IURLList {
+  scraperId: string;
   urls: string[];
+  conflicts: ScraperURLConflict[];
+  scraperNames: Map<string, string>;
 }
 
-const URLList: React.FC<IURLList> = ({ urls }) => {
+const URLList: React.FC<IURLList> = ({
+  scraperId,
+  urls,
+  conflicts,
+  scraperNames,
+}) => {
   const items = useMemo(() => {
     function linkSite(url: string) {
       const u = new URL(url);
@@ -123,26 +137,47 @@ const URLList: React.FC<IURLList> = ({ urls }) => {
       .map((u) => {
         const sanitised = TextUtils.sanitiseURL(u);
         const siteURL = linkSite(sanitised!);
+        const conflict = findConflict(conflicts, scraperId, u);
 
         return (
           <li key={u}>
             <ExternalLink href={siteURL}>{sanitised}</ExternalLink>
+            {conflict && (
+              <ConflictBadge
+                conflict={conflict}
+                mineName={scraperNames.get(scraperId) ?? scraperId}
+                otherName={
+                  scraperNames.get(conflict.otherID) ?? conflict.otherID
+                }
+              />
+            )}
           </li>
         );
       });
 
     return ret;
-  }, [urls]);
+  }, [urls, conflicts, scraperId, scraperNames]);
 
   return <ul>{items}</ul>;
 };
 
 const ScraperTableRow: React.FC<{
+  id: string;
   name: string;
   entityType: string;
   supportedScrapes: ScrapeType[];
   urls: string[];
-}> = ({ name, entityType, supportedScrapes, urls }) => {
+  conflicts: ScraperURLConflict[];
+  scraperNames: Map<string, string>;
+}> = ({
+  id,
+  name,
+  entityType,
+  supportedScrapes,
+  urls,
+  conflicts,
+  scraperNames,
+}) => {
   return (
     <tr>
       <td>{name}</td>
@@ -150,7 +185,12 @@ const ScraperTableRow: React.FC<{
         <ScrapeTypeList types={supportedScrapes} entityType={entityType} />
       </td>
       <td>
-        <URLList urls={urls} />
+        <URLList
+          scraperId={id}
+          urls={urls}
+          conflicts={conflicts}
+          scraperNames={scraperNames}
+        />
       </td>
     </tr>
   );
@@ -183,6 +223,44 @@ const ScrapersSection: React.FC = () => {
     useListImageScrapers();
   const { data: groupScrapers, loading: loadingGroups } =
     useListGroupScrapers();
+  const { data: conflictsData } = useScraperURLConflicts();
+
+  const scraperNames = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const list of [
+      performerScrapers?.listScrapers,
+      sceneScrapers?.listScrapers,
+      galleryScrapers?.listScrapers,
+      imageScrapers?.listScrapers,
+      groupScrapers?.listScrapers,
+    ]) {
+      list?.forEach((s) => {
+        m.set(s.id, s.name);
+      });
+    }
+    return m;
+  }, [
+    performerScrapers,
+    sceneScrapers,
+    galleryScrapers,
+    imageScrapers,
+    groupScrapers,
+  ]);
+
+  const conflictsByType = useMemo(() => {
+    const conflicts = conflictsData?.scraperURLConflicts ?? [];
+    return {
+      performers: conflicts.filter(
+        (c) => c.type === GQL.ScrapeContentType.Performer
+      ),
+      scenes: conflicts.filter((c) => c.type === GQL.ScrapeContentType.Scene),
+      galleries: conflicts.filter(
+        (c) => c.type === GQL.ScrapeContentType.Gallery
+      ),
+      images: conflicts.filter((c) => c.type === GQL.ScrapeContentType.Image),
+      groups: conflicts.filter((c) => c.type === GQL.ScrapeContentType.Group),
+    };
+  }, [conflictsData]);
 
   const filteredScrapers = useMemo(() => {
     const filterFn = filterScraper(filter.toLowerCase());
@@ -261,10 +339,13 @@ const ScrapersSection: React.FC = () => {
             {filteredScrapers.scenes?.map((scraper) => (
               <ScraperTableRow
                 key={scraper.id}
+                id={scraper.id}
                 name={scraper.name}
                 entityType="scene"
                 supportedScrapes={scraper.scene?.supported_scrapes ?? []}
                 urls={scraper.scene?.urls ?? []}
+                conflicts={conflictsByType.scenes}
+                scraperNames={scraperNames}
               />
             ))}
           </ScraperTable>
@@ -278,10 +359,13 @@ const ScrapersSection: React.FC = () => {
             {filteredScrapers.galleries?.map((scraper) => (
               <ScraperTableRow
                 key={scraper.id}
+                id={scraper.id}
                 name={scraper.name}
                 entityType="gallery"
                 supportedScrapes={scraper.gallery?.supported_scrapes ?? []}
                 urls={scraper.gallery?.urls ?? []}
+                conflicts={conflictsByType.galleries}
+                scraperNames={scraperNames}
               />
             ))}
           </ScraperTable>
@@ -295,10 +379,13 @@ const ScrapersSection: React.FC = () => {
             {filteredScrapers.images?.map((scraper) => (
               <ScraperTableRow
                 key={scraper.id}
+                id={scraper.id}
                 name={scraper.name}
                 entityType="image"
                 supportedScrapes={scraper.image?.supported_scrapes ?? []}
                 urls={scraper.image?.urls ?? []}
+                conflicts={conflictsByType.images}
+                scraperNames={scraperNames}
               />
             ))}
           </ScraperTable>
@@ -312,10 +399,13 @@ const ScrapersSection: React.FC = () => {
             {filteredScrapers.performers?.map((scraper) => (
               <ScraperTableRow
                 key={scraper.id}
+                id={scraper.id}
                 name={scraper.name}
                 entityType="performer"
                 supportedScrapes={scraper.performer?.supported_scrapes ?? []}
                 urls={scraper.performer?.urls ?? []}
+                conflicts={conflictsByType.performers}
+                scraperNames={scraperNames}
               />
             ))}
           </ScraperTable>
@@ -329,10 +419,13 @@ const ScrapersSection: React.FC = () => {
             {filteredScrapers.groups?.map((scraper) => (
               <ScraperTableRow
                 key={scraper.id}
+                id={scraper.id}
                 name={scraper.name}
                 entityType="group"
                 supportedScrapes={scraper.group?.supported_scrapes ?? []}
                 urls={scraper.group?.urls ?? []}
+                conflicts={conflictsByType.groups}
+                scraperNames={scraperNames}
               />
             ))}
           </ScraperTable>

--- a/ui/v2.5/src/components/Settings/styles.scss
+++ b/ui/v2.5/src/components/Settings/styles.scss
@@ -264,6 +264,28 @@
   justify-content: space-between;
 }
 
+.scraper-url-conflict-badge {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.scraper-conflict-sides {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.scraper-conflict-side {
+  flex: 1 1 0;
+}
+
+.scraper-conflict-side-heading {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
 .job-table.card {
   background-color: $card-bg;
   height: 10em;

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -2510,6 +2510,8 @@ export const useListGalleryScrapers = () => GQL.useListGalleryScrapersQuery();
 
 export const useListImageScrapers = () => GQL.useListImageScrapersQuery();
 
+export const useScraperURLConflicts = () => GQL.useScraperUrlConflictsQuery();
+
 export const queryScrapeGallery = (scraperId: string, galleryId: string) =>
   client.query<GQL.ScrapeSingleGalleryQuery>({
     query: GQL.ScrapeSingleGalleryDocument,
@@ -2626,6 +2628,7 @@ export const scraperMutationImpactedQueries = [
   GQL.ListImageScrapersDocument,
   GQL.InstalledScraperPackagesDocument,
   GQL.InstalledScraperPackagesStatusDocument,
+  GQL.ScraperUrlConflictsDocument,
 ];
 
 export const mutateReloadScrapers = () =>

--- a/ui/v2.5/src/docs/en/Changelog/v0310.md
+++ b/ui/v2.5/src/docs/en/Changelog/v0310.md
@@ -60,6 +60,7 @@
 * Added `d d` keyboard shortcut to delete scene in scene details page. ([#6755](https://github.com/stashapp/stash/pull/6755))
 * VAAPI dri device can now be overridden using `STASH_HW_DRI_DEVICE` environment variable. ([#6728](https://github.com/stashapp/stash/pull/6728))
 * Added support for `{phash}` in `queryURL` scraper field. ([#6701](https://github.com/stashapp/stash/pull/6701))
+* Added a warning when installed scrapers have conflicting URL patterns, with an option to uninstall one of the conflicting packages. ([#7203](https://github.com/stashapp/stash/pull/7203))
 * Systray notification now shows the port stash is running on. ([#6448](https://github.com/stashapp/stash/pull/6448))
 
 ### 🐛 Bug fixes
@@ -106,3 +107,4 @@
 * Added `basename` filter field to `FolderFilterType`. ([#6494](https://github.com/stashapp/stash/pull/6494))
 * Added `parent_folder` filter field to `GalleryFilterType`. ([#6636](https://github.com/stashapp/stash/pull/6636))
 * Performer `career_length` field is deprecated in favour of `career_start` and `career_end`.
+* Added `scraperURLConflicts` query to list installed scrapers with overlapping URL patterns. ([#7203](https://github.com/stashapp/stash/pull/7203))

--- a/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
+++ b/ui/v2.5/src/docs/en/Manual/ScraperDevelopment.md
@@ -56,6 +56,8 @@ The scraping types and their required fields are outlined in the following table
 
 URL-based scraping accepts multiple scrape configurations, and each configuration requires a `url` field. stash iterates through these configurations, attempting to match the entered URL against the `url` fields in the configuration. It executes the first scraping configuration where the entered URL contains the value of the `url` field. 
 
+If another installed scraper declares a `url` value that is a substring of (or identical to) one of yours, Stash cannot reliably determine which scraper to use, and users will see a URL conflict warning in `Settings > Metadata Providers`. Avoid declaring broader `url` patterns than necessary, and prefer a single consolidated scraper over multiple scrapers covering overlapping domains.
+
 ## Actions
 
 ### Script

--- a/ui/v2.5/src/docs/en/Manual/Scraping.md
+++ b/ui/v2.5/src/docs/en/Manual/Scraping.md
@@ -44,6 +44,12 @@ These are the scraper sources maintained by the stashapp organisation:
 
 Installed scrapers can be updated or uninstalled from the `Installed Scrapers` section.
 
+### URL pattern conflicts
+
+URL scrapers declare the URL patterns they can handle. If two installed scrapers declare overlapping patterns, Stash cannot reliably determine which one to use when scraping by URL, and the choice becomes effectively random. This commonly happens when a scraper is replaced or consolidated into another scraper upstream, leaving the old one still installed.
+
+When this happens, a warning icon is shown next to the affected URL patterns in the `Scrapers` section of `Settings > Metadata Providers`. Clicking the icon opens a dialog explaining the conflict and offering to uninstall one of the scrapers. The dialog highlights the scraper with the older package as the more likely candidate for removal, but this is only a suggestion, the correct choice depends on which scraper you still want to use.
+
 ### Source URLs
 
 The source URL must return a yaml file containing all the available packages for the source. An example source yaml file looks like the following:

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -491,7 +491,16 @@
       "scrapers": "Scrapers",
       "search_by_name": "Search by name",
       "supported_types": "Supported types",
-      "supported_urls": "URLs"
+      "supported_urls": "URLs",
+      "url_conflict": {
+        "confirm_uninstall": "Are you sure you want to uninstall {name}?{hasSiblings, select, 1 { This will also remove: {siblings}} other {}}",
+        "description": "These installed scrapers declare URL patterns that overlap, so Stash cannot reliably choose between them when scraping by URL. This usually happens when a scraper is replaced or consolidated upstream, uninstalling the older one is usually the correct fix.",
+        "heading": "Conflicting URL patterns",
+        "no_package": "Could not determine which package provides this scraper: it must be removed manually.",
+        "older": "(older)",
+        "tooltip": "This URL pattern overlaps with a pattern from {name}. Click for details",
+        "uninstall": "Uninstall {name}"
+      }
     },
     "stashbox": {
       "add_instance": "Add stash-box instance",


### PR DESCRIPTION
## Description

Adds a warning in the `Scrapers` list in `Settings > Metadata Providers` when a scraper has a pattern that overlaps with another installed scraper. Clicking the warning icon will open a modal that explains what the issue is and suggests resolving it by uninstalling one of the scrapers, heuristically suggesting that the older one is probably the least useful one. Usually a more recently updated scraper will be more correct, and hopefully that's what the user would want.

## Related Issue

This resolves #7200

## Testing
Install two scrapers from the Community feed that overlap: right now I've left intentionally overlapping scrapers ATK and ATKGirlfriends in the repository, but I'll fix them when/if this issue is addressed. There are also false positive matches like Reality Kings (which defines the pattern `rk.com`) and Digital Playground (which defines the pattern `digitalplaygroundnetwork.com` where the substring `rk.com` also appears)

## Screenshots
Before
<img width="993" height="270" alt="image" src="https://github.com/user-attachments/assets/8500f828-af13-461a-9221-476f7a8e33cd" />
After
<img width="1194" height="282" alt="image" src="https://github.com/user-attachments/assets/7a488bc6-59b4-44cb-a63c-4fe41a9bbea0" />

This is the warning modal that appears when you click the warning icon
<img width="1068" height="415" alt="image" src="https://github.com/user-attachments/assets/2dd17302-98f1-46a7-9e23-a29b3a28d156" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [x] I have made corresponding changes to the documentation (if applicable).
