### PR TITLE
Fix: Skip Scenes in Queue That Have no File

### DIFF
--- a/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
+++ b/ui/v2.5/src/components/ScenePlayer/ScenePlayer.tsx
@@ -333,6 +333,8 @@ export const ScenePlayer: React.FC<IScenePlayerProps> = PatchComponent(
           }
         }
       });
+
+      return () => sendSetTimestamp(() => {});
     }, [sendSetTimestamp, getPlayer]);
 
     // Initialize VideoJS player

--- a/ui/v2.5/src/components/ScenePlayer/styles.scss
+++ b/ui/v2.5/src/components/ScenePlayer/styles.scss
@@ -481,6 +481,14 @@ $sceneTabWidth: 450px;
   padding-right: 15px;
 }
 
+.scene-player-no-file {
+  align-items: center;
+  background-color: #000;
+  color: $text-muted;
+  display: flex;
+  justify-content: center;
+}
+
 .scrubber-wrapper {
   display: flex;
   flex-shrink: 0;

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -28,7 +28,7 @@ import { LoadingIndicator } from "src/components/Shared/LoadingIndicator";
 import { Icon } from "src/components/Shared/Icon";
 import { Counter } from "src/components/Shared/Counter";
 import { useToast } from "src/hooks/Toast";
-import SceneQueue, { QueuedScene } from "src/models/sceneQueue";
+import SceneQueue, { isPlayable, QueuedScene } from "src/models/sceneQueue";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import Mousetrap from "mousetrap";
 import { OrganizedButton } from "./OrganizedButton";
@@ -939,20 +939,33 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
     history.replace(sceneLink);
   }
 
-  async function queueNext(autoPlay: boolean) {
+  // skipUnplayable steps over scenes that have no file. Set it when advancing
+  // without the user choosing the destination, since a scene that can't be
+  // played never finishes and so would stall the queue.
+  async function queueNext(autoPlay: boolean, skipUnplayable = false) {
     if (currentQueueIndex === -1) return;
 
-    if (currentQueueIndex < queueScenes.length - 1) {
-      loadScene(queueScenes[currentQueueIndex + 1].id, autoPlay);
-    } else {
+    let nextIndex = currentQueueIndex + 1;
+    while (
+      skipUnplayable &&
+      nextIndex < queueScenes.length &&
+      !isPlayable(queueScenes[nextIndex])
+    ) {
+      nextIndex++;
+    }
+
+    if (nextIndex < queueScenes.length) {
+      loadScene(queueScenes[nextIndex].id, autoPlay);
+    } else if (queueHasMoreScenes) {
       // if we're at the end of the queue, load more scenes
-      if (currentQueueIndex === queueScenes.length - 1 && queueHasMoreScenes) {
-        const loadedScenes = await onQueueMoreScenes();
-        if (loadedScenes && loadedScenes.length > 0) {
-          // set the page to the next page
-          const newPage = (sceneQueue.query?.currentPage ?? 0) + 1;
-          loadScene(loadedScenes[0].id, autoPlay, newPage);
-        }
+      const loadedScenes = await onQueueMoreScenes();
+      const candidates = skipUnplayable
+        ? loadedScenes?.filter(isPlayable)
+        : loadedScenes;
+      if (candidates && candidates.length > 0) {
+        // set the page to the next page
+        const newPage = (sceneQueue.query?.currentPage ?? 0) + 1;
+        loadScene(candidates[0].id, autoPlay, newPage);
       }
     }
   }
@@ -1003,7 +1016,7 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
   function onComplete() {
     // load the next scene if we're continuing
     if (continuePlaylist) {
-      queueNext(true);
+      queueNext(true, true);
     }
   }
 

--- a/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneDetails/Scene.tsx
@@ -1076,18 +1076,26 @@ const SceneLoader: React.FC<RouteComponentProps<ISceneParams>> = ({
         onRefreshScene={onRefreshScene}
       />
       <div className={`scene-player-container ${collapsed ? "expanded" : ""}`}>
-        <ScenePlayer
-          key="ScenePlayer"
-          scene={scene}
-          hideScrubberOverride={hideScrubber}
-          autoplay={autoplay}
-          permitLoop={!continuePlaylist}
-          initialTimestamp={initialTimestamp}
-          sendSetTimestamp={getSetTimestamp}
-          onComplete={onComplete}
-          onNext={() => queueNext(true)}
-          onPrevious={() => queuePrevious(true)}
-        />
+        {isPlayable(scene) ? (
+          <ScenePlayer
+            key="ScenePlayer"
+            scene={scene}
+            hideScrubberOverride={hideScrubber}
+            autoplay={autoplay}
+            permitLoop={!continuePlaylist}
+            initialTimestamp={initialTimestamp}
+            sendSetTimestamp={getSetTimestamp}
+            onComplete={onComplete}
+            onNext={() => queueNext(true)}
+            onPrevious={() => queuePrevious(true)}
+          />
+        ) : (
+          <div className="VideoPlayer">
+            <div className="video-wrapper scene-player-no-file">
+              <FormattedMessage id="scene_has_no_file" />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/ui/v2.5/src/core/files.ts
+++ b/ui/v2.5/src/core/files.ts
@@ -5,7 +5,7 @@ export interface IFile {
   path: string;
 }
 
-interface IObjectWithFiles {
+export interface IObjectWithFiles {
   files?: GQL.Maybe<IFile[]>;
 }
 

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -1446,6 +1446,7 @@
   "scenes_size": "Scene Size",
   "scene_created_at": "Scene Created At",
   "scene_date": "Date of Scene",
+  "scene_has_no_file": "This scene has no file.",
   "scene_id": "Scene ID",
   "scene_tags": "Scene Tags",
   "scene_updated_at": "Scene Updated At",

--- a/ui/v2.5/src/models/sceneQueue.ts
+++ b/ui/v2.5/src/models/sceneQueue.ts
@@ -1,11 +1,18 @@
 import { FilterMode, Scene } from "src/core/generated-graphql";
 import { ListFilterModel } from "./list-filter/filter";
 import { INamedObject } from "src/utils/navigation";
+import { IFile, IObjectWithFiles } from "src/core/files";
 
 export type QueuedScene = Pick<Scene, "id" | "title" | "date" | "paths"> & {
+  files: IFile[];
   performers?: INamedObject[] | null;
   studio?: INamedObject | null;
 };
+
+// a scene with no file has no streams, so it can't be played
+export function isPlayable(s: IObjectWithFiles) {
+  return !!s.files?.length;
+}
 
 export interface IPlaySceneOptions {
   sceneIndex?: number;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the contributing guidelines and this template. -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This modifies up the queue system to check if a scene has a file, and if not, skip it from automatically playing when you have `Continue playlist by default`. 

Fixing that issue brought up another issue of what happens when you click on a fileless scene within the queue. I went ahead and fixed it by checking for a file and then displaying a blank screen noting that this scene is fileless. I'm not 100% in love with this solution but I cant think of a much better one in the moment. Screenshot below.


## Related Issue
<!-- Please link the issue your pull request is referring to. -->
closes https://github.com/stashapp/stash/issues/6814


## Testing
<!-- Describe the testing steps you have performed. -->

Local dev env

## Screenshots
<!-- For visual changes, please add before and after screenshots. -->

<img width="3757" height="1919" alt="No file" src="https://github.com/user-attachments/assets/71d29bb2-47ea-4965-88f3-14ec739dd5b9" />


## Checklist
<!-- Mark [x] to indicate completion. -->

- [X] I have read and understood the [Contributing](https://github.com/stashapp/stash/blob/develop/docs/CONTRIBUTING.md) document.
- [X] I have read and understood the [AI Usage Policy](https://github.com/stashapp/stash/blob/develop/docs/AI_POLICY.md) document.
- [X] I have made corresponding changes to the documentation (if applicable).

## AI Usage Disclosure
<!-- Mark [x] to indicate completion. -->
- [X] I have used AI tools to assist with this pull request, and I have disclosed the tools and how I used them below.
<!-- If you used AI to assist with this pull request, please disclose what tools you used and how you used them. -->
Drafted via Claude Opus. Refactored by myself.


## Additional Context
<!-- Add any other context about the pull request here. -->

Would like design input on the fileless screen. I think it's "functional" but I don't know if this is the best soloution.