### PR TITLE
Chore: Bump CI Node.js from 20 to 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'pnpm'
         cache-dependency-path: ui/v2.5/pnpm-lock.yaml
 

--- a/ui/v2.5/package.json
+++ b/ui/v2.5/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 24"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
### Why

Node 20 is past end-of-life and no longer receives security updates, so CI should move off it.

The `generate` job in `build.yml` was the only remaining Node 20 pin. The compiler image that the cross-compile jobs run in has been on `node:24-bookworm` for a while already (`docker/compiler/Dockerfile`), so this just brings the one native job in line with the toolchain the rest of the build already uses. Node 24 is the current active LTS.

### What changed

- `.github/workflows/build.yml` — `node-version: '20'` → `'24'`
- `ui/v2.5/package.json` — `engines.node` `">= 20"` → `">= 24"`

The `engines` bump matters as much as the workflow one. With a floor of `>= 20`, a contributor on a newer Node can use language features the CI runner cannot parse, so the build passes locally and fails only in CI with an error that looks unrelated to their change.

That is not hypothetical — it is currently happening on #7207, where a regex using inline modifier groups (`(?i:...)`) fails the `generate` job:

```
Invalid regular expression: /((?i:3DSVR|T28|...))/: Invalid group
    at new RegExp (<anonymous>)
    at Array.literalRegExp (rollup/dist/es/shared/node-entry.js:16595:22)
```

Rollup reconstructs regex literals with `new RegExp()` in the host Node process, so whether the build succeeds depends entirely on the runner's V8 version. Modifier groups landed in V8 12.5, so they parse on Node 23+ and throw on Node 20.

To be clear, this PR does not fix #7207 — that regex has a separate bug and needs changing on its own merits. This only removes the version skew that made the failure confusing.

### Testing

Ran the full UI pipeline on a modern Node against current `develop`:

- `pnpm run check` (tsc --noEmit) — clean
- `pnpm run lint` (biome + stylelint) — clean
- `pnpm run build` (vite) — built in 15.91s

No lockfile or dependency changes; `pnpm install --frozen-lockfile` resolves unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoAD2nqsMqbkNGdzSBJJ6q
