### PR TITLE
Auto-save confirmed scene edit fields (opt-in)

### DIFF
--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -28,6 +28,7 @@ import { addUpdateStashID, getStashIDs } from "src/utils/stashIds";
 import { useFormik } from "formik";
 import { Prompt } from "react-router-dom";
 import { useConfigurationContext } from "src/hooks/Config";
+import { IUIConfig } from "src/core/config";
 import { IGroupEntry, SceneGroupTable } from "./SceneGroupTable";
 import {
   faSearch,
@@ -215,8 +216,36 @@ export const SceneEditPanel: React.FC<IProps> = ({
     onSubmit: submit,
   });
 
-  const { tags, updateTagsStateFromScraper, resetTagsState, tagsControl } =
-    useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+  const {
+    tags,
+    onSetTags,
+    updateTagsStateFromScraper,
+    resetTagsState,
+    tagsControl,
+  } = useTagsEdit(scene.tags, (ids) => formik.setFieldValue("tag_ids", ids));
+
+  // auto-save applies only to fields whose value comes from an explicit
+  // selection, and never while creating a new scene
+  const autoSaveEnabled =
+    !isNew &&
+    ((stashConfig?.ui as IUIConfig)?.autoSaveConfirmedFields ?? false);
+
+  // set after a selection to submit once formik state has caught up
+  const [autoSaveRequested, setAutoSaveRequested] = useState(false);
+
+  function requestAutoSave() {
+    if (autoSaveEnabled) {
+      setAutoSaveRequested(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!autoSaveRequested) return;
+    setAutoSaveRequested(false);
+    if (formik.dirty) {
+      formik.submitForm();
+    }
+  }, [autoSaveRequested, formik.dirty, formik.submitForm]);
 
   const coverImagePreview = useMemo(() => {
     const sceneImage = scene.paths?.screenshot;
@@ -248,6 +277,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "gallery_ids",
       items.map((i) => i.id)
     );
+    requestAutoSave();
   }
 
   function onSetPerformers(items: Performer[]) {
@@ -256,11 +286,13 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "performer_ids",
       items.map((item) => item.id)
     );
+    requestAutoSave();
   }
 
   function onSetStudio(item: Studio | null) {
     setStudio(item);
     formik.setFieldValue("studio_id", item ? item.id : null);
+    requestAutoSave();
   }
 
   useEffect(() => {
@@ -622,6 +654,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
       "stash_ids",
       addUpdateStashID(formik.values.stash_ids, item)
     );
+    requestAutoSave();
   }
 
   const image = useMemo(() => {
@@ -750,6 +783,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     }));
 
     formik.setFieldValue("groups", newGroups);
+    requestAutoSave();
   }
 
   function renderGroupsField() {
@@ -763,7 +797,14 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   function renderTagsField() {
     const title = intl.formatMessage({ id: "tags" });
-    return renderField("tag_ids", title, tagsControl(), fullWidthProps);
+    const control = tagsControl({
+      onSelect: (items) => {
+        onSetTags(items);
+        requestAutoSave();
+      },
+    });
+
+    return renderField("tag_ids", title, control, fullWidthProps);
   }
 
   function renderDetailsField() {

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneEditPanel.tsx
@@ -10,6 +10,7 @@ import {
   SplitButton,
 } from "react-bootstrap";
 import Mousetrap from "mousetrap";
+import cx from "classnames";
 import * as GQL from "src/core/generated-graphql";
 import * as yup from "yup";
 import {
@@ -148,6 +149,8 @@ export const SceneEditPanel: React.FC<IProps> = ({
 
   // Network state
   const [isLoading, setIsLoading] = useState(false);
+  // when auto-save is on, keep the form mounted during save so scroll is not reset
+  const [isSaving, setIsSaving] = useState(false);
 
   const schema = yup.object({
     title: yup.string().ensure(),
@@ -234,7 +237,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
   const [autoSaveRequested, setAutoSaveRequested] = useState(false);
 
   function requestAutoSave() {
-    if (autoSaveEnabled) {
+    if (autoSaveEnabled && !isSaving) {
       setAutoSaveRequested(true);
     }
   }
@@ -336,10 +339,16 @@ export const SceneEditPanel: React.FC<IProps> = ({
   }
 
   async function onSave(input: InputValues, andNew?: boolean) {
-    setIsLoading(true);
+    if (autoSaveEnabled) {
+      setIsSaving(true);
+    } else {
+      setIsLoading(true);
+    }
     try {
       await onSubmit(input, andNew);
-      formik.resetForm();
+      if (!autoSaveEnabled) {
+        formik.resetForm();
+      }
       if (andNew) {
         setGalleries(
           scene.galleries?.map((g) => ({
@@ -357,6 +366,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
     } catch (e) {
       Toast.error(e);
     }
+    setIsSaving(false);
     setIsLoading(false);
   }
 
@@ -855,7 +865,9 @@ export const SceneEditPanel: React.FC<IProps> = ({
                 className="edit-button"
                 variant="primary"
                 disabled={
-                  !isEqual(formik.errors, {}) || customFieldsError !== undefined
+                  isSaving ||
+                  !isEqual(formik.errors, {}) ||
+                  customFieldsError !== undefined
                 }
                 title={intl.formatMessage({ id: "actions.save" })}
                 onClick={() => formik.submitForm()}
@@ -870,6 +882,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
                 variant="primary"
                 disabled={
                   (!isNew && !formik.dirty) ||
+                  isSaving ||
                   !isEqual(formik.errors, {}) ||
                   customFieldsError !== undefined
                 }
@@ -882,6 +895,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
               <Button
                 className="edit-button"
                 variant="danger"
+                disabled={isSaving}
                 onClick={() => onDelete()}
               >
                 <FormattedMessage id="actions.delete" />
@@ -910,7 +924,7 @@ export const SceneEditPanel: React.FC<IProps> = ({
             </div>
           )}
         </Row>
-        <Row className="form-container px-3">
+        <Row className={cx("form-container px-3", { saving: isSaving })}>
           <Col lg={7} xl={12}>
             {renderInputField("title")}
             {renderInputField("code", "text", "scene_code")}

--- a/ui/v2.5/src/components/Scenes/SceneDetails/SceneGroupTable.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/SceneGroupTable.tsx
@@ -111,6 +111,7 @@ export const SceneGroupTable: React.FC<IProps> = (props) => {
         <Row className="group-row">
           <Col xs={12}>
             <GroupSelect
+              key={groupIDs.join(",")}
               onSelect={(items) => onNewGroupSet(items)}
               values={[]}
               excludeIds={groupIDs}

--- a/ui/v2.5/src/components/Scenes/styles.scss
+++ b/ui/v2.5/src/components/Scenes/styles.scss
@@ -565,6 +565,11 @@ input[type="range"].blue-slider {
     font-size: 0.85em;
   }
 
+  .form-container.saving {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
   @include media-breakpoint-up(xl) {
     .custom-fields-input {
       .custom-fields-field {

--- a/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
+++ b/ui/v2.5/src/components/Settings/SettingsInterfacePanel/SettingsInterfacePanel.tsx
@@ -711,6 +711,13 @@ export const SettingsInterfacePanel: React.FC = PatchComponent(
         </SettingSection>
 
         <SettingSection headingID="config.ui.editing.heading">
+          <BooleanSetting
+            id="auto-save-confirmed-fields"
+            headingID="config.ui.editing.auto_save_confirmed_fields.heading"
+            subHeadingID="config.ui.editing.auto_save_confirmed_fields.description"
+            checked={ui.autoSaveConfirmedFields ?? false}
+            onChange={(v) => saveUI({ autoSaveConfirmedFields: v })}
+          />
           <div className="setting-group">
             <div className="setting">
               <div>

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -55,6 +55,10 @@ export interface IUIConfig {
 
   abbreviateCounters?: boolean;
 
+  // if true, selecting a value in a confirmed selector (tags, performers,
+  // studio, galleries, groups, stash IDs) saves the edit form immediately
+  autoSaveConfirmedFields?: boolean;
+
   ratingSystemOptions?: RatingSystemOptions;
 
   // if true a background image will be display on header

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -732,6 +732,10 @@
         }
       },
       "editing": {
+        "auto_save_confirmed_fields": {
+          "description": "Immediately save the edit form when a tag, performer, studio, gallery, group, or stash-box ID is selected, without needing to press Save.",
+          "heading": "Auto-save on selection"
+        },
         "disable_dropdown_create": {
           "description": "Remove the ability to create new objects from the dropdown selectors.",
           "heading": "Disable dropdown create"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds an opt-in "Auto-save on selection" setting under Settings → Interface → Editing (off by default). When enabled, adding or removing a tag, performer, studio, gallery, group, or stash-box ID selection on the scene edit form immediately saves the form, skipping the extra manual "Save" click. It **does not** apply to free-text fields or while creating a new (unsaved) scene. Applying a scrape result can also fire auto-save when tag, studio or performers are part of what was applied. Otherwise it still requires pressing the Save button.

When the setting is on, Save keeps the edit form mounted and dims it in place so scroll position is preserved. With the setting off, Save still uses the original full-panel spinner.

No backend/GraphQL schema changes — the setting is a client-side UI config field.

## Related Issue
<!-- Please link the issue your pull request is referring to. -->

Closes #4353

## Testing
<!-- Describe the testing steps you have performed. -->

`make validate-ui` (biome lint, biome format, stylelint, tsc) passed on this branch.

Manual pass against a running dev instance (backend on `:9999`, this branch's UI on `:3000`).

**Setting off (default) — original save behavior**

- Settings → Interface → Editing shows "Auto-save on selection", off by default.
- Selecting a tag, performer, studio, or group does not save until Save is clicked.
- Save still uses the original full-panel spinner: the form unmounts, then remounts.
- Groups picker is unchanged: adding a group removes it from the add list immediately; removing it puts it back.

**Setting on**

- Toggled the setting on and confirmed it persisted.
- On an existing scene edit tab, selecting a tag, performer, studio, or group saved immediately without clicking Save. Removing a performer or group also auto-saved.
- During that save the form stays mounted, dims, and ignores clicks; scroll position is kept. After save, an "Updated scene" toast appears.
- Groups keep the same picker behavior as with the setting off: an added group is no longer offered in the add list; a removed group is available again. (The in-place save path is what required a small extra fix here so that list would still refresh.)
- Confirmed via a GraphQL query against the dev database that the new tag was actually persisted, then reverted the test scene and turned the setting back off.

Free-text fields and creating a new scene were not auto-saved, as intended.

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

A [video](https://www.loom.com/share/e8a8fe1412fe4ff89ede0f3c9e381884) is worth a thousand screenshots

## Checklist
<!-- Mark [x] to indicate completion. -->

- [x] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [x] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [ ] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [x] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->

Implemented with Claude Code (Anthropic): the feature implementation (frontend changes, setting/locale strings), the manual testing pass described above.

## Additional Context
<!-- Add any other context about the pull request here. -->
