### PR TITLE
Fix: Stop Endless findJob Queries After Package Manager Jobs

### DIFF
--- a/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/PluginPackageManager.tsx
@@ -24,7 +24,7 @@ import { SettingSection } from "./SettingSection";
 export const InstalledPluginPackages: React.FC = () => {
   const [loadUpgrades, setLoadUpgrades] = useState(false);
   const [jobID, setJobID] = useState<string>();
-  const { job } = useMonitorJob(jobID, () => onPackageChanges());
+  const { job } = useMonitorJob(jobID, onPackageChanges);
 
   const { data, previousData, refetch, networkStatus, error } =
     useInstalledPluginPackages(loadUpgrades);
@@ -44,7 +44,8 @@ export const InstalledPluginPackages: React.FC = () => {
   }
 
   function onPackageChanges() {
-    // job is complete, refresh all local data
+    // job is complete, stop monitoring it and refresh all local data
+    setJobID(undefined);
     const ac = getClient();
     evictQueries(ac.cache, pluginMutationImpactedQueries);
   }
@@ -98,7 +99,7 @@ export const AvailablePluginPackages: React.FC = () => {
   const { general, loading: configLoading, error, saveGeneral } = useSettings();
 
   const [jobID, setJobID] = useState<string>();
-  const { job } = useMonitorJob(jobID, () => onPackageChanges());
+  const { job } = useMonitorJob(jobID, onPackageChanges);
 
   // Get installed packages to filter them out from available list
   const { data: installedData } = useInstalledPluginPackages(false);
@@ -113,7 +114,8 @@ export const AvailablePluginPackages: React.FC = () => {
   }
 
   function onPackageChanges() {
-    // job is complete, refresh all local data
+    // job is complete, stop monitoring it and refresh all local data
+    setJobID(undefined);
     const ac = getClient();
     evictQueries(ac.cache, pluginMutationImpactedQueries);
   }

--- a/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
+++ b/ui/v2.5/src/components/Settings/ScraperPackageManager.tsx
@@ -24,7 +24,7 @@ import { SettingSection } from "./SettingSection";
 export const InstalledScraperPackages: React.FC = () => {
   const [loadUpgrades, setLoadUpgrades] = useState(false);
   const [jobID, setJobID] = useState<string>();
-  const { job } = useMonitorJob(jobID, () => onPackageChanges());
+  const { job } = useMonitorJob(jobID, onPackageChanges);
 
   const { data, previousData, refetch, networkStatus, error } =
     useInstalledScraperPackages(loadUpgrades);
@@ -44,7 +44,8 @@ export const InstalledScraperPackages: React.FC = () => {
   }
 
   function onPackageChanges() {
-    // job is complete, refresh all local data
+    // job is complete, stop monitoring it and refresh all local data
+    setJobID(undefined);
     const ac = getClient();
     evictQueries(ac.cache, scraperMutationImpactedQueries);
   }
@@ -98,7 +99,7 @@ export const AvailableScraperPackages: React.FC = () => {
   const { general, loading: configLoading, error, saveGeneral } = useSettings();
 
   const [jobID, setJobID] = useState<string>();
-  const { job } = useMonitorJob(jobID, () => onPackageChanges());
+  const { job } = useMonitorJob(jobID, onPackageChanges);
 
   // Get installed packages to filter them out from available list
   const { data: installedData } = useInstalledScraperPackages(false);
@@ -113,7 +114,8 @@ export const AvailableScraperPackages: React.FC = () => {
   }
 
   function onPackageChanges() {
-    // job is complete, refresh all local data
+    // job is complete, stop monitoring it and refresh all local data
+    setJobID(undefined);
     const ac = getClient();
     evictQueries(ac.cache, scraperMutationImpactedQueries);
   }

--- a/ui/v2.5/src/utils/job.ts
+++ b/ui/v2.5/src/utils/job.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getWSClient, useWSState } from "src/core/StashService";
 import {
   Job,
@@ -18,6 +18,11 @@ export const useMonitorJob = (
   onComplete?: (job?: JobFragment) => void
 ) => {
   const { state } = useWSState(getWSClient());
+
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
 
   const jobsSubscribe = useJobsSubscribeSubscription({
     skip: !jobID,
@@ -48,22 +53,22 @@ export const useMonitorJob = (
 
     const j = jobData?.findJob;
     if (j) {
-      setJob(j);
-
       if (
         j.status === JobStatus.Finished ||
         j.status === JobStatus.Failed ||
         j.status === JobStatus.Cancelled
       ) {
         setJob(undefined);
-        onComplete?.(j);
+        onCompleteRef.current?.(j);
+      } else {
+        setJob(j);
       }
     } else {
       // must've already finished
       setJob(undefined);
-      onComplete?.();
+      onCompleteRef.current?.();
     }
-  }, [jobID, jobData, loading, onComplete]);
+  }, [jobID, jobData, loading]);
 
   // monitor job
   useEffect(() => {
@@ -84,9 +89,9 @@ export const useMonitorJob = (
       setJob(event.job);
     } else {
       setJob(undefined);
-      onComplete?.(event.job);
+      onCompleteRef.current?.(event.job);
     }
-  }, [jobsSubscribe, jobID, onComplete]);
+  }, [jobsSubscribe, jobID]);
 
   // it's possible that the websocket connection isn't present
   // in that case, we'll just poll the server


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The plugin/scraper package managers never cleared their job ID once an install/uninstall/update job finished, so `useMonitorJob` kept the `findJob` query alive and polled it every second. This fix clears the job ID on completion.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->

closes https://github.com/stashapp/stash/issues/7044

## Testing
<!-- Describe the testing steps you have performed. -->
Local dev env


## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

NA

## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [X] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [ ] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
No AI, went old school for this one.


## Additional Context
<!-- Add any other context about the pull request here. -->

