### PR TITLE
Chore: Update JAV Code Parser Regex

### DIFF
--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -29,7 +29,7 @@ const MMddyyRegex = new RegExp(
   `(${months.join("|")})\\.?.(\\d{1,2}),?.(\\d{4})`,
   "i"
 );
-const javcodeRegex = /([a-zA-Z|tT28|tT38]+-\d+[zZeE]?)/;
+const javcodeRegex = /((?i:3DSVR|T28|T38|\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\w{1,2}|MBR-\w{1,2}|MMR-\w{1,2}|SRE-\w{1,2}|SRN-\w{1,2}|SVBD-\w{1,2}|PA0|[A-Z]+)-?(?i:\d+[A-Z]?))/;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -30,7 +30,7 @@ const MMddyyRegex = new RegExp(
   "i"
 );
 const javcodeRegex =
-  /((?:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?:\\d+[A-Z]?))/i;
+  /((?:\d{3})?(?:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?:\\d+[A-Z]?))/i;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -30,7 +30,7 @@ const MMddyyRegex = new RegExp(
   "i"
 );
 const javcodeRegex =
-  /((?:\d{3})?(?:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?:\\d+[A-Z]?))/i;
+  /((?:\d{3})?(?:3DSVR|T28|T38|\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\w{1,2}|MBR-\w{1,2}|MMR-\w{1,2}|SRE-\w{1,2}|SRN-\w{1,2}|SVBD-\w{1,2}|PA0|[A-Z]+)-?(?:\d+[A-Z]?))/i;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -30,7 +30,7 @@ const MMddyyRegex = new RegExp(
   "i"
 );
 const javcodeRegex =
-  /((?i:3DSVR|T28|T38|\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\w{1,2}|MBR-\w{1,2}|MMR-\w{1,2}|SRE-\w{1,2}|SRN-\w{1,2}|SVBD-\w{1,2}|PA0|[A-Z]+)-?(?i:\d+[A-Z]?))/;
+  /((?i:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?i:\\d+[A-Z]?))/;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -29,7 +29,8 @@ const MMddyyRegex = new RegExp(
   `(${months.join("|")})\\.?.(\\d{1,2}),?.(\\d{4})`,
   "i"
 );
-const javcodeRegex = /((?i:3DSVR|T28|T38|\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\w{1,2}|MBR-\w{1,2}|MMR-\w{1,2}|SRE-\w{1,2}|SRN-\w{1,2}|SVBD-\w{1,2}|PA0|[A-Z]+)-?(?i:\d+[A-Z]?))/;
+const javcodeRegex =
+  /((?i:3DSVR|T28|T38|\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\w{1,2}|MBR-\w{1,2}|MMR-\w{1,2}|SRE-\w{1,2}|SRN-\w{1,2}|SVBD-\w{1,2}|PA0|[A-Z]+)-?(?i:\d+[A-Z]?))/;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;

--- a/ui/v2.5/src/components/Tagger/utils.ts
+++ b/ui/v2.5/src/components/Tagger/utils.ts
@@ -30,7 +30,7 @@ const MMddyyRegex = new RegExp(
   "i"
 );
 const javcodeRegex =
-  /((?i:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?i:\\d+[A-Z]?))/;
+  /((?:3DSVR|T28|T38|\\d{1,2}ID|CPZ69|CPZ69-H|D1|WVR\\w{1,2}|MBR-\\w{1,2}|MMR-\\w{1,2}|SRE-\\w{1,2}|SRN-\\w{1,2}|SVBD-\\w{1,2}|PA0|[A-Z]+)-?(?:\\d+[A-Z]?))/i;
 
 const handleSpecialStrings = (input: string): string => {
   let output = input;


### PR DESCRIPTION
## Description
This pull request updates the JAV code parser regex in the Tagger.

## Related issue
Closes https://github.com/stashapp/stash/issues/7223

## Testing
I have used this regex in several projects including javstash for a few months and it seems to be fine.

## Checklist

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- n/a I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure

Absolutely no AI assistance was used in creating the regex and writing this pull request.

## Additional Context

The new regex consists of two non-capturing groups inside a capturing group. The first non-capturing group looks for the prefix and the second non-capturing group looks for the suffix. 

Test cases can be found here: https://regex101.com/r/QtGRfg/1